### PR TITLE
Many PDF tests time out sporadically as a result of the PDF not loading

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1995,8 +1995,6 @@ webkit.org/b/287865 pdf/two-pages-continuous-to-discrete.html [ Pass ImageOnlyFa
 [ Sonoma x86_64 Release ] fast/borders/border-painting-inset.html [ Pass ImageOnlyFailure  ]
 [ Sonoma x86_64 Release ] fast/borders/border-painting-outset.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/287877 pdf/pdf-plugin-printing.html [ Pass Timeout ]
-
 webkit.org/b/287967 media/modern-media-controls/overflow-support/playback-speed.html [ Pass Timeout ]
 
 webkit.org/b/287987 media/media-source/media-source-minimumupcomingpresentationtime.html [ Pass Failure ]
@@ -2158,8 +2156,6 @@ webkit.org/b/283410 media/media-vp8-webm-with-poster.html [ Pass ImageOnlyFailur
 
 webkit.org/b/293761 http/tests/navigation/keyboard-events-during-provisional-navigation.html [ Failure ]
 
-webkit.org/b/293804 [ Debug ] pdf/annotations/checkbox-set-active.html [ Pass Timeout ]
-
 # webkit.org/b/294272 REGRESSION(295925@main?) [macOS Debug]: 2x tests in fast/scrolling/Mac/scrollbars are flaky crash
 [ Debug ] fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html [ Pass Crash ]
 [ Debug ] fast/scrolling/mac/scrollbars/overlay-scrollbar-reveal.html [ Pass Crash ]
@@ -2224,11 +2220,7 @@ webkit.org/b/296017 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/s
 
 webkit.org/b/296066 [ Sequoia Debug arm64 ] accessibility/mac/scrolling-in-pdf-crash.html [ Pass Timeout ]
 
-webkit.org/b/296070 [ Debug arm64 ] pdf/pdf-in-styled-embed.html [ Pass Timeout Failure ]
-
 webkit.org/b/295929 [ Release ] imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-002.html [ Pass ImageOnlyFailure ]
-
-webkit.org/b/296096 [ Debug arm64 ] pdf/annotations/radio-buttons-select-second.html [ Pass Timeout ]
 
 webkit.org/b/296130 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-4.html [ Pass Failure ]
 

--- a/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
+++ b/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
@@ -145,14 +145,14 @@ void NetscapePlugInStreamLoader::didReceiveResponse(ResourceResponse&& response,
     });
 }
 
-void NetscapePlugInStreamLoader::didReceiveData(const SharedBuffer& buffer, long long encodedDataLength, DataPayloadType dataPayloadType)
+void NetscapePlugInStreamLoader::didReceiveBuffer(const FragmentedSharedBuffer& buffer, long long encodedDataLength, DataPayloadType dataPayloadType)
 {
     Ref protectedThis { *this };
 
     if (m_client)
-        m_client->didReceiveData(this, buffer);
+        m_client->didReceiveData(this, buffer.makeContiguous());
 
-    ResourceLoader::didReceiveData(buffer, encodedDataLength, dataPayloadType);
+    ResourceLoader::didReceiveBuffer(buffer, encodedDataLength, dataPayloadType);
 }
 
 void NetscapePlugInStreamLoader::didFinishLoading(const NetworkLoadMetrics& networkLoadMetrics)

--- a/Source/WebCore/loader/NetscapePlugInStreamLoader.h
+++ b/Source/WebCore/loader/NetscapePlugInStreamLoader.h
@@ -72,7 +72,7 @@ private:
 
     void willSendRequest(ResourceRequest&&, const ResourceResponse& redirectResponse, CompletionHandler<void(ResourceRequest&&)>&& callback) override;
     void didReceiveResponse(ResourceResponse&&, CompletionHandler<void()>&& policyCompletionHandler) override;
-    void didReceiveData(const SharedBuffer&, long long encodedDataLength, DataPayloadType) override;
+    void didReceiveBuffer(const FragmentedSharedBuffer&, long long encodedDataLength, DataPayloadType) override;
     void didFinishLoading(const NetworkLoadMetrics&) override;
     void didFail(const ResourceError&) override;
 


### PR DESCRIPTION
#### 2ed6bef9617d5d063f1edd7d2a8d596bab83fa98
<pre>
Many PDF tests time out sporadically as a result of the PDF not loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=296096">https://bugs.webkit.org/show_bug.cgi?id=296096</a>
<a href="https://rdar.apple.com/156008706">rdar://156008706</a>

Reviewed by Abrar Rahman Protyasha.

ResourceLoader has a fast path, `deliverResponseAndData`, which seems - at least
for PDFs - to be somewhat rarely encountered in practice. However, with small
test PDFs loaded from the filesystem, it is hit enough to cause reproducible flaky test failures.

This fast path calls `didReceiveBuffer` to hand the data to the client, and
then immediately `didFinishLoading`.

Currently NetscapePlugInStreamLoader overrides ResourceLoader&apos;s `didReceiveData`,
but not `didReceiveBuffer`, in order to slurp the data aside for the plugin.
This bug stems from this fact, and the fact that `deliverResponseAndData`
does not call `didReceiveData`, skipping the override.

Since `didReceiveBuffer` now appears to be the bottleneck for all paths,
replace NetscapePlugInStreamLoader&apos;s `didReceiveData` override with an override
of this method. Thus, the PDF plugin now intercepts the data when we arrive via
`deliverResponseAndData`, where it wouldn&apos;t before.

No new tests, covered by existing tests that were previously expected to be flaky.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/loader/NetscapePlugInStreamLoader.cpp:
(WebCore::NetscapePlugInStreamLoader::didReceiveBuffer):
(WebCore::NetscapePlugInStreamLoader::didReceiveData): Deleted.
* Source/WebCore/loader/NetscapePlugInStreamLoader.h:

Canonical link: <a href="https://commits.webkit.org/301346@main">https://commits.webkit.org/301346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb9f82b46cbc32478e2897d314e4599d0dea2ee7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77558 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02163a2f-6c6c-424d-a68d-76ee90158f08) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95744 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63862 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5313e936-450d-41c7-b2d8-3b54c480c3eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76237 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5b23a87-1f49-4b1e-a7db-46847c9cedc5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30567 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76017 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135225 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40227 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104217 "Found 1 new test failure: http/wpt/mediastream/getDisplayMedia-deviceid-persistency.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103945 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26470 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49297 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27610 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49694 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52362 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58167 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51709 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55061 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53406 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->