### PR TITLE
Upgrade buildbot version in autoinstalled

### DIFF
--- a/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,29 +33,31 @@ AutoInstall.install('markupsafe')
 AutoInstall.install('jinja2')
 
 AutoInstall.install(Package('attrs', Version(21, 3), aliases=['attr']))
-AutoInstall.install(Package('constantly', Version(15, 1, 0)))
+AutoInstall.install(Package('constantly', Version(23, 10, 4)))
 AutoInstall.install(Package('dateutil', Version(2, 8, 1), pypi_name='python-dateutil', wheel=True))
 AutoInstall.install(Package('future', Version(0, 18, 2), aliases=['libfuturize', 'libpasteurize', 'past']))
 AutoInstall.install(Package('pbr', Version(5, 9, 0)))
-AutoInstall.install(Package('lz4', Version(4, 3, 2)))
-AutoInstall.install(Package('jwt', Version(1, 7, 1), pypi_name='PyJWT'))
+AutoInstall.install(Package('lz4', Version(4, 4, 4)))
+AutoInstall.install(Package('jwt', Version(2, 10, 1), pypi_name='PyJWT'))
 
-AutoInstall.install(Package('autobahn', Version(20, 7, 1), wheel=False))
-AutoInstall.install(Package('automat', Version(20, 2, 0), pypi_name='Automat'))
-AutoInstall.install(Package('decorator', Version(5, 1, 1)))
+AutoInstall.install(Package('autobahn', Version(24, 4, 2), wheel=False))
+AutoInstall.install(Package('automat', Version(25, 4, 16), pypi_name='Automat'))
 AutoInstall.install(Package('hamcrest', Version(2, 0, 3), pypi_name='PyHamcrest'))
 AutoInstall.install(Package('mock', Version(5, 2, 0)))
 AutoInstall.install(Package('pyyaml', Version(6, 0, 2)))
-AutoInstall.install(Package('sqlalchemy', Version(1, 3, 20), pypi_name='SQLAlchemy'))
+AutoInstall.install(Package('sqlalchemy', Version(2, 0, 41), pypi_name='SQLAlchemy'))
 AutoInstall.install(Package('sqlalchemy_migrate', Version(0, 13, 0), pypi_name='sqlalchemy-migrate'))
-AutoInstall.install(Package('sqlparse', Version(0, 4, 2)))
-AutoInstall.install(Package('txaio', Version(20, 4, 1)))
-AutoInstall.install(Package('tempita', Version(0, 5, 2), pypi_name='Tempita'))
+AutoInstall.install(Package('txaio', Version(23, 1, 1)))
+AutoInstall.install(Package('treq', Version(25, 5, 0)))
+AutoInstall.install(Package('alembic', Version(1, 14, 0)))
+AutoInstall.install(Package('Mako', Version(1, 3, 10)))
+AutoInstall.install(Package('croniter', Version(6, 0, 0)))
+AutoInstall.install(Package('pytz', Version(2025, 2)))
 
 # buildbot has wheel=False because we rely on items in buildbot.test that only
 # became public API and started being included in wheels from 3.5.0.
-AutoInstall.install(Package('buildbot', Version(2, 10, 5), wheel=False))
-AutoInstall.install(Package('buildbot_worker', Version(2, 10, 5), pypi_name='buildbot-worker'))
+AutoInstall.install(Package('buildbot', Version(4, 3, 0), wheel=False))
+AutoInstall.install(Package('buildbot_worker', Version(4, 3, 0), pypi_name='buildbot-worker'))
 
 
 sys.modules[__name__] = __import__('buildbot')

--- a/Tools/Scripts/webkitpy/autoinstalled/twisted.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/twisted.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -25,14 +25,11 @@ import sys
 
 from webkitscmpy import AutoInstall, Package, Version
 
-AutoInstall.install(Package('constantly', Version(15, 1, 0), pypi_name='constantly'))
+AutoInstall.install(Package('constantly', Version(23, 10, 4), pypi_name='constantly'))
 AutoInstall.install(Package('hyperlink', Version(21, 0, 0), pypi_name='hyperlink'))
 AutoInstall.install(Package('incremental', Version(21, 3, 0), pypi_name='incremental'))
 
-if sys.version_info >= (3, 11):
-    AutoInstall.install(Package('twisted', Version(22, 10, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
-else:
-    AutoInstall.install(Package('twisted', Version(20, 3, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
+AutoInstall.install(Package('twisted', Version(23, 10, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
 
 # There are no prebuilt binaries for arm-32 of 'bcrypt' and building it requires cargo/rust
 # Since this dep is not really needed for the current arm-32 bots we skip it instead of


### PR DESCRIPTION
#### faa4dce75256c717842bb11061fc99bcf3cd97e6
<pre>
Upgrade buildbot version in autoinstalled
<a href="https://bugs.webkit.org/show_bug.cgi?id=300455">https://bugs.webkit.org/show_bug.cgi?id=300455</a>
<a href="https://rdar.apple.com/162304504">rdar://162304504</a>

Reviewed by Carlos Alberto Lopez Perez.

We have upgraded both build.webkit.org and ews-build.webkit.org to buildbot v4.3.0.
We should also update the version in webkitpy autoinstalled.

* Tools/Scripts/webkitpy/autoinstalled/buildbot.py:
* Tools/Scripts/webkitpy/autoinstalled/twisted.py:

Canonical link: <a href="https://commits.webkit.org/301545@main">https://commits.webkit.org/301545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b62138070f2ab27b08175dc3f1b25399c443af0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133273 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54525 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129270 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/37314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/113001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/125674 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135791 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53062 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/40775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109257 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/49819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19750 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52964 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/53995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->