### PR TITLE
Cheaper ctor of VideoFrame from OffscreenCanvas.

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/videoFrame-webglCanvasImageSource-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-webglCanvasImageSource-expected.txt
@@ -1,5 +1,5 @@
 
-PASS VideoFrame from canvas snapshots drawing at call time, context: webgl offscreen: true, premultipliedAlpha: true
+FAIL VideoFrame from canvas snapshots drawing at call time, context: webgl offscreen: true, premultipliedAlpha: true assert_equals: expected 8388736 but got 4194432
 PASS VideoFrame from canvas snapshots drawing at call time, context: webgl offscreen: true, premultipliedAlpha: false
 PASS VideoFrame from canvas snapshots drawing at call time, context: 2d offscreen: true
 FAIL VideoFrame from canvas snapshots drawing at call time, context: webgl offscreen: false, premultipliedAlpha: true assert_equals: expected 8388736 but got 4194432

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -229,11 +229,11 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
         if (!canvas->width() || !canvas->height())
             return Exception { ExceptionCode::InvalidStateError,  "Input canvas has a bad size"_s };
 
-        RefPtr imageBuffer = canvas->makeRenderingResultsAvailable();
-        if (!imageBuffer)
-            return Exception { ExceptionCode::InvalidStateError,  "Input canvas has no image buffer"_s };
+        RefPtr videoFrame = canvas->toVideoFrame();
+        if (!videoFrame)
+            return Exception { ExceptionCode::InvalidStateError,  "Canvas has no frame"_s };
 
-        return create(context, *imageBuffer, { static_cast<int>(canvas->width()), static_cast<int>(canvas->height()) }, WTFMove(init));
+        return initializeFrameFromOtherFrame(context, videoFrame.releaseNonNull(), WTFMove(init), VideoFrame::ShouldCloneWithDifferentTimestamp::Yes);
     },
 #endif // ENABLE(OFFSCREEN_CANVAS)
     [&] (RefPtr<ImageBitmap>& image) -> ExceptionOr<Ref<WebCodecsVideoFrame>> {

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -482,6 +482,30 @@ ScriptExecutionContext* OffscreenCanvas::canvasBaseScriptExecutionContext() cons
     return ContextDestructionObserver::scriptExecutionContext();
 }
 
+#if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
+
+RefPtr<VideoFrame> OffscreenCanvas::toVideoFrame()
+{
+    if (RefPtr context = dynamicDowncast<WebGLRenderingContextBase>(renderingContext()))
+        return context->surfaceBufferToVideoFrame(CanvasRenderingContext::SurfaceBuffer::DrawingBuffer);
+
+    RefPtr imageBuffer = makeRenderingResultsAvailable();
+    if (!imageBuffer)
+        return nullptr;
+
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, DestinationColorSpace::SRGB() };
+    IntRect region { IntPoint::zero(), { static_cast<int>(width()), static_cast<int>(height()) } };
+
+    auto pixelBuffer = imageBuffer->getPixelBuffer(format, region);
+
+    if (!pixelBuffer)
+        return nullptr;
+
+    return VideoFrame::createFromPixelBuffer(pixelBuffer.releaseNonNull(), { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Iec6196621, PlatformVideoMatrixCoefficients::Rgb, true });
+}
+
+#endif
+
 }
 
 #endif

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -56,6 +56,7 @@ class DeferredPromise;
 class GPU;
 class GPUCanvasContext;
 class HTMLCanvasElement;
+class VideoFrame;
 class ImageBitmap;
 class ImageBitmapRenderingContext;
 class ImageData;
@@ -151,6 +152,10 @@ public:
     void queueTaskKeepingObjectAlive(TaskSource, Function<void(CanvasBase&)>&&) final;
     void dispatchEvent(Event&) final;
     bool isDetached() const { return m_detached; };
+
+#if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
+    RefPtr<VideoFrame> toVideoFrame();
+#endif
 
 private:
     OffscreenCanvas(ScriptExecutionContext&, IntSize, RefPtr<PlaceholderRenderingContextSource>&&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -192,7 +192,6 @@ void RemoteGraphicsContextGLProxy::drawSurfaceBufferToImageBuffer(SurfaceBuffer 
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
 RefPtr<WebCore::VideoFrame> RemoteGraphicsContextGLProxy::surfaceBufferToVideoFrame(SurfaceBuffer buffer)
 {
-    ASSERT(isMainRunLoop());
     if (isContextLost())
         return nullptr;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::SurfaceBufferToVideoFrame(buffer));
@@ -203,7 +202,14 @@ RefPtr<WebCore::VideoFrame> RemoteGraphicsContextGLProxy::surfaceBufferToVideoFr
     auto [result] = sendResult.takeReply();
     if (!result)
         return nullptr;
-    return RemoteVideoFrameProxy::create(WebProcess::singleton().ensureGPUProcessConnection().connection(), WebProcess::singleton().ensureProtectedGPUProcessConnection()->protectedVideoFrameObjectHeapProxy(), WTFMove(*result));
+
+    RefPtr<VideoFrame> videoFrame;
+    callOnMainRunLoopAndWait([&] {
+        if (RefPtr gpuProcess = m_gpuProcessConnection.get())
+            videoFrame = RemoteVideoFrameProxy::create(gpuProcess->connection(), gpuProcess->protectedVideoFrameObjectHeapProxy(), WTFMove(*result));
+    });
+
+    return videoFrame;
 }
 #endif
 


### PR DESCRIPTION
#### 0c70aefca1f7881f706616c2fc53ca7e322dfc86
<pre>
Cheaper ctor of VideoFrame from OffscreenCanvas.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300579">https://bugs.webkit.org/show_bug.cgi?id=300579.</a>

Reviewed by NOBODY (OOPS!).

VideoFrame constructor had existing optimized code to construct
from &lt;canvas&gt;, while the construction from offscreen canvas had
different implementation which was much more CPU expensive.
The current change makes construction from offscreen canvas behave
similar to construction from regular canvas, which also
rely on SurfaceBufferToVideoFrame command and RemoteVideoFrameProxy.

The change unfortunately makes one test case from
(LayoutTests/http/wpt/webcodecs/videoFrame-webglCanvasImageSource.html)
fail:
```
VideoFrame from canvas snapshots drawing at call time, context: webgl offscreen: true, premultipliedAlpha: true
````
in addition to already failing case for regular canvas:
```
VideoFrame from canvas snapshots drawing at call time, context: webgl offscreen: false, premultipliedAlpha: true
```
The RemoteVideoFrameProxy does not perform unpremultiply at all,
while previous implementation for VideoFrame(OffscreenCanvas) performed
it always.

* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::toVideoFrame):
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::surfaceBufferToVideoFrame):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f607eccd57f61ac9237674e49c72508f94f6e4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132892 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54275 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96007 "2 flakes 16 failures") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64106 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76496 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30937 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76364 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106901 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135597 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40565 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104509 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104227 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49628 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27954 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50217 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52731 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58564 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52059 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55405 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->