### PR TITLE
Align maximally nested DOM timers to 4 milliseconds

### DIFF
--- a/LayoutTests/fast/dom/setInterval-aligned-when-nested-expected.txt
+++ b/LayoutTests/fast/dom/setInterval-aligned-when-nested-expected.txt
@@ -1,0 +1,20 @@
+Tests that a setInterval timer gets a nonzero alignment once it has reached the maximum nesting level.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.isTimerAligned(intervalHandle) is false
+PASS internals.isTimerAligned(intervalHandle) is false
+PASS internals.isTimerAligned(intervalHandle) is false
+PASS internals.isTimerAligned(intervalHandle) is false
+PASS internals.isTimerAligned(intervalHandle) is true
+PASS internals.isTimerAligned(intervalHandle) is true
+PASS internals.isTimerAligned(intervalHandle) is true
+PASS internals.isTimerAligned(intervalHandle) is true
+PASS internals.isTimerAligned(intervalHandle) is true
+PASS internals.isTimerAligned(intervalHandle) is true
+PASS internals.isTimerAligned(intervalHandle) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/setInterval-aligned-when-nested.html
+++ b/LayoutTests/fast/dom/setInterval-aligned-when-nested.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+jsTestIsAsync = true;
+description("Tests that a setInterval timer gets a nonzero alignment once it has reached the maximum nesting level.");
+
+if (!window.testRunner || !window.internals) {
+    testFailed("Test requires internals.");
+    finishJSTest();
+}
+
+const maxNestingLevel = 5;
+var intervalsCount = 0;
+var intervalHandle;
+
+function intervalFired()
+{
+    shouldBe("internals.isTimerAligned(intervalHandle)", `${++intervalsCount >= maxNestingLevel}`);
+    if (intervalsCount > maxNestingLevel + 5) {
+        clearInterval(intervalHandle);
+        return finishJSTest();
+    }
+}
+
+window.addEventListener("load", () => {
+    intervalHandle = setInterval(intervalFired, 10);
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/setTimeout-aligned-when-nested-expected.txt
+++ b/LayoutTests/fast/dom/setTimeout-aligned-when-nested-expected.txt
@@ -1,0 +1,25 @@
+Tests that a setTimeout timer gets a nonzero alignment once it has reached the maximum nesting level.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.isTimerAligned(timeoutHandle) is false
+PASS internals.isTimerAligned(timeoutHandle) is false
+PASS internals.isTimerAligned(timeoutHandle) is false
+PASS internals.isTimerAligned(timeoutHandle) is false
+PASS internals.isTimerAligned(timeoutHandle) is false
+PASS internals.isTimerAligned(timeoutHandle) is false
+PASS internals.isTimerAligned(timeoutHandle) is false
+PASS internals.isTimerAligned(timeoutHandle) is false
+PASS internals.isTimerAligned(timeoutHandle) is false
+PASS internals.isTimerAligned(timeoutHandle) is true
+PASS internals.isTimerAligned(timeoutHandle) is true
+PASS internals.isTimerAligned(timeoutHandle) is true
+PASS internals.isTimerAligned(timeoutHandle) is true
+PASS internals.isTimerAligned(timeoutHandle) is true
+PASS internals.isTimerAligned(timeoutHandle) is true
+PASS internals.isTimerAligned(timeoutHandle) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/setTimeout-aligned-when-nested.html
+++ b/LayoutTests/fast/dom/setTimeout-aligned-when-nested.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+jsTestIsAsync = true;
+description("Tests that a setTimeout timer gets a nonzero alignment once it has reached the maximum nesting level.");
+
+if (!window.testRunner || !window.internals) {
+    testFailed("Test requires internals.");
+    finishJSTest();
+}
+
+
+const maxNestingLevel = 10;
+var timeoutsCount = 0;
+var timeoutHandle;
+
+function checkIfAligned(expectAligned)
+{
+    // We need to schedule a new timer here since the timer that fired to execute
+    // the current task is no longer being tracked by the context.
+    timeoutHandle = setTimeout(() => { }, 10);
+    shouldBe("internals.isTimerAligned(timeoutHandle)", `${expectAligned}`);
+    clearTimeout(timeoutHandle);
+}
+
+function timeoutFired()
+{
+    checkIfAligned(++timeoutsCount >= maxNestingLevel);
+
+    if (timeoutsCount > maxNestingLevel + 5)
+        return finishJSTest();
+
+    setTimeout(timeoutFired, 5);
+}
+
+window.addEventListener("load", () => setTimeout(timeoutFired, 5));
+</script>
+</body>
+</html>

--- a/Source/WTF/wtf/Seconds.h
+++ b/Source/WTF/wtf/Seconds.h
@@ -301,12 +301,12 @@ constexpr Seconds operator""_ns(unsigned long long nanoseconds)
 
 } // inline seconds_literals
 
-inline Seconds operator*(double scalar, Seconds seconds)
+inline constexpr Seconds operator*(double scalar, Seconds seconds)
 {
     return Seconds(scalar * seconds.value());
 }
 
-inline Seconds operator/(double scalar, Seconds seconds)
+inline constexpr Seconds operator/(double scalar, Seconds seconds)
 {
     return Seconds(scalar / seconds.value());
 }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4595,6 +4595,8 @@ Seconds Document::domTimerAlignmentInterval(bool hasReachedMaxNestingLevel) cons
         return alignmentInterval;
 
     // Apply Document-level DOMTimer throttling only if timers have reached their maximum nesting level as the Page may still be visible.
+    alignmentInterval = std::max(alignmentInterval, DOMTimer::minimumAlignmentForMaximallyNestedTimers());
+
     if (m_isTimerThrottlingEnabled)
         alignmentInterval = std::max(alignmentInterval, DOMTimer::hiddenPageAlignmentInterval());
 

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -301,7 +301,7 @@ public:
     virtual Seconds domTimerAlignmentInterval(bool hasReachedMaxNestingLevel) const;
 
     // TimerAlignment
-    WEBCORE_EXPORT std::optional<MonotonicTime> alignedFireTime(bool hasReachedMaxNestingLevel, MonotonicTime fireTime) const final;
+    WEBCORE_EXPORT MonotonicTime alignedFireTime(bool hasReachedMaxNestingLevel, MonotonicTime fireTime) const final;
 
     virtual EventTarget* errorEventTarget() = 0;
 

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -431,11 +431,11 @@ Seconds DOMTimer::intervalClampedToMinimum() const
     return interval;
 }
 
-std::optional<MonotonicTime> ScriptExecutionContext::alignedFireTime(bool hasReachedMaxNestingLevel, MonotonicTime fireTime) const
+MonotonicTime ScriptExecutionContext::alignedFireTime(bool hasReachedMaxNestingLevel, MonotonicTime fireTime) const
 {
     Seconds alignmentInterval = domTimerAlignmentInterval(hasReachedMaxNestingLevel);
     if (!alignmentInterval)
-        return std::nullopt;
+        return fireTime;
     
     static const double randomizedProportion = cryptographicallyRandomUnitInterval();
 

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -52,11 +52,12 @@ public:
 
     WEBCORE_EXPORT virtual ~DOMTimer();
 
-    static Seconds defaultMinimumInterval() { return 4_ms; }
-    static Seconds defaultAlignmentInterval() { return 0_s; }
-    static Seconds defaultAlignmentIntervalInLowPowerOrThermallyMitigatedMode() { return 30_ms; }
-    static Seconds nonInteractedCrossOriginFrameAlignmentInterval() { return 30_ms; }
-    static Seconds hiddenPageAlignmentInterval() { return 1_s; }
+    static constexpr Seconds defaultMinimumInterval() { return 4_ms; }
+    static constexpr Seconds minimumAlignmentForMaximallyNestedTimers() { return 4_ms; }
+    static constexpr Seconds defaultAlignmentInterval() { return 0_s; }
+    static constexpr Seconds defaultAlignmentIntervalInLowPowerOrThermallyMitigatedMode() { return 30_ms; }
+    static constexpr Seconds nonInteractedCrossOriginFrameAlignmentInterval() { return 30_ms; }
+    static constexpr Seconds hiddenPageAlignmentInterval() { return 1_s; }
 
     enum class Type : bool { SingleShot, Repeating };
     static int install(ScriptExecutionContext&, std::unique_ptr<ScheduledAction>, Seconds timeout, Type);

--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -528,10 +528,8 @@ void TimerBase::setNextFireTime(MonotonicTime newTime)
     // Keep heap valid while changing the next-fire time.
     MonotonicTime oldTime = nextFireTime();
     // Don't realign zero-delay timers.
-    if (auto* alignment = m_alignment.get(); newTime && alignment) {
-        if (auto newAlignedTime = alignment->alignedFireTime(hasReachedMaxNestingLevel(), newTime))
-            newTime = newAlignedTime.value();
-    }
+    if (auto* alignment = m_alignment.get(); newTime && alignment)
+        newTime = alignment->alignedFireTime(hasReachedMaxNestingLevel(), newTime);
 
     if (oldTime != newTime) {
         auto newOrder = threadGlobalDataSingleton().threadTimers().nextHeapInsertionCount();

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -59,7 +59,7 @@ namespace WebCore {
 class TimerAlignment : public CanMakeWeakPtr<TimerAlignment> {
 public:
     virtual ~TimerAlignment() = default;
-    virtual std::optional<MonotonicTime> alignedFireTime(bool hasReachedMaxNestingLevel, MonotonicTime) const = 0;
+    virtual MonotonicTime alignedFireTime(bool hasReachedMaxNestingLevel, MonotonicTime) const = 0;
 };
 
 class TimerBase {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -296,6 +296,7 @@ public:
     // DOMTimers throttling testing.
     int timerNestingLevel();
     ExceptionOr<bool> isTimerThrottled(int timeoutId);
+    ExceptionOr<bool> isTimerAligned(int timeoutId);
     String requestAnimationFrameThrottlingReasons() const;
     double requestAnimationFrameInterval() const;
     bool scriptedAnimationsAreSuspended() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -913,6 +913,7 @@ enum ContentsFormat {
     long timerNestingLevel();
     // Query if a timer is currently throttled, to debug timer throttling.
     boolean isTimerThrottled(long timerHandle);
+    boolean isTimerAligned(long timerHandle);
 
     DOMString requestAnimationFrameThrottlingReasons();
     boolean areTimersThrottled();


### PR DESCRIPTION
#### c0b0499d32c9520d52b49e9742b003e61a596e7c
<pre>
Align maximally nested DOM timers to 4 milliseconds
<a href="https://bugs.webkit.org/show_bug.cgi?id=300530">https://bugs.webkit.org/show_bug.cgi?id=300530</a>
<a href="https://rdar.apple.com/160531755">rdar://160531755</a>

Reviewed by Ryosuke Niwa.

Aligning maximally nested DOM timers to a non-zero alignment can prevent abandoned repeating timers
or a large volume of timers from keeping the main thread busy indefinitely. It is especially bad if these
timers end up scheduling more timers which can cause an explosion in outstanding timer-driven work. In the
worst case, the 16ms duty cycle limit for firing timers will be hit but we have so much work backed up we only
sleep the main thread for a few tens of microseconds at most. This keeps CPU perf states
elevated and drives thermal and power use issues.

As a mitigation, we can align DOM timers which have reached their maximum nesting level to
4ms. We already clamp their timeouts to a 4ms minimum but this change will additionally align timeouts to
the nearest 4ms multiple (+/- a randomized proportion, see ScriptExecutionContext::alignedFireTime).

This mitigation is especially helpful on sites with many nested DOM timers or on sites which inadvertantly
leak their DOM timer handles and abandon repeating timers to fire indefinitely. By aligning
these timers to a 4ms multiple we end up lessening timer pile up back pressure and we can sleep the
main thread for at least a few milliseconds at a time between rendering frames. This prevents the main thread
from being more or less continuously scheduled and keeps the system from putting the CPU into maximum perf states
for prolonged or even indefinite periods of time which can drive thermals and draw excessive power.

This tested neutral on our benchmarks with the exception of PLT on iPhone where it is a 4% progression.

* LayoutTests/fast/dom/setInterval-aligned-when-nested-expected.txt: Added.
* LayoutTests/fast/dom/setInterval-aligned-when-nested.html: Added.
* LayoutTests/fast/dom/setTimeout-aligned-when-nested-expected.txt: Added.
* LayoutTests/fast/dom/setTimeout-aligned-when-nested.html: Added.
    Internals tests that check alignment happen when the respective DOM timer reaches its
    maximum nesting level. These are internals tests since trying to observe alignment
    from the web is extremely flaky. It&apos;s easier to tell if a zero-delay timer has been
    clamped, but smaller alignments for longer timeouts are very difficult to observe
    reliably.

* Source/WTF/wtf/Seconds.h:
(WTF::operator*):
(WTF::operator/):
    These should be constexpr.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::domTimerAlignmentInterval const):
    This is where the 4ms alignment is applied when the timer
    has reached its max nesting level.

* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::ScriptExecutionContext::alignedFireTime const):
* Source/WebCore/page/DOMTimer.h:
    The DOM timer interval defaults should be constexpr.

* Source/WebCore/platform/Timer.cpp:
(WebCore::TimerBase::setNextFireTime):
* Source/WebCore/platform/Timer.h:
    Change the TimerAlignment interface from returning an optional fire time
    to instead return a fire time directly, even if no alignment was applied.
    There isn&apos;t a need to differentiate between aligned and unaligned fire times
    being returned from this interface due to testing changes.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isTimerThrottled):
    I adjusted this to account for the 4ms adjustment we will make
    when a timer reaches the max nesting level. I&apos;m not sure if we want to
    call this throttled or not. It is worthwhile to distinguish between
    throttled (like 1s for background timers, for instance) and aligned. The
    former is obviously throttling but the latter is more of a slight adjustment
    to timeouts in order to ensure the main thread is more efficiently scheduled.
(WebCore::Internals::isTimerAligned):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/302278@main">https://commits.webkit.org/302278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fb2f97287b1db7bd9e27f1da3b08cf276a2ded4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79964 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/72fbf657-2fcc-4e3e-81e2-fcd208419402) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97851 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65772 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/485f5845-f327-49ea-8ebe-9b6e83e19f47) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131483 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/550 "Found 6 new test failures: fast/events/ios/do-not-show-keyboard-when-focusing-after-blur.html fast/forms/ios/accessory-bar-navigation.html fast/forms/ios/focus-input-via-button.html fast/forms/ios/focus-long-textarea.html fast/forms/ios/zoom-after-input-tap-wide-input.html fast/forms/ios/zoom-after-input-tap.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78468 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bfb8f8aa-7d98-4eab-b219-5becbd461cba) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/127886 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33273 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79210 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120549 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138376 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126995 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106387 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106205 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27061 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/538 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52975 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/694 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63908 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160017 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/574 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39964 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/635 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/648 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->