### PR TITLE
REGRESSION(301100@main): run-gtk-tests and run-wpe-tests failed to spawn child process for debug builds

### DIFF
--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -41,22 +41,25 @@ import subprocess
 UNKNOWN_CRASH_STR = "CRASH_OR_PROBLEM_IN_TEST_EXECUTABLE"
 
 
+def port_options(options):
+    port_options = optparse.Values()
+    if options.debug:
+        setattr(port_options, 'configuration', 'Debug')
+    elif options.release:
+        setattr(port_options, 'configuration', 'Release')
+    return port_options
+
 class TestRunner(object):
     TEST_TARGETS = []
 
     def __init__(self, port, options, tests=[]):
         self._options = options
-        self._port = Host().port_factory.get(port)
+        self._port = Host().port_factory.get(port, port_options(options))
         self._driver = self._create_driver()
         self._weston = None
         self._monado = None
 
-        if self._options.debug:
-            self._build_type = "Debug"
-        elif self._options.release:
-            self._build_type = "Release"
-        else:
-            self._build_type = self._port.default_configuration()
+        self._build_type = self._port.get_option('configuration')
         common.set_build_types((self._build_type,))
 
         self._programs_path = common.binary_build_path(self._port)


### PR DESCRIPTION
#### ef1a267530021d9d51035b99520a3a2d9289135a
<pre>
REGRESSION(301100@main): run-gtk-tests and run-wpe-tests failed to spawn child process for debug builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=300545">https://bugs.webkit.org/show_bug.cgi?id=300545</a>

Reviewed by Carlos Garcia Campos.

run-gtk-tests and run-wpe-tests failed to spawn child processes only for debug
builds because environment variables WEBKIT_EXEC_PATH and
TEST_RUNNER_INJECTED_BUNDLE_FILENAME always pointed to the release build
directory.

&lt;<a href="https://commits.webkit.org/301100@main">https://commits.webkit.org/301100@main</a>&gt; moved code of setting the env
variables from glib/api_test_runner.py to webkitpy.port.Port class. However,
api_test_runner.py didn&apos;t initialize the Port object properly.

Create a options for port_factory, and pass it to create a Port object. Get
_build_type from the Port object.

* Tools/glib/api_test_runner.py:
(port_options):
(TestRunner.__init__):

Canonical link: <a href="https://commits.webkit.org/301352@main">https://commits.webkit.org/301352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6b7cb5a0e0db784b199a9af626adeeb9490b63b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132562 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95763 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76255 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30587 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76032 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/106588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135240 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104228 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103956 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49318 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27629 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49729 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19677 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52383 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51731 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55082 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->