### PR TITLE
[WPE] Build regression after libsoup2 removal breaks third-party pkg-config discovery

### DIFF
--- a/Source/WebKit/gtk/gtk3-webkitgtk.toml.in
+++ b/Source/WebKit/gtk/gtk3-webkitgtk.toml.in
@@ -5,7 +5,7 @@ authors = "The WebKit GTK and WPE teams"
 version = "@PROJECT_VERSION@"
 repository_url = "https://github.com/WebKit/WebKit"
 website_url = "https://webkit.org"
-dependencies = ["GObject-2.0", "Gio-2.0", "Gtk-@GTK_API_VERSION@.0", "Soup-@SOUP_API_VERSION@"]
+dependencies = ["GObject-2.0", "Gio-2.0", "Gtk-@GTK_API_VERSION@.0", "Soup-3.0"]
 devhelp = true
 search_index = true
 
@@ -24,10 +24,10 @@ name = "Gtk"
 description = "The GTK widget toolkit"
 docs_url = "https://docs.gtk.org/gtk@GTK_API_VERSION@/"
 
-[dependencies."Soup-@SOUP_API_VERSION@"]
+[dependencies."Soup-3.0"]
 name = "Soup"
 description = "HTTP client/server library"
-docs_url = "https://gnome.pages.gitlab.gnome.org/libsoup/libsoup-@SOUP_API_VERSION@"
+docs_url = "https://gnome.pages.gitlab.gnome.org/libsoup/libsoup-3.0"
 
 [theme]
 name = "basic"

--- a/Source/WebKit/gtk/gtk4-webkitgtk.toml.in
+++ b/Source/WebKit/gtk/gtk4-webkitgtk.toml.in
@@ -5,7 +5,7 @@ authors = "The WebKit GTK and WPE teams"
 version = "@PROJECT_VERSION@"
 repository_url = "https://github.com/WebKit/WebKit"
 website_url = "https://webkit.org"
-dependencies = ["GObject-2.0", "Gio-2.0", "Gtk-@GTK_API_VERSION@.0", "Soup-@SOUP_API_VERSION@"]
+dependencies = ["GObject-2.0", "Gio-2.0", "Gtk-@GTK_API_VERSION@.0", "Soup-3.0"]
 devhelp = true
 search_index = true
 
@@ -24,10 +24,10 @@ name = "Gtk"
 description = "The GTK widget toolkit"
 docs_url = "https://docs.gtk.org/gtk@GTK_API_VERSION@/"
 
-[dependencies."Soup-@SOUP_API_VERSION@"]
+[dependencies."Soup-3.0"]
 name = "Soup"
 description = "HTTP client/server library"
-docs_url = "https://gnome.pages.gitlab.gnome.org/libsoup/libsoup-@SOUP_API_VERSION@"
+docs_url = "https://gnome.pages.gitlab.gnome.org/libsoup/libsoup-3.0"
 
 [theme]
 name = "basic"

--- a/Source/WebKit/gtk/webkitgtk-web-process-extension.pc.in
+++ b/Source/WebKit/gtk/webkitgtk-web-process-extension.pc.in
@@ -8,6 +8,6 @@ Name: WebKitGTK web process extensions
 Description: Web content engine for GTK - web process extensions
 URL: https://webkitgtk.org
 Version: @PROJECT_VERSION@
-Requires: glib-2.0 @GTK_PC_NAME@ libsoup-@SOUP_API_VERSION@ javascriptcoregtk-@WEBKITGTK_API_VERSION@
+Requires: glib-2.0 @GTK_PC_NAME@ libsoup-3.0 javascriptcoregtk-@WEBKITGTK_API_VERSION@
 Libs: -L${libdir} -lwebkit@WEBKITGTK_API_INFIX@gtk-@WEBKITGTK_API_VERSION@
 Cflags: -I${includedir}/webkitgtk-@WEBKITGTK_API_VERSION@

--- a/Source/WebKit/gtk/webkitgtk-web-process-extension.toml.in
+++ b/Source/WebKit/gtk/webkitgtk-web-process-extension.toml.in
@@ -5,7 +5,7 @@ authors = "The WebKit GTK and WPE teams"
 version = "@PROJECT_VERSION@"
 repository_url = "https://github.com/WebKit/WebKit"
 website_url = "https://webkit.org"
-dependencies = ["GObject-2.0", "Gio-2.0", "Soup-@SOUP_API_VERSION@"]
+dependencies = ["GObject-2.0", "Gio-2.0", "Soup-3.0"]
 devhelp = true
 search_index = true
 
@@ -19,10 +19,10 @@ name = "Gio"
 description = "GObject Interfaces and Objects, Networking, IPC, and I/O"
 docs_url = "https://docs.gtk.org/gio/"
 
-[dependencies."Soup-@SOUP_API_VERSION@"]
+[dependencies."Soup-3.0"]
 name = "Soup"
 description = "HTTP client/server library"
-docs_url = "https://gnome.pages.gitlab.gnome.org/libsoup/libsoup-@SOUP_API_VERSION@"
+docs_url = "https://gnome.pages.gitlab.gnome.org/libsoup/libsoup-3.0"
 
 [theme]
 name = "basic"

--- a/Source/WebKit/gtk/webkitgtk.pc.in
+++ b/Source/WebKit/gtk/webkitgtk.pc.in
@@ -8,6 +8,6 @@ Name: WebKitGTK
 Description: Web content engine for GTK
 URL: https://webkitgtk.org
 Version: @PROJECT_VERSION@
-Requires: glib-2.0 @GTK_PC_NAME@ libsoup-@SOUP_API_VERSION@ javascriptcoregtk-@WEBKITGTK_API_VERSION@
+Requires: glib-2.0 @GTK_PC_NAME@ libsoup-3.0 javascriptcoregtk-@WEBKITGTK_API_VERSION@
 Libs: -L${libdir} -lwebkit@WEBKITGTK_API_INFIX@gtk-@WEBKITGTK_API_VERSION@
 Cflags: -I${includedir}/webkitgtk-@WEBKITGTK_API_VERSION@

--- a/Source/WebKit/wpe/wpe-web-process-extension-uninstalled.pc.in
+++ b/Source/WebKit/wpe/wpe-web-process-extension-uninstalled.pc.in
@@ -7,6 +7,6 @@ Name: WPE WebKit Web process extensions
 Description: Embeddable Web content engine - Web process extensions
 URL: https://wpewebkit.org
 Version: @PROJECT_VERSION@
-Requires: glib-2.0 libsoup-@SOUP_API_VERSION@ wpe-1.0
+Requires: glib-2.0 libsoup-3.0 wpe-1.0
 Libs: -L${libdir} -lWPEWebKit-@WPE_API_VERSION@
 Cflags: -I${includedir}/wpe-extension

--- a/Source/WebKit/wpe/wpe-web-process-extension.pc.in
+++ b/Source/WebKit/wpe/wpe-web-process-extension.pc.in
@@ -7,6 +7,6 @@ Name: WPE WebKit Web process extensions
 Description: Embeddable Web content engine - Web process extensions
 URL: https://wpewebkit.org
 Version: @PROJECT_VERSION@
-Requires: glib-2.0 libsoup-@SOUP_API_VERSION@ wpe-1.0
+Requires: glib-2.0 libsoup-3.0 wpe-1.0
 Libs: -L${libdir} -lWPEWebKit-@WPE_API_VERSION@
 Cflags: -I${includedir}/wpe-webkit-@WPE_API_VERSION@

--- a/Source/WebKit/wpe/wpe-web-process-extension.toml.in
+++ b/Source/WebKit/wpe/wpe-web-process-extension.toml.in
@@ -5,7 +5,7 @@ authors = "The WebKit GTK and WPE teams"
 version = "@PROJECT_VERSION@"
 repository_url = "https://github.com/WebKit/WebKit"
 website_url = "https://webkit.org"
-dependencies = ["GObject-2.0", "Gio-2.0", "Soup-@SOUP_API_VERSION@"]
+dependencies = ["GObject-2.0", "Gio-2.0", "Soup-3.0"]
 devhelp = true
 search_index = true
 
@@ -19,10 +19,10 @@ name = "Gio"
 description = "GObject Interfaces and Objects, Networking, IPC, and I/O"
 docs_url = "https://docs.gtk.org/gio/"
 
-[dependencies."Soup-@SOUP_API_VERSION@"]
+[dependencies."Soup-3.0"]
 name = "Soup"
 description = "HTTP client/server library"
-docs_url = "https://gnome.pages.gitlab.gnome.org/libsoup/libsoup-@SOUP_API_VERSION@"
+docs_url = "https://gnome.pages.gitlab.gnome.org/libsoup/libsoup-3.0"
 
 [theme]
 name = "basic"

--- a/Source/WebKit/wpe/wpe-webkit-uninstalled.pc.in
+++ b/Source/WebKit/wpe/wpe-webkit-uninstalled.pc.in
@@ -7,6 +7,6 @@ Name: WPE WebKit
 Description: Embeddable Web content engine
 URL: https://wpewebkit.org
 Version: @PROJECT_VERSION@
-Requires: glib-2.0 libsoup-@SOUP_API_VERSION@ wpe-1.0 @WPE_PLATFORM_PC_UNINSTALLED_REQUIRES@
+Requires: glib-2.0 libsoup-3.0 wpe-1.0 @WPE_PLATFORM_PC_UNINSTALLED_REQUIRES@
 Libs: -L${libdir} -lWPEWebKit-@WPE_API_VERSION@
 Cflags: -I${includedir}/DerivedSources/ForwardingHeaders/wpe -I${includedir}/DerivedSources/WebKit/ -I${includedir}/DerivedSources/ForwardingHeaders/wpe-jsc -I${includedir}/JavaScriptCoreGLib/Headers -I${includedir}/JavaScriptCoreGLib/DerivedSources

--- a/Source/WebKit/wpe/wpe-webkit.pc.in
+++ b/Source/WebKit/wpe/wpe-webkit.pc.in
@@ -7,6 +7,6 @@ Name: WPE WebKit
 Description: Embeddable Web content engine
 URL: https://wpewebkit.org
 Version: @PROJECT_VERSION@
-Requires: glib-2.0 libsoup-@SOUP_API_VERSION@ wpe-1.0 @WPE_PLATFORM_PC_REQUIRES@
+Requires: glib-2.0 libsoup-3.0 wpe-1.0 @WPE_PLATFORM_PC_REQUIRES@
 Libs: -L${libdir} -lWPEWebKit-@WPE_API_VERSION@
 Cflags: -I${includedir}/wpe-webkit-@WPE_API_VERSION@

--- a/Source/WebKit/wpe/wpewebkit.toml.in
+++ b/Source/WebKit/wpe/wpewebkit.toml.in
@@ -5,7 +5,7 @@ authors = "The WebKit GTK and WPE teams"
 version = "@PROJECT_VERSION@"
 repository_url = "https://github.com/WebKit/WebKit"
 website_url = "https://webkit.org"
-dependencies = ["GObject-2.0", "Gio-2.0", "Soup-@SOUP_API_VERSION@"]
+dependencies = ["GObject-2.0", "Gio-2.0", "Soup-3.0"]
 devhelp = true
 search_index = true
 
@@ -19,10 +19,10 @@ name = "Gio"
 description = "GObject Interfaces and Objects, Networking, IPC, and I/O"
 docs_url = "https://docs.gtk.org/gio/"
 
-[dependencies."Soup-@SOUP_API_VERSION@"]
+[dependencies."Soup-3.0"]
 name = "Soup"
 description = "HTTP client/server library"
-docs_url = "https://gnome.pages.gitlab.gnome.org/libsoup/libsoup-@SOUP_API_VERSION@"
+docs_url = "https://gnome.pages.gitlab.gnome.org/libsoup/libsoup-3.0"
 
 [theme]
 name = "basic"


### PR DESCRIPTION
#### bc743a3f24a003e82dbdae41bf7a6ba2deaf3125
<pre>
[WPE] Build regression after libsoup2 removal breaks third-party pkg-config discovery
<a href="https://bugs.webkit.org/show_bug.cgi?id=300382">https://bugs.webkit.org/show_bug.cgi?id=300382</a>

Reviewed by Adrian Perez de Castro.

The recent removal of libsoup2 support also removed the
`SOUP_API_VERSION` CMake variable. Several pkg-config (.pc.in) and
GObject Introspection (.toml.in) template files were not updated and
continued to reference the now-undefined `@SOUP_API_VERSION@`.

This resulted in malformed dependency files being generated, where
`Requires:` fields would incorrectly list `libsoup-`. This breaks the
build for any third-party application that relies on `pkg-config` to
find the WebKit dependency.

This patch fixes the issue by replacing all remaining instances of
`@SOUP_API_VERSION@` with the hardcoded version `3.0`.

This is related to to the changes in commit `301131@main`.

* Source/WebKit/gtk/gtk3-webkitgtk.toml.in:
* Source/WebKit/gtk/gtk4-webkitgtk.toml.in:
* Source/WebKit/gtk/webkitgtk-web-process-extension.pc.in:
* Source/WebKit/gtk/webkitgtk-web-process-extension.toml.in:
* Source/WebKit/gtk/webkitgtk.pc.in:
* Source/WebKit/wpe/wpe-web-process-extension-uninstalled.pc.in:
* Source/WebKit/wpe/wpe-web-process-extension.pc.in:
* Source/WebKit/wpe/wpe-web-process-extension.toml.in:
* Source/WebKit/wpe/wpe-webkit-uninstalled.pc.in:
* Source/WebKit/wpe/wpe-webkit.pc.in:
* Source/WebKit/wpe/wpewebkit.toml.in:

Canonical link: <a href="https://commits.webkit.org/301201@main">https://commits.webkit.org/301201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca251ecf9fffb204c7e8fa9867dd405e151c4552

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132093 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53470 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36409 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/75894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75571 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106176 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/30392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52051 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52486 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/108220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/48942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/27232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49141 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19612 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51943 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/57722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51306 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54661 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52999 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->