### PR TITLE
WebGLRenderingContextBase::getUniformLocation spends time resolving uniform type

### DIFF
--- a/PerformanceTests/Canvas/WebGL-getAttribLocation-getUniformLocation.html
+++ b/PerformanceTests/Canvas/WebGL-getAttribLocation-getUniformLocation.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/runner.js"></script>
+<script>
+
+var canvas = document.createElement("canvas");
+var gl = canvas.getContext("webgl2");
+let vsText = `
+precision highp float;
+attribute vec2 a_position;
+uniform vec2 u_resolution;
+void main() {
+    vec2 clipSpace = (a_position / u_resolution) * 2.0 - 1.0;
+    gl_Position = vec4(clipSpace, 0, 1);
+}`;
+
+let fsText = `
+precision highp float;
+uniform vec4 u_color;
+void main() {
+    gl_FragColor = u_color;
+}`;
+let program;
+
+function testIteration()
+{
+    let pos = gl.getAttribLocation(program, "a_position");
+    if (pos == -1)
+        throw "Unused position";    
+    for (let i = 0; i < 50; ++i) {
+        if (pos != gl.getAttribLocation(program, "a_position"))
+            throw "Unexpected position";
+        if (!gl.getUniformLocation(program, "u_resolution"))
+            throw "Unused resolution";
+        if (!gl.getUniformLocation(program, "u_color"))
+            throw "Unused color";
+    }
+}
+
+async function test()
+{
+    let fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, fsText);
+    gl.compileShader(fs);
+    if (!gl.getShaderParameter(fs, gl.COMPILE_STATUS))
+        throw "Test error";
+    let vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, vsText);
+    gl.compileShader(vs);
+    if (!gl.getShaderParameter(vs, gl.COMPILE_STATUS))
+        throw "Test error";
+    program = gl.createProgram();
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    var success = gl.getProgramParameter(program, gl.LINK_STATUS);
+    if (!success)
+        throw `Test error: ${gl.getProgramInfoLog(program)}`;
+    gl.useProgram(program);
+
+    testIteration();
+    PerfTestRunner.measureRunsPerSecond({
+        description: 'Measures performance of WebGL attribute and uniform location getters.',
+        run: testIteration
+    });
+}
+
+test();
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -271,7 +271,7 @@ public:
     String getShaderSource(WebGLShader&);
     virtual std::optional<Vector<String>> getSupportedExtensions() = 0;
     virtual WebGLAny getTexParameter(GCGLenum target, GCGLenum pname);
-    WebGLAny getUniform(WebGLProgram&, const WebGLUniformLocation&);
+    WebGLAny getUniform(WebGLProgram&, WebGLUniformLocation&);
     RefPtr<WebGLUniformLocation> getUniformLocation(WebGLProgram&, const String&);
     WebGLAny getVertexAttrib(GCGLuint index, GCGLenum pname);
     long long getVertexAttribOffset(GCGLuint index, GCGLenum pname);

--- a/Source/WebCore/html/canvas/WebGLUniformLocation.cpp
+++ b/Source/WebCore/html/canvas/WebGLUniformLocation.cpp
@@ -32,43 +32,44 @@
 
 namespace WebCore {
 
-Ref<WebGLUniformLocation> WebGLUniformLocation::create(WebGLProgram* program, GCGLint location, GCGLenum type)
+Ref<WebGLUniformLocation> WebGLUniformLocation::create(WebGLProgram& program, GCGLint location)
 {
-    return adoptRef(*new WebGLUniformLocation(program, location, type));
+    return adoptRef(*new WebGLUniformLocation(program, location));
 }
 
-WebGLUniformLocation::WebGLUniformLocation(WebGLProgram* program, GCGLint location, GCGLenum type)
+WebGLUniformLocation::WebGLUniformLocation(WebGLProgram& program, GCGLint location)
     : m_program(program)
     , m_location(location)
-    , m_type(type)
+    , m_linkCount(m_program->getLinkCount())
 {
-    ASSERT(m_program);
-    m_linkCount = m_program->getLinkCount();
 }
 
-WebGLProgram* WebGLUniformLocation::program() const
+RefPtr<WebGLProgram> WebGLUniformLocation::program() const
 {
     // If the program has been linked again, then this UniformLocation is no
     // longer valid.
     if (m_program->getLinkCount() != m_linkCount)
-        return 0;
+        return nullptr;
     return m_program.get();
 }
 
 GCGLint WebGLUniformLocation::location() const
 {
-    // If the program has been linked again, then this UniformLocation is no
-    // longer valid.
     ASSERT(m_program->getLinkCount() == m_linkCount);
     return m_location;
 }
     
-GCGLenum WebGLUniformLocation::type() const
+std::optional<GCGLenum> WebGLUniformLocation::type() const
 {
-    // If the program has been linked again, then this UniformLocation is no
-    // longer valid.
     ASSERT(m_program->getLinkCount() == m_linkCount);
     return m_type;
+}
+
+void WebGLUniformLocation::setType(GCGLenum type)
+{
+    ASSERT(m_program->getLinkCount() == m_linkCount);
+    ASSERT(!m_type);
+    m_type = type;
 }
 
 }

--- a/Source/WebCore/html/canvas/WebGLUniformLocation.h
+++ b/Source/WebCore/html/canvas/WebGLUniformLocation.h
@@ -36,22 +36,19 @@ namespace WebCore {
 class WebGLUniformLocation final : public RefCounted<WebGLUniformLocation> {
 public:
     ~WebGLUniformLocation() = default;
-
-    static Ref<WebGLUniformLocation> create(WebGLProgram*, GCGLint location, GCGLenum type);
-
-    WebGLProgram* program() const;
-
+    static Ref<WebGLUniformLocation> create(WebGLProgram&, GCGLint location);
+    RefPtr<WebGLProgram> program() const;
     GCGLint location() const;
-    
-    GCGLenum type() const;
+    std::optional<GCGLenum> type() const;
+    void setType(GCGLenum);
 
 private:
-    WebGLUniformLocation(WebGLProgram*, GCGLint location, GCGLenum type);
+    WebGLUniformLocation(WebGLProgram&, GCGLint location);
 
-    RefPtr<WebGLProgram> m_program;
-    GCGLint m_location;
+    const Ref<WebGLProgram> m_program;
+    const GCGLint m_location;
     unsigned m_linkCount;
-    GCGLenum m_type;
+    std::optional<GCGLenum> m_type;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0669e3ca82a2c6da0b973c22806fe2d9674eed8b
<pre>
WebGLRenderingContextBase::getUniformLocation spends time resolving uniform type
<a href="https://bugs.webkit.org/show_bug.cgi?id=300386">https://bugs.webkit.org/show_bug.cgi?id=300386</a>
<a href="https://rdar.apple.com/162191254">rdar://162191254</a>

Reviewed by Dan Glastonbury.

Return the uniform location without resolving the type to speed up this
common operation.

The uniform type is needed when getting the uniform value. The type can
be resolved at that moment.

Improves the added test from 500 to 1500 iterations.

* PerformanceTests/Canvas/WebGL-getAttribLocation-getUniformLocation.html: Added.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::getUniform):
(WebCore::WebGLRenderingContextBase::getUniformLocation):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/html/canvas/WebGLUniformLocation.cpp:
(WebCore::WebGLUniformLocation::create):
(WebCore::WebGLUniformLocation::WebGLUniformLocation):
(WebCore::WebGLUniformLocation::type const):
(WebCore::WebGLUniformLocation::setType):
* Source/WebCore/html/canvas/WebGLUniformLocation.h:

Canonical link: <a href="https://commits.webkit.org/301300@main">https://commits.webkit.org/301300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c450d9c055e649ee826acb189bc435a7a658fd07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77351 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ade0128-38e4-4ff7-ac2d-cb9434ff9258) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95465 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63461 "Found 60 new test failures: compositing/clipping/border-radius-with-composited-descendant-nested.html compositing/clipping/border-radius-with-composited-descendant.html compositing/overlap-blending/children-opacity-huge.html compositing/overlap-blending/children-opacity-no-overlap.html compositing/overlap-blending/nested-non-overlap-clipping.html compositing/overlap-blending/nested-overlap.html compositing/reflections/nested-reflection-opacity2.html compositing/transitions/transform-on-large-layer.html compositing/webgl/update-composited-canvas-layer.html compositing/webgl/webgl-no-alpha.html ... (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c996e5e-10c1-43ba-8216-c1b46ba99960) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112132 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76004 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3edaf59-c2ab-4e89-8cdd-a156d8579335) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30302 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75710 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106306 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134918 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39962 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103939 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103698 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26436 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49069 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27363 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49317 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52082 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57861 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51438 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54795 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53132 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->