### PR TITLE
[iOS] implement watchdog for completing fullscreen exit.

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -51,6 +51,7 @@
 #import <WebCore/GeometryUtilities.h>
 #import <WebCore/IntRect.h>
 #import <WebCore/LocalizedStrings.h>
+#import <WebCore/Timer.h>
 #import <WebCore/VideoPresentationInterfaceAVKitLegacy.h>
 #import <WebCore/VideoPresentationInterfaceTVOS.h>
 #import <WebCore/VideoPresentationModel.h>
@@ -74,6 +75,8 @@
 #if !HAVE(URL_FORMATTING)
 SOFT_LINK_PRIVATE_FRAMEWORK_OPTIONAL(LinkPresentation)
 #endif
+
+static constexpr Seconds DefaultWatchdogTimerInterval = 1_s;
 
 namespace WebKit {
 using namespace WebKit;
@@ -785,6 +788,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     CGRect _initialFrame;
     CGRect _finalFrame;
+    std::unique_ptr<WebCore::Timer> _watchdogTimer;
     CGSize _originalWindowSize;
 
     RetainPtr<NSString> _EVOrganizationName;
@@ -795,6 +799,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     BOOL _exitingFullScreen;
 
     RetainPtr<id> _notificationListener;
+
 #if !RELEASE_LOG_DISABLED
     RefPtr<Logger> _logger;
     uint64_t _logIdentifier;
@@ -1298,6 +1303,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)exitFullScreen:(CompletionHandler<void()>&&)completionHandler
 {
+    [self _cancelWatchdogTimer];
+
     if (_fullScreenState == WebKit::NotInFullScreen) {
         OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, _fullScreenState, ", dropping");
         return completionHandler();
@@ -1340,6 +1347,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (auto* manager = self._manager) {
         OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER);
         manager->setAnimatingFullScreen(true);
+        [self _startWatchdogTimer];
         return completionHandler();
     }
 
@@ -1412,6 +1420,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_completedExitFullScreen:(CompletionHandler<void()>&&)completionHandler
 {
+    [self _cancelWatchdogTimer];
+
     if (_fullScreenState != WebKit::ExitingFullScreen) {
         OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, _fullScreenState, " != ExitingFullScreen, dropping");
         return completionHandler();
@@ -1620,11 +1630,35 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 }
 
+- (void)_startWatchdogTimer
+{
+    // If the page doesn't respond in DefaultWatchdogTimerInterval seconds, it could be because
+    // the WebProcess has hung, so exit anyway.
+    if (!_watchdogTimer) {
+        _watchdogTimer = makeUnique<WebCore::Timer>([weakSelf = WeakObjCPtr { self }] {
+            RetainPtr strongSelf = weakSelf.get();
+            if (strongSelf)
+                [strongSelf _exitFullscreenImmediately];
+        });
+        _watchdogTimer->startOneShot(DefaultWatchdogTimerInterval);
+    }
+}
+
+- (void)_cancelWatchdogTimer
+{
+    if (!_watchdogTimer)
+        return;
+    _watchdogTimer->stop();
+    _watchdogTimer = nullptr;
+}
+
 #pragma mark -
 #pragma mark Internal Interface
 
 - (void)_exitFullscreenImmediately
 {
+    [self _cancelWatchdogTimer];
+
     if (_fullScreenState == WebKit::NotInFullScreen) {
         OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, _fullScreenState, ", dropping");
         return;


### PR DESCRIPTION
#### c026408da578c98b3cd0ccdecc681c7353504542
<pre>
[iOS] implement watchdog for completing fullscreen exit.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300380">https://bugs.webkit.org/show_bug.cgi?id=300380</a>
<a href="https://rdar.apple.com/162112548">rdar://162112548</a>

Reviewed by Jer Noble.

Following 290536@main ; exiting fullscreen relies on the web process to
complete its task and to call WebFullScreenManagerProxy::beganEnterFullScreen

If the web process has hung or died, the fullscreen window remains on screen with non-functional controls,
giving the appearance that Safari is completely locked up.

Like we do on Mac, we set a 1s watchdog that should the we failed to complete the exit of fullscreen mode
we will dismiss the webview placeholder.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController exitFullScreen:]):
(-[WKFullScreenWindowController _completedExitFullScreen:]):
(-[WKFullScreenWindowController _startWatchdogTimer]):
(-[WKFullScreenWindowController _watchdogTimerFired:]):
(-[WKFullScreenWindowController _cancelWatchdogTimer]):
(-[WKFullScreenWindowController _exitFullscreenImmediately]):

Canonical link: <a href="https://commits.webkit.org/301296@main">https://commits.webkit.org/301296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccd03c194d54a416a2ced2169879be7f2ac4dca5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132378 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77410 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02326810-90ea-4354-8784-43d80cb5110d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53745 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/705bceea-2e8a-432b-aefc-e172d5de7dec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128469 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/36655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76109 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1e09d7d-7da7-4f00-a549-d1b186bceb14) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75853 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106428 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135052 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40084 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108464 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26433 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49172 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27481 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49504 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52214 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58009 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51567 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54922 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53262 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->