### PR TITLE
didGeneratePageLoadTiming sometimes does not fire if a subresource request occurs around the time of a main frame navigation

### DIFF
--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -470,6 +470,13 @@ void WebFrameProxy::disconnect()
         parentFrame->m_childFrames.remove(*this);
 }
 
+bool WebFrameProxy::isConnected() const
+{
+    if (RefPtr parentFrame = m_parentFrame.get())
+        return parentFrame->m_childFrames.contains(*this);
+    return false;
+}
+
 void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID, String&& frameName, SandboxFlags effectiveSandboxFlags, ReferrerPolicy effectiveReferrerPolicy, WebCore::ScrollbarMode scrollingMode)
 {
     // The DecidePolicyForNavigationActionSync IPC is synchronous and may therefore get processed before the DidCreateSubframe one.

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -195,6 +195,7 @@ public:
     void transferNavigationCallbackToFrame(WebFrameProxy&);
     void setNavigationCallback(CompletionHandler<void(std::optional<WebCore::PageIdentifier>, std::optional<WebCore::FrameIdentifier>)>&&);
 
+    bool isConnected() const;
     void disconnect();
     void didCreateSubframe(WebCore::FrameIdentifier, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
     ProcessID processID() const;


### PR DESCRIPTION
#### fe0a3853f26cdab89db9785c4409334207de4667
<pre>
didGeneratePageLoadTiming sometimes does not fire if a subresource request occurs around the time of a main frame navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=300416">https://bugs.webkit.org/show_bug.cgi?id=300416</a>
<a href="https://rdar.apple.com/162239496">rdar://162239496</a>

Reviewed by Alex Christensen and Ryosuke Niwa.

PLT depends on didGeneratePageLoadTiming being fired reliably. It isn&apos;t firing reliably on some
devices right now especially when there is a subresource request made at around the time of a main
frame navigation.

After add a bunch of logging, it looks like the issue is this. Suppose there is a webpage containing
a main frame MF and an OOP iframe IF. MF is hosted in process A and IF is hosted in process B.

1. We commit a main frame load in A. This causes a DidDestroyFrame(IF) message to be sent from
   process A to UIProcess.
2. The UIProcess handles the DidDestroyFrame(IF) message, which also clears
   `m_framesWithSubresourceLoadingForPageLoadTiming` for IF.
3. In B, we start a subresource load in IF and send the StartNetworkRequestsForPageLoadTiming(IF)
   IPC to UIProcess.
4. The UIProcess handles the StartNetworkRequestsForPageLoadTiming(IF) IPC and inserts IF in to
   `m_framesWithSubresourceLoadingForPageLoadTiming` map, indicating IF has outstanding requests.
5. Process B handles `FrameWasRemovedInAnotherProcess`, which eventually causes the local IF to be
   invalidated. But B never sends a DidDestroyFrame for IF to UIProcess since it was already
   destroyed in another process (see the `wasRemovedInAnotherProcess` check in `removeWebFrame`).
6. Now the UIProcess has a `m_framesWithSubresourceLoadingForPageLoadTiming` map containing a frame
   ID that is never be removed (i.e. it thinks that frame contains a pending network request
   forever), so it never calls didGeneratePageLoadTiming.

To fix this, have the UIProcess `StartNetworkRequestsForPageLoadTiming` ignore any requests
corresponding to disconnected frames.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::isConnected const):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::startNetworkRequestsForPageLoadTiming):
(WebKit::WebPageProxy::endNetworkRequestsForPageLoadTiming):
(WebKit::WebPageProxy::didCommitLoadForFrame):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, GeneratesPageLoadTimingAfterOnUnloadFetch)):

Canonical link: <a href="https://commits.webkit.org/301253@main">https://commits.webkit.org/301253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cf1f08b8c3226de3d3ecf153fffc3beeb6da1d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132204 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77221 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f27fc01b-d085-404a-9d72-4844a9914c0f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95440 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5dc1537-6e08-4b31-88de-67c705c017d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75980 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e7cbe2e-5e85-4f37-b9cb-61c4805b37af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30269 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75681 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134889 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103914 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103673 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26410 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49041 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27333 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49274 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52052 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57831 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51409 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54765 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53103 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->