### PR TITLE
Resync `Navigation API` from WPT Upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6944,7 +6944,13 @@ imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-
 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler.html?currententrychange [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler.html?no-currententrychange [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-no-popstate.html [ Skip ]
+imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/precommit-handler/ [ Skip ]
+
+# rdar://160391355
+imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-reload.html [ Failure ]
+imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-traverse.html [ Failure ]
+imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-with-target.html [ Failure ]
 
 # -- View Transitions -- #
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/META.yml
@@ -1,4 +1,3 @@
-spec: https://wicg.github.io/navigation-api/
+spec: https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api
 suggested_reviewers:
-  - domenic
   - natechapin

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-back-same-doc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-back-same-doc.html
@@ -9,7 +9,7 @@ promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
   await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
-  await navigation.navigate("#foo");
+  await navigation.navigate("#foo").finished;
   assert_equals(navigation.entries().length, start_length + 1);
 
   let oncurrententrychange_called = false;

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/change-focus-then-remove-during-intercept.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/change-focus-then-remove-during-intercept.html
@@ -24,13 +24,10 @@ promise_test(async t => {
 
   const finished = navigation.navigate("#1").finished;
 
-  let onfocus_called = false;
-  document.body.onfocus = onfocus_called = true;
+  document.body.onfocus = t.unreached_func("onfocus shouldn't fire due to focus reset");
   button.remove();
   assert_equals(document.activeElement, document.body, "Removing the element reset focus");
-  assert_true(onfocus_called);
 
-  document.body.onfocus = t.unreached_func("onfocus shouldn't fire a second time due to focus reset");
   intercept_resolve();
   await finished;
   assert_equals(document.activeElement, document.body, "Focus remains on document.body after promise fulfills");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-reload.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-reload.html
@@ -12,7 +12,7 @@ async_test(t => {
     iframe.contentWindow.navigation.onnavigate = t.step_func(e => {
       assert_equals(e.navigationType, "push");
       assert_not_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      assert_equals(e.sourceElement, form);
 
       iframe.onload = t.step_func(() => {
         iframe.contentWindow.navigation.onnavigate = t.step_func_done(e => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-traverse.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-traverse.html
@@ -12,7 +12,7 @@ async_test(t => {
     iframe.contentWindow.navigation.onnavigate = t.step_func(e => {
       assert_equals(e.navigationType, "push");
       assert_not_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      assert_equals(e.sourceElement, form);
 
       iframe.onload = t.step_func(() => {
         // Avoid the replace behavior that occurs if you navigate during the load handler

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-with-target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-with-target.html
@@ -22,7 +22,7 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_not_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      assert_equals(e.sourceElement, form);
     });
     form.submit();
   });

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to.tentative-expected.txt
@@ -1,0 +1,5 @@
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT navigation.transition.to matches the navigate event's destination Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to.tentative.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async (t) => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(r => window.onload = () => t.step_timeout(r, 0));
+  const precommit = Promise.withResolvers();
+  const handler = Promise.withResolvers();
+  const handler_done = Promise.withResolvers();
+  const commit = Promise.withResolvers();
+  navigation.addEventListener("navigate", e => {
+    e.intercept({
+        async precommitHandler() {
+            precommit.resolve(e);
+            await commit.promise;
+        },
+        async handler() {
+            handler.resolve();
+            await handler_done.promise;
+        }
+    });
+  });
+
+  assert_equals(navigation.transition, null);
+  navigation.navigate("?next");
+  const navigate_event = await precommit.promise;
+  const old_entry = navigation.currentEntry;
+  assert_equals(navigation.transition.from, old_entry);
+  assert_equals(navigation.transition.to, navigate_event.destination);
+  commit.resolve();
+  await handler.promise;
+  assert_equals(navigation.transition.from, old_entry);
+  assert_equals(navigation.transition.to, navigate_event.destination);
+  assert_equals(navigation.transition.to.url, navigation.currentEntry.url);
+  handler_done.resolve();
+}, "navigation.transition.to matches the navigate event's destination");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/w3c-import.log
@@ -51,3 +51,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-cross-document.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-finished-mark-as-handled.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-realms-and-identity.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to.tentative.html

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache.html
@@ -17,7 +17,7 @@ runBfcacheTest({
   targetOrigin: originSameOrigin,
   funcBeforeNavigation: async () => {
     window.events = [];
-    await navigation.navigate("#1");
+    await navigation.navigate("#1").finished;
     await navigation.back();
     window.originalEntry1 = navigation.entries()[1];
     window.originalEntry1.ondispose = () => events.push("dispose");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-basic.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-change-history-scroll-restoration-during-promise.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-change-history-scroll-restoration-during-promise.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-explicit-scroll.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-explicit-scroll.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-intercept-handler-modifies.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-intercept-handler-modifies.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div id="main" style="height: 1000px; width: 1000px;"></div>
+<div id="main" style="height: 200vh; width: 200vw;"></div>
 <script>
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-push.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-push.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reject.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reject.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload.html
@@ -1,10 +1,11 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div id="buffer" style="height: 1000px; width: 1000px;"></div>
+<div id="buffer" style="height: 1000px; width: 200vw;"></div>
 <div id="frag"></div>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <script>
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-replace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-replace.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-timing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-timing.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-basic.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-immediate-scroll.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-immediate-scroll.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-after-dispatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-after-dispatch.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-after-resolve.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-after-resolve.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-fragment-does-not-exist.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-fragment-does-not-exist.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-in-precommit-handler.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-in-precommit-handler.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-push.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-push.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-reload.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-reload.html
@@ -1,10 +1,11 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div id="buffer" style="height: 1000px; width: 1000px;"></div>
+<div id="buffer" style="height: 1000px; width: 200vw;"></div>
 <div id="frag"></div>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <script>
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-repeated.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-repeated.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-replace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-replace.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-resets-when-no-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-resets-when-no-fragment.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault.html
@@ -1,9 +1,10 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../navigation-methods/return-value/resources/helpers.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-on-synthetic-event.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-on-synthetic-event.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-without-intercept.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-without-intercept.html
@@ -1,8 +1,9 @@
 <!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<div style="height: 1000px; width: 1000px;"></div>
+<div style="height: 200vh; width: 200vw;"></div>
 <div id="frag"></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/same-document-away-and-back-location-api.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/same-document-away-and-back-location-api.html
@@ -11,7 +11,7 @@ async_test(t => {
     let start_index = entry0.index;
 
     let navState = { statevar: "state" };
-    await navigation.navigate("#1", { state: navState });
+    await navigation.navigate("#1", { state: navState }).finished;
     let entry1 = navigation.currentEntry;
 
     location.href = "#2";


### PR DESCRIPTION
#### 264cb07b634d767f1e13e1b462e6cb202463a2bf
<pre>
Resync `Navigation API` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=300394">https://bugs.webkit.org/show_bug.cgi?id=300394</a>
<a href="https://rdar.apple.com/162211706">rdar://162211706</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/4657034a3092367d86fbc3bccdc4e21d6482a34b">https://github.com/web-platform-tests/wpt/commit/4657034a3092367d86fbc3bccdc4e21d6482a34b</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-back-same-doc.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/change-focus-then-remove-during-intercept.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-reload.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-traverse.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-with-target.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-basic.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-change-history-scroll-restoration-during-promise.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-explicit-scroll.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-intercept-handler-modifies.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-push.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reject.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-replace.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-timing.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-basic.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-immediate-scroll.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-after-dispatch.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-after-resolve.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-fragment-does-not-exist.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-in-precommit-handler.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-push.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-reload.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-repeated.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-replace.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-resets-when-no-fragment.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-on-synthetic-event.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-without-intercept.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/same-document-away-and-back-location-api.html:

Canonical link: <a href="https://commits.webkit.org/301223@main">https://commits.webkit.org/301223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f4b846acfd411653a60d17136eaa6b82ffac9e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77150 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95380 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/818c267c-b238-4dfc-bd30-a50334e84ca7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112029 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75921 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb9e7f24-aae9-4bda-91a2-8141a6307789) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35338 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30197 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75605 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106206 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134809 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103851 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103617 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26393 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48970 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27262 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49188 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51976 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51340 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54693 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53031 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->