### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for WorkerScriptLoaderClient

### DIFF
--- a/Source/WebCore/bindings/js/WorkerModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/WorkerModuleScriptLoader.h
@@ -51,6 +51,9 @@ public:
 
     virtual ~WorkerModuleScriptLoader();
 
+    void ref() const final { ModuleScriptLoader::ref(); }
+    void deref() const final { ModuleScriptLoader::deref(); }
+
     void load(ScriptExecutionContext&, URL&& sourceURL);
 
     WorkerScriptLoader& scriptLoader() { return m_scriptLoader.get(); }

--- a/Source/WebCore/workers/WorkerScriptLoaderClient.h
+++ b/Source/WebCore/workers/WorkerScriptLoaderClient.h
@@ -28,21 +28,13 @@
 
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
-
-namespace WebCore {
-class WorkerScriptLoaderClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::WorkerScriptLoaderClient> : std::true_type { };
-}
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
 class ResourceResponse;
 
-class WorkerScriptLoaderClient : public CanMakeWeakPtr<WorkerScriptLoaderClient> {
+class WorkerScriptLoaderClient : public AbstractRefCountedAndCanMakeWeakPtr<WorkerScriptLoaderClient> {
 public:
     virtual void didReceiveResponse(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const ResourceResponse&) = 0;
     virtual void notifyFinished(std::optional<ScriptExecutionContextIdentifier>) = 0;

--- a/Source/WebCore/workers/service/SWClientConnection.cpp
+++ b/Source/WebCore/workers/service/SWClientConnection.cpp
@@ -92,7 +92,7 @@ bool SWClientConnection::postTaskForJob(ServiceWorkerJobIdentifier jobIdentifier
     }
     auto isPosted = dispatchToContextThreadIfNecessary(iterator->value, [jobIdentifier, task = WTFMove(task)] (ScriptExecutionContext& context) mutable {
         if (RefPtr container = context.serviceWorkerContainer()) {
-            if (auto* job = container->job(jobIdentifier))
+            if (RefPtr job = container->job(jobIdentifier))
                 task(*job);
         }
     });

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -241,7 +241,7 @@ void ServiceWorkerContainer::addRegistration(Variant<RefPtr<TrustedScriptURL>, S
     jobData.domainForCachePartition = context->domainForCachePartition();
     jobData.registrationOptions = options;
 
-    scheduleJob(makeUnique<ServiceWorkerJob>(*this, WTFMove(promise), WTFMove(jobData)));
+    scheduleJob(ServiceWorkerJob::create(*this, WTFMove(promise), WTFMove(jobData)));
 }
 
 void ServiceWorkerContainer::willSettleRegistrationPromise(bool success)
@@ -299,10 +299,10 @@ void ServiceWorkerContainer::updateRegistration(const URL& scopeURL, const URL& 
 
     CONTAINER_RELEASE_LOG("removeRegistration: Updating service worker. jobID=%" PRIu64, jobData.identifier().jobIdentifier.toUInt64());
 
-    scheduleJob(makeUnique<ServiceWorkerJob>(*this, WTFMove(promise), WTFMove(jobData)));
+    scheduleJob(ServiceWorkerJob::create(*this, WTFMove(promise), WTFMove(jobData)));
 }
 
-void ServiceWorkerContainer::scheduleJob(std::unique_ptr<ServiceWorkerJob>&& job)
+void ServiceWorkerContainer::scheduleJob(Ref<ServiceWorkerJob>&& job)
 {
     ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     RefPtr swConnection = m_swConnection;
@@ -407,7 +407,7 @@ void ServiceWorkerContainer::jobFailedWithException(ServiceWorkerJob& job, const
     ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT_WITH_MESSAGE(job.hasPromise() || job.data().type == ServiceWorkerJobType::Update, "Only soft updates have no promise");
 
-    auto guard = makeScopeExit([this, protectedThis = Ref { *this }, &job] {
+    auto guard = makeScopeExit([this, protectedThis = Ref { *this }, job = Ref { job }] {
         destroyJob(job);
     });
 
@@ -446,7 +446,7 @@ void ServiceWorkerContainer::jobResolvedWithRegistration(ServiceWorkerJob& job, 
         CONTAINER_RELEASE_LOG("jobResolvedWithRegistration: Update job %" PRIu64 " succeeded", job.identifier().toUInt64());
     }
 
-    auto guard = makeScopeExit([this, protectedThis = Ref { *this }, &job] {
+    auto guard = makeScopeExit([this, protectedThis = Ref { *this }, job = Ref { job }] {
         destroyJob(job);
     });
 
@@ -528,7 +528,7 @@ void ServiceWorkerContainer::jobResolvedWithUnregistrationResult(ServiceWorkerJo
     ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(job.hasPromise());
 
-    auto guard = makeScopeExit([this, protectedThis = Ref { *this }, &job] {
+    auto guard = makeScopeExit([this, protectedThis = Ref { *this }, job = Ref { job }] {
         destroyJob(job);
     });
 
@@ -726,7 +726,7 @@ void ServiceWorkerContainer::stop()
     m_readyPromise = nullptr;
     auto jobMap = WTFMove(m_jobMap);
     for (auto& ongoingJob : jobMap.values()) {
-        if (ongoingJob.job->cancelPendingLoad())
+        if (Ref { *ongoingJob.job }->cancelPendingLoad())
             notifyFailedFetchingScript(*ongoingJob.job.get(), ResourceError { errorDomainWebKitInternal, 0, ongoingJob.job->data().scriptURL, "Job cancelled"_s, ResourceError::Type::Cancellation });
     }
 

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -125,7 +125,7 @@ private:
 
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions& = { }) final;
 
-    void scheduleJob(std::unique_ptr<ServiceWorkerJob>&&);
+    void scheduleJob(Ref<ServiceWorkerJob>&&);
 
     void jobFailedWithException(ServiceWorkerJob&, const Exception&) final;
     void jobResolvedWithRegistration(ServiceWorkerJob&, ServiceWorkerRegistrationData&&, ShouldNotifyWhenResolved) final;
@@ -162,7 +162,7 @@ private:
     RefPtr<SWClientConnection> m_swConnection;
 
     struct OngoingJob {
-        std::unique_ptr<ServiceWorkerJob> job;
+        RefPtr<ServiceWorkerJob> job;
         RefPtr<PendingActivity<ServiceWorkerContainer>> pendingActivity;
     };
     HashMap<ServiceWorkerJobIdentifier, OngoingJob> m_jobMap;

--- a/Source/WebCore/workers/service/ServiceWorkerJob.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.h
@@ -48,11 +48,14 @@ class ScriptExecutionContext;
 enum class ServiceWorkerJobType : uint8_t;
 struct ServiceWorkerRegistrationData;
 
-class ServiceWorkerJob : public WorkerScriptLoaderClient {
+class ServiceWorkerJob final : public RefCounted<ServiceWorkerJob>, public WorkerScriptLoaderClient {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ServiceWorkerJob, WEBCORE_EXPORT);
 public:
-    ServiceWorkerJob(ServiceWorkerJobClient&, RefPtr<DeferredPromise>&&, ServiceWorkerJobData&&);
+    static Ref<ServiceWorkerJob> create(ServiceWorkerJobClient&, RefPtr<DeferredPromise>&&, ServiceWorkerJobData&&);
     WEBCORE_EXPORT ~ServiceWorkerJob();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void failedWithException(const Exception&);
     void resolvedWithRegistration(ServiceWorkerRegistrationData&&, ShouldNotifyWhenResolved);
@@ -77,11 +80,13 @@ public:
     bool isRegistering() const;
 
 private:
+    ServiceWorkerJob(ServiceWorkerJobClient&, RefPtr<DeferredPromise>&&, ServiceWorkerJobData&&);
+
     // WorkerScriptLoaderClient
     void didReceiveResponse(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const ResourceResponse&) final;
     void notifyFinished(std::optional<ScriptExecutionContextIdentifier>) final;
 
-    ServiceWorkerJobClient& m_client;
+    WeakPtr<ServiceWorkerJobClient> m_client;
     ServiceWorkerJobData m_jobData;
     RefPtr<DeferredPromise> m_promise;
 

--- a/Source/WebCore/workers/service/ServiceWorkerJobClient.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJobClient.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/FetchOptions.h>
 #include <WebCore/ServiceWorkerTypes.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -40,7 +41,7 @@ struct CrossOriginEmbedderPolicy;
 struct ServiceWorkerRegistrationData;
 struct WorkerFetchResult;
 
-class ServiceWorkerJobClient {
+class ServiceWorkerJobClient : public AbstractRefCountedAndCanMakeWeakPtr<ServiceWorkerJobClient> {
 public:
     virtual ~ServiceWorkerJobClient() = default;
 

--- a/Source/WebCore/workers/shared/SharedWorkerObjectConnection.h
+++ b/Source/WebCore/workers/shared/SharedWorkerObjectConnection.h
@@ -64,7 +64,7 @@ protected:
     WEBCORE_EXPORT SharedWorkerObjectConnection();
 
 private:
-    HashMap<uint64_t, UniqueRef<SharedWorkerScriptLoader>> m_loaders;
+    HashMap<uint64_t, Ref<SharedWorkerScriptLoader>> m_loaders;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
@@ -40,6 +40,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SharedWorkerScriptLoader);
 
+Ref<SharedWorkerScriptLoader> SharedWorkerScriptLoader::create(URL&& url, SharedWorker& worker, WorkerOptions&& options)
+{
+    return adoptRef(*new SharedWorkerScriptLoader(WTFMove(url), worker, WTFMove(options)));
+}
+
 SharedWorkerScriptLoader::SharedWorkerScriptLoader(URL&& url, SharedWorker& worker, WorkerOptions&& options)
     : m_options(WTFMove(options))
     , m_worker(worker)

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.h
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.h
@@ -43,10 +43,13 @@ class WorkerScriptLoader;
 struct WorkerFetchResult;
 struct WorkerInitializationData;
 
-class SharedWorkerScriptLoader : private WorkerScriptLoaderClient {
+class SharedWorkerScriptLoader final : public RefCounted<SharedWorkerScriptLoader>, private WorkerScriptLoaderClient {
     WTF_MAKE_TZONE_ALLOCATED(SharedWorkerScriptLoader);
 public:
-    SharedWorkerScriptLoader(URL&&, SharedWorker&, WorkerOptions&&);
+    static Ref<SharedWorkerScriptLoader> create(URL&&, SharedWorker&, WorkerOptions&&);
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void load(CompletionHandler<void(WorkerFetchResult&&, WorkerInitializationData&&)>&&);
 
@@ -55,6 +58,8 @@ public:
     const WorkerOptions& options() const { return m_options; }
 
 private:
+    SharedWorkerScriptLoader(URL&&, SharedWorker&, WorkerOptions&&);
+
     void didReceiveResponse(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const ResourceResponse&) final;
     void notifyFinished(std::optional<ScriptExecutionContextIdentifier>) final;
 


### PR DESCRIPTION
#### a51b72e765d46af7f17714bbb6cb036c1f4b3b1b
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for WorkerScriptLoaderClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=300481">https://bugs.webkit.org/show_bug.cgi?id=300481</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/bindings/js/WorkerModuleScriptLoader.h:
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::didReceiveResponse):
(WebCore::WorkerScriptLoader::notifyFinished):
* Source/WebCore/workers/WorkerScriptLoaderClient.h:
* Source/WebCore/workers/service/SWClientConnection.cpp:
(WebCore::SWClientConnection::postTaskForJob):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::addRegistration):
(WebCore::ServiceWorkerContainer::updateRegistration):
(WebCore::ServiceWorkerContainer::scheduleJob):
(WebCore::ServiceWorkerContainer::jobFailedWithException):
(WebCore::ServiceWorkerContainer::jobResolvedWithRegistration):
(WebCore::ServiceWorkerContainer::jobResolvedWithUnregistrationResult):
(WebCore::ServiceWorkerContainer::stop):
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/ServiceWorkerJob.cpp:
(WebCore::ServiceWorkerJob::create):
(WebCore::ServiceWorkerJob::failedWithException):
(WebCore::ServiceWorkerJob::resolvedWithRegistration):
(WebCore::ServiceWorkerJob::resolvedWithUnregistrationResult):
(WebCore::ServiceWorkerJob::startScriptFetch):
(WebCore::ServiceWorkerJob::didReceiveResponse):
(WebCore::ServiceWorkerJob::notifyFinished):
* Source/WebCore/workers/service/ServiceWorkerJob.h:
(WebCore::ServiceWorkerJob::identifier const): Deleted.
(WebCore::ServiceWorkerJob::data const): Deleted.
(WebCore::ServiceWorkerJob::hasPromise const): Deleted.
(WebCore::ServiceWorkerJob::contextIdentifier): Deleted.
* Source/WebCore/workers/service/ServiceWorkerJobClient.h:
* Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp:
(WebCore::SharedWorkerObjectConnection::fetchScriptInClient):
* Source/WebCore/workers/shared/SharedWorkerObjectConnection.h:
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp:
(WebCore::SharedWorkerScriptLoader::create):
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.h:
(WebCore::SharedWorkerScriptLoader::url const): Deleted.
(WebCore::SharedWorkerScriptLoader::worker): Deleted.
(WebCore::SharedWorkerScriptLoader::options const): Deleted.

Canonical link: <a href="https://commits.webkit.org/301314@main">https://commits.webkit.org/301314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7db7547b8f50c9cec8cc30b811dc4b86a370fb3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125580 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132441 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77471 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4bb70f50-bf7b-41af-95fe-e3c1b490fb13) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53802 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95659 "7 flakes 16 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d45383ef-f21a-4c79-b951-834c6aa9f6f7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76156 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9cf5f8f3-5990-4111-a374-11898cc00edc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30478 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75913 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135114 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40131 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104133 "30 flakes 88 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103866 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26447 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49214 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27528 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49582 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52270 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58067 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51623 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54976 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53318 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->