### PR TITLE
REGRESSION (Safari 26): Container queries length unit wrong values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom-expected.txt
@@ -4,7 +4,7 @@ PASS Match container in walking flat tree ancestors
 PASS Match container in ::slotted selector's originating element tree
 PASS Match container in outer tree for :host
 PASS Match container in ::part selector's originating element tree
-FAIL Match container for ::before in ::slotted selector's originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Match container for ::before in ::slotted selector's originating element tree
 PASS Match container in outer tree for :host::before
 PASS Match container for ::before in ::part selector's originating element tree
 PASS Match container for ::part selector's originating element tree for exportparts
@@ -18,4 +18,6 @@ PASS Container name set inside a shadow tree should match query for host child o
 PASS Container name set on :host from inside a shadow tree matching query inside the shadow tree
 PASS Container name set on :host from inside a shadow tree matching query for ::slotted inside the shadow tree
 PASS Container name set on :host from inside a shadow tree should match query for slotted from the outside of the shadow tree
+PASS The originating element should be the first container candidate of ::before
+PASS Search flat tree anchestors of the originating element of ::before
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom.html
@@ -341,6 +341,32 @@
   </style>
 </div>
 
+<div>
+  <template shadowrootmode="open">
+    <style>
+      .container {
+        width: 400px;
+        container-type: inline-size;
+      }
+    </style>
+    <div class="container"><slot></slot></div>
+  </template>
+  <style>
+    @container (width = 200px) {
+      #pseudo-1::before { color: green; }
+    }
+    @container (width = 400px) {
+      #pseudo-2::before { color: green; }
+    }
+    #pseudo-1 {
+      container-type: inline-size;
+      width: 200px;
+    }
+  </style>
+  <div id="pseudo-1"></div>
+  <div id="pseudo-2"></div>
+</div>
+
 <script>
   setup(() => {
     assert_implements_size_container_queries();
@@ -446,4 +472,13 @@
     assert_equals(getComputedStyle(target).color, green);
   }, "Container name set on :host from inside a shadow tree should match query for slotted from the outside of the shadow tree");
 
+  test(() => {
+    const target = document.querySelector("#pseudo-1");
+    assert_equals(getComputedStyle(target, "::before").color, green);
+  }, "The originating element should be the first container candidate of ::before");
+
+  test(() => {
+    const target = document.querySelector("#pseudo-2");
+    assert_equals(getComputedStyle(target, "::before").color, green);
+  }, "Search flat tree anchestors of the originating element of ::before");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-shadow-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Direct slotted child queries flat tree assert_equals: expected "15px" but got "100px"
-FAIL Nondirect slotted child queries flat tree ancestors assert_equals: expected "1.5px" but got "10px"
+PASS Direct slotted child queries flat tree
+PASS Nondirect slotted child queries flat tree ancestors
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-container-for-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-container-for-shadow-dom-expected.txt
@@ -4,7 +4,7 @@ PASS Match container in the shadow tree for a host child in the host child's tre
 PASS Match <slot> as a container for ::slotted element
 PASS Match container in outer tree for :host
 PASS Match ::part's parent in the shadow tree as the container for ::part
-FAIL Match ::slotted as a container for its ::before assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Match ::slotted as a container for its ::before
 PASS Match container in outer tree for :host::before
 FAIL Match the ::part as a container for ::before on ::part elements assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS Match container for ::part selector in inner shadow tree for exportparts

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -141,6 +141,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     const CSSSelector* firstInCompound() const;
     const CSSSelector* lastInCompound() const;
+    const CSSSelector* precedingInCompound() const;
 
     const QualifiedName& tagQName() const;
     const AtomString& tagLowercaseLocalName() const;
@@ -274,6 +275,7 @@ private:
 };
 
 bool complexSelectorCanMatchPseudoElement(const CSSSelector&);
+bool complexSelectorMatchesElementBackedPseudoElement(const CSSSelector&);
 
 inline bool operator==(const PossiblyQuotedIdentifier& a, const AtomString& b) { return a.identifier == b; }
 

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -637,7 +637,7 @@ bool ElementRuleCollector::containerQueriesMatch(const RuleData& ruleData, const
     auto selectionMode = [&] {
         if (matchRequest.matchingPartPseudoElementRules)
             return ContainerQueryEvaluator::SelectionMode::PartPseudoElement;
-        if (ruleData.canMatchPseudoElement())
+        if (ruleData.canMatchPseudoElement() && !complexSelectorMatchesElementBackedPseudoElement(*ruleData.selector()))
             return ContainerQueryEvaluator::SelectionMode::PseudoElement;
         return ContainerQueryEvaluator::SelectionMode::Element;
     }();


### PR DESCRIPTION
#### 3286a2880158270dee0e75025413395f58459132
<pre>
REGRESSION (Safari 26): Container queries length unit wrong values
<a href="https://bugs.webkit.org/show_bug.cgi?id=300089">https://bugs.webkit.org/show_bug.cgi?id=300089</a>
<a href="https://rdar.apple.com/161897768">rdar://161897768</a>

Reviewed by Alan Baradlay.

Fix computation of the originating element for pseudo-elements.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-container-for-shadow-dom-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::precedingInCompound const):
(WebCore::complexSelectorMatchesElementBackedPseudoElement):

Add a helper.

* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::selectContainer):

Traverse the flat tree ancestors instead of &quot;shadow-including inclusive ancestors&quot;.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::containerQueriesMatch):

Only use SelectionMode::PseudoElement for pseudo-elements that are not element backed (not ::slotted() or ::part()).

Canonical link: <a href="https://commits.webkit.org/301324@main">https://commits.webkit.org/301324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da04963226f828be020d9d017cdd8b6fd277294d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77495 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7f097e12-c256-4884-8384-aaf197513b2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95685 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f188955b-e43d-41fc-8f58-fdd8907e9d38) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76182 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c05b0e4-71c5-4d2a-81a5-2b498e3e0ced) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30509 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75941 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135140 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104155 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26455 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49237 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27553 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49617 "Hash da049632 for PR 52125 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52296 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58093 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51648 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55000 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53343 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->