### PR TITLE
[macOS Safari] Local and outgoing shared screen is not adjusted to the full screen when User resizes the shared window

### DIFF
--- a/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h
+++ b/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h
@@ -70,7 +70,7 @@ public:
     void setMaximumBufferPoolSize(size_t maxBufferPoolSize) { m_maxBufferPoolSize = maxBufferPoolSize; }
 
     RetainPtr<CMSampleBufferRef> convertCMSampleBuffer(CMSampleBufferRef, const IntSize&, const WTF::MediaTime* = nullptr);
-    void setCroppingRectangle(std::optional<FloatRect>);
+    void setCroppingRectangle(std::optional<FloatRect>, FloatSize = { });
 
 private:
     WEBCORE_EXPORT ImageTransferSessionVT(uint32_t pixelFormat, bool shouldUseIOSurface);

--- a/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.mm
+++ b/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.mm
@@ -75,23 +75,34 @@ ImageTransferSessionVT::ImageTransferSessionVT(uint32_t pixelFormat, bool should
     m_pixelFormat = pixelFormat;
 }
 
-void ImageTransferSessionVT::setCroppingRectangle(std::optional<FloatRect> rectangle)
+void ImageTransferSessionVT::setCroppingRectangle(std::optional<FloatRect> rectangle, FloatSize size)
 {
-    if (m_croppingRectangle == rectangle)
-        return;
-
-    m_croppingRectangle = rectangle;
-
-    if (!m_croppingRectangle) {
+    if (!rectangle) {
         m_sourceCroppingDictionary = { };
         return;
     }
 
+    auto width = rectangle->width();
+    auto height = rectangle->height();
+    // Offsets are relative from center of image buffer
+    auto horizontalOffset = rectangle->x() - size.width() / 2 + width / 2;
+    auto verticalOffset = rectangle->y() - size.height() / 2 + height / 2;
+
+    FloatRect apertureRectangle {
+        FloatPoint { horizontalOffset, verticalOffset },
+        FloatSize { width, height }
+    };
+
+    if (m_croppingRectangle == apertureRectangle)
+        return;
+
+    m_croppingRectangle = apertureRectangle;
+
     m_sourceCroppingDictionary = @{
-        (__bridge NSString *)kCVImageBufferCleanApertureWidthKey: @(rectangle->width()),
-        (__bridge NSString *)kCVImageBufferCleanApertureHeightKey: @(rectangle->height()),
-        (__bridge NSString *)kCVImageBufferCleanApertureVerticalOffsetKey: @(rectangle->x()),
-        (__bridge NSString *)kCVImageBufferCleanApertureHorizontalOffsetKey: @(rectangle->y()),
+        (__bridge NSString *)kCVImageBufferCleanApertureWidthKey: @(apertureRectangle.width()),
+        (__bridge NSString *)kCVImageBufferCleanApertureHeightKey: @(apertureRectangle.height()),
+        (__bridge NSString *)kCVImageBufferCleanApertureVerticalOffsetKey: @(apertureRectangle.y()),
+        (__bridge NSString *)kCVImageBufferCleanApertureHorizontalOffsetKey: @(apertureRectangle.x()),
     };
 }
 

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -624,7 +624,7 @@ void ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer(RetainPtr<C
         if (!m_transferSession)
             m_transferSession = ImageTransferSessionVT::create(preferedPixelBufferFormat());
 
-        m_transferSession->setCroppingRectangle(contentRect);
+        m_transferSession->setCroppingRectangle(contentRect, intrinsicSize);
         if (auto newFrame = m_transferSession->convertCMSampleBuffer(m_currentFrame.get(), IntSize { contentRect.size() })) {
             m_currentFrame = WTFMove(newFrame);
             intrinsicSize = FloatSize(PAL::CMVideoFormatDescriptionGetPresentationDimensions(PAL::CMSampleBufferGetFormatDescription(m_currentFrame.get()), true, true));


### PR DESCRIPTION
#### f2be77ec4f12e63ec21c3d34238e1ea4d66b1218
<pre>
[macOS Safari] Local and outgoing shared screen is not adjusted to the full screen when User resizes the shared window
<a href="https://rdar.apple.com/161736839">rdar://161736839</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299955">https://bugs.webkit.org/show_bug.cgi?id=299955</a>

Reviewed by Eric Carlson.

The offsets need to be computed based on the input buffer to get proper cropping.
We update ImageTransferSessionVT::setCroppingRectangle to take the intrinsic size as input to compute the proper offsets.
We update ScreenCaptureKitCaptureSource call site.

Manually tested.

* Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h:
(WebCore::ImageTransferSessionVT::setCroppingRectangle):
* Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.mm:
(WebCore::ImageTransferSessionVT::setCroppingRectangle):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer):

Canonical link: <a href="https://commits.webkit.org/301477@main">https://commits.webkit.org/301477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0ba14adeac932a2f486ac7252de3e4cddb7442b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77456 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88a2dff0-3e69-4d58-8212-955762585fe2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95647 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63529 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f84fc167-1f0e-4a62-9803-f7e4d9971d9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36692 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112285 "Found 1 new API test failure: TestWebKitAPI.PasteMixedContent.CopyAndPasteWithCustomPasteboardDataOnly (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76147 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30467 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75899 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135099 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40120 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104117 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103855 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26563 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49205 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27517 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49563 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58053 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51609 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54962 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53304 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->