### PR TITLE
[CSS Zoom] Fix zoom factor for word-spacing (296165)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7539,7 +7539,6 @@ imported/w3c/web-platform-tests/css/css-viewport/zoom/relative-units-from-parent
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-indent.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-shadow.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-stroke-width.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-viewport/zoom/word-spacing.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/border.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/bottom.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/length-implicit-and-explicit-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/length-implicit-and-explicit-inheritance-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL width: inherit from 100px assert_equals: expected "100px" but got "50px"
 FAIL height: inherit from 100px assert_equals: expected "100px" but got "50px"
-FAIL word-spacing: inherit from 100px assert_equals: expected "100px" but got "50px"
-FAIL word-spacing: unset from 100px assert_equals: expected "100px" but got "50px"
-FAIL word-spacing:  from 100px assert_equals: expected "100px" but got "50px"
+PASS word-spacing: inherit from 100px
+PASS word-spacing: unset from 100px
+PASS word-spacing:  from 100px
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/word-spacing-inherited-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/word-spacing-inherited-computed-expected.txt
@@ -1,0 +1,8 @@
+unzoomed lorem ipsum
+zoomed lorem ipsum
+zoomed inherited lorem ipsum
+
+PASS computed inherited word-spacing
+PASS computed zoomed word-spacing
+PASS computed zoomed inherited word-spacing
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/word-spacing-inherited-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/word-spacing-inherited-computed.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<!-- Based on css/css-viewport/zoom/word-spacing.html by Stefan Zager -->
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<style>
+.spacing {
+  word-spacing: 2rem;
+}
+.zoom {
+  zoom: 2;
+}
+</style>
+
+<div class="spacing">
+  <div id="inherited-word-spacing">unzoomed lorem ipsum</div>
+</div>
+
+<div class="zoom">
+  <div id="zoomed-word-spacing" class="spacing">zoomed lorem ipsum</div>
+</div>
+
+<div class="spacing">
+  <div id="zoomed-inherited-word-spacing" class="zoom">zoomed inherited lorem ipsum</div>
+</div>
+
+<script>
+test(() => {
+    assert_equals(getComputedStyle(document.getElementById("inherited-word-spacing")).wordSpacing, '32px');
+}, "computed inherited word-spacing");
+test(() => {
+    assert_equals(getComputedStyle(document.getElementById("zoomed-word-spacing")).wordSpacing, '32px');
+}, "computed zoomed word-spacing");
+test(() => {
+    assert_equals(getComputedStyle(document.getElementById("zoomed-inherited-word-spacing")).wordSpacing, '32px');
+}, "computed zoomed inherited word-spacing");
+</script>

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -245,7 +245,7 @@ void BuilderState::updateFontForSizeChange()
     auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
     auto fontSize = fontCascade.size();
 
-    auto newWordSpacing = evaluate<float>(m_style.computedWordSpacing(), fontSize, ZoomNeeded { });
+    auto newWordSpacing = evaluate<float>(m_style.computedWordSpacing(), fontSize, m_style.usedZoomForLength());
     auto newLetterSpacing = evaluate<float>(m_style.computedLetterSpacing(), fontSize, m_style.usedZoomForLength());
 
     if (newWordSpacing != fontCascade.wordSpacing())

--- a/Source/WebCore/style/values/text/StyleWordSpacing.cpp
+++ b/Source/WebCore/style/values/text/StyleWordSpacing.cpp
@@ -39,7 +39,8 @@ auto CSSValueConversion<WordSpacing>::operator()(BuilderState& state, const CSSV
         auto zoomWithTextZoomFactor = [](BuilderState& state) -> float {
             if (RefPtr frame = state.document().frame()) {
                 float textZoomFactor = state.style().textZoom() != TextZoom::Reset ? frame->textZoomFactor() : 1.0f;
-                return state.style().usedZoom() * textZoomFactor;
+                auto usedZoom = shouldUseEvaluationTimeZoom(state) ? 1.0f : state.style().usedZoom();
+                return usedZoom * textZoomFactor;
             }
             return state.cssToLengthConversionData().zoom();
         };

--- a/Source/WebCore/style/values/text/StyleWordSpacing.h
+++ b/Source/WebCore/style/values/text/StyleWordSpacing.h
@@ -33,7 +33,7 @@ namespace Style {
 // <'word-spacing'> = normal | <length-percentage>
 // NOTE: Computed value resolves `normal` to 0px.
 // https://drafts.csswg.org/css-text-4/#propdef-word-spacing
-struct WordSpacing : LengthWrapperBase<LengthPercentage<>> {
+struct WordSpacing : LengthWrapperBase<LengthPercentage<CSS::AllUnzoomed>> {
     using Base::Base;
 
     WordSpacing(CSS::Keyword::Normal)


### PR DESCRIPTION
#### 17fd36ea6586754534db9e63058907956e254efa
<pre>
[CSS Zoom] Fix zoom factor for word-spacing (296165)
<a href="https://bugs.webkit.org/show_bug.cgi?id=296165">https://bugs.webkit.org/show_bug.cgi?id=296165</a>
<a href="https://rdar.apple.com/156118978">rdar://156118978</a>

Reviewed by Tim Nguyen.

We want to store the unzoomed word-spacing value at RenderStyle
and the zoomeed value at FontCascade.

Test: imported/w3c/web-platform-tests/css/css-viewport/zoom/word-spacing-inherited-computed.html
* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/length-implicit-and-explicit-inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/word-spacing-inherited-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/word-spacing-inherited-computed.html: Added.
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::updateFontForSizeChange):
* Source/WebCore/style/values/text/StyleWordSpacing.cpp:
(WebCore::Style::CSSValueConversion&lt;WordSpacing&gt;::operator):
* Source/WebCore/style/values/text/StyleWordSpacing.h:

Canonical link: <a href="https://commits.webkit.org/301284@main">https://commits.webkit.org/301284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f6e646daa693f9b44c1b72b7460a8fb58dd4057

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125474 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132334 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77364 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf6e88e9-46d6-4e9e-b221-729e4e751de0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95553 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/adf96a38-6e2b-4b03-9882-392cd3d3466e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112209 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76077 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d423031-97ab-4033-aa6c-08fa1d4da011) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35518 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30388 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75808 "Built successfully") | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106390 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; Running re-run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135011 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104033 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108425 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26425 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49135 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49436 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52173 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57958 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51524 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54880 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53219 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->