### PR TITLE
Reduce of `free()` in the project

### DIFF
--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -1275,7 +1275,7 @@ static StructHandlers* createStructHandlerMap()
         char idType[3];
         // Check 2nd argument type is "@"
         {
-            auto secondType = WTF::adoptSystem<char[]>(method_copyArgumentType(method, 3));
+            auto secondType = adoptSystem(method_copyArgumentType(method, 3));
             if (strcmp(secondType.get(), "@") != 0)
                 return;
         }
@@ -1284,7 +1284,7 @@ static StructHandlers* createStructHandlerMap()
         if (strcmp(idType, "@") != 0)
             return;
         {
-            auto type = WTF::adoptSystem<char[]>(method_copyArgumentType(method, 2));
+            auto type = adoptSystem(method_copyArgumentType(method, 2));
             structHandlers->add(StringImpl::createFromCString(type.get()), (StructTagHandler) { selector, 0 });
         }
     });
@@ -1300,7 +1300,7 @@ static StructHandlers* createStructHandlerMap()
         if (method_getNumberOfArguments(method) != 2)
             return;
         // Try to find a matching valueWith<Foo>:context: method.
-        auto type = WTF::adoptSystem<char[]>(method_copyReturnType(method));
+        auto type = adoptSystem(method_copyReturnType(method));
         StructHandlers::iterator iter = structHandlers->find(String::fromLatin1(type.get()));
         if (iter == structHandlers->end())
             return;

--- a/Source/JavaScriptCore/disassembler/Disassembler.cpp
+++ b/Source/JavaScriptCore/disassembler/Disassembler.cpp
@@ -32,6 +32,7 @@
 #include <wtf/Deque.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/SystemFree.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
 

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3915,18 +3915,15 @@ static void runInteractive(GlobalObject* globalObject)
         String source;
         do {
             error = ParserError();
-            char* line = readline(source.isEmpty() ? interactivePrompt : "... ");
+            auto line = adoptSystem(readline(source.isEmpty() ? interactivePrompt : "... "));
             shouldQuit = !line;
             if (!line)
                 break;
-            source = makeString(source, String::fromUTF8(line), '\n');
+            source = makeString(source, byteCast<char8_t>(unsafeSpan(line.get())), '\n');
             checkSyntax(vm, jscSource(source, sourceOrigin), error);
-            if (!line[0]) {
-                free(line);
+            if (!*line)
                 break;
-            }
-            add_history(line);
-            free(line);
+            add_history(line.get());
         } while (error.syntaxErrorType() == ParserError::SyntaxErrorRecoverable);
         
         if (error.isValid()) {

--- a/Source/WTF/wtf/ObjCRuntimeExtras.h
+++ b/Source/WTF/wtf/ObjCRuntimeExtras.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,6 +51,7 @@ WTF_EXPORT_PRIVATE MallocSpan<Method, SystemMalloc> class_copyMethodListSpan(Cla
 WTF_EXPORT_PRIVATE MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> class_copyProtocolListSpan(Class);
 WTF_EXPORT_PRIVATE MallocSpan<objc_property_t, SystemMalloc> class_copyPropertyListSpan(Class);
 WTF_EXPORT_PRIVATE MallocSpan<Ivar, SystemMalloc> class_copyIvarListSpan(Class);
+WTF_EXPORT_PRIVATE MallocSpan<objc_property_attribute_t, SystemMalloc> property_copyAttributeListSpan(objc_property_t);
 WTF_EXPORT_PRIVATE MallocSpan<objc_method_description, SystemMalloc> protocol_copyMethodDescriptionListSpan(Protocol *, BOOL isRequiredMethod, BOOL isInstanceMethod);
 WTF_EXPORT_PRIVATE MallocSpan<objc_property_t, SystemMalloc> protocol_copyPropertyListSpan(Protocol *);
 WTF_EXPORT_PRIVATE MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> protocol_copyProtocolListSpan(Protocol *);
@@ -82,6 +83,7 @@ using WTF::class_copyProtocolListSpan;
 using WTF::methodHasReturnType;
 using WTF::nsValueHasObjCType;
 using WTF::objcEncode;
+using WTF::property_copyAttributeListSpan;
 using WTF::protocol_copyMethodDescriptionListSpan;
 using WTF::protocol_copyPropertyListSpan;
 using WTF::protocol_copyProtocolListSpan;

--- a/Source/WTF/wtf/ObjCRuntimeExtras.mm
+++ b/Source/WTF/wtf/ObjCRuntimeExtras.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,6 +57,13 @@ MallocSpan<Ivar, SystemMalloc> class_copyIvarListSpan(Class cls)
     unsigned ivarCount = 0;
     auto* ivars = class_copyIvarList(cls, &ivarCount);
     return adoptMallocSpan<Ivar, SystemMalloc>(unsafeMakeSpan(ivars, ivarCount));
+}
+
+MallocSpan<objc_property_attribute_t, SystemMalloc> property_copyAttributeListSpan(objc_property_t property)
+{
+    unsigned attributeCount = 0;
+    auto* attributes = property_copyAttributeList(property, &attributeCount);
+    return adoptMallocSpan<objc_property_attribute_t, SystemMalloc>(unsafeMakeSpan(attributes, attributeCount));
 }
 
 MallocSpan<objc_method_description, SystemMalloc> protocol_copyMethodDescriptionListSpan(Protocol *protocol, BOOL isRequiredMethod, BOOL isInstanceMethod)

--- a/Source/WTF/wtf/StackTrace.h
+++ b/Source/WTF/wtf/StackTrace.h
@@ -110,7 +110,7 @@ public:
         { }
 
         const char* m_mangledName { nullptr };
-        std::unique_ptr<const char[], SystemFree<const char[]>> m_demangledName;
+        std::unique_ptr<const char, SystemFree<const char>> m_demangledName;
     };
 
     WTF_EXPORT_PRIVATE static std::optional<DemangleEntry> demangle(void*);

--- a/Source/WTF/wtf/SystemFree.h
+++ b/Source/WTF/wtf/SystemFree.h
@@ -31,28 +31,20 @@ namespace WTF {
 
 template<typename T>
 struct SystemFree {
-    static_assert(std::is_trivially_destructible<T>::value);
+    static_assert(std::is_trivially_destructible_v<T> || std::is_void_v<T>);
 
     void operator()(T* pointer) const
     {
-        free(const_cast<typename std::remove_cv<T>::type*>(pointer));
+        free(const_cast<std::remove_cv_t<T>*>(pointer));
     }
 };
 
 template<typename T>
-struct SystemFree<T[]> {
-    static_assert(std::is_trivially_destructible<T>::value);
-
-    void operator()(T* pointer) const
-    {
-        free(const_cast<typename std::remove_cv<T>::type*>(pointer));
-    }
-};
-
-template<typename T, typename U>
-inline std::unique_ptr<T, WTF::SystemFree<T>> adoptSystem(U value)
+inline std::unique_ptr<T, WTF::SystemFree<T>> adoptSystem(T* value)
 {
     return std::unique_ptr<T, WTF::SystemFree<T>>(value);
 }
 
 } // namespace WTF
+
+using WTF::adoptSystem;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -41,6 +41,7 @@
 #include <webrtc/rtc_base/time_utils.h>
 #include <wtf/BlockPtr.h>
 #include <wtf/SoftLinking.h>
+#include <wtf/SystemFree.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/cocoa/SpanCocoa.h>
@@ -173,9 +174,8 @@ static webrtc::SocketAddress socketAddressFromIncomingConnection(nw_connection_t
     auto endpoint = adoptNS(nw_connection_copy_endpoint(connection));
     auto type = nw_endpoint_get_type(endpoint.get());
     if (type == nw_endpoint_type_address) {
-        auto* ipAddress = nw_endpoint_copy_address_string(endpoint.get());
-        webrtc::SocketAddress remoteAddress { ipAddress, nw_endpoint_get_port(endpoint.get()) };
-        free(ipAddress);
+        auto ipAddress = adoptSystem(nw_endpoint_copy_address_string(endpoint.get()));
+        webrtc::SocketAddress remoteAddress { ipAddress.get(), nw_endpoint_get_port(endpoint.get()) };
         return remoteAddress;
     }
     return webrtc::SocketAddress { nw_endpoint_get_hostname(endpoint.get()), nw_endpoint_get_port(endpoint.get()) };

--- a/Source/WebKit/Platform/cocoa/NetworkIssueReporter.h
+++ b/Source/WebKit/Platform/cocoa/NetworkIssueReporter.h
@@ -28,6 +28,7 @@
 #if ENABLE(NETWORK_ISSUE_REPORTING)
 
 #import <wtf/Forward.h>
+#import <wtf/SystemFree.h>
 #import <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSURLSessionTaskMetrics;
@@ -48,7 +49,7 @@ public:
 
 private:
     HashSet<String> m_reportedHosts;
-    void* m_stackTrace { nullptr };
+    std::unique_ptr<void, WTF::SystemFree<void>> m_stackTrace;
     size_t m_stackTraceSize { 0 };
 };
 

--- a/Source/WebKit/Platform/cocoa/NetworkIssueReporter.mm
+++ b/Source/WebKit/Platform/cocoa/NetworkIssueReporter.mm
@@ -63,14 +63,10 @@ bool NetworkIssueReporter::shouldReport(NSURLSessionTaskMetrics *metrics)
 NetworkIssueReporter::NetworkIssueReporter()
 {
     if (auto* copyStacktrace = ne_tracker_copy_current_stacktracePtr())
-        m_stackTrace = copyStacktrace(&m_stackTraceSize);
+        m_stackTrace = adoptSystem(copyStacktrace(&m_stackTraceSize));
 }
 
-NetworkIssueReporter::~NetworkIssueReporter()
-{
-    if (m_stackTrace)
-        free(m_stackTrace);
-}
+NetworkIssueReporter::~NetworkIssueReporter() = default;
 
 void NetworkIssueReporter::report(const URL& requestURL)
 {
@@ -82,7 +78,7 @@ void NetworkIssueReporter::report(const URL& requestURL)
         return;
 
     if (auto createIssue = ne_tracker_create_xcode_issuePtr())
-        createIssue(host.utf8().data(), m_stackTrace, m_stackTraceSize);
+        createIssue(host.utf8().data(), m_stackTrace.get(), m_stackTraceSize);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/LaunchLogHook.mm
+++ b/Source/WebKit/Shared/Cocoa/LaunchLogHook.mm
@@ -71,7 +71,7 @@ void LaunchLogHook::initialize(xpc_connection_t connection)
         if (type == OS_LOG_TYPE_FAULT)
             type = OS_LOG_TYPE_ERROR;
 
-        if (auto messageString = WTF::adoptSystem<char[]>(os_log_copy_message_string(msg))) {
+        if (auto messageString = adoptSystem(os_log_copy_message_string(msg))) {
             auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
             xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, logMessageName);
             if (auto* subsystem = msg->subsystem)


### PR DESCRIPTION
#### 59ab652174061d307b08c1e631a7883560f09615
<pre>
Reduce of `free()` in the project
<a href="https://bugs.webkit.org/show_bug.cgi?id=300491">https://bugs.webkit.org/show_bug.cgi?id=300491</a>

Reviewed by Ryosuke Niwa and Darin Adler.

Reduce of `free()` in the project as manual memory management is dangerous.

* Source/JavaScriptCore/API/JSValue.mm:
(createStructHandlerMap):
* Source/JavaScriptCore/API/JSWrapperMap.mm:
(parsePropertyAttributes):
* Source/JavaScriptCore/disassembler/Disassembler.cpp:
* Source/JavaScriptCore/jsc.cpp:
(runInteractive):
* Source/WTF/wtf/ObjCRuntimeExtras.h:
* Source/WTF/wtf/ObjCRuntimeExtras.mm:
(WTF::property_copyAttributeListSpan):
* Source/WTF/wtf/StackTrace.h:
* Source/WTF/wtf/SystemFree.h:
(WTF::SystemFree::operator() const):
(WTF::adoptSystem):
(WTF::SystemFree&lt;T::operator() const): Deleted.
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::socketAddressFromIncomingConnection):
* Source/WebKit/Platform/cocoa/NetworkIssueReporter.h:
* Source/WebKit/Platform/cocoa/NetworkIssueReporter.mm:
(WebKit::NetworkIssueReporter::NetworkIssueReporter):
(WebKit::NetworkIssueReporter::report):
(WebKit::NetworkIssueReporter::~NetworkIssueReporter): Deleted.
* Source/WebKit/Shared/Cocoa/LaunchLogHook.mm:
(WebKit::LaunchLogHook::initialize):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::registerLogClient):
* Source/WebKitLegacy/mac/WebView/WebPDFView.mm:
(-[WebPDFView _temporaryPDFDirectoryPath]):

Canonical link: <a href="https://commits.webkit.org/301351@main">https://commits.webkit.org/301351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60f38cce9c755231ac6d2d9be615a725721c7101

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77559 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65f0fbb1-31a8-4344-b9f3-0617c1d8d1a5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95749 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63864 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e99c9e1-74a3-4a77-8093-57848027209e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76241 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d80a244f-dcc2-4c22-a386-3acbd32ecd13) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30568 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76009 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117761 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135214 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124185 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40230 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104214 "3 flakes 57 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103943 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26475 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49304 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27611 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49707 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58168 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157201 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51710 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39340 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55062 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->