### PR TITLE
[GTK][WPE] Integrate MALLOC_HEAP_BREAKDOWN with sysprof

### DIFF
--- a/Source/WTF/wtf/MallocHeapBreakdown.cmake
+++ b/Source/WTF/wtf/MallocHeapBreakdown.cmake
@@ -11,3 +11,14 @@ target_include_directories(MallocHeapBreakdown
     PUBLIC
     malloc_heap_breakdown
 )
+
+if (USE_SYSPROF_CAPTURE)
+  target_link_libraries(MallocHeapBreakdown
+    PRIVATE
+    SysProfCapture::SysProfCapture
+  )
+  target_compile_definitions(MallocHeapBreakdown
+    PRIVATE
+    USE_SYSPROF_CAPTURE
+  )
+endif ()

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -269,6 +269,12 @@ public:
         } else {
             unsigned newId = sysprof_collector_request_counters(1);
 
+            // Temporary workaround for libsysprof-capture providing conflicting IDs to threads.
+            static unsigned maxId = 0;
+            if (newId <= maxId)
+                newId = sysprof_collector_request_counters(maxId - newId + 1) + maxId - newId;
+            maxId = newId;
+
             m_counters.add(static_cast<const void*>(name.data()), newId);
 
             SysprofCaptureCounter counter = { };

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -241,6 +241,7 @@ _PATH_RULES_SPECIFIER = [
      ["-readability/naming/underscores",
       "-safercpp/atoi",
       "-safercpp/printf",
+      "-security/printf",
       "-runtime/lock_guard",
       "-runtime/wtf_make_unique",
       "-runtime/wtf_move"]),


### PR DESCRIPTION
#### acd6dfd044d0135e6f8d9ade11e4140c852b6f31
<pre>
[GTK][WPE] Integrate MALLOC_HEAP_BREAKDOWN with sysprof
<a href="https://bugs.webkit.org/show_bug.cgi?id=300430">https://bugs.webkit.org/show_bug.cgi?id=300430</a>

Reviewed by Adrian Perez de Castro.

This change integrates MALLOC_HEAP_BREAKDOWN feature with sysprof on
GTK and WPE ports.

With this change, when the sysprof is actively used to profile WebKit,
the heap usage breakdown is reported to sysprof using sysprof counters
instead of printing to stdout.

Other than providing the integration itself, this change also
introduces a couple workarounds for the libsysprof-capture library
bug that results in generating colliding counter IDs across threads.

Canonical link: <a href="https://commits.webkit.org/301702@main">https://commits.webkit.org/301702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38e5a5cf4f56c5a15ee81bc8b97283f07a1acfd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133766 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54995 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113439 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/77022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/126169 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77160 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118861 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107503 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136346 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125282 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41175 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109798 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50220 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50954 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19835 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53420 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59222 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158321 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52676 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39607 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56010 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->