### PR TITLE
Stop using std::aligned_storage as it is deprecated in C++23

### DIFF
--- a/Source/JavaScriptCore/assembler/ProbeStack.h
+++ b/Source/JavaScriptCore/assembler/ProbeStack.h
@@ -141,10 +141,7 @@ private:
     static_assert(s_pageSize > s_chunkSize, "bad pageSize or chunkSize");
     static_assert(s_chunkSize == (1 << s_chunkSizeShift), "bad chunkSizeShift");
 
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    typedef typename std::aligned_storage<s_pageSize, std::alignment_of<uintptr_t>::value>::type Buffer;
-    ALLOW_DEPRECATED_DECLARATIONS_END
-    Buffer m_buffer;
+    alignas(uintptr_t) std::byte m_buffer[s_pageSize];
 };
 
 class Stack {

--- a/Source/WTF/wtf/SizeLimits.cpp
+++ b/Source/WTF/wtf/SizeLimits.cpp
@@ -80,9 +80,7 @@ template<typename T, unsigned inlineCapacity>
 struct SameSizeAsVectorWithInlineCapacity : SameSizeAsVectorWithInlineCapacityBase<T> {
     WTF_MAKE_NONCOPYABLE(SameSizeAsVectorWithInlineCapacity);
 public:
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type inlineBuffer[inlineCapacity];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    alignas(T) std::byte inlineBuffer[sizeof(T) * inlineCapacity];
 };
 
 static_assert(sizeof(Vector<int>) == sizeof(SameSizeAsVectorWithInlineCapacity<int>), "Vector should stay small!");

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -121,9 +121,7 @@
 #import "_WKWebExtensionSidebarInternal.h"
 #endif
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-static const size_t minimumObjectAlignment = alignof(std::aligned_storage<std::numeric_limits<size_t>::max()>::type);
-ALLOW_DEPRECATED_DECLARATIONS_END
+static const size_t minimumObjectAlignment = alignof(std::max_align_t);
 static_assert(minimumObjectAlignment >= alignof(void*), "Objects should always be at least pointer-aligned.");
 static const size_t maximumExtraSpaceForAlignment = minimumObjectAlignment - alignof(void*);
 

--- a/Source/bmalloc/bmalloc/PerHeapKind.h
+++ b/Source/bmalloc/bmalloc/PerHeapKind.h
@@ -54,7 +54,7 @@ public:
     
     const T& at(size_t i) const
     {
-        return *reinterpret_cast<T*>(&m_memory[i]);
+        return *reinterpret_cast<const T*>(&m_memory[i]);
     }
     
     T& at(HeapKind heapKind)
@@ -73,10 +73,10 @@ public:
     const T& operator[](HeapKind heapKind) const { return at(heapKind); }
 
 private:
-    BALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    typedef typename std::array<typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type, numHeaps> Memory;
-    BALLOW_DEPRECATED_DECLARATIONS_END
-    Memory m_memory;
+    struct alignas(T) Element {
+        std::byte data[sizeof(T)];
+    };
+    std::array<Element, numHeaps> m_memory;
 };
 
 template<typename T>

--- a/Source/bmalloc/bmalloc/StaticPerProcess.h
+++ b/Source/bmalloc/bmalloc/StaticPerProcess.h
@@ -96,7 +96,9 @@ private:
 // instantiated does not have export symbol visibility.
 #define DECLARE_STATIC_PER_PROCESS_STORAGE_WITH_LINKAGE(Type, Linkage) \
 template<> struct StaticPerProcessStorageTraits<Type> { \
-    using Memory = typename std::aligned_storage<sizeof(Type), std::alignment_of<Type>::value>::type; \
+    struct alignas(Type) Memory { \
+        std::byte data[sizeof(Type)]; \
+    }; \
     struct Linkage Storage { \
         static std::atomic<Type*> s_object; \
         static Mutex s_mutex; \


### PR DESCRIPTION
#### 0833418db689252b6e5d4fedf4fcfbc3e96da792
<pre>
Stop using std::aligned_storage as it is deprecated in C++23
<a href="https://bugs.webkit.org/show_bug.cgi?id=300501">https://bugs.webkit.org/show_bug.cgi?id=300501</a>

Reviewed by Yusuke Suzuki and Ryosuke Niwa.

* Source/JavaScriptCore/assembler/ProbeStack.h:
* Source/WTF/wtf/SizeLimits.cpp:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
* Source/bmalloc/bmalloc/PerHeapKind.h:
(bmalloc::PerHeapKindBase::at const):
* Source/bmalloc/bmalloc/StaticPerProcess.h:

Canonical link: <a href="https://commits.webkit.org/301389@main">https://commits.webkit.org/301389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9dc36a81fa5f82f407a52e335126ff3857a9754

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132710 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77704 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8060127f-95d7-48c9-a5ff-e4cd7705531d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54053 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95867 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63968 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e4755e2b-3c65-4195-a919-50c3f6ade76c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112522 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76358 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf6c286d-b37e-407b-8134-1b10b3edaed6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30706 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76181 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117913 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135383 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124339 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40360 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104329 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108732 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26497 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49423 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27745 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49966 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52512 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58323 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157352 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51860 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39399 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55208 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53555 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->