### PR TITLE
[Win] Regression - crashing while drawing text blob

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -219,9 +219,14 @@ RefPtr<const DisplayList::DisplayList> FontCascade::displayListForTextRun(Graphi
     if (glyphBuffer.isEmpty())
         return nullptr;
 
+#if USE(SKIA)
+    const auto drawGlyphsMode = context.hasPlatformContext() ? DisplayList::Recorder::DrawGlyphsMode::TextBlob : DisplayList::Recorder::DrawGlyphsMode::Normal;
+#else
+    constexpr auto drawGlyphsMode = DisplayList::Recorder::DrawGlyphsMode::Deconstruct;
+#endif
+
     DisplayList::RecorderImpl recordingContext(context.state().clone(GraphicsContextState::Purpose::Initial), { },
-        context.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale), context.colorSpace(),
-        DisplayList::Recorder::DrawGlyphsMode::Deconstruct);
+        context.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale), context.colorSpace(), drawGlyphsMode);
 
     FloatPoint startPoint = toFloatPoint(WebCore::size(glyphBuffer.initialAdvance()));
     drawGlyphBuffer(recordingContext, glyphBuffer, startPoint, customFontNotReadyAction);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -103,6 +103,9 @@ class ApplyStrokePattern;
 class BeginPage;
 class EndPage;
 class SetURLForRect;
+#if USE(SKIA)
+class DrawTextBlob;
+#endif
 
 using Item = Variant
     < ApplyDeviceScaleFactor
@@ -169,6 +172,9 @@ using Item = Variant
     , BeginPage
     , EndPage
     , SetURLForRect
+#if USE(SKIA)
+    , DrawTextBlob
+#endif
 >;
 
 enum class AsTextFlag : uint8_t {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -280,12 +280,7 @@ void DrawFilteredImageBuffer::dump(TextStream& ts, OptionSet<AsTextFlag> flags) 
 
 void DrawGlyphs::apply(GraphicsContext& context) const
 {
-#if USE(SKIA)
-    if (m_textBlob)
-        static_cast<GraphicsContextSkia*>(&context)->drawSkiaText(m_textBlob, SkFloatToScalar(m_localAnchor.x()), SkFloatToScalar(m_localAnchor.y()), m_enableAntialiasing, m_isVertical);
-#else
     context.drawGlyphs(m_font, m_glyphs.span(), m_advances.span(), m_localAnchor, m_fontSmoothingMode);
-#endif
 }
 
 void DrawGlyphs::dump(TextStream& ts, OptionSet<AsTextFlag>) const
@@ -295,6 +290,21 @@ void DrawGlyphs::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("font-smoothing-mode"_s, fontSmoothingMode());
     ts.dumpProperty("length"_s, length());
 }
+
+#if USE(SKIA)
+void DrawTextBlob::apply(GraphicsContext& context) const
+{
+    if (m_textBlob)
+        static_cast<GraphicsContextSkia*>(&context)->drawSkiaText(m_textBlob, SkFloatToScalar(m_localAnchor.x()), SkFloatToScalar(m_localAnchor.y()), m_enableAntialiasing, m_isVertical);
+}
+
+void DrawTextBlob::dump(TextStream& ts, OptionSet<AsTextFlag>) const
+{
+    ts.dumpProperty("local-anchor"_s, localAnchor());
+    ts.dumpProperty("font-smoothing-mode"_s, fontSmoothingMode());
+    ts.dumpProperty("length"_s, length());
+}
+#endif // USE(SKIA)
 
 DrawDisplayList::DrawDisplayList(Ref<const DisplayList>&& displayList)
     : m_displayList(WTFMove(displayList))

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -495,8 +495,40 @@ class DrawGlyphs {
 public:
     static constexpr char name[] = "draw-glyphs";
 
-#if USE(SKIA)
     DrawGlyphs(Ref<const Font>&& font, Vector<GlyphBufferGlyph>&& glyphs, Vector<GlyphBufferAdvance>&& advances, const FloatPoint& localAnchor, FontSmoothingMode smoothingMode)
+        : m_font(WTFMove(font))
+        , m_glyphs(WTFMove(glyphs))
+        , m_advances(WTFMove(advances))
+        , m_localAnchor(localAnchor)
+        , m_fontSmoothingMode(smoothingMode)
+    {
+    }
+
+    Ref<const Font> font() const { return m_font; }
+    const Vector<GlyphBufferGlyph>& glyphs() const { return m_glyphs; }
+    const Vector<GlyphBufferAdvance>& advances() const { return m_advances; }
+    size_t length() const { return m_glyphs.size(); }
+
+    FloatPoint localAnchor() const { return m_localAnchor; }
+    FontSmoothingMode fontSmoothingMode() const { return m_fontSmoothingMode; }
+
+    WEBCORE_EXPORT void apply(GraphicsContext&) const;
+    void dump(TextStream&, OptionSet<AsTextFlag>) const;
+
+private:
+    Ref<const Font> m_font;
+    Vector<GlyphBufferGlyph> m_glyphs;
+    Vector<GlyphBufferAdvance> m_advances;
+    FloatPoint m_localAnchor;
+    FontSmoothingMode m_fontSmoothingMode;
+};
+
+#if USE(SKIA)
+class DrawTextBlob {
+public:
+    static constexpr char name[] = "draw-text-blob";
+
+    DrawTextBlob(Ref<const Font>&& font, Vector<GlyphBufferGlyph>&& glyphs, Vector<GlyphBufferAdvance>&& advances, const FloatPoint& localAnchor, FontSmoothingMode smoothingMode)
         : m_textBlob(font->buildTextBlob(glyphs, advances, smoothingMode))
         , m_enableAntialiasing(font->enableAntialiasing(smoothingMode))
         , m_isVertical(font->platformData().orientation() == FontOrientation::Vertical)
@@ -517,21 +549,6 @@ public:
             glyphsCount += run.fGlyphCount;
         return glyphsCount;
     }
-#else
-    DrawGlyphs(Ref<const Font>&& font, Vector<GlyphBufferGlyph>&& glyphs, Vector<GlyphBufferAdvance>&& advances, const FloatPoint& localAnchor, FontSmoothingMode smoothingMode)
-        : m_font(WTFMove(font))
-        , m_glyphs(WTFMove(glyphs))
-        , m_advances(WTFMove(advances))
-        , m_localAnchor(localAnchor)
-        , m_fontSmoothingMode(smoothingMode)
-    {
-    }
-
-    Ref<const Font> font() const { return m_font; }
-    const Vector<GlyphBufferGlyph>& glyphs() const { return m_glyphs; }
-    const Vector<GlyphBufferAdvance>& advances() const { return m_advances; }
-    size_t length() const { return m_glyphs.size(); }
-#endif
 
     FloatPoint localAnchor() const { return m_localAnchor; }
     FontSmoothingMode fontSmoothingMode() const { return m_fontSmoothingMode; }
@@ -540,18 +557,13 @@ public:
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-#if USE(SKIA)
     sk_sp<SkTextBlob> m_textBlob;
     bool m_enableAntialiasing { false };
     bool m_isVertical { false };
-#else
-    Ref<const Font> m_font;
-    Vector<GlyphBufferGlyph> m_glyphs;
-    Vector<GlyphBufferAdvance> m_advances;
-#endif
     FloatPoint m_localAnchor;
     FontSmoothingMode m_fontSmoothingMode;
 };
+#endif // USE(SKIA)
 
 class DrawDisplayList {
 public:

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -49,14 +49,11 @@ Recorder::Recorder(IsDeferred isDeferred, const GraphicsContextState& state, con
     : GraphicsContext(isDeferred, state)
     , m_colorSpace(colorSpace)
     , m_initialClip(initialClip)
+    , m_drawGlyphsMode(drawGlyphsMode)
 #if USE(CORE_TEXT)
     , m_initialScale(initialCTM.xScale())
-    , m_drawGlyphsMode(drawGlyphsMode)
 #endif
 {
-#if !USE(CORE_TEXT)
-    UNUSED_PARAM(drawGlyphsMode);
-#endif
     ASSERT(!state.changes());
     m_stateStack.append({ state, initialCTM, initialCTM.mapRect(initialClip) });
 }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -60,7 +60,10 @@ public:
         Normal,
         // Deconstruct different text layers into separate DrawGlyphs commands. Allows for doing the deconstruct work once during recording instead of
         // multiple times during multiple playbacks.
-        Deconstruct
+        Deconstruct,
+#if USE(SKIA)
+        TextBlob
+#endif
     };
 
     Recorder(const GraphicsContextState& state, const FloatRect& initialClip, const AffineTransform& transform, const DestinationColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode = DrawGlyphsMode::Normal)
@@ -123,6 +126,7 @@ protected:
     WEBCORE_EXPORT void updateStateForApplyDeviceScaleFactor(float);
     WEBCORE_EXPORT bool decomposeDrawGlyphsIfNeeded(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& anchorPoint, FontSmoothingMode);
     FloatRect initialClip() const { return m_initialClip; }
+    DrawGlyphsMode drawGlyphsMode() const { return m_drawGlyphsMode; }
 
     const DestinationColorSpace& colorSpace() const final { return m_colorSpace; }
 
@@ -151,10 +155,10 @@ private:
     Vector<ContextState, 4> m_stateStack;
     DestinationColorSpace m_colorSpace;
     const FloatRect m_initialClip;
+    const DrawGlyphsMode m_drawGlyphsMode { DrawGlyphsMode::Normal };
 #if USE(CORE_TEXT)
     std::unique_ptr<DrawGlyphsRecorder> m_drawGlyphsRecorder;
     float m_initialScale { 1 };
-    const DrawGlyphsMode m_drawGlyphsMode { DrawGlyphsMode::Normal };
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -199,6 +199,14 @@ void RecorderImpl::drawGlyphs(const Font& font, std::span<const GlyphBufferGlyph
 {
     if (decomposeDrawGlyphsIfNeeded(font, glyphs, advances, localAnchor, smoothingMode))
         return;
+
+#if USE(SKIA)
+    if (drawGlyphsMode() == Recorder::DrawGlyphsMode::TextBlob) {
+        m_items.append(DrawTextBlob(Ref { font }, Vector(glyphs), Vector(advances), localAnchor, smoothingMode));
+        return;
+    }
+#endif
+
     drawGlyphsImmediate(font, glyphs, advances, localAnchor, smoothingMode);
 }
 

--- a/Source/WebCore/rendering/GlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.cpp
@@ -182,6 +182,9 @@ bool GlyphDisplayListCache::canShareDisplayList(const DisplayList::DisplayList& 
             || std::holds_alternative<DisplayList::DrawGlyphs>(item)
             || std::holds_alternative<DisplayList::DrawImageBuffer>(item)
             || std::holds_alternative<DisplayList::DrawNativeImage>(item)
+#if USE(SKIA)
+            || std::holds_alternative<DisplayList::DrawTextBlob>(item)
+#endif
             || std::holds_alternative<DisplayList::BeginTransparencyLayer>(item)
             || std::holds_alternative<DisplayList::BeginTransparencyLayerWithCompositeMode>(item)
             || std::holds_alternative<DisplayList::EndTransparencyLayer>(item)))


### PR DESCRIPTION
#### a1fe0eb9782301bc2d58fcf8808f2eb3a93d9529
<pre>
[Win] Regression - crashing while drawing text blob
<a href="https://bugs.webkit.org/show_bug.cgi?id=300412">https://bugs.webkit.org/show_bug.cgi?id=300412</a>

Reviewed by Fujii Hironori.

In 300818@main we assumed that the only possible GraphicsContext for which we
replay a display list is GraphicsContextSkia, which is true for GTK and
WPE ports that don&apos;t use the GPU process yet for DOM rendering, but not
for win port. This patch adds a new DisplayList::Recorder::DrawGlyphsMode
for skia that uses a new DrawTextBlob display list item, leaving
DrawGlyphs item as it was before 300818@main. This new mode is only set
then recording for a GraphicsContext that has a platform context.

Canonical link: <a href="https://commits.webkit.org/301321@main">https://commits.webkit.org/301321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb9d22d215ed8fd72d32c5b47447fbf9ed32e11d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132255 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77315 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95687 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63436 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (exception)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76017 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30317 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75729 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134936 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104144 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103876 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26452 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49080 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27375 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49342 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52101 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57880 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->