### PR TITLE
Reduce IsDeprecatedWeakRefSmartPointerExceptions in Modules/encryptedmedia and Modules/model-element

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/CDMClient.h
+++ b/Source/WebCore/Modules/encryptedmedia/CDMClient.h
@@ -30,24 +30,15 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class CDMClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CDMClient> : std::true_type { };
-}
 
 namespace WebCore {
 
 class CDMInstance;
 class SharedBuffer;
 
-class CDMClient : public CanMakeWeakPtr<CDMClient> {
+class CDMClient : public AbstractRefCountedAndCanMakeWeakPtr<CDMClient> {
 public:
     virtual ~CDMClient() = default;
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -169,8 +169,8 @@ void MediaKeys::detachCDMClient(CDMClient& client)
 
 void MediaKeys::attemptToResumePlaybackOnClients()
 {
-    for (auto& cdmClient : m_cdmClients)
-        cdmClient.cdmClientAttemptToResumePlaybackIfNecessary();
+    for (Ref cdmClient : m_cdmClients)
+        cdmClient->cdmClientAttemptToResumePlaybackIfNecessary();
 }
 
 bool MediaKeys::hasOpenSessions() const
@@ -183,8 +183,8 @@ bool MediaKeys::hasOpenSessions() const
 
 void MediaKeys::unrequestedInitializationDataReceived(const String& initDataType, Ref<SharedBuffer>&& initData)
 {
-    for (auto& cdmClient : m_cdmClients)
-        cdmClient.cdmClientUnrequestedInitializationDataReceived(initDataType, initData.copyRef());
+    for (Ref cdmClient : m_cdmClients)
+        cdmClient->cdmClientUnrequestedInitializationDataReceived(initDataType, initData.copyRef());
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/model-element/DDModelPlayer.mm
+++ b/Source/WebCore/Modules/model-element/DDModelPlayer.mm
@@ -160,8 +160,8 @@ void DDModelPlayer::load(Model& modelSource, LayoutSize size)
         m_modelLoader = adoptNS([[WebUSDModelLoader alloc] init]);
         RetainPtr nsURL = modelSource.url().createNSURL();
         [m_modelLoader setCallbacksWithModelAddedCallback:^(WebAddMeshRequest *addRequest) {
-            if (m_client)
-                m_client->didFinishLoading(*this);
+            if (RefPtr client = m_client.get())
+                client->didFinishLoading(*this);
 
             if (m_currentModel)
                 m_currentModel->addMesh(toCpp(addRequest));
@@ -296,7 +296,7 @@ void DDModelPlayer::update()
     if (auto* machSendRight = displayBuffer(); machSendRight && contentsDisplayDelegate())
         RefPtr { m_contentsDisplayDelegate }->setDisplayBuffer(*machSendRight);
 
-    if (auto client = m_client.get())
+    if (RefPtr client = m_client.get())
         client->didUpdateDisplayDelegate();
 }
 

--- a/Source/WebCore/Modules/model-element/ModelPlayerClient.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerClient.h
@@ -28,26 +28,17 @@
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/PlatformLayerIdentifier.h>
 #include <WebCore/TransformationMatrix.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
 
 namespace WebCore {
+
 class FloatPoint3D;
-class ModelPlayerClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ModelPlayerClient> : std::true_type { };
-}
-
-namespace WebCore {
-
 class HTMLModelElement;
 class ModelPlayer;
 class ResourceError;
 
-class WEBCORE_EXPORT ModelPlayerClient : public CanMakeWeakPtr<ModelPlayerClient> {
+class WEBCORE_EXPORT ModelPlayerClient : public AbstractRefCountedAndCanMakeWeakPtr<ModelPlayerClient> {
 public:
     virtual ~ModelPlayerClient();
 

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
@@ -48,8 +48,8 @@ DummyModelPlayer::~DummyModelPlayer() = default;
 
 void DummyModelPlayer::load(Model& model, LayoutSize)
 {
-    if (m_client)
-        m_client->didFailLoading(*this, ResourceError { errorDomainWebKitInternal, 0, model.url(), "Trying to load model via DummyModelPlayer"_s });
+    if (RefPtr client = m_client.get())
+        client->didFailLoading(*this, ResourceError { errorDomainWebKitInternal, 0, model.url(), "Trying to load model via DummyModelPlayer"_s });
 }
 
 PlatformLayer* DummyModelPlayer::layer()

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm
@@ -163,8 +163,8 @@ void SceneKitModelPlayer::didFinishLoading(SceneKitModelLoader& loader, Ref<Scen
 
     updateScene();
 
-    if (m_client)
-        m_client->didFinishLoading(*this);
+    if (RefPtr client = m_client.get())
+        client->didFinishLoading(*this);
 }
 
 void SceneKitModelPlayer::didFailLoading(SceneKitModelLoader& loader, const ResourceError& error)
@@ -174,8 +174,8 @@ void SceneKitModelPlayer::didFailLoading(SceneKitModelLoader& loader, const Reso
 
     m_loader = nullptr;
 
-    if (!m_client)
-        m_client->didFailLoading(*this, error);
+    if (RefPtr client = m_client.get())
+        client->didFailLoading(*this, error);
 }
 
 void SceneKitModelPlayer::updateScene()

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -65,6 +65,7 @@ private:
 
     WebPage* page() { return m_page.get(); }
     WebCore::ModelPlayerClient* client() { return m_client.get(); }
+    RefPtr<WebCore::ModelPlayerClient> protectedClient() { return m_client.get(); }
 
     template<typename T> void send(T&& message);
     template<typename T, typename C> void sendWithAsyncReply(T&& message, C&& completionHandler);

--- a/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
+++ b/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
@@ -136,7 +136,7 @@ void ARKitInlinePreviewModelPlayerMac::load(WebCore::Model& modelSource, WebCore
 {
     m_size = size;
 
-    auto* client = this->client();
+    RefPtr client = this->client();
     if (!client)
         return;
 
@@ -156,7 +156,7 @@ void ARKitInlinePreviewModelPlayerMac::createPreviewsForModelWithURL(const URL& 
     m_inlinePreview = adoptNS([allocASVInlinePreviewInstance() initWithFrame:CGRectMake(0, 0, m_size.width(), m_size.height())]);
     LOG(ModelElement, "ARKitInlinePreviewModelPlayerMac::createPreviewsForModelWithURL() created preview with UUID %s and size %f x %f.", ((String)[m_inlinePreview uuid].UUIDString).utf8().data(), m_size.width().toDouble(), m_size.height().toDouble());
 
-    auto* client = this->client();
+    RefPtr client = this->client();
     if (!client)
         return;
 
@@ -171,7 +171,7 @@ void ARKitInlinePreviewModelPlayerMac::createPreviewsForModelWithURL(const URL& 
         if (!strongSelf)
             return;
 
-        auto* client = strongSelf->client();
+        RefPtr client = strongSelf->client();
         if (!client)
             return;
 
@@ -202,7 +202,7 @@ void ARKitInlinePreviewModelPlayerMac::createPreviewsForModelWithURL(const URL& 
 
 void ARKitInlinePreviewModelPlayerMac::didCreateRemotePreviewForModelWithURL(const URL& url)
 {
-    auto* client = this->client();
+    RefPtr client = this->client();
     if (!client)
         return;
 
@@ -217,7 +217,7 @@ void ARKitInlinePreviewModelPlayerMac::didCreateRemotePreviewForModelWithURL(con
         if (!strongSelf)
             return;
 
-        auto* client = strongSelf->client();
+        RefPtr client = strongSelf->client();
         if (!client)
             return;
 


### PR DESCRIPTION
#### 4618406fa93b60fe9d0fbb9204ab2591a6f9024c
<pre>
Reduce IsDeprecatedWeakRefSmartPointerExceptions in Modules/encryptedmedia and Modules/model-element
<a href="https://bugs.webkit.org/show_bug.cgi?id=300542">https://bugs.webkit.org/show_bug.cgi?id=300542</a>
<a href="https://rdar.apple.com/162412418">rdar://162412418</a>

Reviewed by Chris Dumez and Darin Adler.

Reduce usage of IsDeprecatedWeakRefSmartPointerException and a drive-by fix of an
incorrect if-statement condition in SceneKitModelPlayer::didFailLoading().

* Source/WebCore/Modules/encryptedmedia/CDMClient.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp:
(WebCore::MediaKeys::attemptToResumePlaybackOnClients):
(WebCore::MediaKeys::unrequestedInitializationDataReceived):
* Source/WebCore/Modules/model-element/DDModelPlayer.mm:
(WebCore::DDModelPlayer::load):
(WebCore::DDModelPlayer::update):
* Source/WebCore/Modules/model-element/ModelPlayerClient.h:
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp:
(WebCore::DummyModelPlayer::load):
* Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm:
(WebCore::SceneKitModelPlayer::didFinishLoading):
(WebCore::SceneKitModelPlayer::didFailLoading):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::didCreateLayer):
(WebKit::ModelProcessModelPlayer::didFinishLoading):
(WebKit::ModelProcessModelPlayer::didFailLoading):
(WebKit::ModelProcessModelPlayer::didUpdateEntityTransform):
(WebKit::ModelProcessModelPlayer::didFinishEnvironmentMapLoading):
(WebKit::ModelProcessModelPlayer::load):
(WebKit::ModelProcessModelPlayer::didUnload):
(WebKit::ModelProcessModelPlayer::visibilityStateDidChange):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
(WebKit::ModelProcessModelPlayer::protectedClient):
* Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm:
(WebKit::ARKitInlinePreviewModelPlayerMac::load):
(WebKit::ARKitInlinePreviewModelPlayerMac::createPreviewsForModelWithURL):
(WebKit::ARKitInlinePreviewModelPlayerMac::didCreateRemotePreviewForModelWithURL):

Canonical link: <a href="https://commits.webkit.org/301483@main">https://commits.webkit.org/301483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb7c5e0b54afdd0b7da848479ca8ae73fadd22a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77889 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b4475e4-9f7e-468f-a587-1dee3b417020) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96012 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64112 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e205d384-b97a-48b1-be6e-c52fe0e31686) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76501 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e2b4690a-1d06-40f6-aa33-0426936a1242) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36030 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30948 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76370 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135605 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104518 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104234 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49636 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27962 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50226 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19725 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52740 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58574 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52068 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55414 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53778 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->