### PR TITLE
Unreviewed. Update safer C++ expectations for iOS.

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,3 +1,4 @@
 API/JSContextInternal.h
 API/JSValue.mm
 API/tests/Regress141275.mm
+[ iOS ] API/JSValue.h

--- a/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -4,6 +4,7 @@ page/EventHandler.h
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp
 platform/ios/WebAVPlayerController.h
 platform/ios/WebAVPlayerController.mm
+[ iOS ] platform/cocoa/WebAVPlayerLayer.h
 [ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
 [ iOS ] platform/ios/DeviceMotionClientIOS.h
 [ iOS ] platform/ios/LegacyTileCache.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -100,7 +100,7 @@ dom/StaticRange.cpp
 dom/TreeScope.cpp
 dom/TypedElementDescendantIteratorInlines.h
 dom/ViewTransition.cpp
-dom/mac/ImageControlsMac.cpp
+[ Mac ] dom/mac/ImageControlsMac.cpp
 [ Mac ] editing/AlternativeTextController.cpp
 editing/ApplyBlockElementCommand.cpp
 editing/ApplyStyleCommand.cpp

--- a/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -2,3 +2,7 @@ Platform/IPC/ArgumentCoders.h
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
 WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
 WebProcess/WebPage/WebPage.cpp
+[ iOS ] UIProcess/API/ios/WKWebViewIOS.mm
+[ iOS ] UIProcess/ViewGestureController.h
+[ iOS ] UIProcess/ios/PageClientImplIOS.mm
+[ iOS ] UIProcess/ios/SmartMagnificationController.h

--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -7,9 +7,27 @@ UIProcess/API/Cocoa/_WKSpatialBackdropSource.h
 UIProcess/API/Cocoa/_WKWebPushMessage.h
 [ Mac ] UIProcess/mac/WebViewImpl.mm
 [ iOS ] Platform/ios/PaymentAuthorizationController.mm
+[ iOS ] UIProcess/API/Cocoa/WKSnapshotConfiguration.h
+[ iOS ] UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
 [ iOS ] UIProcess/API/Cocoa/WKPreviewActionItem.h
 [ iOS ] UIProcess/API/Cocoa/WKWebView.h
+[ iOS ] UIProcess/API/Cocoa/_WKArchiveConfiguration.h
+[ iOS ] UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h
+[ iOS ] UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.h
+[ iOS ] UIProcess/API/Cocoa/_WKAuthenticatorResponse.h
+[ iOS ] UIProcess/API/Cocoa/_WKInspectorConfiguration.h
+[ iOS ] UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.h
+[ iOS ] UIProcess/API/Cocoa/_WKPublicKeyCredentialDescriptor.h
+[ iOS ] UIProcess/API/Cocoa/_WKPublicKeyCredentialEntity.h
+[ iOS ] UIProcess/API/Cocoa/_WKPublicKeyCredentialParameters.h
+[ iOS ] UIProcess/API/Cocoa/_WKPublicKeyCredentialRelyingPartyEntity.h
+[ iOS ] UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.h
+[ iOS ] UIProcess/API/Cocoa/_WKPublicKeyCredentialUserEntity.h
+[ iOS ] UIProcess/API/Cocoa/_WKTextManipulationConfiguration.h
+[ iOS ] UIProcess/API/Cocoa/_WKTextManipulationToken.h
 [ iOS ] UIProcess/API/Cocoa/_WKTouchEventGeneratorInternal.h
+[ iOS ] UIProcess/API/Cocoa/_WKWebPushAction.mm
+[ iOS ] UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h
 [ iOS ] UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
 [ iOS ] UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
 [ iOS ] UIProcess/ViewGestureController.h

--- a/Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -69,6 +69,7 @@ WebCoreSupport/WebCryptoClient.h
 [ iOS ] ios/WebView/WebPDFViewPlaceholder.h
 [ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
 [ iOS ] mac/WebView/WebDataSource.mm
+[ iOS ] mac/WebView/WebFeature.h
 [ iOS ] mac/WebView/WebIndicateLayer.h
 [ iOS ] mac/WebView/WebViewPrivate.h
 [ iOS ] mac/WebView/WebViewRenderingUpdateScheduler.h


### PR DESCRIPTION
#### 8e0e42d89efa2dff74d8d104c2a32d242c8cad9c
<pre>
Unreviewed. Update safer C++ expectations for iOS.

* Source/JavaScriptCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/301342@main">https://commits.webkit.org/301342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6774e7701a795d4c8f1aaae03ffcea9bf6041aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125677 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/45339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36089 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/deb3cc73-01a2-422a-b6fa-396e5a311383) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127548 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/46024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/53898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/132541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12b8d6ed-57e2-414c-a603-75cfaeb65650) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128625 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/46024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/112387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2879c94-b9ea-4efb-97a5-03295bcb5824) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/46024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/30570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/117762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/46024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/30786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124186 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/52469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/53898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/135215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/52916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/108598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/27613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/49696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19674 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/52364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58169 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/157202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/51711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/157202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/53408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->