### PR TITLE
Resync `Navigation API` from WPT Upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6999,6 +6999,10 @@ imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-no
 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/precommit-handler/ [ Skip ]
 
+# Require enabling CSS Scroll Anchoring
+imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload.html [ Skip ]
+imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-reload.html [ Skip ]
+
 # -- View Transitions -- #
 
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-clip-with-border-radius.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload-no-scroll-anchoring-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload-no-scroll-anchoring-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scroll: after-transition should work on a reload navigation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload-no-scroll-anchoring.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload-no-scroll-anchoring.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<div id="buffer" style="height: 1000px; width: 200vw;"></div>
+<div id="frag"></div>
+<div style="height: 2000px; width: 200vw;"></div>
+<style>
+  * {
+    overflow-anchor: none;
+  }
+</style>
+<script>
+promise_test(async t => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  assert_equals(window.scrollY, 0);
+  await navigation.navigate("#frag").finished;
+  // Scroll down 10px from #frag
+  window.scrollBy(0, 10);
+  let scrollY_frag_plus_10 = window.scrollY;
+
+  let intercept_resolve;
+  let navigate_event;
+  navigation.onnavigate = e => {
+    navigate_event = e;
+    e.intercept({ handler: () => new Promise(r => intercept_resolve = r),
+                  scroll: "after-transition" });
+  };
+  let reload_promises = navigation.reload();
+  await reload_promises.committed;
+
+  // removing the <div id="buffer"> should stay in same position.
+  assert_equals(window.scrollY, scrollY_frag_plus_10);
+  buffer.remove();
+  let scrollY_after_buffer_remove = window.scrollY;
+  assert_equals(scrollY_after_buffer_remove, scrollY_frag_plus_10);
+
+  // Finishing should scroll to #frag, which is 10px up from the current location
+  intercept_resolve();
+  await reload_promises.finished;
+  assert_equals(window.scrollY, scrollY_after_buffer_remove - 1000 - 10);
+}, "scroll: after-transition should work on a reload navigation");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-reload-no-scroll-anchoring-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-reload-no-scroll-anchoring-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scroll: scroll() should work on a reload navigation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-reload-no-scroll-anchoring.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-reload-no-scroll-anchoring.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<div id="buffer" style="height: 1000px; width: 200vw;"></div>
+<div id="frag"></div>
+<div style="height: 2000px; width: 200vw;"></div>
+<style>
+  * {
+    overflow-anchor: none;
+  }
+</style>
+<script>
+promise_test(async t => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  assert_equals(window.scrollY, 0);
+  await navigation.navigate("#frag").finished;
+  // Scroll down 10px from #frag
+  window.scrollBy(0, 10);
+  let scrollY_frag_plus_10 = window.scrollY;
+
+  let intercept_resolve;
+  let navigate_event;
+  navigation.onnavigate = e => {
+    navigate_event = e;
+    e.intercept({ handler: () => new Promise(r => intercept_resolve = r),
+                  scroll: "manual" });
+  };
+  let reload_promises = navigation.reload();
+  await reload_promises.committed;
+
+  // removing the <div id="buffer"> should stay in same position.
+  assert_equals(window.scrollY, scrollY_frag_plus_10);
+  buffer.remove();
+  let scrollY_after_buffer_remove = window.scrollY;
+  assert_equals(scrollY_after_buffer_remove, scrollY_frag_plus_10);
+
+  // scroll() should scroll to #frag, which is 10px up from the current location
+  navigate_event.scroll();
+  assert_equals(window.scrollY, scrollY_after_buffer_remove - 1000 - 10);
+
+  // Finishing should not scroll.
+  intercept_resolve();
+  await reload_promises.finished;
+  assert_equals(window.scrollY, scrollY_after_buffer_remove - 1000 - 10);
+}, "scroll: scroll() should work on a reload navigation");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/w3c-import.log
@@ -20,6 +20,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-intercept-handler-modifies.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-push.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reject.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload-no-scroll-anchoring.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-replace.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-timing.html
@@ -30,6 +31,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-fragment-does-not-exist.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-in-precommit-handler.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-push.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-reload-no-scroll-anchoring.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-reload.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-repeated.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-replace.html


### PR DESCRIPTION
#### 57d54381a14b4ddb8a346dbc090619109de7bf2b
<pre>
Resync `Navigation API` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=300543">https://bugs.webkit.org/show_bug.cgi?id=300543</a>
<a href="https://rdar.apple.com/162296262">rdar://162296262</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/a130b01dc9f437a02437c3a0847456c1bafc24af">https://github.com/web-platform-tests/wpt/commit/a130b01dc9f437a02437c3a0847456c1bafc24af</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload-no-scroll-anchoring-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload-no-scroll-anchoring.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-reload-no-scroll-anchoring-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-reload-no-scroll-anchoring.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/301360@main">https://commits.webkit.org/301360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46e36e01a0c314ccad1c20319fe279bdc133dfe0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132563 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77583 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/daed1833-d6c3-4b63-8647-4e0f732f090b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95764 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63881 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1bbb3d4-c848-40ad-8264-f0ea647fdc2f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76256 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8bd1f788-567f-41b6-b5bb-411ea257236f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35710 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30588 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76033 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135241 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104230 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103958 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26481 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49316 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27630 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49730 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52384 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51732 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55083 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53428 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->