### PR TITLE
Add URL path to AppSSO authorization options

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AppSSOSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AppSSOSPI.h
@@ -29,6 +29,8 @@ DECLARE_SYSTEM_HEADER
 
 #if HAVE(APP_SSO)
 
+#define kSOAuthorizationOptionInitiatingPath @"path"
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <AppSSO/AppSSO.h>

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -241,7 +241,8 @@ void SOAuthorizationSession::continueStartAfterDecidePolicy(const SOAuthorizatio
     RetainPtr<NSDictionary> authorizationOptions = @{
         SOAuthorizationOptionUserActionInitiated: @(m_navigationAction->isProcessingUserGesture()),
         SOAuthorizationOptionInitiatorOrigin: initiatorOrigin.createNSString().get(),
-        SOAuthorizationOptionInitiatingAction: @(static_cast<NSInteger>(m_action))
+        SOAuthorizationOptionInitiatingAction: @(static_cast<NSInteger>(m_action)),
+        kSOAuthorizationOptionInitiatingPath: m_page->mainFrame()->url().path().createNSString().get()
     };
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<WKWebView> webView = m_page->cocoaView();


### PR DESCRIPTION
#### 4eab8e49375032bf46f57899fad8a901ede19495
<pre>
Add URL path to AppSSO authorization options
<a href="https://bugs.webkit.org/show_bug.cgi?id=300507">https://bugs.webkit.org/show_bug.cgi?id=300507</a>
<a href="https://rdar.apple.com/162366845">rdar://162366845</a>

Reviewed by Brent Fulgham.

AppSSO extensions may need to know the path component of the URL being
authorized. Add the path to the authorizationOptions dictionary passed
to SOAuthorization with the key &quot;path&quot;.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
* Source/WebCore/PAL/pal/spi/cocoa/AppSSOSPI.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::continueStartAfterDecidePolicy):
Extract the URL path and add it to authorizationOptions.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(checkAuthorizationOptions): Add optional path parameter.
(TestWebKitAPI::TEST(SOAuthorizationRedirect, AuthorizationOptionsWithPath)):
Add test verifying the path is included in authorization options.

Canonical link: <a href="https://commits.webkit.org/302356@main">https://commits.webkit.org/302356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41edb7be8963a2ad635dc18202c602f37e1eebad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135405 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79546 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fe7e63dd-0b7c-4a88-9c2a-83724b191eeb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97469 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65362 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c4e69e94-24ea-4e26-b2a7-08cf9d00b1f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114694 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78036 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/61925978-7336-4c8b-a11b-72b3c9f652ed) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32802 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78714 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137893 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/168 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105996 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105732 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27100 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/130 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29595 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52353 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/220 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61680 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/139 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/215 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/180 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->