### PR TITLE
Speculation Rules: implement Navigation Timing's deliveryType

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any-expected.txt
@@ -11,7 +11,7 @@ PASS PerformanceResourceTiming interface: existence and properties of interface 
 PASS PerformanceResourceTiming interface: existence and properties of interface prototype object's "constructor" property
 PASS PerformanceResourceTiming interface: existence and properties of interface prototype object's @@unscopables property
 PASS PerformanceResourceTiming interface: attribute initiatorType
-FAIL PerformanceResourceTiming interface: attribute deliveryType assert_true: The prototype object must have a property "deliveryType" expected true got false
+PASS PerformanceResourceTiming interface: attribute deliveryType
 PASS PerformanceResourceTiming interface: attribute nextHopProtocol
 PASS PerformanceResourceTiming interface: attribute workerStart
 PASS PerformanceResourceTiming interface: attribute redirectStart
@@ -38,7 +38,7 @@ PASS PerformanceResourceTiming interface: operation toJSON()
 PASS PerformanceResourceTiming must be primary interface of resource
 PASS Stringification of resource
 PASS PerformanceResourceTiming interface: resource must inherit property "initiatorType" with the proper type
-FAIL PerformanceResourceTiming interface: resource must inherit property "deliveryType" with the proper type assert_inherits: property "deliveryType" not found in prototype chain
+PASS PerformanceResourceTiming interface: resource must inherit property "deliveryType" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "nextHopProtocol" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "workerStart" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "redirectStart" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any.worker-expected.txt
@@ -11,7 +11,7 @@ PASS PerformanceResourceTiming interface: existence and properties of interface 
 PASS PerformanceResourceTiming interface: existence and properties of interface prototype object's "constructor" property
 PASS PerformanceResourceTiming interface: existence and properties of interface prototype object's @@unscopables property
 PASS PerformanceResourceTiming interface: attribute initiatorType
-FAIL PerformanceResourceTiming interface: attribute deliveryType assert_true: The prototype object must have a property "deliveryType" expected true got false
+PASS PerformanceResourceTiming interface: attribute deliveryType
 PASS PerformanceResourceTiming interface: attribute nextHopProtocol
 PASS PerformanceResourceTiming interface: attribute workerStart
 PASS PerformanceResourceTiming interface: attribute redirectStart
@@ -38,7 +38,7 @@ PASS PerformanceResourceTiming interface: operation toJSON()
 PASS PerformanceResourceTiming must be primary interface of resource
 PASS Stringification of resource
 PASS PerformanceResourceTiming interface: resource must inherit property "initiatorType" with the proper type
-FAIL PerformanceResourceTiming interface: resource must inherit property "deliveryType" with the proper type assert_inherits: property "deliveryType" not found in prototype chain
+PASS PerformanceResourceTiming interface: resource must inherit property "deliveryType" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "nextHopProtocol" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "workerStart" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "redirectStart" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&bypass_cache=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&bypass_cache=false-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL PerformanceNavigationTiming.deliveryType test, same origin prefetch. assert_equals: expected (string) "" but got (undefined) undefined
+PASS PerformanceNavigationTiming.deliveryType test, same origin prefetch.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&bypass_cache=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&bypass_cache=true-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL PerformanceNavigationTiming.deliveryType test, same origin prefetch. assert_equals: expected (string) "" but got (undefined) undefined
+PASS PerformanceNavigationTiming.deliveryType test, same origin prefetch.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&bypass_cache=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&bypass_cache=false-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL PerformanceNavigationTiming.deliveryType test, same origin prefetch. assert_equals: expected (string) "navigational-prefetch" but got (undefined) undefined
+PASS PerformanceNavigationTiming.deliveryType test, same origin prefetch.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&bypass_cache=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&bypass_cache=true-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL PerformanceNavigationTiming.deliveryType test, same origin prefetch. assert_equals: expected (string) "navigational-prefetch" but got (undefined) undefined
+PASS PerformanceNavigationTiming.deliveryType test, same origin prefetch.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_cross-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_cross-site-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test that prefetches use/store responses to/from the HTTP cache. assert_equals: expected (string) "" but got (undefined) undefined
+FAIL Test that prefetches use/store responses to/from the HTTP cache. assert_equals: Navigation should have used the prefetch expected "navigational-prefetch" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_same-site-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test that prefetches use/store responses to/from the HTTP cache. assert_equals: expected (string) "" but got (undefined) undefined
+FAIL Test that prefetches use/store responses to/from the HTTP cache. assert_equals: Navigation should have retrieved the response from the HTTP Cache. expected "cache" but got "navigational-prefetch"
 

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -172,12 +172,17 @@ void DocumentPrefetcher::notifyFinished(CachedResource& resource, const NetworkL
         resource.removeClient(*this);
 }
 
+bool DocumentPrefetcher::wasPrefetched(const URL& url) const
+{
+    return m_prefetchedData.contains(url);
+}
+
 Box<NetworkLoadMetrics> DocumentPrefetcher::takePrefetchedNetworkLoadMetrics(const URL& url)
 {
     auto it = m_prefetchedData.find(url);
     if (it != m_prefetchedData.end() && it->value.metrics) {
         auto metrics = WTFMove(it->value.metrics);
-        it->value.metrics = { };
+        m_prefetchedData.remove(it);
         return metrics;
     }
     return { };

--- a/Source/WebCore/loader/DocumentPrefetcher.h
+++ b/Source/WebCore/loader/DocumentPrefetcher.h
@@ -55,6 +55,7 @@ public:
     ~DocumentPrefetcher();
 
     void prefetch(const URL&, const Vector<String>& tags, std::optional<ReferrerPolicy>, bool lowPriority = false);
+    bool wasPrefetched(const URL&) const;
     Box<NetworkLoadMetrics> takePrefetchedNetworkLoadMetrics(const URL&);
 
     // CachedRawResourceClient

--- a/Source/WebCore/loader/ResourceTiming.h
+++ b/Source/WebCore/loader/ResourceTiming.h
@@ -48,6 +48,7 @@ public:
 
     const URL& url() const { return m_url; }
     const String& initiatorType() const { return m_initiatorType; }
+    String deliveryType() const { return m_networkLoadMetrics.fromPrefetch ? "navigational-prefetch"_s : emptyString(); }
     const ResourceLoadTiming& resourceLoadTiming() const { return m_resourceLoadTiming; }
     const NetworkLoadMetrics& networkLoadMetrics() const { return m_networkLoadMetrics; }
     NetworkLoadMetrics& networkLoadMetrics() { return m_networkLoadMetrics; }

--- a/Source/WebCore/page/PerformanceResourceTiming.h
+++ b/Source/WebCore/page/PerformanceResourceTiming.h
@@ -47,6 +47,7 @@ public:
     static Ref<PerformanceResourceTiming> create(MonotonicTime timeOrigin, ResourceTiming&&);
 
     const String& initiatorType() const { return m_resourceTiming.initiatorType(); }
+    String deliveryType() const { return m_resourceTiming.deliveryType(); }
     const String& nextHopProtocol() const;
 
     double workerStart() const;
@@ -66,6 +67,7 @@ public:
     uint64_t decodedBodySize() const;
 
     const Vector<Ref<PerformanceServerTiming>>& serverTiming() const { return m_serverTiming; }
+    ResourceTiming& resourceTiming() { return m_resourceTiming; }
 
     Type performanceEntryType() const override { return Type::Resource; }
     ASCIILiteral entryType() const override { return "resource"_s; }

--- a/Source/WebCore/page/PerformanceResourceTiming.idl
+++ b/Source/WebCore/page/PerformanceResourceTiming.idl
@@ -54,6 +54,9 @@ typedef double DOMHighResTimeStamp;
     readonly attribute unsigned long long encodedBodySize;
     readonly attribute unsigned long long decodedBodySize;
 
+    // https://w3c.github.io/resource-timing/#dfn-delivery-type
+    readonly attribute DOMString deliveryType;
+
     // https://www.w3.org/TR/server-timing/#extension-to-the-performanceresourcetiming-interface
     readonly attribute FrozenArray<PerformanceServerTiming> serverTiming;
 

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 NetworkLoadMetrics::NetworkLoadMetrics() = default;
 
-NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, PrivacyStance privacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&& additionalNetworkLoadMetricsForWebInspector)
+NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, PrivacyStance privacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&& additionalNetworkLoadMetricsForWebInspector)
     : redirectStart(WTFMove(redirectStart))
     , fetchStart(WTFMove(fetchStart))
     , domainLookupStart(WTFMove(domainLookupStart))
@@ -54,6 +54,7 @@ NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicT
     , isReusedConnection(isReusedConnection)
     , failsTAOCheck(failsTAOCheck)
     , hasCrossOriginRedirect(hasCrossOriginRedirect)
+    , fromPrefetch(fromPrefetch)
     , privacyStance(privacyStance)
     , responseBodyBytesReceived(responseBodyBytesReceived)
     , responseBodyDecodedSize(responseBodyDecodedSize)
@@ -155,6 +156,7 @@ NetworkLoadMetrics NetworkLoadMetrics::isolatedCopy() const
     copy.isReusedConnection = isReusedConnection;
     copy.failsTAOCheck = failsTAOCheck;
     copy.hasCrossOriginRedirect = hasCrossOriginRedirect;
+    copy.fromPrefetch = fromPrefetch;
 
     copy.privacyStance = privacyStance;
 

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.h
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.h
@@ -65,7 +65,7 @@ class NetworkLoadMetrics {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NetworkLoadMetrics);
 public:
     WEBCORE_EXPORT NetworkLoadMetrics();
-    WEBCORE_EXPORT NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, PrivacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&&);
+    WEBCORE_EXPORT NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, PrivacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&&);
 
     WEBCORE_EXPORT static const NetworkLoadMetrics& emptyMetrics();
 
@@ -109,6 +109,7 @@ public:
     bool isReusedConnection : 1 { false };
     bool failsTAOCheck : 1 { false };
     bool hasCrossOriginRedirect : 1 { false };
+    bool fromPrefetch : 1 { false };
 
     PrivacyStance privacyStance { PrivacyStance::Unknown };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7380,14 +7380,15 @@ class WebCore::NetworkLoadMetrics {
 
     uint16_t redirectCount;
 
-    bool isComplete();
-    bool isCellular();
-    bool isExpensive();
-    bool isConstrained();
-    bool isMultipath();
-    bool reusedConnection();
-    bool doesFailTAOCheck();
-    bool crossOriginRedirect();
+    [BitField] bool complete;
+    [BitField] bool cellular;
+    [BitField] bool expensive;
+    [BitField] bool constrained;
+    [BitField] bool multipath;
+    [BitField] bool isReusedConnection;
+    [BitField] bool failsTAOCheck;
+    [BitField] bool hasCrossOriginRedirect;
+    [BitField] bool fromPrefetch;
 
     WebCore::PrivacyStance privacyStance;
 


### PR DESCRIPTION
#### f009b61f8d117e884ec2750b47bf387d85695d77
<pre>
Speculation Rules: implement Navigation Timing&apos;s deliveryType
<a href="https://bugs.webkit.org/show_bug.cgi?id=300586">https://bugs.webkit.org/show_bug.cgi?id=300586</a>

Reviewed by Alex Christensen.

This PR exposes the `deliveryType` attribute on Resource Timing, with an empty string value in most cases.
It then sets that value to &quot;navigational-prefetch&quot; for prefetched documents, exposed in their navigation timing entries.

No new tests, but existing test expectations progress.

* LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&amp;bypass_cache=false-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&amp;bypass_cache=true-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&amp;bypass_cache=false-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&amp;bypass_cache=true-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_cross-site-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_same-site-expected.txt:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::notifyFinished): Set the `fromPrefetch` parameter on metrics that come from a prefetched resource.
(WebCore::DocumentLoader::commitData): Set the `fromPrefetch` parameter on metrics where there&apos;s an in-flight prefetch with the same URL.
* Source/WebCore/loader/DocumentPrefetcher.cpp:
(WebCore::DocumentPrefetcher::wasPrefetched const): Returns true if there&apos;s an in-flight prefetch with that URL.
(WebCore::DocumentPrefetcher::takePrefetchedNetworkLoadMetrics):
* Source/WebCore/loader/DocumentPrefetcher.h:
* Source/WebCore/loader/ResourceTiming.h:
(WebCore::ResourceTiming::deliveryType const): Getter.
* Source/WebCore/page/PerformanceResourceTiming.h:
(WebCore::PerformanceResourceTiming::deliveryType const):
(WebCore::PerformanceResourceTiming::resourceTiming):
* Source/WebCore/page/PerformanceResourceTiming.idl: Add the deliveryType attribute.
* Source/WebCore/platform/network/NetworkLoadMetrics.cpp:
(WebCore::NetworkLoadMetrics::NetworkLoadMetrics): Initialize fromPrefetch.
(WebCore::NetworkLoadMetrics::isolatedCopy const): Copy fromPrefetch.
* Source/WebCore/platform/network/NetworkLoadMetrics.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/303527@main">https://commits.webkit.org/303527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50c492c7d663945c41b2680c8283c9c8e45e9431

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140220 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84719 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101449 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68748 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135638 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82242 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1451 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83459 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142875 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4857 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37593 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109829 "Found 1 new test failure: fast/scrolling/rtl-scrollbars-sticky-document.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4939 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4203 "Found 1 new test failure: http/tests/ipc/ipc-fetch-task-message-crash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110006 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27887 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3706 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115161 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58339 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4911 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33508 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4749 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68362 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4868 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->