### PR TITLE
[CSS Zoom] Make `EvaluationTimeZoomEnabled` testable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-spacing-without-border.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-spacing-without-border.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ EvaluationTimeZoomEnabled=true ] -->
 <!DOCTYPE html>
 <title>CSS zoom applies to border-spacing when specified and inherited</title>
 <link rel="help" href="https://drafts.csswg.org/css-viewport/">

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/border-spacing-svg-zoom-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/border-spacing-svg-zoom-computed.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ EvaluationTimeZoomEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/border-spacing-svg-zoom-table-display.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/border-spacing-svg-zoom-table-display.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ EvaluationTimeZoomEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2694,7 +2694,7 @@ EnumeratingVisibleNetworkInterfacesEnabled:
 EvaluationTimeZoomEnabled:
   category: css
   type: bool
-  status: unstable
+  status: testable
   humanReadableName: "Evaluation time zoom enabled"
   humanReadableDescription: "Enables used zoom value to be applied during layout and avoid applying at style-build time"
   defaultValue:


### PR DESCRIPTION
#### 66c13411dc475d9eb62e61e7d925ae08fc1578ac
<pre>
[CSS Zoom] Make `EvaluationTimeZoomEnabled` testable
<a href="https://bugs.webkit.org/show_bug.cgi?id=300411">https://bugs.webkit.org/show_bug.cgi?id=300411</a>
<a href="https://rdar.apple.com/162233254">rdar://162233254</a>

Reviewed by Tim Nguyen, Sammy Gill, Vitor Roriz, and Brent Fulgham.

Make unstable flag testable to enable isolated PR testing
and reveal side effects earlier.

* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-spacing-without-border.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/border-spacing-svg-zoom-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/border-spacing-svg-zoom-table-display.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml

Canonical link: <a href="https://commits.webkit.org/301236@main">https://commits.webkit.org/301236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/677f2fcc5e64c1bd54f4ddf1dcf24af64c348fa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132167 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95412 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75951 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30236 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75644 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117408 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134853 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123836 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103885 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103646 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26400 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49009 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27300 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49231 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52016 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57796 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156855 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51373 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39278 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54729 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53067 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->