### PR TITLE
Adopt LIFETIME_BOUND for WTF::Ref

### DIFF
--- a/Source/JavaScriptCore/API/JSWeakObjectMapRefPrivate.cpp
+++ b/Source/JavaScriptCore/API/JSWeakObjectMapRefPrivate.cpp
@@ -44,7 +44,7 @@ JSWeakObjectMapRef JSWeakObjectMapCreate(JSContextRef context, void* privateData
     JSLockHolder locker(vm);
     auto map = OpaqueJSWeakObjectMap::create(vm, privateData, callback);
     globalObject->registerWeakMap(map.ptr());
-    return map.ptr();
+    return map.unsafePtr();
 }
 
 void JSWeakObjectMapSet(JSContextRef ctx, JSWeakObjectMapRef map, void* key, JSObjectRef object)

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FunctionIPIntMetadataGenerator);
 const RTT* FunctionIPIntMetadataGenerator::addSignature(const TypeDefinition& signature)
 {
     // This is held by wasm module.
-    return TypeInformation::getCanonicalRTT(signature.index()).ptr();
+    return TypeInformation::getCanonicalRTT(signature.index()).unsafePtr();
 }
 
 void FunctionIPIntMetadataGenerator::setTailCall(uint32_t functionIndex, bool isImportedFunctionFromFunctionIndexSpace)

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -560,7 +560,7 @@ const TypeDefinition& TypeDefinition::unrollSlow() const
         Ref unrolled = underlyingType.replacePlaceholders(projectee.index());
         TypeInformation::addCachedUnrolling(index(), unrolled);
         RELEASE_ASSERT(unrolled->refCount() > 2); // TypeInformation registry + Ref + owner (unrolling cache).
-        return unrolled; // TypeInformation unrolling cache now owns, with lifetime tied to 'this'.
+        return unrolled.unsafeGet(); // TypeInformation unrolling cache now owns, with lifetime tied to 'this'.
     }
     RELEASE_ASSERT(underlyingType.refCount() > 1); // TypeInformation registry + owner(s).
     return underlyingType;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -528,7 +528,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         // this point when we know which memory mode to use.
         Wasm::CalleeGroup* calleeGroup = m_instance->calleeGroup();
         if (!calleeGroup || !calleeGroup->runnable()) {
-            calleeGroup = m_instance->module().compileSync(vm, m_instance->memory()->mode()).ptr();
+            calleeGroup = m_instance->module().compileSync(vm, m_instance->memory()->mode()).unsafePtr();
             if (!calleeGroup->runnable())
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, calleeGroup->errorMessage()));
         }

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -129,13 +129,15 @@ public:
     bool isHashTableEmptyValue() const { return m_ptr == hashTableEmptyValue(); }
     static T* hashTableEmptyValue() { return nullptr; }
 
-    const T* ptrAllowingHashTableEmptyValue() const { ASSERT(m_ptr || isHashTableEmptyValue()); return PtrTraits::unwrap(m_ptr); }
-    T* ptrAllowingHashTableEmptyValue() { ASSERT(m_ptr || isHashTableEmptyValue()); return PtrTraits::unwrap(m_ptr); }
+    const T* ptrAllowingHashTableEmptyValue() const LIFETIME_BOUND { ASSERT(m_ptr || isHashTableEmptyValue()); return PtrTraits::unwrap(m_ptr); }
+    T* ptrAllowingHashTableEmptyValue() LIFETIME_BOUND { ASSERT(m_ptr || isHashTableEmptyValue()); return PtrTraits::unwrap(m_ptr); }
 
-    T* operator->() const { ASSERT(m_ptr); return PtrTraits::unwrap(m_ptr); }
-    T* ptr() const RETURNS_NONNULL { ASSERT(m_ptr); return PtrTraits::unwrap(m_ptr); }
-    T& get() const { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
-    operator T&() const { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
+    T* operator->() const LIFETIME_BOUND { ASSERT(m_ptr); return PtrTraits::unwrap(m_ptr); }
+    T* ptr() const LIFETIME_BOUND RETURNS_NONNULL { ASSERT(m_ptr); return PtrTraits::unwrap(m_ptr); }
+    T* unsafePtr() const RETURNS_NONNULL { ASSERT(m_ptr); return PtrTraits::unwrap(m_ptr); } // FIXME: Replace with ptr() then remove.
+    T& get() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
+    T& unsafeGet() const { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); } // FIXME: Replace with get() then remove.
+    operator T&() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
     bool operator!() const { ASSERT(m_ptr); return !*m_ptr; }
 
     template<typename X, typename Y, typename Z> Ref<T, PtrTraits, RefDerefTraits> replace(Ref<X, Y, Z>&&) WARN_UNUSED_RETURN;

--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -75,7 +75,7 @@ protected:
 #if USE(COCOA_EVENT_LOOP)
     const OSObjectPtr<dispatch_queue_t> m_dispatchQueue;
 #else
-    RunLoop* m_runLoop;
+    RefPtr<RunLoop> m_runLoop;
 #endif
     uint32_t m_threadID { 0 };
 private:

--- a/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
+++ b/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
@@ -35,14 +35,14 @@
 namespace WTF {
 
 WorkQueueBase::WorkQueueBase(RunLoop& runLoop)
-    : m_runLoop(&runLoop)
+    : m_runLoop(runLoop)
     , m_threadID(mainThreadID)
 {
 }
 
 void WorkQueueBase::platformInitialize(ASCIILiteral name, Type, QOS qos)
 {
-    m_runLoop = RunLoop::create(name, ThreadType::Unknown, qos).ptr();
+    m_runLoop = RunLoop::create(name, ThreadType::Unknown, qos);
     BinarySemaphore semaphore;
     m_runLoop->dispatch([&] {
         m_threadID = Thread::currentSingleton().uid();
@@ -54,7 +54,7 @@ void WorkQueueBase::platformInitialize(ASCIILiteral name, Type, QOS qos)
 void WorkQueueBase::platformInvalidate()
 {
     if (m_runLoop) {
-        Ref<RunLoop> protector(*m_runLoop);
+        Ref<RunLoop> protector = m_runLoop.releaseNonNull();
         protector->stop();
         protector->dispatch([] {
             RunLoop::currentSingleton().stop();

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp
@@ -145,7 +145,7 @@ UniqueIDBDatabaseTransaction& UniqueIDBDatabaseConnection::createVersionChangeTr
     Ref<UniqueIDBDatabaseTransaction> transaction = UniqueIDBDatabaseTransaction::create(*this, info);
     m_transactionMap.set(transaction->info().identifier(), &transaction.get());
 
-    return transaction.get();
+    return transaction.unsafeGet();
 }
 
 void UniqueIDBDatabaseConnection::establishTransaction(const IDBTransactionInfo& info)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -390,7 +390,7 @@ RTCRtpTransceiver& LibWebRTCPeerConnectionBackend::newRemoteTransceiver(std::uni
     auto receiver = createReceiver(transceiverBackend->createReceiverBackend());
     auto transceiver = RTCRtpTransceiver::create(WTFMove(sender), WTFMove(receiver), WTFMove(transceiverBackend));
     peerConnection->addInternalTransceiver(transceiver.copyRef());
-    return transceiver.get();
+    return transceiver.unsafeGet();
 }
 
 void LibWebRTCPeerConnectionBackend::collectTransceivers()

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -465,7 +465,7 @@ AXCoreObject* AXCoreObject::nextInPreOrder(bool updateChildrenIfNeeded , AXCoreO
         if (role != AccessibilityRole::Column && role != AccessibilityRole::TableHeaderContainer) {
             // Table columns and header containers add cells despite not being their "true" parent (which are the rows).
             // Don't allow a pre-order traversal of these object types to return cells to avoid an infinite loop.
-            return children[0].ptr();
+            return children[0].unsafePtr();
         }
     }
 
@@ -510,7 +510,7 @@ AXCoreObject* AXCoreObject::deepestLastChildIncludingIgnored(bool updateChildren
             break;
         deepestChild = descendants[descendants.size() - 1];
     }
-    return deepestChild.ptr();
+    return deepestChild.unsafePtr();
 }
 
 size_t AXCoreObject::indexInSiblings(const AccessibilityChildrenVector& siblings) const
@@ -543,7 +543,7 @@ AXCoreObject* AXCoreObject::nextSiblingIncludingIgnored(bool updateChildrenIfNee
     if (indexOfThis == notFound)
         return nullptr;
 
-    return indexOfThis + 1 < siblings.size() ? siblings[indexOfThis + 1].ptr() : nullptr;
+    return indexOfThis + 1 < siblings.size() ? siblings[indexOfThis + 1].unsafePtr() : nullptr;
 }
 
 AXCoreObject* AXCoreObject::previousSiblingIncludingIgnored(bool updateChildrenIfNeeded)
@@ -576,7 +576,7 @@ AXCoreObject* AXCoreObject::nextUnignoredSibling(bool updateChildrenIfNeeded, AX
     if (indexOfThis == notFound)
         return nullptr;
 
-    return indexOfThis + 1 < siblings.size() ? siblings[indexOfThis + 1].ptr() : nullptr;
+    return indexOfThis + 1 < siblings.size() ? siblings[indexOfThis + 1].unsafePtr() : nullptr;
 }
 
 AXCoreObject* AXCoreObject::nextSiblingIncludingIgnoredOrParent() const
@@ -1125,7 +1125,7 @@ AXCoreObject* AXCoreObject::rowHeader()
     for (const auto& child : rowChildren) {
         // We found a non-header cell, so this is not an entire row of headers -- return the original header cell.
         if (!isARIAGridRow && !child->hasElementName(ElementName::HTML_th))
-            return firstCell.ptr();
+            return firstCell.unsafePtr();
 
         // For grid rows, the first header encountered is the row header.
         if (isARIAGridRow && child->isRowHeader())
@@ -1499,7 +1499,7 @@ AXCoreObject* AXCoreObject::activeDescendant() const
     auto activeDescendants = relatedObjects(AXRelation::ActiveDescendant);
     ASSERT(activeDescendants.size() <= 1);
     if (!activeDescendants.isEmpty())
-        return activeDescendants[0].ptr();
+        return activeDescendants[0].unsafePtr();
     return nullptr;
 }
 
@@ -1714,9 +1714,9 @@ AXCoreObject* AXCoreObject::titleUIElement() const
 #if PLATFORM(COCOA)
     // We impose the restriction that if there is more than one label, then we should return none.
     // FIXME: the behavior should be the same in all platforms.
-    return labels.size() == 1 ? labels.first().ptr() : nullptr;
+    return labels.size() == 1 ? labels.first().unsafePtr() : nullptr;
 #else
-    return labels.size() ? labels.first().ptr() : nullptr;
+    return labels.size() ? labels.first().unsafePtr() : nullptr;
 #endif
 }
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -835,7 +835,7 @@ AccessibilityObject* AXObjectCache::getOrCreate(RenderObject& renderer)
     if (object->isDetached())
         return nullptr;
 
-    return object.ptr();
+    return object.unsafePtr();
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -279,7 +279,7 @@ AXCoreObject* AccessibilityMathMLElement::mathRootIndexObject()
     if (children.size() < 2)
         return nullptr;
 
-    return children[1].ptr();
+    return children[1].unsafePtr();
 }
 
 AXCoreObject* AccessibilityMathMLElement::mathNumeratorObject()
@@ -291,7 +291,7 @@ AXCoreObject* AccessibilityMathMLElement::mathNumeratorObject()
     if (children.size() != 2)
         return nullptr;
 
-    return children[0].ptr();
+    return children[0].unsafePtr();
 }
 
 AXCoreObject* AccessibilityMathMLElement::mathDenominatorObject()
@@ -303,7 +303,7 @@ AXCoreObject* AccessibilityMathMLElement::mathDenominatorObject()
     if (children.size() != 2)
         return nullptr;
 
-    return children[1].ptr();
+    return children[1].unsafePtr();
 }
 
 AXCoreObject* AccessibilityMathMLElement::mathUnderObject()
@@ -317,7 +317,7 @@ AXCoreObject* AccessibilityMathMLElement::mathUnderObject()
 
     auto elementName = this->elementName();
     if (elementName == ElementName::MathML_munder || elementName == ElementName::MathML_munderover)
-        return children[1].ptr();
+        return children[1].unsafePtr();
 
     return nullptr;
 }
@@ -330,10 +330,10 @@ AXCoreObject* AccessibilityMathMLElement::mathOverObject()
     const auto& children = unignoredChildren();
     auto elementName = this->elementName();
     if (children.size() >= 2 && elementName == ElementName::MathML_mover)
-        return children[1].ptr();
+        return children[1].unsafePtr();
 
     if (children.size() >= 3 && elementName == ElementName::MathML_munderover)
-        return children[2].ptr();
+        return children[2].unsafePtr();
 
     return nullptr;
 }
@@ -346,7 +346,7 @@ AXCoreObject* AccessibilityMathMLElement::mathBaseObject()
     const auto& children = unignoredChildren();
     // The base object in question is always the first child.
     if (children.size() > 0)
-        return children[0].ptr();
+        return children[0].unsafePtr();
 
     return nullptr;
 }
@@ -362,7 +362,7 @@ AXCoreObject* AccessibilityMathMLElement::mathSubscriptObject()
 
     auto elementName = this->elementName();
     if (elementName == ElementName::MathML_msub || elementName == ElementName::MathML_msubsup)
-        return children[1].ptr();
+        return children[1].unsafePtr();
 
     return nullptr;
 }
@@ -377,10 +377,10 @@ AXCoreObject* AccessibilityMathMLElement::mathSuperscriptObject()
 
     auto elementName = this->elementName();
     if (count >= 2 && elementName == ElementName::MathML_msup)
-        return children[1].ptr();
+        return children[1].unsafePtr();
 
     if (count >= 3 && elementName == ElementName::MathML_msubsup)
-        return children[2].ptr();
+        return children[2].unsafePtr();
 
     return nullptr;
 }

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2114,7 +2114,7 @@ AccessibilityObject* AccessibilityNodeObject::tableHeaderContainer()
     tableHeader->setParent(this);
     rareData->setTableHeaderContainer(tableHeader.get());
 
-    return tableHeader.ptr();
+    return tableHeader.unsafePtr();
 }
 
 AXCoreObject::AccessibilityChildrenVector AccessibilityNodeObject::columns()
@@ -2772,7 +2772,7 @@ AccessibilityObject* AccessibilityNodeObject::disclosedByRow() const
 
     for (int k = index - 1; k >= 0; --k) {
         if (allRows[k]->hierarchicalLevel() == level - 1)
-            return downcast<AccessibilityObject>(allRows[k]).ptr();
+            return downcast<AccessibilityObject>(allRows[k]).unsafePtr();
     }
     return nullptr;
 }

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -254,7 +254,7 @@ AccessibilityScrollbar* AccessibilityScrollView::addChildScrollbar(Scrollbar* sc
     Ref scrollBarObject = uncheckedDowncast<AccessibilityScrollbar>(*cache->getOrCreate(*scrollbar));
     scrollBarObject->setParent(this);
     addChild(scrollBarObject.get());
-    return scrollBarObject.ptr();
+    return scrollBarObject.unsafePtr();
 }
 
 void AccessibilityScrollView::clearChildren()

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -87,7 +87,7 @@ ScrollTimeline& StyleOriginatedTimelinesController::inactiveNamedTimeline(const 
 {
     auto inactiveTimeline = ScrollTimeline::createInactiveStyleOriginatedTimeline(name);
     timelinesForName(name).append(inactiveTimeline);
-    return inactiveTimeline.get();
+    return inactiveTimeline.unsafeGet();
 }
 
 static bool containsElement(const Vector<WeakStyleable>& timelineScopeElements, Element* matchElement)
@@ -109,11 +109,11 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vec
         if (!matchedTimelines.isEmpty()) {
             if (containsElement(timelineScopeElements, element.get())) {
                 if (matchedTimelines.size() == 1)
-                    return matchedTimelines.first().ptr();
+                    return matchedTimelines.first().unsafePtr();
                 // Naming conflict due to timeline-scope, see if the element declares a non-deferred timeline.
                 for (auto& matchedTimeline : matchedTimelines) {
                     if (element == originatingElement(matchedTimeline).element().get())
-                        return matchedTimeline.ptr();
+                        return matchedTimeline.unsafePtr();
                 }
                 // If we only have deferred timelines, then the timeline is the inactive timeline.
                 return &inactiveNamedTimeline(matchedTimelines.first()->name());
@@ -121,8 +121,8 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vec
             ASSERT(matchedTimelines.size() <= 2);
             // Favor scroll timelines in case of conflict
             if (!is<ViewTimeline>(matchedTimelines.first()))
-                return matchedTimelines.first().ptr();
-            return matchedTimelines.last().ptr();
+                return matchedTimelines.first().unsafePtr();
+            return matchedTimelines.last().unsafePtr();
         }
         // Has blocking timeline scope element
         if (containsElement(timelineScopeElements, element.get()))

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -88,7 +88,7 @@ MutableStyleProperties& StyleRuleKeyframe::mutableProperties()
     if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(m_properties.get()))
         return *mutableProperties;
     Ref mutableProperties = m_properties->mutableCopy();
-    auto& mutablePropertiesRef = mutableProperties.get();
+    auto& mutablePropertiesRef = mutableProperties.unsafeGet();
     m_properties = WTFMove(mutableProperties);
     return mutablePropertiesRef;
 }

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -87,7 +87,7 @@ public:
 
     operator const CSSPrimitiveValue&() const
     {
-        return downcast<CSSPrimitiveValue>(m_value);
+        return downcast<CSSPrimitiveValue>(m_value).unsafeGet();
     }
 
     operator const CSSValue&() const

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -1217,7 +1217,7 @@ String ShorthandSerializer::serializeGridTemplate() const
 
     StringBuilder result;
     unsigned row = 0;
-    for (auto& currentValue : downcast<CSSValueList>(rowTrackSizes).get()) {
+    for (auto& currentValue : downcast<CSSValueList>(rowTrackSizes).unsafeGet()) {
         if (!result.isEmpty())
             result.append(' ');
         if (auto lineNames = dynamicDowncast<CSSGridLineNamesValue>(currentValue))

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -314,7 +314,7 @@ MutableStyleProperties& StyleRule::mutableProperties()
     if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(m_properties.get()))
         return *mutableProperties;
     Ref mutableProperties = m_properties->mutableCopy();
-    auto& mutablePropertiesRef = mutableProperties.get();
+    auto& mutablePropertiesRef = mutableProperties.unsafeGet();
     m_properties = WTFMove(mutableProperties);
     return mutablePropertiesRef;
 }
@@ -465,7 +465,7 @@ MutableStyleProperties& StyleRulePage::mutableProperties()
     if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(m_properties.get()))
         return *mutableProperties;
     Ref mutableProperties = m_properties->mutableCopy();
-    auto& mutablePropertiesRef = mutableProperties.get();
+    auto& mutablePropertiesRef = mutableProperties.unsafeGet();
     m_properties = WTFMove(mutableProperties);
     return mutablePropertiesRef;
 }
@@ -489,7 +489,7 @@ MutableStyleProperties& StyleRuleFontFace::mutableProperties()
     if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(m_properties.get()))
         return *mutableProperties;
     Ref mutableProperties = m_properties->mutableCopy();
-    auto& mutablePropertiesRef = mutableProperties.get();
+    auto& mutablePropertiesRef = mutableProperties.unsafeGet();
     m_properties = WTFMove(mutableProperties);
     return mutablePropertiesRef;
 }

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -126,7 +126,7 @@ Element* DocumentFragment::getElementById(const AtomString& id) const
     // Otherwise, fall back to iterating all of the element descendants.
     for (Ref element : descendantsOfType<Element>(*this)) {
         if (element->getIdAttribute() == id)
-            return const_cast<Element*>(element.ptr());
+            return const_cast<Element*>(element.unsafePtr());
     }
 
     return nullptr;

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -103,7 +103,7 @@ Element* DocumentFullscreen::fullscreenElement() const
 {
     for (Ref element : makeReversedRange(document().topLayerElements())) {
         if (element->hasFullscreenFlag())
-            return element.ptr();
+            return element.unsafePtr();
     }
 
     return nullptr;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3530,7 +3530,7 @@ ShadowRoot& Element::createUserAgentShadowRoot()
 {
     ASSERT(!userAgentShadowRoot());
     Ref newShadow = ShadowRoot::create(document(), ShadowRootMode::UserAgent);
-    ShadowRoot& shadow = newShadow;
+    ShadowRoot& shadow = newShadow.unsafeGet();
     addShadowRoot(WTFMove(newShadow));
     return shadow;
 }

--- a/Source/WebCore/dom/FindRevealAlgorithms.cpp
+++ b/Source/WebCore/dom/FindRevealAlgorithms.cpp
@@ -58,7 +58,7 @@ void revealClosedDetailsAndHiddenUntilFoundAncestors(Node& node)
         if (slot && slot->userAgentPart() == UserAgentParts::detailsContent() && slot->shadowHost()) {
             Ref details = downcast<HTMLDetailsElement>(*slot->shadowHost());
             if (!details->hasAttributeWithoutSynchronization(HTMLNames::openAttr))
-                return details.ptr();
+                return details.unsafePtr();
         }
         return nullptr;
     };

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -90,13 +90,13 @@ MutableStyleProperties& StyledElement::ensureMutableInlineStyle()
     if (!inlineStyle) {
         Ref mutableProperties = MutableStyleProperties::create(strictToCSSParserMode(isHTMLElement() && !document().inQuirksMode()));
         inlineStyle = mutableProperties.copyRef();
-        return mutableProperties.get();
+        return mutableProperties.unsafeGet();
     }
     if (RefPtr mutableProperties = dynamicDowncast<MutableStyleProperties>(*inlineStyle))
         return *mutableProperties.unsafeGet();
     Ref mutableProperties = inlineStyle->mutableCopy();
     inlineStyle = mutableProperties.copyRef();
-    return mutableProperties.get();
+    return mutableProperties.unsafeGet();
 }
 
 void StyledElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason reason)

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1240,7 +1240,7 @@ Node* TextIterator::node() const
 {
     auto start = this->range().start;
     if (start.container->isCharacterDataNode())
-        return start.container.ptr();
+        return start.container.unsafePtr();
     return start.container->traverseToChildAt(start.offset);
 }
 

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -573,7 +573,7 @@ static VisiblePosition previousBoundary(const VisiblePosition& position, Boundar
     if (!next)
         return it.atEnd() ? makeDeprecatedLegacyPosition(searchRange->start) : position;
 
-    auto& node = (it.atEnd() ? *searchRange : it.range()).start.container.get();
+    auto& node = (it.atEnd() ? *searchRange : it.range()).start.container.unsafeGet();
     auto* textNode = dynamicDowncast<Text>(node);
     if (textNode && !suffixLength && next <= textNode->length()) {
         // The next variable contains a usable index into a text node.

--- a/Source/WebCore/html/track/AudioTrackList.cpp
+++ b/Source/WebCore/html/track/AudioTrackList.cpp
@@ -89,7 +89,7 @@ AudioTrack* AudioTrackList::getTrackById(const AtomString& id) const
     for (auto& inbandTrack : m_inbandTracks) {
         Ref track = downcast<AudioTrack>(*inbandTrack);
         if (track->id() == id)
-            return track.ptr();
+            return track.unsafePtr();
     }
     return nullptr;
 }
@@ -99,7 +99,7 @@ AudioTrack* AudioTrackList::getTrackById(TrackID id) const
     for (auto& inbandTrack : m_inbandTracks) {
         Ref track = downcast<AudioTrack>(*inbandTrack);
         if (track->trackId() == id)
-            return track.ptr();
+            return track.unsafePtr();
     }
     return nullptr;
 }

--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -131,7 +131,7 @@ TextTrack* TextTrackList::getTrackById(const AtomString& id) const
     for (unsigned i = 0; i < length(); ++i) {
         Ref track = *item(i);
         if (track->id() == id)
-            return track.ptr();
+            return track.unsafePtr();
     }
 
     // When no tracks match the given argument, the method must return null.
@@ -143,7 +143,7 @@ TextTrack* TextTrackList::getTrackById(TrackID id) const
     for (unsigned i = 0; i < length(); ++i) {
         Ref track = *item(i);
         if (track->trackId() == id)
-            return track.ptr();
+            return track.unsafePtr();
     }
     return nullptr;
 }

--- a/Source/WebCore/html/track/VideoTrackList.cpp
+++ b/Source/WebCore/html/track/VideoTrackList.cpp
@@ -72,7 +72,7 @@ VideoTrack* VideoTrackList::getTrackById(const AtomString& id) const
     for (auto& inbandTracks : m_inbandTracks) {
         Ref track = downcast<VideoTrack>(*inbandTracks);
         if (track->id() == id)
-            return track.ptr();
+            return track.unsafePtr();
     }
     return nullptr;
 }

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -666,7 +666,7 @@ InspectorCanvas& InspectorCanvasAgent::bindCanvas(CanvasRenderingContext& contex
     }
 #endif
 
-    return inspectorCanvas;
+    return inspectorCanvas.unsafeGet();
 }
 
 void InspectorCanvasAgent::unbindCanvas(InspectorCanvas& inspectorCanvas)

--- a/Source/WebCore/loader/cache/CachedSVGFont.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGFont.cpp
@@ -117,7 +117,7 @@ SVGFontElement* CachedSVGFont::getSVGFontById(const AtomString& fontName) const
 
     for (Ref element : elements) {
         if (element->getIdAttribute() == fontName)
-            return element.ptr();
+            return element.unsafePtr();
     }
     return nullptr;
 }

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -791,7 +791,7 @@ RegionOverlay& DebugPageOverlays::ensureRegionOverlayForPage(Page& page, RegionT
     auto visualizer = RegionOverlay::create(page, regionType);
     visualizers[indexOf(regionType)] = visualizer.copyRef();
     m_pageRegionOverlays.add(page, WTFMove(visualizers));
-    return visualizer;
+    return visualizer.unsafeGet();
 }
 
 void DebugPageOverlays::showRegionOverlay(Page& page, RegionType regionType)

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -749,7 +749,7 @@ const UserContentProvider* LocalFrame::userContentProvider() const
     if (RefPtr userContentProvider = documentLoader ? documentLoader->preferences().userContentProvider : nullptr)
         return userContentProvider.unsafeGet();
     if (RefPtr page = this->page())
-        return page->protectedUserContentProviderForFrame().ptr();
+        return page->protectedUserContentProviderForFrame().unsafePtr();
     return nullptr;
 }
 
@@ -760,7 +760,7 @@ UserContentProvider* LocalFrame::userContentProvider()
     if (RefPtr userContentProvider = documentLoader ? documentLoader->preferences().userContentProvider : nullptr)
         return userContentProvider.unsafeGet();
     if (RefPtr page = this->page())
-        return page->protectedUserContentProviderForFrame().ptr();
+        return page->protectedUserContentProviderForFrame().unsafePtr();
     return nullptr;
 }
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1881,7 +1881,7 @@ bool Quirks::needsPointerTouchCompatibility(const Element& target) const
         RefPtr pageContainer = [&target] -> const HTMLElement* {
             for (Ref ancestor : lineageOfType<HTMLElement>(target)) {
                 if (ancestor->hasClassName("PageContainer"_s))
-                    return ancestor.ptr();
+                    return ancestor.unsafePtr();
             }
             return nullptr;
         }();

--- a/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
+++ b/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
@@ -78,7 +78,7 @@ void MediaResourceSniffer::cancel()
 
 MediaResourceSniffer::Promise& MediaResourceSniffer::promise() const
 {
-    return m_producer.promise().get();
+    return m_producer.promise().unsafeGet();
 }
 
 void MediaResourceSniffer::dataReceived(PlatformMediaResource&, const SharedBuffer& buffer)

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -409,7 +409,7 @@ static CounterNode* makeCounterNode(RenderElement& renderer, const AtomString& i
     renderer.setHasCounterNodeMap(true);
 
     if (newNode->parent() || renderer.shouldApplyStyleContainment())
-        return newNode.ptr();
+        return newNode.unsafePtr();
 
     // Check if some nodes that were previously root nodes should become children of this node now.
     auto* currentRenderer = &renderer;
@@ -430,7 +430,7 @@ static CounterNode* makeCounterNode(RenderElement& renderer, const AtomString& i
         newNode->insertAfter(*currentCounter, newNode->lastChild(), identifier);
     }
 
-    return newNode.ptr();
+    return newNode.unsafePtr();
 }
 
 RenderCounter::RenderCounter(Document& document, const Style::Content::Counter& counter)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3026,7 +3026,7 @@ NetworkConnectionToWebProcess* NetworkProcess::webProcessConnection(const IPC::C
 {
     for (Ref webProcessConnection : m_webProcessConnections.values()) {
         if (webProcessConnection->connection().uniqueID() == connection.uniqueID())
-            return webProcessConnection.ptr();
+            return webProcessConnection.unsafePtr();
     }
     return nullptr;
 }

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -124,7 +124,7 @@ WebBackForwardListFrameItem& WebBackForwardListFrameItem::rootFrame()
     Ref rootFrame = *this;
     while (rootFrame->m_parent && rootFrame->m_parent->identifier().processIdentifier() == identifier().processIdentifier())
         rootFrame = *rootFrame->m_parent;
-    return rootFrame.get();
+    return rootFrame.unsafeGet();
 }
 
 WebBackForwardListFrameItem& WebBackForwardListFrameItem::mainFrame()
@@ -132,7 +132,7 @@ WebBackForwardListFrameItem& WebBackForwardListFrameItem::mainFrame()
     Ref mainFrame = *this;
     while (mainFrame->m_parent)
         mainFrame = *mainFrame->m_parent;
-    return mainFrame.get();
+    return mainFrame.unsafeGet();
 }
 
 Ref<WebBackForwardListFrameItem> WebBackForwardListFrameItem::protectedMainFrame()

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -243,7 +243,7 @@ void WebBackForwardListItem::setWasRestoredFromSession()
 WebBackForwardListFrameItem& WebBackForwardListItem::navigatedFrameItem() const
 {
     if (RefPtr childItem = m_navigatedFrameID ? m_mainFrameItem->childItemForFrameID(*m_navigatedFrameID) : nullptr)
-        return childItem.releaseNonNull();
+        return childItem.releaseNonNull().unsafeGet();
     return m_mainFrameItem;
 }
 

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -255,7 +255,7 @@ RemotePageProxy* BrowsingContextGroup::remotePageInProcess(const WebPageProxy& p
         return nullptr;
     for (Ref remotePage : it->value) {
         if (remotePage->process().coreProcessIdentifier() == process.coreProcessIdentifier())
-            return remotePage.ptr();
+            return remotePage.unsafePtr();
     }
     return nullptr;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -716,7 +716,7 @@ WebExtensionAction* WebExtensionAction::fallbackAction() const
 
     // Tab actions whose tab references have not dropped fallback to the window action.
     if (RefPtr tab = this->tab())
-        return extensionContext->getAction(tab->window().get()).ptr();
+        return extensionContext->getAction(tab->window().get()).unsafePtr();
 
     // Window actions and tab actions whose tab references have dropped fallback to the default action.
     if (m_window.has_value() || m_tab.has_value())

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -485,7 +485,7 @@ WebsiteDataStore* WebExtensionController::websiteDataStore(std::optional<PAL::Se
 
     for (Ref dataStore : allWebsiteDataStores()) {
         if (dataStore->sessionID() == sessionID.value())
-            return dataStore.ptr();
+            return dataStore.unsafePtr();
     }
 
     return nullptr;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
@@ -58,7 +58,7 @@ WebsiteDataStore& WebExtensionControllerConfiguration::defaultWebsiteDataStore()
 {
     if (m_defaultWebsiteDataStore)
         return *m_defaultWebsiteDataStore;
-    return WebsiteDataStore::defaultDataStore();
+    return WebsiteDataStore::defaultDataStore().unsafeGet();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -179,7 +179,7 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
 
         switch (currNode->nodeType()) {
         case ScrollingNodeType::Overflow: {
-            ScrollingStateOverflowScrollingNode& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(currNode);
+            ScrollingStateOverflowScrollingNode& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(currNode).unsafeGet();
 
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
                 auto platformLayerID = scrollingStateNode.scrollContainerLayer().layerID();
@@ -194,7 +194,7 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
         };
         case ScrollingNodeType::MainFrame:
         case ScrollingNodeType::Subframe: {
-            ScrollingStateFrameScrollingNode& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(currNode);
+            ScrollingStateFrameScrollingNode& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(currNode).unsafeGet();
 
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
                 auto platformLayerID = scrollingStateNode.scrollContainerLayer().layerID();
@@ -218,7 +218,7 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
             break;
         }
         case ScrollingNodeType::PluginScrolling: {
-            ScrollingStatePluginScrollingNode& scrollingStateNode = downcast<ScrollingStatePluginScrollingNode>(currNode);
+            ScrollingStatePluginScrollingNode& scrollingStateNode = downcast<ScrollingStatePluginScrollingNode>(currNode).unsafeGet();
 
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
                 auto platformLayerID = scrollingStateNode.scrollContainerLayer().layerID();

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -791,7 +791,7 @@ WebFrameProxy& WebFrameProxy::rootFrame()
     Ref rootFrame = *this;
     while (rootFrame->m_parentFrame && rootFrame->m_parentFrame->process().coreProcessIdentifier() == process().coreProcessIdentifier())
         rootFrame = *rootFrame->m_parentFrame;
-    return rootFrame;
+    return rootFrame.unsafeGet();
 }
 
 bool WebFrameProxy::isMainFrame() const

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1868,7 +1868,7 @@ WebProcessProxy* WebProcessPool::webProcessProxyFromConnection(const IPC::Connec
 {
     for (Ref process : m_processes) {
         if (process->hasConnection(connection))
-            return process.ptr();
+            return process.unsafePtr();
     }
 
     ASSERT_NOT_REACHED();

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2818,7 +2818,7 @@ def check_wtf_move(clean_lines, line_number, file_state, error):
 
 
 def check_unsafe_get(clean_lines, line_number, file_state, error):
-    """Looks for use of 'unsafeGet()' which should be avoided.
+    """Looks for use of 'unsafeGet()' or 'unsafePtr()' which should be avoided.
 
     Args:
       clean_lines: A CleansedLines instance containing the file.
@@ -2836,7 +2836,11 @@ def check_unsafe_get(clean_lines, line_number, file_state, error):
 
     using_unsafe_get = search(r'\bunsafeGet\s*\(\s*\)', line)
     if using_unsafe_get:
-        error(line_number, 'runtime/unsafe_get', 5, "Avoid using 'unsafeGet()' by extending the lifetime of the RefPtr.")
+        error(line_number, 'runtime/unsafe_get_ptr', 5, "Avoid using 'unsafeGet()' by extending the lifetime of the RefPtr.")
+
+    using_unsafe_ptr = search(r'\bunsafePtr\s*\(\s*\)', line)
+    if using_unsafe_ptr:
+        error(line_number, 'runtime/unsafe_get_ptr', 5, "Avoid using 'unsafePtr()' by extending the lifetime of the Ref.")
 
 
 def check_callonmainthread(filename, clean_lines, line_number, file_state, error):
@@ -5030,7 +5034,7 @@ class CppChecker(object):
         'runtime/soft-linked-alloc',
         'runtime/string',
         'runtime/threadsafe_fn',
-        'runtime/unsafe_get',
+        'runtime/unsafe_get_ptr',
         'runtime/unsigned',
         'runtime/virtual',
         'runtime/wtf_checked_size',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6114,13 +6114,25 @@ class WebKitStyleTest(CppStyleTestBase):
         self.assert_lint(
             'auto ptr = obj.unsafeGet();',
             "Avoid using 'unsafeGet()' by extending the lifetime of the RefPtr."
-            "  [runtime/unsafe_get] [5]",
+            "  [runtime/unsafe_get_ptr] [5]",
             'foo.cpp')
 
         self.assert_lint(
             'auto ptr = obj.unsafeGet();',
             "Avoid using 'unsafeGet()' by extending the lifetime of the RefPtr."
-            "  [runtime/unsafe_get] [5]",
+            "  [runtime/unsafe_get_ptr] [5]",
+            'foo.mm')
+
+        self.assert_lint(
+            'auto ptr = obj.unsafePtr();',
+            "Avoid using 'unsafePtr()' by extending the lifetime of the Ref."
+            "  [runtime/unsafe_get_ptr] [5]",
+            'foo.cpp')
+
+        self.assert_lint(
+            'auto ptr = obj.unsafePtr();',
+            "Avoid using 'unsafePtr()' by extending the lifetime of the Ref."
+            "  [runtime/unsafe_get_ptr] [5]",
             'foo.mm')
 
     def test_wtf_never_destroyed(self):


### PR DESCRIPTION
#### 29dee38886475f1b32dfc9c2281f68e51c5511ae
<pre>
Adopt LIFETIME_BOUND for WTF::Ref
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=300560">https://bugs.webkit.org/show_bug.cgi?id=300560</a>&gt;
&lt;<a href="https://rdar.apple.com/162444456">rdar://162444456</a>&gt;

Reviewed by Geoffrey Garen.

Introduce Ref::unsafeGet() and Ref::unsafePtr() for pre-existing unsafe
uses.

Add a style checker to warn when unsafePtr() is used or when the code is
modified without fixing it.

* Source/JavaScriptCore/API/JSWeakObjectMapRefPrivate.cpp:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addSignature):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeDefinition::unrollSlow const):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):

* Source/WTF/wtf/Ref.h:
(WTF::Ref::ptrAllowingHashTableEmptyValue const):
(WTF::Ref::ptrAllowingHashTableEmptyValue):
(WTF::Ref::operator-&gt; const):
(WTF::Ref::ptr const):
(WTF::Ref::unsafePtr const): Add.
(WTF::Ref::get const):
(WTF::Ref::unsafeGet const): Add.
(WTF::Ref::operator T&amp; const):
- Add LIFETIME_BOUND to existing methods, and add unsafePtr() and
  unsafeGet() for existing code until it is fixed.
* Source/WTF/wtf/WorkQueue.h:
(WTF::WorkQueueBase::m_runLoop):
- Switch from raw pointer to RefPtr.
* Source/WTF/wtf/generic/WorkQueueGeneric.cpp:
(WTF::WorkQueueBase::WorkQueueBase):
(WTF::WorkQueueBase::platformInitialize):
(WTF::WorkQueueBase::platformInvalidate):
- Update after changing m_runLoop to RefPtr.

* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseConnection::createVersionChangeTransaction):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp:
(WebCore::LibWebRTCPeerConnectionBackend::newRemoteTransceiver):
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::nextInPreOrder):
(WebCore::AXCoreObject::deepestLastChildIncludingIgnored):
(WebCore::AXCoreObject::nextSiblingIncludingIgnored const):
(WebCore::AXCoreObject::nextUnignoredSibling const):
(WebCore::AXCoreObject::rowHeader):
(WebCore::AXCoreObject::activeDescendant const):
(WebCore::AXCoreObject::titleUIElement const):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::getOrCreate):
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
(WebCore::AccessibilityMathMLElement::mathRootIndexObject):
(WebCore::AccessibilityMathMLElement::mathNumeratorObject):
(WebCore::AccessibilityMathMLElement::mathDenominatorObject):
(WebCore::AccessibilityMathMLElement::mathUnderObject):
(WebCore::AccessibilityMathMLElement::mathOverObject):
(WebCore::AccessibilityMathMLElement::mathBaseObject):
(WebCore::AccessibilityMathMLElement::mathSubscriptObject):
(WebCore::AccessibilityMathMLElement::mathSuperscriptObject):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::tableHeaderContainer):
(WebCore::AccessibilityNodeObject::disclosedByRow const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::addChildScrollbar):
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::inactiveNamedTimeline):
(WebCore::StyleOriginatedTimelinesController::determineTreeOrder):
* Source/WebCore/css/CSSKeyframeRule.cpp:
(WebCore::StyleRuleKeyframe::mutableProperties):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::TypeDeducingCSSValueMapper::operator const CSSPrimitiveValue&amp; const):
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeGridTemplate const):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::mutableProperties):
(WebCore::StyleRulePage::mutableProperties):
(WebCore::StyleRuleFontFace::mutableProperties):
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::getElementById const):
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::fullscreenElement const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::createUserAgentShadowRoot):
* Source/WebCore/dom/FindRevealAlgorithms.cpp:
(WebCore::revealClosedDetailsAndHiddenUntilFoundAncestors):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::ensureMutableInlineStyle):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::node const):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::previousBoundary):
* Source/WebCore/html/track/AudioTrackList.cpp:
(WebCore::AudioTrackList::getTrackById const):
* Source/WebCore/html/track/TextTrackList.cpp:
(WebCore::TextTrackList::getTrackById const):
* Source/WebCore/html/track/VideoTrackList.cpp:
(WebCore::VideoTrackList::getTrackById const):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::bindCanvas):
* Source/WebCore/loader/cache/CachedSVGFont.cpp:
(WebCore::CachedSVGFont::getSVGFontById const):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::DebugPageOverlays::ensureRegionOverlayForPage):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::userContentProvider const):
(WebCore::LocalFrame::userContentProvider):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsPointerTouchCompatibility const):
* Source/WebCore/platform/graphics/MediaResourceSniffer.cpp:
(WebCore::MediaResourceSniffer::promise const):
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::makeCounterNode):

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::webProcessConnection const):
* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::rootFrame):
(WebKit::WebBackForwardListFrameItem::mainFrame):
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::navigatedFrameItem const):
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::remotePageInProcess):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::fallbackAction const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::websiteDataStore const):
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp:
(WebKit::WebExtensionControllerConfiguration::defaultWebsiteDataStore const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::rootFrame):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::webProcessProxyFromConnection const):

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_unsafe_get):
- Add check for use of unsafePtr().
(CppChecker):
- Rename runtime/unsafe_get to runtime/unsafe_get_ptr.
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_unsafe_get):
- Add tests.

Canonical link: <a href="https://commits.webkit.org/301385@main">https://commits.webkit.org/301385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c63cfb74f19e60d03b1b94e398571162e3bc47f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125823 "74 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36236 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cef0f613-735f-440b-a7be-40fd7df79af3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54044 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/132692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cfffec57-daa0-4fbc-a7de-7275e20021d6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128771 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/36912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/112512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b59cf89c-d15c-42df-8b58-2a4f42517779) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/125175 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/30696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117904 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/106691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/30909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135372 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124330 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52609 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/40352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53058 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/108722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/49415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/27735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/49947 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19691 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52503 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58314 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157343 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/51851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/39395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55199 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53546 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->