### PR TITLE
Add some testing for the "kill ring", including the two different yank commands

### DIFF
--- a/LayoutTests/editing/kill-ring-expected.txt
+++ b/LayoutTests/editing/kill-ring-expected.txt
@@ -1,0 +1,42 @@
+
+Dump of markup 1:
+| <#selection-caret>
+| "This line of text goes into the kill ring"
+
+Dump of markup 2:
+| <#selection-caret>
+| <br>
+
+Dump of markup 3:
+| "Text yanked out of the kill ring appears just below this sentence."
+| <div>
+|   "This line of text goes into the kill ring<#selection-caret>"
+
+Dump of markup 4:
+| "Text yanked out of the kill ring appears selected just below this sentence."
+| <div>
+|   "<#selection-anchor>This line of text goes into the kill ring<#selection-focus>"
+
+Dump of markup 5:
+| <#selection-caret>
+| "These two lines of text"
+| <div>
+|   "go into the kill ring"
+
+Dump of markup 6:
+| <#selection-caret>
+| <br>
+
+Dump of markup 7:
+| "Text yanked out of the kill ring appears just below this sentence."
+| <div>
+|   "These two lines of text"
+| <div>
+|   "go into the kill ring<#selection-caret>"
+
+Dump of markup 8:
+| "Text yanked out of the kill ring appears selected just below this sentence."
+| <div>
+|   "These two lines of text"
+| <div>
+|   "<#selection-anchor>go into the kill ring<#selection-focus>"

--- a/LayoutTests/editing/kill-ring.html
+++ b/LayoutTests/editing/kill-ring.html
@@ -1,0 +1,46 @@
+<script src="../resources/dump-as-markup.js"></script>
+<p>This does some basic testing of kill ring commands, deleting to put text into the kill ring and yanking out of it.</p>
+<div id="container" contenteditable="true"></div>
+<script>
+const selection = window.getSelection();
+const container = document.getElementById("container");
+selection.setPosition(container, 0);
+document.execCommand("InsertText", false, "This line of text goes into the kill ring")
+selection.setPosition(container, 0);
+Markup.dump("container");
+internals.executeEditingCommand("DeleteToEndOfParagraph");
+Markup.dump("container");
+document.execCommand("InsertText", false, "Text yanked out of the kill ring appears just below this sentence.\n");
+internals.executeEditingCommand("Yank");
+Markup.dump("container");
+while (container.firstChild)
+    container.removeChild(container.firstChild);
+document.execCommand("InsertText", false, "This line of text goes into the kill ring")
+selection.setPosition(container, 0);
+internals.executeEditingCommand("DeleteToEndOfParagraph");
+document.execCommand("InsertText", false, "Text yanked out of the kill ring appears selected just below this sentence.\n");
+internals.executeEditingCommand("YankAndSelect");
+Markup.dump("container");
+while (container.firstChild)
+    container.removeChild(container.firstChild);
+document.execCommand("InsertText", false, "These two lines of text\ngo into the kill ring")
+selection.setPosition(container, 0);
+Markup.dump("container");
+internals.executeEditingCommand("DeleteToEndOfParagraph");
+internals.executeEditingCommand("DeleteToEndOfParagraph");
+internals.executeEditingCommand("DeleteToEndOfParagraph");
+Markup.dump("container");
+document.execCommand("InsertText", false, "Text yanked out of the kill ring appears just below this sentence.\n");
+internals.executeEditingCommand("Yank");
+Markup.dump("container");
+while (container.firstChild)
+    container.removeChild(container.firstChild);
+document.execCommand("InsertText", false, "These two lines of text\ngo into the kill ring")
+selection.setPosition(container, 0);
+internals.executeEditingCommand("DeleteToEndOfParagraph");
+internals.executeEditingCommand("DeleteToEndOfParagraph");
+internals.executeEditingCommand("DeleteToEndOfParagraph");
+document.execCommand("InsertText", false, "Text yanked out of the kill ring appears selected just below this sentence.\n");
+internals.executeEditingCommand("YankAndSelect");
+Markup.dump("container");
+</script>

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4857,6 +4857,12 @@ void Internals::setSelectionFromNone()
         localFrame->selection().setSelectionFromNone();
 }
 
+bool Internals::executeEditingCommand(const String& command, const String& argument)
+{
+    RefPtr frame = this->frame();
+    return frame && frame->editor().command(command).execute(argument);
+}
+
 #if ENABLE(MEDIA_SOURCE)
 
 void Internals::initializeMockMediaSource()

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -843,6 +843,8 @@ public:
     void setSelectionWithoutValidation(Ref<Node> baseNode, unsigned baseOffset, RefPtr<Node> extentNode, unsigned extentOffset);
     void setSelectionFromNone();
 
+    bool executeEditingCommand(const String& command, const String& argument);
+
 #if ENABLE(MEDIA_SOURCE)
     WEBCORE_TESTSUPPORT_EXPORT void initializeMockMediaSource();
     void setMaximumSourceBufferSize(SourceBuffer&, uint64_t, DOMPromiseDeferred<void>&&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1030,6 +1030,9 @@ enum ContentsFormat {
     undefined setSelectionWithoutValidation(Node baseNode, unsigned long baseOffset, Node? extentNode, unsigned long extentOffset);
     undefined setSelectionFromNone();
 
+    // Like execCommand, but also exposes the many commands that are normally restricted to key bindings or app menus.
+    boolean executeEditingCommand(DOMString command, optional DOMString value = "");
+
     [Conditional=MEDIA_SOURCE] undefined initializeMockMediaSource();
     [Conditional=MEDIA_SOURCE] Promise<sequence<DOMString>> bufferedSamplesForTrackId(SourceBuffer buffer, [AtomString] DOMString trackId);
     [Conditional=MEDIA_SOURCE] Promise<undefined> setMaximumSourceBufferSize(SourceBuffer buffer, unsigned long long maximumSize);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5868,9 +5868,8 @@ NSUInteger WebViewImpl::characterIndexForPoint(NSPoint point)
     return 0;
 }
 
-NSRect WebViewImpl::firstRectForCharacterRange(NSRange range, NSRangePointer actualRange)
+NSRect WebViewImpl::firstRectForCharacterRange(NSRange, NSRangePointer)
 {
-    ASSERT_NOT_REACHED();
     return NSZeroRect;
 }
 

--- a/Tools/WebEditingTester/WK2WebDocumentController.m
+++ b/Tools/WebEditingTester/WK2WebDocumentController.m
@@ -29,10 +29,8 @@
 #import <WebKit/WKNavigationDelegate.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKUIDelegate.h>
-#import <WebKit/WKWebView.h>
-#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewConfiguration.h>
 #import <WebKit/WKWebViewPrivate.h>
-#import <WebKit/_WKWebsiteDataStore.h>
 
 @interface WK2WebDocumentController () <WKUIDelegate, NSTextFinderBarContainer>
 @property (nonatomic, strong) WKWebView *webView;
@@ -50,7 +48,7 @@ static WKWebViewConfiguration *defaultConfiguration()
 
     if (!configuration) {
         configuration = [[WKWebViewConfiguration alloc] init];
-        configuration.preferences._fullScreenEnabled = YES;
+        configuration.preferences.elementFullscreenEnabled = YES;
         configuration.preferences._developerExtrasEnabled = YES;
     }
 

--- a/Tools/WebEditingTester/WebEditingTester.xcodeproj/project.pbxproj
+++ b/Tools/WebEditingTester/WebEditingTester.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -12,12 +12,12 @@
 		2D6B05C21A97365300613256 /* dice.png in Resources */ = {isa = PBXBuildFile; fileRef = 2D6B05C11A97365300613256 /* dice.png */; };
 		C53E7D0D1A9546E600818F19 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = C53E7D0B1A9546E600818F19 /* MainMenu.xib */; };
 		C53E7D0E1A9546E600818F19 /* WebDocument.xib in Resources */ = {isa = PBXBuildFile; fileRef = C53E7D0C1A9546E600818F19 /* WebDocument.xib */; };
-		C558CDB31A92D6900059A907 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C558CDB21A92D6900059A907 /* AppDelegate.m */; };
+		C558CDB31A92D6900059A907 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C558CDB21A92D6900059A907 /* AppDelegate.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated"; }; };
 		C558CDB51A92D6900059A907 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C558CDB41A92D6900059A907 /* main.m */; };
 		C558CDB81A92D6900059A907 /* WebDocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = C558CDB71A92D6900059A907 /* WebDocumentController.m */; };
 		C59F9B971A93C8E00041A959 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C59F9B961A93C8E00041A959 /* Cocoa.framework */; };
 		C59F9B991A93C8E90041A959 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C59F9B981A93C8E90041A959 /* WebKit.framework */; };
-		C59F9B9F1A93CB630041A959 /* WK1WebDocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = C59F9B9C1A93CB630041A959 /* WK1WebDocumentController.m */; };
+		C59F9B9F1A93CB630041A959 /* WK1WebDocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = C59F9B9C1A93CB630041A959 /* WK1WebDocumentController.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated"; }; };
 		C59F9BA01A93CB630041A959 /* WK2WebDocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = C59F9B9E1A93CB630041A959 /* WK2WebDocumentController.m */; };
 /* End PBXBuildFile section */
 


### PR DESCRIPTION
#### a33a2e2e42b6e273deb7fbd3a101fb9485972c1b
<pre>
Add some testing for the &quot;kill ring&quot;, including the two different yank commands
<a href="https://rdar.apple.com/162449097">rdar://162449097</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300567">https://bugs.webkit.org/show_bug.cgi?id=300567</a>

Reviewed by NOBODY (OOPS!).

Test: editing/kill-ring.html

* LayoutTests/editing/kill-ring-expected.txt: Added.
* LayoutTests/editing/kill-ring.html: Added.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::executeEditingCommand): Added.
* Source/WebCore/testing/Internals.h: Added executeEditingCommand.
* Source/WebCore/testing/Internals.idl: Ditto.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::firstRectForCharacterRange): Removed assertion that was hit
while I was using the WebEditingTester. It&apos;s not correct to assert something is
not reached based on wishful thinking! There may be work to do here at some point,
but an assertion is the wrong tool.

* Tools/WebEditingTester/WK2WebDocumentController.m:
(defaultConfiguration): Switched from private interface to public.

* Tools/WebEditingTester/WebEditingTester.xcodeproj/project.pbxproj:
Added -Wno-deprecated to the classic WebKit part of this tool to keep it compiling.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a33a2e2e42b6e273deb7fbd3a101fb9485972c1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132620 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77636 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/006410b1-d18d-4ed7-acac-3ceed877a674) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53977 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95807 "Found 1 new test failure: editing/kill-ring.html (failure)") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63924 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7da0326-23c6-46b9-bf17-11064d26249e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128704 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36858 "Found 1 new test failure: editing/kill-ring.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76298 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e652c82d-e6e7-4237-b6a7-a6bffb1bd896) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35761 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30643 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76091 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135300 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40299 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104271 "Found 1 new test failure: editing/kill-ring.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103998 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49364 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27682 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49837 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52438 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58247 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55137 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53482 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->