### PR TITLE
Make compute-safer-cpp-statistics work with platform specific safer C++ expectations

### DIFF
--- a/Tools/Scripts/compute-safer-cpp-statistics
+++ b/Tools/Scripts/compute-safer-cpp-statistics
@@ -21,14 +21,16 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
 import argparse
+import os
+import re
 
 from webkitpy.safer_cpp.checkers import Checker
 
 # FIXME: Make this configurable
 EXCLUDED_DIRNAMES = ['CoordinatedGraphics', 'atoms', 'cairo', 'curl', 'gbm', 'glib', 'gstreamer', 'gtk', 'libwpe', 'linux', 'manette', 'playstation', 'skia', 'socket', 'soup', 'unified-sources', 'unix', 'wc', 'win', 'wpe']
 RELEVANT_FILE_EXTENSIONS = ['.c', '.cpp', '.h', '.m', '.mm']
+EXPECTATION_LINE_RE = r'(\s*\[\s*(?P<platform>\w+)\s*\]\s*)?(?P<path>.+)'
 
 
 def parser():
@@ -54,6 +56,10 @@ def parser():
         help='Specify the directory to ignore relative to the project root (e.g. WebProcess for Source/WebKit/WebProcess)'
     )
     parser.add_argument(
+        '--platform',
+        help='Specify the platform to compute statistics for. e.g. mac'
+    )
+    parser.add_argument(
         '--csv',
         help='Specify a path to a CSV file to be generated. CSV file will not be generated if omitted'
     )
@@ -70,18 +76,30 @@ def matching_checkers(checker):
     return [matching_checker]
 
 
-def load_expectations(checker_list, project):
+def load_expectations(checker_list, project, platform):
     file_to_expectations_map = {}
+    expectation_line_re = re.compile(EXPECTATION_LINE_RE)
     for checker in checker_list:
         expectations_path = checker.expectations_path(project)
         if not os.path.isfile(expectations_path):
             return
         with open(expectations_path) as expectation_file:
-            for file_key in expectation_file:
-                file_key = file_key.strip()
+            for line in expectation_file:
+                if line.startswith('//') or line.startswith('#'):
+                    continue
+                match = expectation_line_re.match(line)
+                if not match:
+                    print(f'Unexpected line: {line}')
+                    continue
+                expectation_platform = match.group('platform')
+                file_key = match.group('path')
+                if platform and expectation_platform and expectation_platform.lower() != platform.lower():
+                    print(f'Excluding: {file_key} ({expectation_platform})')
+                    continue
                 file_to_expectations_map.setdefault(file_key, set())
                 file_to_expectations_map[file_key].add(checker.name())
     return file_to_expectations_map
+
 
 def count_number_of_lines(file_path):
     with open(file_path) as file_handle:
@@ -142,7 +160,7 @@ def main():
     if not checkers:
         return
 
-    file_to_expectations_map = load_expectations(checkers, args.project)
+    file_to_expectations_map = load_expectations(checkers, args.project, args.platform)
     line_counts = {'safe': 0, 'unsafe': 0, 'safeFiles': 0, 'unsafeFiles': 0, 'checkers': {}}
     for checker in checkers:
         line_counts['checkers'][checker.name()] = {'safe': 0, 'unsafe': 0, 'safeFiles': 0, 'unsafeFiles': 0}


### PR DESCRIPTION
#### 27f838938772f0a3602d139435d9725b0b17faaf
<pre>
Make compute-safer-cpp-statistics work with platform specific safer C++ expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=300463">https://bugs.webkit.org/show_bug.cgi?id=300463</a>

Reviewed by Geoffrey Garen.

Made this tool work with platform specific annotations introduced in 301254@main.

* Tools/Scripts/compute-safer-cpp-statistics:
(parser):
(matching_checkers):
(load_expectations):
(main):

Canonical link: <a href="https://commits.webkit.org/301281@main">https://commits.webkit.org/301281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bc1ac40fab66ac790d89207d4dba5fee10f10a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132338 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/232cc46d-7bb2-4ea1-9906-96a4673e4a4f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53706 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/690f14fc-7027-47f5-a23d-f74fa0f0a001) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128430 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/36627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/112214 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76081 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5f8a1e9-a7de-4978-a822-b276f8a8bcb6) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/30391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75812 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/106398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135015 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40052 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104035 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52722 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108430 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/49142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/27445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/49440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19650 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52177 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/51528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54884 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53223 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->