### PR TITLE
REGRESSION(300927@main) RELEASE_ASSERT(entry) in RemoteResourceCacheProxy::willDestroyNativeImage

### DIFF
--- a/LayoutTests/svg/custom/pattern-memory-pressure-no-crash-expected.html
+++ b/LayoutTests/svg/custom/pattern-memory-pressure-no-crash-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body style="margin: 0;">
+<svg width="300" height="300">
+    <rect x="5" y="5" width="100" height="100" fill="url(#pattern)"/>
+    <defs>
+        <pattern id="pattern" width="10%" height="10%">
+            <circle fill="green" cx="5" cy="5" r="5"/>
+        </pattern>
+    </defs>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/custom/pattern-memory-pressure-no-crash.html
+++ b/LayoutTests/svg/custom/pattern-memory-pressure-no-crash.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<body style="margin: 0;">
+<svg width="300" height="300">
+    <rect x="5" y="5" width="100" height="100" fill="url(#pattern)"/>
+    <defs>
+        <pattern id="pattern" width="10%" height="10%">
+            <circle fill="green" cx="5" cy="5" r="5"/>
+        </pattern>
+    </defs>
+</svg>
+<script>
+// At the time of writing, the pattern would be rendered in accelerated manner in GPUP.
+// This would produce a RemoteNativeImageProxy. Memory pressure would remove all
+// GPUP images. Later destroying the pattern -induced RemoteNativeImageProxy would
+// try to remove itself from the cache and assert as it could not do this.
+window?.testRunner?.waitUntilDone();
+requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+        window?.internals?.beginSimulatedMemoryPressure();
+        window?.internals?.endSimulatedMemoryPressure();
+        requestAnimationFrame(() => {
+            window?.testRunner?.notifyDone();
+        });
+    });
+});
+</script>
+</body>
+</html>

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -499,12 +499,6 @@ void RemoteRenderingBackend::releaseMemory()
     m_remoteResourceCache.releaseMemory();
 }
 
-void RemoteRenderingBackend::releaseNativeImages()
-{
-    ASSERT(!RunLoop::isMain());
-    m_remoteResourceCache.releaseNativeImages();
-}
-
 #if USE(GRAPHICS_LAYER_WC)
 void RemoteRenderingBackend::flush(IPC::Semaphore&& semaphore)
 {

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -170,7 +170,6 @@ private:
     void cacheFontCustomPlatformData(WebCore::FontCustomPlatformSerializedData&&);
     void releaseFontCustomPlatformData(WebCore::RenderingResourceIdentifier);
     void releaseMemory();
-    void releaseNativeImages();
     void finalizeRenderingUpdate(RenderingUpdateID);
     void markSurfacesVolatile(MarkSurfacesAsVolatileRequestIdentifier, const Vector<std::pair<ImageBufferSetIdentifier, OptionSet<BufferInSetType>>>&, bool forcePurge);
     void createImageBufferSet(WebKit::ImageBufferSetIdentifier, RemoteGraphicsContextIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -47,7 +47,6 @@ messages -> RemoteRenderingBackend Stream {
     CacheFilter(Ref<WebCore::Filter> filter) NotStreamEncodable
     ReleaseFilter(WebCore::RenderingResourceIdentifier identifier)
     ReleaseMemory()
-    ReleaseNativeImages()
     CreateImageBufferSet(WebKit::ImageBufferSetIdentifier identifier, WebKit::RemoteGraphicsContextIdentifier contextIdentifier)
     ReleaseImageBufferSet(WebKit::ImageBufferSetIdentifier identifier)
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -138,22 +138,17 @@ bool RemoteResourceCache::releaseDisplayList(RemoteDisplayListIdentifier identif
 void RemoteResourceCache::releaseAllResources()
 {
     m_imageBuffers.clear();
+    m_nativeImages.clear();
     releaseMemory();
 }
 
 void RemoteResourceCache::releaseMemory()
 {
-    m_nativeImages.clear();
     m_gradients.clear();
     m_filters.clear();
     m_fonts.clear();
     m_fontCustomPlatformDatas.clear();
     m_displayLists.clear();
-}
-
-void RemoteResourceCache::releaseNativeImages()
-{
-    m_nativeImages.clear();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -78,7 +78,6 @@ public:
 
     void releaseAllResources();
     void releaseMemory();
-    void releaseNativeImages();
 
 private:
     HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::ImageBuffer>> m_imageBuffers;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -492,14 +492,6 @@ void RemoteRenderingBackendProxy::releaseMemory()
     send(Messages::RemoteRenderingBackend::ReleaseMemory());
 }
 
-void RemoteRenderingBackendProxy::releaseNativeImages()
-{
-    m_remoteResourceCacheProxy->releaseNativeImages();
-    if (!m_connection)
-        return;
-    send(Messages::RemoteRenderingBackend::ReleaseNativeImages());
-}
-
 #if PLATFORM(COCOA)
 void RemoteRenderingBackendProxy::startPreparingImageBufferSetsForDisplay()
 {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -121,7 +121,6 @@ public:
     void cacheDisplayList(RemoteDisplayListIdentifier, const WebCore::DisplayList::DisplayList&);
     void releaseDisplayList(RemoteDisplayListIdentifier);
     void releaseMemory();
-    void releaseNativeImages();
     void markSurfacesVolatile(Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>>&&, CompletionHandler<void(bool madeAllVolatile)>&&, bool forcePurge);
     Ref<RemoteImageBufferSetProxy> createImageBufferSet(ImageBufferSetClient&);
     void releaseImageBufferSet(RemoteImageBufferSetProxy&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -265,12 +265,6 @@ void RemoteResourceCacheProxy::willDestroyDisplayList(const DisplayList::Display
     m_remoteRenderingBackendProxy->releaseDisplayList(*identifier);
 }
 
-void RemoteResourceCacheProxy::releaseNativeImages()
-{
-    m_nativeImageResourceObserverWeakFactory.revokeAll();
-    m_nativeImages.clear();
-}
-
 void RemoteResourceCacheProxy::prepareForNextRenderingUpdate()
 {
     m_numberOfFontsUsedInCurrentRenderingUpdate = 0;
@@ -337,11 +331,12 @@ void RemoteResourceCacheProxy::didPaintLayers()
 
 void RemoteResourceCacheProxy::releaseMemory()
 {
+    // Release all resources that consume memory in GPUP.
+    // Other resources should be released by releasing the resource object references.
     m_resourceObserverWeakFactory.revokeAll();
     m_filters.clear();
     m_gradients.clear();
     m_displayLists.clear();
-    releaseNativeImages();
     releaseFonts();
     releaseFontCustomPlatformDatas();
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -72,7 +72,6 @@ public:
 
     void disconnect();
     void releaseMemory();
-    void releaseNativeImages();
 
     void willDestroyRemoteNativeImageProxy(const RemoteNativeImageProxy&);
     WebCore::PlatformImagePtr platformImage(const RemoteNativeImageProxy&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5205,11 +5205,6 @@ void WebPage::releaseMemory(Critical)
 
 void WebPage::willDestroyDecodedDataForAllImages()
 {
-#if ENABLE(GPU_PROCESS)
-    if (RefPtr renderingBackend = m_remoteRenderingBackendProxy)
-        renderingBackend->releaseNativeImages();
-#endif
-
     if (RefPtr drawingArea = m_drawingArea)
         drawingArea->setNextRenderingUpdateRequiresSynchronousImageDecoding();
 }
@@ -5220,7 +5215,7 @@ unsigned WebPage::remoteImagesCountForTesting() const
     if (RefPtr renderingBackend = m_remoteRenderingBackendProxy)
         return renderingBackend->nativeImageCountForTesting();
 #endif
-return 0;
+    return 0;
 }
 
 WebInspector* WebPage::inspector(LazyCreationPolicy behavior)


### PR DESCRIPTION
#### 1f5ba2e6e96371c9ce59c471d635f15ad5a7535f
<pre>
REGRESSION(300927@main) RELEASE_ASSERT(entry) in RemoteResourceCacheProxy::willDestroyNativeImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=300508">https://bugs.webkit.org/show_bug.cgi?id=300508</a>
<a href="https://rdar.apple.com/162330287">rdar://162330287</a>

Reviewed by Simon Fraser.

WebContent process would clear the WCP side RemoteResourceCacheProxy
image list in two cases: when it would destroy decoded image data
and upon memory pressure. RemoteNativeImageProxy were added to the same
list. This would cause RELEASE_ASSERT on destruction of
RemoteNativeImageProxy after these two events, because the instances
were unexpectedly removed.

Both of these cases are ineffective. The RemoteResourceCacheProxy and
GPUP do not own any additional memory for the cross-process images.
The data is held by the NativeImage instances themselves. Thus removing
the images from the cache should not be done, it only pessimizes the
behavior. In decode discard case, the decode cache discards the
NativeImage references and if the references are the only ones, the
data will be freed.

Test: svg/custom/pattern-memory-pressure-no-crash.html
* LayoutTests/svg/custom/pattern-memory-pressure-no-crash-expected.html: Added.
* LayoutTests/svg/custom/pattern-memory-pressure-no-crash.html: Added.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::releaseNativeImages): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::releaseAllResources):
(WebKit::RemoteResourceCache::releaseMemory):
(WebKit::RemoteResourceCache::releaseNativeImages): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::releaseNativeImages): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::releaseMemory):
(WebKit::RemoteResourceCacheProxy::releaseNativeImages):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willDestroyDecodedDataForAllImages):
(WebKit::WebPage::remoteImagesCountForTesting const):

Canonical link: <a href="https://commits.webkit.org/301460@main">https://commits.webkit.org/301460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/008555b303c60681536feea81d829979118e4062

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132503 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77526 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/755fd329-153b-4074-b7df-bcbfe148c71f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95718 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63837 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6888f538-404d-4a42-a3cb-f30befd541a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76210 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/00f33081-22d8-4c79-8a34-8d368312dc03) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35670 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30535 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75975 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106547 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135175 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40199 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104185 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103914 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49276 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27580 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49656 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52332 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58134 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51680 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55033 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53376 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->