### PR TITLE
CRASH in WebFullScreenManagerProxy::~WebFullScreenManagerProxy()

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -68,7 +68,6 @@ UIProcess/Cocoa/_WKWarningView.mm
 [ Mac ] UIProcess/mac/DisplayCaptureSessionManager.mm
 [ Mac ] UIProcess/mac/PageClientImplMac.mm
 UIProcess/mac/SecItemShimProxy.cpp
-[ Mac ] UIProcess/mac/WKFullScreenWindowController.mm
 [ Mac ] UIProcess/mac/WKTextAnimationManagerMac.mm
 [ Mac ] UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
 [ Mac ] UIProcess/mac/WebPopupMenuProxyMac.mm

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -82,8 +82,7 @@ WebFullScreenManagerProxy::~WebFullScreenManagerProxy()
 {
     if (RefPtr page = m_page.get())
         page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
-    if (CheckedPtr client = m_client)
-        client->closeFullScreenManager();
+    detachFromClient();
     callCloseCompletionHandlers();
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1787,6 +1787,11 @@ void WebPageProxy::close()
             automationSession->willClosePage(*this);
     }
 
+#if ENABLE(FULLSCREEN_API)
+    if (RefPtr fullscreenManager = std::exchange(m_fullScreenManager, nullptr))
+        fullscreenManager->detachFromClient();
+#endif
+
 #if ENABLE(WK_WEB_EXTENSIONS) && PLATFORM(COCOA)
     if (RefPtr webExtensionController = m_webExtensionController)
         webExtensionController->removePage(*this);

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -322,7 +322,8 @@ static void makeResponderFirstResponderIfDescendantOfView(NSWindow *window, NSRe
     // If the page doesn't respond in DefaultWatchdogTimerInterval seconds, it could be because
     // the WebProcess has hung, so exit anyway.
     if (!_watchdogTimer) {
-        [self _protectedManager]->requestExitFullScreen();
+        if (RefPtr manager = [self _manager])
+            manager->requestExitFullScreen();
         _watchdogTimer = adoptNS([[NSTimer alloc] initWithFireDate:[NSDate dateWithTimeIntervalSinceNow:DefaultWatchdogTimerInterval] interval:0 target:self selector:@selector(_watchdogTimerFired:) userInfo:nil repeats:NO]);
         [[NSRunLoop mainRunLoop] addTimer:_watchdogTimer.get() forMode:NSDefaultRunLoopMode];
     }
@@ -428,7 +429,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     _savedScale = page->pageScaleFactor();
     page->scalePageRelativeToScrollPosition(1, { });
-    [self _protectedManager]->setAnimatingFullScreen(true);
+    if (RefPtr manager = [self _manager])
+        manager->setAnimatingFullScreen(true);
     completionHandler(true);
 }
 
@@ -604,7 +606,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     page->startDeferringScrollEvents();
     [_webViewPlaceholder setTarget:nil];
 
-    [self _protectedManager]->setAnimatingFullScreen(true);
+    if (RefPtr manager = [self _manager])
+        manager->setAnimatingFullScreen(true);
     completionHandler();
 }
 
@@ -613,7 +616,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (_fullScreenState == NotInFullScreen)
         return;
 
-    [self _protectedManager]->requestExitFullScreen();
+    if (RefPtr manager = [self _manager])
+        manager->requestExitFullScreen();
     [_webViewPlaceholder setExitWarningVisible:NO];
     _fullScreenState = ExitingFullScreen;
     [self finishedExitFullScreenAnimationAndExitImmediately:YES];
@@ -626,7 +630,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)requestExitFullScreen
 {
-    [self _protectedManager]->requestExitFullScreen();
+    if (RefPtr manager = [self _manager])
+        manager->requestExitFullScreen();
 }
 
 - (void)beganExitFullScreenWithInitialFrame:(NSRect)initialFrame finalFrame:(NSRect)finalFrame completionHandler:(CompletionHandler<void()>&&)completionHandler
@@ -1050,7 +1055,8 @@ static RetainPtr<CAAnimation> fadeAnimation(CFTimeInterval duration, AnimationDi
     if ([self isFullScreen]) {
         // We still believe we're in full screen mode, so we must have been asked to exit full
         // screen by the system full screen button.
-        [self _protectedManager]->requestExitFullScreen();
+        if (RefPtr manager = [self _manager])
+            manager->requestExitFullScreen();
         [self exitFullScreen:[] { }];
         _fullScreenState = ExitingFullScreen;
     }


### PR DESCRIPTION
#### 8c4ef631f4ab66e9819a0194509926a66770fab7
<pre>
CRASH in WebFullScreenManagerProxy::~WebFullScreenManagerProxy()
<a href="https://rdar.apple.com/161686617">rdar://161686617</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300522">https://bugs.webkit.org/show_bug.cgi?id=300522</a>

Reviewed by Simon Fraser.

Crash logs show an increase in crashes in the WebFullScreenManagerProxy destructor,
called from the WebPageProxy destructor. It should be an impossible case to hit the
destructor of the WebPageProxy without first having that page&apos;s close() method called,
but that code path doesn&apos;t result in the fullscreen manager being torn down.

Close out the WebFullScreenManagerProxy when WebPageProxy is called, and for
full safety, clear out the client pointer by calling detachFromClient()
in the WebFullScreenManagerProxy destructor.

Additionally, existing tests discovered places in WKFullScreenWindowController where
a RefPtr was used un-guarded, causing crashes during testing. These have been turned
into guarded checks.

Canonical link: <a href="https://commits.webkit.org/301388@main">https://commits.webkit.org/301388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b9eeca10335d0f39d6efbd1925284f0932dae32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132605 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77623 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ceb13121-b3b1-4d2f-9720-8ed0117e1024) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95794 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63914 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c9b0ced-518a-434b-9af1-241dba06f279) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112441 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76286 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9fe8eb5-c5d3-4a50-bb16-e54852e4e3d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35747 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76077 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106623 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135286 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40286 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104262 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103989 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26496 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49353 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27667 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49808 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52424 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58233 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51773 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55123 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53468 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->