### PR TITLE
Re-import dom/events WPT

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -9742,6 +9742,7 @@
         "web-platform-tests/dom/events/EventListener-incumbent-global-subframe-1.sub.html",
         "web-platform-tests/dom/events/EventListener-incumbent-global-subframe-2.sub.html",
         "web-platform-tests/dom/events/EventListener-incumbent-global-subsubframe.sub.html",
+        "web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none.sub.html",
         "web-platform-tests/dom/events/scrolling/scroll-cross-origin-iframes.sub.html",
         "web-platform-tests/dom/events/scrolling/scrollend-event-fires-to-iframe-inner-frame.html",
         "web-platform-tests/dom/nodes/Element-getElementsByTagName-change-document-HTMLNess-iframe.xml",

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-throwing-multiple-globals-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-throwing-multiple-globals-expected.txt
@@ -1,0 +1,4 @@
+
+PASS exception thrown in event listener function should result in error event on listener's global
+PASS exception thrown in event listener interface object should result in error event on listener's global
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-throwing-multiple-globals.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-throwing-multiple-globals.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+function createIframe(t, srcdoc = '') {
+  let iframe = document.createElement('iframe');
+  iframe.srcdoc = srcdoc;
+  t.add_cleanup(() => iframe.remove());
+  return new Promise((resolve, reject) => {
+    iframe.addEventListener('load', () => resolve(iframe.contentWindow));
+    document.body.appendChild(iframe);
+  });
+}
+
+// Returns a promise which will resolve with the next error event fired at any
+// of `windows`, after the invocation of this function. Once one does, this
+// function removes its listeners and produces that error event so that it can
+// be examined (most notably for which global proxy it was targeted at).
+async function nextErrorEvent(windows) {
+  let listener;
+  let p = new Promise((resolve, reject) => {
+    listener = (event) => { resolve(event); event.preventDefault(); };
+  });
+  for (let w of windows) {
+    w.addEventListener('error', listener);
+  }
+  try {
+    return await p;
+  } finally {
+    for (let w of windows) {
+      w.removeEventListener('error', listener);
+    }
+  }
+}
+
+promise_test(async t => {
+  let w = await createIframe(t, `<script>function listener() { throw new Error(); }<`+`/script>`);
+  let w2 = await createIframe(t);
+
+  let target = new w2.EventTarget();
+  target.addEventListener('party', w.listener);
+  let nextErrorPromise = nextErrorEvent([self, w, w2]);
+  target.dispatchEvent(new Event('party'));
+  let errorEvent = await nextErrorPromise;
+  if (errorEvent.error) {
+    assert_true(errorEvent.error instanceof w.Error, 'error should be an instance created inside the listener function');
+  }
+  assert_equals(errorEvent.target, w, `error event should target listener's global but instead targets ${event.currentTarget === w2 ? 'target\'s global' : 'test harness global'}`);
+}, 'exception thrown in event listener function should result in error event on listener\'s global');
+
+promise_test(async t => {
+  let w = await createIframe(t, `<script>listener = {};<`+`/script>`);
+  let w2 = await createIframe(t, `<script>handleEvent = () => { throw new Error; };<`+`/script>`);
+  let w3 = await createIframe(t);
+  w.listener.handleEvent = w2.handleEvent;
+
+  let target = new w3.EventTarget();
+  target.addEventListener('party', w.listener);
+  let nextErrorPromise = nextErrorEvent([self, w, w2, w3]);
+  target.dispatchEvent(new Event('party'));
+  let errorEvent = await nextErrorPromise;
+  if (errorEvent.error) {
+    assert_true(errorEvent.error instanceof w2.Error, 'error should be an instance created inside the listener function');
+  }
+  assert_equals(errorEvent.target, w, `error event should target listener's global but instead targets ${event.currentTarget === w2 ? 'target\'s global' : event.currentTarget === w3 ? 'function\'s global' : 'test harness global'}`);
+}, 'exception thrown in event listener interface object should result in error event on listener\'s global');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<meta name="variant" content="?document">
+<meta name="variant" content="?window">
+<meta name="variant" content="?element">
+<link rel="help"
+      href="https://dom.spec.whatwg.org/#add-an-event-listener">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  #target {
+    background-color: green;
+    width: 100px;
+    height: 100px;
+  }
+  @keyframes fade-out {
+    from { opacity: 1; }
+    to { opacity: 0; }
+  }
+  #target.animate {
+    animation: fade-out 300ms ease-in;
+  }
+</style>
+<!-- Tests handlers with various means of set up and tear down -->
+<body>
+  <div id="target"></div>
+</body>
+<script>
+let eventTally  = 0;
+let nextListenerId = 0;
+
+function createEventTallyListener() {
+  return (event) => {
+    eventTally++;
+  }
+}
+
+function resetAndRecordEvents() {
+  const target = document.getElementById('target');
+  eventTally = 0;
+  const ready = new Promise(async resolve => {
+    target.addEventListener('click', () => {
+      requestAnimationFrame(resolve);
+    }, { once: true });
+    await new test_driver.Actions()
+        .pointerMove(0, 0, {origin: target})
+        .pointerDown()
+        .pointerUp()
+        .send();
+  });
+  return ready;
+}
+
+const variant = location.search.substring(1) || 'window';
+let source = undefined;
+switch(variant) {
+  case 'document':
+    source = document;
+    break;
+
+  case 'window':
+    source = window;
+    break;
+
+  case 'element':
+    source = document.getElementById('target');
+    break;
+
+  default:
+    source = window;
+}
+
+promise_test(async t => {
+  // Add listeners
+  const first = createEventTallyListener();
+  source.addEventListener('click', first, true);
+  await resetAndRecordEvents();
+  assert_equals(eventTally, 1, 'After adding first listener');
+  const second = createEventTallyListener();
+  source.addEventListener('click', second, false);
+  await resetAndRecordEvents();
+  assert_equals(eventTally, 2, 'After adding second listener');
+
+  // Duplicate listener is discarded.
+  source.addEventListener('click', second, false);
+  await resetAndRecordEvents();
+  assert_equals(eventTally, 2,
+                'After adding third listener with matching useCapture');
+
+  // Remove first listener
+  source.removeEventListener('click', first, true);
+  await resetAndRecordEvents();
+  assert_equals(eventTally, 1, 'After removing first listener');
+
+  // Try to remove again.
+  source.removeEventListener('click', first, true);
+  await resetAndRecordEvents();
+  assert_equals(eventTally, 1, 'Cannot remove a second time');
+
+  // Try to remove second, but with mismatched capture
+  source.removeEventListener('click', second, true);
+  await resetAndRecordEvents();
+  assert_equals(eventTally, 1, 'Capture argument must match');
+
+  // Remove second listener.
+  source.removeEventListener('click', second, false);
+  await resetAndRecordEvents();
+  assert_equals(eventTally, 0, 'After removal of second listener');
+}, `Test addEventListener/removeEventListener on the ${variant}.`);
+
+promise_test(async t => {
+  // Add listener
+  source.onclick = createEventTallyListener();
+  await resetAndRecordEvents();
+  assert_equals(eventTally, 1, 'After adding listener');
+
+  // Replace listener.
+  source.onclick = createEventTallyListener();
+  await resetAndRecordEvents();
+  assert_equals(eventTally, 1, 'After replacing listener');
+
+  // Remove listener
+  source.onclick = null;
+  await resetAndRecordEvents();
+  assert_equals(eventTally, 0, 'After removing listener');
+}, `Test setting onanimationstart handler on the ${variant}.`);
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count_document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count_document-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test addEventListener/removeEventListener on the document.
+PASS Test setting onanimationstart handler on the document.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count_element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count_element-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test addEventListener/removeEventListener on the element.
+PASS Test setting onanimationstart handler on the element.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count_window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count_window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test addEventListener/removeEventListener on the window.
+PASS Test setting onanimationstart handler on the window.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/generic-events-stay-cancelable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/generic-events-stay-cancelable-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A generic event with only passive listeners remains cancelable
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/generic-events-stay-cancelable.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/generic-events-stay-cancelable.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+async_test((t) => {
+    const et = new EventTarget();
+    et.addEventListener('test', t.step_func_done((e) => {
+        assert_true(e.cancelable);
+    }), {passive: true});
+    et.dispatchEvent(new Event('test', {cancelable: true}));
+}, "A generic event with only passive listeners remains cancelable");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/generic-events-stay-cancelable.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-body.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-div.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-document.html

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/resources/large-dimension-document.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/resources/large-dimension-document.sub.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body>
+    <div style="width: 10000px; height: 10000px;"></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/resources/w3c-import.log
@@ -17,4 +17,5 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/resources/empty-document.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/resources/event-global-extra-frame.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/resources/event-global-is-still-set-when-coercing-beforeunload-result-frame.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/events/resources/large-dimension-document.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/resources/prefixed-animation-event-tests.js

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Ensure that the scroll position is not lost when the local iframe is set to display:none and shown again.
+PASS Ensure that the scroll position is not lost when the remote iframe is set to display:none and shown again.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Ensure that the scroll position isn't lost when the iframe is set to display:none and shown again</title>
+<link rel="author" href="mailto:perryuwang@gmail.com">
+<link rel="help" href="https://issues.chromium.org/issues/41368291">
+<script src="scroll_support.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div>
+  <iframe id="frame"></iframe>
+</div>
+
+<script>
+const IFRAME_PATH = '/dom/events/scrolling/save-iframe-scroll-offset-when-display-none.sub.html';
+
+function waitForFrameLoadAsync(frame) {
+  return new Promise(async (resolve) => {
+    frame.addEventListener('load', resolve, { once: true });
+  });
+}
+
+function waitForMessageAsync(expected_frame_id, expected_command) {
+  return new Promise((resolve) => {
+    window.addEventListener('message', (event) => {
+      assert_equals(event.data.command, expected_command);
+      assert_equals(event.data.frame_id, expected_frame_id);
+      resolve({scrollX: event.data.scrollX, scrollY: event.data.scrollY});
+    }, { once: true });
+  });
+}
+
+function iframeScrollTo(frame, x, y) {
+  return new Promise(async (resolve) => {
+    const scroll_ack_waiter = waitForMessageAsync(frame.id, 'scrollTo');
+    await frame.contentWindow.postMessage({
+      command: 'scrollTo',
+      frame_id: frame.id,
+      scrollX: x,
+      scrollY: y,
+    }, '*');
+    const ret = await scroll_ack_waiter;
+    resolve(ret);
+  });
+}
+
+function iframeGetScroll(frame) {
+  return new Promise(async (resolve) => {
+    const scroll_ack_waiter = waitForMessageAsync(frame.id, 'getScroll');
+    await frame.contentWindow.postMessage({
+      command: 'getScroll',
+      frame_id: frame.id,
+    }, '*');
+    const ret = await scroll_ack_waiter;
+    resolve(ret);
+  });
+}
+
+async function testIFrame(src) {
+  const frame = document.getElementById('frame');
+  frame.src = src;
+  await waitForFrameLoadAsync(frame);
+  let ret = await iframeScrollTo(frame, 1000, 2000);
+  assert_equals(ret.scrollX, 1000);
+  assert_equals(ret.scrollY, 2000);
+  frame.style.display = 'none';
+  await waitForCompositorCommit();
+  frame.style.display = '';
+  await waitForCompositorCommit();
+  ret = await iframeGetScroll(frame);
+  assert_equals(ret.scrollX, 1000);
+  assert_equals(ret.scrollY, 2000);
+}
+
+window.onload = async () => {
+  promise_test(async () => {
+    await testIFrame(IFRAME_PATH);
+  }, 'Ensure that the scroll position is not lost when the local iframe is set to display:none and shown again.');
+
+  promise_test(async () => {
+    await testIFrame(get_host_info().HTTP_NOTSAMESITE_ORIGIN + IFRAME_PATH);
+  }, 'Ensure that the scroll position is not lost when the remote iframe is set to display:none and shown again.');
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none.sub.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<div style="width: 10000px; height: 10000px">
+  <!-- Adding <input> is to reproduce scroll offset reset when display:none -->
+  <input type="text">
+</div>
+<script>
+function postReplyMessage(target, frame_id, command) {
+  target.postMessage({
+    command: command,
+    frame_id: frame_id,
+    scrollX: window.scrollX,
+    scrollY: window.scrollY
+  }, "*");
+}
+
+function handleMessage(event) {
+  switch (event.data.command) {
+    case 'scrollTo':
+      window.scrollTo(event.data.scrollX, event.data.scrollY);
+      break;
+    case 'getScroll':
+      // No-op, just reply with current scroll position.
+      break;
+    default:
+      throw Error(`Unknown command: ${event.data.command}`);
+      break;
+  }
+  requestAnimationFrame(() => {
+    postReplyMessage(event.source, event.data.frame_id, event.data.command);
+  });
+}
+
+window.addEventListener('message', handleMessage);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-element-expected.txt
@@ -1,0 +1,6 @@
+
+PASS scrollTop and scrollLeft should fire scroll event.
+PASS scrollTop and scrollLeft being set with the same value.
+PASS scrollTop and scrollLeft being set with invalid scroll offset.
+PASS scrollTop and scrollLeft when scrolling above maximum offset.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-element.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Scroll event should behave correctly for Element.offsetTop and Element.offsetLeft</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="scroll_support.js"></script>
+<link rel="author" title="Jo Steven Novaryo" href="mailto:jo.steven.novaryo@huawei.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-events">
+<div id=log></div>
+<div id="container">
+</div>
+<script>
+
+function setupTarget() {
+  var container = document.getElementById("container");
+  container.innerHTML = "";
+
+  var target = document.createElement("div");
+  var overflowing_child = document.createElement("div");
+
+  target.style = "overflow:scroll; height: 100px; width: 100px; scrollbar-width: none";
+  overflowing_child.style = "height: 200px; width: 200px;";
+  target.appendChild(overflowing_child);
+  container.appendChild(target);
+  return target;
+}
+
+promise_test(async (t) => {
+  var target = setupTarget();
+
+  assert_equals(target.scrollTop, 0);
+  var promiseForScrollTop = waitForEvent("scroll", t, target);
+  target.scrollTop = 10;
+  await promiseForScrollTop;
+  assert_equals(target.scrollTop, 10);
+
+  assert_equals(target.scrollLeft, 0);
+  var promiseForScrollLeft = waitForEvent("scroll", t, target);
+  target.scrollLeft = 10;
+  await promiseForScrollLeft;
+  assert_equals(target.scrollLeft, 10);
+
+}, "scrollTop and scrollLeft should fire scroll event.");
+
+promise_test(async (t) => {
+  var target = setupTarget();
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  assert_equals(target.scrollTop, 0);
+  target.scrollTop = 0;
+
+  assert_equals(target.scrollLeft, 0);
+  target.scrollLeft = 0;
+
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
+}, "scrollTop and scrollLeft being set with the same value.");
+
+promise_test(async (t) => {
+  var target = setupTarget();
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  target.scrollTop = -100;
+  target.scrollLeft = -100;
+
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
+}, "scrollTop and scrollLeft being set with invalid scroll offset.");
+
+promise_test(async (t) => {
+  var target = setupTarget();
+
+  assert_equals(target.scrollTop, 0);
+  var promiseForScrollTop = waitForEvent("scroll", t, target);
+  target.scrollTop = 1000;
+  await promiseForScrollTop;
+  assert_equals(target.scrollTop, 100);
+
+  assert_equals(target.scrollLeft, 0);
+  var promiseForScrollLeft = waitForEvent("scroll", t, target);
+  target.scrollLeft = 1000;
+  await promiseForScrollLeft;
+  assert_equals(target.scrollLeft, 100);
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  target.scrollTop = 1000;
+  target.scrollLeft = 1000;
+
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
+}, "scrollTop and scrollLeft when scrolling above maximum offset.");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-iframe-expected.txt
@@ -1,0 +1,6 @@
+
+PASS scrollX and scrollY should fire scroll event.
+PASS scrollX and scrollY being set with the same value.
+PASS scrollX and scrollY being set with invalid scroll Scroll.
+PASS scrollX and scrollY when scrolling above maximum Scroll.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-iframe.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Scroll event should behave correctly for Element.ScrollX and Element.ScrollLeft</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="scroll_support.js"></script>
+<link rel="author" title="Jo Steven Novaryo" href="mailto:jo.steven.novaryo@huawei.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-events">
+<div id=log></div>
+<div id="container">
+</div>
+<script>
+
+
+function promiseForFrameLoad(frame) {
+  return new Promise(async (resolve) => {
+    frame.addEventListener("load", () => resolve(frame), { once: true });
+  });
+}
+
+async function promiseForSetupTargetFrame() {
+  const target = document.createElement("iframe");
+  target.src = "../resources/large-dimension-document.sub.html";
+  target.width = "200";
+  target.height = "200";
+
+  var container = document.getElementById("container");
+  container.innerHTML = "";
+  container.appendChild(target);
+
+  return promiseForFrameLoad(target);
+}
+
+promise_test(async (t) => {
+  var frame = await promiseForSetupTargetFrame();
+  var target = frame.contentWindow;
+
+  assert_equals(target.scrollX, 0);
+  var promiseForScrollX = waitForEvent("scroll", t, target);
+  target.scrollTo({left: 10});
+  await promiseForScrollX;
+  assert_equals(target.scrollX, 10);
+
+  assert_equals(target.scrollY, 0);
+  var promiseForScrollY = waitForEvent("scroll", t, target);
+  target.scrollTo({top: 10});
+  await promiseForScrollY;
+  assert_equals(target.scrollY, 10);
+
+}, "scrollX and scrollY should fire scroll event.");
+
+promise_test(async (t) => {
+  var frame = await promiseForSetupTargetFrame();
+  var target = frame.contentWindow;
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  assert_equals(target.scrollX, 0);
+  target.scrollTo({left: 0});
+
+  assert_equals(target.scrollY, 0);
+  target.scrollTo({top: 0});
+
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
+}, "scrollX and scrollY being set with the same value.");
+
+promise_test(async (t) => {
+  var frame = await promiseForSetupTargetFrame();
+  var target = frame.contentWindow;
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  target.scrollTo({left: -100});
+  target.scrollTo({top: -100});
+
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
+}, "scrollX and scrollY being set with invalid scroll Scroll.");
+
+promise_test(async (t) => {
+  var frame = await promiseForSetupTargetFrame();
+  var target = frame.contentWindow;
+  var frameDocEl = frame.contentDocument.documentElement;
+
+  assert_equals(target.scrollX, 0);
+  var promiseForScrollX = waitForEvent("scroll", t, target);
+  target.scrollTo({left: frameDocEl.scrollWidth});
+  await promiseForScrollX;
+  assert_greater_than(target.scrollX, 0);
+
+  assert_equals(target.scrollY, 0);
+  var promiseForScrollY = waitForEvent("scroll", t, target);
+  target.scrollTo({
+    top: frameDocEl.scrollHeight,
+    left: target.scrollX
+  });
+  await promiseForScrollY;
+  assert_greater_than(target.scrollY, 0);
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  target.scrollTo({
+    left: target.scrollX + 10,
+    top: target.scrollY + 10,
+  });
+
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
+}, "scrollX and scrollY when scrolling above maximum Scroll.");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll_support.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll_support.js
@@ -105,10 +105,15 @@ async function waitForScrollReset(test, scroller, x = 0, y = 0) {
 
 async function createScrollendPromiseForTarget(test,
                                                target_div,
-                                               timeoutMs = 500) {
+                                               timeoutMs = 500,
+                                               targetIsRoot = false) {
   return waitForScrollendEvent(test, target_div, timeoutMs).then(evt => {
     assert_false(evt.cancelable, 'Event is not cancelable');
-    assert_false(evt.bubbles, 'Event targeting element does not bubble');
+    if (targetIsRoot) {
+      assert_true(evt.bubbles, 'Event targeting element does not bubble');
+    } else {
+      assert_false(evt.bubbles, 'Event targeting element does not bubble');
+    }
   });
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-programmatic-scroll.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-programmatic-scroll.html
@@ -39,20 +39,10 @@ html {
 </div>
 </body>
 <script>
-let element_scrollend_arrived = false;
-let document_scrollend_arrived = false;
+let invalid_scrollend_arrived = false;
 
-function onElementScrollEnd(event) {
-  assert_false(event.cancelable);
-  assert_false(event.bubbles);
-  element_scrollend_arrived = true;
-}
-
-function onDocumentScrollEnd(event) {
-  assert_false(event.cancelable);
-  // scrollend events are bubbled when the target node is document.
-  assert_true(event.bubbles);
-  document_scrollend_arrived = true;
+function onInvalidScrollEnd(event) {
+  invalid_scrollend_arrived = true;
 }
 
 let scroll_fn_variants = [
@@ -119,20 +109,20 @@ function runTest() {
   async function testScrollFn(testInfo, t) {
     await waitForCompositorCommit();
 
-    targetDiv.addEventListener("scrollend", onElementScrollEnd);
-    document.addEventListener("scrollend", onDocumentScrollEnd);
+    let scrollendPromise = null;
+    if (testInfo.target == document.scrollingElement) {
+      targetDiv.addEventListener("scrollend", onInvalidScrollEnd);
+      scrollendPromise = createScrollendPromiseForTarget(t, document, 2000, true);
+    } else {
+      document.addEventListener("scrollend", onInvalidScrollEnd);
+      scrollendPromise = createScrollendPromiseForTarget(t, targetDiv, 2000, false);
+    }
 
     testInfo.target[testInfo.fn]({ top: 200, left: 200,
                                    behavior: testInfo.behavior });
 
-    await waitFor(() => {
-      return element_scrollend_arrived || document_scrollend_arrived;
-    }, testInfo.target.tagName + "." + testInfo.fn + " did not receive scrollend event.");
-    if (testInfo.target == document.scrollingElement) {
-      assert_false(element_scrollend_arrived);
-    } else {
-      assert_false(document_scrollend_arrived);
-    }
+    await scrollendPromise;
+    assert_false(invalid_scrollend_arrived, "Scrollend should not fire to target that has not scrolled");
 
     assert_equals(testInfo.target.scrollLeft, 200,
                   testInfo.target.tagName + "." + testInfo.fn + " scrollLeft");

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-scroll-attr-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-scroll-attr-change.html
@@ -39,20 +39,10 @@ html {
 </div>
 </body>
 <script>
-var element_scrollend_arrived = false;
-var document_scrollend_arrived = false;
+let invalid_scrollend_arrived = false;
 
-function onElementScrollEnd(event) {
-  assert_false(event.cancelable);
-  assert_false(event.bubbles);
-  element_scrollend_arrived = true;
-}
-
-function onDocumentScrollEnd(event) {
-  assert_false(event.cancelable);
-  // scrollend events are bubbled when the target node is document.
-  assert_true(event.bubbles);
-  document_scrollend_arrived = true;
+function onInvalidScrollEnd(event) {
+  invalid_scrollend_arrived = true;
 }
 
 let scroll_attr_change_variants = [
@@ -117,24 +107,25 @@ let scroll_attr_change_variants = [
 function runTest() {
 
   async function testScrollAttrChange(testInfo, t) {
-    targetDiv.addEventListener("scrollend", onElementScrollEnd);
-    document.addEventListener("scrollend", onDocumentScrollEnd);
-
     testInfo.target.style.scrollBehavior = testInfo.behavior;
 
     await waitForCompositorCommit();
 
+    let scrollendPromise = null;
+    const TIMEOUT = 2000;
+    if (testInfo.target == document.scrollingElement) {
+      targetDiv.addEventListener("scrollend", onInvalidScrollEnd);
+      scrollendPromise = createScrollendPromiseForTarget(t, document, TIMEOUT, true);
+    } else {
+      document.addEventListener("scrollend", onInvalidScrollEnd);
+      scrollendPromise = createScrollendPromiseForTarget(t, targetDiv, TIMEOUT, false);
+    }
+
     testInfo.target[testInfo.attribute] = 200;
 
-    await waitFor(() => {
-      return element_scrollend_arrived || document_scrollend_arrived;
-    }, testInfo.target.tagName + "." + testInfo.attribute + " did not receive scrollend event.");
+    await scrollendPromise;
+    assert_false(invalid_scrollend_arrived, "Scrollend should not fire to target that has not scrolled");
 
-    if (testInfo.target == document.scrollingElement) {
-      assert_false(element_scrollend_arrived);
-    } else {
-      assert_false(document_scrollend_arrived);
-    }
     assert_equals(testInfo.target[testInfo.attribute], 200,
                   testInfo.target.tagName + "." + testInfo.attribute + " " + testInfo.behavior);
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll-expected.txt
@@ -1,10 +1,8 @@
 target
 doc
 
-Harness Error (FAIL), message = Unhandled rejection: assert_true: no scroll, so no scrollend expected expected true got false
-
 PASS No scroll via wheel on div shouldn't fire scrollend.
 PASS No scroll via keys on div shouldn't fire scrollend.
-FAIL No scroll via wheel on document shouldn't fire scrollend. assert_true: no scroll, so no scrollend expected expected true got false
+FAIL No scroll via wheel on document shouldn't fire scrollend. assert_unreached: no scroll, so no scrollend expected Reached unreachable code
 PASS No scroll via keys on document shouldn't fire scrollend.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll.html
@@ -25,7 +25,7 @@
   }
 </style>
 
-<body style="margin:0" onload=runTest()>
+<body style="margin:0">
   <div id="targetDiv">
     <!-- This test uses button elements as a consistent mechanism for
       ensuring that focus is on the correct scrolling element when
@@ -59,7 +59,7 @@
       let delta_x = 0;
       let delta_y = -50;
       let actions = new test_driver.Actions()
-      .scroll(x, y, delta_x, delta_y, {origin: scrolling_element});
+        .scroll(x, y, delta_x, delta_y, {origin: scrolling_element});
       await actions.send();
     } else if (scroll_type == "keys") {
       const num_keydowns = 5;
@@ -73,18 +73,18 @@
   async function testScrollendNotFiredOnNoScroll(test, scrolling_element,
                                                  listening_element,
                                                  button_element, scroll_type) {
-    await resetScrollers(test);
-    await waitForCompositorCommit();
+    test.add_cleanup(async () => {
+      await resetScrollers(test);
+      await waitForCompositorCommit();
+    });
 
     assert_greater_than(scrolling_element.scrollHeight,
                         scrolling_element.clientHeight);
     assert_equals(scrolling_element.scrollTop, 0);
 
     let scrollend_promise = waitForScrollendEvent(test, listening_element).then(
-      (/*resolve*/) => {
-        assert_true(false, "no scroll, so no scrollend expected");
-      },
-      (/*reject*/) => { /* Did not see scrollend, which is okay. */ }
+      /* resolve */ test.unreached_func("no scroll, so no scrollend expected"),
+      /* reject */  () => { /* Did not see scrollend, which is okay. */ }
     );
     await upwardScroll(scrolling_element, button_element, scroll_type);
     await scrollend_promise;
@@ -111,4 +111,5 @@
                                             document, docButton, "keys");
     }, "No scroll via keys on document shouldn't fire scrollend.")
   }
+  window.onload = runTest;
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/w3c-import.log
@@ -22,8 +22,12 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/overscroll-event-fired-to-element-with-overscroll-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/overscroll-event-fired-to-scrolled-element.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/overscroll-event-fired-to-window.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-cross-origin-iframes.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-cross-origin-iframes.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-element.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll_support.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-after-sequence-of-scrolls.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-after-snap.html

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/w3c-import.log
@@ -46,6 +46,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-target-moved.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-target-removed.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-throwing-multiple-globals.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-throwing.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-init-while-dispatching.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-initEvent.html
@@ -88,6 +89,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global.worker.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/focus-event-document-move.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/keypress-dispatch-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/legacy-pre-activation-behavior.window.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/mouse-event-retarget.html
@@ -103,3 +105,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/webkit-animation-iteration-event.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/webkit-animation-start-event.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/webkit-transition-end-event.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/events/window-composed-path.html

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/window-composed-path-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/window-composed-path-expected.txt
@@ -1,0 +1,3 @@
+
+PASS window target has an empty path after dispatch
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/window-composed-path.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/window-composed-path.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Window: Event.composedPath()</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+test(() => {
+  const target = window;
+  const event = new Event("foo");
+
+  function listener(e) {
+    assert_array_equals(e.composedPath(), [target]);
+  }
+  target.addEventListener("foo", listener);
+  target.dispatchEvent(event);
+  assert_array_equals(event.composedPath(), []);
+}, "window target has an empty path after dispatch");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4786,6 +4786,10 @@ imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-w
 imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-root.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-window.html [ Skip ]
 
+imported/w3c/web-platform-tests/dom/events/handler-count.html?document [ Skip ]
+imported/w3c/web-platform-tests/dom/events/handler-count.html?element [ Skip ]
+imported/w3c/web-platform-tests/dom/events/handler-count.html?window [ Skip ]
+
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-scrolling.html [ Skip ]
 


### PR DESCRIPTION
#### 80cee4fef09e62b1285e661429e11e7557e84e9f
<pre>
Re-import dom/events WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=300573">https://bugs.webkit.org/show_bug.cgi?id=300573</a>
<a href="https://rdar.apple.com/162456467">rdar://162456467</a>

Reviewed by Simon Fraser.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/829c502885fd450555e590ae188716b50da83f20">https://github.com/web-platform-tests/wpt/commit/829c502885fd450555e590ae188716b50da83f20</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-throwing-multiple-globals-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-throwing-multiple-globals.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count_document-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count_element-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/handler-count_window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/generic-events-stay-cancelable-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/generic-events-stay-cancelable.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/resources/large-dimension-document.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-element-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-element.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-iframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll-event-fired-to-iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scroll_support.js:
(async createScrollendPromiseForTarget):
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-programmatic-scroll.html:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-scroll-attr-change.html:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll.html:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/window-composed-path-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/window-composed-path.html: Added.
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/301383@main">https://commits.webkit.org/301383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d652426537428be04a9ae40ea141e918173c954a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77680 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f222dc6-7f98-4ae6-9fb1-73cd2e679c52) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95840 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63953 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d5801a64-5156-4a25-8a31-03eae2c2f31f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76332 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/884f9279-7605-4a6d-b4ec-5ace8fd748f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30681 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76143 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135351 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40337 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104305 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104033 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26492 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49402 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27720 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49924 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52486 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51834 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55183 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53528 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->