### PR TITLE
[Temporal] Add PlainMonthDay

### DIFF
--- a/JSTests/stress/temporal-plainmonthday.js
+++ b/JSTests/stress/temporal-plainmonthday.js
@@ -1,0 +1,39 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+function shouldThrow(func, errorType, message) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+
+    if (!(error instanceof errorType))
+        throw new Error(`Expected ${errorType.name}!`);
+    if (message !== undefined)
+        shouldBe(String(error), message);
+}
+
+shouldBe(Temporal.PlainMonthDay instanceof Function, true);
+shouldBe(Temporal.PlainMonthDay.length, 2);
+shouldBe(Object.getOwnPropertyDescriptor(Temporal.PlainMonthDay, 'prototype').writable, false);
+shouldBe(Object.getOwnPropertyDescriptor(Temporal.PlainMonthDay, 'prototype').enumerable, false);
+shouldBe(Object.getOwnPropertyDescriptor(Temporal.PlainMonthDay, 'prototype').configurable, false);
+shouldBe(Temporal.PlainMonthDay.prototype.constructor, Temporal.PlainMonthDay);
+
+const monthDay = new Temporal.PlainMonthDay(4, 29);
+
+{
+    shouldBe(monthDay.monthCode, "M04");
+    shouldBe(monthDay.day, 29);
+    shouldBe(monthDay.year, undefined);
+    shouldBe(monthDay.calendarId, "iso8601");
+
+    shouldThrow(() => new Temporal.PlainMonthDay(20, 1), RangeError);
+    shouldThrow(() => new Temporal.PlainMonthDay(1, 40), RangeError);
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -23,16 +23,12 @@ skip:
     - test/built-ins/Temporal/Now/plainDateTimeISO
     - test/built-ins/Temporal/Now/plainTimeISO
     - test/built-ins/Temporal/Now/zonedDateTimeISO
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth
     - test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime
     - test/built-ins/Temporal/PlainDate/prototype/withCalendar
     - test/built-ins/Temporal/PlainDateTime/prototype/since
     - test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime
     - test/built-ins/Temporal/PlainDateTime/prototype/until
     - test/built-ins/Temporal/PlainDateTime/prototype/withCalendar
-    - test/built-ins/Temporal/PlainMonthDay
-    - test/built-ins/Temporal/PlainYearMonth
     - test/built-ins/Temporal/ZonedDateTime
     - test/intl402/Temporal/Instant/prototype/toZonedDateTimeISO
     - test/intl402/Temporal/Now
@@ -155,6 +151,551 @@ skip:
     - test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-upper-p.js
     - test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-lower-p.js
 
+    # Depends on Temporal.PlainMonthDay
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/basic.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/branding.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/builtin.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/length.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/name.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/not-a-constructor.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/prop-desc.js
+    - test/built-ins/Temporal/PlainMonthDay/basic.js
+    - test/built-ins/Temporal/PlainMonthDay/calendar-always.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-plainmonthday.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-invalid-iso-string.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-string.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-year-zero.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-string-calendar-annotation-invalid-key.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-string-critical-unknown-annotation.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-string-minus-sign.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-string-multiple-calendar.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-string-multiple-time-zone.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-string-time-separators.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-string-with-utc-designator.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-wrong-type.js
+    - test/built-ins/Temporal/PlainMonthDay/from/basic.js
+    - test/built-ins/Temporal/PlainMonthDay/from/builtin.js
+    - test/built-ins/Temporal/PlainMonthDay/from/constrain-to-leap-day.js
+    - test/built-ins/Temporal/PlainMonthDay/from/fields-leap-day.js
+    - test/built-ins/Temporal/PlainMonthDay/from/fields-object.js
+    - test/built-ins/Temporal/PlainMonthDay/from/fields-plainmonthday.js
+    - test/built-ins/Temporal/PlainMonthDay/from/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainMonthDay/from/leap-second.js
+    - test/built-ins/Temporal/PlainMonthDay/from/length.js
+    - test/built-ins/Temporal/PlainMonthDay/from/monthcode-invalid.js
+    - test/built-ins/Temporal/PlainMonthDay/from/name.js
+    - test/built-ins/Temporal/PlainMonthDay/from/not-a-constructor.js
+    - test/built-ins/Temporal/PlainMonthDay/from/observable-get-overflow-argument-primitive.js
+    - test/built-ins/Temporal/PlainMonthDay/from/observable-get-overflow-argument-string-invalid.js
+    - test/built-ins/Temporal/PlainMonthDay/from/one-of-era-erayear-undefined.js
+    - test/built-ins/Temporal/PlainMonthDay/from/options-object.js
+    - test/built-ins/Temporal/PlainMonthDay/from/options-read-before-algorithmic-validation.js
+    - test/built-ins/Temporal/PlainMonthDay/from/options-undefined.js
+    - test/built-ins/Temporal/PlainMonthDay/from/options-wrong-type.js
+    - test/built-ins/Temporal/PlainMonthDay/from/order-of-operations.js
+    - test/built-ins/Temporal/PlainMonthDay/from/overflow-invalid-string.js
+    - test/built-ins/Temporal/PlainMonthDay/from/overflow.js
+    - test/built-ins/Temporal/PlainMonthDay/from/overflow-undefined.js
+    - test/built-ins/Temporal/PlainMonthDay/from/overflow-wrong-type.js
+    - test/built-ins/Temporal/PlainMonthDay/from/prop-desc.js
+    - test/built-ins/Temporal/PlainMonthDay/from/subclassing-ignored.js
+    - test/built-ins/Temporal/PlainMonthDay/from/year-zero.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-invalid-iso-string.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-string.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-year-zero.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-calendar-annotation-invalid-key.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-critical-unknown-annotation.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-invalid.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-minus-sign.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-multiple-calendar.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-multiple-time-zone.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-time-separators.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-with-utc-designator.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-wrong-type.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/basic.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/branding.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/builtin.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/leap-second.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/length.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/name.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/not-a-constructor.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/prop-desc.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/year-zero.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/basic.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/branding.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/builtin.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/length.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/name.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/not-a-constructor.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/prop-desc.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toLocaleString/branding.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toLocaleString/prop-desc.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/basic.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/branding.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/builtin.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/default-overflow-behaviour.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/length.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/limits.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/name.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/not-a-constructor.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/prop-desc.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/branding.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/calendarname-always.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/calendarname-invalid-string.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/calendarname-undefined.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/options-object.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/options-wrong-type.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/prop-desc.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/valueOf/basic.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/valueOf/branding.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/valueOf/prop-desc.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/basic.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/branding.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/builtin.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/copy-properties-not-undefined.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/length.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/name.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/not-a-constructor.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/options-object.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/options-read-before-algorithmic-validation.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/options-undefined.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/options-wrong-type.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/order-of-operations.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/overflow-invalid-string.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/overflow-undefined.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/overflow-wrong-type.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/prop-desc.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/subclassing-ignored.js
+    - test/built-ins/Temporal/PlainMonthDay/subclass.js
+    - test/intl402/DateTimeFormat/prototype/format/temporal-plainmonthday-formatting-datetime-style.js
+
+    # Depends on Temporal.PlainYearMonth
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/basic.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/branding.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/builtin.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/length.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/limits.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/name.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/not-a-constructor.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/argument-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/basic.js
+    - test/built-ins/Temporal/PlainYearMonth/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-cast.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-invalid-iso-string.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-string.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-year-zero.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-calendar-annotation-invalid-key.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-limits.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-minus-sign.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-multiple-calendar.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-multiple-time-zone.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-time-separators.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-with-utc-designator.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/basic.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/compare-reference-day.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/leap-second.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/length.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/name.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/use-internal-slots.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/year-zero.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-object.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-plaindate.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-plainyearmonth.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-invalid-iso-string.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-string.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-year-zero.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-calendar-annotation-invalid-key.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-critical-unknown-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-limits.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-minus-sign.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-multiple-calendar.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-multiple-time-zone.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-time-separators.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-trailing-junk.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-with-utc-designator.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/from/basic.js
+    - test/built-ins/Temporal/PlainYearMonth/from/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/from/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/from/leap-second.js
+    - test/built-ins/Temporal/PlainYearMonth/from/length.js
+    - test/built-ins/Temporal/PlainYearMonth/from/limits.js
+    - test/built-ins/Temporal/PlainYearMonth/from/missing-properties.js
+    - test/built-ins/Temporal/PlainYearMonth/from/monthcode-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/from/name.js
+    - test/built-ins/Temporal/PlainYearMonth/from/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/from/observable-get-overflow-argument-primitive.js
+    - test/built-ins/Temporal/PlainYearMonth/from/observable-get-overflow-argument-string-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/from/one-of-era-erayear-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/from/options-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/from/options-object.js
+    - test/built-ins/Temporal/PlainYearMonth/from/options-read-before-algorithmic-validation.js
+    - test/built-ins/Temporal/PlainYearMonth/from/options-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/from/options-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/from/order-of-operations.js
+    - test/built-ins/Temporal/PlainYearMonth/from/overflow-constrain.js
+    - test/built-ins/Temporal/PlainYearMonth/from/overflow-invalid-string.js
+    - test/built-ins/Temporal/PlainYearMonth/from/overflow-reject.js
+    - test/built-ins/Temporal/PlainYearMonth/from/overflow-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/from/overflow-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/from/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/from/reference-day.js
+    - test/built-ins/Temporal/PlainYearMonth/from/subclassing-ignored.js
+    - test/built-ins/Temporal/PlainYearMonth/from/year-zero.js
+    - test/built-ins/Temporal/PlainYearMonth/get-prototype-from-constructor-throws.js
+    - test/built-ins/Temporal/PlainYearMonth/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/length.js
+    - test/built-ins/Temporal/PlainYearMonth/missing-arguments.js
+    - test/built-ins/Temporal/PlainYearMonth/name.js
+    - test/built-ins/Temporal/PlainYearMonth/negative-infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-duration-max.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-duration-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-duration-out-of-range.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-invalid-property.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-lower-units.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-mixed-sign.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-not-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-singular-properties.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-string-negative-fractional-units.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/blank-duration.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/end-of-month-out-of-range.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/limits.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/month-length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/name.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/negative-infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/non-integer-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/options-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/options-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/options-read-before-algorithmic-validation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/options-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/order-of-operations.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/overflow-invalid-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/overflow-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/overflow-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/subclassing-ignored.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/subtract-from-last-representable-month.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/add/throws-if-year-outside-valid-iso-range.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/calendarId/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/calendarId/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/daysInMonth/basic.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/daysInMonth/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/daysInMonth/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/daysInYear/basic.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/daysInYear/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/daysInYear/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-cast.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-number.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-invalid-iso-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-year-zero.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-calendar-annotation-invalid-key.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-critical-unknown-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-limits.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-minus-sign.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-multiple-calendar.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-multiple-time-zone.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-time-separators.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-with-utc-designator.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/basic.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/compare-reference-day.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/leap-second.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/name.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/use-internal-slots.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/year-zero.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/inLeapYear/basic.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/inLeapYear/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/inLeapYear/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/month/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/monthCode/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/monthCode/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/month/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/monthsInYear/basic.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/monthsInYear/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/monthsInYear/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-casting.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-number.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-invalid-iso-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-year-zero.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/arguments-missing-throws.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-calendar-annotation-invalid-key.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-critical-unknown-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-limits.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-minus-sign.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-multiple-calendar.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-multiple-time-zone.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-time-separators.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-with-utc-designator.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/blank-result.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/builtin-calendar-no-array-iteration.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-auto.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-disallowed-units.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-invalid-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-months.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-plurals-accepted.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-smallestunit-mismatch.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-years.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/leap-second.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/name.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/options-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/options-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/options-read-before-algorithmic-validation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/options-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/options-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/order-of-operations.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingincrement-as-expected.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingincrement-nan.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingincrement-non-integer.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingincrement-out-of-range.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingincrement-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingincrement-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmode-ceil.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmode-expand.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmode-floor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmode-halfCeil.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmode-halfEven.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmode-halfExpand.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmode-halfFloor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmode-halfTrunc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmode-invalid-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmode-trunc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmode-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmode-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/smallestunit-invalid-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/smallestunit-plurals-accepted.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/smallestunit-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/smallestunit-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/symmetry.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/throws-if-rounded-date-outside-valid-iso-range.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/throws-if-year-outside-valid-iso-range.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/year-zero.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-duration-max.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-duration-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-duration-out-of-range.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-invalid-property.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-lower-units.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-mixed-sign.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-not-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-singular-properties.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-string-negative-fractional-units.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/blank-duration.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/builtin-calendar-no-array-iteration.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/end-of-month-out-of-range.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/limits.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/month-length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/name.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/negative-infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/non-integer-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/options-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/options-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/options-read-before-algorithmic-validation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/options-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/order-of-operations.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/overflow-invalid-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/overflow-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/overflow-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/subclassing-ignored.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/subtract-from-last-representable-month.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/subtract/throws-if-year-outside-valid-iso-range.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toJSON/basic.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toJSON/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toJSON/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toJSON/length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toJSON/name.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toJSON/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toJSON/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toJSON/year-format.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toLocaleString/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toLocaleString/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toLocaleString/length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toLocaleString/name.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toLocaleString/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toLocaleString/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toLocaleString/return-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/argument-not-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/basic.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/default-overflow-behaviour.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/limits.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/name.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/calendarname-always.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/calendarname-invalid-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/calendarname-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/name.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/options-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/options-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toStringTag/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/year-format.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-casting.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-number.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-invalid-iso-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-year-zero.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/arguments-missing-throws.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-calendar-annotation-invalid-key.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-critical-unknown-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-limits.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-minus-sign.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-multiple-calendar.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-multiple-time-zone.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-time-separators.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-with-utc-designator.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/blank-result.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-auto.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-disallowed-units.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-invalid-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-months.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-plurals-accepted.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-smallestunit-mismatch.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-years.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/leap-second.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/name.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/options-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/options-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/options-read-before-algorithmic-validation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/options-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/options-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/order-of-operations.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/round-cross-unit-boundary.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingincrement-as-expected.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingincrement-nan.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingincrement-non-integer.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingincrement-out-of-range.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingincrement-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingincrement-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingmode-ceil.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingmode-expand.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingmode-floor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingmode-halfCeil.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingmode-halfEven.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingmode-halfExpand.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingmode-halfFloor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingmode-halfTrunc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingmode-invalid-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingmode-trunc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingmode-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingmode-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/smallestunit-invalid-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/smallestunit-plurals-accepted.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/smallestunit-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/smallestunit-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/throws-if-rounded-date-outside-valid-iso-range.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/throws-if-year-outside-valid-iso-range.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/year-zero.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/valueOf/basic.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/valueOf/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/valueOf/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/valueOf/length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/valueOf/name.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/valueOf/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/valueOf/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/argument-calendar-field.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/argument-missing-fields.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/argument-timezone-field.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/basic.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/builtin.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/copy-properties-not-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/infinity-throws-rangeerror.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/length.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/name.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/not-a-constructor.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/options-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/options-read-before-algorithmic-validation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/options-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/options-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/order-of-operations.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/overflow-invalid-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/overflow-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/overflow-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/subclassing-ignored.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/year/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/year/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/subclass.js
+    - test/intl402/DateTimeFormat/prototype/formatRange/fails-on-distinct-temporal-types.js
+    - test/intl402/DateTimeFormat/prototype/formatRangeToParts/fails-on-distinct-temporal-types.js
+
     # Depends on Temporal.Duration relativeTo option
     - test/built-ins/Temporal/Duration/compare/basic.js
     - test/built-ins/Temporal/Duration/compare/calendar-possibly-required.js
@@ -177,6 +718,7 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/round/calendar-temporal-object.js
     - test/built-ins/Temporal/Duration/prototype/round/duration-out-of-range-added-to-relativeto.js
     - test/built-ins/Temporal/Duration/prototype/round/february-leap-year.js
+    - test/built-ins/Temporal/Duration/prototype/round/largestunit-plurals-accepted.js
     - test/built-ins/Temporal/Duration/prototype/round/largestunit-smallestunit-default.js
     - test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-infinity-throws-rangeerror.js
@@ -205,6 +747,7 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfFloor.js
     - test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfTrunc.js
     - test/built-ins/Temporal/Duration/prototype/round/roundingmode-trunc.js
+    - test/built-ins/Temporal/Duration/prototype/round/smallestunit-plurals-accepted.js
     - test/built-ins/Temporal/Duration/prototype/round/total-duration-nanoseconds-too-large-with-zoned-datetime.js
     - test/built-ins/Temporal/Duration/prototype/round/year-zero.js
     - test/built-ins/Temporal/Duration/prototype/total/balances-days-up-to-both-years-and-months.js
@@ -230,7 +773,9 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-string-zoneddatetime.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-sub-minute-offset.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-wrong-type.js
+    - test/built-ins/Temporal/Duration/prototype/total/unit-plurals-accepted.js
     - test/built-ins/Temporal/PlainDateTime/datetime-math.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/round-cross-unit-boundary.js
     - test/intl402/Temporal/Duration/compare/relativeto-hour.js
     - test/intl402/Temporal/Duration/prototype/round/relativeto-infinity-throws-rangeerror.js
     - test/intl402/Temporal/Duration/prototype/round/relativeto-string-datetime.js
@@ -339,37 +884,88 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainMonthDay/calendar-case-insensitive.js
+    - test/built-ins/Temporal/PlainMonthDay/calendar-invalid.js
+    - test/built-ins/Temporal/PlainMonthDay/calendar-invalid-iso-string.js
+    - test/built-ins/Temporal/PlainMonthDay/calendar-iso-string.js
+    - test/built-ins/Temporal/PlainMonthDay/calendar-number.js
+    - test/built-ins/Temporal/PlainMonthDay/calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-case-insensitive.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-iso-string.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-leap-second.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-number.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainMonthDay/from/fields-string.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-case-insensitive.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-iso-string.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-leap-second.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-number.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/calendarname-auto.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/calendarname-critical.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/calendarname-never.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/calendarname-wrong-type.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/order-of-operations.js
+    - test/built-ins/Temporal/PlainMonthDay/refisoyear-undefined.js
     - test/built-ins/Temporal/PlainTime/compare/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainTime/from/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainTime/prototype/since/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainTime/prototype/until/argument-string-time-designator-required-for-disambiguation.js
-
-    # Depends on PlainMonthDay, PlainYearMonth
-    - test/built-ins/Temporal/Duration/prototype/round/largestunit-plurals-accepted.js
-    - test/built-ins/Temporal/Duration/prototype/round/smallestunit-plurals-accepted.js
-    - test/built-ins/Temporal/Duration/prototype/toString/smallestunit-plurals-accepted.js
-    - test/built-ins/Temporal/Duration/prototype/total/unit-plurals-accepted-string.js
-    - test/built-ins/Temporal/Duration/prototype/total/unit-plurals-accepted.js
-    - test/built-ins/Temporal/Instant/prototype/toString/smallestunit-plurals-accepted.js
-    - test/built-ins/Temporal/PlainDate/prototype/with/plaindatelike-invalid.js
-    - test/built-ins/Temporal/PlainDateTime/prototype/toString/smallestunit-plurals-accepted.js
-    - test/built-ins/Temporal/PlainTime/prototype/round/smallestunit-plurals-accepted.js
-    - test/built-ins/Temporal/PlainTime/prototype/toString/smallestunit-plurals-accepted.js
-    - test/built-ins/Temporal/PlainTime/prototype/with/plaintimelike-invalid.js
-    - test/intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js
-    - test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-resolved-time-zone.js
-    - test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-resolved-time-zone.js
-    - test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-resolved-time-zone.js
-    - test/intl402/Intl/DateTimeFormat/prototype/formatRange/fails-on-distinct-temporal-types.js
-    - test/intl402/Intl/DateTimeFormat/prototype/formatRangeToParts/fails-on-distinct-temporal-types.js
-    - test/built-ins/Temporal/Instant/prototype/toString/timezone-offset.js
-    - test/built-ins/Temporal/Instant/prototype/toString/timezone-string-datetime.js
-    - test/built-ins/Temporal/Instant/prototype/toString/timezone-string-leap-second.js
-    - test/built-ins/Temporal/Instant/prototype/toString/timezone-string-multiple-offsets.js
-    - test/built-ins/Temporal/Instant/prototype/toString/timezone-string.js
-    - test/intl402/Temporal/Instant/prototype/toString/timezone-offset.js
-    - test/intl402/Temporal/Instant/prototype/toString/timezone-string-datetime.js
+    - test/built-ins/Temporal/PlainYearMonth/calendar-always.js
+    - test/built-ins/Temporal/PlainYearMonth/calendar-case-insensitive.js
+    - test/built-ins/Temporal/PlainYearMonth/calendar-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/calendar-invalid-iso-string.js
+    - test/built-ins/Temporal/PlainYearMonth/calendar-iso-string.js
+    - test/built-ins/Temporal/PlainYearMonth/calendar-number.js
+    - test/built-ins/Temporal/PlainYearMonth/calendar-string.js
+    - test/built-ins/Temporal/PlainYearMonth/calendar-undefined.js
+    - test/built-ins/Temporal/PlainYearMonth/calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-case-insensitive.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-iso-string.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-leap-second.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-critical-unknown-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-case-insensitive.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-iso-string.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-leap-second.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/limits.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-number.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-case-insensitive.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-iso-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-leap-second.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-number.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/era/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/era/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/eraYear/branding.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/eraYear/prop-desc.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-case-insensitive.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-iso-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-leap-second.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-number.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/calendarname-auto.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/calendarname-critical.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/calendarname-never.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/calendarname-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/toString/order-of-operations.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-case-insensitive.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-iso-string.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-leap-second.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-number.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/refisoday-undefined.js
 
     # Depends on annotations in datetime strings
     - test/built-ins/Temporal/PlainDate/compare/argument-string-time-zone-annotation.js
@@ -377,6 +973,41 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/since/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/until/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-date-with-utc-offset.js
+    - test/built-ins/Temporal/PlainMonthDay/from/argument-string-date-with-utc-offset.js
+    - test/built-ins/Temporal/PlainTime/compare/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainTime/compare/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainTime/compare/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainTime/from/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainTime/from/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainTime/from/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainTime/prototype/since/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainTime/prototype/since/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainTime/prototype/since/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainTime/prototype/until/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainTime/prototype/until/argument-string-time-zone-annotation.js
+    - test/built-ins/Temporal/PlainTime/prototype/until/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/argument-string-date-with-utc-offset.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-unknown-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/from/argument-string-date-with-utc-offset.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-date-with-utc-offset.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-date-with-utc-offset.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-date-with-utc-offset.js
 
     # Depends on Temporal.ZonedDateTime
     - test/built-ins/Temporal/Duration/compare/relativeto-zoneddatetime-negative-epochnanoseconds.js
@@ -384,10 +1015,18 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-zoneddatetime-slots.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-zoneddatetime-negative-epochnanoseconds.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-zoneddatetime-with-fractional-days.js
+    - test/built-ins/Temporal/Duration/prototype/total/unit-plurals-accepted-string.js
+    - test/built-ins/Temporal/Duration/prototype/toString/smallestunit-plurals-accepted.js
     - test/built-ins/Temporal/Instant/compare/argument-zoneddatetime.js
     - test/built-ins/Temporal/Instant/from/argument-zoneddatetime.js
     - test/built-ins/Temporal/Instant/prototype/equals/argument-zoneddatetime.js
     - test/built-ins/Temporal/Instant/prototype/since/argument-zoneddatetime.js
+    - test/built-ins/Temporal/Instant/prototype/toString/smallestunit-plurals-accepted.js
+    - test/built-ins/Temporal/Instant/prototype/toString/timezone-offset.js
+    - test/built-ins/Temporal/Instant/prototype/toString/timezone-string.js
+    - test/built-ins/Temporal/Instant/prototype/toString/timezone-string-datetime.js
+    - test/built-ins/Temporal/Instant/prototype/toString/timezone-string-leap-second.js
+    - test/built-ins/Temporal/Instant/prototype/toString/timezone-string-multiple-offsets.js
     - test/built-ins/Temporal/Instant/prototype/until/argument-zoneddatetime.js
     - test/built-ins/Temporal/PlainDate/compare/argument-zoneddatetime-slots.js
     - test/built-ins/Temporal/PlainDate/compare/argument-zoneddatetime.js
@@ -399,13 +1038,18 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-balance-negative-time-units.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-negative-epochnanoseconds.js
     - test/built-ins/Temporal/PlainDate/prototype/until/argument-zoneddatetime-slots.js
+    - test/built-ins/Temporal/PlainDate/prototype/with/plaindatelike-invalid.js
     - test/built-ins/Temporal/PlainDateTime/compare/argument-zoneddatetime-negative-epochnanoseconds.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-zoneddatetime-balance-negative-time-units.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-zoneddatetime-negative-epochnanoseconds.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-zoneddatetime-balance-negative-time-units.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-zoneddatetime-negative-epochnanoseconds.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/toString/smallestunit-plurals-accepted.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-zoneddatetime-balance-negative-time-units.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-zoneddatetime-negative-epochnanoseconds.js
+    - test/built-ins/Temporal/PlainMonthDay/from/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/equals/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainMonthDay/prototype/with/monthdaylike-invalid.js
     - test/built-ins/Temporal/PlainTime/compare/argument-zoneddatetime-negative-epochnanoseconds.js
     - test/built-ins/Temporal/PlainTime/from/argument-zoneddatetime-balance-negative-time-units.js
     - test/built-ins/Temporal/PlainTime/from/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -413,8 +1057,21 @@ skip:
     - test/built-ins/Temporal/PlainTime/prototype/equals/argument-zoneddatetime-negative-epochnanoseconds.js
     - test/built-ins/Temporal/PlainTime/prototype/since/argument-zoneddatetime-balance-negative-time-units.js
     - test/built-ins/Temporal/PlainTime/prototype/since/argument-zoneddatetime-negative-epochnanoseconds.js
+    - test/built-ins/Temporal/PlainTime/prototype/toString/smallestunit-plurals-accepted.js
     - test/built-ins/Temporal/PlainTime/prototype/until/argument-zoneddatetime-balance-negative-time-units.js
     - test/built-ins/Temporal/PlainTime/prototype/until/argument-zoneddatetime-negative-epochnanoseconds.js
+    - test/built-ins/Temporal/PlainTime/prototype/with/plaintimelike-invalid.js
+    - test/built-ins/Temporal/PlainYearMonth/compare/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainYearMonth/from/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/equals/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/since/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/until/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainYearMonth/prototype/with/yearmonthlike-invalid.js
+    - test/intl402/Intl/DateTimeFormat/prototype/formatRange/fails-on-distinct-temporal-types.js
+    - test/intl402/Intl/DateTimeFormat/prototype/formatRangeToParts/fails-on-distinct-temporal-types.js
+    - test/intl402/Temporal/Instant/prototype/toString/timezone-offset.js
+    - test/intl402/Temporal/Instant/prototype/toString/timezone-string-datetime.js
+
 
     # transferToImmutable() is not implemented yet
     - test/built-ins/ArrayBuffer/prototype/resize/this-is-immutable-arraybuffer-object.js
@@ -431,3 +1088,9 @@ skip:
     - test/built-ins/DataView/prototype/setUint16/immutable-buffer.js
     - test/built-ins/DataView/prototype/setUint32/immutable-buffer.js
     - test/built-ins/DataView/prototype/setUint8/immutable-buffer.js
+ 
+    # Depends on Temporal support in IntlDateTimeFormat::handleDateTimeValue()
+    - test/intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js
+    - test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-resolved-time-zone.js
+    - test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-resolved-time-zone.js
+    - test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-resolved-time-zone.js

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -125,6 +125,8 @@ set(JavaScriptCore_OBJECT_LUT_SOURCES
     runtime/TemporalPlainDatePrototype.cpp
     runtime/TemporalPlainDateTimeConstructor.cpp
     runtime/TemporalPlainDateTimePrototype.cpp
+    runtime/TemporalPlainMonthDayConstructor.cpp
+    runtime/TemporalPlainMonthDayPrototype.cpp
     runtime/TemporalPlainTimeConstructor.cpp
     runtime/TemporalPlainTimePrototype.cpp
     runtime/TemporalTimeZoneConstructor.cpp

--- a/Source/JavaScriptCore/DerivedSources.make
+++ b/Source/JavaScriptCore/DerivedSources.make
@@ -223,6 +223,8 @@ OBJECT_LUT_HEADERS = \
     TemporalPlainDatePrototype.lut.h \
     TemporalPlainDateTimeConstructor.lut.h \
     TemporalPlainDateTimePrototype.lut.h \
+    TemporalPlainMonthDayConstructor.lut.h \
+    TemporalPlainMonthDayPrototype.lut.h \
     TemporalPlainTimeConstructor.lut.h \
     TemporalPlainTimePrototype.lut.h \
     TemporalTimeZoneConstructor.lut.h \

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1087,6 +1087,9 @@ runtime/TemporalPlainDatePrototype.cpp
 runtime/TemporalPlainDateTime.cpp
 runtime/TemporalPlainDateTimeConstructor.cpp
 runtime/TemporalPlainDateTimePrototype.cpp
+runtime/TemporalPlainMonthDay.cpp
+runtime/TemporalPlainMonthDayConstructor.cpp
+runtime/TemporalPlainMonthDayPrototype.cpp
 runtime/TemporalPlainTime.cpp
 runtime/TemporalPlainTimeConstructor.cpp
 runtime/TemporalPlainTimePrototype.cpp

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -274,6 +274,8 @@ private:
     // since the validity checking is separate from date parsing.
     // For example, see the test262 test
     // Temporal/PlainDate/prototype/until/throws-if-rounded-date-outside-valid-iso-range.js
+    // FIXME: Change to int32_t and represent out-of-range years using
+    // special Int32, per https://github.com/WebKit/WebKit/pull/52010#discussion_r2414715114
     double m_year;
     int32_t m_month : 5; // Starts with 1.
     int32_t m_day : 6; // Starts with 1.
@@ -287,6 +289,34 @@ public:
     double month;
     PlainYearMonth(double y, double m)
         : year(y), month(m) { }
+};
+
+class PlainMonthDay {
+    WTF_MAKE_TZONE_ALLOCATED(PlainMonthDay);
+public:
+    constexpr PlainMonthDay()
+        : m_isoPlainDate(0, 1, 1)
+    {
+    }
+
+    constexpr PlainMonthDay(unsigned month, int32_t day)
+        : m_isoPlainDate(2, month, day)
+    {
+    }
+
+    constexpr PlainMonthDay(PlainDate&& d)
+        : m_isoPlainDate(d)
+    {
+    }
+
+    friend bool operator==(const PlainMonthDay&, const PlainMonthDay&) = default;
+
+    uint8_t month() const { return m_isoPlainDate.month(); }
+    uint32_t day() const { return m_isoPlainDate.day(); }
+
+    const PlainDate& isoPlainDate() const { return m_isoPlainDate; }
+private:
+    PlainDate m_isoPlainDate;
 };
 
 // https://tc39.es/proposal-temporal/#sec-temporal-parsetemporaltimezonestring

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -267,6 +267,8 @@
 #include "TemporalPlainDatePrototype.h"
 #include "TemporalPlainDateTime.h"
 #include "TemporalPlainDateTimePrototype.h"
+#include "TemporalPlainMonthDay.h"
+#include "TemporalPlainMonthDayPrototype.h"
 #include "TemporalPlainTime.h"
 #include "TemporalPlainTimePrototype.h"
 #include "TemporalTimeZone.h"
@@ -1626,6 +1628,13 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
                 init.set(TemporalPlainDateTime::createStructure(init.vm, globalObject, plainDateTimePrototype));
             });
 
+        m_plainMonthDayStructure.initLater(
+            [] (const Initializer<Structure>& init) {
+                auto* globalObject = jsCast<JSGlobalObject*>(init.owner);
+                auto* plainMonthDayPrototype = TemporalPlainMonthDayPrototype::create(init.vm, globalObject, TemporalPlainMonthDayPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
+                init.set(TemporalPlainMonthDay::createStructure(init.vm, globalObject, plainMonthDayPrototype));
+            });
+
         m_plainTimeStructure.initLater(
             [] (const Initializer<Structure>& init) {
                 auto* globalObject = jsCast<JSGlobalObject*>(init.owner);
@@ -2773,6 +2782,7 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_instantStructure.visit(visitor);
     thisObject->m_plainDateStructure.visit(visitor);
     thisObject->m_plainDateTimeStructure.visit(visitor);
+    thisObject->m_plainMonthDayStructure.visit(visitor);
     thisObject->m_plainTimeStructure.visit(visitor);
     thisObject->m_timeZoneStructure.visit(visitor);
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -275,6 +275,7 @@ public:
     LazyProperty<JSGlobalObject, Structure> m_instantStructure;
     LazyProperty<JSGlobalObject, Structure> m_plainDateStructure;
     LazyProperty<JSGlobalObject, Structure> m_plainDateTimeStructure;
+    LazyProperty<JSGlobalObject, Structure> m_plainMonthDayStructure;
     LazyProperty<JSGlobalObject, Structure> m_plainTimeStructure;
     LazyProperty<JSGlobalObject, Structure> m_timeZoneStructure;
 
@@ -972,6 +973,7 @@ public:
     Structure* instantStructure() { return m_instantStructure.get(this); }
     Structure* plainDateStructure() { return m_plainDateStructure.get(this); }
     Structure* plainDateTimeStructure() { return m_plainDateTimeStructure.get(this); }
+    Structure* plainMonthDayStructure() { return m_plainMonthDayStructure.get(this); }
     Structure* plainTimeStructure() { return m_plainTimeStructure.get(this); }
     Structure* timeZoneStructure() { return m_timeZoneStructure.get(this); }
 

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -42,6 +42,8 @@
 #include "TemporalPlainDateTime.h"
 #include "TemporalPlainDateTimeConstructor.h"
 #include "TemporalPlainDateTimePrototype.h"
+#include "TemporalPlainMonthDayConstructor.h"
+#include "TemporalPlainMonthDayPrototype.h"
 #include "TemporalPlainTime.h"
 #include "TemporalPlainTimeConstructor.h"
 #include "TemporalPlainTimePrototype.h"
@@ -99,6 +101,13 @@ static JSValue createPlainDateTimeConstructor(VM& vm, JSObject* object)
     return TemporalPlainDateTimeConstructor::create(vm, TemporalPlainDateTimeConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<TemporalPlainDateTimePrototype*>(globalObject->plainDateTimeStructure()->storedPrototypeObject()));
 }
 
+static JSValue createPlainMonthDayConstructor(VM& vm, JSObject* object)
+{
+    TemporalObject* temporalObject = jsCast<TemporalObject*>(object);
+    auto* globalObject = temporalObject->globalObject();
+    return TemporalPlainMonthDayConstructor::create(vm, TemporalPlainMonthDayConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<TemporalPlainMonthDayPrototype*>(globalObject->plainMonthDayStructure()->storedPrototypeObject()));
+}
+
 static JSValue createPlainTimeConstructor(VM& vm, JSObject* object)
 {
     TemporalObject* temporalObject = jsCast<TemporalObject*>(object);
@@ -128,6 +137,7 @@ namespace JSC {
   PlainDate      createPlainDateConstructor      DontEnum|PropertyCallback
   PlainDateTime  createPlainDateTimeConstructor  DontEnum|PropertyCallback
   PlainTime      createPlainTimeConstructor      DontEnum|PropertyCallback
+  PlainMonthDay  createPlainMonthDayConstructor  DontEnum|PropertyCallback
   TimeZone       createTimeZoneConstructor       DontEnum|PropertyCallback
 @end
 */
@@ -708,6 +718,16 @@ TemporalOverflow toTemporalOverflow(JSGlobalObject* globalObject, JSObject* opti
     return intlOption<TemporalOverflow>(globalObject, options, globalObject->vm().propertyNames->overflow,
         { { "constrain"_s, TemporalOverflow::Constrain }, { "reject"_s, TemporalOverflow::Reject } },
         "overflow must be either \"constrain\" or \"reject\""_s, TemporalOverflow::Constrain);
+}
+
+TemporalOverflow toTemporalOverflow(JSGlobalObject* globalObject, JSValue val)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* options = intlGetOptionsObject(globalObject, val);
+    RETURN_IF_EXCEPTION(scope, { });
+    RELEASE_AND_RETURN(scope, toTemporalOverflow(globalObject, options));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-rejectobjectwithcalendarortimezone

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -31,6 +31,10 @@ namespace JSC {
     macro(month, Month) \
     macro(day, Day) \
 
+#define JSC_TEMPORAL_PLAIN_MONTH_DAY_UNITS(macro) \
+    macro(month, Month) \
+    macro(day, Day)
+
 
 #define JSC_TEMPORAL_PLAIN_TIME_UNITS(macro) \
     macro(hour, Hour) \
@@ -58,6 +62,7 @@ enum class TemporalUnit : uint8_t {
 static constexpr unsigned numberOfTemporalUnits = 0 JSC_TEMPORAL_UNITS(JSC_COUNT_TEMPORAL_UNITS);
 static constexpr unsigned numberOfTemporalPlainDateUnits = 0 JSC_TEMPORAL_PLAIN_DATE_UNITS(JSC_COUNT_TEMPORAL_UNITS);
 static constexpr unsigned numberOfTemporalPlainTimeUnits = 0 JSC_TEMPORAL_PLAIN_TIME_UNITS(JSC_COUNT_TEMPORAL_UNITS);
+static constexpr unsigned numberOfTemporalPlainMonthDayUnits = 0 JSC_TEMPORAL_PLAIN_MONTH_DAY_UNITS(JSC_COUNT_TEMPORAL_UNITS);
 #undef JSC_COUNT_TEMPORAL_UNITS
 
 extern const TemporalUnit temporalUnitsInTableOrder[numberOfTemporalUnits];
@@ -215,6 +220,7 @@ enum class TemporalOverflow : bool {
 };
 
 TemporalOverflow toTemporalOverflow(JSGlobalObject*, JSObject*);
+TemporalOverflow toTemporalOverflow(JSGlobalObject*, JSValue);
 
 enum class TemporalDisambiguation : uint8_t {
     Compatible,

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TemporalPlainMonthDay.h"
+
+#include "IntlObjectInlines.h"
+#include "JSCInlines.h"
+#include "LazyPropertyInlines.h"
+#include "TemporalDuration.h"
+#include "TemporalPlainDate.h"
+#include "TemporalPlainDateTime.h"
+#include "VMTrapsInlines.h"
+
+namespace JSC {
+
+const ClassInfo TemporalPlainMonthDay::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TemporalPlainMonthDay) };
+
+TemporalPlainMonthDay* TemporalPlainMonthDay::create(VM& vm, Structure* structure, ISO8601::PlainMonthDay&& plainMonthDay)
+{
+    auto* object = new (NotNull, allocateCell<TemporalPlainMonthDay>(vm)) TemporalPlainMonthDay(vm, structure, WTFMove(plainMonthDay));
+    object->finishCreation(vm);
+    return object;
+}
+
+Structure* TemporalPlainMonthDay::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
+}
+
+TemporalPlainMonthDay::TemporalPlainMonthDay(VM& vm, Structure* structure, ISO8601::PlainMonthDay&& plainMonthDay)
+    : Base(vm, structure)
+    , m_plainMonthDay(WTFMove(plainMonthDay))
+{
+}
+
+void TemporalPlainMonthDay::finishCreation(VM& vm)
+{
+    Base::finishCreation(vm);
+    ASSERT(inherits(info()));
+    m_calendar.initLater(
+        [] (const auto& init) {
+            VM& vm = init.vm;
+            auto* plainMonthDay = jsCast<TemporalPlainMonthDay*>(init.owner);
+            auto* globalObject = plainMonthDay->globalObject();
+            auto* calendar = TemporalCalendar::create(vm, globalObject->calendarStructure(), iso8601CalendarID());
+            init.set(calendar);
+        });
+}
+
+template<typename Visitor>
+void TemporalPlainMonthDay::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    Base::visitChildren(cell, visitor);
+
+    auto* thisObject = jsCast<TemporalPlainMonthDay*>(cell);
+    thisObject->m_calendar.visit(visitor);
+}
+
+DEFINE_VISIT_CHILDREN(TemporalPlainMonthDay);
+
+// CreateTemporalMonthDay ( isoDate, calendar [, newTarget ]
+// https://tc39.es/proposal-temporal/#sec-temporal-createtemporalmonthday
+TemporalPlainMonthDay* TemporalPlainMonthDay::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!ISO8601::isValidISODate(plainDate.year(), plainDate.month(), plainDate.day())) {
+        throwRangeError(globalObject, scope, "PlainMonthDay: invalid date"_s);
+        return { };
+    }
+
+    if (!ISO8601::isDateTimeWithinLimits(plainDate.year(), plainDate.month(), plainDate.day(), 12, 0, 0, 0, 0, 0)) {
+        throwRangeError(globalObject, scope, "PlainMonthDay: date out of range of ECMAScript representation"_s);
+        return { };
+    }
+
+    return TemporalPlainMonthDay::create(vm, structure, ISO8601::PlainMonthDay(WTFMove(plainDate)));
+}
+
+String TemporalPlainMonthDay::monthCode() const
+{
+    return ISO8601::monthCode(m_plainMonthDay.month());
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ISO8601.h"
+#include "LazyProperty.h"
+#include "TemporalCalendar.h"
+
+namespace JSC {
+
+class TemporalPlainMonthDay final : public JSNonFinalObject {
+public:
+    using Base = JSNonFinalObject;
+
+    template<typename CellType, SubspaceAccess mode>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        return vm.temporalPlainDateSpace<mode>();
+    }
+
+    static TemporalPlainMonthDay* create(VM&, Structure*, ISO8601::PlainMonthDay&&);
+    static TemporalPlainMonthDay* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&);
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    DECLARE_INFO;
+
+    static TemporalPlainMonthDay* from(JSGlobalObject*, JSValue, std::optional<JSValue>);
+    static TemporalPlainMonthDay* from(JSGlobalObject*, WTF::String);
+
+    TemporalCalendar* calendar() { return m_calendar.get(this); }
+    ISO8601::PlainMonthDay plainMonthDay() const { return m_plainMonthDay; }
+
+#define JSC_DEFINE_TEMPORAL_PLAIN_MONTH_DAY_FIELD(name, capitalizedName) \
+    decltype(auto) name() const { return m_plainMonthDay.name(); }
+    JSC_TEMPORAL_PLAIN_MONTH_DAY_UNITS(JSC_DEFINE_TEMPORAL_PLAIN_MONTH_DAY_FIELD);
+#undef JSC_DEFINE_TEMPORAL_PLAIN_MONTH_DAY_FIELD
+
+    String monthCode() const;
+
+    DECLARE_VISIT_CHILDREN;
+
+private:
+    TemporalPlainMonthDay(VM&, Structure*, ISO8601::PlainMonthDay&&);
+    void finishCreation(VM&);
+
+    template<typename CharacterType>
+    static std::optional<ISO8601::PlainMonthDay> parse(StringParsingBuffer<CharacterType>&);
+    static ISO8601::PlainMonthDay fromObject(JSGlobalObject*, JSObject*);
+
+    ISO8601::PlainMonthDay m_plainMonthDay;
+    LazyProperty<TemporalPlainMonthDay, TemporalCalendar> m_calendar;
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TemporalPlainMonthDayConstructor.h"
+
+#include "IntlObjectInlines.h"
+#include "JSCInlines.h"
+#include "TemporalPlainMonthDay.h"
+#include "TemporalPlainMonthDayPrototype.h"
+
+namespace JSC {
+
+STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(TemporalPlainMonthDayConstructor);
+
+}
+
+#include "TemporalPlainMonthDayConstructor.lut.h"
+
+namespace JSC {
+
+const ClassInfo TemporalPlainMonthDayConstructor::s_info = { "Function"_s, &Base::s_info, &temporalPlainMonthDayConstructorTable, nullptr, CREATE_METHOD_TABLE(TemporalPlainMonthDayConstructor) };
+
+/* Source for TemporalPlainMonthDayConstructor.lut.h
+@begin temporalPlainMonthDayConstructorTable
+@end
+*/
+
+TemporalPlainMonthDayConstructor* TemporalPlainMonthDayConstructor::create(VM& vm, Structure* structure, TemporalPlainMonthDayPrototype* plainDatePrototype)
+{
+    auto* constructor = new (NotNull, allocateCell<TemporalPlainMonthDayConstructor>(vm)) TemporalPlainMonthDayConstructor(vm, structure);
+    constructor->finishCreation(vm, plainDatePrototype);
+    return constructor;
+}
+
+Structure* TemporalPlainMonthDayConstructor::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(InternalFunctionType, StructureFlags), info());
+}
+
+static JSC_DECLARE_HOST_FUNCTION(callTemporalPlainMonthDay);
+static JSC_DECLARE_HOST_FUNCTION(constructTemporalPlainMonthDay);
+
+TemporalPlainMonthDayConstructor::TemporalPlainMonthDayConstructor(VM& vm, Structure* structure)
+    : Base(vm, structure, callTemporalPlainMonthDay, constructTemporalPlainMonthDay)
+{
+}
+
+void TemporalPlainMonthDayConstructor::finishCreation(VM& vm, TemporalPlainMonthDayPrototype* plainMonthDayPrototype)
+{
+    Base::finishCreation(vm, 2, "PlainMonthDay"_s, PropertyAdditionMode::WithoutStructureTransition);
+    putDirectWithoutTransition(vm, vm.propertyNames->prototype, plainMonthDayPrototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    plainMonthDayPrototype->putDirectWithoutTransition(vm, vm.propertyNames->constructor, this, static_cast<unsigned>(PropertyAttribute::DontEnum));
+}
+
+JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainMonthDay, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* newTarget = asObject(callFrame->newTarget());
+    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, plainMonthDayStructure, newTarget, callFrame->jsCallee());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    double isoMonth = 1;
+    double isoDay = 1;
+    auto argumentCount = callFrame->argumentCount();
+
+    if (argumentCount > 0) {
+        auto value = callFrame->uncheckedArgument(0).toIntegerWithTruncation(globalObject);
+        if (!std::isfinite(value))
+            return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay month property must be finite"_s);
+        isoMonth = value;
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    if (argumentCount > 1) {
+        auto value = callFrame->uncheckedArgument(1).toIntegerWithTruncation(globalObject);
+        if (!std::isfinite(value))
+            return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay day property must be finite"_s);
+        isoDay = value;
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    if (argumentCount < 2)
+        return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay requires at least two arguments"_s);
+
+    // Argument 2 is calendar -- ignored for now. TODO
+
+    double referenceYear = 1972; // First ISO leap year after the epoch
+    if (argumentCount > 3) {
+        auto value = callFrame->uncheckedArgument(3).toIntegerWithTruncation(globalObject);
+        if (!std::isfinite(value))
+            return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay reference year must be finite"_s);
+        referenceYear = value;
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainMonthDay::tryCreateIfValid(globalObject, structure, ISO8601::PlainDate(referenceYear, isoMonth, isoDay))));
+}
+
+JSC_DEFINE_HOST_FUNCTION(callTemporalPlainMonthDay, (JSGlobalObject* globalObject, CallFrame*))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "PlainMonthDay"_s));
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InternalFunction.h"
+
+namespace JSC {
+
+class TemporalPlainMonthDayPrototype;
+
+class TemporalPlainMonthDayConstructor final : public InternalFunction {
+public:
+    using Base = InternalFunction;
+    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+
+    static TemporalPlainMonthDayConstructor* create(VM&, Structure*, TemporalPlainMonthDayPrototype*);
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    DECLARE_INFO;
+
+private:
+    TemporalPlainMonthDayConstructor(VM&, Structure*);
+    void finishCreation(VM&, TemporalPlainMonthDayPrototype*);
+};
+STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(TemporalPlainMonthDayConstructor, InternalFunction);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TemporalPlainMonthDayPrototype.h"
+
+#include "IntlObjectInlines.h"
+#include "JSCInlines.h"
+#include "ObjectConstructor.h"
+#include "TemporalDuration.h"
+#include "TemporalPlainDate.h"
+#include "TemporalPlainDateTime.h"
+#include "TemporalPlainMonthDay.h"
+#include "TemporalPlainTime.h"
+
+namespace JSC {
+
+static JSC_DECLARE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterCalendarId);
+static JSC_DECLARE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterDay);
+static JSC_DECLARE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterMonthCode);
+
+}
+
+#include "TemporalPlainMonthDayPrototype.lut.h"
+
+namespace JSC {
+
+const ClassInfo TemporalPlainMonthDayPrototype::s_info = { "Temporal.PlainMonthDay"_s, &Base::s_info, &plainMonthDayPrototypeTable, nullptr, CREATE_METHOD_TABLE(TemporalPlainMonthDayPrototype) };
+
+/* Source for TemporalPlainMonthDayPrototype.lut.h
+@begin plainMonthDayPrototypeTable
+  calendarId       temporalPlainMonthDayPrototypeGetterCalendarId       DontEnum|ReadOnly|CustomAccessor
+  day              temporalPlainMonthDayPrototypeGetterDay              DontEnum|ReadOnly|CustomAccessor
+  monthCode        temporalPlainMonthDayPrototypeGetterMonthCode        DontEnum|ReadOnly|CustomAccessor
+@end
+*/
+
+TemporalPlainMonthDayPrototype* TemporalPlainMonthDayPrototype::create(VM& vm, JSGlobalObject* globalObject, Structure* structure)
+{
+    auto* prototype = new (NotNull, allocateCell<TemporalPlainMonthDayPrototype>(vm)) TemporalPlainMonthDayPrototype(vm, structure);
+    prototype->finishCreation(vm, globalObject);
+    return prototype;
+}
+
+Structure* TemporalPlainMonthDayPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
+}
+
+TemporalPlainMonthDayPrototype::TemporalPlainMonthDayPrototype(VM& vm, Structure* structure)
+    : Base(vm, structure)
+{
+}
+
+void TemporalPlainMonthDayPrototype::finishCreation(VM& vm, JSGlobalObject*)
+{
+    Base::finishCreation(vm);
+    ASSERT(inherits(info()));
+    JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+}
+
+// https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.calendarid
+JSC_DEFINE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterCalendarId, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(JSValue::decode(thisValue));
+    if (!monthDay)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.calendar called on value that's not a PlainMonthDay"_s);
+
+    // TODO: when calendars are supported, get the string ID of the calendar
+    return JSValue::encode(jsString(vm, String::fromLatin1("iso8601")));
+}
+
+// https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.day
+JSC_DEFINE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterDay, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(JSValue::decode(thisValue));
+    if (!monthDay)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.day called on value that's not a PlainMonthDay"_s);
+
+    return JSValue::encode(jsNumber(monthDay->day()));
+}
+
+// https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.monthcode
+JSC_DEFINE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterMonthCode, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(JSValue::decode(thisValue));
+    if (!monthDay)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.monthCode called on value that's not a PlainMonthDay"_s);
+
+    return JSValue::encode(jsNontrivialString(vm, monthDay->monthCode()));
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSObject.h"
+
+namespace JSC {
+
+class TemporalPlainMonthDayPrototype final : public JSNonFinalObject {
+public:
+    using Base = JSNonFinalObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+
+    template<typename CellType, SubspaceAccess>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(TemporalPlainMonthDayPrototype, Base);
+        return &vm.plainObjectSpace();
+    }
+
+    static TemporalPlainMonthDayPrototype* create(VM&, JSGlobalObject*, Structure*);
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    DECLARE_INFO;
+
+private:
+    TemporalPlainMonthDayPrototype(VM&, Structure*);
+    void finishCreation(VM&, JSGlobalObject*);
+};
+
+} // namespace JSC


### PR DESCRIPTION
#### dab2cf707db19ca3bc7f2379b7217a9a47510506
<pre>
[Temporal] Add PlainMonthDay
<a href="https://bugs.webkit.org/show_bug.cgi?id=300389">https://bugs.webkit.org/show_bug.cgi?id=300389</a>

Reviewed by Yusuke Suzuki.

Add basic support for Temporal PlainMonthDay type, without most
methods yet.

Test: JSTests/stress/temporal-plainmonthday.js
* JSTests/stress/temporal-plainmonthday.js: Added.
(shouldBe):
(shouldThrow):
(const.monthDay.new.Temporal.PlainMonthDay):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/DerivedSources.make:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::plainMonthDayStructure):
* Source/JavaScriptCore/runtime/TemporalObject.cpp:
(JSC::createPlainMonthDayConstructor):
(JSC::toTemporalOverflow):
* Source/JavaScriptCore/runtime/TemporalObject.h:
* Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp: Added.
(JSC::TemporalPlainMonthDay::create):
(JSC::TemporalPlainMonthDay::createStructure):
(JSC::TemporalPlainMonthDay::TemporalPlainMonthDay):
(JSC::TemporalPlainMonthDay::finishCreation):
(JSC::TemporalPlainMonthDay::visitChildrenImpl):
(JSC::TemporalPlainMonthDay::tryCreateIfValid):
(JSC::TemporalPlainMonthDay::monthCode const):
* Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h: Added.
* Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp: Added.
(JSC::TemporalPlainMonthDayConstructor::create):
(JSC::TemporalPlainMonthDayConstructor::createStructure):
(JSC::TemporalPlainMonthDayConstructor::TemporalPlainMonthDayConstructor):
(JSC::TemporalPlainMonthDayConstructor::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.h: Added.
* Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp: Added.
(JSC::TemporalPlainMonthDayPrototype::create):
(JSC::TemporalPlainMonthDayPrototype::createStructure):
(JSC::TemporalPlainMonthDayPrototype::TemporalPlainMonthDayPrototype):
(JSC::TemporalPlainMonthDayPrototype::finishCreation):
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.h: Added.

Canonical link: <a href="https://commits.webkit.org/301244@main">https://commits.webkit.org/301244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/299221ff0f406bc53ef13f7835eaa67d374b1d6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132143 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77161 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95395 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75936 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35350 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30213 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75619 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117384 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106218 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134827 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123811 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39878 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103865 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103626 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48987 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27277 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/49202 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19629 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51992 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57772 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156830 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51351 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39271 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->