### PR TITLE
[AutoFill Debugging] Adjust interaction descriptions to wrap unstructured text with double quotes

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1275,8 +1275,8 @@ static constexpr auto maxDescriptionLength = 512;
 static String normalizeText(const String& string)
 {
     auto result = foldQuoteMarks(string);
-    for (auto character : { '"', '\'', '\r' })
-        result = makeStringByReplacingAll(result, character, ""_s);
+    result = makeStringByReplacingAll(result, '"', "'"_s);
+    result = makeStringByReplacingAll(result, '\r', ""_s);
     result = makeStringByReplacingAll(result, '\n', " "_s);
     result = result.trim(isASCIIWhitespace<char16_t>);
     if (result.length() <= maxDescriptionLength)
@@ -1296,6 +1296,11 @@ static String normalizedLabelText(const Element& element)
     return { };
 }
 
+static String wrapWithDoubleQuotes(String&& text)
+{
+    return makeString(u"“", WTFMove(text), u"”");
+}
+
 static String textDescription(const Element& element, Vector<String>& stringsToValidate, bool isTargetElement = true)
 {
     StringBuilder description;
@@ -1313,25 +1318,25 @@ static String textDescription(const Element& element, Vector<String>& stringsToV
 
     if (element.isLink()) {
         if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::hrefAttr)); !text.isEmpty()) {
-            description.append(makeString(" with href '"_s, text, '\''));
+            description.append(makeString(" with href "_s, wrapWithDoubleQuotes(WTFMove(text))));
             stringsToValidate.append(WTFMove(text));
             needsParentContext = false;
         }
     }
 
     if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::roleAttr)); !text.isEmpty() && text != tagName) {
-        description.append(makeString(" with role "_s, text));
+        description.append(makeString(" with role "_s, wrapWithDoubleQuotes(WTFMove(text))));
         needsParentContext = false;
     }
 
     if (auto text = normalizedLabelText(element); !text.isEmpty()) {
-        description.append(makeString(" labeled '"_s, text, '\''));
+        description.append(makeString(" labeled "_s, wrapWithDoubleQuotes(WTFMove(text))));
         stringsToValidate.append(WTFMove(text));
         needsParentContext = false;
     }
 
     if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::titleAttr)); !text.isEmpty()) {
-        description.append(makeString(" titled '"_s, text, '\''));
+        description.append(makeString(" titled "_s, wrapWithDoubleQuotes(WTFMove(text))));
         stringsToValidate.append(WTFMove(text));
         needsParentContext = false;
     }
@@ -1340,7 +1345,7 @@ static String textDescription(const Element& element, Vector<String>& stringsToV
         description.append(makeString(" of type "_s, text));
 
     if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::placeholderAttr)); !text.isEmpty()) {
-        description.append(makeString(" with placeholder '"_s, text, '\''));
+        description.append(makeString(" with placeholder "_s, wrapWithDoubleQuotes(WTFMove(text))));
         stringsToValidate.append(WTFMove(text));
         needsParentContext = false;
     }
@@ -1380,7 +1385,7 @@ static String textDescription(std::optional<NodeIdentifier> identifier, Vector<S
         auto range = makeRangeSelectingNodeContents(*node);
         if (auto text = normalizeText(plainText(range, TextIteratorBehavior::EntersTextControls)); !text.isEmpty()) {
             stringsToValidate.append(text);
-            extendedDescription.append(makeString(", with rendered text '"_s, WTFMove(text), '\''));
+            extendedDescription.append(makeString(", with rendered text "_s, wrapWithDoubleQuotes(WTFMove(text))));
         }
 
         String labeledChildSuffix;
@@ -1391,7 +1396,7 @@ static String textDescription(std::optional<NodeIdentifier> identifier, Vector<S
                     continue;
 
                 stringsToValidate.append(label);
-                extendedDescription.append(makeString(", containing child labeled '"_s, WTFMove(label), '\''));
+                extendedDescription.append(makeString(", containing child labeled "_s, wrapWithDoubleQuotes(WTFMove(label))));
                 break;
             }
         }
@@ -1438,7 +1443,7 @@ InteractionDescription interactionDescription(const Interaction& interaction)
         if (auto escapedString = normalizeText(interaction.text); !escapedString.isEmpty()) {
             if (action == Action::Click)
                 description.append(" over text"_s);
-            description.append(makeString(" '"_s, escapedString, '\''));
+            description.append(makeString(" "_s, wrapWithDoubleQuotes(String { escapedString })));
             stringsToValidate.append(WTFMove(escapedString));
         }
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -174,17 +174,17 @@ TEST(TextExtractionTests, InteractionDebugDescription)
 
         [interaction setNodeIdentifier:testButtonID.get()];
         description = [interaction debugDescriptionInWebView:webView.get() error:&error];
-        EXPECT_WK_STREQ("Click on button labeled 'Click Me', with rendered text 'Test'", description);
+        EXPECT_WK_STREQ("Click on button labeled “Click Me”, with rendered text “Test”", description);
         EXPECT_NULL(error);
 
         [interaction setNodeIdentifier:emailID.get()];
         description = [interaction debugDescriptionInWebView:webView.get() error:&error];
-        EXPECT_WK_STREQ("Click on input of type email with placeholder 'Recipient address'", description);
+        EXPECT_WK_STREQ("Click on input of type email with placeholder “Recipient address”", description);
         EXPECT_NULL(error);
 
         [interaction setNodeIdentifier:composeID.get()];
         description = [interaction debugDescriptionInWebView:webView.get() error:&error];
-        EXPECT_WK_STREQ("Click on editable div labeled 'Compose a new message', with rendered text 'Subject  The quick brown fox jumped over the lazy dog', containing child labeled 'Heading'", description);
+        EXPECT_WK_STREQ("Click on editable div labeled “Compose a new message”, with rendered text “Subject  'The quick brown fox jumped over the lazy dog'”, containing child labeled “Heading”", description);
         EXPECT_NULL(error);
     }
     {
@@ -194,14 +194,14 @@ TEST(TextExtractionTests, InteractionDebugDescription)
         [interaction setText:@"squirrelfish@webkit.org"];
         [interaction setReplaceAll:YES];
         description = [interaction debugDescriptionInWebView:webView.get() error:&error];
-        EXPECT_WK_STREQ("Enter text 'squirrelfish@webkit.org' into input of type email with placeholder 'Recipient address', replacing any existing content", description);
+        EXPECT_WK_STREQ("Enter text “squirrelfish@webkit.org” into input of type email with placeholder “Recipient address”, replacing any existing content", description);
         EXPECT_NULL(error);
 
         [interaction setNodeIdentifier:composeID.get()];
         [interaction setText:@"«Testing»"];
         [interaction setReplaceAll:NO];
         description = [interaction debugDescriptionInWebView:webView.get() error:&error];
-        EXPECT_WK_STREQ("Enter text 'Testing' into editable div labeled 'Compose a new message', with rendered text 'Subject  The quick brown fox jumped over the lazy dog', containing child labeled 'Heading'", description);
+        EXPECT_WK_STREQ("Enter text “'Testing'” into editable div labeled “Compose a new message”, with rendered text “Subject  'The quick brown fox jumped over the lazy dog'”, containing child labeled “Heading”", description);
         EXPECT_NULL(error);
     }
     {
@@ -209,7 +209,7 @@ TEST(TextExtractionTests, InteractionDebugDescription)
         [interaction setNodeIdentifier:selectID.get()];
         [interaction setText:@"Three"];
         description = [interaction debugDescriptionInWebView:webView.get() error:&error];
-        EXPECT_WK_STREQ("Select menu item 'Three' in select with role menu", description);
+        EXPECT_WK_STREQ("Select menu item “Three” in select with role “menu”", description);
         EXPECT_NULL(error);
     }
 }


### PR DESCRIPTION
#### 8bf1d777c71404798b8fe00ec5ec06a638540e1c
<pre>
[AutoFill Debugging] Adjust interaction descriptions to wrap unstructured text with double quotes
<a href="https://bugs.webkit.org/show_bug.cgi?id=300524">https://bugs.webkit.org/show_bug.cgi?id=300524</a>
<a href="https://rdar.apple.com/162394815">rdar://162394815</a>

Reviewed by Aditya Keerthi and Timothy Hatcher.

Adjust one-line text extraction interaction descriptions, such that variable-length strings embedded
in each description are wrapped with double curly quotes (“”), and all single and double quotes
(including folded quotes) are replaced with single straight quotes.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::normalizeText):
(WebCore::TextExtraction::wrapWithDoubleQuotes):

Pull this logic out into a separate helper method, and deploy it in various places below.

(WebCore::TextExtraction::textDescription):

Drive-by fix: also wrap the `role` string in quotes.

(WebCore::TextExtraction::interactionDescription):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, InteractionDebugDescription)):

Canonical link: <a href="https://commits.webkit.org/301341@main">https://commits.webkit.org/301341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b07891f1484813c81d263b72d1241da5b4945e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77538 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/19717571-64bf-4938-8574-e6ab6a9f8f32) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53876 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95725 "16 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36b591fe-a718-435d-bceb-1f96002c6836) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76219 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30547 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75985 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135185 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40209 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104194 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103921 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26467 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49282 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27593 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49673 "Hash 8b07891f for PR 52141 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58144 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51690 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55043 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53386 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->