### PR TITLE
Unable to remove all dynamic or session rules

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp
@@ -97,7 +97,7 @@ void WebExtensionSQLiteDatabase::reportErrorWithCode(int errorCode, sqlite3_stmt
         }
     }
 
-    reportErrorWithCode(errorCode, { }, outError);
+    reportErrorWithCode(errorCode, emptyString(), outError);
 }
 
 RefPtr<API::Error> WebExtensionSQLiteDatabase::errorWithSQLiteErrorCode(int errorCode)

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.h
@@ -95,6 +95,7 @@ private:
     RefPtr<WebExtensionSQLiteDatabase> m_database;
     const Ref<WorkQueue> m_queue;
     bool m_useInMemoryDatabase;
+    bool m_savepointsAreValid { true };
 };
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -596,11 +596,10 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveSessionRules)
         @"sessionRules = await browser.declarativeNetRequest.getSessionRules({ })",
         @"browser.test.assertEq(sessionRules.length, 3)",
 
-        // FIXME: rdar://162148560 (Unable to remove all dynamic or session rules)
-        @"await browser.declarativeNetRequest.updateSessionRules({ removeRuleIds: [1, 2] })",
+        @"await browser.declarativeNetRequest.updateSessionRules({ removeRuleIds: [1, 2, 3] })",
 
         @"sessionRules = await browser.declarativeNetRequest.getSessionRules({ })",
-        @"browser.test.assertEq(sessionRules.length, 1)",
+        @"browser.test.assertEq(sessionRules.length, 0)",
 
         @"browser.test.notifyPass()"
     ]);
@@ -756,11 +755,10 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveDynamicRules)
         @"dynamicRules = await browser.declarativeNetRequest.getDynamicRules({ })",
         @"browser.test.assertEq(dynamicRules.length, 3)",
 
-        // FIXME: rdar://162148560 (Unable to remove all dynamic or session rules)
-        @"await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds: [1, 2] })",
+        @"await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds: [1, 2, 3] })",
 
         @"dynamicRules = await browser.declarativeNetRequest.getDynamicRules({ })",
-        @"browser.test.assertEq(dynamicRules.length, 1)",
+        @"browser.test.assertEq(dynamicRules.length, 0)",
 
         @"browser.test.notifyPass()"
     ]);


### PR DESCRIPTION
#### fcde62dc8703e095470af862cc34e7a3d45f21b8
<pre>
Unable to remove all dynamic or session rules
<a href="https://bugs.webkit.org/show_bug.cgi?id=300415">https://bugs.webkit.org/show_bug.cgi?id=300415</a>
<a href="https://rdar.apple.com/162148560">rdar://162148560</a>
<a href="https://rdar.apple.com/162235623">rdar://162235623</a>

Reviewed by Timothy Hatcher and Brian Weinstein.

This patch fixes a couple of bugs:

First, and most simple, is that if there are any errors reported when executing a SQL command, we&apos;d
see infinite recursion leading to a crash. This was simply caused by the wrong method with a similar
signature being called recursively.

Second, all dynamic and session rules couldn&apos;t be removed because we&apos;d try to commit a savepoint
after deleting the database (which happens after all rules are removed). This led to the crash I
mentioned above. We should keep a bool set that indicates whether or not savepoints are valid, which
is set to false when the database is deleted and true when a new savepoint is created.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm

* Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp:
(WebExtensionSQLiteDatabase::reportErrorWithCode):
Remove the infinite recursion.

* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.cpp:
(WebKit::WebExtensionSQLiteStore::deleteDatabase):
(WebKit::WebExtensionSQLiteStore::createSavepoint):
(WebKit::WebExtensionSQLiteStore::commitSavepoint):
(WebKit::WebExtensionSQLiteStore::rollbackToSavepoint):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.h:
Add the savepoint validity checks.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveSessionRules)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveDynamicRules)):
Update tests that were reproducing both issues.

Canonical link: <a href="https://commits.webkit.org/301263@main">https://commits.webkit.org/301263@main</a>
</pre>
