### PR TITLE
[CoreIPC] [Fuzz Blocker] TRAP in WebKit::NetworkStorageManager::openDatabase

### DIFF
--- a/LayoutTests/ipc/networkstoragemanager-opendatabase-with-empty-connection-id-expected.txt
+++ b/LayoutTests/ipc/networkstoragemanager-opendatabase-with-empty-connection-id-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/ipc/networkstoragemanager-opendatabase-with-empty-connection-id.html
+++ b/LayoutTests/ipc/networkstoragemanager-opendatabase-with-empty-connection-id.html
@@ -1,0 +1,44 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+ window.testRunner?.dumpAsText();
+ window.testRunner?.waitUntilDone();
+ if (window.IPC) {
+     import('./coreipc.js').then(({ CoreIPC }) => {
+         CoreIPC.Networking.NetworkStorageManager.OpenDatabase(0, {
+             requestData : {
+                 m_serverConnectionIdentifier : { alias : 393216 },
+                 m_requestIdentifier : {
+                     m_idbConnectionIdentifier : {},
+                     m_resourceNumber : { optionalValue : 393217 }
+                 },
+                 m_databaseIdentifier : {
+                     m_databaseName : 'db4',
+                     m_origin : {
+                         topOrigin : {
+                             data : {
+                                 variantType : 'WebCore::OpaqueOriginIdentifierProcessQualified',
+                                 variant : { object : 1, processIdentifier : 1234 }
+                             }
+                         },
+                         clientOrigin : {
+                             data : {
+                                 variantType : 'WebCore::OpaqueOriginIdentifierProcessQualified',
+                                 variant : { object : 1, processIdentifier : 1234 }
+                             }
+                         }
+                     },
+                     m_isTransient : false
+                 },
+                 m_requestedVersion : 1,
+                 m_requestType : 0
+             }
+         });
+     });
+ }
+ function callDone() {
+     window.testRunner?.notifyDone();
+ }
+</script>
+<body onload="setTimeout(callDone, 200)">
+    <p>This test passes if it doesn't crash.</p>
+</body>

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1721,6 +1721,7 @@ void NetworkStorageManager::clear(IPC::Connection& connection, StorageAreaIdenti
 
 void NetworkStorageManager::openDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
 {
+    MESSAGE_CHECK(requestData.requestIdentifier().connectionIdentifier(), connection);
     Ref connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection.uniqueID(), *requestData.requestIdentifier().connectionIdentifier());
     checkedOriginStorageManager(requestData.databaseIdentifier().origin())->checkedIDBStorageManager(*m_idbStorageRegistry)->openDatabase(connectionToClient, requestData);
 }
@@ -1732,6 +1733,7 @@ void NetworkStorageManager::openDBRequestCancelled(const WebCore::IDBOpenRequest
 
 void NetworkStorageManager::deleteDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
 {
+    MESSAGE_CHECK(requestData.requestIdentifier().connectionIdentifier(), connection);
     Ref connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection.uniqueID(), *requestData.requestIdentifier().connectionIdentifier());
     checkedOriginStorageManager(requestData.databaseIdentifier().origin())->checkedIDBStorageManager(*m_idbStorageRegistry)->deleteDatabase(connectionToClient, requestData);
 }


### PR DESCRIPTION
#### d370a0de4bc6ff4936c30ca12b59dc50ecd06b53
<pre>
[CoreIPC] [Fuzz Blocker] TRAP in WebKit::NetworkStorageManager::openDatabase
<a href="https://bugs.webkit.org/show_bug.cgi?id=300499">https://bugs.webkit.org/show_bug.cgi?id=300499</a>

Reviewed by Sihui Liu.

Both openDatabase() and deleteDatabase() expect the request identifier to have a
non-empty IDB connection identifier, so we need to validate the received message.

* LayoutTests/ipc/networkstoragemanager-opendatabase-with-empty-connection-id-expected.txt: Added.
* LayoutTests/ipc/networkstoragemanager-opendatabase-with-empty-connection-id.html: Added.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::openDatabase):
(WebKit::NetworkStorageManager::deleteDatabase):

Canonical link: <a href="https://commits.webkit.org/301316@main">https://commits.webkit.org/301316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04e45d118925fc96f42d0b63a2df4bb6353ddbcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77461 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95653 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63536 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30469 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75904 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135109 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104124 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108503 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103858 "1 api test failed or timed out") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26448 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49207 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27519 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49566 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52259 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58056 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51612 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54965 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->