### PR TITLE
[iOS 26] Camera capture orientation is not correct on SafariViewService

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebKit/Configurations/AllowedSPI-legacy.toml
@@ -175,7 +175,6 @@ selectors = [
     { name = "_adoptEffectiveConfiguration:", class = "?" },
     { name = "_allowsHSTSWithUntrustedRootCertificate", class = "?" },
     { name = "_alternativeServicesStorage", class = "?" },
-    { name = "_appAdoptsUISceneLifecycle", class = "?" },
     { name = "_backlightLevel", class = "?" },
     { name = "_beginPinningInputViews", class = "?" },
     { name = "_cancelAllTouches", class = "?" },

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -253,7 +253,6 @@ WTF_EXTERN_C_END
 - (void)_cancelAllTouches;
 - (BOOL)isSuspendedUnderLock;
 - (void)_enqueueHIDEvent:(IOHIDEventRef)event;
-- (BOOL)_appAdoptsUISceneLifecycle;
 - (void)_registerBSActionHandler:(id<_UIApplicationBSActionHandler>)handler;
 @end
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -354,15 +354,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (WebCore::IntDegrees)_deviceOrientationIgnoringOverrides
 {
-    auto orientation = UIInterfaceOrientationUnknown;
-    auto application = UIApplication.sharedApplication;
+    return deviceOrientationForUIInterfaceOrientation([&] {
+        if (auto windowScene = self.window.windowScene)
+            return windowScene.effectiveGeometry.interfaceOrientation;
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (!application._appAdoptsUISceneLifecycle)
-        orientation = application.statusBarOrientation;
+        return UIApplication.sharedApplication.statusBarOrientation;
 ALLOW_DEPRECATED_DECLARATIONS_END
-    else if (auto windowScene = self.window.windowScene)
-        orientation = windowScene.effectiveGeometry.interfaceOrientation;
-    return deviceOrientationForUIInterfaceOrientation(orientation);
+    }());
 }
 
 - (void)_dynamicUserInterfaceTraitDidChange


### PR DESCRIPTION
#### 3c51043d4a3956629cd5dddfc3a52847564786ac
<pre>
[iOS 26] Camera capture orientation is not correct on SafariViewService
<a href="https://rdar.apple.com/160105158">rdar://160105158</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300428">https://bugs.webkit.org/show_bug.cgi?id=300428</a>

Reviewed by Wenson Hsieh.

On iOS 26, UIApplication.sharedApplication.statusBarOrientation seems to always return the portrait orientation on SVC.
windowScene.effectiveGeometry.interfaceOrientation on the other end provides the correct value.
We switch the order to use windowScene.effectiveGeometry.interfaceOrientation if there is a scene and UIApplication.sharedApplication.statusBarOrientation otherwise.
We also remove one UIKit SPI as part of this change.

Manually tested on Mobile Safari, SVC and WKWebView.

Canonical link: <a href="https://commits.webkit.org/301262@main">https://commits.webkit.org/301262@main</a>
</pre>
