### PR TITLE
[AutoFill Debugging] Add support for several new extraction configuration options to limit text output

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
@@ -1,0 +1,33 @@
+root
+    role='banner'
+        aria-label='Main Page Title','Welcome to Test Page'
+    navigation,role='navigation',aria-label='Main navigation'
+        list
+            list-item
+                link,uid=…,events=[click],'Section 1'
+            list-item
+                link,uid=…,events=[click],'Section 2'
+    role='main'
+        '    \nHere’s to the crazy ones…\n\n\n    '
+        section,aria-label='Interactive Elements'
+            button,uid=…,events=[click],aria-label='Test button','Click Me'
+            '        \nThis button does nothing\n\n        '
+            textFormControl,'text',uid=…,placeholder='Enter text here','Enter text here'
+            uid=…,role='button',events=[click,keyboard],'Clickable Div'
+        section,aria-label='Content with Roles'
+            article,role='article','            \n\n                \nArticle Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content…\n\n\n        '
+            role='complementary',aria-label='Related information'
+                '            \nRelated Links\n\n\n            '
+                list
+                    list-item
+                        link,uid=…,events=[hover],'Example Link'
+                    list-item
+                        link,uid=…,events=[hover],'Test Link'
+            role='region'
+                role='status','Ready'
+                button,uid=…,events=[click],'Update Status'
+        '    \nThe quick brown fox jumped…'
+    role='contentinfo'
+        '    \nFooter content with '
+        role='img',aria-label='copyright symbol','©'
+        ' 2024'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight.html
@@ -26,16 +26,6 @@ body {
     background-color: lightyellow;
     padding: 8px;
 }
-
-canvas {
-    width: 200px;
-    height: 200px;
-}
-
-.canvas-container {
-    border: 1px dashed gray;
-    padding: 1em;
-}
 </style>
 <script src="../../resources/ui-helper.js"></script>
 </head>
@@ -50,6 +40,7 @@ canvas {
     </ul>
 </nav>
 <main role="main">
+    <p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.</p>
     <section id="section1" aria-label="Interactive Elements">
         <button class="clickable" onclick="console.log('clicked')" aria-label="Test button" aria-describedby="btn-help">Click Me</button>
         <div id="btn-help" aria-hidden="true">This button does nothing</div>
@@ -75,10 +66,8 @@ canvas {
             <div role="status" aria-live="polite" id="status-msg">Ready</div>
             <button onclick="document.getElementById('status-msg').textContent = 'Updated!'">Update Status</button>
         </div>
-        <div class="canvas-container" aria-label="Figure 1">
-            <canvas width="400" height="400"></canvas>
-        </div>
     </section>
+    <p>The quick brown fox jumped over the lazy dog.</p>
 </main>
 <footer role="contentinfo">
     <p>Footer content with <span role="img" aria-label="copyright symbol">©</span> 2024</p>
@@ -88,40 +77,7 @@ canvas {
 </div>
 
 <script>
-function paintIntoCanvas() {
-    const context = document.querySelector("canvas").getContext("2d");
-    context.save();
-    context.clearRect(0, 0, 400, 400);
-    context.beginPath();
-    context.strokeStyle = "black";
-    context.rect(20, 20, 160, 160);
-    context.stroke();
-
-    context.beginPath();
-    context.strokeStyle = "red";
-    context.rect(220, 20, 160, 160);
-    context.stroke();
-    context.fillStyle = "red";
-    context.fill();
-
-    context.beginPath();
-    context.rect(20, 220, 160, 160);
-    context.fillStyle = "green";
-    context.fill();
-
-    context.beginPath();
-    context.strokeStyle = "black";
-    context.lineWidth = 20;
-    context.rect(230, 230, 140, 140);
-    context.stroke();
-    context.fillStyle = "gray";
-    context.fill();
-    context.restore();
-}
-
 addEventListener("load", async () => {
-    paintIntoCanvas();
-
     if (!window.testRunner)
         return;
 
@@ -130,8 +86,9 @@ addEventListener("load", async () => {
 
     document.body.textContent = await UIHelper.requestDebugText({
         normalize: true,
-        includeRects: true,
-        includeURLs: true
+        includeRects: false,
+        includeURLs: false,
+        wordLimit: 5
     });
 
     testRunner.notifyDone();

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2459,7 +2459,9 @@ window.UIHelper = class UIHelper {
 
         return new Promise(resolve => {
             testRunner.runUIScript(`(() => {
-                uiController.requestDebugText(result => uiController.uiScriptComplete(result));
+                uiController.requestDebugText(result => {
+                    uiController.uiScriptComplete(result);
+                }, ${JSON.stringify(options)});
             })()`, debugText => {
                 if (options.normalize) {
                     debugText = debugText

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -363,7 +363,7 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
     }
 
     if (RefPtr image = dynamicDowncast<HTMLImageElement>(element))
-        return { ImageItemData { image->getURLAttribute(HTMLNames::srcAttr).lastPathComponent().toString(), image->altText() } };
+        return { ImageItemData { image->getURLAttribute(HTMLNames::srcAttr), image->altText() } };
 
     if (RefPtr control = dynamicDowncast<HTMLTextFormControlElement>(element)) {
         RefPtr input = dynamicDowncast<HTMLInputElement>(control);

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -95,7 +95,7 @@ struct ScrollableItemData {
 };
 
 struct ImageItemData {
-    String name;
+    URL completedSource;
     String altText;
 };
 

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -27,6 +27,7 @@
 
 #include <wtf/CompletionHandler.h>
 #include <wtf/NativePromise.h>
+#include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
 
@@ -45,8 +46,35 @@ using NodeIdentifier = ObjectIdentifier<NodeIdentifierType>;
 
 namespace WebKit {
 
+enum class TextExtractionOptionFlag : uint8_t {
+    IncludeURLs     = 1 << 0,
+    IncludeRects    = 1 << 1,
+};
+
+using TextExtractionOptionFlags = OptionSet<TextExtractionOptionFlag>;
 using TextExtractionFilterPromise = NativePromise<String, void>;
 using TextExtractionFilterCallback = Function<Ref<TextExtractionFilterPromise>(const String&, std::optional<WebCore::NodeIdentifier>&&)>;
-void convertToText(WebCore::TextExtraction::Item&&, CompletionHandler<void(String&&)>&&, TextExtractionFilterCallback&& = { }, Vector<String>&& nativeMenuItems = { });
+
+struct TextExtractionOptions {
+    TextExtractionOptions(TextExtractionOptions&& other)
+        : filterCallback(WTFMove(other.filterCallback))
+        , nativeMenuItems(WTFMove(other.nativeMenuItems))
+        , flags(other.flags)
+    {
+    }
+
+    TextExtractionOptions(TextExtractionFilterCallback&& filter, Vector<String>&& items, TextExtractionOptionFlags flags)
+        : filterCallback(WTFMove(filter))
+        , nativeMenuItems(WTFMove(items))
+        , flags(flags)
+    {
+    }
+
+    TextExtractionFilterCallback filterCallback;
+    Vector<String> nativeMenuItems;
+    TextExtractionOptionFlags flags;
+};
+
+void convertToText(WebCore::TextExtraction::Item&&, TextExtractionOptions&&, CompletionHandler<void(String&&)>&&);
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6805,7 +6805,7 @@ header: <WebCore/TextExtractionTypes.h>
 
 header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::ImageItemData {
-    String name;
+    URL completedSource;
     String altText;
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -41,6 +41,24 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  */
 @property (nonatomic) CGRect targetRect;
 
+/*!
+ Include URL attribute values, such as `href` or `src` on links or images.
+ The default value is `YES`.
+ */
+@property (nonatomic) BOOL includeURLs;
+
+/*!
+ Automatically include bounding rects for all text nodes.
+ The default value is `YES`.
+ */
+@property (nonatomic) BOOL includeRects;
+
+/*!
+ Max number of words to include per paragraph; remaining text is truncated with an ellipsis (…).
+ The default value is `NSUIntegerMax`.
+ */
+@property (nonatomic) NSUInteger maxWordsPerParagraph;
+
 @end
 
 typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -39,7 +39,10 @@
 
     _canIncludeIdentifiers = YES;
     _shouldFilterText = YES;
+    _includeURLs = YES;
+    _includeRects = YES;
     _targetRect = CGRectNull;
+    _maxWordsPerParagraph = NSUIntegerMax;
     return self;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
@@ -160,8 +160,9 @@ inline static RetainPtr<WKTextExtractionItem> createItemWithChildren(const TextE
                 accessibilityRole:accessibilityRole.get()
                 nodeIdentifier:nodeIdentifier.get()]);
         }, [&](const TextExtraction::ImageItemData& data) -> RetainPtr<WKTextExtractionItem> {
+            RetainPtr name = [data.completedSource.createNSURL() lastPathComponent] ?: @"";
             return adoptNS([[WKTextExtractionImageItem alloc]
-                initWithName:data.name.createNSString().get()
+                initWithName:name.get()
                 altText:data.altText.createNSString().get()
                 rectInWebView:rectInWebView
                 children:children

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -42,9 +42,11 @@ dictionary ScrollToOptions {
     boolean unconstrained = false;
 };
 
-dictionary TextExtractionOptions {
+dictionary TextExtractionTestOptions {
+    unsigned long wordLimit = 0;
     boolean clipToBounds = false;
     boolean includeRects = false;
+    boolean includeURLs = false;
     boolean mergeParagraphs = false;
     boolean skipNearlyTransparentContent = false;
 };
@@ -438,8 +440,8 @@ interface UIScriptController {
     undefined setInlinePrediction(DOMString text, unsigned long startIndex);
     undefined acceptInlinePrediction();
 
-    undefined requestTextExtraction(object callback, TextExtractionOptions options);
-    undefined requestDebugText(object callback);
+    undefined requestTextExtraction(object callback, TextExtractionTestOptions options);
+    undefined requestDebugText(object callback, TextExtractionTestOptions options);
     undefined performTextExtractionInteraction(DOMString action, TextExtractionInteractionOptions options, object callback);
 
     undefined requestRenderedTextForFrontmostTarget(long x, long y, object callback);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -57,15 +57,17 @@ struct ScrollToOptions {
 
 ScrollToOptions* toScrollToOptions(JSContextRef, JSValueRef);
 
-struct TextExtractionOptions {
+struct TextExtractionTestOptions {
+    unsigned wordLimit { 0 };
     bool clipToBounds { false };
     bool includeRects { false };
+    bool includeURLs { false };
     bool mergeParagraphs { false };
     bool skipNearlyTransparentContent { false };
     bool canIncludeIdentifiers { false };
 };
 
-TextExtractionOptions* toTextExtractionOptions(JSContextRef, JSValueRef);
+TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef, JSValueRef);
 
 struct TextExtractionInteractionOptions {
     JSRetainPtr<JSStringRef> nodeIdentifier;
@@ -445,8 +447,8 @@ public:
     virtual void installFakeMachineReadableCodeResultsForImageAnalysis() { }
 
     // Text Extraction
-    virtual void requestTextExtraction(JSValueRef, TextExtractionOptions*) { notImplemented(); }
-    virtual void requestDebugText(JSValueRef) { notImplemented(); }
+    virtual void requestTextExtraction(JSValueRef, TextExtractionTestOptions*) { notImplemented(); }
+    virtual void requestDebugText(JSValueRef, TextExtractionTestOptions*) { notImplemented(); }
     virtual void performTextExtractionInteraction(JSStringRef, TextExtractionInteractionOptions*, JSValueRef) { notImplemented(); }
 
     // Element Targeting

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -65,14 +65,16 @@ ScrollToOptions* toScrollToOptions(JSContextRef context, JSValueRef argument)
     return &options;
 }
 
-TextExtractionOptions* toTextExtractionOptions(JSContextRef context, JSValueRef argument)
+TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef context, JSValueRef argument)
 {
     if (!JSValueIsObject(context, argument))
         return nullptr;
 
-    static TextExtractionOptions options;
+    static TextExtractionTestOptions options;
     options.clipToBounds = booleanProperty(context, (JSObjectRef)argument, "clipToBounds", false);
     options.includeRects = booleanProperty(context, (JSObjectRef)argument, "includeRects", false);
+    options.includeURLs = booleanProperty(context, (JSObjectRef)argument, "includeURLs", false);
+    options.wordLimit = static_cast<unsigned>(numericProperty(context, (JSObjectRef)argument, "wordLimit"));
     options.mergeParagraphs = booleanProperty(context, (JSObjectRef)argument, "mergeParagraphs", false);
     options.skipNearlyTransparentContent = booleanProperty(context, (JSObjectRef)argument, "skipNearlyTransparentContent", false);
     options.canIncludeIdentifiers = booleanProperty(context, (JSObjectRef)argument, "canIncludeIdentifiers", false);

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -89,8 +89,8 @@ private:
 
     void setSpellCheckerResults(JSValueRef) final;
 
-    void requestTextExtraction(JSValueRef callback, TextExtractionOptions*) final;
-    void requestDebugText(JSValueRef callback) final;
+    void requestTextExtraction(JSValueRef callback, TextExtractionTestOptions*) final;
+    void requestDebugText(JSValueRef callback, TextExtractionTestOptions*) final;
     void performTextExtractionInteraction(JSStringRef action, TextExtractionInteractionOptions*, JSValueRef callback) final;
 
     void requestRenderedTextForFrontmostTarget(int x, int y, JSValueRef callback) final;


### PR DESCRIPTION
#### 428e849ba738d0d3eaec46dde0a9a453b1f1d575
<pre>
[AutoFill Debugging] Add support for several new extraction configuration options to limit text output
<a href="https://bugs.webkit.org/show_bug.cgi?id=300568">https://bugs.webkit.org/show_bug.cgi?id=300568</a>
<a href="https://rdar.apple.com/162378543">rdar://162378543</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Add support for 3 new text extraction configuration options:
- includeURLs
- includeRects
- maxWordsPerParagraph

See below for more details.

Test: fast/text-extraction/debug-text-extraction-lightweight.html

Test: fast/text-extraction/debug-text-extraction-lightweight.html
* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt: Added.

Add a new layout test, similar to the existing `debug-text-extraction-basic.html`, which exercises
this new functionality by:

1. Forcing a word limit of 5
2. Omitting rects
3. Omitting URLs

* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight.html: Copied from LayoutTests/fast/text-extraction/debug-text-extraction-basic.html.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.prototype.async requestDebugText):

Add options to request extraction with or without rects and URLs, along with word limit. We also
make `requestDebugText` take the newly renamed `TextExtractionTestOptions`.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:

Drive-by fix: also surface entire image `src` URLs here instead of just the last path component
(which was a compromise to keep output length small), now that clients can simply avoid URLs in the
output altogether.

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::commaSeparatedString):
(WebKit::escapeString):
(WebKit::normalizedURLString):

Move these helpers to the top of the file.

(WebKit::TextExtractionAggregator::TextExtractionAggregator):
(WebKit::TextExtractionAggregator::~TextExtractionAggregator):
(WebKit::TextExtractionAggregator::create):
(WebKit::TextExtractionAggregator::includeRects const):
(WebKit::TextExtractionAggregator::includeURLs const):
(WebKit::TextExtractionAggregator::filter const):
(WebKit::TextExtractionAggregator::addLineForNativeMenuItemsIfNeeded):

To support these new behaviors (as well as easily support any new flags that need to be plumbed
through the text extraction lifecycle), we refactor `TextExtractionAggregator` so that it also
carries the `TextExtractionOptions` with it, along with other state like the filtering callback and
native menu items (which it appends at the end, before calling the completion handler).

(WebKit::partsForItem):
(WebKit::addPartsForText):
(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):
(WebKit::convertToText):
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
(WebKit::TextExtractionOptions::TextExtractionOptions):
(WebKit::convertToText): Deleted.
(): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(joinAndTruncateLinesToWordLimit):

Add a helper method to truncate each line (separated by newlines) in a piece of extracted text to
the requested maximum word limit. Use it below, as the last step in the filtering callback. In the
case where `TEXT_EXTRACTION_FILTER` is disabled or sanitization is disabled on the configuration but
a word limit is still specified, we just make the filtering callback truncate the raw output to the
word limit.

(-[WKWebView _debugTextWithConfiguration:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration init]):
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm:
(WebKit::createItemWithChildren):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::requestTextExtraction):
(WTR::UIScriptController::requestDebugText):
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionTestOptions):
(WTR::toTextExtractionOptions): Deleted.

Augment test infrastructure to allow UI-side scripts to pass in configuration options when using
`UIScriptController.requestDebugText`.

* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::createTextExtractionConfiguration):
(WTR::UIScriptControllerCocoa::requestTextExtraction):
(WTR::UIScriptControllerCocoa::requestDebugText):

Canonical link: <a href="https://commits.webkit.org/301420@main">https://commits.webkit.org/301420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9f1a0c72ca20ed8e5c80d05287aafd7c554b67e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125964 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36393 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5098304e-94f4-4cf6-9117-b82ae148936d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54178 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/132826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac4c8942-980d-4d80-8a24-c71783af3291) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37032 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7be7179a-5254-4e65-9d99-2a4f0cb0e06b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30831 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31044 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40473 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/135513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108857 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26514 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49537 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50121 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52637 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58453 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/51981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53678 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->