### PR TITLE
Drop Custom toJS() / toJSNewlyCreated() functions for HTMLCollection

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -704,7 +704,6 @@ bindings/js/JSExtendableMessageEventCustom.cpp
 bindings/js/JSFetchEventCustom.cpp
 bindings/js/JSHTMLAllCollectionCustom.cpp
 bindings/js/JSHTMLCanvasElementCustom.cpp
-bindings/js/JSHTMLCollectionCustom.cpp
 bindings/js/JSHTMLElementCustom.cpp
 bindings/js/JSHTMLTemplateElementCustom.cpp
 bindings/js/JSHistoryCustom.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8156,7 +8156,7 @@ Ref<HTMLCollection> Document::anchors()
     return ensureCachedCollection<CollectionType::DocAnchors>();
 }
 
-Ref<HTMLCollection> Document::all()
+Ref<HTMLAllCollection> Document::all()
 {
     return ensureRareData().ensureNodeLists().addCachedCollection<HTMLAllCollection>(*this, CollectionType::DocAll);
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -623,7 +623,7 @@ public:
     WEBCORE_EXPORT Ref<HTMLCollection> forms();
     WEBCORE_EXPORT Ref<HTMLCollection> anchors();
     WEBCORE_EXPORT Ref<HTMLCollection> scripts();
-    Ref<HTMLCollection> all();
+    Ref<HTMLAllCollection> all();
     Ref<HTMLCollection> allFilteredByName(const AtomString&);
 
     Ref<HTMLCollection> windowNamedItems(const AtomString&);

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -125,6 +125,11 @@ inline ContainerNode& HTMLCollection::ownerNode() const
     return m_ownerNode;
 }
 
+inline CollectionType HTMLCollection::type() const
+{
+    return static_cast<CollectionType>(m_collectionType);
+}
+
 } // namespace WebCore
 
 #define SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(ClassName, Type) \

--- a/Source/WebCore/html/HTMLCollection.idl
+++ b/Source/WebCore/html/HTMLCollection.idl
@@ -19,7 +19,6 @@
  */
 
 [
-    CustomToJSObject,
     ExportToWrappedFunction,
     GenerateIsReachable=ImplOwnerNodeRoot,
     LegacyUnenumerableNamedProperties,

--- a/Source/WebCore/html/HTMLCollectionInlines.h
+++ b/Source/WebCore/html/HTMLCollectionInlines.h
@@ -91,11 +91,6 @@ inline NodeListInvalidationType HTMLCollection::invalidationType() const
     return static_cast<NodeListInvalidationType>(m_invalidationType);
 }
 
-inline CollectionType HTMLCollection::type() const
-{
-    return static_cast<CollectionType>(m_collectionType);
-}
-
 inline Document& HTMLCollection::document() const
 {
     return m_ownerNode->document();


### PR DESCRIPTION
#### 5ee4e2811ebd90d4c026a30aca92c946bfeb502c
<pre>
Drop Custom toJS() / toJSNewlyCreated() functions for HTMLCollection
<a href="https://bugs.webkit.org/show_bug.cgi?id=300467">https://bugs.webkit.org/show_bug.cgi?id=300467</a>

Reviewed by Ryosuke Niwa.

Drop Custom toJS() / toJSNewlyCreated() functions for HTMLCollection as
the bindings generator knows how to generate them now.

Note that unlike the manual code, the generated code doesn&apos;t deal with
HTMLAllCollection. The reason for this is that HTMLAllCollection does
NOT inherit HTMLCollection in Web IDL. However, it does in our C++
implementation. The good news is that HTMLAllCollection is deprecated
and only returned in one place: `document.all` where we can return
a HTMLAllCollection directly instead of an HTMLCollection, so that
`toJS(const HTMLCollection&amp;)` does not get called.

This tested as performance neutral on Speedometer.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::all):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLCollection.h:
(WebCore::HTMLCollection::type const):
* Source/WebCore/html/HTMLCollection.idl:
* Source/WebCore/html/HTMLCollectionInlines.h:
(WebCore::HTMLCollection::type const): Deleted.

Canonical link: <a href="https://commits.webkit.org/301350@main">https://commits.webkit.org/301350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/176502d15c9173e57e886899ac9870ef82da293b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132530 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77550 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03c746c7-7f61-472f-a86f-c348cccdafc5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95740 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63863 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03df28bb-11fe-46e2-a84e-1da8a1204e76) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76234 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09bb56e3-32e2-40e8-9788-133c9ae4f7ed) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30560 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75999 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106561 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135203 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104210 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52906 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103937 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26474 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49293 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27605 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49685 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52354 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58157 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51701 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55053 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53398 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->