### PR TITLE
Speculation Rules: Fix waitForResponse test scenarios

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -891,9 +891,6 @@ imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-data-url
 imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-data-url-cross-origin.html [ Skip ]
 
 # This is failing because the navigationTiming timestamps are not correct.
-imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https.html?include=afterResponse [ Pass Failure ]
-imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https.html?include=waitingForRedirect [ Pass Failure ]
-imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https.html?include=waitingForResponse [ Pass Failure ]
 imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https.html?3-3 [ Pass Failure ]
 # This is passing, but timing out as `Clear-Site-Data: *` is making the test framework fail to get its own messages.
 imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForRedirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForRedirect-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL PerformanceNavigationTiming data should show noticeable TTFB if the response is slow assert_in_array: https://web-platform.test:9443/speculation-rules/prefetch/resources/executor.sub.html?uuid=65f13b47-1d3f-4f15-bce6-178ff3b52539&page=2 should have been prefetched. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
+PASS PerformanceNavigationTiming data should show noticeable TTFB if the response is slow
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForResponse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForResponse-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL PerformanceNavigationTiming data should show noticeable TTFB if the response is slow assert_in_array: https://web-platform.test:9443/speculation-rules/prefetch/resources/slow-executor.py?uuid=ccd54d26-2e28-444c-b435-9e5e2a50bbc5&delay=3&page=2 should have been prefetched. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
+PASS PerformanceNavigationTiming data should show noticeable TTFB if the response is slow
 

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -134,7 +134,7 @@ void DocumentPrefetcher::prefetch(const URL& url, const Vector<String>& tags, co
         CertificateInfoPolicy::IncludeCertificateInfo,
         ContentSecurityPolicyImposition::DoPolicyCheck,
         DefersLoadingPolicy::AllowDefersLoading,
-        CachingPolicy::AllowCachingPrefetch
+        CachingPolicy::AllowCachingMainResourcePrefetch
     );
     prefetchOptions.destination = FetchOptions::Destination::Document;
     CachedResourceRequest prefetchRequest(WTFMove(request), prefetchOptions);

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -96,7 +96,7 @@ static constexpr unsigned bitWidthOfDefersLoadingPolicy = 1;
 enum class CachingPolicy : uint8_t {
     AllowCaching,
     DisallowCaching,
-    AllowCachingPrefetch
+    AllowCachingMainResourcePrefetch
 };
 static constexpr unsigned bitWidthOfCachingPolicy = 2;
 

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -101,7 +101,7 @@ CachedResource::CachedResource(CachedResourceRequest&& request, Type type, PAL::
     setLoadPriority(request.priority(), request.fetchPriority());
 
     // FIXME: We should have a better way of checking for Navigation loads, maybe FetchMode::Options::Navigate.
-    ASSERT(m_origin || m_type == Type::MainResource || m_options.cachingPolicy == CachingPolicy::AllowCachingPrefetch);
+    ASSERT(m_origin || m_type == Type::MainResource || m_options.cachingPolicy == CachingPolicy::AllowCachingMainResourcePrefetch);
 
     if (isRequestCrossOrigin(m_origin.get(), m_resourceRequest.url(), m_options))
         setCrossOrigin();
@@ -538,7 +538,7 @@ bool CachedResource::addClientToSet(CachedResourceClient& client)
     if (allowsCaching() && !hasClients() && inCache())
         MemoryCache::singleton().addToLiveResourcesSize(*this);
 
-    if ((m_type == Type::RawResource || m_type == Type::MainResource) && !response().isNull() && !m_proxyResource && m_options.cachingPolicy != CachingPolicy::AllowCachingPrefetch) {
+    if ((m_type == Type::RawResource || m_type == Type::MainResource) && !response().isNull() && !m_proxyResource && m_options.cachingPolicy != CachingPolicy::AllowCachingMainResourcePrefetch) {
         // Certain resources (especially XHRs and main resources) do crazy things if an asynchronous load returns
         // synchronously (e.g., scripts may not have set all the state they need to handle the load).
         // Therefore, rather than immediately sending callbacks on a cache hit like other CachedResources,

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -272,7 +272,7 @@ public:
     bool shouldSendResourceLoadCallbacks() const { return m_options.sendLoadCallbacks == SendCallbackPolicy::SendCallbacks; }
     DataBufferingPolicy dataBufferingPolicy() const { return m_options.dataBufferingPolicy; }
 
-    bool allowsCaching() const { return m_options.cachingPolicy == CachingPolicy::AllowCaching || m_options.cachingPolicy == CachingPolicy::AllowCachingPrefetch; }
+    bool allowsCaching() const { return m_options.cachingPolicy == CachingPolicy::AllowCaching || m_options.cachingPolicy == CachingPolicy::AllowCachingMainResourcePrefetch; }
     const ResourceLoaderOptions& options() const { return m_options; }
 
     virtual void destroyDecodedData() { }

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -71,7 +71,7 @@ public:
     void setInitiatorType(const AtomString&);
     const AtomString& initiatorType() const;
 
-    bool allowsCaching() const { return m_options.cachingPolicy == CachingPolicy::AllowCaching || m_options.cachingPolicy == CachingPolicy::AllowCachingPrefetch; }
+    bool allowsCaching() const { return m_options.cachingPolicy == CachingPolicy::AllowCaching || m_options.cachingPolicy == CachingPolicy::AllowCachingMainResourcePrefetch; }
     void setCachingPolicy(CachingPolicy policy) { m_options.cachingPolicy = policy;  }
 
     // Whether this request should impact request counting and delay window.onload.

--- a/Source/WebCore/page/PerformanceResourceTiming.cpp
+++ b/Source/WebCore/page/PerformanceResourceTiming.cpp
@@ -47,7 +47,7 @@ namespace WebCore {
 static double networkLoadTimeToDOMHighResTimeStamp(MonotonicTime timeOrigin, MonotonicTime timeStamp)
 {
     ASSERT(timeOrigin);
-    if (!timeStamp)
+    if (timeStamp <= timeOrigin)
         return 0.0;
     return Performance::reduceTimeResolution(timeStamp - timeOrigin).milliseconds();
 }

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -152,7 +152,7 @@ void updateRedirectChainStatus(RedirectChainCacheStatus& redirectChainCacheStatu
 {
     if (redirectChainCacheStatus.status == RedirectChainCacheStatus::Status::NotCachedRedirection)
         return;
-    if (options.cachingPolicy != CachingPolicy::AllowCachingPrefetch && (response.cacheControlContainsNoStore() || response.cacheControlContainsNoCache() || response.cacheControlContainsMustRevalidate())) {
+    if (options.cachingPolicy != CachingPolicy::AllowCachingMainResourcePrefetch && (response.cacheControlContainsNoStore() || response.cacheControlContainsNoCache() || response.cacheControlContainsMustRevalidate())) {
         redirectChainCacheStatus.status = RedirectChainCacheStatus::Status::NotCachedRedirection;
         return;
     }


### PR DESCRIPTION
#### fed984d0feb9b3773d13dfa6270fde810f980994
<pre>
Speculation Rules: Fix waitForResponse test scenarios
<a href="https://bugs.webkit.org/show_bug.cgi?id=300582">https://bugs.webkit.org/show_bug.cgi?id=300582</a>

Reviewed by Alex Christensen.

The navigation-timing waitForResponse and waitForRedirect tests are testing two different things:
(1) That prefetch is working correctly when the prefetched response starts arriving after the navigation to that response.
(2) That when that happens, the navigation timing values for responseStart and requestStart are correct.

Fixing (1) required avoiding canceling loaders for prefetch resources when navigating.
Fixing (2) required making sure that the navigation timing values cannot be negative (relative to the current document&apos;s timeOrigin).

No new tests, but this adjusts existing test expectations.

* LayoutTests/TestExpectations: Remove skipping of the navigation-timing tests.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForRedirect-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForResponse-expected.txt: Progression.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::stopLoadingSubresources): Don&apos;t stop prefetch resource loaders.
(WebCore::DocumentLoader::loadMainResource): Rename to AllowCachingMainResourcePrefetch.
(WebCore::DocumentLoader::cancelMainResourceLoad): Don&apos;t cancel a main resource prefetch.
* Source/WebCore/loader/DocumentPrefetcher.cpp:
(WebCore::DocumentPrefetcher::prefetch): Rename to AllowCachingMainResourcePrefetch.
* Source/WebCore/loader/ResourceLoaderOptions.h:
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::CachedResource): Rename to AllowCachingMainResourcePrefetch.
(WebCore::CachedResource::addClientToSet): Rename to AllowCachingMainResourcePrefetch.
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::allowsCaching const):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::shouldUpdateCachedResourceWithCurrentRequest): Rename to AllowCachingMainResourcePrefetch.
(WebCore::isResourceSuitableForDirectReuse): Rename to AllowCachingMainResourcePrefetch.
(WebCore::CachedResourceLoader::updateCachedResourceWithCurrentRequest): Rename to AllowCachingMainResourcePrefetch.
(WebCore::mustReloadFromServiceWorkerOptions): Rename to AllowCachingMainResourcePrefetch.
(WebCore::CachedResourceLoader::determineRevalidationPolicy const): Rename to AllowCachingMainResourcePrefetch.
* Source/WebCore/loader/cache/CachedResourceRequest.h:
(WebCore::CachedResourceRequest::allowsCaching const): Rename to AllowCachingMainResourcePrefetch.
* Source/WebCore/page/PerformanceResourceTiming.cpp:
(WebCore::networkLoadTimeToDOMHighResTimeStamp): Return 0.0 instead of a negative timestamp.
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::updateRedirectChainStatus): Rename to AllowCachingMainResourcePrefetch.

Canonical link: <a href="https://commits.webkit.org/301456@main">https://commits.webkit.org/301456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c7f5415b2b9e7f9047df7041cd529a1f932264a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95972 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64066 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30857 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76308 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135529 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104454 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104174 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26545 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49554 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50138 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52654 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58476 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55344 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->