### PR TITLE
[GTK] Properly set the path for a newly created WebExtension

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/gtk/WebExtensionGtk.cpp
+++ b/Source/WebKit/UIProcess/Extensions/gtk/WebExtensionGtk.cpp
@@ -46,11 +46,7 @@ WebExtension::WebExtension(GFile* resourcesFile, RefPtr<API::Error>& outError)
     outError = nullptr;
 
     GUniquePtr<char> baseURL(g_file_get_uri(resourcesFile));
-
-    // While there is a check below to make sure that the directory has a path suffix, it can sometimes remove the full path
-    // and leave only the protocol.
-    if (!m_resourceBaseURL.hasPath())
-        m_resourceBaseURL.setPath("/"_s);
+    m_resourceBaseURL = URL { makeString(String::fromUTF8(baseURL.get()), "/"_s) };
 
     if (m_resourceBaseURL.isValid()) {
         auto isDirectory = g_file_query_file_type(resourcesFile, G_FILE_QUERY_INFO_NONE, nullptr) == G_FILE_TYPE_DIRECTORY;
@@ -60,9 +56,6 @@ WebExtension::WebExtension(GFile* resourcesFile, RefPtr<API::Error>& outError)
             return;
         }
     }
-
-    if (m_resourceBaseURL.path().right(1) != "/"_s)
-        m_resourceBaseURL = URL::fileURLWithFileSystemPath(FileSystem::pathByAppendingComponent(m_resourceBaseURL.path(), "/"_s));
 
     if (!manifestParsedSuccessfully()) {
         ASSERT(!m_errors.isEmpty());


### PR DESCRIPTION
#### 8c065d25f2e27af2578713a5b2e22225d1dc1316
<pre>
[GTK] Properly set the path for a newly created WebExtension
<a href="https://bugs.webkit.org/show_bug.cgi?id=300588">https://bugs.webkit.org/show_bug.cgi?id=300588</a>

Reviewed by Patrick Griffis.

When fixing the build on Clang, we accidentally removed the
code that sets the resourceBaseURL for the extension.
Somehow the tests never caught that failure. This properly
sets the path and properly checks and adjusts the path as
necessary

* Source/WebKit/UIProcess/Extensions/gtk/WebExtensionGtk.cpp:
(WebKit::WebExtension::WebExtension):

Canonical link: <a href="https://commits.webkit.org/301403@main">https://commits.webkit.org/301403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17ec10bd464873e65135730dca8e80408579b91b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77712 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95865 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63976 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76356 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35836 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76182 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135392 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104332 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104060 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26507 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49429 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27750 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/49976 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52520 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58331 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51868 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->