### PR TITLE
Add support for Memory64 in WebAssembly in IPInt Tier

### DIFF
--- a/JSTests/wasm/stress/memory64-bulk-memory.js
+++ b/JSTests/wasm/stress/memory64-bulk-memory.js
@@ -1,0 +1,63 @@
+//@ skip if $addressBits <= 32
+//@ runDefaultWasm("-m", "--useBBQJIT=0", "--useWasmMemory64=1")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (memory (export "memory") i64 2)
+    (data (i32.const 0) "hello")
+    (func $testInit (export "testInit") 
+      (memory.init 0
+        (i64.const 5)
+        (i32.const 0)
+        (i32.const 0))
+    )
+    (func $testFill (export "testFill") (param $dest i64) (param $byte i32) (param $sz i64)
+      (memory.fill 
+        (local.get $dest) 
+        (local.get $byte) 
+        (local.get $sz))
+    )
+    (func $testCopy (export "testCopy") (param $dest i64) (param $src i64) (param $sz i64)
+      (memory.copy 
+        (local.get $dest) 
+        (local.get $src) 
+        (local.get $sz))
+    )
+)
+`;
+
+const helloBytes = "hello";
+async function test() {
+  const instance = await instantiate(wat, {}, {reference_types: true});
+  const {testInit, testFill, testCopy, memory} = instance.exports;
+
+  const len = helloBytes.length;
+  const iterable = new DataView(memory.buffer);
+  // Write "hello" to 0 and verify
+  testInit();
+  for (let i = 0; i < len * 2; i++) {
+    const b = iterable.getInt8(i);
+    if (i < len)
+      assert.eq(b, helloBytes.charCodeAt(i % len));
+    else if (i < len * 2)
+      assert.eq(b, 0);
+  }
+
+  // Copy "hello" to index 5 and verify "hello" appears twice
+  testCopy(BigInt(len), 0n, BigInt(len));
+  for (let i = 0; i < len * 2; i++) {
+    const b = iterable.getInt8(i);
+    assert.eq(b, helloBytes.charCodeAt(i % len));
+  }
+
+  // Fill memory with 0 and verify all 0s
+  testFill(0n, 0, BigInt(len * 2));
+  for (let i = 0; i < len * 2; i++) {
+    const b = iterable.getInt8(i);
+    assert.eq(b, 0);
+  }
+}
+
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/memory64-grow-and-size.js
+++ b/JSTests/wasm/stress/memory64-grow-and-size.js
@@ -1,0 +1,158 @@
+//@ skip if $addressBits <= 32
+//@ runDefaultWasm("-m", "--useBBQJIT=0", "--useWasmMemory64=1")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+async function test() {
+    // Test memory.size returns i64 for memory64
+    let wat = `
+    (module
+        (memory (export "memory") i64 1 10)
+        (func (export "getSize") (result i64)
+            memory.size
+        )
+        (func (export "grow") (param $delta i64) (result i64)
+            local.get $delta
+            memory.grow
+        )
+    )
+    `;
+
+    const instance = await instantiate(wat, {}, {reference_types: true});
+    const { getSize, grow, memory } = instance.exports;
+
+    // Initial size should be 1 page (65536 bytes)
+    let size = getSize();
+    assert.eq(size, 1n, "Initial memory size should be 1 page");
+
+    // Grow by 2 pages, should return old size (1)
+    let oldSize = grow(2n);
+    assert.eq(oldSize, 1n, "memory.grow should return old size (1)");
+
+    // New size should be 3 pages
+    size = getSize();
+    assert.eq(size, 3n, "Memory size should be 3 pages after growing by 2");
+
+    // Grow by 5 more pages (total would be 8)
+    oldSize = grow(5n);
+    assert.eq(oldSize, 3n, "memory.grow should return old size (3)");
+
+    // New size should be 8 pages
+    size = getSize();
+    assert.eq(size, 8n, "Memory size should be 8 pages after growing by 5 more");
+
+    // Try to grow beyond max (10 pages), should fail and return -1
+    oldSize = grow(5n);
+    assert.eq(oldSize, -1n, "memory.grow should return -1 when exceeding max");
+
+    // Size should remain 8 pages (unchanged)
+    size = getSize();
+    assert.eq(size, 8n, "Memory size should still be 8 pages after failed grow");
+
+    // Grow by 2 more pages to exactly max (10 pages)
+    oldSize = grow(2n);
+    assert.eq(oldSize, 8n, "memory.grow should return old size (8)");
+
+    // Size should be exactly max (10 pages)
+    size = getSize();
+    assert.eq(size, 10n, "Memory size should be 10 pages (max)");
+
+    // Verify the memory buffer size matches
+    assert.eq(memory.buffer.byteLength, 10 * 65536, "Memory buffer should be 10 pages worth of bytes");
+}
+
+async function testGrowByZero() {
+    // Test growing by 0 pages (should succeed and return current size)
+    let wat = `
+    (module
+        (memory (export "memory") i64 5)
+        (func (export "grow") (param $delta i64) (result i64)
+            local.get $delta
+            memory.grow
+        )
+        (func (export "getSize") (result i64)
+            memory.size
+        )
+    )
+    `;
+
+    const instance = await instantiate(wat, {}, {reference_types: true});
+    const { getSize, grow } = instance.exports;
+
+    let size = getSize();
+    assert.eq(size, 5n, "Initial size should be 5 pages");
+
+    // Grow by 0 should return current size without changing memory
+    let result = grow(0n);
+    assert.eq(result, 5n, "Growing by 0 should return current size");
+
+    size = getSize();
+    assert.eq(size, 5n, "Size should remain 5 pages after growing by 0");
+}
+
+async function testNoMaximum() {
+    // Test memory64 without explicit maximum
+    let wat = `
+    (module
+        (memory (export "memory") i64 2)
+        (func (export "getSize") (result i64)
+            memory.size
+        )
+        (func (export "grow") (param $delta i64) (result i64)
+            local.get $delta
+            memory.grow
+        )
+    )
+    `;
+
+    const instance = await instantiate(wat, {}, {reference_types: true});
+    const { getSize, grow } = instance.exports;
+
+    let size = getSize();
+    assert.eq(size, 2n, "Initial size should be 2 pages");
+
+    // Should be able to grow (implementation-defined limit)
+    let oldSize = grow(1n);
+    assert.eq(oldSize, 2n, "Should successfully grow, returning old size");
+
+    size = getSize();
+    assert.eq(size, 3n, "Size should be 3 pages after growing");
+}
+
+async function testLargeGrowValue() {
+    // Test with larger i64 grow values
+    let wat = `
+    (module
+        (memory (export "memory") i64 1 100)
+        (func (export "grow") (param $delta i64) (result i64)
+            local.get $delta
+            memory.grow
+        )
+        (func (export "getSize") (result i64)
+            memory.size
+        )
+    )
+    `;
+
+    const instance = await instantiate(wat, {}, {reference_types: true});
+    const { getSize, grow } = instance.exports;
+
+    // Try to grow by a large amount at once
+    let oldSize = grow(50n);
+    assert.eq(oldSize, 1n, "Should successfully grow by 50 pages");
+
+    let size = getSize();
+    assert.eq(size, 51n, "Size should be 51 pages");
+
+    // Try to grow by amount that exceeds max
+    oldSize = grow(50n);
+    assert.eq(oldSize, -1n, "Should fail to grow by 50 more pages (would exceed max of 100)");
+
+    size = getSize();
+    assert.eq(size, 51n, "Size should remain 51 pages after failed grow");
+}
+
+await assert.asyncTest(test())
+await assert.asyncTest(testGrowByZero());
+await assert.asyncTest(testNoMaximum());
+await assert.asyncTest(testLargeGrowValue());

--- a/JSTests/wasm/stress/memory64-load-and-store.js
+++ b/JSTests/wasm/stress/memory64-load-and-store.js
@@ -1,0 +1,85 @@
+//@ skip if $addressBits <= 32
+//@ runDefaultWasm("-m", "--useBBQJIT=0", "--useWasmMemory64=1")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+const storeTypes = [
+  {type: "i32", suffix: ""},
+  {type: "i64", suffix: ""},
+  {type: "f32", suffix: ""},
+  {type: "f64", suffix: ""},
+  {type: "i32", suffix: "8"},
+  {type: "i32", suffix: "16"},
+  {type: "i64", suffix: "8"},
+  {type: "i64", suffix: "16"},
+  {type: "i64", suffix: "32"},
+];
+
+const loadTypes = [
+  {type: "i32", suffix: ""},
+  {type: "i64", suffix: ""},
+  {type: "f32", suffix: ""},
+  {type: "f64", suffix: ""},
+  {type: "i32", suffix: "8_s"},
+  {type: "i32", suffix: "8_u"},
+  {type: "i32", suffix: "16_s"},
+  {type: "i32", suffix: "16_u"},
+  {type: "i64", suffix: "8_s"},
+  {type: "i64", suffix: "8_u"},
+  {type: "i64", suffix: "16_s"},
+  {type: "i64", suffix: "16_u"},
+  {type: "i64", suffix: "32_s"},
+  {type: "i64", suffix: "32_u"},
+];
+
+function getWasmTypeWidth(wasmType) {
+  return wasmType.endsWith("64") ? 8n : 4n;
+}
+
+
+let wat = `
+(module
+    (memory i64 1)
+    ${
+      storeTypes.map(storeType =>
+        `(func (export "${storeType.type}_store${storeType.suffix}") (param $sz i64) (param $data ${storeType.type})
+            (${storeType.type}.store${storeType.suffix} (local.get $sz) (local.get $data))
+        )`).join('')
+    }
+    ${
+      loadTypes.map(loadType =>
+        `(func (export "${loadType.type}_load${loadType.suffix}") (param $sz i64) (result ${loadType.type})
+            (${loadType.type}.load${loadType.suffix} (local.get $sz))
+        )`).join('')
+    }
+)`;
+
+async function test() {
+  const instance = await instantiate(wat, {}, {reference_types: true});
+  const exports = instance.exports;
+
+  let index = 0n;  // BigInt for i64 parameter
+  storeTypes.forEach((storeType) => {
+    const valueToLoad = storeType.type == "i64" ? 42n : 42;
+    // store value 42 at index
+    exports[`${storeType.type}_store${storeType.suffix}`](index, valueToLoad);
+    // increment index by the width that was stored
+    index += getWasmTypeWidth(storeType.type);
+  });
+
+  index = 0n;  // BigInt for i64 parameter
+  loadTypes.forEach((loadType) => {
+    const expectedValue = 42;
+    // load value from index
+    const result = exports[`${loadType.type}_load${loadType.suffix}`](index);
+
+    assert.eq(Number(result), Number(expectedValue));
+
+    // read the same adress for signed and unsigned values
+    if (!loadType.suffix.endsWith("_s"))
+      // increment index by the width that was stored
+      index += getWasmTypeWidth(loadType.type);
+  });
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -937,20 +937,32 @@ macro ipintCheckMemoryBound(mem, scratch, size)
 .continuation:
 end
 
+macro loadMemoryOffsetAndAdvanceMC(dstReg, tmpReg, instrLenReg)
+	loadb JSWebAssemblyInstance::m_cachedIsMemory64[wasmInstance], tmpReg
+	btiz tmpReg, .memory32
+	loadq IPInt::Const64Metadata::value[MC], dstReg
+    loadb IPInt::Const64Metadata::instructionLength[MC], instrLenReg
+	advanceMC(constexpr (sizeof(IPInt::Const64Metadata)))
+	jmp .done
+.memory32:
+	loadi IPInt::Const32Metadata::value[MC], dstReg
+    loadb IPInt::Const32Metadata::instructionLength[MC], instrLenReg
+	advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+.done:
+end
+
 ipintOp(_i32_load_mem, macro()
     # i32.load
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     loadi [memoryBase, t0], t1
     pushInt32(t1)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -958,16 +970,14 @@ ipintOp(_i64_load_mem, macro()
     # i32.load
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 8)
     # load memory location
     loadq [memoryBase, t0], t1
     pushInt64(t1)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -975,16 +985,14 @@ ipintOp(_f32_load_mem, macro()
     # f32.load
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     loadf [memoryBase, t0], ft0
     pushFloat32(ft0)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -992,16 +1000,14 @@ ipintOp(_f64_load_mem, macro()
     # f64.load
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 8)
     # load memory location
     loadd [memoryBase, t0], ft0
     pushFloat64(ft0)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1009,7 +1015,7 @@ ipintOp(_i32_load8s_mem, macro()
     # i32.load8_s
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+    loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
     # load memory location
@@ -1017,9 +1023,7 @@ ipintOp(_i32_load8s_mem, macro()
     sxb2i t1, t1
     pushInt32(t1)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1027,16 +1031,14 @@ ipintOp(_i32_load8u_mem, macro()
     # i32.load8_u
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
     # load memory location
     loadb [memoryBase, t0], t1
     pushInt32(t1)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1044,7 +1046,7 @@ ipintOp(_i32_load16s_mem, macro()
     # i32.load16_s
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
     # load memory location
@@ -1052,9 +1054,7 @@ ipintOp(_i32_load16s_mem, macro()
     sxh2i t1, t1
     pushInt32(t1)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1062,16 +1062,14 @@ ipintOp(_i32_load16u_mem, macro()
     # i32.load16_u
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
     # load memory location
     loadh [memoryBase, t0], t1
     pushInt32(t1)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1079,7 +1077,7 @@ ipintOp(_i64_load8s_mem, macro()
     # i64.load8_s
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
     # load memory location
@@ -1087,9 +1085,7 @@ ipintOp(_i64_load8s_mem, macro()
     sxb2q t1, t1
     pushInt64(t1)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1097,16 +1093,14 @@ ipintOp(_i64_load8u_mem, macro()
     # i64.load8_u
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
     # load memory location
     loadb [memoryBase, t0], t1
     pushInt64(t1)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1114,7 +1108,7 @@ ipintOp(_i64_load16s_mem, macro()
     # i64.load16_s
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
     # load memory location
@@ -1122,9 +1116,7 @@ ipintOp(_i64_load16s_mem, macro()
     sxh2q t1, t1
     pushInt64(t1)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1132,16 +1124,14 @@ ipintOp(_i64_load16u_mem, macro()
     # i64.load16_u
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
     # load memory location
     loadh [memoryBase, t0], t1
     pushInt64(t1)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1149,7 +1139,7 @@ ipintOp(_i64_load32s_mem, macro()
     # i64.load32_s
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
@@ -1157,9 +1147,7 @@ ipintOp(_i64_load32s_mem, macro()
     sxi2q t1, t1
     pushInt64(t1)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1167,16 +1155,14 @@ ipintOp(_i64_load32u_mem, macro()
     # i64.load8_s
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     loadi [memoryBase, t0], t1
     pushInt64(t1)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1186,15 +1172,13 @@ ipintOp(_i32_store_mem, macro()
     popInt32(t1)
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     storei t1, [memoryBase, t0]
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1204,15 +1188,13 @@ ipintOp(_i64_store_mem, macro()
     popInt64(t1)
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 8)
     # load memory location
     storeq t1, [memoryBase, t0]
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1222,15 +1204,13 @@ ipintOp(_f32_store_mem, macro()
     popFloat32(ft0)
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     storef ft0, [memoryBase, t0]
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1240,15 +1220,13 @@ ipintOp(_f64_store_mem, macro()
     popFloat64(ft0)
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 8)
     # load memory location
     stored ft0, [memoryBase, t0]
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1258,15 +1236,13 @@ ipintOp(_i32_store8_mem, macro()
     popInt32(t1)
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
     # load memory location
     storeb t1, [memoryBase, t0]
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1276,15 +1252,13 @@ ipintOp(_i32_store16_mem, macro()
     popInt32(t1)
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
     # load memory location
     storeh t1, [memoryBase, t0]
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1294,15 +1268,13 @@ ipintOp(_i64_store8_mem, macro()
     popInt64(t1)
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
     # load memory location
     storeb t1, [memoryBase, t0]
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1312,15 +1284,13 @@ ipintOp(_i64_store16_mem, macro()
     popInt64(t1)
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
     # load memory location
     storeh t1, [memoryBase, t0]
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 
@@ -1330,15 +1300,13 @@ ipintOp(_i64_store32_mem, macro()
     popInt64(t1)
     # pop index
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+	loadMemoryOffsetAndAdvanceMC(t2, t3, t4)
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     storei t1, [memoryBase, t0]
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end)
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -654,9 +654,10 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \
     v(Bool, useTrustedTypes, true, Normal, "Enable trusted types eval protection feature."_s) \
     v(Bool, useWasmJSStringBuiltins, true, Normal, "Enable the implementation of the JS String Builtins proposal."_s) \
+    v(Bool, useWasmMemory64, false, Normal, "Allow the Memory64 proposal for WebAssembly. This feature is currently only supported in the IPInt tier."_s) \
     v(Bool, useWasmMemoryToBufferAPIs, true, Normal, "Enable the toFixedLengthBuffer() and toResizableBuffer() Wasm Memory.prototype functions."_s) \
-    v(Bool, useWasmSIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
     v(Bool, useWasmRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."_s) \
+    v(Bool, useWasmSIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
     v(Bool, useWasmTailCalls, true, Normal, "Allow the new instructions from the wasm tail calls spec."_s) \
 
 

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -75,6 +75,17 @@ void FunctionIPIntMetadataGenerator::addLEB128ConstantInt32AndLength(uint32_t va
     WRITE_TO_METADATA(m_metadata.mutableSpan().data() + size, mdConst, IPInt::Const32Metadata);
 }
 
+void FunctionIPIntMetadataGenerator::addLEB128ConstantInt64AndLength(uint64_t value, size_t length)
+{
+    IPInt::Const64Metadata mdConst {
+        .value = value,
+        .instructionLength = { .length = safeCast<uint8_t>(length) }
+    };
+    size_t size = m_metadata.size();
+    m_metadata.grow(size + sizeof(mdConst));
+    WRITE_TO_METADATA(m_metadata.mutableSpan().data() + size, mdConst, IPInt::Const64Metadata);
+}
+
 void FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType(Type type, uint64_t value, size_t length)
 {
     if (type.isI32()) {

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -118,6 +118,7 @@ private:
 
     void addLength(size_t length);
     void addLEB128ConstantInt32AndLength(uint32_t value, size_t length);
+    void addLEB128ConstantInt64AndLength(uint64_t value, size_t length);
     void addLEB128ConstantAndLengthForType(Type, uint64_t value, size_t length);
     void addLEB128V128Constant(v128_t value, size_t length);
     void addReturnData(const FunctionSignature&, const CallInformation&);

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -548,7 +548,7 @@ WASM_IPINT_EXTERN_CPP_DECL(table_grow, IPIntStackEntry* sp, TableGrowMetadata* m
     WASM_RETURN_TWO(std::bit_cast<void*>(Wasm::tableGrow(instance, metadata->tableIndex, fill, n)), 0);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(memory_grow, int32_t delta)
+WASM_IPINT_EXTERN_CPP_DECL(memory_grow, int64_t delta)
 {
     WASM_RETURN_TWO(reinterpret_cast<void*>(Wasm::growMemory(instance, delta)), 0);
 }
@@ -557,7 +557,7 @@ WASM_IPINT_EXTERN_CPP_DECL(memory_init, int32_t dataIndex, IPIntStackEntry* sp)
 {
     int32_t n = sp[0].i32;
     int32_t s = sp[1].i32;
-    int32_t d = sp[2].i32;
+    int64_t d = sp[2].i64;
 
     if (!Wasm::memoryInit(instance, dataIndex, d, s, n))
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsMemoryAccess);
@@ -570,14 +570,14 @@ WASM_IPINT_EXTERN_CPP_DECL(data_drop, int32_t dataIndex)
     IPINT_END();
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(memory_copy, int32_t dst, int32_t src, int32_t count)
+WASM_IPINT_EXTERN_CPP_DECL(memory_copy, int64_t dst, int64_t src, int64_t count)
 {
     if (!Wasm::memoryCopy(instance, dst, src, count))
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsMemoryAccess);
     IPINT_END();
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(memory_fill, int32_t dst, int32_t targetValue, int32_t count)
+WASM_IPINT_EXTERN_CPP_DECL(memory_fill, int64_t dst, int32_t targetValue, int64_t count)
 {
     if (!Wasm::memoryFill(instance, dst, targetValue, count))
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsMemoryAccess);

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -87,11 +87,11 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_set, unsigned tableIndex, unsigned index
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_init, IPIntStackEntry* sp, TableInitMetadata* metadata);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_fill, IPIntStackEntry* sp, TableFillMetadata* metadata);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_grow, IPIntStackEntry* sp, TableGrowMetadata* metadata);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_grow, int32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_grow, int64_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_init, int32_t, IPIntStackEntry*);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(data_drop, int32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_copy, int32_t, int32_t, int32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_fill, int32_t, int32_t, int32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_copy, int64_t, int64_t, int64_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_fill, int64_t, int32_t, int64_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(elem_drop, int32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_copy, IPIntStackEntry* sp, TableCopyMetadata* metadata);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_size, int32_t);

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -424,7 +424,7 @@ bool Memory::copy(uint32_t dstAddress, uint32_t srcAddress, uint32_t count)
     return true;
 }
 
-bool Memory::init(uint32_t offset, const uint8_t* data, uint32_t length)
+bool Memory::init(uint64_t offset, const uint8_t* data, uint32_t length)
 {
     if (sumOverflows<uint32_t>(offset, length))
         return false;

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -90,7 +90,7 @@ public:
     Expected<PageCount, GrowFailReason> grow(VM&, PageCount);
     bool fill(uint32_t, uint8_t, uint32_t);
     bool copy(uint32_t, uint32_t, uint32_t);
-    bool init(uint32_t, const uint8_t*, uint32_t);
+    bool init(uint64_t, const uint8_t*, uint32_t);
 
     void registerInstance(JSWebAssemblyInstance&);
 

--- a/Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp
@@ -33,11 +33,12 @@
 
 namespace JSC { namespace Wasm {
 
-MemoryInformation::MemoryInformation(PageCount initial, PageCount maximum, bool isShared, bool isImport)
+MemoryInformation::MemoryInformation(PageCount initial, PageCount maximum, bool isShared, bool isImport, bool isMemory64)
     : m_initial(initial)
     , m_maximum(maximum)
     , m_isShared(isShared)
     , m_isImport(isImport)
+    , m_isMemory64(isMemory64)
 {
     RELEASE_ASSERT(!!m_initial);
     RELEASE_ASSERT(!m_maximum || m_maximum >= m_initial);

--- a/Source/JavaScriptCore/wasm/WasmMemoryInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmMemoryInformation.h
@@ -50,12 +50,13 @@ public:
         ASSERT(!*this);
     }
 
-    MemoryInformation(PageCount initial, PageCount maximum, bool isShared, bool isImport);
+    MemoryInformation(PageCount initial, PageCount maximum, bool isShared, bool isImport, bool isMemory64);
 
     PageCount initial() const { return m_initial; }
     PageCount maximum() const { return m_maximum; }
     bool isShared() const { return m_isShared; }
     bool isImport() const { return m_isImport; }
+    bool isMemory64() const { return m_isMemory64; }
 
     explicit operator bool() const { return !!m_initial; }
 
@@ -64,6 +65,7 @@ private:
     PageCount m_maximum { };
     bool m_isShared { false };
     bool m_isImport { false };
+    bool m_isMemory64 { false };
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -677,7 +677,7 @@ inline int32_t growMemory(JSWebAssemblyInstance* instance, int32_t delta)
     return grown.value().pageCount();
 }
 
-inline bool memoryInit(JSWebAssemblyInstance* instance, unsigned dataSegmentIndex, uint32_t dstAddress, uint32_t srcAddress, uint32_t length)
+inline bool memoryInit(JSWebAssemblyInstance* instance, unsigned dataSegmentIndex, uint64_t dstAddress, uint32_t srcAddress, uint32_t length)
 {
     ASSERT(dataSegmentIndex < instance->module().moduleInformation().dataSegmentsCount());
     return instance->memoryInit(dstAddress, srcAddress, length, dataSegmentIndex);

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -66,7 +66,8 @@ private:
     PartialResult WARN_UNUSED_RETURN parseMemoryHelper(bool isImport);
     PartialResult WARN_UNUSED_RETURN parseTableHelper(bool isImport);
     enum class LimitsType { Memory, Table };
-    PartialResult WARN_UNUSED_RETURN parseResizableLimits(uint32_t& initial, std::optional<uint32_t>& maximum, bool& isShared, LimitsType);
+    template <LimitsType T>
+    PartialResult WARN_UNUSED_RETURN parseResizableLimits(uint64_t& initial, std::optional<uint64_t>& maximum, bool& isShared, bool& is64bit);
     PartialResult WARN_UNUSED_RETURN parseInitExpr(uint8_t&, bool&, uint64_t&, v128_t&, Type, Type& initExprType);
     PartialResult WARN_UNUSED_RETURN parseI32InitExpr(std::optional<I32InitExpr>&, ASCIILiteral failMessage);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -474,7 +474,7 @@ void JSWebAssemblyInstance::elemDrop(uint32_t elementIndex)
     m_passiveElements.quickClear(elementIndex);
 }
 
-bool JSWebAssemblyInstance::memoryInit(uint32_t dstAddress, uint32_t srcAddress, uint32_t length, uint32_t dataSegmentIndex)
+bool JSWebAssemblyInstance::memoryInit(uint64_t dstAddress, uint32_t srcAddress, uint32_t length, uint32_t dataSegmentIndex)
 {
     RELEASE_ASSERT(dataSegmentIndex < module().moduleInformation().dataSegmentsCount());
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -163,7 +163,7 @@ public:
 
     void elemDrop(uint32_t elementIndex);
 
-    bool memoryInit(uint32_t dstAddress, uint32_t srcAddress, uint32_t length, uint32_t dataSegmentIndex);
+    bool memoryInit(uint64_t dstAddress, uint32_t srcAddress, uint32_t length, uint32_t dataSegmentIndex);
 
     void dataDrop(uint32_t dataSegmentIndex);
 
@@ -191,12 +191,15 @@ public:
 #endif
             m_cachedMemorySize = memory()->memory().size();
             m_cachedMemory = CagedPtr<Gigacage::Primitive, void>(memory()->memory().basePointer());
+            m_cachedIsMemory64 = moduleInformation().memory.isMemory64();
             ASSERT(memory()->memory().basePointer() == cachedMemory());
         }
     }
 
     uint32_t cachedTable0Length() const { return m_cachedTable0Length; }
     Wasm::FuncRefTable::Function* cachedTable0Buffer() const { return m_cachedTable0Buffer; }
+
+    bool cachedIsMemory64() const { return m_cachedIsMemory64; }
 
     void updateCachedTable0();
 
@@ -276,6 +279,7 @@ public:
     static constexpr ptrdiff_t offsetOfCachedTable0Length() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedTable0Length); }
     static constexpr ptrdiff_t offsetOfTemporaryCallFrame() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_temporaryCallFrame); }
     static constexpr ptrdiff_t offsetOfBuiltinCalleeBits() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_builtinCalleeBits); }
+    static constexpr ptrdiff_t offsetOfCachedIsMemory64() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedIsMemory64); }
 
     // Tail accessors.
     static_assert(sizeof(WasmOrJSImportableFunctionCallLinkInfo) == WTF::roundUpToMultipleOf<sizeof(uint64_t)>(sizeof(WasmOrJSImportableFunctionCallLinkInfo)), "We rely on this for the alignment to be correct");
@@ -417,6 +421,7 @@ private:
     const Ref<const Wasm::ModuleInformation> m_moduleInformation;
     RefPtr<Wasm::InstanceAnchor> m_anchor;
     RefPtr<SourceProvider> m_sourceProvider;
+    bool m_cachedIsMemory64 { false };
 
     CallFrame* m_temporaryCallFrame { nullptr };
     Wasm::Global::Value* m_globals { nullptr };


### PR DESCRIPTION
#### 26868df946342191697031000d7c69d062e29193
<pre>
Add support for Memory64 in WebAssembly in IPInt Tier
<a href="https://bugs.webkit.org/show_bug.cgi?id=300539">https://bugs.webkit.org/show_bug.cgi?id=300539</a>
<a href="https://rdar.apple.com/162406385">rdar://162406385</a>

Reviewed by Keith Miller.

This patch allows the WasmFunctionParser to accept 64 bit pointers while performing
memory operations. This includes all the load and store operations, the bulk memory
operations, and the size and grow operations.

Test: JSTests/wasm/stress/load-and-store-with-64-bit-address.js

* JSTests/wasm/stress/memory64-bulk-memory.js: Added.
(async test):
* JSTests/wasm/stress/memory64-grow-and-size.js: Added.
(async test):
(async testGrowByZero):
(async testNoMaximum):
(async testLargeGrowValue):
* JSTests/wasm/stress/memory64-load-and-store.js: Added.
(getWasmTypeWidth):
(let.wat.module):
(join):
(async test):
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantInt64AndLength):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::load):
(JSC::Wasm::FunctionParser&lt;Context&gt;::store):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::load):
(JSC::Wasm::IPIntGenerator::store):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::init):
* Source/JavaScriptCore/wasm/WasmMemory.h:
* Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp:
(JSC::Wasm::MemoryInformation::MemoryInformation):
* Source/JavaScriptCore/wasm/WasmMemoryInformation.h:
(JSC::Wasm::MemoryInformation::isMemory64 const):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::memoryInit):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::limitsFlagIsValid):
(JSC::Wasm::SectionParser::parseResizableLimits):
(JSC::Wasm::SectionParser::parseTableHelper):
(JSC::Wasm::SectionParser::parseMemoryHelper):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::memoryInit):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:

Canonical link: <a href="https://commits.webkit.org/304075@main">https://commits.webkit.org/304075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70417404e95304661ef5c11fb128de2b8118032b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86329 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102681 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69945 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83474 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5018 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2632 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2626 "Build is being retried. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Failed to compile WebKit; Failed to compile WebKit; Unable to build WebKit without PR, retrying build (failure)") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126372 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114298 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144520 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132809 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6469 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39089 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111074 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111328 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28271 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4854 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116642 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60257 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6521 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34853 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165766 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6356 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70076 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43316 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6593 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6469 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->