### PR TITLE
REGRESSION (iOS 26): Popups timed incorrectly on websites using Hubspot CTA due to localStorage access being blocked

### DIFF
--- a/Source/WebCore/page/ScriptTrackingPrivacyCategory.cpp
+++ b/Source/WebCore/page/ScriptTrackingPrivacyCategory.cpp
@@ -97,7 +97,23 @@ bool shouldEnableScriptTrackingPrivacy(ScriptTrackingPrivacyCategory category, O
     if (protections.contains(AdvancedPrivacyProtections::BaselineProtections))
         return true;
 
-    return category != ScriptTrackingPrivacyCategory::FormControls;
+    switch (category) {
+    case ScriptTrackingPrivacyCategory::Audio:
+    case ScriptTrackingPrivacyCategory::Canvas:
+    case ScriptTrackingPrivacyCategory::HardwareConcurrency:
+    case ScriptTrackingPrivacyCategory::Payments:
+    case ScriptTrackingPrivacyCategory::QueryParameters:
+    case ScriptTrackingPrivacyCategory::Referrer:
+    case ScriptTrackingPrivacyCategory::ScreenOrViewport:
+    case ScriptTrackingPrivacyCategory::Speech:
+        return true;
+    case ScriptTrackingPrivacyCategory::Cookies:
+    case ScriptTrackingPrivacyCategory::LocalStorage:
+    case ScriptTrackingPrivacyCategory::FormControls:
+        return false;
+    }
+
+    return false;
 }
 
 String makeLogMessage(const URL& url, ScriptTrackingPrivacyCategory category)


### PR DESCRIPTION
#### ed98ad21fc2b2c47f42e87023ce95cb316fdd4e8
<pre>
REGRESSION (iOS 26): Popups timed incorrectly on websites using Hubspot CTA due to localStorage access being blocked
<a href="https://bugs.webkit.org/show_bug.cgi?id=299531">https://bugs.webkit.org/show_bug.cgi?id=299531</a>
<a href="https://rdar.apple.com/161424408">rdar://161424408</a>

Reviewed by Sihui Liu.

Add script-written cookie expiry capping and `localStorage` blocking to the list of privacy
protections to only enable when Advanced Privacy Protections are enabled. Given that these three
script categories have been the cause of the nearly all compatibility issues caused by these source
tracking privacy protections thus far, it makes more sense to (at least) only enable them by
default, only when the user has a straightforward way of temporarily disabling these protections
(via `Reload with reduced protections`).

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm

* Source/WebCore/page/ScriptTrackingPrivacyCategory.cpp:
(WebCore::shouldEnableScriptTrackingPrivacy):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm:

Adjust an existing API test to verify that these protections still apply when advanced privacy
protections are enabled.

(-[WKWebsiteDataStore deleteAllCookiesAndLocalStorage]):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, ScriptWrittenCookies)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, LocalStorage)):
(-[WKWebsiteDataStore deleteAllCookies]): Deleted.

Canonical link: <a href="https://commits.webkit.org/301327@main">https://commits.webkit.org/301327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd6ba0d46c938508bb5915fd500d6ee8153ad85a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132488 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0eda4e9f-dbb4-402d-b18a-7e4a808bfa7b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53852 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95702 "19 flakes 26 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ec5caf7-aa9c-46b6-9b99-eb2696a3b84a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112347 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76197 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45bbe8bc-4806-4486-8a1e-133d5a0dc654) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35648 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30528 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75961 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106526 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135160 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40189 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108558 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26457 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49254 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27573 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49643 "Hash dd6ba0d4 for PR 52131 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52319 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58119 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51667 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55020 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53363 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->