### PR TITLE
Update position-visibility: no-overflow invisibility in response to scrolling

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7506,7 +7506,6 @@ webkit.org/b/282024 fast/text/text-box-edge-with-margin-padding-border-simple.ht
 # general failures
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-012.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-with-position.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/transform-001.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/transform-002.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/transform-003.tentative.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll-002-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<style>
+  #scroll-container {
+    overflow: hidden scroll;
+    width: 400px;
+    height: 150px;
+  }
+
+  .anchor {
+    width: 100px;
+    height: 100px;
+    background: orange;
+    display: inline-block;
+  }
+
+  .target {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<div id="scroll-container">
+  <div class="anchor">anchor1</div>
+  <div class="anchor" style="position: relative; top: 100px">anchor2</div>
+  <div id="target1" class="target" style="background: green">target1</div>
+  <div style="height: 200px"></div>
+</div>
+<script>
+document.getElementById('scroll-container').scrollTop = 50;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll-002.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>CSS Anchor Positioning Test: position-visibility: no-overflow + scrolling + anchor()</title>
+<title>CSS Anchor Positioning Test: position-visibility: no-overflow + scrolling + position-area</title>
 <link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-visibility">
 <link rel="match" href="position-visibility-no-overflow-scroll-ref.html">
 <style>
@@ -35,8 +35,8 @@
 <div id="scroll-container">
   <div class="anchor" style="anchor-name: --a1;">anchor1</div>
   <div class="anchor" style="anchor-name: --a2; position: relative; top: 100px">anchor2</div>
-  <div id="target1" class="target" style="position-anchor: --a1; top: anchor(bottom); background: green">target1</div>
-  <div id="target2" class="target" style="position-anchor: --a2; left: anchor(left); bottom: anchor(top); background: red">target2</div>
+  <div id="target1" class="target" style="position-anchor: --a1; position-area: bottom; background: green">target1</div>
+  <div id="target2" class="target" style="position-anchor: --a2; position-area: top; background: red">target2</div>
   <div style="height: 300px"></div>
 </div>
 </div>


### PR DESCRIPTION
#### 98e98755a83541128db112e56f16b1b58b7445ab
<pre>
Update position-visibility: no-overflow invisibility in response to scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=300373">https://bugs.webkit.org/show_bug.cgi?id=300373</a>
<a href="https://rdar.apple.com/162173481">rdar://162173481</a>

Reviewed by Antti Koivisto.

Updates the AnchorScrollAdjuster to also track limits for position-visibility:
no-overflow (which happen to be the same as for fallback restyling), and sets
up appropriate invalidation.

Test: imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll-002.html
* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll-002.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll.html:

Add new test to cover the position-area case.
  <a href="https://github.com/web-platform-tests/wpt/pull/55295">https://github.com/web-platform-tests/wpt/pull/55295</a>
Fix error in the existing anchor() test.
  <a href="https://github.com/web-platform-tests/wpt/pull/55294">https://github.com/web-platform-tests/wpt/pull/55294</a>
Mark existing anchor() test as passing.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::captureScrollSnapshots):

Capture limits for no-oveflow case as well.

(WebCore::Style::AnchorPositionEvaluator::updateScrollAdjustments):

Distinguish fallback vs no-overflow cases and invalidate accordingly.

Canonical link: <a href="https://commits.webkit.org/301211@main">https://commits.webkit.org/301211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31005f246b92826fffbb53b01ef49812be1ef0e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77073 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a98b05f-4849-4ea3-8667-d75a717a612e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53436 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95320 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df01fe32-1343-4d3e-b418-da0fd0bedb58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111967 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75860 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/61e0bfa2-c837-401d-a999-35477461a253) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30135 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75537 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134739 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103786 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103555 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26384 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48912 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27200 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49104 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51909 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57689 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51273 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54629 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52966 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->