### PR TITLE
Add iOS safer C++ expectations for WebKitLegacy

### DIFF
--- a/Source/WebKitLegacy/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -4,5 +4,6 @@ ios/WebCoreSupport/PopupMenuIOS.h
 mac/DOM/DOMAbstractView.mm
 mac/DOM/DOMObject.mm
 mac/WebCoreSupport/PopupMenuMac.h
-mac/WebCoreSupport/WebChromeClient.mm
-mac/WebView/WebView.mm
+[ Mac ] mac/WebCoreSupport/WebChromeClient.mm
+[ Mac ] mac/WebView/WebView.mm
+[ iOS ] ios/WebCoreSupport/WebChromeClientIOS.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -86,18 +86,22 @@ mac/DOM/ObjCEventListener.h
 mac/DOM/WebDOMOperations.mm
 mac/Misc/WebNSViewExtras.m
 mac/WebCoreSupport/WebChromeClient.mm
-mac/WebCoreSupport/WebContextMenuClient.mm
-mac/WebCoreSupport/WebDragClient.mm
+[ Mac ] mac/WebCoreSupport/WebContextMenuClient.mm
+[ Mac ] mac/WebCoreSupport/WebDragClient.mm
 mac/WebCoreSupport/WebEditorClient.mm
 mac/WebCoreSupport/WebFrameLoaderClient.mm
 mac/WebCoreSupport/WebSecurityOrigin.mm
 mac/WebView/WebDataSource.mm
-mac/WebView/WebDynamicScrollBarsView.mm
+[ Mac ] mac/WebView/WebDynamicScrollBarsView.mm
 mac/WebView/WebFrame.mm
 mac/WebView/WebFrameView.mm
 mac/WebView/WebHTMLRepresentation.mm
 mac/WebView/WebHTMLView.mm
-mac/WebView/WebPDFRepresentation.mm
+[ Mac ] mac/WebView/WebPDFRepresentation.mm
 mac/WebView/WebScriptDebugger.mm
-mac/WebView/WebVideoFullscreenController.mm
+[ Mac ] mac/WebView/WebVideoFullscreenController.mm
 mac/WebView/WebView.mm
+[ iOS ] ios/WebCoreSupport/WebFixedPositionContent.mm
+[ iOS ] mac/DOM/DOM.mm
+[ iOS ] mac/DOM/DOMUIKitExtensions.mm
+[ iOS ] mac/WebInspector/WebNodeHighlight.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -1,2 +1,2 @@
-mac/WebCoreSupport/PopupMenuMac.h
+[ Mac ] mac/WebCoreSupport/PopupMenuMac.h
 mac/WebCoreSupport/WebValidationMessageClient.h

--- a/Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,16 +1,16 @@
-mac/DefaultDelegates/WebDefaultUIDelegate.h
+[ Mac ] mac/DefaultDelegates/WebDefaultUIDelegate.h
 mac/History/BackForwardList.h
 mac/History/WebBackForwardList.h
 mac/History/WebHistory.h
 mac/History/WebHistoryItem.h
 mac/Misc/WebDownload.h
 mac/Misc/WebElementDictionary.h
-mac/Misc/WebIconDatabase.h
+[ Mac ] mac/Misc/WebIconDatabase.h
 mac/Misc/WebLocalizableStrings.h
-mac/Misc/WebSharingServicePickerController.h
+[ Mac ] mac/Misc/WebSharingServicePickerController.h
 mac/Misc/WebUserContentURLPattern.h
-mac/Panels/WebAuthenticationPanel.h
-mac/Panels/WebPanelAuthenticationHandler.m
+[ Mac ] mac/Panels/WebAuthenticationPanel.h
+[ Mac ] mac/Panels/WebPanelAuthenticationHandler.m
 mac/Plugins/WebBasePluginPackage.h
 mac/Plugins/WebPluginContainerCheck.h
 mac/Plugins/WebPluginController.h
@@ -23,7 +23,7 @@ mac/WebCoreSupport/WebChromeClient.h
 mac/WebCoreSupport/WebDragClient.h
 mac/WebCoreSupport/WebEditorClient.h
 mac/WebCoreSupport/WebGeolocationClient.h
-mac/WebCoreSupport/WebJavaScriptTextInputPanel.m
+[ Mac ] mac/WebCoreSupport/WebJavaScriptTextInputPanel.m
 mac/WebCoreSupport/WebNotificationClient.h
 mac/WebCoreSupport/WebProgressTrackerClient.h
 mac/WebCoreSupport/WebValidationMessageClient.h
@@ -38,7 +38,7 @@ mac/WebView/WebDocumentLoaderMac.h
 mac/WebView/WebFrame.h
 mac/WebView/WebFrameView.h
 mac/WebView/WebFrameView.mm
-mac/WebView/WebFullScreenController.h
+[ Mac ] mac/WebView/WebFullScreenController.h
 mac/WebView/WebGeolocationPosition.h
 mac/WebView/WebHTMLRepresentation.h
 mac/WebView/WebHTMLRepresentation.mm
@@ -46,19 +46,29 @@ mac/WebView/WebHTMLView.h
 mac/WebView/WebHTMLView.mm
 mac/WebView/WebNavigationData.h
 mac/WebView/WebNotification.h
-mac/WebView/WebPDFView.h
-mac/WebView/WebPDFView.mm
+[ Mac ] mac/WebView/WebPDFView.h
+[ Mac ] mac/WebView/WebPDFView.mm
 mac/WebView/WebPolicyDelegatePrivate.h
 mac/WebView/WebResource.h
 mac/WebView/WebScriptDebugDelegate.h
 mac/WebView/WebScriptDebugDelegate.mm
 mac/WebView/WebScriptWorld.h
-mac/WebView/WebTextCompletionController.h
+[ Mac ] mac/WebView/WebTextCompletionController.h
 mac/WebView/WebTextIterator.h
-mac/WebView/WebVideoFullscreenController.h
+[ Mac ] mac/WebView/WebVideoFullscreenController.h
 mac/WebView/WebView.h
 mac/WebView/WebView.mm
 mac/WebView/WebViewData.h
-mac/WebView/WebWindowAnimation.h
+[ Mac ] mac/WebView/WebWindowAnimation.h
 WebCoreSupport/SocketStreamHandleImplCFNet.cpp
 WebCoreSupport/WebCryptoClient.h
+[ iOS ] ios/Misc/WebGeolocationProviderIOS.mm
+[ iOS ] ios/WebCoreSupport/WebFixedPositionContent.mm
+[ iOS ] ios/WebCoreSupport/WebGeolocationPrivate.h
+[ iOS ] ios/WebView/WebPDFViewIOS.mm
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.h
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
+[ iOS ] mac/WebView/WebDataSource.mm
+[ iOS ] mac/WebView/WebIndicateLayer.h
+[ iOS ] mac/WebView/WebViewPrivate.h
+[ iOS ] mac/WebView/WebViewRenderingUpdateScheduler.h

--- a/Source/WebKitLegacy/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -3,18 +3,24 @@ mac/DefaultDelegates/WebDefaultEditingDelegate.m
 mac/DefaultDelegates/WebDefaultPolicyDelegate.mm
 mac/History/WebHistory.mm
 mac/Misc/WebKitErrors.m
-mac/Misc/WebNSImageExtras.m
+[ Mac ] mac/Misc/WebNSImageExtras.m
 mac/Misc/WebNSObjectExtras.mm
-mac/Misc/WebNSPasteboardExtras.mm
-mac/Panels/WebAuthenticationPanel.m
-mac/Panels/WebPanelAuthenticationHandler.m
+[ Mac ] mac/Misc/WebNSPasteboardExtras.mm
+[ Mac ] mac/Panels/WebAuthenticationPanel.m
+[ Mac ] mac/Panels/WebPanelAuthenticationHandler.m
 mac/Plugins/WebPluginController.mm
 mac/Storage/WebDatabaseManager.mm
 mac/Storage/WebStorageManager.mm
 mac/WebView/WebDeviceOrientationProviderMock.mm
 mac/WebView/WebFormDelegate.m
-mac/WebView/WebHTMLView.mm
-mac/WebView/WebPDFView.mm
+[ Mac ] mac/WebView/WebHTMLView.mm
+[ Mac ] mac/WebView/WebPDFView.mm
 mac/WebView/WebScriptWorld.mm
-mac/WebView/WebVideoFullscreenController.mm
+[ Mac ] mac/WebView/WebVideoFullscreenController.mm
 mac/WebView/WebView.mm
+[ iOS ] ios/DefaultDelegates/WebDefaultFormDelegate.m
+[ iOS ] ios/DefaultDelegates/WebDefaultFrameLoadDelegate.m
+[ iOS ] ios/DefaultDelegates/WebDefaultResourceLoadDelegate.m
+[ iOS ] ios/DefaultDelegates/WebDefaultUIKitDelegate.m
+[ iOS ] ios/WebView/WebPDFViewIOS.mm
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -82,28 +82,32 @@ mac/DOM/DOMXPathExpression.mm
 mac/DOM/DOMXPathResult.mm
 mac/DOM/WebDOMOperations.mm
 mac/Misc/WebElementDictionary.mm
-mac/Misc/WebNSPasteboardExtras.mm
-mac/Misc/WebStringTruncator.mm
+[ Mac ] mac/Misc/WebNSPasteboardExtras.mm
+[ Mac ] mac/Misc/WebStringTruncator.mm
 mac/Plugins/WebPluginContainerCheck.mm
-mac/Plugins/WebPluginController.mm
-mac/WebCoreSupport/PopupMenuMac.mm
+[ Mac ] mac/Plugins/WebPluginController.mm
+[ Mac ] mac/WebCoreSupport/PopupMenuMac.mm
 mac/WebCoreSupport/WebChromeClient.mm
-mac/WebCoreSupport/WebContextMenuClient.mm
-mac/WebCoreSupport/WebEditorClient.mm
+[ Mac ] mac/WebCoreSupport/WebContextMenuClient.mm
+[ Mac ] mac/WebCoreSupport/WebEditorClient.mm
 mac/WebCoreSupport/WebFrameLoaderClient.mm
 mac/WebCoreSupport/WebGeolocationClient.mm
-mac/WebCoreSupport/WebInspectorClient.mm
+[ Mac ] mac/WebCoreSupport/WebInspectorClient.mm
 mac/WebCoreSupport/WebKitFullScreenListener.mm
 mac/WebCoreSupport/WebValidationMessageClient.mm
 mac/WebView/WebDeviceOrientationProviderMock.mm
 mac/WebView/WebFrame.mm
-mac/WebView/WebFullScreenController.mm
+[ Mac ] mac/WebView/WebFullScreenController.mm
 mac/WebView/WebHTMLRepresentation.mm
 mac/WebView/WebHTMLView.mm
-mac/WebView/WebImmediateActionController.mm
-mac/WebView/WebPDFView.mm
+[ Mac ] mac/WebView/WebImmediateActionController.mm
+[ Mac ] mac/WebView/WebPDFView.mm
 mac/WebView/WebPreferences.mm
 mac/WebView/WebScriptDebugger.mm
 mac/WebView/WebTextIterator.mm
-mac/WebView/WebVideoFullscreenController.mm
+[ Mac ] mac/WebView/WebVideoFullscreenController.mm
 mac/WebView/WebView.mm
+[ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
+[ iOS ] ios/WebCoreSupport/WebVisiblePosition.mm
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
+[ iOS ] mac/DOM/DOMUIKitExtensions.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -11,15 +11,20 @@ mac/DOM/DOMNamedNodeMap.mm
 mac/DOM/DOMUtility.mm
 mac/DOM/WebDOMOperations.mm
 mac/Misc/WebElementDictionary.mm
-mac/Misc/WebNSPasteboardExtras.mm
-mac/WebCoreSupport/WebContextMenuClient.mm
+[ Mac ] mac/Misc/WebNSPasteboardExtras.mm
+[ Mac ] mac/WebCoreSupport/WebContextMenuClient.mm
 mac/WebCoreSupport/WebFrameLoaderClient.mm
 mac/WebCoreSupport/WebFrameNetworkingContext.mm
-mac/WebView/WebClipView.mm
-mac/WebView/WebDynamicScrollBarsView.mm
+[ Mac ] mac/WebView/WebClipView.mm
+[ Mac ] mac/WebView/WebDynamicScrollBarsView.mm
 mac/WebView/WebFrame.mm
 mac/WebView/WebFrameView.mm
 mac/WebView/WebHTMLRepresentation.mm
 mac/WebView/WebHTMLView.mm
-mac/WebView/WebImmediateActionController.mm
+[ Mac ] mac/WebView/WebImmediateActionController.mm
 mac/WebView/WebView.mm
+[ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
+[ iOS ] ios/WebCoreSupport/WebVisiblePosition.mm
+[ iOS ] mac/DOM/DOMUIKitExtensions.mm
+[ iOS ] mac/Plugins/WebPluginController.mm
+[ iOS ] mac/WebCoreSupport/WebEditorClient.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -120,14 +120,14 @@ mac/History/WebBackForwardList.mm
 mac/History/WebHistoryItem.mm
 mac/Misc/WebCoreStatistics.mm
 mac/Misc/WebElementDictionary.mm
-mac/Misc/WebNSPasteboardExtras.mm
-mac/Misc/WebSharingServicePickerController.mm
+[ Mac ] mac/Misc/WebNSPasteboardExtras.mm
+[ Mac ] mac/Misc/WebSharingServicePickerController.mm
 mac/Plugins/WebPluginContainerCheck.mm
 mac/Plugins/WebPluginController.mm
 mac/Storage/WebDatabaseManager.mm
 mac/Storage/WebStorageManager.mm
 mac/WebCoreSupport/WebChromeClient.mm
-mac/WebCoreSupport/WebContextMenuClient.mm
+[ Mac ] mac/WebCoreSupport/WebContextMenuClient.mm
 mac/WebCoreSupport/WebDragClient.mm
 mac/WebCoreSupport/WebEditorClient.mm
 mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -142,15 +142,22 @@ mac/WebInspector/WebNodeHighlightView.mm
 mac/WebView/WebArchive.mm
 mac/WebView/WebDataSource.mm
 mac/WebView/WebFrame.mm
-mac/WebView/WebFullScreenController.mm
+[ Mac ] mac/WebView/WebFullScreenController.mm
 mac/WebView/WebHTMLRepresentation.mm
 mac/WebView/WebHTMLView.mm
-mac/WebView/WebImmediateActionController.mm
-mac/WebView/WebMediaPlaybackTargetPicker.mm
-mac/WebView/WebPDFView.mm
+[ Mac ] mac/WebView/WebImmediateActionController.mm
+[ Mac ] mac/WebView/WebMediaPlaybackTargetPicker.mm
+[ Mac ] mac/WebView/WebPDFView.mm
 mac/WebView/WebResource.mm
 mac/WebView/WebScriptDebugger.mm
 mac/WebView/WebScriptWorld.mm
 mac/WebView/WebTextIterator.mm
-mac/WebView/WebVideoFullscreenController.mm
+[ Mac ] mac/WebView/WebVideoFullscreenController.mm
 mac/WebView/WebView.mm
+[ iOS ] ios/WebCoreSupport/WebChromeClientIOS.mm
+[ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
+[ iOS ] ios/WebCoreSupport/WebGeolocation.mm
+[ iOS ] ios/WebCoreSupport/WebVisiblePosition.mm
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
+[ iOS ] mac/DOM/DOMUIKitExtensions.mm
+[ iOS ] mac/Misc/WebCache.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,4 +1,4 @@
 Storage/StorageAreaImpl.cpp
 Storage/StorageThread.cpp
 WebCoreSupport/WebResourceLoadScheduler.cpp
-mac/WebCoreSupport/WebFrameLoaderClient.mm
+[ Mac ] mac/WebCoreSupport/WebFrameLoaderClient.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -19,30 +19,35 @@ mac/History/WebBackForwardList.mm
 mac/History/WebHistory.mm
 mac/History/WebHistoryItem.mm
 mac/Misc/WebElementDictionary.mm
-mac/Misc/WebNSPasteboardExtras.mm
-mac/Misc/WebSharingServicePickerController.mm
+[ Mac ] mac/Misc/WebNSPasteboardExtras.mm
+[ Mac ] mac/Misc/WebSharingServicePickerController.mm
 mac/Plugins/WebPluginContainerCheck.mm
 mac/Plugins/WebPluginController.mm
-mac/WebCoreSupport/PopupMenuMac.mm
-mac/WebCoreSupport/WebContextMenuClient.mm
+[ Mac ] mac/WebCoreSupport/PopupMenuMac.mm
+[ Mac ] mac/WebCoreSupport/WebContextMenuClient.mm
 mac/WebCoreSupport/WebEditorClient.mm
 mac/WebCoreSupport/WebFrameLoaderClient.mm
 mac/WebCoreSupport/WebGeolocationClient.mm
-mac/WebCoreSupport/WebInspectorClient.mm
+[ Mac ] mac/WebCoreSupport/WebInspectorClient.mm
 mac/WebCoreSupport/WebPluginInfoProvider.mm
-mac/WebCoreSupport/WebSelectionServiceController.mm
+[ Mac ] mac/WebCoreSupport/WebSelectionServiceController.mm
 mac/WebInspector/WebInspector.mm
 mac/WebView/WebArchive.mm
-mac/WebView/WebClipView.mm
+[ Mac ] mac/WebView/WebClipView.mm
 mac/WebView/WebDataSource.mm
-mac/WebView/WebDynamicScrollBarsView.mm
+[ Mac ] mac/WebView/WebDynamicScrollBarsView.mm
 mac/WebView/WebFrame.mm
 mac/WebView/WebFrameView.mm
 mac/WebView/WebHTMLRepresentation.mm
 mac/WebView/WebHTMLView.mm
-mac/WebView/WebImmediateActionController.mm
-mac/WebView/WebPDFView.mm
+[ Mac ] mac/WebView/WebImmediateActionController.mm
+[ Mac ] mac/WebView/WebPDFView.mm
 mac/WebView/WebResource.mm
 mac/WebView/WebScriptDebugDelegate.mm
 mac/WebView/WebScriptDebugger.mm
 mac/WebView/WebView.mm
+[ iOS ] ios/WebCoreSupport/WebFixedPositionContent.mm
+[ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
+[ iOS ] ios/WebCoreSupport/WebVisiblePosition.mm
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
+[ iOS ] mac/DOM/DOMUIKitExtensions.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -11,7 +11,7 @@ mac/DOM/DOMObject.mm
 mac/DOM/DOMStyleSheet.mm
 mac/DOM/ObjCEventListener.mm
 mac/DOM/ObjCNodeFilterCondition.mm
-mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm
+[ Mac ] mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm
 mac/DefaultDelegates/WebDefaultPolicyDelegate.mm
 mac/History/WebBackForwardList.mm
 mac/History/WebHistory.mm
@@ -21,13 +21,13 @@ mac/Misc/WebElementDictionary.mm
 mac/Misc/WebKitErrors.m
 mac/Misc/WebKitNSStringExtras.mm
 mac/Misc/WebNSObjectExtras.mm
-mac/Misc/WebNSPasteboardExtras.mm
+[ Mac ] mac/Misc/WebNSPasteboardExtras.mm
 mac/Misc/WebNSURLExtras.mm
-mac/Misc/WebNSViewExtras.m
-mac/Misc/WebSharingServicePickerController.mm
+[ Mac ] mac/Misc/WebNSViewExtras.m
+[ Mac ] mac/Misc/WebSharingServicePickerController.mm
 mac/Misc/WebUserContentURLPattern.mm
-mac/Panels/WebAuthenticationPanel.m
-mac/Panels/WebPanelAuthenticationHandler.m
+[ Mac ] mac/Panels/WebAuthenticationPanel.m
+[ Mac ] mac/Panels/WebPanelAuthenticationHandler.m
 mac/Plugins/WebBasePluginPackage.mm
 mac/Plugins/WebPluginContainerCheck.mm
 mac/Plugins/WebPluginController.mm
@@ -37,21 +37,21 @@ mac/Storage/WebDatabaseManager.mm
 mac/Storage/WebDatabaseManagerClient.mm
 mac/Storage/WebDatabaseProvider.mm
 mac/Storage/WebDatabaseQuotaManager.mm
-mac/WebCoreSupport/PopupMenuMac.mm
-mac/WebCoreSupport/SearchPopupMenuMac.mm
+[ Mac ] mac/WebCoreSupport/PopupMenuMac.mm
+[ Mac ] mac/WebCoreSupport/SearchPopupMenuMac.mm
 mac/WebCoreSupport/WebAlternativeTextClient.mm
 mac/WebCoreSupport/WebChromeClient.mm
-mac/WebCoreSupport/WebContextMenuClient.mm
+[ Mac ] mac/WebCoreSupport/WebContextMenuClient.mm
 mac/WebCoreSupport/WebDragClient.mm
 mac/WebCoreSupport/WebEditorClient.mm
 mac/WebCoreSupport/WebFrameLoaderClient.mm
 mac/WebCoreSupport/WebGeolocationClient.mm
-mac/WebCoreSupport/WebInspectorClient.mm
-mac/WebCoreSupport/WebJavaScriptTextInputPanel.m
+[ Mac ] mac/WebCoreSupport/WebInspectorClient.mm
+[ Mac ] mac/WebCoreSupport/WebJavaScriptTextInputPanel.m
 mac/WebCoreSupport/WebNotificationClient.mm
 mac/WebCoreSupport/WebProgressTrackerClient.mm
 mac/WebCoreSupport/WebSecurityOrigin.mm
-mac/WebCoreSupport/WebSelectionServiceController.mm
+[ Mac ] mac/WebCoreSupport/WebSelectionServiceController.mm
 mac/WebCoreSupport/WebValidationMessageClient.mm
 mac/WebInspector/WebInspector.mm
 mac/WebInspector/WebNodeHighlight.mm
@@ -62,30 +62,38 @@ mac/WebView/WebDelegateImplementationCaching.mm
 mac/WebView/WebDeviceOrientation.mm
 mac/WebView/WebDeviceOrientationProviderMock.mm
 mac/WebView/WebDocumentLoaderMac.mm
-mac/WebView/WebDynamicScrollBarsView.mm
+[ Mac ] mac/WebView/WebDynamicScrollBarsView.mm
 mac/WebView/WebFeature.m
 mac/WebView/WebFrame.mm
 mac/WebView/WebFrameView.mm
-mac/WebView/WebFullScreenController.mm
+[ Mac ] mac/WebView/WebFullScreenController.mm
 mac/WebView/WebGeolocationPosition.mm
 mac/WebView/WebHTMLRepresentation.mm
 mac/WebView/WebHTMLView.mm
-mac/WebView/WebImmediateActionController.mm
+[ Mac ] mac/WebView/WebImmediateActionController.mm
 mac/WebView/WebJSPDFDoc.mm
 mac/WebView/WebNavigationData.mm
 mac/WebView/WebNotification.mm
-mac/WebView/WebPDFDocumentExtras.mm
-mac/WebView/WebPDFView.mm
+[ Mac ] mac/WebView/WebPDFDocumentExtras.mm
+[ Mac ] mac/WebView/WebPDFView.mm
 mac/WebView/WebPolicyDelegate.mm
 mac/WebView/WebPreferences.mm
 mac/WebView/WebResource.mm
 mac/WebView/WebScriptDebugDelegate.mm
 mac/WebView/WebScriptDebugger.mm
 mac/WebView/WebScriptWorld.mm
-mac/WebView/WebTextCompletionController.mm
+[ Mac ] mac/WebView/WebTextCompletionController.mm
 mac/WebView/WebTextIterator.mm
-mac/WebView/WebVideoFullscreenController.mm
+[ Mac ] mac/WebView/WebVideoFullscreenController.mm
 mac/WebView/WebView.mm
-mac/WebView/WebViewData.mm
+[ Mac ] mac/WebView/WebViewData.mm
 mac/WebView/WebViewRenderingUpdateScheduler.mm
-mac/WebView/WebWindowAnimation.mm
+[ Mac ] mac/WebView/WebWindowAnimation.mm
+[ iOS ] ios/Misc/WebGeolocationCoreLocationProvider.mm
+[ iOS ] ios/Misc/WebGeolocationProviderIOS.mm
+[ iOS ] ios/Misc/WebUIKitSupport.mm
+[ iOS ] ios/WebCoreSupport/WebChromeClientIOS.mm
+[ iOS ] ios/WebCoreSupport/WebFixedPositionContent.mm
+[ iOS ] ios/WebView/WebPDFViewIOS.mm
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
+[ iOS ] mac/WebView/WebIndicateLayer.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
@@ -1,2 +1,2 @@
 mac/Misc/WebDownload.mm
-mac/WebView/WebView.mm
+[ Mac ] mac/WebView/WebView.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -32,52 +32,64 @@ mac/DOM/DOMXPath.mm
 mac/DOM/DOMXPathExpression.mm
 mac/DOM/DOMXPathResult.mm
 mac/DOM/ObjCEventListener.mm
-mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm
+[ Mac ] mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm
 mac/History/WebBackForwardList.mm
 mac/History/WebHistory.mm
 mac/History/WebHistoryItem.mm
-mac/Misc/WebDownload.mm
-mac/Misc/WebKitNSStringExtras.mm
+[ Mac ] mac/Misc/WebDownload.mm
+[ Mac ] mac/Misc/WebKitNSStringExtras.mm
 mac/Misc/WebLocalizableStrings.mm
 mac/Misc/WebNSFileManagerExtras.mm
-mac/Misc/WebNSPasteboardExtras.mm
+[ Mac ] mac/Misc/WebNSPasteboardExtras.mm
 mac/Misc/WebNSURLExtras.mm
-mac/Misc/WebNSViewExtras.m
-mac/Misc/WebSharingServicePickerController.mm
-mac/Panels/WebAuthenticationPanel.m
-mac/Panels/WebPanelAuthenticationHandler.m
+[ Mac ] mac/Misc/WebNSViewExtras.m
+[ Mac ] mac/Misc/WebSharingServicePickerController.mm
+[ Mac ] mac/Panels/WebAuthenticationPanel.m
+[ Mac ] mac/Panels/WebPanelAuthenticationHandler.m
 mac/Plugins/WebBasePluginPackage.mm
-mac/Plugins/WebPluginController.mm
+[ Mac ] mac/Plugins/WebPluginController.mm
 mac/Plugins/WebPluginDatabase.mm
 mac/Storage/WebStorageManager.mm
-mac/WebCoreSupport/PopupMenuMac.mm
+[ Mac ] mac/WebCoreSupport/PopupMenuMac.mm
 mac/WebCoreSupport/WebChromeClient.mm
-mac/WebCoreSupport/WebContextMenuClient.mm
-mac/WebCoreSupport/WebDragClient.mm
+[ Mac ] mac/WebCoreSupport/WebContextMenuClient.mm
+[ Mac ] mac/WebCoreSupport/WebDragClient.mm
 mac/WebCoreSupport/WebEditorClient.mm
 mac/WebCoreSupport/WebFrameLoaderClient.mm
 mac/WebCoreSupport/WebFrameNetworkingContext.mm
-mac/WebCoreSupport/WebInspectorClient.mm
+[ Mac ] mac/WebCoreSupport/WebInspectorClient.mm
 mac/WebCoreSupport/WebNotificationClient.mm
 mac/WebCoreSupport/WebVisitedLinkStore.mm
-mac/WebInspector/WebNodeHighlight.mm
+[ Mac ] mac/WebInspector/WebNodeHighlight.mm
 mac/WebView/WebArchive.mm
 mac/WebView/WebDataSource.mm
 mac/WebView/WebDelegateImplementationCaching.mm
-mac/WebView/WebDynamicScrollBarsView.mm
+[ Mac ] mac/WebView/WebDynamicScrollBarsView.mm
 mac/WebView/WebFrame.mm
 mac/WebView/WebFrameView.mm
 mac/WebView/WebHTMLView.mm
-mac/WebView/WebImmediateActionController.mm
+[ Mac ] mac/WebView/WebImmediateActionController.mm
 mac/WebView/WebJSPDFDoc.mm
-mac/WebView/WebPDFRepresentation.mm
-mac/WebView/WebPDFView.mm
+[ Mac ] mac/WebView/WebPDFRepresentation.mm
+[ Mac ] mac/WebView/WebPDFView.mm
 mac/WebView/WebPreferences.mm
 mac/WebView/WebResource.mm
 mac/WebView/WebScriptDebugDelegate.mm
 mac/WebView/WebScriptDebugger.mm
 mac/WebView/WebScriptWorld.mm
-mac/WebView/WebTextCompletionController.mm
-mac/WebView/WebVideoFullscreenController.mm
+[ Mac ] mac/WebView/WebTextCompletionController.mm
+[ Mac ] mac/WebView/WebVideoFullscreenController.mm
 mac/WebView/WebView.mm
 mac/WebView/WebViewRenderingUpdateScheduler.mm
+[ iOS ] ios/WebCoreSupport/WebChromeClientIOS.mm
+[ iOS ] ios/WebCoreSupport/WebFixedPositionContent.mm
+[ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
+[ iOS ] ios/WebCoreSupport/WebInspectorClientIOS.mm
+[ iOS ] ios/WebCoreSupport/WebVisiblePosition.mm
+[ iOS ] ios/WebView/WebPDFViewIOS.mm
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
+[ iOS ] ios/WebView/WebPlainWhiteView.mm
+[ iOS ] mac/Storage/WebDatabaseManager.mm
+[ iOS ] mac/Storage/WebDatabaseManagerClient.mm
+[ iOS ] mac/WebCoreSupport/WebProgressTrackerClient.mm
+[ iOS ] mac/WebInspector/WebNodeHighlighter.mm


### PR DESCRIPTION
#### 68293b9e4082579fd09962fc6cdcd6cc3e391140
<pre>
Add iOS safer C++ expectations for WebKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=300497">https://bugs.webkit.org/show_bug.cgi?id=300497</a>

Reviewed by Rupin Mittal.

Added iOS specific failures and annotated Mac specific failures for WebCore.

* Source/WebKitLegacy/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/301335@main">https://commits.webkit.org/301335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94b5411d1d12d29eb00b9912260e75664427207e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77449 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53782 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95635 "19 flakes 29 failures") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63521 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76142 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35582 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30461 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75892 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135093 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40117 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104119 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52801 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103844 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49197 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27511 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49557 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19671 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58047 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51603 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54956 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53298 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->