### PR TITLE
[Tools] git-webkit should link commit IDs like "301069@main" in the commit message

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
@@ -114,7 +114,8 @@ class PullRequest(object):
     @classmethod
     def escape_html(cls, message):
         message = ''.join(cls.ESCAPE_TABLE.get(c, c) for c in message)
-        message = re.sub(r'(https?://[^\s<>,:;]+?)(?=[\s<>,:;]|(&gt))', r'<a href="\1">\1</a>', message)
+        message = re.sub(r'(https?://[^\s<>,:;]+?)(?=[\s<>,:;]|(&gt)|$)', r'<a href="\1">\1</a>', message)
+        message = re.sub(r'(?<![/"\d.])(\d+(?:\.\d+)?)@([a-zA-Z0-9_-]+)', r'<a href="https://commits.webkit.org/\1@\2">\1@\2</a>', message)
         return re.sub(r'rdar://([^\s<>,:;]+?)(?=[\s<>,:;().]|(&gt))', r'<a href="https://rdar.apple.com/\1">rdar://\1</a>', message)
 
     @classmethod

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -70,6 +70,38 @@ Reviewed by Tim Contributor.
 </pre>''',
         )
 
+    def test_create_body_commit_identifiers(self):
+        self.assertEqual(
+            PullRequest.create_body(None, [Commit(
+                hash='11aa76f9fc380e9fe06157154f32b304e8dc4749',
+                message='[scoping] Bug to fix\nCherry-picked from 301069@main.\nAlso related to 297297.521@safari-7622-branch.\n\nReviewed by Tim Contributor.\n',
+            )]), '''#### 11aa76f9fc380e9fe06157154f32b304e8dc4749
+<pre>
+[scoping] Bug to fix
+Cherry-picked from <a href="https://commits.webkit.org/301069@main">301069@main</a>.
+Also related to <a href="https://commits.webkit.org/297297.521@safari-7622-branch">297297.521@safari-7622-branch</a>.
+
+Reviewed by Tim Contributor.
+</pre>''',
+        )
+
+    def test_create_body_commit_identifiers_in_urls(self):
+        self.assertEqual(
+            PullRequest.create_body(None, [Commit(
+                hash='11aa76f9fc380e9fe06157154f32b304e8dc4749',
+                message='[scoping] Bug to fix\n291838@main did not fix the issue.\n\nReviewed by Tim Contributor.\n\n    Canonical link: https://commits.webkit.org/296933@main\nCanonical link: https://commits.webkit.org/289651.600@safari-7621-branch\n',
+            )]), '''#### 11aa76f9fc380e9fe06157154f32b304e8dc4749
+<pre>
+[scoping] Bug to fix
+<a href="https://commits.webkit.org/291838@main">291838@main</a> did not fix the issue.
+
+Reviewed by Tim Contributor.
+
+    Canonical link: <a href="https://commits.webkit.org/296933@main">https://commits.webkit.org/296933@main</a>
+Canonical link: <a href="https://commits.webkit.org/289651.600@safari-7621-branch">https://commits.webkit.org/289651.600@safari-7621-branch</a>
+</pre>''',
+        )
+
     def test_create_body_single_no_link(self):
         self.assertEqual(
             PullRequest.create_body(None, [Commit(


### PR DESCRIPTION
#### 56837d22f51528cad8c1dc45c49085ef9b20bdad
<pre>
[Tools] git-webkit should link commit IDs like &quot;301069@main&quot; in the commit message
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=300512">https://bugs.webkit.org/show_bug.cgi?id=300512</a>&gt;
&lt;<a href="https://rdar.apple.com/162374652">rdar://162374652</a>&gt;

Reviewed by Jonathan Bedard.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
(PullRequest.escape_html):
- Update URL regex to match at end-of-string to handle URLs at the end
  of commit messages.
- Add regex to match and link commit IDs.  Use negative lookbehind to
  prevent matching commit IDs that are part of URLs.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
(TestPullRequest.test_create_body_commit_identifiers):
- Test standalone commit ID linking.
(TestPullRequest.test_create_body_commit_identifiers_in_urls):
- Test that commit IDs within existing URLs are not double-linked.

Canonical link: <a href="https://commits.webkit.org/301411@main">https://commits.webkit.org/301411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f1287bf6a5118169620116306b021610d526d05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77506 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7b4e09e-5cc3-4a6f-8f5a-06ce19449338) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95695 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63823 "Found 60 new test failures: compositing/clipping/border-radius-with-composited-descendant-nested.html compositing/clipping/border-radius-with-composited-descendant.html compositing/overlap-blending/children-opacity-huge.html compositing/overlap-blending/children-opacity-no-overlap.html compositing/overlap-blending/nested-non-overlap-clipping.html compositing/overlap-blending/nested-overlap.html compositing/reflections/nested-reflection-opacity2.html compositing/transitions/transform-on-large-layer.html compositing/webgl/update-composited-canvas-layer.html compositing/webgl/webgl-no-alpha.html ... (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c5ed54e-46fe-430c-a574-2575252c42de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76190 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c29694e3-3b03-4636-ac4b-280dae919f37) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124974 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35653 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30512 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75956 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106531 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135154 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104166 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/125045 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103896 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49250 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27558 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49638 "Hash 6f1287bf for PR 52126 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19701 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52314 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51662 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55015 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53358 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->