### PR TITLE
[Temporal] Implement toString, toJSON, and toLocaleString for PlainMonthDay

### DIFF
--- a/JSTests/stress/temporal-plainmonthday.js
+++ b/JSTests/stress/temporal-plainmonthday.js
@@ -37,3 +37,10 @@ const monthDay = new Temporal.PlainMonthDay(4, 29);
     shouldThrow(() => new Temporal.PlainMonthDay(20, 1), RangeError);
     shouldThrow(() => new Temporal.PlainMonthDay(1, 40), RangeError);
 }
+
+{
+    shouldBe(monthDay.toString(), '04-29');
+    shouldBe(monthDay.toJSON(), monthDay.toString());
+    shouldBe(monthDay.toLocaleString(), monthDay.toString());
+}
+

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -159,7 +159,6 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/name.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/not-a-constructor.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/prop-desc.js
-    - test/built-ins/Temporal/PlainMonthDay/basic.js
     - test/built-ins/Temporal/PlainMonthDay/calendar-always.js
     - test/built-ins/Temporal/PlainMonthDay/from/argument-plainmonthday.js
     - test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-invalid-iso-string.js
@@ -224,15 +223,6 @@ skip:
     - test/built-ins/Temporal/PlainMonthDay/prototype/equals/not-a-constructor.js
     - test/built-ins/Temporal/PlainMonthDay/prototype/equals/prop-desc.js
     - test/built-ins/Temporal/PlainMonthDay/prototype/equals/year-zero.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/basic.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/branding.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/builtin.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/length.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/name.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/not-a-constructor.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/prop-desc.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toLocaleString/branding.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toLocaleString/prop-desc.js
     - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/basic.js
     - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/branding.js
     - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/builtin.js
@@ -243,13 +233,6 @@ skip:
     - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/name.js
     - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/not-a-constructor.js
     - test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/prop-desc.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/branding.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/calendarname-always.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/calendarname-invalid-string.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/calendarname-undefined.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/options-object.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/options-wrong-type.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/toString/prop-desc.js
     - test/built-ins/Temporal/PlainMonthDay/prototype/valueOf/basic.js
     - test/built-ins/Temporal/PlainMonthDay/prototype/valueOf/branding.js
     - test/built-ins/Temporal/PlainMonthDay/prototype/valueOf/prop-desc.js
@@ -271,8 +254,6 @@ skip:
     - test/built-ins/Temporal/PlainMonthDay/prototype/with/overflow-wrong-type.js
     - test/built-ins/Temporal/PlainMonthDay/prototype/with/prop-desc.js
     - test/built-ins/Temporal/PlainMonthDay/prototype/with/subclassing-ignored.js
-    - test/built-ins/Temporal/PlainMonthDay/subclass.js
-    - test/intl402/DateTimeFormat/prototype/format/temporal-plainmonthday-formatting-datetime-style.js
 
     # Depends on Temporal.PlainYearMonth
     - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/basic.js
@@ -1094,3 +1075,4 @@ skip:
     - test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-resolved-time-zone.js
     - test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-resolved-time-zone.js
     - test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-resolved-time-zone.js
+    - test/intl402/DateTimeFormat/prototype/format/temporal-plainmonthday-formatting-datetime-style.js

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -87,6 +87,7 @@
     macro(bytecodes) \
     macro(bytecodesID) \
     macro(calendar) \
+    macro(calendarName) \
     macro(callee) \
     macro(caller) \
     macro(captureStackTrace) \

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -373,6 +373,7 @@ String formatTimeZoneOffsetString(int64_t);
 String temporalTimeToString(PlainTime, std::tuple<Precision, unsigned>);
 String temporalDateToString(PlainDate);
 String temporalDateTimeToString(PlainDate, PlainTime, std::tuple<Precision, unsigned>);
+String temporalMonthDayToString(PlainMonthDay, StringView);
 String monthCode(uint32_t);
 uint8_t monthFromCode(StringView);
 

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -730,6 +730,13 @@ TemporalOverflow toTemporalOverflow(JSGlobalObject* globalObject, JSValue val)
     RELEASE_AND_RETURN(scope, toTemporalOverflow(globalObject, options));
 }
 
+String toTemporalCalendarName(JSGlobalObject* globalObject, JSObject* options)
+{
+    return intlOption<String>(globalObject, options, globalObject->vm().propertyNames->calendarName,
+        { { ""_s, ""_s }, { "always"_s, "always"_s } },
+        "calendarName must be empty or \"always\""_s, ""_s);
+}
+
 // https://tc39.es/proposal-temporal/#sec-temporal-rejectobjectwithcalendarortimezone
 void rejectObjectWithCalendarOrTimeZone(JSGlobalObject* globalObject, JSObject* object)
 {

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -221,6 +221,7 @@ enum class TemporalOverflow : bool {
 
 TemporalOverflow toTemporalOverflow(JSGlobalObject*, JSObject*);
 TemporalOverflow toTemporalOverflow(JSGlobalObject*, JSValue);
+String toTemporalCalendarName(JSGlobalObject*, JSObject*);
 
 enum class TemporalDisambiguation : uint8_t {
     Compatible,

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
@@ -101,6 +101,23 @@ TemporalPlainMonthDay* TemporalPlainMonthDay::tryCreateIfValid(JSGlobalObject* g
     return TemporalPlainMonthDay::create(vm, structure, ISO8601::PlainMonthDay(WTFMove(plainDate)));
 }
 
+String TemporalPlainMonthDay::toString(JSGlobalObject* globalObject, JSValue optionsValue) const
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* options = intlGetOptionsObject(globalObject, optionsValue);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (!options)
+        return toString();
+
+    String calendarName = toTemporalCalendarName(globalObject, options);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    return ISO8601::temporalMonthDayToString(m_plainMonthDay, calendarName);
+}
+
 String TemporalPlainMonthDay::monthCode() const
 {
     return ISO8601::monthCode(m_plainMonthDay.month());

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
@@ -60,6 +60,12 @@ public:
 
     String monthCode() const;
 
+    String toString(JSGlobalObject*, JSValue options) const;
+    String toString() const
+    {
+        return ISO8601::temporalMonthDayToString(m_plainMonthDay, ""_s);
+    }
+
     DECLARE_VISIT_CHILDREN;
 
 private:

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -37,6 +37,9 @@
 
 namespace JSC {
 
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToString);
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToJSON);
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToLocaleString);
 static JSC_DECLARE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterCalendarId);
 static JSC_DECLARE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterDay);
 static JSC_DECLARE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterMonthCode);
@@ -51,6 +54,9 @@ const ClassInfo TemporalPlainMonthDayPrototype::s_info = { "Temporal.PlainMonthD
 
 /* Source for TemporalPlainMonthDayPrototype.lut.h
 @begin plainMonthDayPrototypeTable
+  toString         temporalPlainMonthDayPrototypeFuncToString           DontEnum|Function 0
+  toJSON           temporalPlainMonthDayPrototypeFuncToJSON             DontEnum|Function 0
+  toLocaleString   temporalPlainMonthDayPrototypeFuncToLocaleString     DontEnum|Function 0
   calendarId       temporalPlainMonthDayPrototypeGetterCalendarId       DontEnum|ReadOnly|CustomAccessor
   day              temporalPlainMonthDayPrototypeGetterDay              DontEnum|ReadOnly|CustomAccessor
   monthCode        temporalPlainMonthDayPrototypeGetterMonthCode        DontEnum|ReadOnly|CustomAccessor
@@ -79,6 +85,45 @@ void TemporalPlainMonthDayPrototype::finishCreation(VM& vm, JSGlobalObject*)
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tostring
+JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToString, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(callFrame->thisValue());
+    if (!monthDay)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toString called on value that's not a PlainMonthDay"_s);
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, monthDay->toString(globalObject, callFrame->argument(0)))));
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tojson
+JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToJSON, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(callFrame->thisValue());
+    if (!monthDay)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toJSON called on value that's not a PlainMonthDay"_s);
+
+    return JSValue::encode(jsString(vm, monthDay->toString()));
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tolocalestring
+JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToLocaleString, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(callFrame->thisValue());
+    if (!monthDay)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toLocaleString called on value that's not a PlainMonthDay"_s);
+
+    return JSValue::encode(jsString(vm, monthDay->toString()));
 }
 
 // https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.calendarid


### PR DESCRIPTION
#### 0675fe14f2e29674c71a7c7344dab235ae8a7333
<pre>
[Temporal] Implement toString, toJSON, and toLocaleString for PlainMonthDay
<a href="https://bugs.webkit.org/show_bug.cgi?id=300423">https://bugs.webkit.org/show_bug.cgi?id=300423</a>

Reviewed by Yusuke Suzuki.

Implement these methods.

* JSTests/stress/temporal-plainmonthday.js:
(shouldThrow):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::temporalDateToString):
(JSC::ISO8601::temporalMonthDayToString):
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/TemporalObject.cpp:
(JSC::toTemporalCalendarName):
* Source/JavaScriptCore/runtime/TemporalObject.h:
* Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp:
(JSC::TemporalPlainMonthDay::toString const):
* Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h:
* Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/301375@main">https://commits.webkit.org/301375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51b9ef8ee72b919a61d35f571aa5bd65a5be1d0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132482 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77505 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53846 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95698 "11 flakes 15 failures") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63826 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Exiting early after 60 failures. 5210 tests run. 60 failures; Uploaded test results; Exiting early after 60 failures. 5440 tests run. 60 failures; Compiled WebKit; layout-tests (exception)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76193 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35647 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30519 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75955 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117708 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106525 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135162 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124131 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104172 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103901 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49257 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27564 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/49637 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19687 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58112 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157148 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51661 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39327 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53357 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->