### PR TITLE
REGRESSION(299348@main): [WPE][GTK] Media control time fields displayed incorrectly after timecontrol update to flexbox

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/adwaita-fullscreen-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/adwaita-fullscreen-media-controls.css
@@ -85,6 +85,11 @@
     align-items: center;
 }
 
+.media-controls.adwaita.fullscreen .time-control .scrubber {
+    flex: 1 1 0%;
+    min-width: 0;
+}
+
 /* Status Label */
 
 .media-controls.adwaita.fullscreen > .controls-bar .status-label {
@@ -94,4 +99,14 @@
     bottom: 13px;
     font-size: 14px;
     text-align: center;
+}
+
+/* Time labels */
+
+.media-controls.adwaita.fullscreen .time-control.duration #time-label-remaining {
+    display: none !important;
+}
+
+.media-controls.adwaita.fullscreen .time-control.remaining #time-label-duration {
+    display: none !important;
 }

--- a/Source/WebCore/Modules/modern-media-controls/controls/adwaita-inline-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/adwaita-inline-media-controls.css
@@ -32,3 +32,20 @@
 .media-controls.adwaita.inline .volume-slider-container > .slider {
     margin-left: 6px;
 }
+
+/* Scrubber */
+
+.media-controls.adwaita.inline .time-control .scrubber {
+    flex: 1 1 0%;
+    min-width: 0;
+}
+
+/* Time labels */
+
+.media-controls.adwaita.inline .time-control.duration #time-label-remaining {
+    display: none !important;
+}
+
+.media-controls.adwaita.inline .time-control.remaining #time-label-duration {
+    display: none !important;
+}


### PR DESCRIPTION
#### 223d32e82b8d54873cacd0197ba60ceb9971fa41
<pre>
REGRESSION(299348@main): [WPE][GTK] Media control time fields displayed incorrectly after timecontrol update to flexbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=298766">https://bugs.webkit.org/show_bug.cgi?id=298766</a>

Reviewed by Carlos Garcia Campos and Philippe Normand.

Fix scrubber layout and time label visibility in inline and fullscreen media controls.

The scrubber in Adwaita inline and fullscreen media controls had zero width due to missing flex constraints. This change applies `flex: 1 1 0%` and `min-width: 0` to allow the scrubber to expand between the time labels.

Additionally, both duration and remaining time labels were shown simultaneously and it was not possible to switch between them by clicking the label.
This restores platform-specific CSS rules to ensure only one is visible at a time.

* Source/WebCore/Modules/modern-media-controls/controls/adwaita-fullscreen-media-controls.css:
(.media-controls.adwaita.fullscreen .time-control .scrubber):
(.media-controls.adwaita.fullscreen .time-control.duration #time-label-remaining):
(.media-controls.adwaita.fullscreen .time-control.remaining #time-label-duration):
* Source/WebCore/Modules/modern-media-controls/controls/adwaita-inline-media-controls.css:
(.media-controls.adwaita.inline .time-control .scrubber):
(.media-controls.adwaita.inline .time-control.duration #time-label-remaining):
(.media-controls.adwaita.inline .time-control.remaining #time-label-duration):

Canonical link: <a href="https://commits.webkit.org/301461@main">https://commits.webkit.org/301461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/963886a7d1dd93d05c84c8546896f16252d2bf65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77824 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95966 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64063 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112665 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76455 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30851 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76304 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135523 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104442 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104162 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26550 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49549 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27876 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50132 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52648 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58470 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51990 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->