### PR TITLE
[JSC] Conform `String.prototype.substring` to TC39 spec

### DIFF
--- a/JSTests/microbenchmarks/string-substring-constants-binary.js
+++ b/JSTests/microbenchmarks/string-substring-constants-binary.js
@@ -1,16 +1,16 @@
 function shouldBe(actual, expected) {
     if (actual !== expected)
-        throw new Error('bad value: ' + actual);
+        throw new Error("bad value: " + actual);
 }
 
 function test1() {
-    return "/assets/omfg".substring(1) === 'assets/omfg';
+    return "/assets/omfg".substring(1) === "assets/omfg";
 }
 noInline(test1);
 
 var count = 0;
-for (var i = 0; i < 1e6; ++i) {
+for (var i = 0; i < testLoopCount; ++i) {
     if (test1())
         ++count;
 }
-shouldBe(count, 1e6);
+shouldBe(count, testLoopCount);

--- a/JSTests/microbenchmarks/string-substring-constants-identity.js
+++ b/JSTests/microbenchmarks/string-substring-constants-identity.js
@@ -1,16 +1,16 @@
 function shouldBe(actual, expected) {
     if (actual !== expected)
-        throw new Error('bad value: ' + actual);
+        throw new Error("bad value: " + actual);
 }
 
 function test1() {
-    return "/assets/omfg".substring(0) === '/assets/';
+    return "/assets/omfg".substring(0) === "/assets/";
 }
 noInline(test1);
 
 var count = 0;
-for (var i = 0; i < 1e6; ++i) {
+for (var i = 0; i < testLoopCount; ++i) {
     if (!test1())
         ++count;
 }
-shouldBe(count, 1e6);
+shouldBe(count, testLoopCount);

--- a/JSTests/microbenchmarks/string-substring-infinity.js
+++ b/JSTests/microbenchmarks/string-substring-infinity.js
@@ -1,16 +1,18 @@
 function shouldBe(actual, expected) {
-    if (actual !== expected)
+    if (actual !== expected) {
         throw new Error("bad value: " + actual);
+    }
 }
 
-function test1() {
-    return "/assets/omfg".substring(0, 8) === "/assets/";
+function test(start, end) {
+    return "/assets/nanona".substring(0, Infinity) === "/assets/nanona";
 }
-noInline(test1);
+noInline(test);
 
 var count = 0;
 for (var i = 0; i < testLoopCount; ++i) {
-    if (test1())
+    if (test()) {
         ++count;
+    }
 }
 shouldBe(count, testLoopCount);

--- a/JSTests/microbenchmarks/string-substring-length-constant.js
+++ b/JSTests/microbenchmarks/string-substring-length-constant.js
@@ -1,16 +1,16 @@
 function shouldBe(actual, expected) {
     if (actual !== expected)
-        throw new Error('bad value: ' + actual);
+        throw new Error("bad value: " + actual);
 }
 
 function test1() {
-    return "/assets/omfg".substring(0,'/assets/'.length) === '/assets/';
+    return "/assets/omfg".substring(0, "/assets/".length) === "/assets/";
 }
 noInline(test1);
 
 var count = 0;
-for (var i = 0; i < 1e6; ++i) {
+for (var i = 0; i < testLoopCount; ++i) {
     if (test1())
         ++count;
 }
-shouldBe(count, 1e6);
+shouldBe(count, testLoopCount);

--- a/JSTests/microbenchmarks/string-substring-nan.js
+++ b/JSTests/microbenchmarks/string-substring-nan.js
@@ -1,16 +1,18 @@
 function shouldBe(actual, expected) {
-    if (actual !== expected)
+    if (actual !== expected) {
         throw new Error("bad value: " + actual);
+    }
 }
 
-function test1() {
-    return "/assets/omfg".substring(0, 8) === "/assets/";
+function test() {
+    return "/assets/sakana".substring(0, NaN) === "";
 }
-noInline(test1);
+noInline(test);
 
 var count = 0;
 for (var i = 0; i < testLoopCount; ++i) {
-    if (test1())
+    if (test()) {
         ++count;
+    }
 }
 shouldBe(count, testLoopCount);

--- a/JSTests/microbenchmarks/string-substring.js
+++ b/JSTests/microbenchmarks/string-substring.js
@@ -1,16 +1,16 @@
 function shouldBe(actual, expected) {
     if (actual !== expected)
-        throw new Error('bad value: ' + actual);
+        throw new Error("bad value: " + actual);
 }
 
 function test1(start, end) {
-    return "/assets/omfg".substring(start, end) === '/assets/';
+    return "/assets/omfg".substring(start, end) === "/assets/";
 }
 noInline(test1);
 
 var count = 0;
-for (var i = 0; i < 1e6; ++i) {
+for (var i = 0; i < testLoopCount; ++i) {
     if (test1(0, 8))
         ++count;
 }
-shouldBe(count, 1e6);
+shouldBe(count, testLoopCount);

--- a/JSTests/stress/string-substring.js
+++ b/JSTests/stress/string-substring.js
@@ -1,0 +1,100 @@
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected)) {
+        throw new Error(`Bad value: ${actual}!`);
+    }
+}
+
+for (var i = 0; i < testLoopCount; i++) {
+    // basic
+    const str = "ABCDE";
+    shouldBe(str.substring(0, 5), str);
+    shouldBe(str.substring(1, 4), "BCD");
+    shouldBe(str.substring(2), "CDE");
+    shouldBe(str.substring(3, 3), "");
+    shouldBe(str.substring(4, 1), "BCD");
+
+    // out of range
+    shouldBe(str.substring(10, 12), "");
+    shouldBe(str.substring(2, 10), "CDE");
+    shouldBe(str.substring(99, 100), "");
+    shouldBe(str.substring(5, 5), "");
+    shouldBe(str.substring(5, 99), "");
+
+    // negative value
+    shouldBe(str.substring(-3), str);
+    shouldBe(str.substring(-1), str);
+    shouldBe(str.substring(-str.length), str);
+    shouldBe(str.substring(-str.length - 1), str);
+    shouldBe(str.substring(-3, 2), "AB");
+    shouldBe(str.substring(1, -2), "A");
+    shouldBe(str.substring(-5, -1), "");
+    shouldBe(str.substring(-1, 3), "ABC");
+    shouldBe(str.substring(0, -5), "");
+
+    // NaN, Infinity
+    shouldBe(str.substring(NaN), str);
+    shouldBe(str.substring(NaN, NaN), "");
+    shouldBe(str.substring(NaN, 2), "AB");
+    shouldBe(str.substring(2, NaN), "AB");
+    shouldBe(str.substring(Infinity), "");
+    shouldBe(str.substring(-Infinity), str);
+    shouldBe(str.substring(Infinity, 0), str);
+    shouldBe(str.substring(0, Infinity), str);
+    shouldBe(str.substring(Infinity, Infinity), "");
+    shouldBe(str.substring(-Infinity, 2), "AB");
+    shouldBe(str.substring(2, -Infinity), "AB");
+    shouldBe(str.substring(-Infinity, -Infinity), "");
+    shouldBe(str.substring(-Infinity, 0), "");
+    shouldBe(str.substring(-Infinity, Infinity), str);
+    shouldBe(str.substring(Infinity, -Infinity), str);
+
+    // type cast
+    shouldBe(str.substring("1", "3"), "BC");
+    shouldBe(str.substring("3", "1"), "BC");
+    shouldBe(str.substring("a", "c"), "");
+    shouldBe(str.substring("A", "C"), "");
+    shouldBe(str.substring(true, false), "A");
+    shouldBe(str.substring(null, undefined), str);
+    shouldBe(str.substring(undefined, null), "");
+    shouldBe(str.substring(false, true), "A");
+    shouldBe(str.substring("2", 4), "CD");
+    shouldBe(str.substring(4, "2"), "CD");
+
+    // decimal number
+    shouldBe(str.substring(1.9, 4.2), "BCD");
+    shouldBe(str.substring(0.1, 0.9), "");
+    shouldBe(str.substring(0.9, 1.1), "A");
+
+    // empty string
+    shouldBe("".substring(-10), "");
+    shouldBe("".substring(0), "");
+    shouldBe("".substring(10), "");
+    shouldBe("".substring(0, 1), "");
+    shouldBe("".substring(1, 1), "");
+    shouldBe("".substring(-1, 2), "");
+
+    // unicode
+    const uni = "𠮷野家";
+    shouldBe(uni.substring(0, 2), "𠮷");
+    shouldBe(uni.substring(0, 99), "𠮷野家");
+    shouldBe(uni.substring(-10, 10), "𠮷野家");
+
+    // emmoji
+    const emoji1 = "🐟💨🍅🌈";
+    shouldBe(emoji1.substring(0, 2), "🐟");
+    shouldBe(emoji1.substring(2, 4), "💨");
+    shouldBe(emoji1.substring(0, 4), "🐟💨");
+    shouldBe(emoji1.substring(0, 0), "");
+    shouldBe(emoji1.substring(0), emoji1);
+    shouldBe(emoji1.substring(0, emoji1.length), emoji1);
+    shouldBe(emoji1.substring(-Infinity, Infinity), emoji1);
+
+    // edge cases
+    shouldBe(str.substring(), str);
+    shouldBe(str.substring(undefined), str);
+    shouldBe(str.substring(null), str);
+    shouldBe(str.substring(undefined, undefined), str);
+    shouldBe(str.substring(0, 0), "");
+    shouldBe(str.substring(0, -0), "");
+    shouldBe(str.substring(-0, 0), "");
+}


### PR DESCRIPTION
#### dd3af5604c58cde8de0ed7632419d6f386b1b3d3
<pre>
[JSC] Conform `String.prototype.substring` to TC39 spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=300578">https://bugs.webkit.org/show_bug.cgi?id=300578</a>

Reviewed by Yusuke Suzuki and Darin Adler.

This patch conforms `String.prototype.substring` to TC39 spec [1],
such as using `ToIntegerOrInfinity` instead of `ToNumber`.

This patch introduces no performance regressions.

                                                TipOfTree                   Patched                            Ratio
string-substring-constants                 0.4274+-0.0569            0.4026+-0.0112          might be 1.0617x faster
string-substring-constants-binary          0.3904+-0.0315     ?      0.3952+-0.0442        ? might be 1.0122x slower
string-substring-infinity                  0.5556+-0.0095            0.5314+-0.0269          might be 1.0455x faster
string-substring-length-constant           0.3914+-0.0278     ?      0.4163+-0.0378        ? might be 1.0636x slower
string-substring-nan                       0.4938+-0.0259            0.4894+-0.0293
string-substring-constants-identity        0.3593+-0.0146            0.3423+-0.0323          might be 1.0496x faster

[1]: <a href="https://tc39.es/ecma262/#sec-string.prototype.substring">https://tc39.es/ecma262/#sec-string.prototype.substring</a>

Tests: JSTests/microbenchmarks/string-substring-infinity.js
       JSTests/microbenchmarks/string-substring-nan.js
       JSTests/stress/string-substring.js

* JSTests/microbenchmarks/string-substring-constants-binary.js:
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-substring-constants-identity.js:
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-substring-constants.js:
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-substring-infinity.js: Added.
(shouldBe):
(test):
(i.test):
* JSTests/microbenchmarks/string-substring-length-constant.js:
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-substring-nan.js: Added.
(shouldBe):
(test):
(i.test):
* JSTests/microbenchmarks/string-substring.js:
(shouldBe):
(test1):
* JSTests/stress/string-substring.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/301783@main">https://commits.webkit.org/301783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16a0dff3d37fe581c8f02728e5190298a257ad59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78269 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96343 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64425 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76869 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31415 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76970 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118649 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136141 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125064 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53290 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104854 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104560 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26746 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50033 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28378 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50722 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53210 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59023 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158109 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52491 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39564 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->