### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for more classes

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechRecognizer.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognizer.cpp
@@ -28,6 +28,7 @@
 
 #include "SpeechRecognitionRequest.h"
 #include "SpeechRecognitionUpdate.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/MediaTime.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -48,6 +49,8 @@ SpeechRecognizer::SpeechRecognizer(DelegateCallback&& delegateCallback, UniqueRe
 #endif
 {
 }
+
+SpeechRecognizer::~SpeechRecognizer() = default;
 
 void SpeechRecognizer::abort(std::optional<SpeechRecognitionError>&& error)
 {
@@ -105,13 +108,13 @@ void SpeechRecognizer::start(Ref<RealtimeMediaSource>&& source, bool mockSpeechR
 void SpeechRecognizer::startCapture(Ref<RealtimeMediaSource>&& source)
 {
     auto dataCallback = [weakThis = WeakPtr { *this }](const auto& time, const auto& data, const auto& description, auto sampleCount) {
-        if (weakThis)
-            weakThis->dataCaptured(time, data, description, sampleCount);
+        if (CheckedPtr checkedThis = weakThis.get())
+            checkedThis->dataCaptured(time, data, description, sampleCount);
     };
 
     auto stateUpdateCallback = [weakThis = WeakPtr { *this }](const auto& update) {
-        if (weakThis)
-            weakThis->m_delegateCallback(update);
+        if (CheckedPtr checkedThis = weakThis.get())
+            checkedThis->m_delegateCallback(update);
     };
 
     m_source = makeUnique<SpeechRecognitionCaptureSource>(clientIdentifier(), WTFMove(dataCallback), WTFMove(stateUpdateCallback), WTFMove(source));

--- a/Source/WebCore/Modules/speech/SpeechRecognizer.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognizer.h
@@ -28,6 +28,7 @@
 #include <WebCore/SpeechRecognitionCaptureSource.h>
 #include <WebCore/SpeechRecognitionConnectionClientIdentifier.h>
 #include <WebCore/SpeechRecognitionError.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
@@ -38,24 +39,17 @@ OBJC_CLASS WebSpeechRecognizerTask;
 #endif
 
 namespace WebCore {
-class SpeechRecognizer;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SpeechRecognizer> : std::true_type { };
-}
-
-namespace WebCore {
 
 class SpeechRecognitionRequest;
 class SpeechRecognitionUpdate;
 
-class SpeechRecognizer : public CanMakeWeakPtr<SpeechRecognizer> {
+class SpeechRecognizer final : public CanMakeWeakPtr<SpeechRecognizer>, public CanMakeCheckedPtr<SpeechRecognizer> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(SpeechRecognizer, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SpeechRecognizer);
 public:
     using DelegateCallback = Function<void(const SpeechRecognitionUpdate&)>;
     WEBCORE_EXPORT explicit SpeechRecognizer(DelegateCallback&&, UniqueRef<SpeechRecognitionRequest>&&);
+    WEBCORE_EXPORT ~SpeechRecognizer();
 
 #if ENABLE(MEDIA_STREAM)
     WEBCORE_EXPORT void start(Ref<RealtimeMediaSource>&&, bool mockSpeechRecognitionEnabled);

--- a/Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.h
+++ b/Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.h
@@ -28,22 +28,15 @@
 #if PLATFORM(MAC)
 
 #include <pal/system/SystemSleepListener.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace PAL {
-class SystemSleepListenerMac;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<PAL::SystemSleepListenerMac> : std::true_type { };
-}
-
-namespace PAL {
-
-class SystemSleepListenerMac : public SystemSleepListener, public CanMakeWeakPtr<SystemSleepListenerMac> {
+class SystemSleepListenerMac : public SystemSleepListener, public CanMakeWeakPtr<SystemSleepListenerMac>, public CanMakeCheckedPtr<SystemSleepListenerMac> {
     WTF_MAKE_TZONE_ALLOCATED(SystemSleepListenerMac);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SystemSleepListenerMac);
 protected:
     SystemSleepListenerMac(Client&);
     virtual ~SystemSleepListenerMac();

--- a/Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.mm
+++ b/Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import <AppKit/AppKit.h>
+#import <wtf/CheckedPtr.h>
 #import <wtf/MainThread.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -53,15 +54,15 @@ SystemSleepListenerMac::SystemSleepListenerMac(Client& client)
 
     m_sleepObserver = [center addObserverForName:NSWorkspaceWillSleepNotification object:nil queue:queue usingBlock:^(NSNotification *) {
         callOnMainThread([weakThis] {
-            if (weakThis)
-                weakThis->m_client.systemWillSleep();
+            if (CheckedPtr checkedThis = weakThis.get())
+                checkedThis->m_client.systemWillSleep();
         });
     }];
 
     m_wakeObserver = [center addObserverForName:NSWorkspaceDidWakeNotification object:nil queue:queue usingBlock:^(NSNotification *) {
         callOnMainThread([weakThis] {
-            if (weakThis)
-                weakThis->m_client.systemDidWake();
+            if (CheckedPtr checkedThis = weakThis.get())
+                checkedThis->m_client.systemDidWake();
         });
     }];
 }

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -48,27 +48,29 @@
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
-struct SameSizeAsScrollableArea;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SameSizeAsScrollableArea> : std::true_type { };
-}
-
-namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollableArea);
 
-struct SameSizeAsScrollableArea final : public CanMakeWeakPtr<SameSizeAsScrollableArea> {
+struct SameSizeAsScrollableArea : public CanMakeWeakPtr<SameSizeAsScrollableArea> {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(SameSizeAsScrollableArea);
 
-    ~SameSizeAsScrollableArea() { }
+    // CheckedPtr interface
+    virtual uint32_t checkedPtrCount() const { return 0; }
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const { return 0; }
+    virtual void incrementCheckedPtrCount() const { }
+    virtual void decrementCheckedPtrCount() const { }
+
+    virtual ~SameSizeAsScrollableArea() { }
     SameSizeAsScrollableArea() { }
-    void* pointer[3];
-    IntPoint origin;
-    Markable<ScrollingNodeID> testID;
-    bool bytes[9];
+    void* pointer[2];
+    IntPoint scrollOrigin;
+    bool scrollClamping;
+    uint8_t scrollElasticity[2];
+    uint8_t scrollbarOverlayStyle;
+    bool currentScrollType;
+    uint8_t scrollAnimationStatus;
+    bool bytes[4];
+    Markable<ScrollingNodeID> scrollingNodeIDForTesting;
 };
 
 #if CPU(ADDRESS64)

--- a/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h
+++ b/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h
@@ -28,17 +28,9 @@
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
 
 #include <WebCore/AudioSession.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
-
-namespace WebCore {
-class SharedRoutingArbitratorToken;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SharedRoutingArbitratorToken> : std::true_type { };
-}
 
 namespace WTF {
 class Logger;
@@ -46,8 +38,9 @@ class Logger;
 
 namespace WebCore {
 
-class WEBCORE_EXPORT SharedRoutingArbitratorToken : public CanMakeWeakPtr<SharedRoutingArbitratorToken> {
+class WEBCORE_EXPORT SharedRoutingArbitratorToken : public CanMakeWeakPtr<SharedRoutingArbitratorToken>, public CanMakeCheckedPtr<SharedRoutingArbitratorToken> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(SharedRoutingArbitratorToken, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SharedRoutingArbitratorToken);
 public:
     static UniqueRef<SharedRoutingArbitratorToken> create();
     uint64_t logIdentifier() const;

--- a/Source/WebCore/platform/cf/MainThreadSharedTimerCF.cpp
+++ b/Source/WebCore/platform/cf/MainThreadSharedTimerCF.cpp
@@ -31,6 +31,7 @@
 
 #if PLATFORM(MAC)
 #import "PowerObserverMac.h"
+#import <wtf/NeverDestroyed.h>
 #elif PLATFORM(IOS_FAMILY)
 #import "WebCoreThreadInternal.h"
 #import "WebCoreThreadRun.h"
@@ -67,9 +68,9 @@ static void setupPowerObserver()
     if (!MainThreadSharedTimer::shouldSetupPowerObserver())
         return;
 #if PLATFORM(MAC)
-    static PowerObserver* powerObserver;
-    if (!powerObserver)
-        powerObserver = makeUnique<PowerObserver>(MainThreadSharedTimer::restartSharedTimer).release();
+    static NeverDestroyed<std::unique_ptr<PowerObserver>> powerObserver;
+    if (!powerObserver.get())
+        powerObserver.get() = makeUnique<PowerObserver>(MainThreadSharedTimer::restartSharedTimer);
 #elif PLATFORM(IOS_FAMILY)
     static bool registeredForApplicationNotification = false;
     if (!registeredForApplicationNotification) {

--- a/Source/WebCore/platform/cocoa/PowerSourceNotifier.h
+++ b/Source/WebCore/platform/cocoa/PowerSourceNotifier.h
@@ -30,18 +30,10 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class PowerSourceNotifier;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PowerSourceNotifier> : std::true_type { };
-}
-
-namespace WebCore {
-
-class PowerSourceNotifier : public CanMakeWeakPtr<PowerSourceNotifier> {
+class PowerSourceNotifier : public CanMakeWeakPtr<PowerSourceNotifier>, public CanMakeCheckedPtr<PowerSourceNotifier> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(PowerSourceNotifier, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PowerSourceNotifier);
 public:
     using PowerSourceNotifierCallback = Function<void(bool hasAC)>;
     WEBCORE_EXPORT explicit PowerSourceNotifier(PowerSourceNotifierCallback&&);

--- a/Source/WebCore/platform/cocoa/PowerSourceNotifier.mm
+++ b/Source/WebCore/platform/cocoa/PowerSourceNotifier.mm
@@ -42,8 +42,8 @@ PowerSourceNotifier::PowerSourceNotifier(PowerSourceNotifierCallback&& callback)
 {
     int token = 0;
     auto status = notify_register_dispatch(kIOPSNotifyPowerSource, &token, mainDispatchQueueSingleton(), [weakThis = WeakPtr { *this }] (int) {
-        if (weakThis)
-            weakThis->notifyPowerSourceChanged();
+        if (CheckedPtr checkedThis = weakThis.get())
+            checkedThis->notifyPowerSourceChanged();
     });
     if (status == NOTIFY_STATUS_OK)
         m_tokenID = token;
@@ -51,8 +51,8 @@ PowerSourceNotifier::PowerSourceNotifier(PowerSourceNotifierCallback&& callback)
     // If the current value of systemHasAC() is uncached, force a notification.
     if (!cachedSystemHasAC()) {
         RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }] {
-            if (weakThis)
-                weakThis->notifyPowerSourceChanged();
+            if (CheckedPtr checkedThis = weakThis.get())
+                checkedThis->notifyPowerSourceChanged();
         });
     }
 }

--- a/Source/WebCore/platform/mac/PowerObserverMac.cpp
+++ b/Source/WebCore/platform/mac/PowerObserverMac.cpp
@@ -27,6 +27,7 @@
 
 #if PLATFORM(MAC)
 #import "PowerObserverMac.h"
+#import <wtf/CheckedPtr.h>
 #import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -71,8 +72,8 @@ void PowerObserver::didReceiveSystemPowerNotification(io_service_t, uint32_t mes
     // We need to restart the timer on the main thread.
     WeakPtr weakThis { *this };
     CFRunLoopPerformBlock(RetainPtr { CFRunLoopGetMain() }.get(), kCFRunLoopCommonModes, ^() {
-        if (weakThis)
-            weakThis->m_powerOnHander();
+        if (CheckedPtr checkedThis = weakThis.get())
+            checkedThis->m_powerOnHander();
     });
 }
 

--- a/Source/WebCore/platform/mac/PowerObserverMac.h
+++ b/Source/WebCore/platform/mac/PowerObserverMac.h
@@ -28,6 +28,7 @@
 
 #import <IOKit/IOMessage.h>
 #import <IOKit/pwr_mgt/IOPMLib.h>
+#import <wtf/CheckedRef.h>
 #import <wtf/Function.h>
 #import <wtf/Noncopyable.h>
 #import <wtf/OSObjectPtr.h>
@@ -35,20 +36,11 @@
 #import <wtf/WeakPtr.h>
 
 namespace WebCore {
-class PowerObserver;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PowerObserver> : std::true_type { };
-}
-
-namespace WebCore {
-
-class PowerObserver : public CanMakeWeakPtr<PowerObserver, WeakPtrFactoryInitialization::Eager> {
+class PowerObserver : public CanMakeWeakPtr<PowerObserver, WeakPtrFactoryInitialization::Eager>, public CanMakeCheckedPtr<PowerObserver> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(PowerObserver, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(PowerObserver);
-
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PowerObserver);
 public:
     WEBCORE_EXPORT PowerObserver(Function<void()>&& powerOnHander);
     WEBCORE_EXPORT ~PowerObserver();

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.h
@@ -87,6 +87,8 @@ private:
     void sendUpdate(WebCore::SpeechRecognitionConnectionClientIdentifier, WebCore::SpeechRecognitionUpdateType, std::optional<WebCore::SpeechRecognitionError> = std::nullopt, std::optional<Vector<WebCore::SpeechRecognitionResultData>> = std::nullopt);
     void sendUpdate(const WebCore::SpeechRecognitionUpdate&);
 
+    CheckedPtr<WebCore::SpeechRecognizer> checkedRecognizer() const;
+
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 


### PR DESCRIPTION
#### fb3655a31cceea420f8cf2ea19c60f8f4b4ca696
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for more classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=300376">https://bugs.webkit.org/show_bug.cgi?id=300376</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/speech/SpeechRecognizer.cpp:
(WebCore::SpeechRecognizer::startCapture):
* Source/WebCore/Modules/speech/SpeechRecognizer.h:
(WebCore::SpeechRecognizer::source): Deleted.
(WebCore::SpeechRecognizer::setInactive): Deleted.
* Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.h:
* Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.mm:
(PAL::SystemSleepListenerMac::SystemSleepListenerMac):
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::SameSizeAsScrollableArea::checkedPtrCount const):
(WebCore::SameSizeAsScrollableArea::checkedPtrCountWithoutThreadCheck const):
(WebCore::SameSizeAsScrollableArea::incrementCheckedPtrCount const):
(WebCore::SameSizeAsScrollableArea::decrementCheckedPtrCount const):
(WebCore::SameSizeAsScrollableArea::~SameSizeAsScrollableArea):
(): Deleted.
* Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h:
* Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm:
(WebCore::SharedRoutingArbitrator::beginRoutingArbitrationForToken):
* Source/WebCore/platform/cf/MainThreadSharedTimerCF.cpp:
(WebCore::setupPowerObserver):
* Source/WebCore/platform/cocoa/PowerSourceNotifier.h:
* Source/WebCore/platform/cocoa/PowerSourceNotifier.mm:
(WebCore::PowerSourceNotifier::PowerSourceNotifier):
* Source/WebCore/platform/mac/PowerObserverMac.cpp:
(WebCore::PowerObserver::didReceiveSystemPowerNotification):
* Source/WebCore/platform/mac/PowerObserverMac.h:
* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::convertSVGToOTFFont):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp:
(WebCore::BackgroundFetchResponseBodyLoader::BackgroundFetchResponseBodyLoader): Deleted.
* Source/WebKit/UIProcess/SpeechRecognitionServer.cpp:
(WebKit::SpeechRecognitionServer::checkedRecognizer const):
(WebKit::SpeechRecognitionServer::handleRequest):
(WebKit::SpeechRecognitionServer::stop):
(WebKit::SpeechRecognitionServer::abort):
(WebKit::SpeechRecognitionServer::invalidate):
* Source/WebKit/UIProcess/SpeechRecognitionServer.h:

Canonical link: <a href="https://commits.webkit.org/301240@main">https://commits.webkit.org/301240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a719a2b1c310874df1b2c46b68c187818fc86044

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77191 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c34adbd4-b6b6-493d-9e40-e25168ba3e62) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95416 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef761918-a0e8-45b0-a30f-54f66f6322ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75955 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b271f4c9-217e-4456-b328-3bf5b5e098ce) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30241 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75648 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134857 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103886 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103647 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26402 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27305 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49235 "Hash a719a2b1 for PR 51994 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52020 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57800 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51377 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54733 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53071 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->