### PR TITLE
Use MTLSetShaderCachePath to allow WKTR to reach the MTLCompilerCache

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
@@ -70,6 +70,8 @@ struct GPUProcessCreationParameters {
 
     Vector<String> overrideLanguages;
 #if PLATFORM(COCOA)
+    std::optional<WebKit::SandboxExtensionHandle> overrideMetalShaderCacheHandle;
+    String overrideMetalShaderCachePath;
     bool enableMetalDebugDeviceForTesting { false };
     bool enableMetalShaderValidationForTesting { false };
 #if ENABLE(VP9)

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in
@@ -53,6 +53,8 @@
 
     Vector<String> overrideLanguages;
 #if PLATFORM(COCOA)
+    std::optional<WebKit::SandboxExtensionHandle> overrideMetalShaderCacheHandle;
+    String overrideMetalShaderCachePath;
     bool enableMetalDebugDeviceForTesting;
     bool enableMetalShaderValidationForTesting;
 #if ENABLE(VP9)

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -152,6 +152,12 @@ void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters& para
 
 #if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS) && USE(EXTENSIONKIT)
     MTLSetShaderCachePath(parameters.containerCachesDirectory.createNSString().get());
+#elif PLATFORM(MAC)
+    if (auto handle = parameters.overrideMetalShaderCacheHandle) {
+        SandboxExtension::consumePermanently(*handle);
+        auto& path = parameters.overrideMetalShaderCachePath;
+        MTLSetShaderCachePath([NSString stringWithUTF8String:path.utf8().data()]);
+    }
 #endif
 
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -570,6 +570,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     WebKit::GPUProcessProxy::setEnableMetalShaderValidationInNewGPUProcessesForTesting(enable);
 }
 
++ (void)_setEnableMetalShaderCacheOverridenForTesting:(BOOL)enable
+{
+    WebKit::GPUProcessProxy::setEnableMetalShaderCacheOverriden(enable);
+}
+
 + (BOOL)_isMetalDebugDeviceEnabledInGPUProcessForTesting
 {
     if (RefPtr gpuProcess = WebKit::GPUProcessProxy::singletonIfCreated())

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -168,6 +168,7 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 // Test only. Should be called before a GPU process has been launched.
 + (void)_setEnableMetalDebugDeviceInNewGPUProcessesForTesting:(BOOL)enable WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 + (void)_setEnableMetalShaderValidationInNewGPUProcessesForTesting:(BOOL)enable WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
++ (void)_setEnableMetalShaderCacheOverridenForTesting:(BOOL)enable WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 + (BOOL)_isMetalDebugDeviceEnabledInGPUProcessForTesting WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 + (BOOL)_isMetalShaderValidationEnabledInGPUProcessForTesting WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 

--- a/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
@@ -48,6 +48,7 @@ namespace WebKit {
 
 bool GPUProcessProxy::s_enableMetalDebugDeviceInNewGPUProcessesForTesting { false };
 bool GPUProcessProxy::s_enableMetalShaderValidationInNewGPUProcessesForTesting { false };
+bool GPUProcessProxy::s_enableMetalShaderCacheOverriden { false };
 
 void GPUProcessProxy::platformInitializeGPUProcessParameters(GPUProcessCreationParameters& parameters)
 {
@@ -58,6 +59,11 @@ void GPUProcessProxy::platformInitializeGPUProcessParameters(GPUProcessCreationP
     if (auto launchServicesExtensionHandle = SandboxExtension::createHandleForMachLookup("com.apple.coreservices.launchservicesd"_s, std::nullopt))
         parameters.launchServicesExtensionHandle = WTFMove(*launchServicesExtensionHandle);
 #endif
+    if (m_isMetalShaderCacheOverriden) {
+        parameters.overrideMetalShaderCachePath = WebsiteDataStore::defaultResolvedContainerTemporaryDirectory();
+        parameters.overrideMetalShaderCachePath = String([parameters.overrideMetalShaderCachePath.createNSString().get() stringByDeletingLastPathComponent]);
+        parameters.overrideMetalShaderCacheHandle = SandboxExtension::createHandleWithoutResolvingPath(parameters.overrideMetalShaderCachePath, SandboxExtension::Type::ReadWrite);
+    }
     parameters.enableMetalDebugDeviceForTesting = m_isMetalDebugDeviceEnabledForTesting;
     parameters.enableMetalShaderValidationForTesting = m_isMetalShaderValidationEnabledForTesting;
 }

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -210,6 +210,7 @@ GPUProcessProxy::GPUProcessProxy()
 #if PLATFORM(COCOA)
     m_isMetalDebugDeviceEnabledForTesting = s_enableMetalDebugDeviceInNewGPUProcessesForTesting;
     m_isMetalShaderValidationEnabledForTesting = s_enableMetalShaderValidationInNewGPUProcessesForTesting;
+    m_isMetalShaderCacheOverriden = s_enableMetalShaderCacheOverriden;
     if (s_gpuProcessMediaCodecCapabilities) {
 #if ENABLE(VP9)
         parameters.hasVP9HardwareDecoder = s_gpuProcessMediaCodecCapabilities->hasVP9HardwareDecoder;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -152,6 +152,7 @@ public:
     static bool isMetalShaderValidationEnabledInNewGPUProcessesForTesting() { return s_enableMetalShaderValidationInNewGPUProcessesForTesting; }
     bool isMetalDebugDeviceEnabledForTesting() const { return m_isMetalDebugDeviceEnabledForTesting; }
     bool isMetalShaderValidationEnabledForTesting() const { return m_isMetalShaderValidationEnabledForTesting; }
+    static void setEnableMetalShaderCacheOverriden(bool enable) { s_enableMetalShaderCacheOverriden = enable; }
 #endif
 
 #if ENABLE(VIDEO)
@@ -254,6 +255,7 @@ private:
     bool m_hasSentGPUToolsSandboxExtensions { false };
     bool m_isMetalDebugDeviceEnabledForTesting { false };
     bool m_isMetalShaderValidationEnabledForTesting { false };
+    bool m_isMetalShaderCacheOverriden { false };
 #endif
 
 #if HAVE(SCREEN_CAPTURE_KIT)
@@ -263,6 +265,7 @@ private:
 #if PLATFORM(COCOA)
     static bool s_enableMetalDebugDeviceInNewGPUProcessesForTesting;
     static bool s_enableMetalShaderValidationInNewGPUProcessesForTesting;
+    static bool s_enableMetalShaderCacheOverriden;
 #endif
 
     HashSet<PAL::SessionID> m_sessionIDs;

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -960,6 +960,20 @@ UnifiedOriginStorageLevel WebsiteDataStore::defaultUnifiedOriginStorageLevel()
     return UnifiedOriginStorageLevel::Standard;
 }
 
+#if PLATFORM(COCOA)
+
+String WebsiteDataStore::defaultResolvedContainerTemporaryDirectory()
+{
+    static NeverDestroyed<String> resolvedTemporaryDirectory;
+    static std::once_flag once;
+    std::call_once(once, [] {
+        resolvedTemporaryDirectory.get() = resolveAndCreateReadWriteDirectoryForSandboxExtension(String(NSTemporaryDirectory()));
+    });
+    return resolvedTemporaryDirectory;
+}
+
+#endif
+
 #if PLATFORM(IOS_FAMILY)
 
 String WebsiteDataStore::cacheDirectoryInContainerOrHomeDirectory(const String& subpath)
@@ -1013,16 +1027,6 @@ String WebsiteDataStore::resolvedContainerTemporaryDirectory()
         m_resolvedContainerTemporaryDirectory = defaultResolvedContainerTemporaryDirectory();
 
     return m_resolvedContainerTemporaryDirectory;
-}
-
-String WebsiteDataStore::defaultResolvedContainerTemporaryDirectory()
-{
-    static NeverDestroyed<String> resolvedTemporaryDirectory;
-    static std::once_flag once;
-    std::call_once(once, [] {
-        resolvedTemporaryDirectory.get() = resolveAndCreateReadWriteDirectoryForSandboxExtension(String(NSTemporaryDirectory()));
-    });
-    return resolvedTemporaryDirectory;
 }
 
 void WebsiteDataStore::setBackupExclusionPeriodForTesting(Seconds period, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -194,10 +194,11 @@ public:
 #if PLATFORM(IOS_FAMILY)
     String resolvedCookieStorageDirectory();
     String resolvedContainerTemporaryDirectory();
-    static String defaultResolvedContainerTemporaryDirectory();
     static String cacheDirectoryInContainerOrHomeDirectory(const String& subpath);
 #endif
-
+#if PLATFORM(COCOA)
+    static String defaultResolvedContainerTemporaryDirectory();
+#endif
     void clearResourceLoadStatisticsInWebProcesses(CompletionHandler<void()>&&);
     void setUserAgentStringQuirkForTesting(const String& domain, const String& userAgentString, CompletionHandler<void()>&&);
     void setPrivateTokenIPCForTesting(bool enabled);


### PR DESCRIPTION
#### dd7de1200061fc0b7fe208f8c4a280fa37bd2bd1
<pre>
Use MTLSetShaderCachePath to allow WKTR to reach the MTLCompilerCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=300558">https://bugs.webkit.org/show_bug.cgi?id=300558</a>
<a href="https://rdar.apple.com/162388681">rdar://162388681</a>

Reviewed by NOBODY (OOPS!).

WKTR was not reaching the MTLCompilerCache due to the way it spawns
multiple processes and has a unique temporary directory.

Instead point the MTLCompilerService to a path which is consistent
across invocations.

Locally, http/tests/webgpu/webgpu/api/validation/render_pipeline/resource_compatibility.html
went from 25s to 15s on an M2 Mac Studio

* Source/WebKit/GPUProcess/GPUProcessCreationParameters.h:
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in:
* Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm:
(WebKit::GPUProcess::platformInitializeGPUProcess):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(+[WKProcessPool _setEnableMetalShaderCacheOverridenForTesting:]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm:
(WebKit::GPUProcessProxy::platformInitializeGPUProcessParameters):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::GPUProcessProxy):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::defaultResolvedContainerTemporaryDirectory):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd7de1200061fc0b7fe208f8c4a280fa37bd2bd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77620 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d325262-06b5-4dff-8b8c-37943b81c38c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53959 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95793 "16 failures") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63910 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f427146-00d6-4d08-8586-2a82a4f901fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112446 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76285 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ceeb7df6-94d2-40ce-b99e-13618c37bb10) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35746 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76073 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135282 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104257 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103985 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49352 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27670 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49805 "Hash dd7de120 for PR 52179 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52421 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58230 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51770 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55120 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53465 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->