### PR TITLE
[Tools][CISupport] start-local-buildbot-server updates for launching ews with last buildbot version

### DIFF
--- a/Tools/CISupport/Shared/steps.py
+++ b/Tools/CISupport/Shared/steps.py
@@ -44,12 +44,6 @@ GITHUB_URL = 'https://github.com/'
 SCAN_BUILD_OUTPUT_DIR = 'scan-build-output'
 LLVM_DIR = 'llvm-project'
 
-try:
-    # For Buildbot < 3.0
-    shellCommand = shell.ShellCommandNewStyle
-except AttributeError:
-    shellCommand = shell.ShellCommand
-
 
 class ShellMixin(object):
     WINDOWS_SHELL_PLATFORMS = ['win', 'playstation']
@@ -119,7 +113,7 @@ class SetBuildSummary(buildstep.BuildStep, AddToLogMixin):
         return defer.returnValue(SUCCESS)
 
 
-class InstallCMake(shellCommand):
+class InstallCMake(shell.ShellCommand):
     name = 'install-cmake'
     haltOnFailure = True
     summary = 'Successfully installed CMake'
@@ -157,7 +151,7 @@ class InstallCMake(shellCommand):
         return {u'step': self.summary}
 
 
-class InstallNinja(shellCommand, ShellMixin):
+class InstallNinja(shell.ShellCommand, ShellMixin):
     name = 'install-ninja'
     haltOnFailure = True
     summary = 'Successfully installed Ninja'
@@ -195,7 +189,7 @@ class InstallNinja(shellCommand, ShellMixin):
         return {u'step': self.summary}
 
 
-class GetLLVMVersion(shellCommand, ShellMixin):
+class GetLLVMVersion(shell.ShellCommand, ShellMixin):
     name = 'get-llvm-version'
     summary = 'Found LLVM version'
 
@@ -322,7 +316,7 @@ class UpdateClang(steps.ShellSequence, ShellMixin):
         return {'step': self.summary}
 
 
-class PrintClangVersion(shellCommand):
+class PrintClangVersion(shell.ShellCommand):
     name = 'print-clang-version'
     haltOnFailure = False
     flunkOnFailure = False
@@ -345,7 +339,7 @@ class PrintClangVersion(shellCommand):
             return {'step': match.group(0)}
 
 
-class PrintClangVersion(shellCommand):
+class PrintClangVersion(shell.ShellCommand):
     name = 'print-clang-version'
     haltOnFailure = False
     flunkOnFailure = False
@@ -395,7 +389,7 @@ class PrintClangVersionAfterUpdate(PrintClangVersion, ShellMixin):
         return super().getResultSummary()
 
 
-class PruneCoreSymbolicationdCacheIfTooLarge(shellCommand):
+class PruneCoreSymbolicationdCacheIfTooLarge(shell.ShellCommand):
     name = "prune-coresymbolicationd-cache-if-too-large"
     description = ["pruning coresymbolicationd cache to < 10GB"]
     descriptionDone = ["pruned coresymbolicationd cache"]

--- a/Tools/CISupport/start-local-buildbot-server
+++ b/Tools/CISupport/start-local-buildbot-server
@@ -273,13 +273,7 @@ class BuildbotTestRunner(object):
             print('Setting up buildbot dependencies on the virtualenv ... ')
             # The idea is to install the very same version of buildbot and its
             # dependencies than the ones used for running https://build.webkit.org/about
-            is_ews = self._subdir_with_configuration.endswith('ews-build')
-            buildbot_version = '2.10.5' if is_ews else '4.3.0'
-            twisted_version = '21.2.0' if is_ews else '23.10.0'
-            requests_version = '2.21.0' if is_ews else '2.26.0'
-            lz4_version = '1.1.0' if is_ews else '4.3.2'
-            mock_version = '4' if is_ews else '5.2.0'
-            rapidfuzz_version = '2.11.1' if is_ews else '3.4.0'
+            buildbot_version = '4.3.0'
             pip_cmd = [virtualenv_pip, 'install',
                        f'buildbot=={buildbot_version}',
                        f'buildbot-console-view=={buildbot_version}',
@@ -287,11 +281,11 @@ class BuildbotTestRunner(object):
                        f'buildbot-waterfall-view=={buildbot_version}',
                        f'buildbot-worker=={buildbot_version}',
                        f'buildbot-www=={buildbot_version}',
-                       f'lz4=={lz4_version}',
-                       f'mock=={mock_version}',
-                       f'rapidfuzz=={rapidfuzz_version}',
-                       f'requests=={requests_version}',
-                       f'twisted=={twisted_version}',
+                       f'lz4==4.3.2',
+                       f'mock==5.2.0',
+                       f'rapidfuzz==3.4.0',
+                       f'requests==2.26.0',
+                       f'twisted==23.10.0',
                        'zope.interface==7.0.1']
             pip_process = subprocess.Popen(pip_cmd, cwd=self._base_workdir_temp,
                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
#### c15d64eaddde42abf354b99f93f50834ab28a6fb
<pre>
[Tools][CISupport] start-local-buildbot-server updates for launching ews with last buildbot version
<a href="https://bugs.webkit.org/show_bug.cgi?id=300513">https://bugs.webkit.org/show_bug.cgi?id=300513</a>

Reviewed by Aakash Jain.

The EWS buildbot server has been upgraded to last buildbot version on 301260@main
This is a follow-up patch for 300676@main to make also this test tool use the last
buildbot version for the test ews.

* Tools/CISupport/Shared/steps.py:
(InstallCMake):
(InstallNinja):
(GetLLVMVersion):
(PrintClangVersion):
(PruneCoreSymbolicationdCacheIfTooLarge):
* Tools/CISupport/start-local-buildbot-server:
(BuildbotTestRunner._setup_virtualenv):

Canonical link: <a href="https://commits.webkit.org/301395@main">https://commits.webkit.org/301395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bde7ae032b4bf44d646b5553129e584d32f3b4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77561 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95697 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63866 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30523 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75958 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106523 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135157 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104167 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/125047 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103897 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49251 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27568 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49640 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19692 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52316 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51664 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53360 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->