### PR TITLE
[LCP] Use a bit on Element to store LCP's "in content set" state

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4426,10 +4426,10 @@ void Document::enqueuePaintTimingEntryIfNeeded()
     };
 
     auto enqueueLargestContentfulPaintIfNecessary = [&]() {
-        if (RefPtr entry = largestContentfulPaintData().takePendingEntry(nowTime)) {
+        if (RefPtr entry = largestContentfulPaintData().generateLargestContentfulPaintEntry(nowTime)) {
             WTFEmitSignpost(this, NavigationAndPaintTiming, "largestContentfulPaint");
             Ref entryRef = entry.releaseNonNull();
-            protectedWindow()->performance().reportLargestContentfulPaint(WTFMove(entryRef));
+            protectedWindow()->performance().enqueueLargestContentfulPaint(WTFMove(entryRef));
         }
     };
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -451,6 +451,9 @@ public:
     RefPtr<Element> resolveReferenceTarget() const;
     RefPtr<Element> retargetReferenceTargetForBindings(RefPtr<Element>) const;
 
+    bool isInLargestContentfulPaintTextContentSet() const { return hasStateFlag(StateFlag::InLargestContentfulPaintTextContentSet); }
+    void setInLargestContentfulPaintTextContentSet() { setStateFlag(StateFlag::InLargestContentfulPaintTextContentSet); }
+
     void didDispatchShadowRootAttachedEvent() { clearStateFlag(StateFlag::IsShadowRootAttachedEventPending); }
     void dispatchShadowRootAttachedEvent();
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -672,7 +672,8 @@ protected:
         IsFullscreen = 1 << 19,
 #endif
         IsShadowRootAttachedEventPending = 1 << 20,
-        // 12 bits free.
+        InLargestContentfulPaintTextContentSet = 1 << 21,
+        // 11 bits free.
     };
 
     enum class TabIndexState : uint8_t {

--- a/Source/WebCore/page/LargestContentfulPaintData.h
+++ b/Source/WebCore/page/LargestContentfulPaintData.h
@@ -55,7 +55,7 @@ public:
     void didPaintImage(Element&, CachedImage*, FloatRect localRect);
     void didPaintText(const RenderBlockFlow& formattingContextRoot, FloatRect localRect);
 
-    RefPtr<LargestContentfulPaint> takePendingEntry(DOMHighResTimeStamp);
+    RefPtr<LargestContentfulPaint> generateLargestContentfulPaintEntry(DOMHighResTimeStamp);
 
     static bool isExposedForPaintTiming(const Element&);
 
@@ -76,8 +76,6 @@ private:
         FloatRect rect;
         Markable<MonotonicTime> loadTime;
     };
-
-    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_textContentSet;
 
     WeakHashMap<Element, WeakHashSet<CachedImage>, WeakPtrImplWithEventTargetData> m_imageContentSet;
     WeakHashMap<Element, WeakHashMap<CachedImage, PendingImageData>, WeakPtrImplWithEventTargetData> m_pendingImageRecords;

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -380,7 +380,7 @@ void Performance::reportFirstContentfulPaint(DOMHighResTimeStamp timestamp)
     queueEntry(*m_firstContentfulPaint);
 }
 
-void Performance::reportLargestContentfulPaint(Ref<LargestContentfulPaint>&& paintEntry)
+void Performance::enqueueLargestContentfulPaint(Ref<LargestContentfulPaint>&& paintEntry)
 {
     m_largestContentfulPaint = RefPtr { WTFMove(paintEntry) };
     queueEntry(*m_largestContentfulPaint);

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -115,7 +115,7 @@ public:
     void addResourceTiming(ResourceTiming&&);
 
     void reportFirstContentfulPaint(DOMHighResTimeStamp);
-    void reportLargestContentfulPaint(Ref<LargestContentfulPaint>&&);
+    void enqueueLargestContentfulPaint(Ref<LargestContentfulPaint>&&);
 
     void removeAllObservers();
     void registerPerformanceObserver(PerformanceObserver&);


### PR DESCRIPTION
#### be4064807ce44c56388dc871908f7ed158b2b6a5
<pre>
[LCP] Use a bit on Element to store LCP&apos;s &quot;in content set&quot; state
<a href="https://bugs.webkit.org/show_bug.cgi?id=300570">https://bugs.webkit.org/show_bug.cgi?id=300570</a>
<a href="https://rdar.apple.com/162451937">rdar://162451937</a>

Reviewed by Tim Nguyen.

LCP only counts each element once for having text content (in spec terms, elements get
added to the &quot;content set&quot;). This is currently tracked by adding elements to a `WeakHashSet&lt;Element&gt;`
but it&apos;s cheaper to just use a bit on Node instead.

Also rename `takePendingEntry()` to `generateLargestContentfulPaintEntry()` and `reportLargestContentfulPaint()`
to `enqueueLargestContentfulPaint()`.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::enqueuePaintTimingEntryIfNeeded):
* Source/WebCore/dom/Element.h:
(WebCore::Element::isInLargestContentfulPaintTextContentSet const):
(WebCore::Element::setInLargestContentfulPaintTextContentSet):
* Source/WebCore/dom/Node.h:
* Source/WebCore/page/LargestContentfulPaintData.cpp:
(WebCore::LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry):
(WebCore::LargestContentfulPaintData::generateLargestContentfulPaintEntry):
(WebCore::LargestContentfulPaintData::didPaintText):
(WebCore::LargestContentfulPaintData::takePendingEntry): Deleted.
* Source/WebCore/page/LargestContentfulPaintData.h:
* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::enqueueLargestContentfulPaint):
(WebCore::Performance::reportLargestContentfulPaint): Deleted.
* Source/WebCore/page/Performance.h:

Canonical link: <a href="https://commits.webkit.org/301382@main">https://commits.webkit.org/301382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2d4071cb19827b854c77fe624fe44c4bf66b175

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132672 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77679 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e53f84ec-4bf2-4528-9c93-aff7da13182c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95839 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63952 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e072f309-f03b-472b-a62c-37374c50225d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76331 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86961387-7b3b-48ed-aced-c4e38c479236) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30680 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76142 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106675 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.PostMessageWithMessagePorts (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135350 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40336 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104304 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104032 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26491 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49401 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27719 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49923 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52485 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58294 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51833 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55182 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53527 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->