### PR TITLE
imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.{worker/sharedworker/serviceworker.}html tests are flaky

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1325,10 +1325,6 @@ imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-MediaEleme
 imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-enumerateDevices-per-origin-ids.sub.https.html [ Skip ]
 
 # These fetch tests are flaky or fail.
-webkit.org/b/247290 imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.html [ Pass Failure ]
-webkit.org/b/247290 imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.worker.html [ Pass Failure ]
-webkit.org/b/247290 imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.sharedworker.html [ Pass Failure ]
-webkit.org/b/247290 imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.serviceworker.html [ Pass Failure ]
 imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count.any.html [ Pass Failure ]
 imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count.any.worker.html [ Pass Failure ]
 imported/w3c/web-platform-tests/fetch/content-encoding/bad-gzip-body.any.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL Response.body is null for responses with status=204 (method=GET) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=204 (method=POST) promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Response.body is null for responses with status=204 (method=OPTIONS) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=205 (method=GET) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=205 (method=POST) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=205 (method=OPTIONS) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=304 (method=GET) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=304 (method=POST) promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Response.body is null for responses with status=304 (method=OPTIONS) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with method=HEAD assert_equals: the body should be null expected null but got object "[object ReadableStream]"
+PASS Response.body is null for responses with status=204 (method=GET)
+PASS Response.body is null for responses with status=204 (method=POST)
+PASS Response.body is null for responses with status=204 (method=OPTIONS)
+PASS Response.body is null for responses with status=205 (method=GET)
+PASS Response.body is null for responses with status=205 (method=POST)
+PASS Response.body is null for responses with status=205 (method=OPTIONS)
+PASS Response.body is null for responses with status=304 (method=GET)
+PASS Response.body is null for responses with status=304 (method=POST)
+PASS Response.body is null for responses with status=304 (method=OPTIONS)
+PASS Response.body is null for responses with method=HEAD
 PASS Null body status with subresource integrity should abort
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.serviceworker-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL Response.body is null for responses with status=204 (method=GET) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
+PASS Response.body is null for responses with status=204 (method=GET)
 FAIL Response.body is null for responses with status=204 (method=POST) promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Response.body is null for responses with status=204 (method=OPTIONS) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=205 (method=GET) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=205 (method=POST) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=205 (method=OPTIONS) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=304 (method=GET) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
+PASS Response.body is null for responses with status=204 (method=OPTIONS)
+PASS Response.body is null for responses with status=205 (method=GET)
+PASS Response.body is null for responses with status=205 (method=POST)
+PASS Response.body is null for responses with status=205 (method=OPTIONS)
+PASS Response.body is null for responses with status=304 (method=GET)
 FAIL Response.body is null for responses with status=304 (method=POST) promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Response.body is null for responses with status=304 (method=OPTIONS) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with method=HEAD assert_equals: the body should be null expected null but got object "[object ReadableStream]"
+PASS Response.body is null for responses with status=304 (method=OPTIONS)
+PASS Response.body is null for responses with method=HEAD
 PASS Null body status with subresource integrity should abort
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.sharedworker-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL Response.body is null for responses with status=204 (method=GET) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
+PASS Response.body is null for responses with status=204 (method=GET)
 FAIL Response.body is null for responses with status=204 (method=POST) promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Response.body is null for responses with status=204 (method=OPTIONS) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=205 (method=GET) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=205 (method=POST) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=205 (method=OPTIONS) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=304 (method=GET) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
+PASS Response.body is null for responses with status=204 (method=OPTIONS)
+PASS Response.body is null for responses with status=205 (method=GET)
+PASS Response.body is null for responses with status=205 (method=POST)
+PASS Response.body is null for responses with status=205 (method=OPTIONS)
+PASS Response.body is null for responses with status=304 (method=GET)
 FAIL Response.body is null for responses with status=304 (method=POST) promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Response.body is null for responses with status=304 (method=OPTIONS) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with method=HEAD assert_equals: the body should be null expected null but got object "[object ReadableStream]"
+PASS Response.body is null for responses with status=304 (method=OPTIONS)
+PASS Response.body is null for responses with method=HEAD
 PASS Null body status with subresource integrity should abort
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.worker-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL Response.body is null for responses with status=204 (method=GET) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=204 (method=POST) promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Response.body is null for responses with status=204 (method=OPTIONS) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=205 (method=GET) assert_equals: the body should be null expected null but got object "[object ReadableStream]"
-FAIL Response.body is null for responses with status=205 (method=POST) promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Response.body is null for responses with status=205 (method=OPTIONS) promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Response.body is null for responses with status=304 (method=GET) promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Response.body is null for responses with status=304 (method=POST) promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Response.body is null for responses with status=304 (method=OPTIONS) promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Response.body is null for responses with method=HEAD promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Response.body is null for responses with status=204 (method=GET)
+PASS Response.body is null for responses with status=204 (method=POST)
+PASS Response.body is null for responses with status=204 (method=OPTIONS)
+PASS Response.body is null for responses with status=205 (method=GET)
+PASS Response.body is null for responses with status=205 (method=POST)
+PASS Response.body is null for responses with status=205 (method=OPTIONS)
+PASS Response.body is null for responses with status=304 (method=GET)
+PASS Response.body is null for responses with status=304 (method=POST)
+PASS Response.body is null for responses with status=304 (method=OPTIONS)
+PASS Response.body is null for responses with method=HEAD
 PASS Null body status with subresource integrity should abort
 

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -88,8 +88,8 @@ protected:
     FetchBodyOwner(ScriptExecutionContext*, std::optional<FetchBody>&&, Ref<FetchHeaders>&&);
 
     const FetchBody& body() const { return *m_body; }
-    bool isBodyNull() const { return !m_body; }
-    bool isBodyNullOrOpaque() const { return !m_body || m_isBodyOpaque; }
+    bool isBodyNull() const { return !m_body || m_isBodyNull; }
+    bool isBodyNullOrOpaque() const { return isBodyNull() || m_isBodyOpaque; }
     void cloneBody(JSDOMGlobalObject&, FetchBodyOwner&);
 
     ExceptionOr<void> extractBody(FetchBody::Init&&);
@@ -103,6 +103,7 @@ protected:
 
     void setDisturbed() { m_isDisturbed = true; }
 
+    void setBodyAsNull() { m_isBodyNull = true; }
     void setBodyAsOpaque() { m_isBodyOpaque = true; }
     bool isBodyOpaque() const { return m_isBodyOpaque; }
 
@@ -149,6 +150,7 @@ protected:
 private:
     RefPtr<BlobLoader> m_blobLoader;
     bool m_isBodyOpaque { false };
+    bool m_isBodyNull { false };
 
     Variant<std::nullptr_t, Exception, ResourceError> m_loadingError;
 };

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -51,7 +51,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FetchResponseBodyLoader);
 // https://fetch.spec.whatwg.org/#null-body-status
 static inline bool isNullBodyStatus(int status)
 {
-    return status == 101 || status == 204 || status == 205 || status == 304;
+    return status == 101 || status == 103 || status == 204 || status == 205 || status == 304;
 }
 
 FetchResponse::~FetchResponse() = default;
@@ -265,6 +265,9 @@ Ref<FetchResponse> FetchResponse::createFetchResponse(ScriptExecutionContext& co
     auto response = adoptRef(*new FetchResponse(&context, FetchBody { }, FetchHeaders::create(FetchHeaders::Guard::Immutable), { }));
     response->suspendIfNeeded();
 
+    if (request.internalRequest().httpMethod() == "HEAD"_s)
+        response->setBodyAsNull();
+
     response->body().checkedConsumer()->setAsLoading();
 
     response->addAbortSteps(request.signal());
@@ -371,6 +374,9 @@ void FetchResponse::setReceivedInternalResponse(const ResourceResponse& resource
         m_opaqueLoadIdentifier = ++nextOpaqueLoadIdentifier;
         setBodyAsOpaque();
     }
+
+    if (isNullBodyStatus(resourceResponse.httpStatusCode()))
+        setBodyAsNull();
 
     m_headers->filterAndFill(m_filteredResponse->httpHeaderFields(), FetchHeaders::Guard::Response);
 }


### PR DESCRIPTION
#### cbe9ab35e5ce94263e13644a265bd7fb9c9db0a0
<pre>
imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.{worker/sharedworker/serviceworker.}html tests are flaky
<a href="https://rdar.apple.com/101775774">rdar://101775774</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=247290">https://bugs.webkit.org/show_bug.cgi?id=247290</a>

Reviewed by NOBODY (OOPS!).

We align with the spec, by making sure that either responses to HEAD requests or responses with a body-null status code end up having a null body.
We do this by introducing an explicit boolean flag.

Covered by rebased tests.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbe9ab35e5ce94263e13644a265bd7fb9c9db0a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132080 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77187 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4dada324-3c83-422e-b2cc-e8e0088f6900) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53457 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95343 "Found 2 new test failures: imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.serviceworker.html imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.sharedworker.html (failure)") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63342 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/04b145e2-40da-4990-9192-50f470fb281a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75892 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64a5d963-9615-49c1-91df-758c290aa787) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35293 "Found 8 new test failures: imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.serviceworker.html imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.sharedworker.html imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any.serviceworker.html imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any.sharedworker.html imported/w3c/web-platform-tests/fetch/http-cache/status.any.html imported/w3c/web-platform-tests/fetch/http-cache/status.any.serviceworker.html imported/w3c/web-platform-tests/fetch/http-cache/status.any.sharedworker.html imported/w3c/web-platform-tests/fetch/http-cache/status.any.worker.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30154 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75558 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106164 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30379 "Exiting early after 10 failures. 14 tests run. 1 flakes 2 failures") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134761 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52038 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39818 "Found 7 new test failures: http/tests/media/modern-media-controls/status-support/status-support-live-broadcast.html http/tests/media/track/track-webvtt-slow-loading-2.html http/tests/media/video-redirect.html imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.serviceworker.html imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.sharedworker.html imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252.html?include=loading imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-insert-source-networkState.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103809 "Found 2 new test failures: imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.serviceworker.html imported/w3c/web-platform-tests/fetch/api/basic/response-null-body.any.sharedworker.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52473 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108207 "Exiting early after 10 failures. 14 tests run. 1 flakes 2 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103578 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48929 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27219 "Exiting early after 10 failures. 10 tests run. 1 flakes 3 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49124 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51930 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57709 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51292 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54648 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52986 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->