### PR TITLE
[JSC] WASM IPInt SIMD: explicitly skip JIT-less test modes for SIMD tests that require JIT

### DIFF
--- a/JSTests/wasm/stress/armv7-simple-loop-osr.js
+++ b/JSTests/wasm/stress/armv7-simple-loop-osr.js
@@ -1,4 +1,6 @@
 //@ requireOptions("--useWasmSIMD=1", "--useOMGJIT=1", "--useOMGInlining=0", "--useConcurrentJIT=0", "--useDollarVM=1", "--thresholdForBBQOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeSoon=0", "--thresholdForOMGOptimizeAfterWarmUp=50", "--thresholdForOMGOptimizeSoon=50")
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
 // jsc -m armv7-simple-loop-osr.js --useOMGJIT=1 --useOMGInlining=0 --useConcurrentJIT=0 --useDollarVM=1 --thresholdForBBQOptimizeAfterWarmUp=0 --thresholdForBBQOptimizeSoon=0 --thresholdForOMGOptimizeAfterWarmUp=50 --thresholdForOMGOptimizeSoon=50
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/inline-simd-function.js
+++ b/JSTests/wasm/stress/inline-simd-function.js
@@ -1,5 +1,8 @@
 //@ slow!
 //@ skip if $buildType == "debug" or $memoryLimited
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// Too slow without JIT
 
 function instantiate(moduleBase64, importObject) {
     let bytes = Uint8Array.fromBase64(moduleBase64);

--- a/JSTests/wasm/stress/ipint-bbq-osr-with-try3.js
+++ b/JSTests/wasm/stress/ipint-bbq-osr-with-try3.js
@@ -1,3 +1,7 @@
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// Too slow without JIT
+
 function instantiate(moduleBase64, importObject) {
     let bytes = Uint8Array.fromBase64(moduleBase64);
     return WebAssembly.instantiate(bytes, importObject);

--- a/JSTests/wasm/stress/ipint-bbq-osr-with-try4.js
+++ b/JSTests/wasm/stress/ipint-bbq-osr-with-try4.js
@@ -1,3 +1,7 @@
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// Too slow without JIT
+
 function instantiate(moduleBase64, importObject) {
     let bytes = Uint8Array.fromBase64(moduleBase64);
     return WebAssembly.instantiate(bytes, importObject);


### PR DESCRIPTION
#### 458378f07587d51f54b1945c5b1f1c0a4158b1df
<pre>
[JSC] WASM IPInt SIMD: explicitly skip JIT-less test modes for SIMD tests that require JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=300517">https://bugs.webkit.org/show_bug.cgi?id=300517</a>
<a href="https://rdar.apple.com/162381319">rdar://162381319</a>

Reviewed by Yusuke Suzuki.

Soon we will set useWasmIPIntSIMD to true by default. When doing so,
I will remove the code in run-jsc-stress-tests that skips the
wasm-no-jit and wasm-no-wasm-jit modes for tests that use SIMD
since those tests should now be runnable using IPInt.

However, there are a few tests that we&apos;ll continue to skip when
JIT is disabled. Mark those explicitly now to prepare.

While inline-simd-function.js, ipint-bbq-osr-with-try3.js,
and ipint-bbq-osr-with-try4.js aren&apos;t explicitly marked with
@requireOptions(&quot;--useWasmSIMD=1&quot;), the test code itself catches
the CompileError that is thrown when running with JIT disabled and
IPInt SIMD disabled. So skipping these JIT-less modes is not a loss
of test coverage but will be necessary once IPInt SIMD is enabled
because these tests run too slowly without JIT.

armv7-simple-loop-osr.js explicitly checks that it tiered up to OMG,
so lets explicitly skip that when JIT is disabled.

* JSTests/wasm/stress/armv7-simple-loop-osr.js:
* JSTests/wasm/stress/inline-simd-function.js:
* JSTests/wasm/stress/ipint-bbq-osr-with-try3.js:
* JSTests/wasm/stress/ipint-bbq-osr-with-try4.js:

Canonical link: <a href="https://commits.webkit.org/301410@main">https://commits.webkit.org/301410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9f4274ab90e3b8fc55a1f16096431c13f79e552

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77563 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88913acd-5a82-45f1-be0c-8bbbff7137c7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53850 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95699 "10 flakes 14 failures") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63865 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0e05e4f-3228-4608-8d65-19ac74c89f88) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76194 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ce54585-fff0-44e0-9a68-fe2f6752872e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35663 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75959 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117713 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106532 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135158 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124135 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104168 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103898 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49253 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27570 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49641 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19700 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52317 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157152 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51665 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39328 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55018 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->