### PR TITLE
Make generate-dirty-files and compare-static-analysis-results work with iOS

### DIFF
--- a/Source/WTF/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -1,7 +1,7 @@
-WebKitBuild/Release/usr/local/include/wtf/text/SymbolImpl.h
-WebKitBuild/Release/usr/local/include/wtf/text/TextBreakIterator.h
-WebKitBuild/Release/usr/local/include/wtf/text/icu/TextBreakIteratorICU.h
-WebKitBuild/Release/usr/local/include/wtf/unicode/Collator.h
+usr/local/include/wtf/text/SymbolImpl.h
+usr/local/include/wtf/text/TextBreakIterator.h
+usr/local/include/wtf/text/icu/TextBreakIteratorICU.h
+usr/local/include/wtf/unicode/Collator.h
 wtf/ParkingLot.h
 wtf/PrintStream.h
 wtf/RetainPtr.h

--- a/Source/WTF/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,1 +1,1 @@
-WebKitBuild/Release/usr/local/include/wtf/text/cf/StringConcatenateCF.h
+usr/local/include/wtf/text/cf/StringConcatenateCF.h

--- a/Source/WTF/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,4 +1,4 @@
-WebKitBuild/Release/usr/local/include/wtf/text/cf/StringConcatenateCF.h
+usr/local/include/wtf/text/cf/StringConcatenateCF.h
 wtf/RetainPtr.h
 wtf/SchedulePair.h
 wtf/cf/RunLoopCF.cpp

--- a/Tools/Scripts/compare-static-analysis-results
+++ b/Tools/Scripts/compare-static-analysis-results
@@ -38,7 +38,8 @@ STATIC_ANALYZER_UNEXPECTED = 'StaticAnalyzerUnexpectedRegressions'
 UNEXPECTED_PASS = {'actual': 'PASS', 'expected': 'FAIL'}
 UNEXPECTED_FAILURE = {'actual': 'FAIL', 'expected': 'PASS'}
 EXPECTED_FAILURE = {'actual': 'FAIL', 'expected': 'FAIL'}
-DERIVED_SOURCES_RE = r'.*\/DerivedSources\/.*\/JS.*'
+DERIVED_SOURCES_RE = r'(^|.*\/)DerivedSources\/.*\/JS.*'
+EXPECTATION_LINE_RE = r'(\s*\[\s*(?P<platform>\w+)\s*\]\s*)?(?P<path>.+)'
 
 
 def parser():
@@ -95,20 +96,32 @@ def parser():
     return parser.parse_args()
 
 
-def find_diff(args, file1, file2):
+def find_diff(args, expectation_file_path, results_file_path):
     # Create empty file if the corresponding one doesn't exist - this happens if a checker is added or removed
-    if not os.path.exists(file1):
-        os.makedirs(os.path.dirname(file1), exist_ok=True)
-        f = open(file1, 'a')
+    if not os.path.exists(expectation_file_path):
+        os.makedirs(os.path.dirname(expectation_file_path), exist_ok=True)
+        f = open(expectation_file_path, 'a')
         f.close()
 
-    if not os.path.exists(file2):
-        os.makedirs(os.path.dirname(file2), exist_ok=True)
-        f = open(file2, 'a')
+    if not os.path.exists(results_file_path):
+        os.makedirs(os.path.dirname(results_file_path), exist_ok=True)
+        f = open(results_file_path, 'a')
         f.close()
 
-    with open(file1) as baseline_file, open(file2) as new_file:
-        baseline_list = [line for line in baseline_file.read().splitlines() if not line.startswith('//') and line.strip()]  # Remove lines from the copyright
+    with open(expectation_file_path) as baseline_file, open(results_file_path) as new_file:
+        baseline_list = []
+        expectation_line_re = re.compile(EXPECTATION_LINE_RE)
+        for line in baseline_file.read().splitlines():
+            if line.startswith('//') or line.startswith('#'):
+                continue
+            match = expectation_line_re.match(line)
+            if not match:
+                print(f'Unexpected line: {line}')
+                continue
+            platform = match.group('platform')
+            if platform and arg.platform.lower() != platform.lower():
+                continue
+            baseline_list.append(match.group('path'))
         new_file_list = new_file.read().splitlines()
         # Find new regressions
         diff_new_from_baseline = set(new_file_list) - set(baseline_list)

--- a/Tools/Scripts/generate-dirty-files
+++ b/Tools/Scripts/generate-dirty-files
@@ -30,7 +30,7 @@ import re
 
 from webkitpy.safer_cpp.checkers import Checker
 
-DERIVED_SOURCES_RE = r'.*\/DerivedSources\/.*\/JS.*'
+DERIVED_SOURCES_RE = r'(^|.*\/)DerivedSources\/.*\/JS.*'
 
 
 def parser():
@@ -67,6 +67,8 @@ def parse_results_file(args, file_path):
                     bug_file = line.removeprefix('<!-- BUGFILE ')
                     bug_file = bug_file.removesuffix(' -->\n')
                     bug_file = bug_file.removeprefix(f'{args.build_dir}/')
+                    bug_file = bug_file.removeprefix('WebKitBuild/Release/')
+                    bug_file = bug_file.removeprefix('WebKitBuild/Release-iphonesimulator/')
                 if 'ISSUEHASHCONTENTOFLINEINCONTEXT' in line:
                     issue_hash = line.removeprefix('<!-- ISSUEHASHCONTENTOFLINEINCONTEXT ')
                     issue_hash = issue_hash.removesuffix(' -->\n')


### PR DESCRIPTION
#### 31050dea93207bce9c9f7139936233b0b89880a7
<pre>
Make generate-dirty-files and compare-static-analysis-results work with iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=300377">https://bugs.webkit.org/show_bug.cgi?id=300377</a>

Reviewed by Chris Dumez.

Extend generate-dirty-files and compare-static-analysis-results so that we can add
static analyzer expectations for iOS. We do by allowing micro-syntax similar to the one
used in TestExpectations in the expectation files; e.g. `[ iOS ] FileWithIssue.cpp`

Also strip WebKitBuild/Release/ or WebKitBuild/Release-iphonesimulator/ from the file
path when generating a &quot;dirty&quot; list of files so that the results can be shared across
platforms.

* Source/WTF/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WTF/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Tools/Scripts/compare-static-analysis-results:
(parser):
(find_diff):
* Tools/Scripts/generate-dirty-files:
(parse_results_file):

Canonical link: <a href="https://commits.webkit.org/301254@main">https://commits.webkit.org/301254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa47d7aa0c9034e293515368327f7c416d9106f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77189 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/56cdd166-ec2c-4cc6-be7b-1736523da221) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95414 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41b22c11-df79-449d-93fa-ac02814a916c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75953 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aa81fb80-0341-4580-bde1-917577cd98de) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30238 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75646 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117410 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134855 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123838 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103887 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103648 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49007 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27302 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49233 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19633 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52018 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57798 "Found 3048 new failures in DerivedSources/WebCore/JSDeprecatedCSSOMValueList.cpp, DerivedSources/WebCore/JSDOMPlugin.cpp, DerivedSources/WebKit/JSWebExtensionAPIDeclarativeNetRequest.mm, DerivedSources/WebCore/JSNVShaderNoperspectiveInterpolation.cpp, DerivedSources/WebCore/JSDatabaseCallback.cpp, DerivedSources/WebCore/JSShadowRealmGlobalScope.cpp, DerivedSources/WebCore/JSTrustedTypePolicyFactory.cpp, DerivedSources/WebCore/JSWebGLFramebuffer.cpp, DerivedSources/WebCore/JSWebGLCompressedTexturePVRTC.cpp, DerivedSources/WebCore/JSErrorCallback.cpp ...") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156857 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51375 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39279 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54731 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53069 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->