### PR TITLE
REGRESSION: Crash in Navigation::initializeForNewWindow

### DIFF
--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -158,10 +158,13 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
             else {
                 auto previousEntry = m_entries[*previousNavigation->m_currentEntryIndex];
 
-                if (navigationType == NavigationNavigationType::Replace)
+                if (navigationType == NavigationNavigationType::Replace) {
                     m_entries[*previousNavigation->m_currentEntryIndex] = NavigationHistoryEntry::create(*this, *currentItem);
-
-                m_currentEntryIndex = getEntryIndexOfHistoryItem(m_entries, *currentItem);
+                    m_currentEntryIndex = *previousNavigation->m_currentEntryIndex;
+                } else if (navigationType == NavigationNavigationType::Reload)
+                    m_currentEntryIndex = *previousNavigation->m_currentEntryIndex;
+                else
+                    m_currentEntryIndex = getEntryIndexOfHistoryItem(m_entries, *currentItem);
 
                 ASSERT(navigationType);
                 m_activation = NavigationActivation::create(*navigationType, *currentEntry(), WTFMove(previousEntry));


### PR DESCRIPTION
#### 9f97b4cd4bdda34f0dc88778cda69a0bb3e6c31f
<pre>
REGRESSION: Crash in Navigation::initializeForNewWindow
<a href="https://bugs.webkit.org/show_bug.cgi?id=300402">https://bugs.webkit.org/show_bug.cgi?id=300402</a>

Reviewed by NOBODY (OOPS!).

As it is now, &apos;initializeForNewWindow&apos; doesn&apos;t distinguish the cases where
&apos;navigationType&apos; is &apos;Reload&apos; or empty.

When &apos;navigationType&apos; equals &apos;Replace&apos; or &apos;Reload&apos;, then set
&apos;m_currentEntryIndex&apos; to &apos;previousNavigation-&gt;m_currentEntryIndex&apos;
(re-use entry index). On the other hand, leave the current default case
(search entry index in history) for the case where &apos;navigationType&apos; is empty.

* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f97b4cd4bdda34f0dc88778cda69a0bb3e6c31f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95455 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63382 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75994 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30287 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75699 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134907 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52174 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39951 "Found 1 new test failure: fast/webgpu/type-checker-array-without-argument.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103929 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103688 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49056 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27350 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49294 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52070 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57849 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51426 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54782 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53120 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->