### PR TITLE
Disable WebGPU Swift for Intel Macs

### DIFF
--- a/Source/WebGPU/Configurations/WebGPU.xcconfig
+++ b/Source/WebGPU/Configurations/WebGPU.xcconfig
@@ -91,12 +91,12 @@ UNEXPORT_SWIFT_CXX_LDFLAGS = -Wl,-unexported_symbol,_$s*3Cxx* -Wl,-unexported_sy
 OTHER_LDFLAGS = $(inherited) $(UNEXPORT_SWIFT_CXX_LDFLAGS) $(SOURCE_VERSION_LDFLAGS) $(WK_NO_STATIC_INITIALIZERS) -Wl,-unexported_symbol,*s_heapSpec;
 
 ENABLE_WEBGPU_SWIFT = ;
-ENABLE_WEBGPU_SWIFT[sdk=macosx*26*] = ENABLE_WEBGPU_SWIFT;
+ENABLE_WEBGPU_SWIFT[sdk=macosx*26*][arch=arm64*] = ENABLE_WEBGPU_SWIFT;
 ENABLE_WEBGPU_SWIFT[sdk=iphoneos26*] = ENABLE_WEBGPU_SWIFT;
 // FIXME: Support WebGPU swift in iOS simulator builds once the underlying
 // modules issue is fixed (https://bugs.webkit.org/show_bug.cgi?id=300146).
 ENABLE_WEBGPU_SWIFT[sdk=iphonesimulator26*] = ;
-ENABLE_WEBGPU_SWIFT[sdk=iphonesimulator26*.internal] = ENABLE_WEBGPU_SWIFT;
+ENABLE_WEBGPU_SWIFT[sdk=macosx*26*][arch=x86*] = ;
 ENABLE_WEBGPU_SWIFT[sdk=xros*26*] = ENABLE_WEBGPU_SWIFT;
 
 SWIFT_OBJC_INTERFACE_HEADER_NAME = WebGPUSwift-Generated.h;
@@ -134,6 +134,4 @@ EXCLUDED_SOURCE_FILE_NAMES_ENABLE_WEBGPU_SWIFT =;
 EXCLUDED_SOURCE_FILE_NAMES_ = *.swift;
 
 BUILD_LIBRARY_FOR_DISTRIBUTION = YES; // This is required for all frameworks in the OS.
-SWIFT_EMIT_PRIVATE_MODULE_INTERFACE = YES;
-SWIFT_LIBRARY_LEVEL = spi;
 RUN_SWIFT_ABI_CHECKER_TOOL = NO

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -853,9 +853,14 @@ WGPUBufferUsageFlags wgpuBufferGetUsage(WGPUBuffer buffer)
     return WebGPU::protectedFromAPI(buffer)->usage();
 }
 
-#if ENABLE(WEBGPU_SWIFT)
 void wgpuBufferCopy(WGPUBuffer buffer, std::span<const uint8_t> data, size_t offset)
 {
+#if ENABLE(WEBGPU_SWIFT)
     WebGPU::protectedFromAPI(buffer)->copyFrom(data, offset);
-}
+#else
+    UNUSED_PARAM(buffer);
+    UNUSED_PARAM(data);
+    UNUSED_PARAM(offset);
+
 #endif
+}

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -1646,9 +1646,7 @@ WGPU_EXPORT void wgpuBufferSetLabel(WGPUBuffer buffer, char const * label) WGPU_
 WGPU_EXPORT void wgpuBufferUnmap(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBufferReference(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBufferRelease(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
-#if ENABLE(WEBGPU_SWIFT)
 WGPU_EXPORT void wgpuBufferCopy(WGPUBuffer buffer, std::span<const uint8_t> data, size_t offset) WGPU_FUNCTION_ATTRIBUTE;
-#endif
 
 // Methods of CommandBuffer
 WGPU_EXPORT void wgpuCommandBufferSetLabel(WGPUCommandBuffer commandBuffer, char const * label) WGPU_FUNCTION_ATTRIBUTE;


### PR DESCRIPTION
#### 48b742ce2b42925d7d10126d19ad7081b7692f3a
<pre>
Disable WebGPU Swift for Intel Macs
<a href="https://bugs.webkit.org/show_bug.cgi?id=300485">https://bugs.webkit.org/show_bug.cgi?id=300485</a>
<a href="https://rdar.apple.com/162340797">rdar://162340797</a>

Reviewed by Tadeu Zagallo.

Intel triggers OpenGLES verifier warnings, so disable
this config on WebGPU Swift for now.

* Source/WebGPU/Configurations/WebGPU.xcconfig:
* Source/WebGPU/WebGPU/Buffer.mm:
(wgpuBufferCopy):
* Source/WebGPU/WebGPU/WebGPU.h:

Canonical link: <a href="https://commits.webkit.org/301339@main">https://commits.webkit.org/301339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44e900ae985d0c6e8ab1eba10f701927895bdc3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77533 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1a62505-7553-42ed-a0de-d046ca8d7d97) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95724 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5669f1e-3141-4f04-a696-ae9c60bd8a01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76218 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b2ed6c3-a89b-4786-8b45-8ccf562c13c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35672 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75982 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135182 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104193 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103920 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26466 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49278 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27590 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49667 "Hash 44e900ae for PR 52102 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58141 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51687 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55040 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53383 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->