### PR TITLE
[webkitpy] fuzzy meta tags in xml documents not parsed when tag is html:meta

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-012.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-012.svg
@@ -11,7 +11,7 @@
     <html:link rel="help"
           href="https://www.w3.org/TR/SVG2/painting.html#Markers"/>
     <html:link rel="match"  href="marker-path-012-ref.svg" />
-    <html:meta name="fuzzy" content="0-7;0-14" />
+    <html:meta name="fuzzy" content="0-7;0-17" />
   </g>
 
   <defs>

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
@@ -526,7 +526,7 @@ class SingleTestRunner(object):
 
     def _fuzzy_metadata_for_file(self, filename):
         test_doc = Parser(self._filesystem.read_binary_file(filename))
-        fuzzy_nodes = test_doc.findAll('meta', attrs={"name": "fuzzy"})
+        fuzzy_nodes = test_doc.findAll(['meta', 'html:meta'], attrs={"name": "fuzzy"})
         if not fuzzy_nodes:
             return None
 

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner_unittest.py
@@ -90,6 +90,15 @@ class SingleTestRunnerTest(unittest.TestCase):
         fuzzy_data = single_test_runner._fuzzy_tolerance_for_reference('/test.checkout/LayoutTests/fast/resources/common-ref.html')
         self.assertEqual(fuzzy_data, {'max_difference': [5, 8], 'total_pixels': [78, 84]})
 
+    def test_fuzzy_matching_values_for_xml_document(self):
+        test_name = 'fuzzy-test.svg'
+        single_test_runner = self._make_test_runner(test_name)
+        self._add_file(single_test_runner._port, test_name, """<svg width="340" height="140" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+            <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-2"/>
+        """)
+        fuzzy_data = single_test_runner._fuzzy_tolerance_for_reference('/test.checkout/LayoutTests/fuzzy-test-expected.svg')
+        self.assertEqual(fuzzy_data, {'max_difference': [0, 1], 'total_pixels': [0, 2]})
+
     def test_fuzzy_matching_values_no_common_data(self):
         test_name = 'fast/borders/fuzzy-test.html'
         single_test_runner = self._make_test_runner(test_name)


### PR DESCRIPTION
#### 590faa37cb98ac8b87d62b37f285338b84ceb006
<pre>
[webkitpy] fuzzy meta tags in xml documents not parsed when tag is html:meta
<a href="https://bugs.webkit.org/show_bug.cgi?id=300436">https://bugs.webkit.org/show_bug.cgi?id=300436</a>

Reviewed by Fujii Hironori.

There are some SVG tests where the fuzzy meta is in a html:meta tag,
which is not parsed by the test runner. This is because the parser only
searches for meta tags, not html:meta.

* LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-012.svg:
* Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py:
(SingleTestRunner._fuzzy_metadata_for_file):
* Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner_unittest.py:
(SingleTestRunnerTest):

Canonical link: <a href="https://commits.webkit.org/301348@main">https://commits.webkit.org/301348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c061923e1cdc643ce5fc2133962c0959cadc3370

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132405 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77436 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95615 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63513 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76130 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124898 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30453 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75878 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135079 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104092 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103828 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26472 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49189 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27503 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49539 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52238 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53287 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->