### PR TITLE
[TikTok][iOS] Comments can be clipped when watching videos on iPad portrait mode.

### DIFF
--- a/LayoutTests/fast/layout/flex-force-shrink-tiktok-quirk-expected.html
+++ b/LayoutTests/fast/layout/flex-force-shrink-tiktok-quirk-expected.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<style>
+.fixed-position-containing-block {
+  width: 300px;
+  transform: translateZ(0);
+}
+.css-mpsq7l-5e6d46e3--DivBrowserModeContainer {
+  display: flex;
+  position: fixed;
+  inset: 0;
+}
+
+.css-syysv3-5e6d46e3--DivVideoContainer {
+  height: 100px;
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.css-yhb7qp-5e6d46e3--DivContentContainer {
+  width: 500px;
+  flex-shrink: 1;
+  min-width: 0;
+}
+</style>
+<body>
+<div class="fixed-position-containing-block">
+  <div class="css-mpsq7l-5e6d46e3--DivBrowserModeContainer">
+    <div class="css-syysv3-5e6d46e3--DivVideoContainer">
+      <div style="width: 400px; height: 100px; background-color: green;"></div>
+    </div>
+    <div class="css-yhb7qp-5e6d46e3--DivContentContainer">
+      <div>
+        this is a long comment and should hopefully get wrapped
+      </div>
+      <div style="font-size: 50px">largemincontentcontribution</div>
+    </div>
+  </div>
+</div>
+</body>
+</html>
+

--- a/LayoutTests/fast/layout/flex-force-shrink-tiktok-quirk.html
+++ b/LayoutTests/fast/layout/flex-force-shrink-tiktok-quirk.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<!-- The css-* class names come from the the elements we are attempting
+to target with the quirk as of the time of this patch. The first bits
+look like they could very easily change so the quirk checks to see if
+the latter portion of the class name is a subtring. -->
+<style>
+.fixed-position-containing-block {
+  width: 300px;
+  transform: translateZ(0);
+}
+.css-mpsq7l-5e6d46e3--DivBrowserModeContainer {
+  display: flex;
+  position: fixed;
+  inset: 0;
+}
+
+.css-syysv3-5e6d46e3--DivVideoContainer {
+  height: 100px;
+  flex-grow: 1;
+  flex-shrink: 0;
+}
+
+.css-yhb7qp-5e6d46e3--DivContentContainer {
+  width: 500px;
+  flex-shrink: 0;
+}
+</style>
+<script>
+window.internals?.setTopDocumentURLForQuirks("https://www.tiktok.com");
+</script>
+<body>
+<div class="fixed-position-containing-block">
+  <div class="css-mpsq7l-5e6d46e3--DivBrowserModeContainer">
+    <div class="css-syysv3-5e6d46e3--DivVideoContainer">
+      <div style="width: 400px; height: 100px; background-color: green;"></div>
+    </div>
+    <div class="css-yhb7qp-5e6d46e3--DivContentContainer">
+      <div>
+        this is a long comment and should hopefully get wrapped
+      </div>
+      <div style="font-size: 50px">largemincontentcontribution</div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -276,6 +276,10 @@ public:
 
     WEBCORE_EXPORT bool needsNowPlayingFullscreenSwapQuirk() const;
 
+
+    enum class TikTokOverflowingContentQuirkType : bool { VideoSectionQuirk, CommentsSectionQuirk };
+    std::optional<TikTokOverflowingContentQuirkType> needsTikTokOverflowingContentQuirk(const Element&, const RenderStyle& parentStyle) const;
+
     bool needsWebKitMediaTextTrackDisplayQuirk() const;
 
     bool shouldSupportHoverMediaQueries() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -63,6 +63,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool needsResettingTransitionCancelsRunningTransitionQuirk : 1 { false };
     bool needsScrollbarWidthThinDisabledQuirk : 1 { false };
     bool needsSeekingSupportDisabledQuirk : 1 { false };
+    bool needsTikTokOverflowingContentQuirk : 1 { false };
     bool needsVP9FullRangeFlagQuirk : 1 { false };
     bool needsVideoShouldMaintainAspectRatioQuirk : 1 { false };
     bool returnNullPictureInPictureElementDuringFullscreenChangeQuirk : 1 { false };

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1012,6 +1012,16 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
             style.setUserSelect(UserSelect::None);
     }
 
+    if (auto tikTokOverflowingContentQuery = m_document->quirks().needsTikTokOverflowingContentQuirk(*m_element, m_parentStyle)) {
+        if (*tikTokOverflowingContentQuery == Quirks::TikTokOverflowingContentQuirkType::CommentsSectionQuirk)  {
+            style.setFlexShrink({ 1 });
+            style.setMinWidth(0_css_px);
+        } else {
+            ASSERT(tikTokOverflowingContentQuery == Quirks::TikTokOverflowingContentQuirkType::VideoSectionQuirk);
+            style.setFlexShrink({ 2 });
+        }
+    }
+
 #if PLATFORM(MAC)
     if (m_document->quirks().needsZomatoEmailLoginLabelQuirk()) {
         static MainThreadNeverDestroyed<const AtomString> class1("eNjKGZ"_s);


### PR DESCRIPTION
#### da27aabdc21225e0c17876c39a6d084a9dd92d44
<pre>
[TikTok][iOS] Comments can be clipped when watching videos on iPad portrait mode.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300413">https://bugs.webkit.org/show_bug.cgi?id=300413</a>
<a href="https://rdar.apple.com/138083287">rdar://138083287</a>

Reviewed by Brandon Stewart.

When viewing content on TikTok with an iPad in portrait mode, the video
and comment section may be presented side by side. Depending on the
width of the device, this may result in comments overflowing off the
screen, making them unreadable.

From looking at the markup and styling, it appears that the video and
comments, which are really the two main pieces of content on the page,
are two flex items within a fixed-position flexbox. The styling ends up
disabling shrinking on the two flex items, which is one of the reasons
the comments section ends up overflowing. To help improve the user
experience, this patch adds a quirk that addresses this problem with two
sets of changes:

1.) Setting flex-shrink on both of the flex items that hold the video
and comments section.

2.) Setting min-width: 0 on the flex item to hold the comments section.
This is to disable the automatic minimum size that flex layout will
compute on the item, which can limit the amount of shrinking that can
happen.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsTikTokOverflowingContentQuirk const):
The general heuristic used to determine whether or not we need to apply
the quirk is based upon the style of the element that is passed in along
with the style of the parent. StyleAdjuster will give us both of these,
and we will make a decision if we need to apply the quirk and how,
depending on:

1.) First, we check to see if the parent is the fixed-position flexbox
since this is what we expect to hold these two pieces of content.

2.) Check to see if that element has &quot;DivBrowserModeContainer,&quot;
contained somewhere as a substring in one of its class names. We check
to see if it is a substring rather than an exact match of a class name
since the prefix for this class name seems to be a random identifier,
which could very easily change depending on how it was generated/chosen.

3.) Check to see if the passed-in element has either &quot;DivVideoContainer,&quot;
or &quot;DivContentContainer,&quot; as a substring. The former appears to be the
flex item which holds the video and the latter appears to be the flex
item which holds the comments section.

Depending on the result of 3, we return an enum to the StyleAdjuster
code to tell it which quirk to apply since we want to apply slightly
different styles depending on the element.

Canonical link: <a href="https://commits.webkit.org/301273@main">https://commits.webkit.org/301273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94eb6456fd95787e117eccc5588fcbcb4a100a7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77332 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fcc724cb-7429-44d7-a43c-e7e4cc499823) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53673 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95528 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/982e1041-cb57-42ad-848e-496cb5862080) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76054 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68d5b80f-e66f-49ae-a461-29aaf30fdad4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30357 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75778 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134982 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40028 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104002 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103751 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26421 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27415 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49405 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52144 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57928 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51495 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54851 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53190 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->