### PR TITLE
Replace PseudoIdSet with OptionSet<PseudoId>

### DIFF
--- a/Source/WTF/wtf/OptionSet.h
+++ b/Source/WTF/wtf/OptionSet.h
@@ -207,6 +207,8 @@ public:
 
     static OptionSet all() { return fromRaw(-1); }
 
+    static constexpr ptrdiff_t storageMemoryOffset() { return OBJECT_OFFSETOF(OptionSet, m_storage); }
+
 private:
     enum InitializationTag { FromRawValue };
     constexpr OptionSet(E e, InitializationTag)

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -216,15 +216,15 @@ bool SelectorChecker::match(const CSSSelector& selector, const Element& element,
         context.mustMatchHostPseudoClass = true;
     }
 
-    PseudoIdSet pseudoIdSet;
+    OptionSet<PseudoId> pseudoIdSet;
     MatchResult result = matchRecursively(checkingContext, context, pseudoIdSet);
     if (result.match != Match::SelectorMatches)
         return false;
-    if (checkingContext.pseudoId != PseudoId::None && !pseudoIdSet.has(checkingContext.pseudoId))
+    if (checkingContext.pseudoId != PseudoId::None && !pseudoIdSet.contains(checkingContext.pseudoId))
         return false;
 
     if (checkingContext.pseudoId == PseudoId::None && pseudoIdSet) {
-        PseudoIdSet publicPseudoIdSet = pseudoIdSet & PseudoIdSet::fromMask(PublicPseudoIdMask);
+        OptionSet<PseudoId> publicPseudoIdSet = pseudoIdSet & allPublicPseudoIds;
         if (checkingContext.resolvingMode == Mode::ResolvingStyle && publicPseudoIdSet)
             checkingContext.pseudoIDSet = publicPseudoIdSet;
 
@@ -245,28 +245,28 @@ bool SelectorChecker::matchHostPseudoClass(const CSSSelector& selector, const El
         LocalContext context(*selectorList->first(), element, VisitedMatchType::Enabled, std::nullopt);
         context.inFunctionalPseudoClass = true;
         context.pseudoElementEffective = false;
-        PseudoIdSet ignoreDynamicPseudo;
+        OptionSet<PseudoId> ignoreDynamicPseudo;
         if (matchRecursively(checkingContext, context, ignoreDynamicPseudo).match != Match::SelectorMatches)
             return false;
     }
     return true;
 }
 
-inline static bool hasViewTransitionPseudoElement(const PseudoIdSet& dynamicPseudoIdSet)
+inline static bool hasViewTransitionPseudoElement(OptionSet<PseudoId> dynamicPseudoIdSet)
 {
-    PseudoIdSet functionalPseudoElementSet = {
+    auto functionalPseudoElementSet = OptionSet {
         PseudoId::ViewTransition,
         PseudoId::ViewTransitionGroup,
         PseudoId::ViewTransitionImagePair,
         PseudoId::ViewTransitionNew,
         PseudoId::ViewTransitionOld,
     };
-    return !!(dynamicPseudoIdSet & functionalPseudoElementSet);
+    return dynamicPseudoIdSet.containsAny(functionalPseudoElementSet);
 }
 
-inline static bool hasScrollbarPseudoElement(const PseudoIdSet& dynamicPseudoIdSet)
+inline static bool hasScrollbarPseudoElement(OptionSet<PseudoId> dynamicPseudoIdSet)
 {
-    PseudoIdSet scrollbarIdSet = {
+    auto scrollbarIdSet = OptionSet {
         PseudoId::WebKitScrollbar,
         PseudoId::WebKitScrollbarThumb,
         PseudoId::WebKitScrollbarButton,
@@ -274,12 +274,12 @@ inline static bool hasScrollbarPseudoElement(const PseudoIdSet& dynamicPseudoIdS
         PseudoId::WebKitScrollbarTrackPiece,
         PseudoId::WebKitScrollbarCorner
     };
-    if (dynamicPseudoIdSet & scrollbarIdSet)
+    if (dynamicPseudoIdSet.containsAny(scrollbarIdSet))
         return true;
 
     // PseudoId::WebKitResizer does not always have a scrollbar but it is a scrollbar-like pseudo element
     // because it can have more than one pseudo element.
-    return dynamicPseudoIdSet.has(PseudoId::WebKitResizer);
+    return dynamicPseudoIdSet.contains(PseudoId::WebKitResizer);
 }
 
 static SelectorChecker::LocalContext localContextForParent(const SelectorChecker::LocalContext& context)
@@ -314,7 +314,7 @@ static SelectorChecker::LocalContext localContextForParent(const SelectorChecker
 // * SelectorFailsLocally     - the selector fails for the element e
 // * SelectorFailsAllSiblings - the selector fails for e and any sibling of e
 // * SelectorFailsCompletely  - the selector fails for e and any sibling or ancestor of e
-SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& checkingContext, LocalContext& context, PseudoIdSet& dynamicPseudoIdSet) const
+SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& checkingContext, LocalContext& context, OptionSet<PseudoId>& dynamicPseudoIdSet) const
 {
     MatchType matchType = MatchType::Element;
 
@@ -375,7 +375,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
 
     if (relation != CSSSelector::Relation::Subselector) {
         // Bail-out if this selector is irrelevant for the pseudoId
-        if (context.pseudoElementIdentifier && !dynamicPseudoIdSet.has(context.pseudoElementIdentifier->pseudoId))
+        if (context.pseudoElementIdentifier && !dynamicPseudoIdSet.contains(context.pseudoElementIdentifier->pseudoId))
             return MatchResult::fails(Match::SelectorFailsCompletely);
 
         // Disable :visited matching when we try to match anything else than an ancestors.
@@ -397,7 +397,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
         nextContext = localContextForParent(nextContext);
         nextContext.firstSelectorOfTheFragment = nextContext.selector;
         for (; nextContext.element; nextContext = localContextForParent(nextContext)) {
-            PseudoIdSet ignoreDynamicPseudo;
+            OptionSet<PseudoId> ignoreDynamicPseudo;
             MatchResult result = matchRecursively(checkingContext, nextContext, ignoreDynamicPseudo);
             ASSERT(!nextContext.pseudoElementEffective && !ignoreDynamicPseudo);
 
@@ -412,7 +412,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
             if (!nextContext.element)
                 return MatchResult::fails(Match::SelectorFailsCompletely);
             nextContext.firstSelectorOfTheFragment = nextContext.selector;
-            PseudoIdSet ignoreDynamicPseudo;
+            OptionSet<PseudoId> ignoreDynamicPseudo;
             MatchResult result = matchRecursively(checkingContext, nextContext, ignoreDynamicPseudo);
             ASSERT(!nextContext.pseudoElementEffective && !ignoreDynamicPseudo);
 
@@ -434,7 +434,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
 
             nextContext.element = previousElement;
             nextContext.firstSelectorOfTheFragment = nextContext.selector;
-            PseudoIdSet ignoreDynamicPseudo;
+            OptionSet<PseudoId> ignoreDynamicPseudo;
             MatchResult result = matchRecursively(checkingContext, nextContext, ignoreDynamicPseudo);
             ASSERT(!nextContext.pseudoElementEffective && !ignoreDynamicPseudo);
 
@@ -449,7 +449,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
         for (; nextContext.element; nextContext.element = nextContext.element->previousElementSibling()) {
             addStyleRelation(checkingContext, *nextContext.element, Style::Relation::AffectsNextSibling);
 
-            PseudoIdSet ignoreDynamicPseudo;
+            OptionSet<PseudoId> ignoreDynamicPseudo;
             MatchResult result = matchRecursively(checkingContext, nextContext, ignoreDynamicPseudo);
             ASSERT(!nextContext.pseudoElementEffective && !ignoreDynamicPseudo);
 
@@ -464,7 +464,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
             // We make an exception for scrollbar pseudo elements and allow a set of pseudo classes (but nothing else)
             // to follow the pseudo elements.
             nextContext.hasScrollbarPseudo = hasScrollbarPseudoElement(dynamicPseudoIdSet);
-            nextContext.hasSelectionPseudo = dynamicPseudoIdSet.has(PseudoId::Selection);
+            nextContext.hasSelectionPseudo = dynamicPseudoIdSet.contains(PseudoId::Selection);
             nextContext.hasViewTransitionPseudo = hasViewTransitionPseudoElement(dynamicPseudoIdSet);
 
             if ((context.isMatchElement || checkingContext.resolvingMode == Mode::CollectingRules) && dynamicPseudoIdSet
@@ -484,7 +484,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
         nextContext.element = host;
         nextContext.firstSelectorOfTheFragment = nextContext.selector;
         nextContext.isSubjectOrAdjacentElement = false;
-        PseudoIdSet ignoreDynamicPseudo;
+        OptionSet<PseudoId> ignoreDynamicPseudo;
         MatchResult result = matchRecursively(checkingContext, nextContext, ignoreDynamicPseudo);
 
         return MatchResult::updateWithMatchType(result, matchType);
@@ -502,7 +502,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
         nextContext.isSubjectOrAdjacentElement = false;
         // ::part rules from the element's own scope can only match if they apply to :host.
         nextContext.mustMatchHostPseudoClass = checkingContext.styleScopeOrdinal == Style::ScopeOrdinal::Element;
-        PseudoIdSet ignoreDynamicPseudo;
+        OptionSet<PseudoId> ignoreDynamicPseudo;
         MatchResult result = matchRecursively(checkingContext, nextContext, ignoreDynamicPseudo);
 
         return MatchResult::updateWithMatchType(result, matchType);
@@ -516,7 +516,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
         nextContext.element = slot;
         nextContext.firstSelectorOfTheFragment = nextContext.selector;
         nextContext.isSubjectOrAdjacentElement = false;
-        PseudoIdSet ignoreDynamicPseudo;
+        OptionSet<PseudoId> ignoreDynamicPseudo;
         MatchResult result = matchRecursively(checkingContext, nextContext, ignoreDynamicPseudo);
 
         return MatchResult::updateWithMatchType(result, matchType);
@@ -792,7 +792,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
                 subcontext.pseudoElementEffective = false;
                 subcontext.selector = &subselector;
                 subcontext.firstSelectorOfTheFragment = selectorList->first();
-                PseudoIdSet ignoreDynamicPseudo;
+                OptionSet<PseudoId> ignoreDynamicPseudo;
 
                 if (matchRecursively(checkingContext, subcontext, ignoreDynamicPseudo).match == Match::SelectorMatches) {
                     ASSERT(!ignoreDynamicPseudo);
@@ -919,7 +919,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
                     subcontext.selector = &subselector;
                     subcontext.firstSelectorOfTheFragment = &subselector;
                     subcontext.pseudoElementIdentifier = std::nullopt;
-                    PseudoIdSet localDynamicPseudoIdSet;
+                    OptionSet<PseudoId> localDynamicPseudoIdSet;
                     MatchResult result = matchRecursively(checkingContext, subcontext, localDynamicPseudoIdSet);
                     context.matchedHostPseudoClass |= subcontext.matchedHostPseudoClass;
 
@@ -1242,7 +1242,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
                 subcontext.firstSelectorOfTheFragment = &subselector;
                 subcontext.inFunctionalPseudoClass = true;
                 subcontext.pseudoElementEffective = false;
-                PseudoIdSet ignoredDynamicPseudo;
+                OptionSet<PseudoId> ignoredDynamicPseudo;
                 if (matchRecursively(checkingContext, subcontext, ignoredDynamicPseudo).match == Match::SelectorMatches)
                     return true;
             }
@@ -1261,7 +1261,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
             subcontext.firstSelectorOfTheFragment = subselector;
             subcontext.pseudoElementEffective = false;
             subcontext.inFunctionalPseudoClass = true;
-            PseudoIdSet ignoredDynamicPseudo;
+            OptionSet<PseudoId> ignoredDynamicPseudo;
             return matchRecursively(checkingContext, subcontext, ignoredDynamicPseudo).match == Match::SelectorMatches;
         }
         case CSSSelector::PseudoElement::Part: {
@@ -1354,7 +1354,7 @@ bool SelectorChecker::matchSelectorList(CheckingContext& checkingContext, const 
         subcontext.inFunctionalPseudoClass = true;
         subcontext.pseudoElementEffective = false;
         subcontext.firstSelectorOfTheFragment = &subselector;
-        PseudoIdSet ignoreDynamicPseudo;
+        OptionSet<PseudoId> ignoreDynamicPseudo;
         if (matchRecursively(checkingContext, subcontext, ignoreDynamicPseudo).match == Match::SelectorMatches) {
             ASSERT(!ignoreDynamicPseudo);
 
@@ -1447,7 +1447,7 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
         hasContext.inFunctionalPseudoClass = true;
         hasContext.pseudoElementEffective = false;
 
-        PseudoIdSet ignorePseudoElements;
+        OptionSet<PseudoId> ignorePseudoElements;
         auto result = matchRecursively(hasCheckingContext, hasContext, ignorePseudoElements).match == Match::SelectorMatches;
 
         if (hasCheckingContext.matchedInsideScope)

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -101,7 +101,7 @@ public:
 
         // FIXME: It would be nicer to have a separate object for return values. This requires some more work in the selector compiler.
         Style::Relations styleRelations;
-        PseudoIdSet pseudoIDSet;
+        OptionSet<PseudoId> pseudoIDSet;
         bool matchedInsideScope { false };
         bool disallowHasPseudoClass { false };
         bool scopingRootMatchesVisited { false };
@@ -120,7 +120,7 @@ public:
     struct LocalContext;
     
 private:
-    MatchResult matchRecursively(CheckingContext&, LocalContext&, PseudoIdSet&) const;
+    MatchResult matchRecursively(CheckingContext&, LocalContext&, OptionSet<PseudoId>&) const;
     bool checkOne(CheckingContext&, LocalContext&, MatchType&) const;
     bool matchSelectorList(CheckingContext&, const LocalContext&, const Element&, const CSSSelectorList&) const;
     bool matchHasPseudoClass(CheckingContext&, const Element&, const CSSSelector&) const;

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -4359,16 +4359,16 @@ void SelectorCodeGenerator::generateElementHasPseudoElement(Assembler::JumpList&
 void SelectorCodeGenerator::generateRequestedPseudoElementEqualsToSelectorPseudoElement(Assembler::JumpList& failureCases, const SelectorFragment& fragment, Assembler::RegisterID checkingContext)
 {
     ASSERT(m_selectorContext != SelectorContext::QuerySelector);
-
     // Make sure that the requested pseudoId equals to the pseudo element of the rightmost fragment.
     // If the rightmost fragment doesn't have a pseudo element, the requested pseudoId need to be PseudoId::None to succeed the matching.
     // Otherwise, if the requested pseudoId is not PseudoId::None, the requested pseudoId need to equal to the pseudo element of the rightmost fragment.
     if (fragmentMatchesTheRightmostElement(fragment)) {
+        static_assert(sizeof(SelectorChecker::CheckingContext::pseudoId) == 4);
         if (!fragment.pseudoElementSelector)
-            failureCases.append(m_assembler.branch8(Assembler::NotEqual, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(PseudoId::None))));
+            failureCases.append(m_assembler.branch32(Assembler::NotEqual, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(PseudoId::None))));
         else {
-            Assembler::Jump skip = m_assembler.branch8(Assembler::Equal, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(PseudoId::None)));
-            failureCases.append(m_assembler.branch8(Assembler::NotEqual, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(CSSSelector::pseudoId(fragment.pseudoElementSelector->pseudoElement())))));
+            Assembler::Jump skip = m_assembler.branch32(Assembler::Equal, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(PseudoId::None)));
+            failureCases.append(m_assembler.branch32(Assembler::NotEqual, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(CSSSelector::pseudoId(fragment.pseudoElementSelector->pseudoElement())))));
             skip.link(&m_assembler);
         }
     }
@@ -4452,20 +4452,21 @@ void SelectorCodeGenerator::generateMarkPseudoStyleForPseudoElement(Assembler::J
     Assembler::JumpList successCases;
 
     // When the requested pseudoId isn't PseudoId::None, there's no need to mark the pseudo element style.
-    successCases.append(m_assembler.branch8(Assembler::NotEqual, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(PseudoId::None))));
+    static_assert(sizeof(SelectorChecker::CheckingContext::pseudoId) == 4);
+    successCases.append(m_assembler.branch32(Assembler::NotEqual, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(PseudoId::None))));
 
     // When style invalidation, there's no need to mark the pseudo element style.
     successCases.append(branchOnResolvingModeWithCheckingContext(Assembler::Equal, SelectorChecker::Mode::StyleInvalidation, checkingContext));
 
     // When resolving mode is ResolvingStyle, mark the pseudo style for pseudo element.
     PseudoId dynamicPseudo = CSSSelector::pseudoId(fragment.pseudoElementSelector->pseudoElement());
-    if (dynamicPseudo < PseudoId::FirstInternalPseudoId) {
+    if (allPublicPseudoIds.contains(dynamicPseudo)) {
         failureCases.append(branchOnResolvingModeWithCheckingContext(Assembler::NotEqual, SelectorChecker::Mode::ResolvingStyle, checkingContext));
 
         Assembler::Address pseudoIDSetAddress(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoIDSet));
-        auto pseudoIDSetDataAddress = pseudoIDSetAddress.withOffset(PseudoIdSet::dataMemoryOffset());
-        PseudoIdSet value { dynamicPseudo };
-        m_assembler.store32(Assembler::TrustedImm32(value.data()), pseudoIDSetDataAddress);
+        auto pseudoIDSetDataAddress = pseudoIDSetAddress.withOffset(OptionSet<PseudoId>::storageMemoryOffset());
+        OptionSet<PseudoId> value { dynamicPseudo };
+        m_assembler.store32(Assembler::TrustedImm32(value.toRaw()), pseudoIDSetDataAddress);
     }
 
     // We have a pseudoElementSelector, we are not in CollectingRulesIgnoringVirtualPseudoElements so

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -500,7 +500,7 @@ Inspector::Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Inspector::Pr
     if (!originalElement->isPseudoElement()) {
         if (!includePseudo || *includePseudo) {
             pseudoElements = JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>::create();
-            for (PseudoId pseudoId = PseudoId::FirstPublicPseudoId; pseudoId < PseudoId::AfterLastInternalPseudoId; pseudoId = static_cast<PseudoId>(static_cast<unsigned>(pseudoId) + 1)) {
+            for (PseudoId pseudoId : allPseudoIds) {
                 // `*::marker` selectors are only applicable to elements with `display: list-item`.
                 if (pseudoId == PseudoId::Marker && element->computedStyle()->display() != DisplayType::ListItem)
                     continue;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1554,9 +1554,9 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(co
             }
 
             if (context.pseudoIDSet) {
-                auto pseudoIDs = PseudoIdSet::fromMask(context.pseudoIDSet.data());
+                auto pseudoIDs = context.pseudoIDSet;
 
-                if (pseudoIDs.has(PseudoId::Before)) {
+                if (pseudoIDs.contains(PseudoId::Before)) {
                     pseudoIDs.remove(PseudoId::Before);
                     if (RefPtr beforePseudoElement = descendantElement->beforePseudoElement()) {
                         if (seenNodes.add(*beforePseudoElement))
@@ -1564,7 +1564,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(co
                     }
                 }
 
-                if (pseudoIDs.has(PseudoId::After)) {
+                if (pseudoIDs.contains(PseudoId::After)) {
                     pseudoIDs.remove(PseudoId::After);
                     if (RefPtr afterPseudoElement = descendantElement->afterPseudoElement()) {
                         if (seenNodes.add(*afterPseudoElement))

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1793,7 +1793,7 @@ bool RenderElement::repaintForPausedImageAnimationsIfNeeded(const IntRect& visib
 
 const RenderStyle* RenderElement::getCachedPseudoStyle(const Style::PseudoElementIdentifier& pseudoElementIdentifier, const RenderStyle* parentStyle) const
 {
-    if (pseudoElementIdentifier.pseudoId < PseudoId::FirstInternalPseudoId && !style().hasPseudoStyle(pseudoElementIdentifier.pseudoId))
+    if (allPublicPseudoIds.contains(pseudoElementIdentifier.pseudoId) && !style().hasPseudoStyle(pseudoElementIdentifier.pseudoId))
         return nullptr;
 
     auto* cachedStyle = style().getCachedPseudoStyle(pseudoElementIdentifier);
@@ -1808,7 +1808,7 @@ const RenderStyle* RenderElement::getCachedPseudoStyle(const Style::PseudoElemen
 
 std::unique_ptr<RenderStyle> RenderElement::getUncachedPseudoStyle(const Style::PseudoElementRequest& pseudoElementRequest, const RenderStyle* parentStyle, const RenderStyle* ownStyle) const
 {
-    if (pseudoElementRequest.pseudoId() < PseudoId::FirstInternalPseudoId && !ownStyle && !style().hasPseudoStyle(pseudoElementRequest.pseudoId()))
+    if (allPublicPseudoIds.contains(pseudoElementRequest.pseudoId()) && !ownStyle && !style().hasPseudoStyle(pseudoElementRequest.pseudoId()))
         return nullptr;
 
     if (!parentStyle) {

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -108,11 +108,9 @@ struct SameSizeAsRenderStyle : CanMakeCheckedPtr<SameSizeAsRenderStyle> {
 
 static_assert(sizeof(RenderStyle) == sizeof(SameSizeAsRenderStyle), "RenderStyle should stay small");
 
-static_assert(PublicPseudoIDBits == enumToUnderlyingType(PseudoId::FirstInternalPseudoId) - enumToUnderlyingType(PseudoId::FirstPublicPseudoId));
-
 static_assert(!(static_cast<unsigned>(maxTextTransformValue) >> TextTransformBits));
 
-static_assert(!((enumToUnderlyingType(PseudoId::AfterLastInternalPseudoId) - 1) >> PseudoElementTypeBits));
+static_assert(!(pseudoIdToIndex(PseudoId::Last) >> PseudoElementTypeBits));
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PseudoStyleCache);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(RenderStyle);
@@ -225,8 +223,8 @@ RenderStyle::RenderStyle(CreateDefaultStyleTag)
     m_nonInheritedFlags.firstChildState = false;
     m_nonInheritedFlags.lastChildState = false;
     m_nonInheritedFlags.isLink = false;
-    m_nonInheritedFlags.pseudoElementType = static_cast<unsigned>(PseudoId::None);
-    m_nonInheritedFlags.pseudoBits = static_cast<unsigned>(PseudoId::None);
+    m_nonInheritedFlags.pseudoElementTypeIndex = 0;
+    m_nonInheritedFlags.pseudoBits = 0;
 
     static_assert((sizeof(InheritedFlags) <= 8), "InheritedFlags does not grow");
     static_assert((sizeof(NonInheritedFlags) <= 8), "NonInheritedFlags does not grow");
@@ -3754,7 +3752,7 @@ void RenderStyle::NonInheritedFlags::dumpDifferences(TextStream& ts, const NonIn
     LOG_IF_DIFFERENT(lastChildState);
     LOG_IF_DIFFERENT(isLink);
 
-    LOG_IF_DIFFERENT_WITH_CAST(PseudoId, pseudoElementType);
+    LOG_IF_DIFFERENT_WITH_CAST(unsigned, pseudoElementTypeIndex);
     LOG_IF_DIFFERENT_WITH_CAST(unsigned, pseudoBits);
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -64,7 +64,6 @@ class LayoutSize;
 class LayoutUnit;
 class OutlineValue;
 class PositionArea;
-class PseudoIdSet;
 class RenderElement;
 class RenderStyle;
 class SVGRenderStyle;
@@ -503,8 +502,8 @@ public:
     StyleSelfAlignmentData resolvedJustifySelf(const RenderStyle* parentStyle, ItemPosition normalValueBehavior) const;
     StyleContentAlignmentData resolvedJustifyContent(const StyleContentAlignmentData& normalValueBehavior) const;
 
-    PseudoId pseudoElementType() const { return static_cast<PseudoId>(m_nonInheritedFlags.pseudoElementType); }
-    void setPseudoElementType(PseudoId pseudoElementType) { m_nonInheritedFlags.pseudoElementType = static_cast<unsigned>(pseudoElementType); }
+    PseudoId pseudoElementType() const;
+    void setPseudoElementType(PseudoId);
     const AtomString& pseudoElementNameArgument() const;
     void setPseudoElementNameArgument(const AtomString&);
 
@@ -572,7 +571,7 @@ public:
 
     inline bool hasAnyPublicPseudoStyles() const;
     inline bool hasPseudoStyle(PseudoId) const;
-    inline void setHasPseudoStyles(PseudoIdSet);
+    inline void setHasPseudoStyles(OptionSet<PseudoId>);
 
     inline bool hasDisplayAffectedByAnimations() const;
     inline void setHasDisplayAffectedByAnimations();
@@ -2515,7 +2514,7 @@ private:
 
         inline bool hasAnyPublicPseudoStyles() const;
         bool hasPseudoStyle(PseudoId) const;
-        void setHasPseudoStyles(PseudoIdSet);
+        void setHasPseudoStyles(OptionSet<PseudoId>);
 
 #if !LOG_DISABLED
         void dumpDifferences(TextStream&, const NonInheritedFlags&) const;
@@ -2541,7 +2540,7 @@ private:
         PREFERRED_TYPE(bool) unsigned firstChildState : 1;
         PREFERRED_TYPE(bool) unsigned lastChildState : 1;
         PREFERRED_TYPE(bool) unsigned isLink : 1;
-        PREFERRED_TYPE(PseudoId) unsigned pseudoElementType : PseudoElementTypeBits;
+        PREFERRED_TYPE(unsigned) unsigned pseudoElementTypeIndex : PseudoElementTypeBits;
         unsigned pseudoBits : PublicPseudoIDBits;
         PREFERRED_TYPE(Style::TextDecorationLine) unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element.
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -798,6 +798,7 @@ inline bool RenderStyle::specifiesColumns() const { return !columnCount().isAuto
 constexpr OptionSet<Containment> RenderStyle::strictContainment() { return { Containment::Size, Containment::Layout, Containment::Paint, Containment::Style }; }
 inline const Style::Color& RenderStyle::strokeColor() const { return m_rareInheritedData->strokeColor; }
 inline Style::StrokeMiterlimit RenderStyle::strokeMiterLimit() const { return m_rareInheritedData->miterLimit; }
+inline PseudoId RenderStyle::pseudoElementType() const { return indexToPseudoId(m_nonInheritedFlags.pseudoElementTypeIndex); }
 inline const AtomString& RenderStyle::pseudoElementNameArgument() const { return m_nonInheritedData->rareData->pseudoElementNameArgument; }
 inline const Style::TabSize& RenderStyle::tabSize() const { return m_rareInheritedData->tabSize; }
 inline TableLayoutType RenderStyle::tableLayout() const { return static_cast<TableLayoutType>(m_nonInheritedData->miscData->tableLayout); }
@@ -1045,14 +1046,13 @@ inline Style::SVGBaselineShift RenderStyle::initialBaselineShift() { return CSS:
 
 inline bool RenderStyle::NonInheritedFlags::hasPseudoStyle(PseudoId pseudo) const
 {
-    ASSERT(pseudo > PseudoId::None);
-    ASSERT(pseudo < PseudoId::FirstInternalPseudoId);
-    return pseudoBits & (1 << (static_cast<unsigned>(pseudo) - 1 /* PseudoId::None */));
+    ASSERT(allPublicPseudoIds.contains(pseudo));
+    return OptionSet<PseudoId>::fromRaw(pseudoBits).contains(pseudo);
 }
 
 inline bool RenderStyle::NonInheritedFlags::hasAnyPublicPseudoStyles() const
 {
-    return PublicPseudoIdMask & pseudoBits;
+    return !!pseudoBits;
 }
 
 inline bool RenderStyle::breakOnlyAfterWhiteSpace() const

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -177,7 +177,7 @@ inline void RenderStyle::setHasExplicitlySetPaddingRight(bool value) { SET_NESTE
 inline void RenderStyle::setHasExplicitlySetPaddingTop(bool value) { SET_NESTED(m_nonInheritedData, surroundData, hasExplicitlySetPaddingTop, value); }
 inline void RenderStyle::setHasExplicitlySetStrokeColor(bool value) { SET(m_rareInheritedData, hasSetStrokeColor, static_cast<unsigned>(value)); }
 inline void RenderStyle::setHasExplicitlySetStrokeWidth(bool value) { SET(m_rareInheritedData, hasSetStrokeWidth, static_cast<unsigned>(value)); }
-inline void RenderStyle::setHasPseudoStyles(PseudoIdSet set) { m_nonInheritedFlags.setHasPseudoStyles(set); }
+inline void RenderStyle::setHasPseudoStyles(OptionSet<PseudoId> set) { m_nonInheritedFlags.setHasPseudoStyles(set); }
 inline void RenderStyle::setHasVisitedLinkAutoCaretColor() { SET_PAIR(m_rareInheritedData, hasVisitedLinkAutoCaretColor, true, visitedLinkCaretColor, Style::Color::currentColor()); }
 inline void RenderStyle::setHeight(Style::PreferredSize&& length) { SET_NESTED(m_nonInheritedData, boxData, m_height, WTFMove(length)); }
 inline void RenderStyle::setHyphenateLimitAfter(Style::HyphenateLimitEdge limit) { SET(m_rareInheritedData, hyphenateLimitAfter, limit); }
@@ -442,11 +442,11 @@ inline void RenderStyle::setMarkerStart(Style::SVGMarkerResource&& marker) { SET
 inline void RenderStyle::setMarkerMid(Style::SVGMarkerResource&& marker) { SET_NESTED(m_svgStyle, inheritedResourceData, markerMid, WTFMove(marker)); }
 inline void RenderStyle::setMarkerEnd(Style::SVGMarkerResource&& marker) { SET_NESTED(m_svgStyle, inheritedResourceData, markerEnd, WTFMove(marker)); }
 
-inline void RenderStyle::NonInheritedFlags::setHasPseudoStyles(PseudoIdSet pseudoIdSet)
+inline void RenderStyle::NonInheritedFlags::setHasPseudoStyles(OptionSet<PseudoId> pseudoIdSet)
 {
     ASSERT(pseudoIdSet);
-    ASSERT((pseudoIdSet.data() & PublicPseudoIdMask) == pseudoIdSet.data());
-    pseudoBits |= pseudoIdSet.data() >> 1; // Shift down as we do not store a bit for PseudoId::None.
+    ASSERT(pseudoIdSet.containsOnly(allPublicPseudoIds));
+    pseudoBits = pseudoIdSet.toRaw();
 }
 
 inline void RenderStyle::resetBorder()
@@ -517,6 +517,11 @@ inline void RenderStyle::setPseudoElementNameArgument(const AtomString& identifi
         || pseudoElementType() == PseudoId::Highlight
         || identifier.isNull());
     SET_NESTED(m_nonInheritedData, rareData, pseudoElementNameArgument, identifier);
+}
+
+inline void RenderStyle::setPseudoElementType(PseudoId pseudoElementType)
+{
+    m_nonInheritedFlags.pseudoElementTypeIndex = pseudoIdToIndex(pseudoElementType);
 }
 
 inline void RenderStyle::setGridTemplateColumns(Style::GridTemplateList&& list)

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -570,7 +570,7 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
             specificity = selector->computeSpecificity();
     }
 
-    m_matchedPseudoElementIds.merge(context.pseudoIDSet);
+    m_matchedPseudoElementIds.add(context.pseudoIDSet);
     m_styleRelations.appendVector(context.styleRelations);
 
     return selectorMatches;

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -72,7 +72,7 @@ public:
 
     void clearMatchedRules();
 
-    const PseudoIdSet& matchedPseudoElementIds() const { return m_matchedPseudoElementIds; }
+    OptionSet<PseudoId> matchedPseudoElementIds() const { return m_matchedPseudoElementIds; }
     const Relations& styleRelations() const { return m_styleRelations; }
 
     void addAuthorKeyframeRules(const StyleRuleKeyframe&);
@@ -135,7 +135,7 @@ private:
     Vector<RefPtr<const StyleRule>> m_matchedRuleList;
     Ref<MatchResult> m_result;
     Relations m_styleRelations;
-    PseudoIdSet m_matchedPseudoElementIds;
+    OptionSet<PseudoId> m_matchedPseudoElementIds;
 };
 
 }

--- a/Source/WebCore/style/PseudoElementIdentifier.h
+++ b/Source/WebCore/style/PseudoElementIdentifier.h
@@ -79,10 +79,10 @@ struct HashTraits<WebCore::Style::PseudoElementIdentifier> : GenericHashTraits<W
     typedef WebCore::Style::PseudoElementIdentifier EmptyValueType;
 
     static constexpr bool emptyValueIsZero = false;
-    static EmptyValueType emptyValue() { return WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::AfterLastInternalPseudoId, nullAtom() }; }
+    static EmptyValueType emptyValue() { return WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::None, nullAtom() }; }
 
-    static void constructDeletedValue(WebCore::Style::PseudoElementIdentifier& pseudoElementIdentifier) { pseudoElementIdentifier = WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::None, nullAtom() }; }
-    static bool isDeletedValue(const WebCore::Style::PseudoElementIdentifier& pseudoElementIdentifier) { return pseudoElementIdentifier == WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::None, nullAtom() }; }
+    static void constructDeletedValue(WebCore::Style::PseudoElementIdentifier& identifer) { new (NotNull, &identifer.nameArgument) AtomString { HashTableDeletedValue }; }
+    static bool isDeletedValue(const WebCore::Style::PseudoElementIdentifier& identifer) { return identifer.nameArgument.isHashTableDeletedValue(); }
 };
 
 template<>
@@ -97,10 +97,16 @@ struct HashTraits<std::optional<WebCore::Style::PseudoElementIdentifier>> : Gene
     typedef std::optional<WebCore::Style::PseudoElementIdentifier> EmptyValueType;
 
     static constexpr bool emptyValueIsZero = false;
-    static EmptyValueType emptyValue() { return WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::AfterLastInternalPseudoId, nullAtom() }; }
+    static EmptyValueType emptyValue() { return WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::None, nullAtom() }; }
 
-    static void constructDeletedValue(std::optional<WebCore::Style::PseudoElementIdentifier>& pseudoElementIdentifier) { pseudoElementIdentifier = WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::None, nullAtom() }; }
-    static bool isDeletedValue(const std::optional<WebCore::Style::PseudoElementIdentifier>& pseudoElementIdentifier) { return pseudoElementIdentifier == WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::None, nullAtom() }; }
+    static void constructDeletedValue(std::optional<WebCore::Style::PseudoElementIdentifier>& identifer)
+    {
+        HashTraits<WebCore::Style::PseudoElementIdentifier>::constructDeletedValue(identifer.emplace());
+    }
+    static bool isDeletedValue(const std::optional<WebCore::Style::PseudoElementIdentifier>& identifer)
+    {
+        return identifer && HashTraits<WebCore::Style::PseudoElementIdentifier>::isDeletedValue(*identifer);
+    }
 };
 
 template<>


### PR DESCRIPTION
#### 025a073a16932ba56ae675a5358329533a6bca80
<pre>
Replace PseudoIdSet with OptionSet&lt;PseudoId&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=300396">https://bugs.webkit.org/show_bug.cgi?id=300396</a>
<a href="https://rdar.apple.com/162214153">rdar://162214153</a>

Reviewed by NOBODY (OOPS!).

Get rid of the PseudoIdSet class.

* Source/WTF/wtf/OptionSet.h:
(WTF::OptionSet::storageMemoryOffset):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::match const):
(WebCore::SelectorChecker::matchHostPseudoClass const):
(WebCore::hasViewTransitionPseudoElement):
(WebCore::hasScrollbarPseudoElement):
(WebCore::SelectorChecker::matchRecursively const):
(WebCore::SelectorChecker::checkOne const):
(WebCore::SelectorChecker::matchSelectorList const):
(WebCore::SelectorChecker::matchHasPseudoClass const):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateMarkPseudoStyleForPseudoElement):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getMatchedStylesForNode):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::highlightSelector):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::getCachedPseudoStyle const):
(WebCore::RenderElement::getUncachedPseudoStyle const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::RenderStyle):
(WebCore::RenderStyle::NonInheritedFlags::dumpDifferences const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.h:

Make the PseudoId directly usable as bitmask.

(WebCore::pseudoIdToIndex):
(WebCore::indexToPseudoId):

Add functions for converting to compact representation to use in the RenderStyle bitfield.

(WebCore::PseudoIdSet::PseudoIdSet): Deleted.
(WebCore::PseudoIdSet::fromMask): Deleted.
(WebCore::PseudoIdSet::has const): Deleted.
(WebCore::PseudoIdSet::add): Deleted.
(WebCore::PseudoIdSet::remove): Deleted.
(WebCore::PseudoIdSet::merge): Deleted.
(WebCore::PseudoIdSet::operator &amp; const): Deleted.
(WebCore::PseudoIdSet::operator | const): Deleted.
(WebCore::PseudoIdSet::operator bool const): Deleted.
(WebCore::PseudoIdSet::data const): Deleted.
(WebCore::PseudoIdSet::dataMemoryOffset): Deleted.
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::pseudoElementType const):
(WebCore::RenderStyle::NonInheritedFlags::hasPseudoStyle const):
(WebCore::RenderStyle::NonInheritedFlags::hasAnyPublicPseudoStyles const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setHasPseudoStyles):
(WebCore::RenderStyle::NonInheritedFlags::setHasPseudoStyles):
(WebCore::RenderStyle::setPseudoElementType):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ruleMatches):
* Source/WebCore/style/ElementRuleCollector.h:
(WebCore::Style::ElementRuleCollector::matchedPseudoElementIds const):
* Source/WebCore/style/PseudoElementIdentifier.h:
(WTF::HashTraits&lt;WebCore::Style::PseudoElementIdentifier&gt;::emptyValue):
(WTF::HashTraits&lt;WebCore::Style::PseudoElementIdentifier&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebCore::Style::PseudoElementIdentifier&gt;::isDeletedValue):
(WTF::HashTraits&lt;std::optional&lt;WebCore::Style::PseudoElementIdentifier&gt;&gt;::emptyValue):
(WTF::HashTraits&lt;std::optional&lt;WebCore::Style::PseudoElementIdentifier&gt;&gt;::constructDeletedValue):
(WTF::HashTraits&lt;std::optional&lt;WebCore::Style::PseudoElementIdentifier&gt;&gt;::isDeletedValue):

Use AtomString hash table deleted value so we don&apos;t need special enum values.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/025a073a16932ba56ae675a5358329533a6bca80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132659 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77667 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28393cae-0e5f-44c4-84a2-dfca9ea0c720) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95828 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63945 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112485 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76321 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7967660a-83f8-49b9-b4c3-9b8cd22aae19) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30669 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76129 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117872 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106665 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135338 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124298 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104294 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104022 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49389 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27708 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49908 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52473 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58282 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157311 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51821 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39386 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55170 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53515 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->