### PR TITLE
Safari crashes on setting action icon path to null.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
@@ -125,7 +125,7 @@ void WebExtensionContext::actionSetIcon(std::optional<WebExtensionWindowIdentifi
         return;
     }
 
-    RefPtr parsedIcons = JSON::Value::parseJSON(iconsJSON);
+    RefPtr parsedIcons = JSON::Value::parseJSON(iconsJSON) ?: JSON::Value::null();
     Ref webExtensionAction = action.value();
 
     if (RefPtr object = parsedIcons->asObject())

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -786,7 +786,7 @@ void WebExtensionAction::setIcons(RefPtr<JSON::Object> icons)
     if (m_customIcons == icons)
         return;
 
-    m_customIcons = icons->size() ? icons : nullptr;
+    m_customIcons = icons && icons->size() ? icons : nullptr;
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
     m_customIconVariants = nullptr;
 #endif
@@ -801,7 +801,7 @@ void WebExtensionAction::setIconVariants(RefPtr<JSON::Array> iconVariants)
     if (m_customIconVariants == iconVariants)
         return;
 
-    m_customIconVariants = iconVariants->length() ? iconVariants : nullptr;
+    m_customIconVariants = iconVariants && iconVariants->length() ? iconVariants : nullptr;
     m_customIcons = nullptr;
 
     clearIconCache();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -903,6 +903,81 @@ TEST(WKWebExtensionAPIAction, SetIconWithBadDataURL)
     [manager run];
 }
 
+TEST(WKWebExtensionAPIAction, SetIconWithNullPath)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"await browser.action.setIcon({ path: null })",
+        @"browser.test.sendMessage('Icon Set')",
+    ]);
+
+    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"toolbar-32.png": largeToolbarIcon,
+        @"popup.html": @"Hello world!",
+    };
+
+    auto manager = Util::loadExtension(actionPopupManifest, resources);
+
+    [manager runUntilTestMessage:@"Icon Set"];
+
+    auto *action = [manager.get().context actionForTab:nil];
+    auto *icon = [action iconForSize:CGSizeMake(32, 32)];
+    EXPECT_NOT_NULL(icon);
+    EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(32, 32)));
+}
+
+TEST(WKWebExtensionAPIAction, SetIconWithNullImageData)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"await browser.action.setIcon({ imageData: null })",
+        @"browser.test.sendMessage('Icon Set')",
+    ]);
+
+    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"toolbar-32.png": largeToolbarIcon,
+        @"popup.html": @"Hello world!",
+    };
+
+    auto manager = Util::loadExtension(actionPopupManifest, resources);
+
+    [manager runUntilTestMessage:@"Icon Set"];
+
+    auto *action = [manager.get().context actionForTab:nil];
+    auto *icon = [action iconForSize:CGSizeMake(32, 32)];
+    EXPECT_NOT_NULL(icon);
+    EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(32, 32)));
+}
+
+TEST(WKWebExtensionAPIAction, SetIconWithNullVariants)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"await browser.action.setIcon({ variants: null })",
+        @"browser.test.sendMessage('Icon Set')",
+    ]);
+
+    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"toolbar-32.png": largeToolbarIcon,
+        @"popup.html": @"Hello world!",
+    };
+
+    auto manager = Util::loadExtension(actionPopupManifest, resources);
+
+    [manager runUntilTestMessage:@"Icon Set"];
+
+    auto *action = [manager.get().context actionForTab:nil];
+    auto *icon = [action iconForSize:CGSizeMake(32, 32)];
+    EXPECT_NOT_NULL(icon);
+    EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(32, 32)));
+}
+
 TEST(WKWebExtensionAPIAction, SetIconWithMultipleDataURLs)
 {
     auto *backgroundScript = Util::constructScript(@[


### PR DESCRIPTION
#### 79064a2406194d4b20fdb42fd68e2271b63f9f61
<pre>
Safari crashes on setting action icon path to null.
<a href="https://webkit.org/b/299460">https://webkit.org/b/299460</a>
<a href="https://rdar.apple.com/problem/161264195">rdar://problem/161264195</a>

Reviewed by Brian Weinstein.

Add null checks for JSON::Value::parseJSON() uses. These were not fatal before in ObjC.
Add new tests for null in `action.setIcon()`. The other null checks were not testable.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
* Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp:
(WebKit::WebExtensionContext::storageSet):
(WebKit::WebExtensionContext::fireStorageChangedEventIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm:
(WebKit::WebExtensionContext::actionSetIcon):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::setIcons):
(WebKit::WebExtensionAction::setIconVariants):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithNullPath)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithNullImageData)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithNullVariants)): Added.

Canonical link: <a href="https://commits.webkit.org/301489@main">https://commits.webkit.org/301489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cdc952ac28fba57a9c39e98c1d4f62b5fec7a10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132521 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77542 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/137c4990-e5de-4fab-ae0f-055c459d80db) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95730 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63849 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f7c948f-d4c3-41f0-bcf9-d1b8707b4c02) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76224 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/337432c3-c3ec-42eb-bcbe-27b000df8aca) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30552 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75993 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106556 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135191 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40213 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104198 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103925 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49286 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27597 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49677 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19728 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52346 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58148 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51694 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55047 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53390 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->