### PR TITLE
Update WTF/JSC safer C++ expectations for iOS

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -29,8 +29,8 @@ dfg/DFGByteCodeParser.cpp
 dfg/DFGConstantFoldingPhase.cpp
 dfg/DFGOSRExitCompilerCommon.cpp
 dfg/DFGOperations.cpp
-disassembler/ARM64/A64DOpcode.cpp
-disassembler/ARM64/A64DOpcode.h
+[ Mac ] disassembler/ARM64/A64DOpcode.cpp
+[ Mac ] disassembler/ARM64/A64DOpcode.h
 ftl/FTLState.cpp
 heap/ConservativeRoots.cpp
 heap/Heap.cpp
@@ -86,6 +86,7 @@ runtime/IntlSegmenter.h
 runtime/IntlSegments.h
 runtime/JSArrayBufferView.cpp
 runtime/JSCJSValueInlines.h
+[ iOS ] runtime/JSCell.cpp
 runtime/JSCell.h
 runtime/JSCustomGetterFunction.cpp
 runtime/JSCustomSetterFunction.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -10,7 +10,7 @@ API/JSTypedArray.cpp
 API/JSWrapperMap.mm
 API/tests/CompareAndSwapTest.cpp
 API/tests/testapi.cpp
-assembler/LinkBuffer.cpp
+[ Mac ] assembler/LinkBuffer.cpp
 b3/B3PatchpointSpecial.cpp
 b3/B3Procedure.cpp
 b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -87,6 +87,7 @@ inspector/agents/JSGlobalObjectRuntimeAgent.cpp
 jit/BaselineJITPlan.cpp
 jit/ExecutableAllocator.cpp
 jit/GCAwareJITStubRoutine.cpp
+[ iOS ] jit/GdbJIT.cpp
 jit/ICStats.cpp
 jit/ICStats.h
 jit/JIT.cpp
@@ -179,6 +180,7 @@ wasm/WasmTypeDefinition.cpp
 wasm/WasmTypeDefinition.h
 wasm/WasmTypeDefinitionInlines.h
 wasm/WasmWorklist.cpp
+[ iOS ] wasm/debugger/WasmModuleDebugInfo.cpp
 wasm/js/JSWebAssembly.cpp
 wasm/js/JSWebAssemblyHelpers.h
 wasm/js/JSWebAssemblyInstance.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -4,3 +4,4 @@ API/JSVirtualMachine.mm
 API/JSWrapperMap.mm
 API/tests/Regress141275.mm
 runtime/JSDateMath.cpp
+[ iOS ] runtime/ObjectPrototype.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -5,3 +5,4 @@ API/JSWrapperMap.mm
 API/ObjCCallbackFunction.mm
 API/ObjcRuntimeExtras.h
 API/tests/testapi.c
+[ iOS ] runtime/ObjectPrototype.cpp

--- a/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,4 +1,5 @@
 wtf/AutomaticThread.cpp
+[ iOS ] wtf/MainThread.cpp
 wtf/MemoryPressureHandler.cpp
 wtf/text/AtomStringImpl.cpp
 wtf/text/CString.cpp

--- a/Source/WTF/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -2,4 +2,4 @@ usr/local/include/wtf/text/cf/StringConcatenateCF.h
 wtf/RetainPtr.h
 wtf/SchedulePair.h
 wtf/cf/RunLoopCF.cpp
-wtf/unicode/icu/CollatorICU.cpp
+[ Mac ] wtf/unicode/icu/CollatorICU.cpp

--- a/Tools/Scripts/compare-static-analysis-results
+++ b/Tools/Scripts/compare-static-analysis-results
@@ -119,7 +119,7 @@ def find_diff(args, expectation_file_path, results_file_path):
                 print(f'Unexpected line: {line}')
                 continue
             platform = match.group('platform')
-            if platform and arg.platform.lower() != platform.lower():
+            if platform and args.platform.lower() != platform.lower():
                 continue
             baseline_list.append(match.group('path'))
         new_file_list = new_file.read().splitlines()


### PR DESCRIPTION
#### 53cb0fa6696fdbe5ebd374a02dfa2c3b08dea612
<pre>
Update WTF/JSC safer C++ expectations for iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=300437">https://bugs.webkit.org/show_bug.cgi?id=300437</a>

Reviewed by Geoffrey Garen.

Update WTF and JavaScriptCore safer C++ expectations for iOS by adding platform modifiers.
e.g. [ Mac ] and [ iOS ]

* Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Tools/Scripts/compare-static-analysis-results:
(find_diff):

Canonical link: <a href="https://commits.webkit.org/301266@main">https://commits.webkit.org/301266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d01a84728c0175e57a3813ad0d67f4f333da907c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132236 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77265 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f97de19-3539-4c00-8df5-58108de1a39f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95467 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63403 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fed0d5bd-d04f-4e2d-8cdb-fcabcc21a198) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76006 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/94d5b841-f516-49ba-9432-1188f6b02d31) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30308 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75713 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117477 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134921 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123905 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103941 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103700 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49067 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27368 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49322 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19639 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52085 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57864 "") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156924 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51441 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39289 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54797 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53135 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->