### PR TITLE
[JSC] Dedupe LLInt configs in offset extractor

### DIFF
--- a/Source/JavaScriptCore/offlineasm/offsets.rb
+++ b/Source/JavaScriptCore/offlineasm/offsets.rb
@@ -250,7 +250,7 @@ def configurationIndicesForVariants(file, variants)
         end
         results << configurationIndices(file + suffix)
     }
-    return results.flatten(1)
+    return results.flatten(1).uniq
 end
 
 #


### PR DESCRIPTION
#### 164134c366a6abe2b8e39eb975d3710965ca1261
<pre>
[JSC] Dedupe LLInt configs in offset extractor

<a href="https://bugs.webkit.org/show_bug.cgi?id=300422">https://bugs.webkit.org/show_bug.cgi?id=300422</a>
<a href="https://rdar.apple.com/161923920">rdar://161923920</a>

Reviewed by Yusuke Suzuki and Justin Michaud.

This PR makes the LLInt offset extractor more robust against duplicated
configs.

There are no tests for this as it&apos;s a build step.

Canonical link: <a href="https://commits.webkit.org/301261@main">https://commits.webkit.org/301261@main</a>
</pre>
