### PR TITLE
Fix background-shorthand-serialization.html WPT expectations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-shorthand-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-shorthand-serialization-expected.txt
@@ -2,8 +2,8 @@
 PASS single value
 PASS multiple values
 PASS multiple backgrounds
-FAIL background-size with non-initial background-position assert_equals: expected "url(\"/favicon.ico\") 0% 0% / 10rem" but got "url(\"/favicon.ico\") 0% 0% / 10rem auto"
-FAIL multiple backgrounds with varying values assert_equals: expected "url(\"/favicon.ico\") left top no-repeat, url(\"/favicon.ico\") center center / 100% 100% no-repeat, white url(\"/favicon.ico\")" but got "url(\"/favicon.ico\") left top no-repeat, url(\"/favicon.ico\") center center / 100% 100% no-repeat, url(\"/favicon.ico\") white"
+PASS background-size with non-initial background-position
+PASS multiple backgrounds with varying values
 PASS all initial values
 PASS border-area border-box
 PASS border-area padding-box

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-shorthand-serialization.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-shorthand-serialization.html
@@ -29,14 +29,15 @@
 
   test((t) => {
     element.style = 'background: url("/favicon.ico") 0% 0% / 10rem;';
-    assert_equals(element.style.background , 'url("/favicon.ico") 0% 0% / 10rem');
+    // background-size should always serialize to two values per https://github.com/w3c/csswg-drafts/issues/7802
+    assert_equals(element.style.background , 'url("/favicon.ico") 0% 0% / 10rem auto');
   }, "background-size with non-initial background-position");
 
   test((t) => {
     element.style = `background: url(/favicon.ico) top left no-repeat,
         url(/favicon.ico) center / 100% 100% no-repeat,
         url(/favicon.ico) white;`;
-    assert_equals(element.style.background , 'url("/favicon.ico") left top no-repeat, url("/favicon.ico") center center / 100% 100% no-repeat, white url("/favicon.ico")');
+    assert_equals(element.style.background , 'url("/favicon.ico") left top no-repeat, url("/favicon.ico") center center / 100% 100% no-repeat, url("/favicon.ico") white');
   }, "multiple backgrounds with varying values");
 
   test((t) => {


### PR DESCRIPTION
#### cdce9dcdd68a7cc1f5e5d8b9b1955d43d0b6e199
<pre>
Fix background-shorthand-serialization.html WPT expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=299912">https://bugs.webkit.org/show_bug.cgi?id=299912</a>
<a href="https://rdar.apple.com/162156366">rdar://162156366</a>

Reviewed by Darin Adler.

Change incorrect WPT expectations:

- First failure: background-size should always serialize to 2 values as per <a href="https://github.com/w3c/csswg-drafts/issues/7802">https://github.com/w3c/csswg-drafts/issues/7802</a>
- Second failure: in canonical order, background-color is last in the background shorthand syntax as per <a href="https://drafts.csswg.org/css-backgrounds/#typedef-final-bg-layer">https://drafts.csswg.org/css-backgrounds/#typedef-final-bg-layer</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-shorthand-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-shorthand-serialization.html:

Canonical link: <a href="https://commits.webkit.org/301362@main">https://commits.webkit.org/301362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a55c4f502865ec089f45349086ccdb29dc66bfed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132592 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77612 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c746ae3-e8e8-460e-aa73-5cce38f0e61d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95786 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8665cc7a-b461-42f3-94d8-ce5f66fb25de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76278 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0da874a0-5849-43d0-ae1d-54869a21ad9b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30620 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76063 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135272 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40276 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104252 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103980 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49344 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27660 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49792 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19680 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52413 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51762 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55112 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53457 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->