### PR TITLE
[JSC] Reduce sizeof(QueuedTask) because of extreme allocation via MicrotaskQueue

### DIFF
--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
@@ -42,7 +42,7 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         &supportsRichSourceInfo,
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
-        nullptr, // queueMicrotaskToEventLoop
+        &queueMicrotaskToEventLoop,
         &shouldInterruptScriptBeforeTimeout,
         nullptr, // moduleLoaderImportModule
         nullptr, // moduleLoaderResolve

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -62,7 +62,7 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         &supportsRichSourceInfo,
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
-        nullptr, // queueMicrotaskToEventLoop
+        &queueMicrotaskToEventLoop,
         &shouldInterruptScriptBeforeTimeout,
         &moduleLoaderImportModule, // moduleLoaderImportModule
         &moduleLoaderResolve, // moduleLoaderResolve

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -957,7 +957,7 @@ const GlobalObjectMethodTable GlobalObject::s_globalObjectMethodTable = {
     &shellSupportsRichSourceInfo,
     &shouldInterruptScript,
     &javaScriptRuntimeFlags,
-    nullptr, // queueMicrotaskToEventLoop
+    &queueMicrotaskToEventLoop,
     &shouldInterruptScriptBeforeTimeout,
     &moduleLoaderImportModule,
     &moduleLoaderResolve,

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -1126,8 +1126,7 @@ public:
     static bool shouldInterruptScriptBeforeTimeout(const JSGlobalObject*) { return false; }
     static RuntimeFlags javaScriptRuntimeFlags(const JSGlobalObject*) { return RuntimeFlags(); }
 
-    JS_EXPORT_PRIVATE void queueMicrotask(InternalMicrotask, JSValue, JSValue, JSValue, JSValue);
-
+    JS_EXPORT_PRIVATE static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, JSC::QueuedTask&&);
     static void reportViolationForUnsafeEval(const JSGlobalObject*, const String&) { }
 
     bool evalEnabled() const { return m_evalEnabled; }
@@ -1150,6 +1149,8 @@ public:
         if (Options::useTrustedTypes())
             m_trustedTypesEnforcement = enforcement;
     }
+
+    void queueMicrotask(InternalMicrotask, JSValue, JSValue, JSValue, JSValue);
 
 #if ASSERT_ENABLED
     const JSGlobalObject* globalObjectAtDebuggerEntry() const { return m_globalObjectAtDebuggerEntry; }

--- a/Source/JavaScriptCore/runtime/Microtask.h
+++ b/Source/JavaScriptCore/runtime/Microtask.h
@@ -30,9 +30,9 @@
 namespace JSC {
 
 enum class MicrotaskIdentifierType { };
-using MicrotaskIdentifier = AtomicObjectIdentifier<MicrotaskIdentifierType>;
+using MicrotaskIdentifier = ObjectIdentifier<MicrotaskIdentifierType>;
 
-enum class InternalMicrotask : int32_t {
+enum class InternalMicrotask : uint16_t {
     PromiseResolveThenableJobFast = 0,
     PromiseResolveThenableJobWithoutPromiseFast,
     PromiseResolveThenableJob,

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/Microtask.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <wtf/CompactRefPtrTuple.h>
 #include <wtf/Deque.h>
 #include <wtf/SentinelLinkedList.h>
 
@@ -39,69 +40,26 @@ class JSGlobalObject;
 class MarkedMicrotaskDeque;
 class MicrotaskDispatcher;
 class MicrotaskQueue;
+class QueuedTask;
 class VM;
 
-class QueuedTask {
-    WTF_MAKE_TZONE_ALLOCATED(QueuedTask);
-    friend class MicrotaskQueue;
-    friend class MarkedMicrotaskDeque;
-public:
-    static constexpr unsigned maxArguments = maxMicrotaskArguments;
-
-    enum class Result : uint8_t {
-        Executed,
-        Discard,
-        Suspended,
-    };
-
-    QueuedTask(Ref<MicrotaskDispatcher>&& dispatcher)
-        : m_dispatcher(WTFMove(dispatcher))
-        , m_identifier(MicrotaskIdentifier::generate())
-        , m_job(InternalMicrotask::Opaque)
-        , m_globalObject(nullptr)
-    {
-    }
-
-    template<typename... Args>
-    requires (sizeof...(Args) <= maxArguments) && (std::is_convertible_v<Args, JSValue> && ...)
-    QueuedTask(RefPtr<MicrotaskDispatcher>&& dispatcher, InternalMicrotask job, JSGlobalObject* globalObject, Args&&...args)
-        : m_dispatcher(WTFMove(dispatcher))
-        , m_identifier(MicrotaskIdentifier::generate())
-        , m_job(job)
-        , m_globalObject(globalObject)
-        , m_arguments { std::forward<Args>(args)... }
-    {
-    }
-
-    void setDispatcher(RefPtr<MicrotaskDispatcher>&& dispatcher)
-    {
-        m_dispatcher = WTFMove(dispatcher);
-    }
-
-    bool isRunnable() const;
-
-    MicrotaskDispatcher* dispatcher() const { return m_dispatcher.get(); }
-    MicrotaskIdentifier identifier() const { return m_identifier; }
-    JSGlobalObject* globalObject() const { return m_globalObject; }
-    InternalMicrotask job() const { return m_job; }
-    std::span<const JSValue, maxArguments> arguments() const { return std::span<const JSValue, maxArguments> { m_arguments, maxArguments }; }
-
-private:
-    RefPtr<MicrotaskDispatcher> m_dispatcher;
-    MicrotaskIdentifier m_identifier;
-    InternalMicrotask m_job;
-    JSGlobalObject* m_globalObject;
-    JSValue m_arguments[maxArguments] { };
+enum class QueuedTaskResult : uint8_t {
+    Executed,
+    Discard,
+    Suspended,
 };
 
 class MicrotaskDispatcher : public RefCounted<MicrotaskDispatcher> {
+    WTF_MAKE_COMPACT_TZONE_ALLOCATED(MicrotaskDispatcher);
 public:
     enum class Type : uint8_t {
         None,
+        JSCDebuggable,
         // WebCoreMicrotaskDispatcher starts from here.
-        JavaScript,
-        UserGestureIndicator,
-        Function,
+        WebCoreJS,
+        WebCoreJSDebuggable,
+        WebCoreUserGestureIndicator,
+        WebCoreFunction,
     };
 
     explicit MicrotaskDispatcher(Type type)
@@ -109,14 +67,79 @@ public:
     { }
 
     virtual ~MicrotaskDispatcher() = default;
-    virtual QueuedTask::Result run(QueuedTask&) = 0;
+    virtual QueuedTaskResult run(QueuedTask&) = 0;
     virtual bool isRunnable() const = 0;
     Type type() const { return m_type; }
-    bool isWebCoreMicrotaskDispatcher() const { return static_cast<uint8_t>(m_type) >= static_cast<uint8_t>(Type::JavaScript); }
+    bool isWebCoreMicrotaskDispatcher() const { return static_cast<uint8_t>(m_type) >= static_cast<uint8_t>(Type::WebCoreJS); }
 
 private:
     Type m_type { Type::None };
 };
+
+class DebuggableMicrotaskDispatcher final : public MicrotaskDispatcher {
+    WTF_MAKE_COMPACT_TZONE_ALLOCATED(DebuggableMicrotaskDispatcher);
+public:
+    explicit DebuggableMicrotaskDispatcher()
+        : MicrotaskDispatcher(Type::JSCDebuggable)
+    { }
+
+    static Ref<DebuggableMicrotaskDispatcher> create()
+    {
+        return adoptRef(*new DebuggableMicrotaskDispatcher());
+    }
+
+    QueuedTaskResult run(QueuedTask&) final;
+    bool isRunnable() const final;
+};
+
+class QueuedTask {
+    WTF_MAKE_TZONE_ALLOCATED(QueuedTask);
+    friend class MicrotaskQueue;
+    friend class MarkedMicrotaskDeque;
+public:
+    static constexpr unsigned maxArguments = maxMicrotaskArguments;
+    using Result = QueuedTaskResult;
+
+    QueuedTask(Ref<MicrotaskDispatcher>&& dispatcher)
+        : m_dispatcher(WTFMove(dispatcher), InternalMicrotask::Opaque)
+        , m_globalObject(nullptr)
+    {
+    }
+
+    template<typename... Args>
+    requires (sizeof...(Args) <= maxArguments) && (std::is_convertible_v<Args, JSValue> && ...)
+    QueuedTask(RefPtr<MicrotaskDispatcher>&& dispatcher, InternalMicrotask job, JSGlobalObject* globalObject, Args&&...args)
+        : m_dispatcher(WTFMove(dispatcher), job)
+        , m_globalObject(globalObject)
+        , m_arguments { std::forward<Args>(args)... }
+    {
+    }
+
+    void setDispatcher(RefPtr<MicrotaskDispatcher>&& dispatcher)
+    {
+        m_dispatcher.setPointer(WTFMove(dispatcher));
+    }
+
+    bool isRunnable() const;
+
+    MicrotaskDispatcher* dispatcher() const { return m_dispatcher.pointer(); }
+    std::optional<MicrotaskIdentifier> identifier() const
+    {
+        auto* pointer = m_dispatcher.pointer();
+        if (!pointer)
+            return std::nullopt;
+        return MicrotaskIdentifier { std::bit_cast<uintptr_t>(pointer) };
+    }
+    JSGlobalObject* globalObject() const { return m_globalObject; }
+    InternalMicrotask job() const { return m_dispatcher.type(); }
+    std::span<const JSValue, maxArguments> arguments() const { return std::span<const JSValue, maxArguments> { m_arguments, maxArguments }; }
+
+private:
+    CompactRefPtrTuple<MicrotaskDispatcher, InternalMicrotask> m_dispatcher;
+    JSGlobalObject* m_globalObject;
+    JSValue m_arguments[maxArguments] { };
+};
+static_assert(sizeof(QueuedTask) <= 48, "Size of QueuedTask is critical for performance");
 
 class MarkedMicrotaskDeque {
 public:
@@ -199,6 +222,7 @@ public:
 
     DECLARE_VISIT_AGGREGATE;
 
+    template<bool useCallOnEachMicrotask>
     inline void performMicrotaskCheckpoint(VM&, NOESCAPE const Invocable<QueuedTask::Result(QueuedTask&)> auto& functor);
 
     bool hasMicrotasksForFullyActiveDocument() const

--- a/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
@@ -31,6 +31,7 @@
 
 namespace JSC {
 
+template<bool useCallOnEachMicrotask>
 inline void MicrotaskQueue::performMicrotaskCheckpoint(VM& vm, NOESCAPE const Invocable<QueuedTask::Result(QueuedTask&)> auto& functor)
 {
     auto catchScope = DECLARE_CATCH_SCOPE(vm);
@@ -45,10 +46,12 @@ inline void MicrotaskQueue::performMicrotaskCheckpoint(VM& vm, NOESCAPE const In
                 break;
             }
 
-            vm.callOnEachMicrotaskTick();
-            if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
-                clear();
-                break;
+            if constexpr (useCallOnEachMicrotask) {
+                vm.callOnEachMicrotaskTick();
+                if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
+                    clear();
+                    break;
+                }
             }
 
             switch (result) {

--- a/Source/WTF/wtf/CompactRefPtrTuple.h
+++ b/Source/WTF/wtf/CompactRefPtrTuple.h
@@ -45,6 +45,12 @@ public:
         setType(type);
     }
 
+    CompactRefPtrTuple(RefPtr<T>&& pointer, Type type)
+    {
+        setPointer(WTFMove(pointer));
+        setType(type);
+    }
+
     CompactRefPtrTuple(const CompactRefPtrTuple& other)
     {
         setPointer(other.pointer());

--- a/Source/WebCore/bindings/js/JSExecState.h
+++ b/Source/WebCore/bindings/js/JSExecState.h
@@ -115,6 +115,7 @@ public:
     }
 
     static void runTask(JSC::JSGlobalObject*, JSC::QueuedTask&);
+    static void runTaskWithDebugger(JSC::JSGlobalObject*, JSC::QueuedTask&);
 
     static JSC::JSInternalPromise* loadModule(JSC::JSGlobalObject& lexicalGlobalObject, const URL& topLevelModuleURL, JSC::JSValue parameters, JSC::JSValue scriptFetcher)
     {

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
@@ -154,7 +154,7 @@ void JSWorkerGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, 
 {
     JSWorkerGlobalScopeBase& thisObject = static_cast<JSWorkerGlobalScopeBase&>(object);
     auto& context = thisObject.wrapped();
-    task.setDispatcher(context.eventLoop().jsMicrotaskDispatcher());
+    task.setDispatcher(context.eventLoop().jsMicrotaskDispatcher(task));
     context.eventLoop().queueMicrotask(WTFMove(task));
 }
 

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
@@ -48,7 +48,7 @@ const GlobalObjectMethodTable* JSWorkletGlobalScopeBase::globalObjectMethodTable
         &supportsRichSourceInfo,
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
-        nullptr, // queueMicrotaskToEventLoop
+        &queueMicrotaskToEventLoop,
         &shouldInterruptScriptBeforeTimeout,
         &moduleLoaderImportModule,
         &moduleLoaderResolve,
@@ -141,6 +141,11 @@ RuntimeFlags JSWorkletGlobalScopeBase::javaScriptRuntimeFlags(const JSGlobalObje
 {
     auto* thisObject = jsCast<const JSWorkletGlobalScopeBase*>(object);
     return thisObject->m_wrapped->jsRuntimeFlags();
+}
+
+void JSWorkletGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, JSC::QueuedTask&& task)
+{
+    return Base::queueMicrotaskToEventLoop(object, WTFMove(task));
 }
 
 JSValue toJS(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject*, WorkletGlobalScope& workletGlobalScope)

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -39,6 +39,7 @@
 #include <wtf/WeakPtr.h>
 
 namespace JSC {
+class JSGlobalObject;
 class QueuedTask;
 class MicrotaskDispatcher;
 }
@@ -231,7 +232,7 @@ public:
     void didAddTimer(EventLoopTimer&);
     void didRemoveTimer(EventLoopTimer&);
 
-    JSC::MicrotaskDispatcher& jsMicrotaskDispatcher() const { return m_jsMicrotaskDispatcher; }
+    Ref<JSC::MicrotaskDispatcher> jsMicrotaskDispatcher(JSC::QueuedTask&);
 
 private:
     enum class State : uint8_t { Running, Suspended, ReadyToStop, Stopped };

--- a/Source/WebCore/dom/Microtasks.h
+++ b/Source/WebCore/dom/Microtasks.h
@@ -35,7 +35,7 @@ class VM;
 namespace WebCore {
 
 class WebCoreMicrotaskDispatcher : public JSC::MicrotaskDispatcher {
-    WTF_MAKE_TZONE_ALLOCATED(WebCoreMicrotaskDispatcher);
+    WTF_MAKE_COMPACT_TZONE_ALLOCATED(WebCoreMicrotaskDispatcher);
 public:
     WebCoreMicrotaskDispatcher(Type type, EventLoopTaskGroup& group)
         : JSC::MicrotaskDispatcher(type)
@@ -70,6 +70,7 @@ public:
     bool isPerformingCheckpoint() const { return m_performingMicrotaskCheckpoint; }
 
     static void runJSMicrotask(JSC::JSGlobalObject*, JSC::VM&, JSC::QueuedTask&);
+    static void runJSMicrotaskWithDebugger(JSC::JSGlobalObject*, JSC::VM&, JSC::QueuedTask&);
 
 private:
     JSC::VM& vm() const { return m_vm.get(); }


### PR DESCRIPTION
#### 2ff26dc8e6cceebece3f831bf8670ea9b45fce29
<pre>
[JSC] Reduce sizeof(QueuedTask) because of extreme allocation via MicrotaskQueue
<a href="https://bugs.webkit.org/show_bug.cgi?id=300565">https://bugs.webkit.org/show_bug.cgi?id=300565</a>
<a href="https://rdar.apple.com/162448703">rdar://162448703</a>

Reviewed by Yijia Huang.

From profiling information, we found that Deque&lt;QueuedTask&gt; allocation
in MicrotaskQueue is extremely hot. We need to make sure that
sizeof(QueuedTask) is much smaller. This patch aims at cleaning
up these code to gain performance improvement for major benchmarks.

1. We use CompactRefPtrTuple for MicrotaskDispatcher and
   InternalMicrotask type in QueuedTask to reduce size.
2. We remove MicrotaskIdentifier generation since it turned out this is
   extremely hot from the profiler data. We go back to the previous
   method using an allocation pointer for ID. We detect debugger
   existence and we create DebuggableMicrotaskDispatcher when there is a
   debugger. And we use a pointer of this dispatcher as an ID. This is
   the previous way before we moved to MicrotaskIdentifier. So going
   back to this because of performance issue.
3. We wrap microtask invocation code with special dispatcher,
   JSDebuggableMicrotaskDispatcher, and use it only when debugger is
   enabled. So we keep the major non-debugger-enabled path succinct and
   extremely fast as we found these debugger() access is very hot from
   the profiler data.
4. We define default implementation of JSGlobalObject::queueMicrotaskToEventLoop
   and stop checking nullptr for this function registration.

* Source/JavaScriptCore/API/JSAPIGlobalObject.cpp:
(JSC::JSAPIGlobalObject::globalObjectMethodTable):
* Source/JavaScriptCore/API/JSAPIGlobalObject.mm:
(JSC::JSAPIGlobalObject::globalObjectMethodTable):
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::baseGlobalObjectMethodTable):
(JSC::JSGlobalObject::queueMicrotaskToEventLoop):
(JSC::JSGlobalObject::queueMicrotask):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/Microtask.h:
* Source/JavaScriptCore/runtime/MicrotaskQueue.cpp:
(JSC::QueuedTask::isRunnable const):
(JSC::DebuggableMicrotaskDispatcher::run):
(JSC::DebuggableMicrotaskDispatcher::isRunnable const):
(JSC::MicrotaskQueue::enqueue):
* Source/JavaScriptCore/runtime/MicrotaskQueue.h:
(JSC::MicrotaskDispatcher::MicrotaskDispatcher):
(JSC::MicrotaskDispatcher::type const):
(JSC::MicrotaskDispatcher::isWebCoreMicrotaskDispatcher const):
(JSC::QueuedTask::QueuedTask):
(JSC::QueuedTask::setDispatcher):
(JSC::QueuedTask::dispatcher const):
(JSC::QueuedTask::identifier const):
(JSC::QueuedTask::job const):
* Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h:
(JSC::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::drainMicrotasks):
* Source/WTF/wtf/CompactRefPtrTuple.h:
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::queueMicrotaskToEventLoop):
* Source/WebCore/bindings/js/JSExecState.cpp:
(WebCore::JSExecState::runTask):
(WebCore::JSExecState::runTaskWithDebugger):
* Source/WebCore/bindings/js/JSExecState.h:
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp:
(WebCore::JSWorkerGlobalScopeBase::queueMicrotaskToEventLoop):
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp:
(WebCore::JSWorkletGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSWorkletGlobalScopeBase::queueMicrotaskToEventLoop):
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoopTaskGroup::jsMicrotaskDispatcher):
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::runJSMicrotaskWithDebugger):
(WebCore::MicrotaskQueue::runJSMicrotask):
(WebCore::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/WebCore/dom/Microtasks.h:

Canonical link: <a href="https://commits.webkit.org/301418@main">https://commits.webkit.org/301418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ec1d790d4b6d5fcf549388803ccad616ff01d5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77764 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4de9cd51-7f26-4840-9a0e-f7eab249084b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95921 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64021 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b7a711b0-50c6-4506-847f-6ecd5afc5e3b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76412 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27a96a89-bdf9-451b-8f49-dc4345722516) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30771 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76242 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117980 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106767 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135453 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124407 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52685 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104389 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104116 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49486 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27805 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50056 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19705 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52579 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58391 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157420 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51922 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39418 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55273 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->