### PR TITLE
run-webkit-tests doesn't properly enable skipped tests when passed on command line with LayoutTests in the path

### DIFF
--- a/Tools/Scripts/webkitpy/common/system/filesystem_mock.py
+++ b/Tools/Scripts/webkitpy/common/system/filesystem_mock.py
@@ -181,6 +181,8 @@ class MockFileSystem(object):
         return len(self.files[path])
 
     def glob(self, glob_string):
+        # Normalize the glob string to handle '..' before matching
+        glob_string = self.normpath(glob_string)
         # FIXME: This handles '*', but not '?', '[', or ']'.
         glob_string = re.escape(glob_string)
         glob_string = glob_string.replace('\\*', '[^\\/]*') + '$'

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -333,15 +333,17 @@ class Manager(object):
         for test in aggregate_tests_to_skip:
             skipped_tests_by_path[test.test_path].add(test)
 
-        # If a test is marked skipped, but was explicitly requested, run it anyways
+        # If a test is marked skipped, but was explicitly requested, run it anyways.
         if self._options.skipped != 'always':
-            for arg in args:
-                if arg in skipped_tests_by_path:
-                    tests = skipped_tests_by_path[arg]
-                    tests_to_run_by_device[device_type_list[0]].extend(tests)
-                    aggregate_tests_to_run |= tests
-                    aggregate_tests_to_skip -= tests
-                    del skipped_tests_by_path[arg]
+            _, explicitly_specified_tests = self._finder.find_tests_for_specified_files(self._options, args)
+            for test in explicitly_specified_tests:
+                path = test.test_path
+                if path in skipped_tests_by_path:
+                    skipped_tests = skipped_tests_by_path[path]
+                    tests_to_run_by_device[device_type_list[0]].extend(skipped_tests)
+                    aggregate_tests_to_run |= skipped_tests
+                    aggregate_tests_to_skip -= skipped_tests
+                    del skipped_tests_by_path[path]
 
         aggregate_tests = aggregate_tests_to_run | aggregate_tests_to_skip
 

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -367,10 +367,22 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
         self.assertEqual(get_tests_run(['--no-retry-failures',  '--skip-failing-tests', '--skipped=always'] + list_of_tests_failing), [])
 
     def test_ews_corner_case_skipped_test(self):
-        # When we specify on the command line the name of a test skipped this test should run
+        # When we specify on the command line the name of a test skipped this test should run.
         self.assertEqual(get_tests_run(['passes/skipped/skip.html']), ['passes/skipped/skip.html'])
-        # Unless we specify also '--skipped=always', then it should be skipped even when we list it on the command line
+        # With '--skipped=always', it should be skipped even when we list it on the command line.
         self.assertEqual(get_tests_run(['--skipped=always', 'passes/skipped/skip.html']), [])
+
+    def test_ews_corner_case_skipped_test_with_layouttests_prefix(self):
+        # When we specify a skipped test with LayoutTests/ prefix, it should run.
+        self.assertEqual(get_tests_run(['LayoutTests/passes/skipped/skip.html']), ['passes/skipped/skip.html'])
+        # With '--skipped=always', it should be skipped even when we list it on the command line.
+        self.assertEqual(get_tests_run(['--skipped=always', 'LayoutTests/passes/skipped/skip.html']), [])
+
+    def test_ews_corner_case_skipped_test_with_relative_path(self):
+        # When we specify a skipped test with a relative path, it should run.
+        self.assertEqual(get_tests_run(['../LayoutTests/passes/skipped/skip.html']), ['passes/skipped/skip.html'])
+        # With '--skipped=always', it should be skipped even when we list it on the command line.
+        self.assertEqual(get_tests_run(['--skipped=always', '../LayoutTests/passes/skipped/skip.html']), [])
 
     def test_ews_corner_case_skipped_directory(self):
         # When a whole directory is skipped, then the tests inside should not run if we specify the name of the directory


### PR DESCRIPTION
#### 70ff75704e53e2947b598287b894ae6a6b3b1caa
<pre>
run-webkit-tests doesn&apos;t properly enable skipped tests when passed on command line with LayoutTests in the path
<a href="https://bugs.webkit.org/show_bug.cgi?id=300464">https://bugs.webkit.org/show_bug.cgi?id=300464</a>
<a href="https://rdar.apple.com/162335032">rdar://162335032</a>

Reviewed by Jonathan Bedard.

run-webkit-tests has weird logic for finding tests specified on command line. All of these
find the test regardless of current working directory:
 - fast/events/keydown-numpad-keys.html
 - LayoutTests/fast/events/keydown-numpad-keys.html
 - ~/LayoutTests/fast/events/keydown-numpad-keys.html

Some of this may not be important to preserve, but this fix focuses on making it work consistently,
namely, just making sure that the test isn&apos;t just found, but is also force enabled if skipped.

run-webkit-tests also has its own globbing used separately from shell globbing.
When run-webkit-tests expands the pattern, that currently doesn&apos;t force enable the tests.
In other words, `run-webkit-tests fast/events/*` may run different tests depending on
current directory. This is arguably bad, but harder to change, because many tests rely on
this quirk.

* Tools/Scripts/webkitpy/common/system/filesystem_mock.py:
(MockFileSystem.glob): Normalize glob string before matching, so that tests can use relative
paths.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py:
(LayoutTestFinder.find_tests_for_specified_files): Added method to find only explicitly
specified individual test files.

* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager.run): Use find_tests_for_specified_files() for skip-override logic instead of
directly checking args.

* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(RunTest.test_ews_corner_case_skipped_test_with_layouttests_prefix): Added.
(RunTest.test_ews_corner_case_skipped_test_with_relative_path): Added.

Canonical link: <a href="https://commits.webkit.org/301409@main">https://commits.webkit.org/301409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97f19f9cba54e51d9830fb6a84cea90649737c79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77469 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1376876c-a45a-45ea-89df-5a9a780cfa01) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95588 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63554 "Found 60 new test failures: compositing/clipping/border-radius-with-composited-descendant-nested.html compositing/clipping/border-radius-with-composited-descendant.html compositing/overlap-blending/children-opacity-huge.html compositing/overlap-blending/children-opacity-no-overlap.html compositing/overlap-blending/nested-non-overlap-clipping.html compositing/overlap-blending/nested-overlap.html compositing/transforms/clipping-layer-and-flattening-layer.html compositing/transforms/perspective-transform-box.html compositing/transforms/perspective-with-clipping.html compositing/webgl/update-composited-canvas-layer.html ... (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/19917f45-9dc9-42e3-8c5a-d30f469900af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76107 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a101a28d-07fc-4d89-9393-8bee4c7a163b) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124869 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30428 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75851 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135050 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40083 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104068 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108462 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103806 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49167 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27478 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49494 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19699 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52212 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51564 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54920 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53260 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->