### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException in ScreenOrientationManager.h

### DIFF
--- a/Source/WebCore/platform/ScreenOrientationManager.h
+++ b/Source/WebCore/platform/ScreenOrientationManager.h
@@ -27,20 +27,9 @@
 
 #include <WebCore/ScreenOrientationLockType.h>
 #include <WebCore/ScreenOrientationType.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
-#include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class ScreenOrientationManager;
-class ScreenOrientationManagerObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ScreenOrientationManager> : std::true_type { };
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ScreenOrientationManagerObserver> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -48,13 +37,13 @@ class DeferredPromise;
 class Exception;
 class ScreenOrientation;
 
-class ScreenOrientationManagerObserver : public CanMakeWeakPtr<ScreenOrientationManagerObserver> {
+class ScreenOrientationManagerObserver : public AbstractRefCountedAndCanMakeWeakPtr<ScreenOrientationManagerObserver> {
 public:
     virtual ~ScreenOrientationManagerObserver() { }
     virtual void screenOrientationDidChange(ScreenOrientationType) = 0;
 };
 
-class ScreenOrientationManager : public CanMakeWeakPtr<ScreenOrientationManager> {
+class ScreenOrientationManager : public AbstractRefCountedAndCanMakeWeakPtr<ScreenOrientationManager> {
 public:
     WEBCORE_EXPORT virtual ~ScreenOrientationManager();
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
@@ -80,8 +80,8 @@ WebCore::ScreenOrientationType WebScreenOrientationManager::currentOrientation()
 void WebScreenOrientationManager::orientationDidChange(WebCore::ScreenOrientationType orientation)
 {
     m_currentOrientation = orientation;
-    for (auto& observer : m_observers)
-        observer.screenOrientationDidChange(orientation);
+    for (Ref observer : m_observers)
+        observer->screenOrientationDidChange(orientation);
 }
 
 void WebScreenOrientationManager::lock(WebCore::ScreenOrientationLockType lockType, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)


### PR DESCRIPTION
#### d7a27bbe1452739d846abad944d6096de3fa8a36
<pre>
Drop IsDeprecatedWeakRefSmartPointerException in ScreenOrientationManager.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=300480">https://bugs.webkit.org/show_bug.cgi?id=300480</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/ScreenOrientationManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp:
(WebKit::WebScreenOrientationManager::orientationDidChange):

Canonical link: <a href="https://commits.webkit.org/301309@main">https://commits.webkit.org/301309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f06c849beced8e0a17d574228f63d9651eca0c8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125528 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77418 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ddff637-5e2d-4ad0-8c2a-d5b50f5c8300) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95597 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76115 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fad7be59-444b-40a2-a11f-55fc82239c04) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35556 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30434 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75859 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135058 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40091 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104076 "Failed to checkout and rebase branch from PR 52097") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52770 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103812 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26443 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49173 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27484 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49516 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58015 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51574 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54928 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53269 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->