### PR TITLE
[ews] Improve error message when passwords.json is missing

### DIFF
--- a/Tools/CISupport/build-webkit-org/master.cfg
+++ b/Tools/CISupport/build-webkit-org/master.cfg
@@ -19,9 +19,9 @@ def load_password(name, default=None, master_prefix_path=os.path.dirname(os.path
         passwords = json.load(open(os.path.join(master_prefix_path, 'passwords.json')))
         return passwords.get(name, default)
     except FileNotFoundError as e:
-        print(f'ERROR: passwords.json missing: {e}, using default value for {name}\n')
+        print(f'Using default value for {name}, {e}')
     except Exception as e:
-        print(f'Error in finding {name} in passwords.json\n')
+        print(f'Error in finding {name} in passwords.json: {e}')
     return default
 
 

--- a/Tools/CISupport/ews-app/ews/common/util.py
+++ b/Tools/CISupport/ews-app/ews/common/util.py
@@ -66,9 +66,9 @@ def load_password(name, default=None):
         passwords = json.load(open('passwords.json'))
         return passwords.get(name, default)
     except FileNotFoundError as e:
-        _log.error('ERROR: passwords.json missing: {}, using default value for {}\n'.format(e, name))
+        _log.error(f'Using default value for {name}, {e}')
     except Exception as e:
-        _log.error('Error in finding {} in passwords.json'.format(name))
+        _log.error(f'Error in finding {name} in passwords.json: {e}')
     return default
 
 

--- a/Tools/CISupport/ews-build/utils.py
+++ b/Tools/CISupport/ews-build/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Apple Inc. All rights reserved.
+# Copyright (C) 2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,9 +32,9 @@ def load_password(name, default=None, master_prefix_path=os.path.dirname(os.path
         passwords = json.load(open(os.path.join(master_prefix_path, 'passwords.json')))
         return passwords.get(name, default)
     except FileNotFoundError as e:
-        print(f'ERROR: passwords.json missing: {e}, using default value for {name}\n')
+        print(f'Using default value for {name}, {e}')
     except Exception as e:
-        print(f'Error in finding {name} in passwords.json\n')
+        print(f'Error in finding {name} in passwords.json: {e}')
     return default
 
 


### PR DESCRIPTION
#### 695b2dc0092e78591afb54df80a03752acf35bd5
<pre>
[ews] Improve error message when passwords.json is missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=300447">https://bugs.webkit.org/show_bug.cgi?id=300447</a>
<a href="https://rdar.apple.com/162287374">rdar://162287374</a>

Reviewed by Jonathan Bedard.

* Tools/CISupport/build-webkit-org/master.cfg:
* Tools/CISupport/ews-app/ews/common/util.py:
* Tools/CISupport/ews-build/utils.py:

Canonical link: <a href="https://commits.webkit.org/301317@main">https://commits.webkit.org/301317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/047e77f459eccca217506c5283e4db66cf28d98f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132458 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65011d4d-161a-4778-9fa3-7ee365fc074e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53818 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84ba436d-f2ff-4f95-8167-58accf1b09ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76173 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/19fed2b6-3376-41fc-9623-e922d809121f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30493 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75931 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30711 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135130 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40147 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104147 "Failed to checkout and rebase branch from PR 52120") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/125020 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103879 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27543 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49607 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19665 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52286 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51639 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53334 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->