### PR TITLE
WebKit::RemoteMediaResourceManager::loadFailed can be called outside its workqueue

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -1018,10 +1018,6 @@ bool GPUConnectionToWebProcess::dispatchMessage(IPC::Connection& connection, IPC
         protectedRemoteMediaPlayerManagerProxy()->didReceivePlayerMessage(connection, decoder);
         return true;
     }
-    if (decoder.messageReceiverName() == Messages::RemoteMediaResourceManager::messageReceiverName()) {
-        protectedRemoteMediaResourceManager()->didReceiveMessage(connection, decoder);
-        return true;
-    }
 #endif
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
@@ -107,39 +107,38 @@ RefPtr<RemoteMediaResource> RemoteMediaResourceManager::resourceForId(RemoteMedi
 
 void RemoteMediaResourceManager::responseReceived(RemoteMediaResourceIdentifier identifier, const ResourceResponse& response, bool didPassAccessControlCheck, CompletionHandler<void(ShouldContinuePolicyCheck)>&& completionHandler)
 {
-    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
-
-    if (auto resource = resourceForId(identifier))
+    if (RefPtr resource = resourceForId(identifier)) {
+        assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
         resource->responseReceived(response, didPassAccessControlCheck, WTFMove(completionHandler));
-    else
+    } else
         completionHandler(ShouldContinuePolicyCheck::No);
 }
 
 void RemoteMediaResourceManager::redirectReceived(RemoteMediaResourceIdentifier identifier, ResourceRequest&& request, const ResourceResponse& response, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler)
 {
-    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
-
-    if (auto resource = resourceForId(identifier))
+    if (RefPtr resource = resourceForId(identifier)) {
+        assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
         resource->redirectReceived(WTFMove(request), response, WTFMove(completionHandler));
-    else
+    } else
         completionHandler({ });
 }
 
 void RemoteMediaResourceManager::dataSent(RemoteMediaResourceIdentifier identifier, uint64_t bytesSent, uint64_t totalBytesToBeSent)
 {
-    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
-
-    if (auto resource = resourceForId(identifier))
+    if (RefPtr resource = resourceForId(identifier)) {
+        assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
         resource->dataSent(bytesSent, totalBytesToBeSent);
+    }
 }
 
 void RemoteMediaResourceManager::dataReceived(RemoteMediaResourceIdentifier identifier, IPC::SharedBufferReference&& buffer, CompletionHandler<void(std::optional<SharedMemory::Handle>&&)>&& completionHandler)
 {
-    auto resource = resourceForId(identifier);
+    RefPtr resource = resourceForId(identifier);
     if (!resource)
         return completionHandler(std::nullopt);
 
-    auto sharedMemory = buffer.sharedCopy();
+    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
+    RefPtr sharedMemory = buffer.sharedCopy();
     if (!sharedMemory)
         return completionHandler(std::nullopt);
 
@@ -153,26 +152,26 @@ void RemoteMediaResourceManager::dataReceived(RemoteMediaResourceIdentifier iden
 
 void RemoteMediaResourceManager::accessControlCheckFailed(RemoteMediaResourceIdentifier identifier, const ResourceError& error)
 {
-    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
-
-    if (auto resource = resourceForId(identifier))
+    if (RefPtr resource = resourceForId(identifier)) {
+        assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
         resource->accessControlCheckFailed(error);
+    }
 }
 
 void RemoteMediaResourceManager::loadFailed(RemoteMediaResourceIdentifier identifier, const ResourceError& error)
 {
-    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
-
-    if (auto resource = resourceForId(identifier))
+    if (RefPtr resource = resourceForId(identifier)) {
+        assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
         resource->loadFailed(error);
+    }
 }
 
 void RemoteMediaResourceManager::loadFinished(RemoteMediaResourceIdentifier identifier, const NetworkLoadMetrics& metrics)
 {
-    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
-
-    if (auto resource = resourceForId(identifier))
+    if (RefPtr resource = resourceForId(identifier)) {
+        assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
         resource->loadFinished(metrics);
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -220,6 +220,8 @@ public:
     MediaTime currentTime() const final;
     MediaTime currentOrPendingSeekTime() const final;
 
+    void gpuProcessConnectionDidClose();
+
 private:
     class TimeProgressEstimator final {
     public:

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -293,8 +293,10 @@ void RemoteMediaPlayerManager::gpuProcessConnectionDidClose(GPUProcessConnection
     m_gpuProcessConnection = nullptr;
 
     for (auto& player : copyToVector(m_players.values())) {
-        if (RefPtr protectedPlayer = player.get())
+        if (RefPtr protectedPlayer = player.get()) {
+            protectedPlayer->gpuProcessConnectionDidClose();
             protectedPlayer->player()->reloadAndResumePlaybackIfNeeded();
+        }
         ASSERT_WITH_MESSAGE(!player.get(), "reloadAndResumePlaybackIfNeeded should destroy this player and construct a new one");
     }
 }


### PR DESCRIPTION
#### 129382fbd3298146f7fb0e1e4c539e683f07b73c
<pre>
WebKit::RemoteMediaResourceManager::loadFailed can be called outside its workqueue
<a href="https://bugs.webkit.org/show_bug.cgi?id=300381">https://bugs.webkit.org/show_bug.cgi?id=300381</a>
<a href="https://rdar.apple.com/162180067">rdar://162180067</a>

Reviewed by Jer Noble.

A RemoteMediaResource should always be created as a WorkQueueMessageReceiver
and so we should only listen for those messages on the workqueue and not
from within the GPUConnectionToWebProcess.
The situation could have happened if the GPUP crashed and at the same time
the web process had sent a RemoteMediaResourceManager::loadFailed()
IPC message. It would have re-created the GPUP and the message would have
then be handled on the main thread.
We now detect if the GPUP crashed and if so, destroy pre-emptively all the
now stale RemoteMediaResources.

Move threading assertions to only be if a resource for the required identifier exists.

* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp:
(WebKit::RemoteMediaResourceManager::responseReceived): replace `auto resource =` with `RefPtr resource =`
(WebKit::RemoteMediaResourceManager::redirectReceived): same
(WebKit::RemoteMediaResourceManager::dataSent): same
(WebKit::RemoteMediaResourceManager::dataReceived): same + add threading assertion.
(WebKit::RemoteMediaResourceManager::accessControlCheckFailed):
(WebKit::RemoteMediaResourceManager::loadFailed): Check if we are on the right workqueue, and dispatch a task to that queue if not.
(WebKit::RemoteMediaResourceManager::loadFinished): same

Canonical link: <a href="https://commits.webkit.org/301305@main">https://commits.webkit.org/301305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca4bb0430c33e71a2ce7b1cde3adaad57fa9f0b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77425 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f1b415c-49cb-412f-a0a4-9710b10f9a11) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95605 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ba6c06e-e1d3-4a5c-bc79-b4212eade09e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76123 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b245699-f3db-469a-a972-4752908b87d6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35565 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75869 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106441 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135069 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104085 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103821 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26439 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27494 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49526 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52229 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58025 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51583 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54936 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53278 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->