### PR TITLE
[GPU] [CoreIPC] Improve expression validation in WebCore::SVGFilterRenderer

### DIFF
--- a/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash-expected.txt
+++ b/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html
+++ b/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html
@@ -1,0 +1,149 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.setTimeout(async () => {
+        if (!window.IPC) return window.testRunner?.notifyDone();
+
+        const { CoreIPC } = await import("./coreipc.js");
+
+        const streamConnection = CoreIPC.newStreamConnection();
+
+        const renderingBackendIdentifier = Math.floor(
+            Math.random() * 0x1000000,
+        );
+        CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+            renderingBackendIdentifier: renderingBackendIdentifier,
+            connectionHandle: streamConnection,
+        });
+        const remoteRenderingBackend = streamConnection.newInterface(
+            "RemoteRenderingBackend",
+            renderingBackendIdentifier,
+        );
+        remoteRenderingBackend.CreateImageBuffer({
+            logicalSize: { width: 100, height: 100 },
+            renderingMode: 1,
+            renderingPurpose: 0,
+            resolutionScale: 1,
+            colorSpace: {
+                serializableColorSpace: {
+                    alias: {
+                        m_cgColorSpace: {
+                            alias: {
+                                variantType: "RetainPtr<CFTypeRef>",
+                                variant: {
+                                    object: {
+                                        alias: {
+                                            variantType: "WebKit::CoreIPCData",
+                                            variant: { dataReference: {} },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            bufferFormat: { pixelFormat: 2, useLosslessCompression: 1 },
+            identifier: 393236,
+            contextIdentifier: 393237,
+        });
+
+        try {
+            o62 = streamConnection.newInterface(
+                "RemoteGraphicsContext",
+                393237,
+            );
+
+            o62.DrawFilteredImageBuffer({
+                sourceImageIdentifier: {},
+                sourceImageRect: {
+                    location: { x: 1, y: 1 },
+                    size: {
+                        width: 1,
+                        height: 1,
+                    },
+                },
+                filter: {
+                    subclasses: {
+                        variantType: "WebCore::SVGFilterRenderer",
+                        variant: {
+                            targetBoundingBox: {
+                                location: { x: 0, y: 0 },
+                                size: {
+                                    width: 1,
+                                    height: 1,
+                                },
+                            },
+                            primitiveUnits: 0,
+                            expression: { alias: [] },
+                            effects: [
+                                {
+                                    subclasses: {
+                                        variantType:
+                                            "WebCore::FEDisplacementMap",
+                                        variant: {
+                                            xChannelSelector: 0,
+                                            yChannelSelector: 4,
+                                            scale: 1,
+                                            operatingColorSpace: {
+                                                serializableColorSpace: {
+                                                    alias: {
+                                                        m_cgColorSpace: {
+                                                            alias: {
+                                                                variantType:
+                                                                    "WebCore::ColorSpace",
+                                                                variant: 17,
+                                                            },
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            ],
+                            renderingResourceIdentifierIfExists: {},
+                            filterRenderingModes: 0,
+                            filterScale: {
+                                width: 1,
+                                height: 1,
+                            },
+                            filterRegion: {
+                                location: {
+                                    x: 1,
+                                    y: 1,
+                                },
+                                size: {
+                                    width: 1,
+                                    height: 1,
+                                },
+                            },
+                        },
+                    },
+                },
+            });
+        } catch (err) {
+            // We expect validation to fail and return a TypeError to us. If we get any other kind of error,
+            // log this so we can address the issue as this may indicate the test is non-functional. If the
+            // validation we are testing is not functioning correctly, the GPU process will crash and the
+            // test will fail.
+            //
+            // Replace this with a specific check for an IPC message validation failure when the
+            // enhancement in rdar://147337600 is implemented.
+            if (!(err instanceof TypeError)) {
+                console.log("Test failed: expected TypeError, got " + err);
+            }
+        }
+
+        streamConnection.connection.invalidate();
+
+        setTimeout(() => {
+            window.testRunner?.notifyDone();
+        }, 500);
+    }, 20);
+</script>
+
+This test passes if WebKit does not crash.

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
@@ -313,6 +313,7 @@ RefPtr<FilterImage> SVGFilterRenderer::apply(FilterImage* sourceImage, FilterRes
 {
     ASSERT(!m_expression.isEmpty());
     ASSERT(filterRenderingModes().contains(FilterRenderingMode::Software));
+    ASSERT(isValidSVGFilterExpression(m_expression, m_effects));
 
     FilterImageVector stack;
 
@@ -349,6 +350,9 @@ RefPtr<FilterImage> SVGFilterRenderer::apply(FilterImage* sourceImage, FilterRes
 
 bool SVGFilterRenderer::isValidSVGFilterExpression(const SVGFilterExpression& expression, const FilterEffectVector& effects)
 {
+    if (expression.isEmpty() || effects.isEmpty())
+        return false;
+
     for (const auto& term : expression) {
         if (term.index >= effects.size())
             return false;


### PR DESCRIPTION
#### d49bc45cdcaa2538b30fce4c01a5980f381ba674
<pre>
[GPU] [CoreIPC] Improve expression validation in WebCore::SVGFilterRenderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=300468">https://bugs.webkit.org/show_bug.cgi?id=300468</a>
<a href="https://rdar.apple.com/161641790">rdar://161641790</a>

Reviewed by Said Abou-Hallawa.

We can sometimes get into a state where we have an empty `expressions` vector with a
non empty `effects` vector when making an SVGFilterRenderer, which should not be the case.

This causes us to crash when trying to get the last valid expression in `WebCore::SVGFilterRenderer::apply`.

Fix by hardening the IPC validation function.

* LayoutTests/ipc/empty-svgfilterrenderer-expression-crash-expected.txt: Added.
* LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html: Added.
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp:
(WebCore::SVGFilterRenderer::apply):
(WebCore::SVGFilterRenderer::isValidSVGFilterExpression):

Canonical link: <a href="https://commits.webkit.org/301540@main">https://commits.webkit.org/301540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0b5c2589d0593a76af458a0ccefb75e49584d2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77995 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92d15166-b208-41a4-969b-d7b8d9dedd97) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96101 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64209 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5111a7ff-6ab6-4da1-8cc5-1a7641421240) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76583 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/962e3d31-c539-492a-9514-ed07d651650e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31077 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76471 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107015 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135700 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104598 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104301 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26609 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49738 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28072 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50353 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52870 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58701 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52186 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55532 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53903 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->