### PR TITLE
[CSS Zoom] Fix font-relative units for unzoomed properties

### DIFF
--- a/LayoutTests/fast/css/line-height-zoom-get-computed-style.html
+++ b/LayoutTests/fast/css/line-height-zoom-get-computed-style.html
@@ -1,5 +1,3 @@
-<!-- webkit-test-runner [ EvaluationTimeZoomEnabled=false ] -->
- <!-- Disabling flag until we fix zoom for font related units http://webkit.org/b/299816-->
 <!DOCTYPE html>
 <html>    
 <head>

--- a/LayoutTests/fast/sub-pixel/zoomed-em-border.html
+++ b/LayoutTests/fast/sub-pixel/zoomed-em-border.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ EvaluationTimeZoomEnabled=false ] -->
 <!DOCTYPE html>
 <html>
     <head>

--- a/LayoutTests/fast/text/line-height-minimumFontSize-zoom.html
+++ b/LayoutTests/fast/text/line-height-minimumFontSize-zoom.html
@@ -1,5 +1,3 @@
-<!-- webkit-test-runner [ EvaluationTimeZoomEnabled=false ] -->
- <!-- Disabling flag until we fix zoom for font related units http://webkit.org/b/299816-->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/svg/zoom/page/zoom-replaced-intrinsic-ratio-001.htm
+++ b/LayoutTests/svg/zoom/page/zoom-replaced-intrinsic-ratio-001.htm
@@ -1,5 +1,3 @@
-<!-- webkit-test-runner [ EvaluationTimeZoomEnabled=false ] -->
- <!-- Disabling flag until we fix zoom for font related units http://webkit.org/b/299816-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
  <head>

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include <WebCore/CSSPrimitiveNumericRange.h>
 #include <WebCore/CSSPropertyNames.h>
 #include <WebCore/Element.h>
 #include <optional>
@@ -64,6 +65,7 @@ public:
     const RenderStyle* rootStyle() const { return m_rootStyle; }
     const RenderStyle* parentStyle() const { return m_parentStyle; }
     float zoom() const;
+    CSS::RangeZoomOptions rangeZoomOption() const { return m_rangeZoomOption; }
     bool computingFontSize() const { return m_propertyToCompute == CSSPropertyFontSize; }
     bool computingLineHeight() const { return m_propertyToCompute == CSSPropertyLineHeight; }
     CSSPropertyID propertyToCompute() const { return m_propertyToCompute.value_or(CSSPropertyInvalid); }
@@ -86,10 +88,11 @@ public:
         return copy;
     };
 
-    CSSToLengthConversionData copyWithAdjustedZoom(float zoom) const
+    CSSToLengthConversionData copyWithAdjustedZoom(float zoom, CSS::RangeZoomOptions rangeZoomOption = CSS::RangeZoomOptions::Default) const
     {
         CSSToLengthConversionData copy(*this);
         copy.m_zoom = zoom;
+        copy.m_rangeZoomOption = rangeZoomOption;
         return copy;
     }
 
@@ -98,6 +101,7 @@ public:
         CSSToLengthConversionData copy(*this);
         copy.m_zoom = zoom;
         copy.m_propertyToCompute = CSSPropertyLineHeight;
+        copy.m_rangeZoomOption = CSS::RangeZoomOptions::Unzoomed;
         return copy;
     }
 
@@ -115,6 +119,7 @@ private:
     std::optional<float> m_zoom;
     std::optional<CSSPropertyID> m_propertyToCompute;
     CheckedPtr<Style::BuilderState> m_styleBuilderState;
+    CSS::RangeZoomOptions m_rangeZoomOption { CSS::RangeZoomOptions::Default };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -56,7 +56,7 @@ enum class RangeClampOptions {
 // Options to indicate how the primitive should consider its value with regards to zoom.
 // NOTE: This option is only meaningful for Style::Length`.
 // FIXME: These options are temporary while `zoom` is moving from style building time to use time.
-enum class RangeZoomOptions {
+enum class RangeZoomOptions : bool {
     // `Default` indicates the value held in the primitive has had zoom applied to it.
     Default,
 

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
@@ -50,6 +50,7 @@ struct SameSizeAsFontCascadeDescription {
     AtomString string2;
     int16_t fontSelectionRequest[3];
     float size;
+    float zoom;
     TextSpacingTrim textSpacingTrim;
     TextAutospace textAutospace;
     unsigned bitfields1;

--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -68,6 +68,7 @@ FontDescription::FontDescription()
     , m_fontStyleAxis(enumToUnderlyingType(FontStyleAxis::slnt))
     , m_shouldAllowUserInstalledFonts(enumToUnderlyingType(AllowUserInstalledFonts::No))
     , m_shouldDisableLigaturesForSpacing(false)
+    , m_enableEvaluationTimeZoom(false)
 {
 }
 

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/CSSPrimitiveNumericRange.h>
 #include <WebCore/FontPalette.h>
 #include <WebCore/FontSelectionAlgorithm.h>
 #include <WebCore/FontSizeAdjust.h>
@@ -46,6 +47,9 @@ public:
     bool operator==(const FontDescription&) const = default;
 
     float computedSize() const { return m_computedSize; }
+    float usedZoomFactor() const { return m_usedZoomFactor; }
+    float computedSizeForRangeZoomOption(CSS::RangeZoomOptions option) const { return (enableEvaluationTimeZoom() && option == CSS::RangeZoomOptions::Unzoomed) ? unzoomedComputedSize() : computedSize(); }
+    float unzoomedComputedSize() const { return m_computedSize / m_usedZoomFactor; }
     // Adjusted size regarding @font-face size-adjust but not regarding font-size-adjust. The latter adjustment is done with updateSizeWithFontSizeAdjust() after the font's creation.
     float adjustedSizeForFontFace(float) const;
     std::optional<FontSelectionValue> fontStyleSlope() const { return m_fontSelectionRequest.slope; }
@@ -58,6 +62,7 @@ public:
     UScriptCode script() const { return static_cast<UScriptCode>(m_script); }
     const AtomString& computedLocale() const { return m_locale; } // This is what you should be using for things like text shaping and font fallback
     const AtomString& specifiedLocale() const { return m_specifiedLocale; } // This is what you should be using for web-exposed things like -webkit-locale
+    bool enableEvaluationTimeZoom() const { return m_enableEvaluationTimeZoom; }
 
     FontOrientation orientation() const { return static_cast<FontOrientation>(m_orientation); }
     NonCJKGlyphOrientation nonCJKGlyphOrientation() const { return static_cast<NonCJKGlyphOrientation>(m_nonCJKGlyphOrientation); }
@@ -97,7 +102,7 @@ public:
     const FontPalette& fontPalette() const { return m_fontPalette; }
     FontSizeAdjust fontSizeAdjust() const { return m_sizeAdjust; }
 
-    void setComputedSize(float s) { m_computedSize = clampToFloat(s); }
+    void setComputedSize(float s, float zoom = 1.0f) { m_computedSize = clampToFloat(s); m_usedZoomFactor = zoom; }
     void setTextSpacingTrim(TextSpacingTrim v) { m_textSpacingTrim = v; }
     void setTextAutospace(TextAutospace v) { m_textAutospace = v; }
     void setFontStyleAxis(FontStyleAxis axis) { m_fontStyleAxis = enumToUnderlyingType(axis); }
@@ -140,6 +145,8 @@ public:
     void setShouldDisableLigaturesForSpacing(bool shouldDisableLigaturesForSpacing) { m_shouldDisableLigaturesForSpacing = shouldDisableLigaturesForSpacing; }
     void setFontPalette(const FontPalette& fontPalette) { m_fontPalette = fontPalette; }
     void setFontSizeAdjust(FontSizeAdjust fontSizeAdjust) { m_sizeAdjust = fontSizeAdjust; }
+    void setEnableEvaluationTimeZoom(bool enableEvaluationTimeZoom) { m_enableEvaluationTimeZoom = enableEvaluationTimeZoom; }
+
 
     static AtomString platformResolveGenericFamily(UScriptCode, const AtomString& locale, const AtomString& familyName);
 
@@ -157,6 +164,8 @@ private:
     TextSpacingTrim m_textSpacingTrim;
     TextAutospace m_textAutospace;
     float m_computedSize { 0 }; // Computed size adjusted for the minimum font size and the zoom factor.
+    float m_usedZoomFactor { 1.0 };
+
     PREFERRED_TYPE(FontOrientation) unsigned m_orientation : 1; // Whether the font is rendering on a horizontal line or a vertical line.
     PREFERRED_TYPE(NonCJKGlyphOrientation) unsigned m_nonCJKGlyphOrientation : 1; // Only used by vertical text. Determines the default orientation for non-ideograph glyphs.
     PREFERRED_TYPE(FontWidthVariant) unsigned m_widthVariant : 2;
@@ -184,6 +193,7 @@ private:
     PREFERRED_TYPE(FontStyleAxis) unsigned m_fontStyleAxis : 1;
     PREFERRED_TYPE(AllowUserInstalledFonts) unsigned m_shouldAllowUserInstalledFonts : 1; // If this description is allowed to match a user-installed font
     PREFERRED_TYPE(bool) unsigned m_shouldDisableLigaturesForSpacing : 1; // If letter-spacing is nonzero, we need to disable ligatures, which affects font preparation
+    PREFERRED_TYPE(bool) unsigned m_enableEvaluationTimeZoom : 1;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -271,7 +271,8 @@ void BuilderState::updateFontForSizeChange()
 void BuilderState::setFontSize(FontCascadeDescription& fontDescription, float size)
 {
     fontDescription.setSpecifiedSize(size);
-    fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules(), &style(), document()));
+    auto computedFontSize = Style::computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules(), &style(), document());
+    fontDescription.setComputedSize(computedFontSize.size, computedFontSize.usedZoomFactor);
 }
 
 CSSPropertyID BuilderState::cssPropertyID() const

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -69,9 +69,9 @@ inline void BuilderState::setFontDescriptionFontSize(float fontSize)
     }
 
     SUPPRESS_UNCOUNTED_ARG auto computedSize = Style::computedFontSizeFromSpecifiedSize(fontSize, m_style.fontDescription().isAbsoluteSize(), useSVGZoomRules(), &style(), document());
-    if (m_style.fontDescription().computedSize() != computedSize) {
+    if (m_style.fontDescription().computedSize() != computedSize.size || m_style.fontDescription().usedZoomFactor() != computedSize.usedZoomFactor) {
         m_fontDirty = true;
-        m_style.mutableFontDescriptionWithoutUpdate().setComputedSize(computedSize);
+        m_style.mutableFontDescriptionWithoutUpdate().setComputedSize(computedSize.size, computedSize.usedZoomFactor);
     }
 }
 

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -83,7 +83,7 @@ float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize
     return std::min(maximumAllowedFontSize, zoomedSize);
 }
 
-float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const RenderStyle* style, const Document& document)
+ComputedFontSize computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const RenderStyle* style, const Document& document)
 {
     float zoomFactor = 1.0f;
     if (!useSVGZoomRules) {
@@ -92,7 +92,7 @@ float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize
         if (frame && style->textZoom() != TextZoom::Reset)
             zoomFactor *= frame->textZoomFactor();
     }
-    return computedFontSizeFromSpecifiedSize(specifiedSize, isAbsoluteSize, zoomFactor, useSVGZoomRules ? MinimumFontSizeRule::None : MinimumFontSizeRule::AbsoluteAndRelative, document.settingsValues());
+    return { computedFontSizeFromSpecifiedSize(specifiedSize, isAbsoluteSize, zoomFactor, useSVGZoomRules ? MinimumFontSizeRule::None : MinimumFontSizeRule::AbsoluteAndRelative, document.settingsValues()), zoomFactor };
 }
 
 float computedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document& document)

--- a/Source/WebCore/style/StyleFontSizeFunctions.h
+++ b/Source/WebCore/style/StyleFontSizeFunctions.h
@@ -36,9 +36,13 @@ struct SettingsValues;
 namespace Style {
 
 enum class MinimumFontSizeRule : uint8_t { None, Absolute, AbsoluteAndRelative };
+struct ComputedFontSize {
+    float size { 0.0f };
+    float usedZoomFactor { 1.0f };
+};
 
 float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, float zoomFactor, MinimumFontSizeRule, const SettingsValues&);
-float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const RenderStyle*, const Document&);
+ComputedFontSize computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const RenderStyle*, const Document&);
 float computedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document&);
 float adjustedFontSize(float size, const WebCore::FontSizeAdjust&, const FontMetrics&);
 

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -87,12 +87,15 @@ RenderStyle resolveForDocument(const Document& document)
         fontDescription.setSpecifiedLocale(document.contentLanguage());
         fontDescription.setOneFamily(standardFamily);
         fontDescription.setShouldAllowUserInstalledFonts(settings.shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);
+        // FIXME: We need enableEvaluationTimeZoom to be accessible from FontDescription, not only from RenderStyle. Would it be weird to move it to FontDescription (which is already accessible from RenderStyle)?
+        fontDescription.setEnableEvaluationTimeZoom(document.settings().evaluationTimeZoomEnabled());
 
         fontDescription.setKeywordSizeFromIdentifier(CSSValueMedium);
         int size = fontSizeForKeyword(CSSValueMedium, false, document);
         fontDescription.setSpecifiedSize(size);
         bool useSVGZoomRules = document.isSVGDocument();
-        fontDescription.setComputedSize(computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules, &documentStyle, document));
+        auto computedFontSize = computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules, &documentStyle, document);
+        fontDescription.setComputedSize(computedFontSize.size, computedFontSize.usedZoomFactor);
 
         auto [fontOrientation, glyphOrientation] = documentStyle.fontAndGlyphOrientation();
         fontDescription.setOrientation(fontOrientation);

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -271,7 +271,7 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
 
                             RefPtr document = dynamicDowncast<Document>(context);
                             return {
-                                .size = static_cast<float>(Style::computeUnzoomedNonCalcLengthDouble(lengthPercentage.value, lengthUnit, CSSPropertyFontSize, &fontCascade, document ? document->renderView() : nullptr)),
+                                .size = static_cast<float>(Style::computeUnzoomedNonCalcLengthDouble(lengthPercentage.value, lengthUnit, CSSPropertyFontSize, &fontCascade, CSS::RangeZoomOptions::Default, document ? document->renderView() : nullptr)),
                                 .keyword = CSSValueInvalid
                             };
                         }

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -643,7 +643,8 @@ std::unique_ptr<RenderStyle> Resolver::defaultStyleForElement(const Element* ele
 
     auto size = fontSizeForKeyword(CSSValueMedium, false, document());
     fontDescription.setSpecifiedSize(size);
-    fontDescription.setComputedSize(computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), is<SVGElement>(element), style.get(), document()));
+    auto computedFontSize = computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), is<SVGElement>(element), style.get(), document());
+    fontDescription.setComputedSize(computedFontSize.size, computedFontSize.usedZoomFactor);
 
     fontDescription.setShouldAllowUserInstalledFonts(settings().shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);
     style->setFontDescription(WTFMove(fontDescription));

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -60,7 +60,7 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSPr
         if (primitiveValue.isLength())
             fixedValue = primitiveValue.resolveAsLength(conversionData);
         else
-            fixedValue = primitiveValue.protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(state.style().computedFontSize());
+            fixedValue = primitiveValue.protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(state.style().fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption()));
 
         if (multiplier != 1.0f)
             fixedValue *= multiplier;
@@ -78,8 +78,9 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSPr
     // values and raw numbers to percentages.
     if (primitiveValue.isPercentage()) {
         // FIXME: percentage should not be restricted to an integer here.
+        auto textZoom = shouldUseEvaluationTimeZoom(state) ? conversionData.zoom() : 1.0f;
         return LineHeight::Fixed {
-            CSS::clampToRange<LineHeight::Fixed::range, float>((state.style().computedFontSize() * primitiveValue.resolveAsPercentage<int>(conversionData)) / 100.0, minValueForCssLength, maxValueForCssLength)
+            CSS::clampToRange<LineHeight::Fixed::range, float>((state.style().fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption()) * primitiveValue.resolveAsPercentage<int>(conversionData) * textZoom) / 100.0, minValueForCssLength, maxValueForCssLength)
         };
     }
 

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -69,7 +69,7 @@ static double lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis logicalA
     return lengthOfViewportPhysicalAxisForLogicalAxis(logicalAxis, size, rootElement->renderStyle());
 }
 
-double computeUnzoomedNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, CSSPropertyID propertyToCompute, const FontCascade* fontCascadeForUnit, const RenderView* renderView)
+double computeUnzoomedNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, CSSPropertyID propertyToCompute, const FontCascade* fontCascadeForUnit, CSS::RangeZoomOptions rangeZoomOption, const RenderView* renderView)
 {
     using enum CSS::LengthUnit;
 
@@ -96,7 +96,7 @@ double computeUnzoomedNonCalcLengthDouble(double value, CSS::LengthUnit lengthUn
     case Rem: {
         ASSERT(fontCascadeForUnit);
         auto& fontDescription = fontCascadeForUnit->fontDescription();
-        return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() : fontDescription.computedSize()) * value;
+        return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() :  fontDescription.computedSizeForRangeZoomOption(rangeZoomOption)) * value;
     }
     case Ex:
     case Rex: {
@@ -105,7 +105,7 @@ double computeUnzoomedNonCalcLengthDouble(double value, CSS::LengthUnit lengthUn
         if (fontMetrics.xHeight())
             return fontMetrics.xHeight().value() * value;
         auto& fontDescription = fontCascadeForUnit->fontDescription();
-        return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() : fontDescription.computedSize()) / 2.0 * value;
+        return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() : fontDescription.computedSizeForRangeZoomOption(rangeZoomOption)) / 2.0 * value;
     }
     case Cap:
     case Rcap: {
@@ -253,7 +253,7 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
         // FIXME: We have a bug right now where the zoom will be applied twice to EX units.
         // We really need to compute EX using fontMetrics for the original specifiedSize and not use
         // our actual constructed rendering font.
-        value = computeUnzoomedNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), &conversionData.fontCascadeForFontUnits());
+        value = computeUnzoomedNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), &conversionData.fontCascadeForFontUnits(), conversionData.rangeZoomOption());
         break;
 
     case Lh:
@@ -271,7 +271,7 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
     case Rem:
     case Rex:
     case Ric:
-        value = computeUnzoomedNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), conversionData.rootStyle() ? &conversionData.rootStyle()->fontCascade() : &conversionData.fontCascadeForFontUnits());
+        value = computeUnzoomedNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), conversionData.rootStyle() ? &conversionData.rootStyle()->fontCascade() : &conversionData.fontCascadeForFontUnits(), conversionData.rangeZoomOption());
         break;
 
     case Rlh:

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <WebCore/CSSPrimitiveNumericRange.h>
+
 namespace WebCore {
 
 class CSSToLengthConversionData;
@@ -51,7 +53,7 @@ namespace Style {
 //
 // If `RenderView` is nullptr, the following LengthUnits will all cause a return value of zero:
 //    Vw, Vh, Vmin, Vmax, Vb, Vi, Svw, Svh, Svmin, Svmax, Svb, Svi, Lvw, Lvh, Lvmin, Lvmax, Lvb, Lvi, Dvw, Dvh, Dvmin, Dvmax, Dvb, Dvi (viewport-percentage units)
-double computeUnzoomedNonCalcLengthDouble(double value, CSS::LengthUnit, CSSPropertyID, const FontCascade* fontCascadeForUnit = nullptr, const RenderView* = nullptr);
+double computeUnzoomedNonCalcLengthDouble(double value, CSS::LengthUnit, CSSPropertyID, const FontCascade* fontCascadeForUnit = nullptr, CSS::RangeZoomOptions = CSS::RangeZoomOptions::Default, const RenderView* = nullptr);
 
 double computeNonCalcLengthDouble(double value, CSS::LengthUnit, const CSSToLengthConversionData&);
 

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
@@ -72,7 +72,7 @@ template<LengthWrapperBaseDerived T> struct CSSValueConversion<T> {
                 : builderState.cssToLengthConversionData();
         } else if constexpr (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
             if (shouldUseEvaluationTimeZoom(builderState))
-                return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+                return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, T::Fixed::range.zoomOptions);
 
             return builderState.useSVGZoomRulesForLength()
                 ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
@@ -105,10 +105,10 @@ template<auto R, typename V> struct CSSValueConversion<Length<R, V>> {
                 : builderState.cssToLengthConversionData();
         } else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
             if (shouldUseEvaluationTimeZoom(builderState))
-                return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+                return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, R.zoomOptions);
 
             return builderState.useSVGZoomRulesForLength()
-                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
+                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, R.zoomOptions)
                 : builderState.cssToLengthConversionData();
         }
     }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -60,7 +60,7 @@ template<auto R, typename V> struct ConversionDataSpecializer<CSS::LengthRaw<R, 
                 : state.cssToLengthConversionData();
         } else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
             if (shouldUseEvaluationTimeZoom(state))
-                return state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+                return state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, R.zoomOptions);
 
             return state.useSVGZoomRulesForLength()
                 ? state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)

--- a/Source/WebCore/style/values/text/StyleWordSpacing.cpp
+++ b/Source/WebCore/style/values/text/StyleWordSpacing.cpp
@@ -40,7 +40,7 @@ auto CSSValueConversion<WordSpacing>::operator()(BuilderState& state, const CSSV
         auto zoom = zoomWithTextZoomFactor(state);
         if (zoom == state.cssToLengthConversionData().zoom())
             return state.cssToLengthConversionData();
-        return state.cssToLengthConversionData().copyWithAdjustedZoom(zoom);
+        return state.cssToLengthConversionData().copyWithAdjustedZoom(zoom, WordSpacing::Fixed::range.zoomOptions);
     };
 
     RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);


### PR DESCRIPTION
#### 4082642c7f1c6335700c6e1a64e362ce92d13758
<pre>
[CSS Zoom] Fix font-relative units for unzoomed properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=299816">https://bugs.webkit.org/show_bug.cgi?id=299816</a>
<a href="https://rdar.apple.com/161590209">rdar://161590209</a>

Reviewed by Brent Fulgham.

In our current architecture, the computed font size has already zoom applied
to it.

Properties that are tagged as “unzoomed” (assuming evaluation flag is enabled)
will have zoom applied to its value during evaluation. If such a value uses a
font-related unit, we would have double zoom applied. So, for such cases we want
to use the unzoomed computed size (which is basically computedSize / zoom, not
necessarily equal to the specified size).

If we indiscriminately use the unzoomed computed font-size when resolving length
this would break the the resolution for all non-converted “length” properties (since
evaluate won’t apply zoom for them during style resolution).

Therefore, we need to request the use of the “unzoomed computed font-size” depending on
the type we are resolving. In order to do that, we propagating RangeZoomOptions via
CSSToLengthConversionData. In that way, we can request the use of the unzoomed computed
font size just when the EvaluationTimeZoomEnabled flag is enabled and when RangeZoomOptions
is RangeZoomOptions::Unzoomed.

Each new unzoomed property will need to set RangeZoomOptions::Unzoomed at
CSSToLengthConversionData in order to font relative units to get evaluated correctly
from now on.

There are different ways this can be done. Here are some exaples:

1. Via copyWithAdjustedZoom: StyleWordSpacing, uses copyWithAdjustedZoom for mutating the
original state&apos;s CSSToLengthConversionData. This funciton can now receive a RangeZoomOptions:
```
state.cssToLengthConversionData().copyWithAdjustedZoom(zoom, CSS::RangeZoomOptions::Unzoomed)
```

2. Via its own copy method. StyleLineHeight already has its own method to produce a conversion data,
in that case it makes sense to explicitly set it there:
```
    CSSToLengthConversionData copyForLineHeight(float zoom) const
    {
        CSSToLengthConversionData copy(*this);
        copy.m_zoom = zoom;
        copy.m_propertyToCompute = CSSPropertyLineHeight;
        copy.m_rangeZoomOption = CSS::RangeZoomOptions::Unzoomed;
        return copy;
    }
```

3. If your property uses toStyleFromCSSValue&lt;LineWidth::Length&gt;(state, value), you might
notice that there are no conversionData propagation. Here, the conversion data is created
by selectConversionData or by the conversion operator CSSToLengthConversionData operator().
For those, this patch are already propagates CSS::RangeZoomOptions::Unzoomed taking advantage
of the existent branches for zoom options there:
Example:
```
    selectConversionData(BuilderState&amp; builderState)
    {
        ...
        else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
        if (shouldUseEvaluationTimeZoom(builderState))
            return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, CSS::RangeZoomOptions::Unzoomed);
        ...
    }
```

Note: Ideally we would have a function template that given a type could return what type of
computed font-size should be used, given that this depends on the StrongTypes which are
already marked with RangeZoomOptions::Unzoomed. This would require some complicate generic
templates given that we have to unroll differente lenght wrappers like, for example:

struct WordSpacing : LengthWrapperBase&lt;LengthPercentage&lt;CSS::AllUnzoomed&gt;&gt;
Length = Style::Length&lt;CSS::NonnegativeUnzoomed&gt;;

Until we do that, I&apos;m propagating it dynamically here.

* LayoutTests/fast/css/line-height-zoom-get-computed-style.html:
* LayoutTests/fast/sub-pixel/zoomed-em-border.html:
* LayoutTests/fast/text/line-height-minimumFontSize-zoom.html:
* LayoutTests/svg/zoom/page/zoom-replaced-intrinsic-ratio-001.htm:
* Source/WebCore/css/CSSToLengthConversionData.h:
(WebCore::CSSToLengthConversionData::rangeZoomOption const):
(WebCore::CSSToLengthConversionData::copyWithAdjustedZoom const):
(WebCore::CSSToLengthConversionData::copyForLineHeight const):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
* Source/WebCore/platform/graphics/FontCascadeDescription.cpp:
* Source/WebCore/platform/graphics/FontDescription.cpp:
(WebCore::m_enableEvaluationTimeZoom):
(WebCore::m_shouldDisableLigaturesForSpacing): Deleted.
* Source/WebCore/platform/graphics/FontDescription.h:
(WebCore::FontDescription::usedZoomFactor const):
(WebCore::FontDescription::computedSizeForRangeZoomOption const):
(WebCore::FontDescription::unzoomedComputedSize const):
(WebCore::FontDescription::enableEvaluationTimeZoom const):
(WebCore::FontDescription::setComputedSize):
(WebCore::FontDescription::setEnableEvaluationTimeZoom):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::updateFontForSizeChange):
(WebCore::Style::BuilderState::setFontSize):
* Source/WebCore/style/StyleBuilderStateInlines.h:
(WebCore::Style::BuilderState::setFontDescriptionFontSize):
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
(WebCore::Style::computedFontSizeFromSpecifiedSize):
* Source/WebCore/style/StyleFontSizeFunctions.h:
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontSizeFromUnresolvedFontSize):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::defaultStyleForElement):
* Source/WebCore/style/values/inline/StyleLineHeight.cpp:
(WebCore::Style::CSSValueConversion&lt;LineHeight&gt;::operator):
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
(WebCore::Style::computeUnzoomedNonCalcLengthDouble):
(WebCore::Style::computeNonCalcLengthDouble):
* Source/WebCore/style/values/primitives/StyleLengthResolution.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h:
(WebCore::Style::CSSValueConversion&lt;T&gt;::selectConversionData):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/text/StyleWordSpacing.cpp:
(WebCore::Style::CSSValueConversion&lt;WordSpacing&gt;::operator):

Canonical link: <a href="https://commits.webkit.org/301757@main">https://commits.webkit.org/301757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d21a9edc3674ef246ef552c2971d2fdc51ec78c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133962 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47211 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55122 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96608 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77120 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77356 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136487 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53614 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/41278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104817 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26728 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50333 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28674 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51093 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53546 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59418 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54546 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->