### PR TITLE
[CSS Zoom] Apply zoom factor to text indent

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7536,7 +7536,6 @@ imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom.sub.html [ Ima
 imported/w3c/web-platform-tests/css/css-viewport/zoom/line-height.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/list-style-image.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/relative-units-from-parent.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-viewport/zoom/text-indent.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-shadow.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-stroke-width.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/border.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/parsing/text-indent-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/parsing/text-indent-computed-expected.txt
@@ -1,0 +1,14 @@
+Test paragraph
+
+
+PASS Property text-indent value '1px' single value no zoom
+PASS Property text-indent value '1rem' rem value no zoom
+PASS Property text-indent value 'inherit' inherit no zoom
+PASS Property text-indent value '5px' explicit px value no zoom
+PASS Property text-indent value '0' zero value no zoom
+PASS Property text-indent value '1px' single value with zoom: 2
+PASS Property text-indent value '1rem' rem value with zoom: 2
+PASS Property text-indent value 'inherit' inherit with zoom: 2
+PASS Property text-indent value '5px' explicit px value with zoom: 2
+PASS Property text-indent value '0' zero value with zoom: 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/parsing/text-indent-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/parsing/text-indent-computed.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Text: text-indent computed values under zoom</title>
+<link rel="help" href="https://www.w3.org/TR/CSS22/text.html#indentation-prop">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-indent-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div style="text-indent: 2rem;">
+  <p id="target">Test paragraph</p>
+</div>
+<script>
+const target = document.getElementById("target");
+
+test_computed_value("text-indent", "1px", "1px", "single value no zoom");
+test_computed_value("text-indent", "1rem", "16px", "rem value no zoom");
+test_computed_value("text-indent", "inherit", "32px", "inherit no zoom");
+test_computed_value("text-indent", "5px", "5px", "explicit px value no zoom");
+test_computed_value("text-indent", "0", "0px", "zero value no zoom");
+
+const parent = target.parentElement;
+parent.style.zoom = "2";
+
+test_computed_value("text-indent", "1px", "1px", "single value with zoom: 2");
+test_computed_value("text-indent", "1rem", "16px", "rem value with zoom: 2");
+test_computed_value("text-indent", "inherit", "32px", "inherit with zoom: 2");
+test_computed_value("text-indent", "5px", "5px", "explicit px value with zoom: 2");
+test_computed_value("text-indent", "0", "0px", "zero value with zoom: 2");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/text-indent-svg-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/text-indent-svg-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+html {
+  --scale: 1;
+}
+.indent {
+  text-indent: calc(1rem * var(--scale));
+}
+.zoom {
+  --scale: 2;
+}
+</style>
+
+<svg width="150" height="30">
+  <text class="indent" x="0" y="20">unzoomed</text>
+</svg>
+
+<div class="zoom">
+  <svg width="300" height="60">
+    <text style="font-size: calc(1rem * var(--scale))" class="indent" x="0" y="40">zoomed</text>
+  </svg>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/text-indent-svg-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/text-indent-svg-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+html {
+  --scale: 1;
+}
+.indent {
+  text-indent: calc(1rem * var(--scale));
+}
+.zoom {
+  --scale: 2;
+}
+</style>
+
+<svg width="150" height="30">
+  <text class="indent" x="0" y="20">unzoomed</text>
+</svg>
+
+<div class="zoom">
+  <svg width="300" height="60">
+    <text style="font-size: calc(1rem * var(--scale))" class="indent" x="0" y="40">zoomed</text>
+  </svg>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/text-indent-svg.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/text-indent-svg.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>CSS zoom does not apply to text-indent on SVG primitives when specified and inherited</title>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/text-indent-svg-ref.html">
+
+<style>
+.indent {
+  text-indent: 1rem;
+}
+.zoom {
+  zoom: 2;
+}
+</style>
+
+<svg width="150" height="30">
+  <text class="indent" x="0" y="20">unzoomed</text>
+</svg>
+
+<div class="zoom">
+  <svg width="150" height="30">
+    <text class="indent" x="0" y="20">zoomed</text>
+  </svg>
+</div>

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -793,7 +793,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         addAttributeIfNeeded("invisible"_s, style.visibility() == Visibility::Hidden ? "true"_s : "false"_s);
         addAttributeIfNeeded("editable"_s, m_coreObject->canSetValueAttribute() ? "true"_s : "false"_s);
         addAttributeIfNeeded("direction"_s, style.writingMode().isBidiLTR() ? "ltr"_s : "rtl"_s);
-        addAttributeIfNeeded("indent"_s, makeString(Style::evaluate<float>(style.textIndent().length, m_coreObject->size().width(), Style::ZoomNeeded { })));
+        addAttributeIfNeeded("indent"_s, makeString(Style::evaluate<float>(style.textIndent().length, m_coreObject->size().width(), style.usedZoomForLength())));
 
         switch (style.textAlign()) {
         case TextAlignMode::Start:

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -179,7 +179,7 @@ InlineLayoutUnit InlineFormattingUtils::computedTextIndent(IsIntrinsicWidthMode 
         // https://drafts.csswg.org/css-text/#text-indent-property
         return { };
     }
-    return Style::evaluate<InlineLayoutUnit>(textIndentLength, availableWidth, Style::ZoomNeeded { });
+    return Style::evaluate<InlineLayoutUnit>(textIndentLength, availableWidth, root.style().usedZoomForLength());
 }
 
 InlineLayoutUnit InlineFormattingUtils::initialLineHeight(bool isFirstLine) const

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1876,7 +1876,7 @@ LayoutUnit RenderBlock::textIndentOffset() const
     LayoutUnit cw;
     if (style().textIndent().length.isPercentOrCalculated())
         cw = contentBoxLogicalWidth();
-    return Style::evaluate<LayoutUnit>(style().textIndent().length, cw, Style::ZoomNeeded { });
+    return Style::evaluate<LayoutUnit>(style().textIndent().length, cw, style().usedZoomForLength());
 }
 
 LayoutUnit RenderBlock::logicalLeftOffsetForContent() const

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4564,7 +4564,7 @@ static inline std::optional<LayoutUnit> textIndentForBlockContainer(const Render
 {
     auto& style = renderer.style();
     if (auto fixedTextIndent = style.textIndent().length.tryFixed())
-        return !fixedTextIndent->isZero() ? std::make_optional(LayoutUnit { fixedTextIndent->resolveZoom(Style::ZoomNeeded { }) }) : std::nullopt;
+        return !fixedTextIndent->isZero() ? std::make_optional(LayoutUnit { fixedTextIndent->resolveZoom(style.usedZoomForLength()) }) : std::nullopt;
 
     auto indentValue = LayoutUnit { };
     if (auto* containingBlock = renderer.containingBlock()) {
@@ -4572,7 +4572,7 @@ static inline std::optional<LayoutUnit> textIndentForBlockContainer(const Render
             auto containingBlockFixedLogicalWidthValue = Style::evaluate<LayoutUnit>(*containingBlockFixedLogicalWidth, Style::ZoomNeeded { });
             // At this point of the shrink-to-fit computation, we don't have a used value for the containing block width
             // (that's exactly to what we try to contribute here) unless the computed value is fixed.
-            indentValue = Style::evaluate<LayoutUnit>(style.textIndent().length, containingBlockFixedLogicalWidthValue, Style::ZoomNeeded { });
+            indentValue = Style::evaluate<LayoutUnit>(style.textIndent().length, containingBlockFixedLogicalWidthValue, containingBlock->style().usedZoomForLength());
         }
     }
     return indentValue ? std::make_optional(indentValue) : std::nullopt;

--- a/Source/WebCore/style/values/text/StyleTextIndent.h
+++ b/Source/WebCore/style/values/text/StyleTextIndent.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 namespace Style {
 
-struct TextIndentLength : LengthWrapperBase<LengthPercentage<>> {
+struct TextIndentLength : LengthWrapperBase<LengthPercentage<CSS::AllUnzoomed>> {
     using Base::Base;
 };
 


### PR DESCRIPTION
#### 9565f155a8f82c3a702d69eb2d9370a33d4ef088
<pre>
[CSS Zoom] Apply zoom factor to text indent
<a href="https://bugs.webkit.org/show_bug.cgi?id=300406">https://bugs.webkit.org/show_bug.cgi?id=300406</a>
<a href="https://rdar.apple.com/162227995">rdar://162227995</a>

Reviewed by Tim Nguyen, Antti Koivisto, and Vitor Roriz.

We apply the zoom factor at evaluation-time for StyleTextIndent

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/parsing/text-indent-computed.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/text-indent-svg-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/text-indent-svg.html
* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/parsing/text-indent-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/parsing/text-indent-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/text-indent-svg-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/text-indent-svg-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/text-indent-svg.html: Added.
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::textAttributes const):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::computedTextIndent const):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::textIndentOffset const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::textIndentForBlockContainer):
* Source/WebCore/style/values/text/StyleTextIndent.h:

Canonical link: <a href="https://commits.webkit.org/301286@main">https://commits.webkit.org/301286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d91f0d55404640a04c3844b6a29f5636a4cca2da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125445 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77333 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7aeccd48-fc21-449e-9607-0883a2ff62e9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95527 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63452 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; Exiting early after 60 failures. 6359 tests run. 60 failures; Uploaded test results; Exiting early after 60 failures. 6337 tests run. 60 failures; Running compile-webkit-without-change") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b98f7747-b556-4483-b692-fd482c2a8293) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112186 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76053 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/30b35738-0ca7-4103-b13a-5a10e7341b74) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35501 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30359 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75779 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134983 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104003 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103752 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/26422 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27417 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49428 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19654 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52145 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57962 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51496 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54852 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53191 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->