### PR TITLE
[JSC] More fine grained microtasks

### DIFF
--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -163,12 +163,12 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
                 }
             }
             scope.release();
-            globalObject->queueMicrotask(InternalMicrotask::PromiseResolveWithoutHandlerJob, promiseToResolve, promise->reactionsOrResult(), jsNumber(static_cast<int32_t>(JSPromise::Status::Rejected)), jsUndefined());
+            globalObject->queueMicrotask(InternalMicrotask::PromiseRejectWithoutHandlerJob, promiseToResolve, promise->reactionsOrResult(), jsUndefined(), jsUndefined());
             break;
         }
         case JSPromise::Status::Fulfilled: {
             scope.release();
-            globalObject->queueMicrotask(InternalMicrotask::PromiseResolveWithoutHandlerJob, promiseToResolve, promise->reactionsOrResult(), jsNumber(static_cast<int32_t>(JSPromise::Status::Fulfilled)), jsUndefined());
+            globalObject->queueMicrotask(InternalMicrotask::PromiseResolveWithoutHandlerJob, promiseToResolve, promise->reactionsOrResult(), jsUndefined(), jsUndefined());
             break;
         }
         }
@@ -225,31 +225,55 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
     case InternalMicrotask::PromiseResolveWithoutHandlerJob: {
         auto* promise = jsCast<JSPromise*>(arguments[0]);
         JSValue resolution = arguments[1];
-        switch (static_cast<JSPromise::Status>(arguments[2].asInt32())) {
-        case JSPromise::Status::Pending: {
-            RELEASE_ASSERT_NOT_REACHED();
-            break;
-        }
-        case JSPromise::Status::Fulfilled: {
-            scope.release();
-            promise->resolvePromise(globalObject, resolution);
-            break;
-        }
-        case JSPromise::Status::Rejected: {
-            scope.release();
-            promise->rejectPromise(globalObject, resolution);
-            break;
-        }
-        }
+        scope.release();
+        promise->resolvePromise(globalObject, resolution);
         return;
     }
 
-    case InternalMicrotask::PromiseReactionJob: {
-        JSValue promiseOrCapability = arguments[0];
+    case InternalMicrotask::PromiseRejectWithoutHandlerJob: {
+        auto* promise = jsCast<JSPromise*>(arguments[0]);
+        JSValue resolution = arguments[1];
+        scope.release();
+        promise->rejectPromise(globalObject, resolution);
+        return;
+    }
+
+    case InternalMicrotask::PromiseReactionJobWithPromise: {
+        auto* promise = jsCast<JSPromise*>(arguments[0]);
         JSValue handler = arguments[1];
         JSValue context = arguments[3];
 
-        ASSERT(!promiseOrCapability.isUndefinedOrNull());
+        JSValue result;
+        JSValue error;
+        {
+            auto catchScope = DECLARE_CATCH_SCOPE(vm);
+            if (context.isUndefinedOrNull())
+                result = callMicrotask(globalObject, handler, jsUndefined(), dynamicCastToCell(handler), ArgList { std::bit_cast<EncodedJSValue*>(arguments.data() + 2), 1 }, "handler is not a function"_s);
+            else
+                result = callMicrotask(globalObject, handler, jsUndefined(), dynamicCastToCell(context), ArgList { std::bit_cast<EncodedJSValue*>(arguments.data() + 2), 2 }, "handler is not a function"_s);
+
+            if (catchScope.exception()) {
+                error = catchScope.exception()->value();
+                if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
+                    scope.release();
+                    return;
+                }
+            }
+        }
+
+        if (error)
+            RELEASE_AND_RETURN(scope, promise->rejectPromise(globalObject, error));
+
+        RELEASE_AND_RETURN(scope, promise->resolvePromise(globalObject, result));
+    }
+
+    case InternalMicrotask::PromiseReactionJobWithPromiseCapability: {
+        JSValue capability = arguments[0];
+        JSValue handler = arguments[1];
+        JSValue context = arguments[3];
+
+        ASSERT(!capability.isUndefinedOrNull());
+        ASSERT(!capability.inherits<JSPromise>());
         JSValue result;
         JSValue error;
         {
@@ -269,10 +293,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
         }
 
         if (error) {
-            if (auto* promise = jsDynamicCast<JSPromise*>(promiseOrCapability))
-                RELEASE_AND_RETURN(scope, promise->rejectPromise(globalObject, error));
-
-            JSValue reject = promiseOrCapability.get(globalObject, vm.propertyNames->reject);
+            JSValue reject = capability.get(globalObject, vm.propertyNames->reject);
             RETURN_IF_EXCEPTION(scope, void());
 
             MarkedArgumentBuffer arguments;
@@ -283,10 +304,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
             return;
         }
 
-        if (auto* promise = jsDynamicCast<JSPromise*>(promiseOrCapability))
-            RELEASE_AND_RETURN(scope, promise->resolvePromise(globalObject, result));
-
-        JSValue resolve = promiseOrCapability.get(globalObject, vm.propertyNames->resolve);
+        JSValue resolve = capability.get(globalObject, vm.propertyNames->resolve);
         RETURN_IF_EXCEPTION(scope, void());
 
         MarkedArgumentBuffer arguments;
@@ -296,6 +314,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
         call(globalObject, resolve, jsUndefined(), arguments, "resolve is not a function"_s);
         return;
     }
+
 
     case InternalMicrotask::PromiseReactionJobWithoutPromise: {
         JSValue handler = arguments[0];

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -292,7 +292,11 @@ void JSPromise::performPromiseThen(JSGlobalObject* globalObject, JSValue onFulfi
             globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithoutPromise, onRejected, reactionsOrResult, context, jsUndefined());
             break;
         }
-        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJob, promiseOrCapability, onRejected, reactionsOrResult, context);
+        if (promiseOrCapability.inherits<JSPromise>()) {
+            globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithPromise, promiseOrCapability, onRejected, reactionsOrResult, context);
+            break;
+        }
+        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithPromiseCapability, promiseOrCapability, onRejected, reactionsOrResult, context);
         break;
     }
     case JSPromise::Status::Fulfilled: {
@@ -301,7 +305,11 @@ void JSPromise::performPromiseThen(JSGlobalObject* globalObject, JSValue onFulfi
             globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithoutPromise, onFulfilled, reactionsOrResult, context, jsUndefined());
             break;
         }
-        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJob, promiseOrCapability, onFulfilled, reactionsOrResult, context);
+        if (promiseOrCapability.inherits<JSPromise>()) {
+            globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithPromise, promiseOrCapability, onFulfilled, reactionsOrResult, context);
+            break;
+        }
+        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithPromiseCapability, promiseOrCapability, onFulfilled, reactionsOrResult, context);
         break;
     }
     }
@@ -566,6 +574,7 @@ void JSPromise::triggerPromiseReactions(JSGlobalObject* globalObject, Status sta
     head = jsCast<JSPromiseReaction*>(previous);
 
     bool isResolved = status == JSPromise::Status::Fulfilled;
+    InternalMicrotask withoutHandlerJob = isResolved ? InternalMicrotask::PromiseResolveWithoutHandlerJob : InternalMicrotask::PromiseRejectWithoutHandlerJob;
     auto* current = head;
     while (current) {
         JSValue promise = current->promise();
@@ -574,7 +583,7 @@ void JSPromise::triggerPromiseReactions(JSGlobalObject* globalObject, Status sta
         current = jsDynamicCast<JSPromiseReaction*>(current->next());
 
         if (handler.isUndefinedOrNull()) {
-            globalObject->queueMicrotask(InternalMicrotask::PromiseResolveWithoutHandlerJob, promise, argument, jsNumber(static_cast<int32_t>(status)), jsUndefined());
+            globalObject->queueMicrotask(withoutHandlerJob, promise, argument, jsUndefined(), jsUndefined());
             RETURN_IF_EXCEPTION(scope, void());
             continue;
         }
@@ -585,7 +594,13 @@ void JSPromise::triggerPromiseReactions(JSGlobalObject* globalObject, Status sta
             continue;
         }
 
-        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJob, promise, handler, argument, context);
+        if (promise.inherits<JSPromise>()) {
+            globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithPromise, promise, handler, argument, context);
+            RETURN_IF_EXCEPTION(scope, void());
+            continue;
+        }
+
+        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithPromiseCapability, promise, handler, argument, context);
         RETURN_IF_EXCEPTION(scope, void());
     }
 }

--- a/Source/JavaScriptCore/runtime/Microtask.h
+++ b/Source/JavaScriptCore/runtime/Microtask.h
@@ -37,7 +37,9 @@ enum class InternalMicrotask : int32_t {
     PromiseResolveThenableJobWithoutPromiseFast,
     PromiseResolveThenableJob,
     PromiseResolveWithoutHandlerJob,
-    PromiseReactionJob,
+    PromiseRejectWithoutHandlerJob,
+    PromiseReactionJobWithPromise,
+    PromiseReactionJobWithPromiseCapability,
     PromiseReactionJobWithoutPromise,
     InvokeFunctionJob,
     Opaque, // Dispatch must handle everything.


### PR DESCRIPTION
#### 35b6970155b3390390da39e7b06cb25d3828e49d
<pre>
[JSC] More fine grained microtasks
<a href="https://bugs.webkit.org/show_bug.cgi?id=300369">https://bugs.webkit.org/show_bug.cgi?id=300369</a>
<a href="https://rdar.apple.com/162172933">rdar://162172933</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::performPromiseThen):
(JSC::JSPromise::triggerPromiseReactions):
* Source/JavaScriptCore/runtime/Microtask.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35b6970155b3390390da39e7b06cb25d3828e49d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77175 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4a3c2478-4075-47ae-b85a-fd6225aaefac) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95333 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63335 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75872 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/382f65d3-1a68-4e70-87ec-64e6d53f73df) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30148 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75551 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117313 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134754 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123740 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52031 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39813 "Found 6 new test failures: http/tests/media/modern-media-controls/skip-back-support/skip-back-support-button-click.html http/tests/media/reload-after-dialog.html http/tests/media/video-auth.html http/tests/media/video-cookie.html imported/w3c/web-platform-tests/fetch/range/non-matching-range-response.html imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251.html?include=loading (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103800 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103570 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48924 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27213 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49117 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51923 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57702 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156763 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51285 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39251 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54641 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52979 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->