### PR TITLE
[GTK][WPE][OpenXR] Run monado-service w/o stdin for API tests

### DIFF
--- a/Tools/Scripts/webkitpy/port/monadodriver.py
+++ b/Tools/Scripts/webkitpy/port/monadodriver.py
@@ -61,6 +61,7 @@ class MonadoDriver(Driver):
         driver_environment = super(MonadoDriver, self)._setup_environ_for_test()
         driver_environment['WITH_OPENXR_RUNTIME'] = 'y'
         driver_environment['XRT_COMPOSITOR_NULL'] = 'TRUE'
+        driver_environment['XRT_NO_STDIN'] = 'TRUE'
         driver_environment['XR_RUNTIME_JSON'] = self._get_runtime_path(driver_environment)
 
         monado_command = ['monado-service']

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -572,9 +572,6 @@
     },
     "TestWebKitWebXR": {
         "subtests": {
-            "/webkit/WebKitWebXR/leave-immersive-mode": {
-                "expected": {"all" : {"status": ["SKIP"], "bug": "webkit.org/b/299080"}}
-            },
             "/webkit/WebKitWebXR/permission-request": {
                 "expected": {"all" : {"status": ["SKIP"], "bug": "webkit.org/b/299080"}}
             }


### PR DESCRIPTION
#### 34ac3ceccd229bc11b53871d7842b83673fee363
<pre>
[GTK][WPE][OpenXR] Run monado-service w/o stdin for API tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=300500">https://bugs.webkit.org/show_bug.cgi?id=300500</a>

Reviewed by Adrian Perez de Castro.

Ensure XRT_NO_STDIN is set by the monado driver so that it is only
stopped by the test runner when the tests have finished running. This
allows us to unskip some of the WebXR API tests.

* Tools/Scripts/webkitpy/port/monadodriver.py:
(MonadoDriver._setup_environ_for_test): set XRT_NO_STDIN as the test
environment.
* Tools/TestWebKitAPI/glib/TestExpectations.json: Unskip
  leave-immersive-mode for GTK and WPE.

Canonical link: <a href="https://commits.webkit.org/301313@main">https://commits.webkit.org/301313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/412dce03f70394a93e919c947b23f17e51a8f528

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132439 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77462 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95656 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63533 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36696 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112289 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76163 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124921 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30471 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75912 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106468 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135106 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104128 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103862 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26446 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49208 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27521 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49567 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52260 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->