### PR TITLE
[LCP] Various minor LargestContentfulPaint optimizations

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4426,9 +4426,8 @@ void Document::enqueuePaintTimingEntryIfNeeded()
     };
 
     auto enqueueLargestContentfulPaintIfNecessary = [&]() {
-        WTFEmitSignpost(this, NavigationAndPaintTiming, "largestContentfulPaint");
-
         if (RefPtr entry = largestContentfulPaintData().takePendingEntry(nowTime)) {
+            WTFEmitSignpost(this, NavigationAndPaintTiming, "largestContentfulPaint");
             Ref entryRef = entry.releaseNonNull();
             protectedWindow()->performance().reportLargestContentfulPaint(WTFMove(entryRef));
         }

--- a/Source/WebCore/page/LargestContentfulPaintData.h
+++ b/Source/WebCore/page/LargestContentfulPaintData.h
@@ -61,14 +61,14 @@ public:
 
 private:
 
-    static std::optional<float> effectiveVisualArea(const Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intersectionRect);
+    static std::optional<float> effectiveVisualArea(const Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intersectionRect, FloatSize viewportSize);
 
     static FloatRect computeViewportIntersectionRect(Element&, FloatRect localRect);
     static FloatRect computeViewportIntersectionRectForTextContainer(Element&, const WeakHashSet<Text, WeakPtrImplWithEventTargetData>&);
 
     static bool isEligibleForLargestContentfulPaint(const Element&, float effectiveVisualArea);
 
-    void potentiallyAddLargestContentfulPaintEntry(Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intsectionRect, MonotonicTime loadTime, DOMHighResTimeStamp paintTime);
+    void potentiallyAddLargestContentfulPaintEntry(Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intersectionRect, MonotonicTime loadTime, DOMHighResTimeStamp paintTimestamp, std::optional<FloatSize>& viewportSize);
 
     float m_largestPaintArea { 0 };
 


### PR DESCRIPTION
#### 7630c1e345cce01b7e56dc6fc512d416f68cadd4
<pre>
[LCP] Various minor LargestContentfulPaint optimizations
<a href="https://bugs.webkit.org/show_bug.cgi?id=300554">https://bugs.webkit.org/show_bug.cgi?id=300554</a>
<a href="https://rdar.apple.com/162440439">rdar://162440439</a>

Reviewed by Tim Nguyen.

Cache the value of visualViewportRect().size() for each call to `LargestContentfulPaintData::takePendingEntry()`,
since computing this is somewhat expensive.

Move `isExposedForPaintTiming()` checks to after the cheaper tests for set membership.

Bail from `didPaintText` when the rect is empty, which is quite common in Speedo.

`Document::enqueuePaintTimingEntryIfNeeded()` should only emit the log when there is an LCP entry.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::enqueuePaintTimingEntryIfNeeded):
* Source/WebCore/page/LargestContentfulPaintData.cpp:
(WebCore::LargestContentfulPaintData::effectiveVisualArea):
(WebCore::LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry):
(WebCore::LargestContentfulPaintData::takePendingEntry):
(WebCore::LargestContentfulPaintData::computeViewportIntersectionRect):
(WebCore::LargestContentfulPaintData::didLoadImage):
(WebCore::LargestContentfulPaintData::didPaintImage):
(WebCore::LargestContentfulPaintData::didPaintText):
* Source/WebCore/page/LargestContentfulPaintData.h:

Canonical link: <a href="https://commits.webkit.org/301363@main">https://commits.webkit.org/301363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/879950fdb2c4e2c391c131213be914d45fdd865c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77615 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/80a23db4-4f63-4639-8646-e031ad3eb329) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95787 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63907 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a25c39d0-7a5c-4556-a63b-b20d353b61e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112435 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76279 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d817852-21c2-4b51-af38-7ff08f820671) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30621 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76066 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106618 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135275 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104253 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52969 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103981 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26482 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27661 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49798 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52416 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58223 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51765 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55115 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53460 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->