### PR TITLE
webkitscmpy.local.git.Git.branch shouldn't call git-status

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -479,10 +479,8 @@ class Git(Scm):
         if self._branch:
             return self._branch
 
-        status = run([self.executable(), 'status'], cwd=self.root_path, capture_output=True, encoding='utf-8')
-        if status.returncode:
-            raise self.Exception('Failed to run `git status` for {}'.format(self.root_path))
-        if status.stdout.splitlines()[0].startswith('HEAD detached at'):
+        head_ref = run([self.executable(), 'symbolic-ref', '-q', 'HEAD'], cwd=self.root_path, stdout=subprocess.DEVNULL)
+        if head_ref.returncode:
             return None
 
         result = run([self.executable(), 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=self.root_path, capture_output=True, encoding='utf-8')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -209,6 +209,15 @@ class Git(mocks.Subprocess):
 
         super(Git, self).__init__(
             mocks.Subprocess.Route(
+                self.executable, 'symbolic-ref', '-q', 'HEAD',
+                cwd=self.path,
+                generator=lambda *args, **kwargs:
+                    mocks.ProcessCompletion(
+                        returncode=1 if self.detached else 0,
+                        stdout='' if self.detached else 'refs/heads/{}\n'.format(self.branch)
+                    ),
+            ),
+            mocks.Subprocess.Route(
                 self.executable, 'status',
                 cwd=self.path,
                 generator=lambda *args, **kwargs:


### PR DESCRIPTION
#### 32c25bb712d4823ffdc1c4de1f56c0e803809136
<pre>
webkitscmpy.local.git.Git.branch shouldn&apos;t call git-status
<a href="https://rdar.apple.com/158438687">rdar://158438687</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297485">https://bugs.webkit.org/show_bug.cgi?id=297485</a>

Reviewed by Jonathan Bedard.

We are running `git status` in this case in order to determine whether or not the checkout
is in a detached head state. As Sam pointed out, running `git symbolic-ref -q HEAD` accomplishes
the same goal and can run much faster.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/popen.py:
(PopenBase.__init__): Add support for handling subprocess.DEVNULL.
(PopenBase.poll): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.branch): Switch to `git symbolic-ref -q HEAD`, which exits with 1 if detached
and 0 if not detached.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git): Add new mock.

Canonical link: <a href="https://commits.webkit.org/301587@main">https://commits.webkit.org/301587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aea2f8ffc82f3a076d41a05fd2088dc709bc7de4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132865 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77856 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13233b00-0ed4-4604-ad0f-ad76b33c4584) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95991 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64152 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ddc9d92c-6b1b-456e-8a84-c7dc4f3c06e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76480 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b93774a6-df7a-43bf-afc7-aab270bf3b3a) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/125387 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35992 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30892 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76336 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106867 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135562 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104475 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/125459 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104195 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49587 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27914 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50174 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19772 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52691 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52027 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55374 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53730 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->