### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException use in platform/network/cocoa

### DIFF
--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -172,6 +172,7 @@ public:
     CFURLStorageSessionRef platformSession() { return m_platformSession.get(); }
     WEBCORE_EXPORT RetainPtr<CFHTTPCookieStorageRef> cookieStorage() const;
     CookieStorageObserver& cookieStorageObserver() const;
+    CheckedRef<CookieStorageObserver> checkedCookieStorageObserver() const;
 #elif USE(SOUP)
     WEBCORE_EXPORT explicit NetworkStorageSession(PAL::SessionID, IsInMemoryCookieStore = IsInMemoryCookieStore::No);
     ~NetworkStorageSession();

--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <pal/spi/cf/CFNetworkSPI.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -38,17 +39,13 @@ namespace WebCore {
 class CookieStorageObserver;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CookieStorageObserver> : std::true_type { };
-}
-
 namespace WebCore {
 
 // Use eager initialization for the WeakPtrFactory since we construct WeakPtrs on a non-main thread.
-class WEBCORE_EXPORT CookieStorageObserver : public CanMakeWeakPtr<CookieStorageObserver, WeakPtrFactoryInitialization::Eager> {
+class WEBCORE_EXPORT CookieStorageObserver final : public CanMakeWeakPtr<CookieStorageObserver, WeakPtrFactoryInitialization::Eager>, public CanMakeCheckedPtr<CookieStorageObserver> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(CookieStorageObserver, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(CookieStorageObserver);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CookieStorageObserver);
 public:
     explicit CookieStorageObserver(NSHTTPCookieStorage *);
     ~CookieStorageObserver();

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -195,6 +195,11 @@ CookieStorageObserver& NetworkStorageSession::cookieStorageObserver() const
     return *m_cookieStorageObserver;
 }
 
+CheckedRef<CookieStorageObserver> NetworkStorageSession::checkedCookieStorageObserver() const
+{
+    return cookieStorageObserver();
+}
+
 RetainPtr<CFURLStorageSessionRef> createPrivateStorageSession(CFStringRef identifier, std::optional<HTTPCookieAcceptPolicy> cookieAcceptPolicy, NetworkStorageSession::ShouldDisableCFURLCache shouldDisableCFURLCache)
 {
     const void* sessionPropertyKeys[] = { _kCFURLStorageSessionIsPrivate };

--- a/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
+++ b/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
@@ -34,24 +34,17 @@
 #import "SharedBuffer.h"
 #import "WebCoreNSURLSession.h"
 #import <pal/spi/cf/CFNetworkSPI.h>
+#import <wtf/CheckedPtr.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/FunctionDispatcher.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringBuilder.h>
 
 namespace WebCore {
-struct RangeResponseGeneratorDataTaskData;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::RangeResponseGeneratorDataTaskData> : std::true_type { };
-}
-
-namespace WebCore {
-
-struct RangeResponseGeneratorDataTaskData : public CanMakeWeakPtr<RangeResponseGeneratorDataTaskData> {
+struct RangeResponseGeneratorDataTaskData final : public CanMakeWeakPtr<RangeResponseGeneratorDataTaskData>, public CanMakeThreadSafeCheckedPtr<RangeResponseGeneratorDataTaskData> {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(RangeResponseGeneratorDataTaskData);
+    WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(RangeResponseGeneratorDataTaskData);
     RangeResponseGeneratorDataTaskData(ParsedRequestRange&& range)
         : range(WTFMove(range))
         , nextByteToGiveBufferIndex(range.begin) { }
@@ -141,14 +134,15 @@ void RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived(WebCoreNSU
         return;
 
     auto buffer = data.buffer.get();
-    auto* taskData = data.taskData.get(task);
+    CheckedPtr taskData = data.taskData.get(task);
     if (!taskData)
         return;
 
-    auto giveBytesToTask = [task = retainPtr(task), buffer, bufferSize, taskData = WeakPtr { *taskData }, weakGenerator = ThreadSafeWeakPtr { *this }, targetQueue = m_targetDispatcher] {
+    auto giveBytesToTask = [task = retainPtr(task), buffer, bufferSize, weakTaskData = WeakPtr { *taskData }, weakGenerator = ThreadSafeWeakPtr { *this }, targetQueue = m_targetDispatcher] {
         assertIsCurrent(targetQueue);
         if ([task state] != NSURLSessionTaskStateRunning)
             return;
+        CheckedPtr taskData = weakTaskData.get();
         if (!taskData)
             return;
         auto& range = taskData->range;
@@ -178,7 +172,7 @@ void RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived(WebCoreNSU
     switch (taskData->responseState) {
     case RangeResponseGeneratorDataTaskData::ResponseState::NotSynthesizedYet: {
         auto response = synthesizedResponseForRange(data.originalResponse, range, expectedContentLength);
-        [task resource:nullptr receivedResponse:response completionHandler:[giveBytesToTask = WTFMove(giveBytesToTask), taskData = WeakPtr { taskData }, task = retainPtr(task)] (WebCore::ShouldContinuePolicyCheck shouldContinue) mutable {
+        [task resource:nullptr receivedResponse:response completionHandler:[giveBytesToTask = WTFMove(giveBytesToTask), taskData = WeakPtr { *taskData }, task = retainPtr(task)] (WebCore::ShouldContinuePolicyCheck shouldContinue) mutable {
             if (taskData)
                 taskData->responseState = RangeResponseGeneratorDataTaskData::ResponseState::SessionCalledCompletionHandler;
             if (shouldContinue == ShouldContinuePolicyCheck::Yes)

--- a/Source/WebCore/platform/network/mac/CookieStorageMac.mm
+++ b/Source/WebCore/platform/network/mac/CookieStorageMac.mm
@@ -33,12 +33,12 @@ namespace WebCore {
 
 void startObservingCookieChanges(NetworkStorageSession& storageSession, WTF::Function<void()>&& callback)
 {
-    storageSession.cookieStorageObserver().startObserving(WTFMove(callback));
+    storageSession.checkedCookieStorageObserver()->startObserving(WTFMove(callback));
 }
 
 void stopObservingCookieChanges(NetworkStorageSession& storageSession)
 {
-    storageSession.cookieStorageObserver().stopObserving();
+    storageSession.checkedCookieStorageObserver()->stopObserving();
 }
 
 }


### PR DESCRIPTION
#### 4eedff48cde7beca99a851c30472d795fd0807e7
<pre>
Drop IsDeprecatedWeakRefSmartPointerException use in platform/network/cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=300360">https://bugs.webkit.org/show_bug.cgi?id=300360</a>
<a href="https://rdar.apple.com/162176256">rdar://162176256</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.h:
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm:
(-[WebCookieObserverAdapter initWithObserver:]):
(-[WebCookieObserverAdapter cookiesChangedNotificationHandler:]):
(WebCore::CookieStorageObserver::cookiesDidChange):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::checkedCookieStorageObserver const):
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived):
(WebCore::RangeResponseGeneratorDataTaskData::RangeResponseGeneratorDataTaskData): Deleted.
* Source/WebCore/platform/network/mac/CookieStorageMac.mm:
(WebCore::startObservingCookieChanges):
(WebCore::stopObservingCookieChanges):

Canonical link: <a href="https://commits.webkit.org/301241@main">https://commits.webkit.org/301241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e80e3a71061de40fb14eff17f08d094140120133

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77192 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a737db5-11ff-413a-8b14-a6eb3e080f25) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95417 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9a947b1-8b5a-4432-9e04-5827219a6f5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36479 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75956 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8e04efc9-49dd-4ffa-a176-3161a7f37855) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30240 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75649 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134858 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52126 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103889 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52564 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103650 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26403 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49011 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49236 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52021 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57801 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51378 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54734 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53072 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->