### PR TITLE
Add iOS safer C++ expectations for WebCore

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -26,7 +26,7 @@ Modules/mediastream/RTCPeerConnection.h
 Modules/notifications/NotificationController.h
 Modules/webdatabase/DatabaseManager.h
 Modules/webdatabase/DatabaseThread.h
-accessibility/AXTextMarker.cpp
+[ Mac ] accessibility/AXTextMarker.cpp
 accessibility/AccessibilityObject.cpp
 bindings/js/GarbageCollectionController.cpp
 bindings/js/JSDOMConvertBase.h
@@ -59,7 +59,7 @@ html/track/InbandGenericTextTrack.cpp
 html/track/InbandWebVTTTextTrack.cpp
 html/track/TrackBase.h
 inspector/InspectorController.h
-inspector/InspectorFrontendHost.h
+[ Mac ] inspector/InspectorFrontendHost.h
 inspector/InspectorInstrumentation.h
 inspector/InspectorOverlay.h
 inspector/InspectorStyleSheet.h
@@ -79,11 +79,11 @@ page/EventHandler.h
 page/Page.h
 page/PageOverlayController.cpp
 page/WheelEventTestMonitor.h
-page/mac/ImageOverlayControllerMac.mm
-page/mac/ServicesOverlayController.mm
+[ Mac ] page/mac/ImageOverlayControllerMac.mm
+[ Mac ] page/mac/ServicesOverlayController.mm
 page/scrolling/ScrollingCoordinator.h
 page/scrolling/ScrollingStateNode.h
-page/scrolling/ScrollingStateScrollingNode.cpp
+[ Mac ] page/scrolling/ScrollingStateScrollingNode.cpp
 platform/PODRedBlackTree.h
 platform/Scrollbar.h
 platform/cocoa/TelephoneNumberDetectorCocoa.cpp
@@ -107,3 +107,8 @@ style/StyleScope.h
 testing/Internals.cpp
 xml/XSLStyleSheetLibxslt.cpp
 xml/parser/XMLDocumentParserLibxml2.cpp
+[ iOS ] page/ios/ContentChangeObserver.h
+[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
+[ iOS ] platform/ios/DeviceMotionClientIOS.h
+[ iOS ] platform/ios/LegacyTileCache.h
+[ iOS ] platform/text/TextBoundaries.cpp

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -86,13 +86,13 @@ layout/layouttree/LayoutTreeBuilder.cpp
 loader/cache/CachedResourceClientWalker.h
 mathml/MathMLRowElement.cpp
 page/NavigatorLoginStatus.cpp
-page/mac/EventHandlerMac.mm
+[ Mac ] page/mac/EventHandlerMac.mm
 platform/graphics/GraphicsLayer.cpp
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
 platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
 platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
-platform/graphics/mac/controls/ControlMac.mm
+[ Mac ] platform/graphics/mac/controls/ControlMac.mm
 rendering/BidiRun.cpp
 rendering/BidiRun.h
 rendering/RenderAncestorIterator.h
@@ -117,3 +117,8 @@ testing/Internals.cpp
 testing/cocoa/WebArchiveDumpSupport.mm
 workers/WorkerGlobalScope.cpp
 workers/WorkerThread.cpp
+[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
+[ iOS ] platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
+[ iOS ] platform/ios/wak/WAKView.mm
+[ iOS ] platform/ios/wak/WAKWindow.mm

--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -104,3 +104,8 @@ style/StyleTreeResolver.h
 style/Styleable.h
 style/values/color/StyleColorResolutionState.h
 svg/properties/SVGPropertyOwnerRegistry.h
+[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.h
+[ iOS ] page/ios/ContentChangeObserver.h
+[ iOS ] platform/ios/DeviceMotionClientIOS.h
+[ iOS ] platform/ios/DeviceOrientationClientIOS.h
+[ iOS ] rendering/ios/RenderThemeIOS.mm

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -33,8 +33,8 @@ html/FormListedElement.cpp
 html/parser/HTMLTreeBuilder.h
 html/track/TrackBase.h
 inspector/DOMPatchSupport.cpp
-inspector/InspectorFrontendHost.cpp
-inspector/InspectorFrontendHost.h
+[ Mac ] inspector/InspectorFrontendHost.cpp
+[ Mac ] inspector/InspectorFrontendHost.h
 inspector/InspectorShaderProgram.h
 inspector/InspectorStyleSheet.cpp
 inspector/InspectorStyleSheet.h
@@ -46,7 +46,7 @@ page/PointerLockController.h
 page/RenderingUpdateScheduler.h
 page/UndoManager.h
 page/WheelEventTestMonitor.h
-page/scrolling/ScrollLatchingController.h
+[ Mac ] page/scrolling/ScrollLatchingController.h
 page/scrolling/ScrollingCoordinator.h
 page/scrolling/ScrollingTreeGestureState.h
 platform/PODInterval.h
@@ -83,3 +83,7 @@ svg/properties/SVGPropertyOwnerRegistry.h
 workers/WorkerMessagingProxy.h
 xml/XPathGrammar.cpp
 xml/XPathGrammar.h
+[ iOS ] page/ios/ContentChangeObserver.h
+[ iOS ] platform/audio/ios/AudioSessionIOS.mm
+[ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
+[ iOS ] platform/ios/wak/WAKWindow.h

--- a/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,7 +1,17 @@
-accessibility/cocoa/AXCoreObjectCocoa.mm
+[ Mac ] accessibility/cocoa/AXCoreObjectCocoa.mm
 bridge/objc/WebScriptObject.h
 page/EventHandler.h
 platform/cocoa/WebAVPlayerLayer.h
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp
 platform/ios/WebAVPlayerController.h
 platform/ios/WebAVPlayerController.mm
+[ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
+[ iOS ] platform/ios/DeviceMotionClientIOS.h
+[ iOS ] platform/ios/LegacyTileCache.h
+[ iOS ] platform/ios/WebEvent.h
+[ iOS ] platform/ios/WebItemProviderPasteboard.h
+[ iOS ] platform/ios/wak/WAKClipView.h
+[ iOS ] platform/ios/wak/WAKScrollView.h
+[ iOS ] platform/ios/wak/WAKWindow.h
+[ iOS ] platform/ios/wak/WKView.h
+[ iOS ] platform/ios/wak/WebCoreThread.h

--- a/Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -1,4 +1,4 @@
-PAL/pal/mac/DataDetectorsSoftLink.h
+[ Mac ] PAL/pal/mac/DataDetectorsSoftLink.h
 platform/audio/cocoa/AudioSampleBufferConverter.mm
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -9,3 +9,10 @@ platform/graphics/cg/ImageDecoderCG.cpp
 platform/graphics/cg/PatternCG.cpp
 platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/network/cf/DNSResolveQueueCFNet.cpp
+[ iOS ] PAL/pal/spi/ios/DataDetectorsUISoftLink.h
+[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
+[ iOS ] platform/ios/QuickLook.mm
+[ iOS ] platform/ios/ValidationBubbleIOS.mm
+[ iOS ] platform/ios/WebCoreMotionManager.mm
+[ iOS ] platform/ios/wak/WKView.mm
+[ iOS ] platform/ios/wak/WebCoreThread.mm

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -44,9 +44,9 @@ accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilitySlider.cpp
 accessibility/AccessibilitySpinButton.cpp
 accessibility/cocoa/AccessibilityObjectCocoa.mm
-accessibility/isolatedtree/AXIsolatedTree.cpp
-accessibility/mac/AXObjectCacheMac.mm
-accessibility/mac/AccessibilityObjectMac.mm
+[ Mac ] accessibility/isolatedtree/AXIsolatedTree.cpp
+[ Mac ] accessibility/mac/AXObjectCacheMac.mm
+[ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 animation/AnimationTimelinesController.cpp
 animation/BlendingKeyframes.cpp
 animation/DocumentTimeline.cpp
@@ -157,7 +157,7 @@ dom/TreeScope.cpp
 dom/TreeScopeOrderedMap.cpp
 dom/TypedElementDescendantIteratorInlines.h
 dom/ViewTransition.cpp
-dom/mac/ImageControlsMac.cpp
+[ Mac ] dom/mac/ImageControlsMac.cpp
 editing/AlternativeTextController.cpp
 editing/ApplyBlockElementCommand.cpp
 editing/ApplyStyleCommand.cpp
@@ -201,7 +201,7 @@ editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/EditorCocoa.mm
 editing/cocoa/NodeHTMLConverter.mm
 editing/cocoa/WebContentReaderCocoa.mm
-editing/mac/EditorMac.mm
+[ Mac ] editing/mac/EditorMac.mm
 editing/mac/FrameSelectionMac.mm
 editing/markup.cpp
 fileapi/BlobLoader.h
@@ -400,7 +400,7 @@ mathml/MathMLOperatorElement.cpp
 mathml/MathMLPresentationElement.cpp
 mathml/MathMLSelectElement.cpp
 page/AutoscrollController.cpp
-page/ContextMenuController.cpp
+[ Mac ] page/ContextMenuController.cpp
 page/DOMSelection.cpp
 page/DebugPageOverlays.cpp
 page/DragController.cpp
@@ -439,11 +439,11 @@ page/SpatialNavigation.cpp
 page/TextIndicator.cpp
 page/VisualViewport.cpp
 page/cocoa/PageCocoa.mm
-page/mac/EventHandlerMac.mm
-page/mac/ServicesOverlayController.mm
+[ Mac ] page/mac/EventHandlerMac.mm
+[ Mac ] page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp
-page/scrolling/ScrollLatchingController.cpp
+[ Mac ] page/scrolling/ScrollLatchingController.cpp
 page/scrolling/ScrollSnapOffsetsInfo.cpp
 page/scrolling/ScrollingCoordinator.cpp
 page/scrolling/ScrollingStateNode.cpp
@@ -457,7 +457,7 @@ platform/ScrollingEffectsController.cpp
 platform/Widget.cpp
 platform/audio/PlatformMediaSession.cpp
 platform/audio/PlatformMediaSessionInterface.h
-platform/cocoa/DragImageCocoa.mm
+[ Mac ] platform/cocoa/DragImageCocoa.mm
 platform/cocoa/LowPowerModeNotifier.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm
 platform/cocoa/WebAVPlayerLayer.mm
@@ -746,7 +746,7 @@ svg/graphics/SVGImage.cpp
 svg/properties/SVGAnimatedString.cpp
 svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
 testing/Internals.cpp
-testing/Internals.mm
+[ Mac ] testing/Internals.mm
 workers/WorkerGlobalScope.cpp
 workers/WorkerMessagingProxy.cpp
 workers/WorkerNotificationClient.cpp
@@ -763,3 +763,23 @@ xml/XSLStyleSheetLibxslt.cpp
 xml/XSLTProcessorLibxslt.cpp
 xml/parser/XMLDocumentParser.cpp
 xml/parser/XMLDocumentParserLibxml2.cpp
+[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
+[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+[ iOS ] editing/ios/EditorIOS.mm
+[ iOS ] html/ColorInputType.cpp
+[ iOS ] page/Chrome.cpp
+[ iOS ] page/DOMTimer.cpp
+[ iOS ] page/Page.cpp
+[ iOS ] page/Quirks.cpp
+[ iOS ] page/ios/ContentChangeObserver.cpp
+[ iOS ] page/ios/EventHandlerIOS.mm
+[ iOS ] page/ios/FrameIOS.mm
+[ iOS ] platform/ios/DeviceMotionClientIOS.mm
+[ iOS ] platform/ios/DeviceOrientationClientIOS.mm
+[ iOS ] platform/ios/PlatformScreenIOS.mm
+[ iOS ] platform/ios/TileControllerMemoryHandlerIOS.cpp
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.h
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
+[ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
+[ iOS ] rendering/RenderLineBreak.cpp
+[ iOS ] rendering/ios/RenderThemeIOS.mm

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -17,9 +17,9 @@ accessibility/AccessibilityRenderObject.cpp
 accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilitySlider.cpp
 accessibility/cocoa/AccessibilityObjectCocoa.mm
-accessibility/isolatedtree/AXIsolatedObject.cpp
-accessibility/isolatedtree/AXIsolatedTree.cpp
-accessibility/mac/AccessibilityObjectMac.mm
+[ Mac ] accessibility/isolatedtree/AXIsolatedObject.cpp
+[ Mac ] accessibility/isolatedtree/AXIsolatedTree.cpp
+[ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 animation/AcceleratedEffectStackUpdater.cpp
 animation/BlendingKeyframes.cpp
 animation/DocumentTimeline.cpp
@@ -101,7 +101,7 @@ dom/TreeScope.cpp
 dom/TypedElementDescendantIteratorInlines.h
 dom/ViewTransition.cpp
 dom/mac/ImageControlsMac.cpp
-editing/AlternativeTextController.cpp
+[ Mac ] editing/AlternativeTextController.cpp
 editing/ApplyBlockElementCommand.cpp
 editing/ApplyStyleCommand.cpp
 editing/BreakBlockquoteCommand.cpp
@@ -130,8 +130,8 @@ editing/cocoa/DictionaryLookup.mm
 editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/NodeHTMLConverter.mm
 editing/cocoa/WebContentReaderCocoa.mm
-editing/mac/EditorMac.mm
-editing/mac/FrameSelectionMac.mm
+[ Mac ] editing/mac/EditorMac.mm
+[ Mac ] editing/mac/FrameSelectionMac.mm
 editing/markup.cpp
 history/CachedFrame.cpp
 html/Autofill.cpp
@@ -258,7 +258,7 @@ loader/cache/CachedImage.cpp
 loader/cache/MemoryCache.cpp
 mathml/MathMLSelectElement.cpp
 page/AutoscrollController.cpp
-page/ContextMenuController.cpp
+[ Mac ] page/ContextMenuController.cpp
 page/DeviceController.cpp
 page/DragController.cpp
 page/ElementTargetingController.cpp
@@ -290,9 +290,9 @@ page/ScrollBehavior.cpp
 page/SpatialNavigation.cpp
 page/TextIndicator.cpp
 page/WorkerNavigator.cpp
-page/mac/EventHandlerMac.mm
-page/mac/ImageOverlayControllerMac.mm
-page/mac/ServicesOverlayController.mm
+[ Mac ] page/mac/EventHandlerMac.mm
+[ Mac ] page/mac/ImageOverlayControllerMac.mm
+[ Mac ] page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -546,9 +546,26 @@ svg/graphics/SVGImage.cpp
 svg/properties/SVGAnimatedString.cpp
 svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
 testing/Internals.cpp
-testing/Internals.mm
+[ Mac ]  testing/Internals.mm
 testing/ServiceWorkerInternals.cpp
 testing/js/WebCoreTestSupport.cpp
 workers/WorkerGlobalScope.cpp
 workers/WorkerOrWorkletThread.cpp
 workers/WorkerRunLoop.cpp
+[ iOS ] accessibility/cocoa/AXTextMarkerCocoa.mm
+[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
+[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+[ iOS ] editing/cocoa/EditorCocoa.mm
+[ iOS ] editing/ios/DictationCommandIOS.cpp
+[ iOS ] html/HTMLAnchorElement.cpp
+[ iOS ] html/HTMLImageLoader.cpp
+[ iOS ] page/Chrome.cpp
+[ iOS ] page/DOMTimer.cpp
+[ iOS ] page/ios/ContentChangeObserver.cpp
+[ iOS ] page/ios/EventHandlerIOS.mm
+[ iOS ] page/ios/FrameIOS.mm
+[ iOS ] platform/ios/DragImageIOS.mm
+[ iOS ] platform/ios/PasteboardIOS.mm
+[ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
+[ iOS ] rendering/RenderLineBreak.cpp
+[ iOS ] rendering/ios/RenderThemeIOS.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -9,8 +9,8 @@ Modules/identity/CredentialRequestCoordinator.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediasession/MediaMetadata.cpp
 Modules/mediasession/MediaSession.cpp
-Modules/mediasession/MediaSessionCoordinator.cpp
-Modules/mediasession/MediaSessionCoordinator.h
+[ Mac ] Modules/mediasession/MediaSessionCoordinator.cpp
+[ Mac ] Modules/mediasession/MediaSessionCoordinator.h
 Modules/mediasource/MediaSourceHandle.cpp
 Modules/mediastream/MediaStreamTrack.cpp
 Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -28,7 +28,7 @@ Modules/mediastream/RTCRtpTransform.cpp
 Modules/mediastream/UserMediaRequest.cpp
 Modules/mediastream/libwebrtc/LibWebRTCObservers.h
 Modules/model-element/HTMLModelElement.cpp
-Modules/model-element/scenekit/SceneKitModelPlayer.mm
+[ Mac ] Modules/model-element/scenekit/SceneKitModelPlayer.mm
 Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
 Modules/push-api/PushManager.cpp
 Modules/push-api/PushSubscription.cpp
@@ -105,9 +105,9 @@ accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilitySlider.cpp
 accessibility/AccessibilitySpinButton.cpp
 accessibility/AccessibilityTableHeaderContainer.cpp
-accessibility/isolatedtree/AXIsolatedTree.cpp
-accessibility/mac/AXObjectCacheMac.mm
-accessibility/mac/AccessibilityObjectMac.mm
+[ Mac ] accessibility/isolatedtree/AXIsolatedTree.cpp
+[ Mac ] accessibility/mac/AXObjectCacheMac.mm
+[ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 animation/AcceleratedEffectStackUpdater.cpp
 animation/AnimationEffectTiming.cpp
 animation/AnimationTimeline.cpp
@@ -363,7 +363,7 @@ dom/TreeScopeOrderedMap.cpp
 dom/TypedElementDescendantIteratorInlines.h
 dom/VisitedLinkState.cpp
 dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
-dom/mac/ImageControlsMac.cpp
+[ Mac ] dom/mac/ImageControlsMac.cpp
 editing/AlternativeTextController.cpp
 editing/ApplyBlockElementCommand.cpp
 editing/ApplyStyleCommand.cpp
@@ -388,7 +388,7 @@ editing/RemoveFormatCommand.cpp
 editing/ReplaceNodeWithSpanCommand.cpp
 editing/ReplaceSelectionCommand.cpp
 editing/ReplaceSelectionCommand.h
-editing/SelectionGeometryGatherer.cpp
+[ Mac ] editing/SelectionGeometryGatherer.cpp
 editing/SpellChecker.cpp
 editing/SplitTextNodeCommand.cpp
 editing/SplitTextNodeContainingElementCommand.cpp
@@ -404,7 +404,7 @@ editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/EditorCocoa.mm
 editing/cocoa/NodeHTMLConverter.mm
 editing/cocoa/WebContentReaderCocoa.mm
-editing/mac/EditorMac.mm
+[ Mac ] editing/mac/EditorMac.mm
 editing/mac/FrameSelectionMac.mm
 editing/markup.cpp
 history/BackForwardCache.cpp
@@ -559,7 +559,7 @@ mathml/MathMLElement.cpp
 mathml/MathMLSelectElement.cpp
 page/AutoscrollController.cpp
 page/Chrome.cpp
-page/ContextMenuController.cpp
+[ Mac ] page/ContextMenuController.cpp
 page/DOMSelection.cpp
 page/DOMTimer.cpp
 page/DOMWindowExtension.cpp
@@ -620,18 +620,18 @@ page/cocoa/ResourceUsageOverlayCocoa.mm
 page/cocoa/ResourceUsageThreadCocoa.mm
 page/cocoa/WebTextIndicatorLayer.mm
 page/mac/DragControllerMac.mm
-page/mac/EventHandlerMac.mm
-page/mac/ImageOverlayControllerMac.mm
-page/mac/ServicesOverlayController.mm
+[ Mac ] page/mac/EventHandlerMac.mm
+[ Mac ] page/mac/ImageOverlayControllerMac.mm
+[ Mac ] page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
-page/scrolling/AsyncScrollingCoordinator.h
+[ Mac ] page/scrolling/AsyncScrollingCoordinator.h
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollSnapOffsetsInfo.cpp
 page/scrolling/ScrollingCoordinator.cpp
-page/scrolling/ScrollingTreeGestureState.cpp
-page/scrolling/ThreadedScrollingCoordinator.cpp
-page/scrolling/mac/ScrollingCoordinatorMac.mm
-page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+[ Mac ] page/scrolling/ScrollingTreeGestureState.cpp
+[ Mac ] page/scrolling/ThreadedScrollingCoordinator.cpp
+[ Mac ] page/scrolling/mac/ScrollingCoordinatorMac.mm
+[ Mac ] page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
 page/text-extraction/TextExtraction.cpp
 page/writing-tools/WritingToolsController.mm
 platform/DragImage.cpp
@@ -643,7 +643,7 @@ platform/ScrollableArea.cpp
 platform/Widget.cpp
 platform/animation/AcceleratedEffectValues.cpp
 platform/audio/cocoa/AudioFileReaderCocoa.cpp
-platform/cocoa/DragImageCocoa.mm
+[ Mac ] platform/cocoa/DragImageCocoa.mm
 platform/cocoa/PlaybackSessionModelMediaElement.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm
 platform/encryptedmedia/CDMProxy.cpp
@@ -678,10 +678,10 @@ platform/graphics/ca/TileGrid.cpp
 platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
-platform/graphics/cocoa/ImageAdapterCocoa.mm
+[ Mac ] platform/graphics/cocoa/ImageAdapterCocoa.mm
 platform/graphics/controls/ButtonPart.h
 platform/graphics/controls/ColorWellPart.h
-platform/graphics/controls/ImageControlsButtonPart.h
+[ Mac ] platform/graphics/controls/ImageControlsButtonPart.h
 platform/graphics/controls/InnerSpinButtonPart.h
 platform/graphics/controls/MenuListButtonPart.h
 platform/graphics/controls/MenuListPart.h
@@ -703,7 +703,7 @@ platform/graphics/filters/software/FELightingSoftwareApplier.cpp
 platform/graphics/filters/software/FELightingSoftwareApplierInlines.h
 platform/graphics/filters/software/FELightingSoftwareParallelApplier.cpp
 platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
-platform/graphics/mac/PDFDocumentImageMac.mm
+[ Mac ] platform/graphics/mac/PDFDocumentImageMac.mm
 platform/graphics/opentype/OpenTypeMathData.cpp
 platform/graphics/transforms/TransformOperations.cpp
 platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.h
@@ -991,9 +991,9 @@ svg/properties/SVGValuePropertyListAnimator.h
 svg/properties/SVGValuePropertyListAnimatorImpl.h
 testing/InternalSettings.cpp
 testing/Internals.cpp
-testing/Internals.mm
+[ Mac ] testing/Internals.mm
 testing/LegacyMockCDM.cpp
-testing/MockMediaSessionCoordinator.cpp
+[ Mac ] testing/MockMediaSessionCoordinator.cpp
 testing/MockPageOverlay.cpp
 testing/MockPageOverlayClient.cpp
 testing/ServiceWorkerInternals.cpp
@@ -1015,3 +1015,39 @@ xml/XSLStyleSheetLibxslt.cpp
 xml/XSLTProcessorLibxslt.cpp
 xml/parser/XMLDocumentParser.cpp
 xml/parser/XMLDocumentParserLibxml2.cpp
+[ iOS ] Modules/system-preview/ARKitBadgeSystemImage.mm
+[ iOS ] Modules/webaudio/ChannelMergerNode.cpp
+[ iOS ] accessibility/ios/AXObjectCacheIOS.mm
+[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
+[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+[ iOS ] accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+[ iOS ] editing/EditCommand.cpp
+[ iOS ] editing/cocoa/DataDetection.mm
+[ iOS ] editing/ios/EditorIOS.mm
+[ iOS ] html/ColorInputType.cpp
+[ iOS ] html/TextFieldInputType.cpp
+[ iOS ] loader/FrameLoader.cpp
+[ iOS ] loader/cache/CachedRawResource.cpp
+[ iOS ] loader/ios/LegacyPreviewLoader.mm
+[ iOS ] page/Quirks.cpp
+[ iOS ] page/ios/ContentChangeObserver.cpp
+[ iOS ] page/ios/EventHandlerIOS.mm
+[ iOS ] page/ios/FrameIOS.mm
+[ iOS ] platform/audio/ios/MediaSessionManagerIOS.mm
+[ iOS ] platform/graphics/avfoundation/SampleBufferDisplayLayer.h
+[ iOS ] platform/graphics/cg/PDFDocumentImage.cpp
+[ iOS ] platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+[ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
+[ iOS ] platform/ios/DeviceMotionClientIOS.mm
+[ iOS ] platform/ios/DeviceOrientationClientIOS.mm
+[ iOS ] platform/ios/LegacyTileGrid.mm
+[ iOS ] platform/ios/PlatformPasteboardIOS.mm
+[ iOS ] platform/ios/PlatformScreenIOS.mm
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.h
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
+[ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
+[ iOS ] platform/ios/wak/WAKWindow.mm
+[ iOS ] platform/mediastream/ios/ReplayKitCaptureSource.mm
+[ iOS ] rendering/RenderBlock.cpp
+[ iOS ] rendering/RenderLineBreak.cpp
+[ iOS ] rendering/ios/RenderThemeIOS.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -18,9 +18,9 @@ Modules/webcodecs/WebCodecsBase.cpp
 Modules/webcodecs/WebCodecsVideoDecoder.cpp
 Modules/webcodecs/WebCodecsVideoEncoder.cpp
 Modules/webdatabase/DatabaseThread.cpp
-accessibility/isolatedtree/AXIsolatedObject.cpp
-accessibility/isolatedtree/AXIsolatedObject.h
-accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+[ Mac ] accessibility/isolatedtree/AXIsolatedObject.cpp
+[ Mac ] accessibility/isolatedtree/AXIsolatedObject.h
+[ Mac ] accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
 animation/KeyframeEffect.cpp
 bindings/js/JSDOMPromiseDeferred.cpp
 contentextensions/ContentExtensionsBackend.cpp
@@ -32,7 +32,7 @@ css/StyleRule.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CustomElementDefaultARIA.cpp
 dom/RejectedPromiseTracker.cpp
-editing/Editor.cpp
+[ Mac ] editing/Editor.cpp
 html/FormAssociatedCustomElement.cpp
 html/track/TrackBase.cpp
 inspector/InspectorOverlay.cpp
@@ -85,8 +85,14 @@ style/values/fonts/StyleFontVariationSettings.cpp
 style/values/images/StyleGradient.cpp
 style/values/primitives/StylePrimitiveKeyword+CSSValueCreation.h
 style/values/primitives/StylePrimitiveKeyword+Serialization.h
-testing/MockMediaSessionCoordinator.cpp
+[ Mac ] testing/MockMediaSessionCoordinator.cpp
 workers/Worker.cpp
 workers/WorkerMessagingProxy.cpp
 workers/WorkerOrWorkletThread.cpp
 workers/shared/SharedWorkerObjectConnection.cpp
+[ iOS ] page/ios/FrameIOS.mm
+[ iOS ] platform/PreviewConverter.cpp
+[ iOS ] platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+[ iOS ] platform/ios/DragImageIOS.mm
+[ iOS ] platform/mediastream/ios/ReplayKitCaptureSource.mm
+[ iOS ] platform/mediastream/mac/CoreAudioSharedUnit.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -2,7 +2,7 @@ Modules/applicationmanifest/ApplicationManifestParser.cpp
 Modules/mediacapabilities/MediaCapabilities.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediarecorder/MediaRecorder.cpp
-Modules/mediasession/MediaSession.cpp
+[ Mac ] Modules/mediasession/MediaSession.cpp
 Modules/mediasource/SourceBuffer.cpp
 Modules/mediastream/PeerConnectionBackend.cpp
 Modules/mediastream/RTCController.cpp
@@ -196,8 +196,8 @@ editing/cocoa/DataDetection.mm
 editing/cocoa/DictionaryLookup.mm
 editing/cocoa/EditorCocoa.mm
 editing/cocoa/NodeHTMLConverter.mm
-editing/mac/EditorMac.mm
-editing/mac/FrameSelectionMac.mm
+[ Mac ] editing/mac/EditorMac.mm
+[ Mac ] editing/mac/FrameSelectionMac.mm
 history/CachedFrame.cpp
 history/CachedPage.cpp
 html/Autofill.cpp
@@ -268,7 +268,7 @@ loader/EmptyClients.cpp
 mathml/MathMLSelectElement.cpp
 page/BarProp.cpp
 page/CaptionUserPreferences.cpp
-page/ContextMenuController.cpp
+[ Mac ] page/ContextMenuController.cpp
 page/DebugPageOverlays.cpp
 page/DeviceController.cpp
 page/DragController.cpp
@@ -312,9 +312,9 @@ page/TextIndicator.cpp
 page/UserContentController.cpp
 page/UserContentProvider.cpp
 page/cocoa/ResourceUsageThreadCocoa.mm
-page/mac/EventHandlerMac.mm
-page/mac/ImageOverlayControllerMac.mm
-page/mac/ServicesOverlayController.mm
+[ Mac ] page/mac/EventHandlerMac.mm
+[ Mac ] page/mac/ImageOverlayControllerMac.mm
+[ Mac ] page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollingCoordinator.cpp
@@ -362,9 +362,9 @@ platform/graphics/filters/software/FETileSoftwareApplier.cpp
 platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
 platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp
 platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
-platform/graphics/mac/controls/MeterMac.mm
-platform/graphics/mac/controls/ProgressBarMac.mm
-platform/graphics/mac/controls/SliderTrackMac.mm
+[ Mac ] platform/graphics/mac/controls/MeterMac.mm
+[ Mac ] platform/graphics/mac/controls/ProgressBarMac.mm
+[ Mac ] platform/graphics/mac/controls/SliderTrackMac.mm
 platform/graphics/transforms/RotateTransformOperation.cpp
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mock/MockRealtimeVideoSource.cpp
@@ -484,8 +484,26 @@ svg/properties/SVGAnimatedString.cpp
 svg/properties/SVGPropertyOwnerRegistry.h
 testing/InternalSettings.cpp
 testing/Internals.cpp
-testing/Internals.mm
+[ Mac ] testing/Internals.mm
 testing/LegacyMockCDM.cpp
 testing/MockCDMFactory.cpp
 testing/MockPageOverlayClient.cpp
 testing/ServiceWorkerInternals.cpp
+[ iOS ] accessibility/AccessibilityNodeObject.cpp
+[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
+[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+[ iOS ] editing/ios/DictationCommandIOS.cpp
+[ iOS ] editing/ios/EditorIOS.mm
+[ iOS ] html/HTMLAnchorElement.cpp
+[ iOS ] html/HTMLImageLoader.cpp
+[ iOS ] page/Chrome.cpp
+[ iOS ] page/Quirks.cpp
+[ iOS ] page/ios/ContentChangeObserver.cpp
+[ iOS ] page/ios/EventHandlerIOS.mm
+[ iOS ] page/ios/FrameIOS.mm
+[ iOS ] platform/audio/ios/AudioSessionIOS.mm
+[ iOS ] platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+[ iOS ] platform/ios/DragImageIOS.mm
+[ iOS ] platform/ios/LegacyTileGrid.mm
+[ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
+[ iOS ] rendering/ios/RenderThemeIOS.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,13 +1,13 @@
 Modules/WebGPU/GPUQueue.cpp
-Modules/model-element/scenekit/SceneKitModelPlayer.mm
-accessibility/cocoa/AXCoreObjectCocoa.mm
-accessibility/cocoa/AXTextMarkerCocoa.mm
-accessibility/cocoa/AccessibilityObjectCocoa.mm
-accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
-accessibility/mac/AXObjectCacheMac.mm
-accessibility/mac/AccessibilityObjectMac.mm
+[ Mac ] Modules/model-element/scenekit/SceneKitModelPlayer.mm
+[ Mac ] accessibility/cocoa/AXCoreObjectCocoa.mm
+[ Mac ] accessibility/cocoa/AXTextMarkerCocoa.mm
+[ Mac ] accessibility/cocoa/AccessibilityObjectCocoa.mm
+[ Mac ] accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+[ Mac ] accessibility/mac/AXObjectCacheMac.mm
+[ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 accessibility/mac/WebAccessibilityObjectWrapperBase.mm
-accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+[ Mac ] accessibility/mac/WebAccessibilityObjectWrapperMac.mm
 bridge/objc/WebScriptObject.mm
 bridge/objc/objc_instance.mm
 bridge/objc/objc_runtime.mm
@@ -15,31 +15,31 @@ bridge/objc/objc_utility.mm
 crypto/cocoa/SerializedCryptoKeyWrapMac.mm
 editing/SmartReplaceCF.cpp
 editing/cocoa/DataDetection.mm
-editing/cocoa/DictionaryLookup.mm
+[ Mac ] editing/cocoa/DictionaryLookup.mm
 editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/FontAttributeChangesCocoa.mm
 editing/cocoa/FontAttributesCocoa.mm
 editing/cocoa/NodeHTMLConverter.mm
 editing/cocoa/WebContentReaderCocoa.mm
-editing/mac/EditorMac.mm
-editing/mac/TextAlternativeWithRange.mm
-editing/mac/TextUndoInsertionMarkupMac.mm
+[ Mac ] editing/mac/EditorMac.mm
+[ Mac ] editing/mac/TextAlternativeWithRange.mm
+[ Mac ] editing/mac/TextUndoInsertionMarkupMac.mm
 inspector/agents/page/PageTimelineAgent.cpp
 page/cocoa/PageCocoa.mm
 page/cocoa/WebTextIndicatorLayer.mm
-page/mac/EventHandlerMac.mm
-page/mac/ImageOverlayControllerMac.mm
-page/mac/ServicesOverlayController.mm
-page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm
-page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm
-page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+[ Mac ] page/mac/EventHandlerMac.mm
+[ Mac ] page/mac/ImageOverlayControllerMac.mm
+[ Mac ] page/mac/ServicesOverlayController.mm
+[ Mac ] page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm
+[ Mac ]page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm
+[ Mac ]page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
 platform/audio/cocoa/AudioFileReaderCocoa.cpp
 platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
 platform/cf/KeyedDecoderCF.cpp
 platform/cf/KeyedEncoderCF.cpp
 platform/cf/MainThreadSharedTimerCF.cpp
-platform/cocoa/DragDataCocoa.mm
-platform/cocoa/DragImageCocoa.mm
+[ Mac ] platform/cocoa/DragDataCocoa.mm
+[ Mac ] platform/cocoa/DragImageCocoa.mm
 platform/cocoa/FileMonitorCocoa.mm
 platform/cocoa/LocalizedStringsCocoa.mm
 platform/cocoa/NetworkExtensionContentFilter.mm
@@ -48,13 +48,13 @@ platform/cocoa/PlatformPasteboardCocoa.mm
 platform/cocoa/SearchPopupMenuCocoa.mm
 platform/cocoa/UserAgentCocoa.mm
 platform/cocoa/WebAVPlayerLayer.mm
-platform/gamepad/mac/HIDGamepadElement.cpp
+[ Mac ] platform/gamepad/mac/HIDGamepadElement.cpp
 platform/graphics/BitmapImageDescriptor.cpp
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
-platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm
-platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
+[ Mac ] platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm
+[ Mac ] platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -68,7 +68,7 @@ platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
 platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/TileCoverageMap.cpp
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
-platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+[ Mac ] platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp
 platform/graphics/cg/GradientCG.cpp
@@ -90,23 +90,62 @@ platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 platform/graphics/cocoa/WebCoreCALayerExtras.mm
 platform/graphics/coreimage/FilterImageCoreImage.mm
 platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
-platform/graphics/mac/ColorMac.mm
-platform/graphics/mac/PDFDocumentImageMac.mm
-platform/graphics/mac/ScrollbarTrackCornerSystemImageMac.mm
-platform/graphics/mac/controls/InnerSpinButtonMac.mm
-platform/graphics/mac/controls/ToggleButtonMac.mm
-platform/graphics/mac/controls/WebControlView.mm
+[ Mac ] platform/graphics/mac/ColorMac.mm
+[ Mac ] platform/graphics/mac/PDFDocumentImageMac.mm
+[ Mac ] platform/graphics/mac/ScrollbarTrackCornerSystemImageMac.mm
+[ Mac ] platform/graphics/mac/controls/InnerSpinButtonMac.mm
+[ Mac ] platform/graphics/mac/controls/ToggleButtonMac.mm
+[ Mac ] platform/graphics/mac/controls/WebControlView.mm
 platform/ios/WebAVPlayerController.mm
 platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
 platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
 platform/mediastream/mac/AVVideoCaptureSource.mm
-platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
-platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+[ Mac ] platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+[ Mac ] platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
 platform/network/cf/DNSResolveQueueCFNet.cpp
 platform/network/mac/ResourceHandleMac.mm
 platform/network/mac/SynchronousLoaderClient.mm
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
 platform/text/cocoa/LocalizedDateCache.mm
 rendering/AttachmentLayout.mm
-testing/ServiceWorkerInternals.mm
+[ Mac ] testing/ServiceWorkerInternals.mm
 testing/cocoa/WebArchiveDumpSupport.mm
+[ iOS ] Modules/notifications/NotificationDataCocoa.mm
+[ iOS ] Modules/system-preview/ARKitBadgeSystemImage.mm
+[ iOS ] accessibility/ios/AXObjectCacheIOS.mm
+[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
+[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+[ iOS ] page/ios/EventHandlerIOS.mm
+[ iOS ] platform/audio/ios/MediaSessionHelperIOS.mm
+[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
+[ iOS ] platform/graphics/cg/PDFDocumentImage.cpp
+[ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
+[ iOS ] platform/ios/ColorIOS.mm
+[ iOS ] platform/ios/DeviceMotionClientIOS.mm
+[ iOS ] platform/ios/DeviceOrientationClientIOS.mm
+[ iOS ] platform/ios/LegacyTileCache.mm
+[ iOS ] platform/ios/LegacyTileGrid.mm
+[ iOS ] platform/ios/LegacyTileGridTile.mm
+[ iOS ] platform/ios/LocalCurrentTraitCollection.mm
+[ iOS ] platform/ios/PasteboardIOS.mm
+[ iOS ] platform/ios/PlatformPasteboardIOS.mm
+[ iOS ] platform/ios/PreviewConverterIOS.mm
+[ iOS ] platform/ios/QuickLook.mm
+[ iOS ] platform/ios/ScrollViewIOS.mm
+[ iOS ] platform/ios/ValidationBubbleIOS.mm
+[ iOS ] platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
+[ iOS ] platform/ios/WebEvent.mm
+[ iOS ] platform/ios/WebItemProviderPasteboard.mm
+[ iOS ] platform/ios/WidgetIOS.mm
+[ iOS ] platform/ios/wak/WAKClipView.mm
+[ iOS ] platform/ios/wak/WAKScrollView.mm
+[ iOS ] platform/ios/wak/WAKView.mm
+[ iOS ] platform/ios/wak/WAKWindow.mm
+[ iOS ] platform/ios/wak/WKView.mm
+[ iOS ] platform/ios/wak/WebCoreThread.mm
+[ iOS ] platform/ios/wak/WebCoreThreadRun.cpp
+[ iOS ] platform/mediastream/ios/ReplayKitCaptureSource.mm
+[ iOS ] platform/network/mac/ResourceErrorMac.mm
+[ iOS ] platform/text/mac/TextBoundaries.mm
+[ iOS ] rendering/ios/RenderThemeIOS.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
@@ -1,2 +1,4 @@
 platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
+[ iOS ] platform/ios/PlatformPasteboardIOS.mm
+[ iOS ] platform/ios/WebItemProviderPasteboard.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,7 +1,7 @@
-accessibility/cocoa/AXCoreObjectCocoa.mm
+[ Mac ] accessibility/cocoa/AXCoreObjectCocoa.mm
 accessibility/cocoa/AccessibilityObjectCocoa.mm
-accessibility/mac/AXObjectCacheMac.mm
-accessibility/mac/AccessibilityObjectMac.mm
+[ Mac ] accessibility/mac/AXObjectCacheMac.mm
+[ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 accessibility/mac/WebAccessibilityObjectWrapperBase.mm
 bindings/js/ScriptControllerMac.mm
 bridge/objc/WebScriptObject.mm
@@ -10,22 +10,22 @@ bridge/objc/objc_instance.mm
 bridge/objc/objc_runtime.mm
 bridge/objc/objc_utility.mm
 crypto/cocoa/SerializedCryptoKeyWrapMac.mm
-editing/cocoa/AlternativeTextUIController.mm
+[ Mac ] editing/cocoa/AlternativeTextUIController.mm
 editing/cocoa/DataDetection.mm
 editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/NodeHTMLConverter.mm
 loader/archive/cf/LegacyWebArchive.cpp
 page/cocoa/ResourceUsageThreadCocoa.mm
 page/mac/ChromeMac.mm
-page/mac/EventHandlerMac.mm
-page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
-page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
-page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+[ Mac ] page/mac/EventHandlerMac.mm
+[ Mac ] page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
+[ Mac ]page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+[ Mac ]page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
 platform/audio/cocoa/AudioEncoderCocoa.cpp
 platform/audio/cocoa/AudioFileReaderCocoa.cpp
 platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
 platform/cf/KeyedDecoderCF.cpp
-platform/cocoa/DragImageCocoa.mm
+[ Mac ] platform/cocoa/DragImageCocoa.mm
 platform/cocoa/PlatformPasteboardCocoa.mm
 platform/cocoa/RemoteCommandListenerCocoa.mm
 platform/cocoa/SearchPopupMenuCocoa.mm
@@ -34,7 +34,7 @@ platform/cocoa/SystemVersion.mm
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
 platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
-platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
+[ Mac ] platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -53,16 +53,16 @@ platform/graphics/cocoa/CMUtilities.mm
 platform/graphics/cocoa/FontCacheCoreText.cpp
 platform/graphics/cocoa/FontPlatformDataCocoa.mm
 platform/graphics/cocoa/GraphicsContextCocoa.mm
-platform/graphics/cocoa/ImageAdapterCocoa.mm
+[ Mac ] platform/graphics/cocoa/ImageAdapterCocoa.mm
 platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm
-platform/graphics/mac/controls/ControlMac.mm
-platform/graphics/mac/controls/ImageControlsButtonMac.mm
-platform/graphics/mac/controls/ProgressBarMac.mm
-platform/graphics/mac/controls/SliderTrackMac.mm
-platform/graphics/mac/controls/SwitchMacUtilities.mm
-platform/graphics/mac/controls/SwitchThumbMac.mm
-platform/graphics/mac/controls/SwitchTrackMac.mm
+[ Mac ] platform/graphics/mac/controls/ControlMac.mm
+[ Mac ] platform/graphics/mac/controls/ImageControlsButtonMac.mm
+[ Mac ] platform/graphics/mac/controls/ProgressBarMac.mm
+[ Mac ] platform/graphics/mac/controls/SliderTrackMac.mm
+[ Mac ] platform/graphics/mac/controls/SwitchMacUtilities.mm
+[ Mac ] platform/graphics/mac/controls/SwitchThumbMac.mm
+[ Mac ] platform/graphics/mac/controls/SwitchTrackMac.mm
 platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
 platform/ios/WebAVPlayerController.mm
 platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -76,3 +76,38 @@ rendering/AttachmentLayout.mm
 testing/Internals.mm
 testing/cocoa/WebArchiveDumpSupport.mm
 testing/cocoa/WebViewVisualIdentificationOverlay.mm
+[ iOS ] Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
+[ iOS ] Modules/system-preview/ARKitBadgeSystemImage.mm
+[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
+[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+[ iOS ] page/ios/EventHandlerIOS.mm
+[ iOS ] platform/audio/ios/AudioSessionIOS.mm
+[ iOS ] platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
+[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
+[ iOS ] platform/graphics/cg/PDFDocumentImage.cpp
+[ iOS ] platform/ios/DragImageIOS.mm
+[ iOS ] platform/ios/LegacyTileCache.mm
+[ iOS ] platform/ios/LegacyTileGrid.mm
+[ iOS ] platform/ios/LegacyTileGridTile.mm
+[ iOS ] platform/ios/LocalCurrentTraitCollection.mm
+[ iOS ] platform/ios/PasteboardIOS.mm
+[ iOS ] platform/ios/PlatformPasteboardIOS.mm
+[ iOS ] platform/ios/PlatformScreenIOS.mm
+[ iOS ] platform/ios/QuickLook.mm
+[ iOS ] platform/ios/ScrollViewIOS.mm
+[ iOS ] platform/ios/UIViewControllerUtilities.mm
+[ iOS ] platform/ios/ValidationBubbleIOS.mm
+[ iOS ] platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
+[ iOS ] platform/ios/WebItemProviderPasteboard.mm
+[ iOS ] platform/ios/WidgetIOS.mm
+[ iOS ] platform/ios/wak/WAKScrollView.mm
+[ iOS ] platform/ios/wak/WAKView.mm
+[ iOS ] platform/ios/wak/WAKViewInternal.h
+[ iOS ] platform/ios/wak/WAKWindow.mm
+[ iOS ] platform/ios/wak/WKView.mm
+[ iOS ] platform/ios/wak/WebCoreThread.mm
+[ iOS ] platform/network/ios/WebCoreURLResponseIOS.mm
+[ iOS ] platform/network/mac/ResourceErrorMac.mm
+[ iOS ] platform/text/mac/TextBoundaries.mm
+[ iOS ] rendering/ios/RenderThemeIOS.mm


### PR DESCRIPTION
#### 8a3a8697b747e3f491c25b5d5b5e9c74ad3031d6
<pre>
Add iOS safer C++ expectations for WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=300453">https://bugs.webkit.org/show_bug.cgi?id=300453</a>

Reviewed by Geoffrey Garen.

Added iOS specific failures and annotated Mac specific failures for WebCore.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/301280@main">https://commits.webkit.org/301280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bb3a4a4c75c9d91d52d9b22c7d47f23f5cd2e28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77336 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a90f7d0-2d6b-49f3-ae4e-9a81b281add7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95530 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c80482b4-ce33-4af6-9281-e03e127fbf78) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112187 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76056 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b8ebfe6-a9f8-4e01-b2e9-528ae562004a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35500 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30360 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75782 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134986 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40031 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104005 "Failed to checkout and rebase branch from PR 52072") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108403 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103754 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49115 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27418 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49409 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19649 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52148 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57932 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51499 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54855 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53194 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->