### PR TITLE
Add preference for web process cache capacity

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebProcessCacheCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessCacheCocoa.mm
@@ -41,6 +41,11 @@ void WebProcessCache::platformInitialize()
         clearingDelayAfterApplicationResignsActive = clearingDelayAfterApplicationResignsActiveOverride;
         WTFLogAlways("Warning: WebProcessCache clearingDelayAfterApplicationResignsActive was overriden via user defaults and is now %g seconds", clearingDelayAfterApplicationResignsActiveOverride.seconds());
     }
+
+    Boolean capacityExists = false;
+    int capacity = CFPreferencesGetAppIntegerValue(CFSTR("WebProcessCacheCapacity"), kCFPreferencesCurrentApplication, &capacityExists);
+    if (capacityExists && capacity >= 0)
+        capacityOverride = capacity;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -50,6 +50,8 @@ Seconds WebProcessCache::clearingDelayAfterApplicationResignsActive { 5_min };
 Seconds WebProcessCache::cachedProcessLifetime { 5_min };
 Seconds WebProcessCache::clearingDelayAfterApplicationResignsActive = cachedProcessLifetime;
 #endif
+
+int WebProcessCache::capacityOverride { -1 };
 static Seconds cachedProcessSuspensionDelay { 30_s };
 
 void WebProcessCache::setCachedProcessSuspensionDelayForTesting(Seconds delay)
@@ -315,6 +317,8 @@ void WebProcessCache::updateCapacity(WebProcessPool& processPool)
         else
             WEBPROCESSCACHE_RELEASE_LOG("updateCapacity: Cache is disabled because cache model is not PrimaryWebBrowser", 0);
         m_capacity = 0;
+    } else if (capacityOverride >= 0) {
+        m_capacity = capacityOverride;
     } else {
 #if PLATFORM(IOS_FAMILY)
         constexpr unsigned maxProcesses = 10;

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -72,6 +72,7 @@ public:
 private:
     static Seconds cachedProcessLifetime;
     static Seconds clearingDelayAfterApplicationResignsActive;
+    static int capacityOverride;
 
     class CachedProcess : public RefCounted<CachedProcess> {
         WTF_MAKE_TZONE_ALLOCATED(CachedProcess);


### PR DESCRIPTION
#### 393fccac87a0b17d344b36c205da593db2940787
<pre>
Add preference for web process cache capacity
<a href="https://bugs.webkit.org/show_bug.cgi?id=300531">https://bugs.webkit.org/show_bug.cgi?id=300531</a>
<a href="https://rdar.apple.com/162402418">rdar://162402418</a>

Reviewed by Ryosuke Niwa.

We should be able to modify the web process cache capacity via a preference without rebuilding
WebKit to make the parameter easier to tune.

* Source/WebKit/UIProcess/Cocoa/WebProcessCacheCocoa.mm:
(WebKit::WebProcessCache::platformInitialize):
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::updateCapacity):
* Source/WebKit/UIProcess/WebProcessCache.h:

Canonical link: <a href="https://commits.webkit.org/301381@main">https://commits.webkit.org/301381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/522103f1032cbcdde725eadbe6fd5fd2115bddde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77549 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5937771a-a79d-496d-b987-9fb74c462d91) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95735 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63856 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76229 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b49100f0-55d5-45c3-9f2b-3a10e74ca9a5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35688 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75997 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135201 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40219 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104203 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52904 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103930 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26490 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49292 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27604 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49683 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52352 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58155 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51700 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55052 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->