### PR TITLE
[WPE][GTK] Can't paste image data (like image/png) from the clipboard in WebKit browsers

### DIFF
--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -197,7 +197,7 @@ class Pasteboard {
     WTF_MAKE_TZONE_ALLOCATED(Pasteboard);
     WTF_MAKE_NONCOPYABLE(Pasteboard);
 public:
-    Pasteboard(std::unique_ptr<PasteboardContext>&&);
+    explicit Pasteboard(std::unique_ptr<PasteboardContext>&&);
     virtual ~Pasteboard();
 
 #if PLATFORM(GTK) || PLATFORM(WPE)

--- a/Source/WebKit/UIProcess/gtk/WebPasteboardProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPasteboardProxyGtk.cpp
@@ -152,7 +152,7 @@ void WebPasteboardProxy::writeCustomData(IPC::Connection&, const Vector<Pasteboa
     clipboard.write(WTFMove(selectionData), WTFMove(completionHandler));
 }
 
-static WebCore::PasteboardItemInfo pasteboardIemInfoFromFormats(Vector<String>&& formats)
+static WebCore::PasteboardItemInfo pasteboardItemInfoFromFormats(Vector<String>&& formats)
 {
     WebCore::PasteboardItemInfo info;
     if (formats.contains("text/plain"_s) || formats.contains("text/plain;charset=utf-8"_s))
@@ -176,7 +176,7 @@ void WebPasteboardProxy::allPasteboardItemInfo(IPC::Connection&, const String& p
     }
 
     clipboard.formats([completionHandler = WTFMove(completionHandler)](Vector<String>&& formats) mutable {
-        completionHandler(Vector<WebCore::PasteboardItemInfo> { pasteboardIemInfoFromFormats(WTFMove(formats)) });
+        completionHandler(Vector<WebCore::PasteboardItemInfo> { pasteboardItemInfoFromFormats(WTFMove(formats)) });
     });
 }
 
@@ -189,7 +189,7 @@ void WebPasteboardProxy::informationForItemAtIndex(IPC::Connection&, uint64_t in
     }
 
     clipboard.formats([completionHandler = WTFMove(completionHandler)](Vector<String>&& formats) mutable {
-        completionHandler(pasteboardIemInfoFromFormats(WTFMove(formats)));
+        completionHandler(pasteboardItemInfoFromFormats(WTFMove(formats)));
     });
 }
 


### PR DESCRIPTION
#### d7d1107bc9b63b1a7aef053d6f900cc81bd28204
<pre>
[WPE][GTK] Can&apos;t paste image data (like image/png) from the clipboard in WebKit browsers
<a href="https://bugs.webkit.org/show_bug.cgi?id=218519">https://bugs.webkit.org/show_bug.cgi?id=218519</a>

Reviewed by Adrian Perez de Castro.

Change the Pasteboard::read PasteboardFileReader overload to more
closely match the Cocoa implementation. Notably, we now accept more
image types as input rather than supporting only PNG. However, our
implementation is simpler because we only support a single clipboard
item, so the index parameter is ignored.

Also, fix a bug that caused us to bail early if
PasteboardStrategy::readFilePathsFromClipboard does not return any
filenames.

Thanks to Miikka, Sonny Piers, and 荒野無燈 for their help in the bug
report.

Also, I&apos;ve snuck in a couple extra fixes in other files, to make the
Pasteboard constructor explicit and fix a typo.

Canonical link: <a href="https://commits.webkit.org/301877@main">https://commits.webkit.org/301877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32e98b2eec7b2316f611bfe3e995d6e7024f296a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78303 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96378 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64467 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113274 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31457 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77009 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136183 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104890 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104589 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26800 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50075 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28418 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50763 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59066 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52530 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55866 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->