### PR TITLE
Fix warning messages about deleting open test databases when running test-webkitpy

### DIFF
--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
@@ -126,6 +126,9 @@ class TestSDKDB(TestCase):
         self.dbfile = tempfile.NamedTemporaryFile(prefix='TestSDKDB-')
         self.sdkdb = SDKDB(Path(self.dbfile.name))
 
+    def tearDown(self):
+        self.sdkdb.con.close()
+
     def add_library(self):
         with self.sdkdb:
             self.sdkdb._cache_hit_preparing_to_insert(F, F_Hash)


### PR DESCRIPTION
#### 8ec8c93c8946619338cf37b4075d70a89c46296e
<pre>
Fix warning messages about deleting open test databases when running test-webkitpy
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=300563">https://bugs.webkit.org/show_bug.cgi?id=300563</a>&gt;
&lt;<a href="https://rdar.apple.com/162447292">rdar://162447292</a>&gt;

Reviewed by Ryan Haddad.

* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py:
(TestSDKDB.tearDown): Add.
- Close the database connection before the temporary file is deleted to
  fix the warning.

Canonical link: <a href="https://commits.webkit.org/301434@main">https://commits.webkit.org/301434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e17594c4da4c9281d5e8e1bff4267a0fa30eb7c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77631 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ffb6012f-d221-4c3a-a44c-38ad37443c5b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95804 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63920 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3e5fc9d-7a8c-40dd-821e-fddc0cc95f1e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112454 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76295 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d178f28-3b55-4de7-a1e2-6ac9bc6833fc) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/125103 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30639 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76086 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135295 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104269 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103996 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49359 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27678 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49826 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19709 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52433 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51783 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55132 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53477 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->