### PR TITLE
Migrate TextRecognitionResult Serialization from using VKCImageAnalysis NSKeyedUnarchiver

### DIFF
--- a/Source/WebCore/platform/TextRecognitionResult.h
+++ b/Source/WebCore/platform/TextRecognitionResult.h
@@ -37,6 +37,8 @@ OBJC_CLASS VKCImageAnalysis;
 OBJC_CLASS DDScannerResult;
 #endif
 
+#include "AttributedString.h"
+
 #include <WebCore/FloatQuad.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/text/WTFString.h>
@@ -110,10 +112,8 @@ struct TextRecognitionResult {
     Vector<TextRecognitionBlockData> blocks;
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    RetainPtr<NSData> imageAnalysisData;
-
-    WEBCORE_EXPORT static RetainPtr<NSData> encodeVKCImageAnalysis(RetainPtr<VKCImageAnalysis>);
-    WEBCORE_EXPORT static RetainPtr<VKCImageAnalysis> decodeVKCImageAnalysis(RetainPtr<NSData>);
+    std::optional<WebCore::AttributedString> imageAnalysisData;
+    WEBCORE_EXPORT static std::optional<WebCore::AttributedString> extractAttributedString(VKCImageAnalysis *);
 #endif
 
     bool isEmpty() const

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6781,7 +6781,7 @@ void Internals::installImageOverlay(Element& element, Vector<ImageOverlayLine>&&
             return TextRecognitionBlockData { block.text, getQuad(block) };
         })
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-        , TextRecognitionResult::encodeVKCImageAnalysis(fakeImageAnalysisResultForTesting(lines))
+        , TextRecognitionResult::extractAttributedString(fakeImageAnalysisResultForTesting(lines).get())
 #endif
     });
 #else

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -74,6 +74,31 @@
 - (instancetype)initWithString:(NSString *)fullText;
 @end
 
+static NSRange clampRange(NSRange rangeToClamp, NSRange extentRange)
+{
+    NSUInteger minRange1 = rangeToClamp.location;
+    NSUInteger maxRange1 = NSMaxRange(rangeToClamp);
+
+    NSUInteger minRange2 = extentRange.location;
+    NSUInteger maxRange2 = NSMaxRange(extentRange);
+
+    NSUInteger minCommon = clampTo(minRange1, minRange2, maxRange2);
+    NSUInteger maxCommon = clampTo(maxRange1, minRange2, maxRange2);
+
+    if (rangeToClamp.location == NSNotFound) {
+        minCommon = maxRange2;
+        maxCommon = maxRange2;
+    } else if (minCommon > maxCommon)
+        std::swap(minCommon, maxCommon);
+
+    NSRange result = NSMakeRange(minCommon, maxCommon - minCommon);
+
+    if (extentRange.location == NSNotFound)
+        result = NSMakeRange(NSNotFound, 0);
+
+    return result;
+}
+
 @implementation FakeImageAnalysisResult {
     RetainPtr<NSAttributedString> _string;
 }
@@ -89,7 +114,9 @@
 
 - (NSAttributedString *)_attributedStringForRange:(NSRange)range
 {
-    return [_string attributedSubstringFromRange:range];
+    NSRange validRange = NSMakeRange(0, [_string length]);
+    NSRange safeRange = clampRange(range, validRange);
+    return [_string attributedSubstringFromRange:safeRange];
 }
 
 @end

--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
@@ -32,6 +32,7 @@
 #import "Logging.h"
 #import "TransactionID.h"
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#import <WebCore/AttributedString.h>
 #import <WebCore/TextRecognitionResult.h>
 #import <pal/cocoa/VisionKitCoreSoftLink.h>
 #import <pal/cocoa/VisionSoftLink.h>
@@ -135,7 +136,7 @@ TextRecognitionResult makeTextRecognitionResult(CocoaImageAnalysis *analysis)
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
     if ([analysis isKindOfClass:PAL::getVKCImageAnalysisClassSingleton()])
-        result.imageAnalysisData = TextRecognitionResult::encodeVKCImageAnalysis(analysis);
+        result.imageAnalysisData = TextRecognitionResult::extractAttributedString(analysis);
 #endif
 
     return result;

--- a/Source/WebKit/Shared/TextRecognitionResult.serialization.in
+++ b/Source/WebKit/Shared/TextRecognitionResult.serialization.in
@@ -51,7 +51,7 @@ header: <WebCore/TextRecognitionResult.h>
 #endif
     Vector<WebCore::TextRecognitionBlockData> blocks;
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    RetainPtr<NSData> imageAnalysisData;
+    std::optional<WebCore::AttributedString> imageAnalysisData;
 #endifs
 };
 


### PR DESCRIPTION
#### 69bf86418a9eb181aae9d7b89b61126b6d2d281d
<pre>
Migrate TextRecognitionResult Serialization from using VKCImageAnalysis NSKeyedUnarchiver
<a href="https://bugs.webkit.org/show_bug.cgi?id=300461">https://bugs.webkit.org/show_bug.cgi?id=300461</a>
<a href="https://rdar.apple.com/108673895">rdar://108673895</a>

Reviewed by Wenson Hsieh.

Refactored the flow to send a WebCore::AttributedString.

Covered by existing tests.
* Source/WebCore/platform/TextRecognitionResult.h:
* Source/WebCore/platform/cocoa/TextRecognitionResultCocoa.mm:
(WebCore::TextRecognitionResult::extractAttributedString):
(WebCore::stringForRange):
(WebCore::TextRecognitionResult::encodeVKCImageAnalysis): Deleted.
(WebCore::TextRecognitionResult::decodeVKCImageAnalysis): Deleted.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::installImageOverlay):
* Source/WebCore/testing/Internals.mm:
(_clamp_int):
(_clamp_range):
(-[FakeImageAnalysisResult _attributedStringForRange:]):
* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:
(WebKit::makeTextRecognitionResult):
* Source/WebKit/Shared/TextRecognitionResult.serialization.in:

Canonical link: <a href="https://commits.webkit.org/301503@main">https://commits.webkit.org/301503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72de93b83a01f3395363230cbf268fda5d8c49de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77918 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4145c4ce-1b4e-45e5-9658-0be8028cb319) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96050 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64144 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5e2b611-324a-4a02-9265-e08967f98c91) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76534 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9465a117-fdf3-4d3d-9d47-649e0c213895) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36059 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30990 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76399 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135635 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104558 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104265 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26582 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49659 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27998 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50268 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52769 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58603 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52097 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55443 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53807 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->