### PR TITLE
[Swift in WebKit] Work towards modularizing WebCore private headers (Part 12)

### DIFF
--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -56,7 +56,7 @@ using namespace HTMLNames;
 
 inline HTMLButtonElement::HTMLButtonElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
     : HTMLFormControlElement(tagName, document, form)
-    , m_type(SUBMIT)
+    , m_type(Type::Submit)
     , m_isActivatedSubmit(false)
 {
     ASSERT(hasTagName(buttonTag));
@@ -89,11 +89,11 @@ int HTMLButtonElement::defaultTabIndex() const
 const AtomString& HTMLButtonElement::formControlType() const
 {
     switch (m_type) {
-    case SUBMIT:
+    case Type::Submit:
         return submitAtom();
-    case BUTTON:
+    case Type::Button:
         return HTMLNames::buttonTag->localName();
-    case RESET:
+    case Type::Reset:
         return resetAtom();
     }
 
@@ -274,19 +274,19 @@ void HTMLButtonElement::defaultEventHandler(Event& event)
             protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
             if (RefPtr currentForm = form()) {
-                if (m_type == SUBMIT)
+                if (m_type == Type::Submit)
                     currentForm->submitIfPossible(&event, this);
 
-                if (m_type == RESET)
+                if (m_type == Type::Reset)
                     currentForm->reset();
             }
 
-            if (m_type == SUBMIT || m_type == RESET) {
+            if (m_type == Type::Submit || m_type == Type::Reset) {
                 event.setDefaultHandled();
                 return;
             }
 
-            if (m_type == BUTTON && !equalLettersIgnoringASCIICase(attributeWithoutSynchronization(HTMLNames::typeAttr), "button"_s))
+            if (m_type == Type::Button && !equalLettersIgnoringASCIICase(attributeWithoutSynchronization(HTMLNames::typeAttr), "button"_s))
                 return;
         }
 
@@ -336,7 +336,7 @@ bool HTMLButtonElement::isSuccessfulSubmitButton() const
 {
     // HTML spec says that buttons must have names to be considered successful.
     // However, other browsers do not impose this constraint.
-    return m_type == SUBMIT;
+    return m_type == Type::Submit;
 }
 
 bool HTMLButtonElement::matchesDefaultPseudoClass() const
@@ -356,7 +356,7 @@ void HTMLButtonElement::setActivatedSubmit(bool flag)
 
 bool HTMLButtonElement::appendFormData(DOMFormData& formData)
 {
-    if (m_type != SUBMIT || name().isEmpty() || !m_isActivatedSubmit)
+    if (m_type != Type::Submit || name().isEmpty() || !m_isActivatedSubmit)
         return false;
     formData.append(name(), value());
     return true;
@@ -374,12 +374,12 @@ const AtomString& HTMLButtonElement::value() const
 
 bool HTMLButtonElement::computeWillValidate() const
 {
-    return m_type == SUBMIT && HTMLFormControlElement::computeWillValidate();
+    return m_type == Type::Submit && HTMLFormControlElement::computeWillValidate();
 }
 
 bool HTMLButtonElement::isSubmitButton() const
 {
-    return m_type == SUBMIT;
+    return m_type == Type::Submit;
 }
 
 bool HTMLButtonElement::isExplicitlySetSubmitButton() const
@@ -391,21 +391,21 @@ void HTMLButtonElement::computeType(const AtomString& typeAttrValue)
 {
     auto oldType = m_type;
     if (equalLettersIgnoringASCIICase(typeAttrValue, "reset"_s))
-        m_type = RESET;
+        m_type = Type::Reset;
     else if (equalLettersIgnoringASCIICase(typeAttrValue, "button"_s))
-        m_type = BUTTON;
+        m_type = Type::Button;
     else if (equalLettersIgnoringASCIICase(typeAttrValue, "submit"_s))
-        m_type = SUBMIT;
+        m_type = Type::Submit;
     else if (document().settings().commandAttributesEnabled()) {
         if (hasAttributeWithoutSynchronization(HTMLNames::commandAttr) || hasAttributeWithoutSynchronization(HTMLNames::commandforAttr))
-            m_type = BUTTON;
+            m_type = Type::Button;
         else
-            m_type = SUBMIT;
+            m_type = Type::Submit;
     } else
-        m_type = SUBMIT;
+        m_type = Type::Submit;
     if (oldType != m_type) {
         updateWillValidateAndValidity();
-        if (RefPtr currentForm = form(); currentForm && (oldType == SUBMIT || m_type == SUBMIT))
+        if (RefPtr currentForm = form(); currentForm && (oldType == Type::Submit || m_type == Type::Submit))
             currentForm->resetDefaultButton();
     }
 }

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -53,7 +53,7 @@ public:
 private:
     HTMLButtonElement(const QualifiedName& tagName, Document&, HTMLFormElement*);
 
-    enum Type { SUBMIT, RESET, BUTTON };
+    enum class Type : uint8_t { Submit, Reset, Button };
 
     const AtomString& formControlType() const final;
 


### PR DESCRIPTION
#### 5a744ba53f791052cfcbd15c56c1aabd0a7e6b8a
<pre>
[Swift in WebKit] Work towards modularizing WebCore private headers (Part 12)
<a href="https://bugs.webkit.org/show_bug.cgi?id=300521">https://bugs.webkit.org/show_bug.cgi?id=300521</a>
<a href="https://rdar.apple.com/162388804">rdar://162388804</a>

Reviewed by Aditya Keerthi.

When building with modules, the `RESET` enum case in HTMLButtonElement conflicts with the `RESET` macro from ANSIColors.h.

Fix by just changing the enum to be an enum class instead since those are preferred anyways.

* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::HTMLButtonElement):
(WebCore::HTMLButtonElement::formControlType const):
(WebCore::HTMLButtonElement::defaultEventHandler):
(WebCore::HTMLButtonElement::isSuccessfulSubmitButton const):
(WebCore::HTMLButtonElement::appendFormData):
(WebCore::HTMLButtonElement::computeWillValidate const):
(WebCore::HTMLButtonElement::isSubmitButton const):
(WebCore::HTMLButtonElement::computeType):
* Source/WebCore/html/HTMLButtonElement.h:

Canonical link: <a href="https://commits.webkit.org/301331@main">https://commits.webkit.org/301331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a4ceb133749058b292494b572146f0b3bdf92aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132504 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4a1807d3-3ec8-4deb-b565-2df3868a3f07) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95716 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7c85284-803f-425b-b62c-0e72f1c086d8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76211 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/82179778-feb0-4094-bcda-4980bd1d0119) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30537 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75976 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106543 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135176 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52438 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/40201 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104186 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108567 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26461 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49271 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27582 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49657 "Hash 3a4ceb13 for PR 52138 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52333 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58135 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51681 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55034 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53377 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->