### PR TITLE
Web Inspector: Remove reference to unused CodeMirror/overlay.js

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -299,7 +299,6 @@
     <script src="External/CodeMirror/livescript.js"></script>
     <script src="External/CodeMirror/mark-selection.js"></script>
     <script src="External/CodeMirror/matchbrackets.js"></script>
-    <script src="External/CodeMirror/overlay.js"></script>
     <script src="External/CodeMirror/placeholder.js"></script>
     <script src="External/CodeMirror/runmode.js"></script>
     <script src="External/CodeMirror/sass.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Views/ConsolePrompt.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsolePrompt.js
@@ -60,8 +60,7 @@ WI.ConsolePrompt = class ConsolePrompt extends WI.View
         this._completionController.addExtendedCompletionProvider("javascript", WI.javaScriptRuntimeCompletionProvider);
 
         let textarea = this._codeMirror.getInputField();
-        if (textarea)
-            textarea.ariaLabel = WI.UIString("Console prompt");
+        (textarea || this.element).ariaLabel = WI.UIString("Console prompt");
 
         this._history = [{}];
         this._historyIndex = 0;


### PR DESCRIPTION
#### f7cbab0158e5d6a0a19a46ea15a3ee6ae3a0cf6b
<pre>
Web Inspector: Remove reference to unused CodeMirror/overlay.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=300034">https://bugs.webkit.org/show_bug.cgi?id=300034</a>
<a href="https://rdar.apple.com/161417233">rdar://161417233</a>

Reviewed by Devin Rousso.

CodeMirror/overlay.js doesn&apos;t exist anymore after
<a href="https://commits.webkit.org/300332@main">https://commits.webkit.org/300332@main</a>

* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Views/ConsolePrompt.js:
(WI.ConsolePrompt):

Canonical link: <a href="https://commits.webkit.org/301208@main">https://commits.webkit.org/301208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/254b6d7c2af9524ed04b83f8d1385167f9f5d560

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132086 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77097 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3e9d5d2-e8b1-46f7-b88b-45dd0cd7c8f2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95347 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c96d2d6-b32f-42e1-9eab-3a8061bdafe0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111992 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75886 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/695a19b1-e8cc-4b68-9023-680aed25648a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75564 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134767 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52044 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39824 "Found 3 new test failures: http/tests/media/pdf-served-as-pdf.html http/tests/media/video-redirect.html imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252.html?include=loading (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103814 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103582 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26383 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48935 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27225 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49130 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57715 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51299 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54654 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52992 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->