### PR TITLE
Reduce calls to VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9) in GPUProcess

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/AV1UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/AV1UtilitiesCocoa.h
@@ -36,6 +36,7 @@ struct MediaCapabilitiesInfo;
 
 std::optional<MediaCapabilitiesInfo> validateAV1Parameters(const AV1CodecConfigurationRecord&, const VideoConfiguration&);
 WEBCORE_EXPORT bool av1HardwareDecoderAvailable();
+WEBCORE_EXPORT void setAV1HardwareDecoderAvailable(bool);
 
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/AV1UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/AV1UtilitiesCocoa.mm
@@ -172,12 +172,23 @@ std::optional<MediaCapabilitiesInfo> validateAV1Parameters(const AV1CodecConfigu
     return info;
 }
 
+static std::optional<bool> s_av1HardwareDecoderAvailable = { };
+void setAV1HardwareDecoderAvailable(bool value)
+{
+    ASSERT(isMainThread());
+
+    ASSERT(!s_av1HardwareDecoderAvailable || *s_av1HardwareDecoderAvailable == value);
+    s_av1HardwareDecoderAvailable = value;
+}
+
 bool av1HardwareDecoderAvailable()
 {
-    if (canLoad_VideoToolbox_VTIsHardwareDecodeSupported())
-        return VTIsHardwareDecodeSupported('av01');
+    ASSERT(isMainThread() || !!s_av1HardwareDecoderAvailable);
 
-    return false;
+    if (!s_av1HardwareDecoderAvailable)
+        s_av1HardwareDecoderAvailable = canLoad_VideoToolbox_VTIsHardwareDecodeSupported() && VTIsHardwareDecodeSupported('av01');
+
+    return *s_av1HardwareDecoderAvailable;
 }
 
 }

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
@@ -48,6 +48,7 @@ WEBCORE_EXPORT void registerSupplementalVP9Decoder();
 bool isVP9DecoderAvailable();
 WEBCORE_EXPORT bool vp9HardwareDecoderAvailable();
 WEBCORE_EXPORT bool vp9HardwareDecoderAvailableInProcess();
+WEBCORE_EXPORT void setVP9HardwareDecoderAvailableInProcess(bool);
 bool isVP8DecoderAvailable();
 bool isVPCodecConfigurationRecordSupported(const VPCodecConfigurationRecord&);
 std::optional<MediaCapabilitiesInfo> validateVPParameters(const VPCodecConfigurationRecord&, const VideoConfiguration&);

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
@@ -72,6 +72,12 @@ struct GPUProcessCreationParameters {
 #if PLATFORM(COCOA)
     bool enableMetalDebugDeviceForTesting { false };
     bool enableMetalShaderValidationForTesting { false };
+#if ENABLE(VP9)
+    std::optional<bool> hasVP9HardwareDecoder;
+#endif
+#if ENABLE(AV1)
+    std::optional<bool> hasAV1HardwareDecoder;
+#endif
 #endif
 };
 

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in
@@ -55,6 +55,12 @@
 #if PLATFORM(COCOA)
     bool enableMetalDebugDeviceForTesting;
     bool enableMetalShaderValidationForTesting;
+#if ENABLE(VP9)
+    std::optional<bool> hasVP9HardwareDecoder;
+#endif
+#if ENABLE(AV1)
+    std::optional<bool> hasAV1HardwareDecoder;
+#endif
 #endif
 };
 

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -34,6 +34,8 @@
 #import "GPUProcessCreationParameters.h"
 #import "Logging.h"
 #import "RemoteRenderingBackend.h"
+#import <WebCore/AV1UtilitiesCocoa.h>
+#import <WebCore/VP9UtilitiesCocoa.h>
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <pal/spi/cocoa/MetalSPI.h>
 #import <wtf/RetainPtr.h>
@@ -138,6 +140,15 @@ void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters& para
         setenv("MTL_SHADER_VALIDATION_REPORT_TO_STDERR", "1", 1);
         setenv("MTL_SHADER_VALIDATION_GPUOPT_ENABLE_RUNTIME_STACKTRACE", "0", 1);
     }
+
+#if ENABLE(VP9)
+    if (parameters.hasVP9HardwareDecoder)
+        setVP9HardwareDecoderAvailableInProcess(*parameters.hasVP9HardwareDecoder);
+#endif
+#if ENABLE(AV1)
+    if (parameters.hasAV1HardwareDecoder)
+        setAV1HardwareDecoderAvailable(*parameters.hasAV1HardwareDecoder);
+#endif
 
 #if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS) && USE(EXTENSIONKIT)
     MTLSetShaderCachePath(parameters.containerCachesDirectory.createNSString().get());

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -210,6 +210,14 @@ GPUProcessProxy::GPUProcessProxy()
 #if PLATFORM(COCOA)
     m_isMetalDebugDeviceEnabledForTesting = s_enableMetalDebugDeviceInNewGPUProcessesForTesting;
     m_isMetalShaderValidationEnabledForTesting = s_enableMetalShaderValidationInNewGPUProcessesForTesting;
+    if (s_gpuProcessMediaCodecCapabilities) {
+#if ENABLE(VP9)
+        parameters.hasVP9HardwareDecoder = s_gpuProcessMediaCodecCapabilities->hasVP9HardwareDecoder;
+#endif
+#if ENABLE(AV1)
+        parameters.hasAV1HardwareDecoder = s_gpuProcessMediaCodecCapabilities->hasAV1HardwareDecoder;
+#endif
+    }
 #endif
 
     platformInitializeGPUProcessParameters(parameters);


### PR DESCRIPTION
#### 38c1a932abd17d996fea59205abd863c1db483c7
<pre>
Reduce calls to VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9) in GPUProcess
<a href="https://rdar.apple.com/157511010">rdar://157511010</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300433">https://bugs.webkit.org/show_bug.cgi?id=300433</a>

Reviewed by Chris Dumez.

Following on <a href="https://commits.webkit.org/300866@main">https://commits.webkit.org/300866@main</a> which got reverted, we want to reduce the number of calls to VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9) in GPUProcess.

<a href="https://commits.webkit.org/300866@main">https://commits.webkit.org/300866@main</a> was reverted as it was buffering VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9) value.
The GPUProcess is first calling vp9HardwareDecoderAvailableInProcess() before calling registerSupplementalVP9Decoder().
vp9HardwareDecoderAvailableInProcess() is always returning false before registerSupplementalVP9Decoder() is called.
The buffering done in <a href="https://commits.webkit.org/300866@main">https://commits.webkit.org/300866@main</a> would then forbid the GPUProcess that it has VP9 HW support.

To fix that issue while keeping the buffering, we do the following approach:
- Given the UIProcess is buffering whether there is VP9 HW support, whenever the GPUProcess gets that info, it stores it in a static value.
- The GPUProcess will use that value when set to answer to vp9HardwareDecoderAvailableInProcess().
- In case of a registerSupplementalVP9Decoder() and GPUProcess thinks there is no HW VP9 support, we clear the static value.

We do the same buffering for AV1.

This ensures that there will be at most:
- one VTIsHardwareDecodeSupported for AV1 for the lifetime of the UIProcess.
- two VTIsHardwareDecodeSupported for VP9 for the lifetime of the UIProcess.

Manually tested.

Canonical link: <a href="https://commits.webkit.org/301307@main">https://commits.webkit.org/301307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfe072a99db37ccb8ef82573f12de6873a324812

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77435 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d87f97e-cf71-4771-a084-596de8afd551) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53643 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95495 "Failed to checkout and rebase branch from PR 52058") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d2d77e1-fc58-4ffa-a3b5-b7b2d07c7440) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128368 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36572 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Skipped layout-tests; 8 new passes 2 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76025 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fcde9003-a8c9-4af4-bba7-f3d506831d82) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35473 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 4 new passes 2 flakes") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30334 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75744 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106343 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30559 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 4 flakes 1 failures; Uploaded test results; 2 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134949 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52214 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40003 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 14 flakes") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103976 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 76 flakes 79 failures; Uploaded test results; 16 flakes 58 failures; Compiled WebKit; 1 flakes 56 failures; Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108377 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103728 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 3 api tests failed or timed out; 1 api test failed or timed out; Compiled WebKit; 1 api test failed or timed out; Passed API tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26441 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49092 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27386 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49366 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52112 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57901 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Checked out pull request; Found 54238 issues") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51464 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54820 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53159 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->