### PR TITLE
[World Leaks] Investigate leaks in LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/

### DIFF
--- a/LayoutTests/webgl/webgl-worker.html
+++ b/LayoutTests/webgl/webgl-worker.html
@@ -12,6 +12,8 @@ function runTest() {
         testRunner.waitUntilDone();
         testRunner.dumpAsText();
     }
+    if (window !== window.parent)
+        window.parent.postMessage("InTest", "*");
 
     const worker = new Worker("./resources/webgl-worker.js");
     worker.addEventListener("message", (e) => {

--- a/LayoutTests/webgl/worker-does-not-leak-expected.txt
+++ b/LayoutTests/webgl/worker-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that creating Workers does not leak the Document object
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/worker-does-not-leak.html
+++ b/LayoutTests/webgl/worker-does-not-leak.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/document-leak-test.js"></script>
+<script>
+    description("Tests that creating Workers does not leak the Document object");
+    onload = () => runDocumentLeakTest({ frameURL: "webgl-worker.html", framesToCreate: 20 });
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -205,7 +205,8 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequest(ResourceRequest&& re
             makeSimpleCrossOriginAccessRequest(WTFMove(request));
     } else {
         if (m_options.serviceWorkersMode == ServiceWorkersMode::All && m_async) {
-            if (m_options.serviceWorkerRegistrationIdentifier || document().activeServiceWorker()) {
+            RefPtr document = m_document.get();
+            if (document && (m_options.serviceWorkerRegistrationIdentifier || document->activeServiceWorker())) {
                 ASSERT(!m_bypassingPreflightForServiceWorkerRequest);
                 m_bypassingPreflightForServiceWorkerRequest = WTFMove(request);
                 m_options.serviceWorkersMode = ServiceWorkersMode::Only;
@@ -217,7 +218,8 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequest(ResourceRequest&& re
             return;
 
         m_simpleRequest = false;
-        if (RefPtr page = document().page(); page && CrossOriginPreflightResultCache::singleton().canSkipPreflight(page->sessionID(), document().clientOrigin(), request.url(), m_options.storedCredentialsPolicy, request.httpMethod(), request.httpHeaderFields()))
+        RefPtr document = m_document.get();
+        if (RefPtr page = document ? document->page() : nullptr; page && CrossOriginPreflightResultCache::singleton().canSkipPreflight(page->sessionID(), document->clientOrigin(), request.url(), m_options.storedCredentialsPolicy, request.httpMethod(), request.httpHeaderFields()))
             preflightSuccess(WTFMove(request));
         else
             makeCrossOriginAccessRequestWithPreflight(WTFMove(request));
@@ -253,11 +255,15 @@ void DocumentThreadableLoader::cancel()
 {
     Ref protectedThis { *this };
 
+    RefPtr document = m_document.get();
+    if (!document)
+        return;
+
     // Cancel can re-enter and m_resource might be null here as a result.
     if (m_client && m_resource) {
         // FIXME: This error is sent to the client in didFail(), so it should not be an internal one. Use LocalFrameLoaderClient::cancelledError() instead.
         ResourceError error(errorDomainWebKitInternal, 0, m_resource->url(), "Load cancelled"_s, ResourceError::Type::Cancellation);
-        m_client->didFail(m_document->identifier(), error); // May destroy the client.
+        m_client->didFail(document->identifier(), error); // May destroy the client.
     }
     clearResource();
     m_client = nullptr;
@@ -310,6 +316,13 @@ void DocumentThreadableLoader::redirectReceived(CachedResource& resource, Resour
     ASSERT_UNUSED(resource, &resource == m_resource);
 
     Ref protectedThis { *this };
+
+    RefPtr document = m_document.get();
+    if (!document) {
+        completionHandler(WTFMove(request));
+        return;
+    }
+
     --m_options.maxRedirectCount;
 
     m_responseURL = request.url();
@@ -408,6 +421,10 @@ void DocumentThreadableLoader::didReceiveResponse(ResourceLoaderIdentifier ident
     ASSERT(m_client);
     ASSERT(response.type() != ResourceResponse::Type::Error);
 
+    RefPtr document = m_document.get();
+    if (!document)
+        return;
+
     // https://fetch.spec.whatwg.org/commit-snapshots/6257e220d70f560a037e46f1b4206325400db8dc/#main-fetch step 17.
     if (response.source() == ResourceResponse::Source::ServiceWorker && response.url() != m_resource->url()) {
         if (!isResponseAllowedByContentSecurityPolicy(response)) {
@@ -416,27 +433,27 @@ void DocumentThreadableLoader::didReceiveResponse(ResourceLoaderIdentifier ident
         }
     }
 
-    InspectorInstrumentation::didReceiveThreadableLoaderResponse(document(), *this, identifier);
+    InspectorInstrumentation::didReceiveThreadableLoaderResponse(*document, *this, identifier);
 
     if (m_delayCallbacksForIntegrityCheck)
         return;
 
     if (options().filteringPolicy == ResponseFilteringPolicy::Disable) {
-        m_client->didReceiveResponse(m_document->identifier(), identifier, WTFMove(response));
+        m_client->didReceiveResponse(document->identifier(), identifier, WTFMove(response));
         return;
     }
 
     if (response.type() == ResourceResponse::Type::Default) {
-        m_client->didReceiveResponse(m_document->identifier(), identifier, ResourceResponse::filter(response, m_options.credentials == FetchOptions::Credentials::Include ? ResourceResponse::PerformExposeAllHeadersCheck::No : ResourceResponse::PerformExposeAllHeadersCheck::Yes));
+        m_client->didReceiveResponse(document->identifier(), identifier, ResourceResponse::filter(response, m_options.credentials == FetchOptions::Credentials::Include ? ResourceResponse::PerformExposeAllHeadersCheck::No : ResourceResponse::PerformExposeAllHeadersCheck::Yes));
         if (response.tainting() == ResourceResponse::Tainting::Opaque) {
             clearResource();
             if (m_client)
-                m_client->didFinishLoading(m_document->identifier(), identifier, { });
+                m_client->didFinishLoading(document->identifier(), identifier, { });
         }
         return;
     }
     ASSERT(response.type() == ResourceResponse::Type::Opaqueredirect || response.source() == ResourceResponse::Source::ServiceWorker || response.source() == ResourceResponse::Source::MemoryCache);
-    m_client->didReceiveResponse(m_document->identifier(), identifier, WTFMove(response));
+    m_client->didReceiveResponse(document->identifier(), identifier, WTFMove(response));
 }
 
 void DocumentThreadableLoader::dataReceived(CachedResource& resource, const SharedBuffer& buffer)
@@ -557,14 +574,18 @@ void DocumentThreadableLoader::preflightFailure(std::optional<ResourceLoaderIden
 {
     m_preflightChecker = std::nullopt;
 
-    RefPtr frame = m_document->frame();
+    RefPtr document = m_document.get();
+    if (!document)
+        return;
+
+    RefPtr frame = document->frame();
     if (identifier)
         InspectorInstrumentation::didFailLoading(frame.get(), frame->loader().protectedDocumentLoader().get(), *identifier, error);
 
     if (m_shouldLogError == ShouldLogError::Yes)
         logError(protectedDocument(), error, m_options.initiatorType);
 
-    m_client->didFail(m_document->identifier(), error);
+    m_client->didFail(document->identifier(), error);
 }
 
 void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCheckPolicy securityCheck)
@@ -586,7 +607,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
         options.loadedFromFetch = m_options.initiatorType == cachedResourceRequestInitiatorTypes().fetch ? LoadedFromFetch::Yes : LoadedFromFetch::No;
         options.clientCredentialPolicy = m_sameOriginRequest ? ClientCredentialPolicy::MayAskClientForCredentials : ClientCredentialPolicy::CannotAskClientForCredentials;
         options.contentSecurityPolicyImposition = ContentSecurityPolicyImposition::SkipPolicyCheck;
-        
+
         // If there is integrity metadata to validate, we must buffer.
         if (!m_options.integrity.isEmpty())
             options.dataBufferingPolicy = DataBufferingPolicy::BufferData;
@@ -600,7 +621,11 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
         if (CachedResourceHandle resource = std::exchange(m_resource, nullptr))
             resource->removeClient(*this);
 
-        auto cachedResource = m_document->protectedCachedResourceLoader()->requestRawResource(WTFMove(newRequest));
+        RefPtr document = m_document.get();
+        if (!document)
+            return;
+
+        auto cachedResource = document->protectedCachedResourceLoader()->requestRawResource(WTFMove(newRequest));
         m_resource = cachedResource.value_or(nullptr);
         if (CachedResourceHandle resource = m_resource)
             resource->addClient(*this);
@@ -612,11 +637,15 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     // If credentials mode is 'Omit', we should disable cookie sending.
     ASSERT(m_options.credentials != FetchOptions::Credentials::Omit);
 
+    RefPtr document = m_document.get();
+    if (!document)
+        return;
+
     ResourceLoadTiming loadTiming;
     loadTiming.markStartTime();
 
     // FIXME: ThreadableLoaderOptions.sniffContent is not supported for synchronous requests.
-    RefPtr frame = m_document->frame();
+    RefPtr frame = document->frame();
     if (!frame)
         return;
 
@@ -690,7 +719,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     if (options().initiatorContext == InitiatorContext::Worker)
         finishedTimingForWorkerLoad(resourceTiming);
     else {
-        if (RefPtr window = document().window())
+        if (RefPtr window = document->window())
             window->protectedPerformance()->addResourceTiming(WTFMove(resourceTiming));
     }
 
@@ -783,15 +812,18 @@ void DocumentThreadableLoader::reportIntegrityMetadataError(const CachedResource
 
 void DocumentThreadableLoader::logErrorAndFail(const ResourceError& error)
 {
+    RefPtr document = m_document.get();
+    if (!document)
+        return;
+
     if (m_shouldLogError == ShouldLogError::Yes) {
-        Ref document = *m_document;
         if (error.isAccessControl() && error.domain() != InspectorNetworkAgent::errorDomain() && !error.localizedDescription().isEmpty())
             document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, error.localizedDescription());
-        logError(document, error, m_options.initiatorType);
+        logError(*document, error, m_options.initiatorType);
     }
     ASSERT(m_client);
     if (m_client)
-        m_client->didFail(m_document->identifier(), error); // May cause the client to get destroyed.
+        m_client->didFail(document->identifier(), error); // May cause the client to get destroyed.
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -109,13 +109,13 @@ static ScriptExecutionContextIdentifier loaderContextIdentifierFromContext(const
 }
 
 WorkerMessagingProxy::WorkerMessagingProxy(Worker& workerObject)
-    : m_scriptExecutionContext(workerObject.scriptExecutionContext())
-    , m_loaderContextIdentifier(loaderContextIdentifierFromContext(*m_scriptExecutionContext))
+    : m_loaderContextIdentifier(loaderContextIdentifierFromContext(*workerObject.scriptExecutionContext()))
     , m_inspectorProxy(WorkerInspectorProxy::create(workerObject.identifier()))
     , m_workerObject(&workerObject)
 {
-    ASSERT((is<Document>(*m_scriptExecutionContext) && isMainThread())
-        || (is<WorkerGlobalScope>(*m_scriptExecutionContext) && downcast<WorkerGlobalScope>(*m_scriptExecutionContext).thread()->thread() == &Thread::currentSingleton()));
+    RefPtr scriptExecutionContext = workerObject.scriptExecutionContext();
+    ASSERT((is<Document>(*scriptExecutionContext) && isMainThread())
+        || (is<WorkerGlobalScope>(*scriptExecutionContext) && downcast<WorkerGlobalScope>(*scriptExecutionContext).thread()->thread() == &Thread::currentSingleton()));
 
     // Nobody outside this class ref counts this object. The original ref
     // is balanced by the deref in workerGlobalScopeDestroyedInternal.
@@ -124,9 +124,6 @@ WorkerMessagingProxy::WorkerMessagingProxy(Worker& workerObject)
 WorkerMessagingProxy::~WorkerMessagingProxy()
 {
     ASSERT(!m_workerObject);
-    ASSERT(!m_scriptExecutionContext
-        || (is<Document>(*m_scriptExecutionContext) && isMainThread())
-        || (is<WorkerGlobalScope>(*m_scriptExecutionContext) && downcast<WorkerGlobalScope>(*m_scriptExecutionContext).thread()->thread() == &Thread::currentSingleton()));
 
     if (m_workerThread)
         m_workerThread->clearProxies();
@@ -134,38 +131,43 @@ WorkerMessagingProxy::~WorkerMessagingProxy()
 
 void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::SessionID sessionID, const String& name, WorkerInitializationData&& initializationData, const ScriptBuffer& sourceCode, const ContentSecurityPolicyResponseHeaders& contentSecurityPolicyResponseHeaders, bool shouldBypassMainWorldContentSecurityPolicy, const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy, MonotonicTime timeOrigin, ReferrerPolicy referrerPolicy, WorkerType workerType, FetchRequestCredentials credentials, JSC::RuntimeFlags runtimeFlags)
 {
-    if (!m_scriptExecutionContext)
+    RefPtr workerObject = m_workerObject;
+    if (!workerObject)
         return;
-    
+
+    RefPtr scriptExecutionContext = workerObject->scriptExecutionContext();
+    if (!scriptExecutionContext)
+        return;
+
     if (m_askedToTerminate) {
         // Worker.terminate() could be called from JS before the thread was created.
         return;
     }
 
-    RefPtr parentWorkerGlobalScope = dynamicDowncast<WorkerGlobalScope>(*m_scriptExecutionContext);
-    WorkerThreadStartMode startMode = m_inspectorProxy->workerStartMode(*m_scriptExecutionContext.get());
+    RefPtr parentWorkerGlobalScope = dynamicDowncast<WorkerGlobalScope>(*scriptExecutionContext);
+    WorkerThreadStartMode startMode = m_inspectorProxy->workerStartMode(*scriptExecutionContext);
     String identifier = m_inspectorProxy->identifier();
 
-    RefPtr proxy = m_scriptExecutionContext->idbConnectionProxy();
-    RefPtr socketProvider = m_scriptExecutionContext->socketProvider();
+    RefPtr proxy = scriptExecutionContext->idbConnectionProxy();
+    RefPtr socketProvider = scriptExecutionContext->socketProvider();
 
     bool isOnline = parentWorkerGlobalScope ? parentWorkerGlobalScope->isOnline() : platformStrategies()->loaderStrategy()->isOnLine();
 
     m_scriptURL = scriptURL;
 
-    WorkerParameters params { scriptURL, m_scriptExecutionContext->url(), name, identifier, WTFMove(initializationData.userAgent), isOnline, contentSecurityPolicyResponseHeaders, shouldBypassMainWorldContentSecurityPolicy, crossOriginEmbedderPolicy, timeOrigin, referrerPolicy, workerType, credentials, m_scriptExecutionContext->settingsValues(), WorkerThreadMode::CreateNewThread, sessionID,
+    WorkerParameters params { scriptURL, scriptExecutionContext->url(), name, identifier, WTFMove(initializationData.userAgent), isOnline, contentSecurityPolicyResponseHeaders, shouldBypassMainWorldContentSecurityPolicy, crossOriginEmbedderPolicy, timeOrigin, referrerPolicy, workerType, credentials, scriptExecutionContext->settingsValues(), WorkerThreadMode::CreateNewThread, sessionID,
         WTFMove(initializationData.serviceWorkerData),
         initializationData.clientIdentifier,
-        m_scriptExecutionContext->advancedPrivacyProtections(),
-        m_scriptExecutionContext->noiseInjectionHashSalt()
+        scriptExecutionContext->advancedPrivacyProtections(),
+        scriptExecutionContext->noiseInjectionHashSalt()
     };
-    auto thread = DedicatedWorkerThread::create(params, sourceCode, *this, *this, *this, *this, startMode, m_scriptExecutionContext->topOrigin(), proxy.get(), socketProvider.get(), runtimeFlags);
+    auto thread = DedicatedWorkerThread::create(params, sourceCode, *this, *this, *this, *this, startMode, scriptExecutionContext->topOrigin(), proxy.get(), socketProvider.get(), runtimeFlags);
 
     if (parentWorkerGlobalScope) {
         parentWorkerGlobalScope->thread()->addChildThread(thread);
         if (auto* parentWorkerClient = parentWorkerGlobalScope->workerClient())
             thread->setWorkerClient(parentWorkerClient->createNestedWorkerClient(thread.get()).moveToUniquePtr());
-    } else if (RefPtr document = dynamicDowncast<Document>(m_scriptExecutionContext.get())) {
+    } else if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext.get())) {
         if (RefPtr page = document->page()) {
             if (auto workerClient = page->chrome().createWorkerClient(thread.get()))
                 thread->setWorkerClient(WTFMove(workerClient));
@@ -175,23 +177,20 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
     workerThreadCreated(thread.get());
     thread->start();
 
-    m_inspectorProxy->workerStarted(*m_scriptExecutionContext, thread.ptr(), scriptURL, name);
+    m_inspectorProxy->workerStarted(*scriptExecutionContext, thread.ptr(), scriptURL, name);
 }
 
 void WorkerMessagingProxy::postMessageToWorkerObject(MessageWithMessagePorts&& message)
 {
-    if (!m_scriptExecutionContext)
-        return;
-
     // Pass a RefPtr to the WorkerUserGestureForwarder, if present, into the main thread
     // task; the m_userGestureForwarder ivar may be cleared after this function returns.
-    m_scriptExecutionContext->postTask([this, message = WTFMove(message), userGestureForwarder = m_userGestureForwarder] (auto& context) mutable {
+    ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, [this, message = WTFMove(message), userGestureForwarder = m_userGestureForwarder] (auto& context) mutable {
         RefPtr workerObject = this->workerObject();
         if (!workerObject || askedToTerminate())
             return;
 
         auto ports = MessagePort::entanglePorts(context, WTFMove(message.transferredPorts));
-        ActiveDOMObject::queueTaskKeepingObjectAlive(*workerObject, TaskSource::PostedMessageQueue, [worker = Ref { *workerObject }, message = WTFMove(message), userGestureForwarder = WTFMove(userGestureForwarder), ports = WTFMove(ports)](auto&) mutable {
+        context.postTask([worker = Ref { *workerObject }, message = WTFMove(message), userGestureForwarder = WTFMove(userGestureForwarder), ports = WTFMove(ports)](auto&) mutable {
             if (!worker->scriptExecutionContext())
                 return;
 
@@ -215,10 +214,7 @@ void WorkerMessagingProxy::postMessageToWorkerObject(MessageWithMessagePorts&& m
 
 void WorkerMessagingProxy::postTaskToWorkerObject(Function<void(Worker&)>&& function)
 {
-    if (!m_scriptExecutionContext)
-        return;
-
-    m_scriptExecutionContext->postTask([this, function = WTFMove(function)](auto&) mutable {
+    ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, [this, function = WTFMove(function)](auto&) mutable {
         RefPtr workerObject = this->workerObject();
         if (!workerObject || askedToTerminate())
             return;
@@ -302,10 +298,11 @@ void WorkerMessagingProxy::postTaskToLoader(ScriptExecutionContext::Task&& task)
 RefPtr<CacheStorageConnection> WorkerMessagingProxy::createCacheStorageConnection()
 {
     ASSERT(isMainThread());
-    if (!m_scriptExecutionContext)
+    RefPtr workerObject = m_workerObject;
+    if (!workerObject)
         return nullptr;
 
-    RefPtr document = dynamicDowncast<Document>(*m_scriptExecutionContext);
+    RefPtr document = dynamicDowncast<Document>(workerObject->scriptExecutionContext());
     ASSERT(document);
     if (!document || !document->page())
         return nullptr;
@@ -315,7 +312,11 @@ RefPtr<CacheStorageConnection> WorkerMessagingProxy::createCacheStorageConnectio
 RefPtr<RTCDataChannelRemoteHandlerConnection> WorkerMessagingProxy::createRTCDataChannelRemoteHandlerConnection()
 {
     ASSERT(isMainThread());
-    RefPtr document = dynamicDowncast<Document>(*m_scriptExecutionContext);
+    RefPtr workerObject = m_workerObject;
+    if (!workerObject)
+        return nullptr;
+
+    RefPtr document = dynamicDowncast<Document>(workerObject->scriptExecutionContext());
     ASSERT(document);
     if (!document || !document->page())
         return nullptr;
@@ -324,10 +325,7 @@ RefPtr<RTCDataChannelRemoteHandlerConnection> WorkerMessagingProxy::createRTCDat
 
 void WorkerMessagingProxy::postExceptionToWorkerObject(const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL)
 {
-    if (!m_scriptExecutionContext)
-        return;
-
-    m_scriptExecutionContext->postTask([this, errorMessage = errorMessage.isolatedCopy(), sourceURL = sourceURL.isolatedCopy(), lineNumber, columnNumber] (ScriptExecutionContext&) {
+    ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, [this, errorMessage = errorMessage.isolatedCopy(), sourceURL = sourceURL.isolatedCopy(), lineNumber, columnNumber] (ScriptExecutionContext&) {
         RefPtr workerObject = this->workerObject();
         if (!workerObject)
             return;
@@ -340,10 +338,7 @@ void WorkerMessagingProxy::postExceptionToWorkerObject(const String& errorMessag
 
 void WorkerMessagingProxy::reportErrorToWorkerObject(const String& errorMessage)
 {
-    if (!m_scriptExecutionContext)
-        return;
-
-    m_scriptExecutionContext->postTask([this,  errorMessage =  errorMessage.isolatedCopy()] (auto&) {
+    ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, [this,  errorMessage =  errorMessage.isolatedCopy()] (auto&) {
         if (RefPtr workerObject = this->workerObject())
             workerObject->reportError(errorMessage);
     });
@@ -384,10 +379,7 @@ void WorkerMessagingProxy::workerThreadCreated(DedicatedWorkerThread& workerThre
 void WorkerMessagingProxy::workerObjectDestroyed()
 {
     m_workerObject = nullptr;
-    if (!m_scriptExecutionContext)
-        return;
-
-    m_scriptExecutionContext->postTask([this] (ScriptExecutionContext&) {
+    ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, [this] (ScriptExecutionContext&) {
         m_mayBeDestroyed = true;
         if (m_workerThread)
             terminateWorkerGlobalScope();
@@ -413,20 +405,14 @@ void WorkerMessagingProxy::notifyNetworkStateChange(bool isOnline)
 
 void WorkerMessagingProxy::workerGlobalScopeDestroyed()
 {
-    if (!m_scriptExecutionContext)
-        return;
-
-    m_scriptExecutionContext->postTask([this] (ScriptExecutionContext&) {
+    ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, [this] (ScriptExecutionContext&) {
         workerGlobalScopeDestroyedInternal();
     });
 }
 
 void WorkerMessagingProxy::workerGlobalScopeClosed()
 {
-    if (!m_scriptExecutionContext)
-        return;
-
-    m_scriptExecutionContext->postTask([this] (ScriptExecutionContext&) {
+    ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, [this] (ScriptExecutionContext&) {
         terminateWorkerGlobalScope();
     });
 }
@@ -439,13 +425,15 @@ void WorkerMessagingProxy::workerGlobalScopeDestroyedInternal()
 
     m_inspectorProxy->workerTerminated();
 
-    if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(m_scriptExecutionContext); workerGlobalScope && m_workerThread)
-        workerGlobalScope->thread()->removeChildThread(*m_workerThread);
+    if (RefPtr workerObject = m_workerObject) {
+        if (RefPtr scriptExecutionContext = workerObject->scriptExecutionContext()) {
+            if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(*scriptExecutionContext); workerGlobalScope && m_workerThread)
+                workerGlobalScope->thread()->removeChildThread(*m_workerThread);
+        }
+    }
 
     if (RefPtr workerThread = std::exchange(m_workerThread, nullptr))
         workerThread->clearProxies();
-
-    m_scriptExecutionContext = nullptr;
 
     // This balances the original ref in construction.
     if (m_mayBeDestroyed)
@@ -462,16 +450,11 @@ void WorkerMessagingProxy::terminateWorkerGlobalScope()
 
     if (m_workerThread)
         m_workerThread->stop(nullptr);
-    else
-        m_scriptExecutionContext = nullptr;
 }
 
 void WorkerMessagingProxy::setAppBadge(std::optional<uint64_t> badge)
 {
     ASSERT(!isMainThread());
-
-    if (!m_scriptExecutionContext)
-        return;
 
     postTaskToLoader([badge = WTFMove(badge), this, protectedThis = Ref { *this }] (auto& context) {
         ASSERT(isMainThread());

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -97,8 +97,7 @@ private:
 
     // WorkerBadgeProxy
     void setAppBadge(std::optional<uint64_t>) final;
-    
-    RefPtr<ScriptExecutionContext> m_scriptExecutionContext;
+
     ScriptExecutionContextIdentifier m_loaderContextIdentifier;
     const Ref<WorkerInspectorProxy> m_inspectorProxy;
     RefPtr<WorkerUserGestureForwarder> m_userGestureForwarder;


### PR DESCRIPTION
#### cb6ea234be6d109f972eb53a183d1203494b6845
<pre>
[World Leaks] Investigate leaks in LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/
<a href="https://bugs.webkit.org/show_bug.cgi?id=300526">https://bugs.webkit.org/show_bug.cgi?id=300526</a>
<a href="https://rdar.apple.com/162395265">rdar://162395265</a>

Reviewed by NOBODY (OOPS!).

We encounter leaks in a selection of tests from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/
and worker-module.http-rp/ and some corresponding tests in
LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/ and
LayoutTests/imported/w3c/web-platform-tests/workers/ which total approximately 15
leaky tests. This patch resolves those leaks by removing the strong
Ref&lt;ScriptExecutionContext&gt; previously held by WorkerMessagingProxy::m_scriptExecutionContext.

Test: webgl/worker-does-not-leak.html

* LayoutTests/webgl/webgl-worker.html:
* LayoutTests/webgl/worker-does-not-leak-expected.txt: Added.
* LayoutTests/webgl/worker-does-not-leak.html: Added.
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::makeCrossOriginAccessRequest):
(WebCore::DocumentThreadableLoader::cancel):
(WebCore::DocumentThreadableLoader::redirectReceived):
(WebCore::DocumentThreadableLoader::didReceiveResponse):
(WebCore::DocumentThreadableLoader::preflightFailure):
(WebCore::DocumentThreadableLoader::loadRequest):
(WebCore::DocumentThreadableLoader::logErrorAndFail):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::WorkerMessagingProxy):
(WebCore::WorkerMessagingProxy::~WorkerMessagingProxy):
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
(WebCore::WorkerMessagingProxy::postMessageToWorkerObject):
(WebCore::WorkerMessagingProxy::postTaskToWorkerObject):
(WebCore::WorkerMessagingProxy::createCacheStorageConnection):
(WebCore::WorkerMessagingProxy::createRTCDataChannelRemoteHandlerConnection):
(WebCore::WorkerMessagingProxy::postExceptionToWorkerObject):
(WebCore::WorkerMessagingProxy::reportErrorToWorkerObject):
(WebCore::WorkerMessagingProxy::workerObjectDestroyed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeClosed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyedInternal):
(WebCore::WorkerMessagingProxy::terminateWorkerGlobalScope):
(WebCore::WorkerMessagingProxy::setAppBadge):
* Source/WebCore/workers/WorkerMessagingProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb6ea234be6d109f972eb53a183d1203494b6845

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132810 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77800 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127812 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/46591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54216 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95952 "Found 17 new test failures: imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-classic.https.html imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-module.https.html imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/unset/worker-classic.https.html imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/unset/worker-module.https.html imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/opt-in/worker-classic.https.html imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/opt-in/worker-module.https.html imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/unset/worker-classic.https.html imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/unset/worker-module.https.html imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https.html imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-classic.http-rp/upgrade/worker-classic.https.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64045 "Found 3 new test failures: imported/w3c/web-platform-tests/wasm/serialization/module/nested-worker-success.any.worker.html storage/indexeddb/transaction-complete-workers-private.html storage/storagemanager/nested-dedicated-workers.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128889 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37199 "7 new passes 14 flakes 6 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76441 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36098 "4 new passes 1 flakes 38 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30809 "Found 60 new test failures: accessibility/mac/details-summary.html animations/background-position.html fast/canvas/offscreen-nested-worker-serialization.html fast/css/aspect-ratio-min-height-replaced.html fast/images/async-image-intersect-different-size-for-drawing.html http/tests/eventsource/eventsource-page-cache-connected.html http/tests/eventsource/eventsource-page-cache-connecting.html imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-123.xht imported/w3c/web-platform-tests/css/css-position/multicol/static-position/vlr-ltr-ltr-in-multicol.html imported/w3c/web-platform-tests/css/css-tables/colspan-002.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76280 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106981 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31021 "Too many flaky failures: fast/canvas/offscreen-nested-worker-serialization.html, imported/w3c/web-platform-tests/fetch/private-network-access/nested-worker.https.window.html, imported/w3c/web-platform-tests/fetch/private-network-access/nested-worker.window.html, imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-worker-success.https.html, imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8.html?include=workers, imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251.html?include=workers, imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252.html?include=workers, imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-classic.https.html, imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-module.https.html, imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/unset/worker-classic.https.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135495 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52725 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40511 "Found 46 new test failures: fast/canvas/offscreen-nested-worker-serialization.html http/tests/workers/service/page-caching.html imported/w3c/web-platform-tests/fetch/private-network-access/nested-worker.https.window.html imported/w3c/web-platform-tests/fetch/private-network-access/nested-worker.window.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-worker-success.https.html imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8.html?include=workers imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251.html?include=workers imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252.html?include=workers imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-classic.https.html imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-module.https.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104422 "Found 8 new test failures: imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251.html?include=workers imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-module.https.html imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/opt-in/worker-module.https.html imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/unset/worker-classic.https.html imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-module.http-rp/upgrade/worker-classic.https.html imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-module.http-rp/upgrade/worker-module.https.html imported/w3c/web-platform-tests/web-locks/query.https.any.worker.html imported/w3c/web-platform-tests/workers/nested_worker_importScripts.worker.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53174 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108834 "Exiting early after 10 failures. 28 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104142 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49518 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27841 "Found 46 new test failures: fast/canvas/offscreen-nested-worker-serialization.html imported/w3c/web-platform-tests/fetch/private-network-access/nested-worker.https.window.html imported/w3c/web-platform-tests/fetch/private-network-access/nested-worker.window.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-worker-success.https.html imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8.html?include=workers imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251.html?include=workers imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252.html?include=workers imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-classic.https.html imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-module.https.html imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/unset/worker-classic.https.html ... (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50103 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52619 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58432 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51963 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55312 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53661 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->