### PR TITLE
[Style] Fix LengthWrapperBase should respect evaluation-time flag

### DIFF
--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
@@ -26,6 +26,7 @@
 
 #include "StyleBuilderChecking.h"
 #include "StyleLengthWrapper.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
 
 namespace WebCore {
 namespace Style {
@@ -70,7 +71,12 @@ template<LengthWrapperBaseDerived T> struct CSSValueConversion<T> {
                 ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
                 : builderState.cssToLengthConversionData();
         } else if constexpr (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+            if (shouldUseEvaluationTimeZoom(builderState))
+                return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+
+            return builderState.useSVGZoomRulesForLength()
+                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
+                : builderState.cssToLengthConversionData();
         }
     }
 


### PR DESCRIPTION
#### ea8db722e368819f20a0c2da48172c2cb15c1b9b
<pre>
[Style] Fix LengthWrapperBase should respect evaluation-time flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=300443">https://bugs.webkit.org/show_bug.cgi?id=300443</a>
<a href="https://rdar.apple.com/162279773">rdar://162279773</a>

Reviewed by Antti Koivisto.

For properties that derive from LengthWrapperBase and are marked with
`Unzoomed`, there was bug causing incorrect getComputedStyle() results.

LengthWrapperBase CSSValueConversion was always storing unzoomed values
(zoom=1.0f) regardless of the evaluation-time flag. It should store
zoomed values when the flag is OFF to preserve trunk behavior.

* Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h:
(WebCore::Style::CSSValueConversion&lt;T&gt;::selectConversionData):

* Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword+Conversions.h:
We were calling adjustForZoom() unconditionally. We should only adjust
when evaluation-time zoom flag is OFF.

Canonical link: <a href="https://commits.webkit.org/301279@main">https://commits.webkit.org/301279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f892f3df45bebf48ea9feeb1aa9e5b5038d3f36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132304 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77334 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/826aaa4d-e608-4468-9d16-73d50a35a3c9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95526 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2a75207-bfe8-4f26-9092-3e63ecb45332) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76052 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5adbeae8-5670-40e5-9b8b-8eea9074b1fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30363 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75780 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134984 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104004 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103753 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26423 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49113 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27421 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49407 "Hash 6f892f3d for PR 52065 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52146 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57930 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51497 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54853 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53192 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->