### PR TITLE
[GTK][OpenXR] Bots need to be updated to run OpenXR tests

### DIFF
--- a/Tools/Scripts/webkitpy/port/monadodriver.py
+++ b/Tools/Scripts/webkitpy/port/monadodriver.py
@@ -30,6 +30,7 @@
 
 import logging
 import os
+import time
 
 from webkitpy.port.driver import Driver
 
@@ -37,16 +38,23 @@ _log = logging.getLogger(__name__)
 
 
 class MonadoDriver(Driver):
+
+    sock_path = "/run/user/1000/monado_comp_ipc"
+    pid_path = "/run/user/1000/monado.pid"
+
     @staticmethod
     def check_driver(port):
         monado_findcmd = ['which', 'monado-service']
-        monado_found = port.host.executive.run_command(monado_findcmd, return_exit_code=True) == 0
-        if not monado_found:
-            _log.error("No monado-service found. Cannot run OpenXR API tests.")
-        return monado_found
+        monado_path = port.host.executive.run_command(monado_findcmd)
+        if len(monado_path) > 0:
+            _log.info("monado-service found at %s", monado_path)
+            return True
+        _log.error("No monado-service found. Cannot run OpenXR API tests.")
+        return False
 
     def __init__(self, *args, **kwargs):
         Driver.__init__(self, *args, **kwargs)
+        self._startup_delay_secs = 1.0
 
     def _get_runtime_path(self, env):
         # Older OpenXR loaders seem to have problems finding the JSON configuration file on their own
@@ -54,18 +62,41 @@ class MonadoDriver(Driver):
         for data_dir in data_dirs:
             candidate = os.path.join(data_dir, "openxr", "1", "openxr_monado.json")
             if os.path.exists(candidate):
+                with open(candidate, 'r') as f:
+                    runtime_config = f.read()
+                _log.info("Using %s for path, which contains %s", candidate, runtime_config)
                 return candidate
+        _log.error("Unable to find a path to openxr_monado.json. Applications won't be able to communicate with the runtime.")
         return ""
 
     def _setup_environ_for_test(self):
         driver_environment = super(MonadoDriver, self)._setup_environ_for_test()
         driver_environment['WITH_OPENXR_RUNTIME'] = 'y'
         driver_environment['XRT_COMPOSITOR_NULL'] = 'TRUE'
+        driver_environment['XRT_NO_STDIN'] = 'TRUE'
         driver_environment['XR_RUNTIME_JSON'] = self._get_runtime_path(driver_environment)
 
         monado_command = ['monado-service']
-        with open(os.devnull, 'w') as devnull:
-            self._monado_service_process = self._port.host.executive.popen(monado_command, stderr=devnull, env=driver_environment)
+        self._monado_service_process = self._port.host.executive.popen(monado_command, stderr=self._port.host.executive.STDOUT, env=driver_environment)
+
+        start = time.time()
+        timeout = 30
+
+        time.sleep(1)
+        while not (os.path.exists(MonadoDriver.sock_path) and os.access(MonadoDriver.pid_path, os.R_OK)):
+            if time.time() - start > timeout:
+                _log.error("Timed out waiting for Monado to start")
+                break
+            time.sleep(0.25)
+
+        if os.path.exists(MonadoDriver.pid_path):
+            try:
+                with open(MonadoDriver.pid_path) as f:
+                    pid = int(f.readline().strip())
+                os.kill(pid, 0)
+                _log.info(f"monado-service successfully running with pid {pid}")
+            except (ValueError, FileNotFoundError, ProcessLookupError, PermissionError) as e:
+                _log.error(f"Pidfile and socket present, but the Monado process does not exist for pid {pid}. Error type: {type(e).__name__}, details: {e}. Tests will time out.")
 
         return driver_environment
 

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -572,9 +572,6 @@
     },
     "TestWebKitWebXR": {
         "subtests": {
-            "/webkit/WebKitWebXR/leave-immersive-mode": {
-                "expected": {"all" : {"status": ["SKIP"], "bug": "webkit.org/b/299080"}}
-            },
             "/webkit/WebKitWebXR/permission-request": {
                 "expected": {"all" : {"status": ["SKIP"], "bug": "webkit.org/b/299080"}}
             }


### PR DESCRIPTION
#### 509133dcb6a3fb88d90c4d7491a473cac6219917
<pre>
[GTK][OpenXR] Bots need to be updated to run OpenXR tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=299080">https://bugs.webkit.org/show_bug.cgi?id=299080</a>

Reviewed by NOBODY (OOPS!).

The bots have been updated with OpenXR dependencies, so WebXR tests
should now run.

* Tools/TestWebKitAPI/glib/TestExpectations.json: Unskip
  leave-immersive-mode test.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/509133dcb6a3fb88d90c4d7491a473cac6219917

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125563 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77453 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53785 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76144 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124914 "Found 1 webkitpy test failure: webkitpy.port.monadodriver_unittest.MonadoDriverTest.test_start") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35586 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30466 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75895 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135096 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104113 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108500 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103846 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49201 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49560 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52253 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51606 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53301 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->