### PR TITLE
[Style] Cleanup CSSCalcValue

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -303,7 +303,7 @@ CSSPrimitiveValue::CSSPrimitiveValue(StaticCSSValueTag, ImplicitInitialValueTag)
     m_isImplicitInitialValue = true;
 }
 
-CSSPrimitiveValue::CSSPrimitiveValue(Ref<CSSCalcValue> value)
+CSSPrimitiveValue::CSSPrimitiveValue(Ref<CSSCalc::Value> value)
     : CSSValue(ClassType::Primitive)
 {
     setPrimitiveUnitType(CSSUnitType::CSS_CALC);
@@ -466,7 +466,7 @@ Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(String value)
     return adoptRef(*new CSSPrimitiveValue(WTFMove(value), CSSUnitType::CSS_STRING));
 }
 
-Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(Ref<CSSCalcValue> value)
+Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(Ref<CSSCalc::Value> value)
 {
     return adoptRef(*new CSSPrimitiveValue(WTFMove(value)));
 }
@@ -1272,15 +1272,6 @@ void CSSPrimitiveValue::collectComputedStyleDependencies(ComputedStyleDependenci
 
     if (auto lengthUnit = CSS::toLengthUnit(primitiveUnitType()))
         CSS::collectComputedStyleDependencies(dependencies, *lengthUnit);
-}
-
-IterationStatus CSSPrimitiveValue::customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
-{
-    if (RefPtr calc = cssCalcValue()) {
-        if (func(const_cast<CSSCalcValue&>(*calc)) == IterationStatus::Done)
-            return IterationStatus::Done;
-    }
-    return IterationStatus::Continue;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -106,7 +106,7 @@ public:
     static Ref<CSSPrimitiveValue> create(double);
     static Ref<CSSPrimitiveValue> create(double, CSSUnitType);
     static Ref<CSSPrimitiveValue> createInteger(double);
-    static Ref<CSSPrimitiveValue> create(Ref<CSSCalcValue>);
+    static Ref<CSSPrimitiveValue> create(Ref<CSSCalc::Value>);
     static Ref<CSSPrimitiveValue> create(Ref<CSSAttrValue>);
 
     static inline Ref<CSSPrimitiveValue> create(CSSValueID);
@@ -194,8 +194,8 @@ public:
     std::optional<bool> isNegative() const;
 
     WEBCORE_EXPORT String stringValue() const;
-    const CSSCalcValue* cssCalcValue() const { return isCalculated() ? m_value.calc : nullptr; }
-    RefPtr<const CSSCalcValue> protectedCssCalcValue() const { return cssCalcValue(); }
+    const CSSCalc::Value* cssCalcValue() const { return isCalculated() ? m_value.calc : nullptr; }
+    RefPtr<const CSSCalc::Value> protectedCssCalcValue() const { return cssCalcValue(); }
     const CSSAttrValue* cssAttrValue() const { return isAttr() ? m_value.attr : nullptr; }
     RefPtr<const CSSAttrValue> protectedCssAttrValue() const { return cssAttrValue(); }
 
@@ -205,10 +205,7 @@ public:
 
     static ASCIILiteral unitTypeString(CSSUnitType);
 
-
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
-
-    IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 
 private:
     friend class CSSValuePool;
@@ -219,7 +216,7 @@ private:
     explicit CSSPrimitiveValue(CSSPropertyID);
     CSSPrimitiveValue(const String&, CSSUnitType);
     CSSPrimitiveValue(double, CSSUnitType);
-    explicit CSSPrimitiveValue(Ref<CSSCalcValue>);
+    explicit CSSPrimitiveValue(Ref<CSSCalc::Value>);
     explicit CSSPrimitiveValue(Ref<CSSAttrValue>);
 
     CSSPrimitiveValue(StaticCSSValueTag, CSSValueID);
@@ -272,7 +269,7 @@ private:
         CSSValueID valueID;
         double number;
         StringImpl* string;
-        const CSSCalcValue* calc;
+        const CSSCalc::Value* calc;
         const CSSAttrValue* attr;
     } m_value;
 };

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -32,37 +32,36 @@
 
 #include "CSSFontFaceSrcValue.h"
 #include "StyleBuilderState.h"
-#include <WebCore/AnchorPositionEvaluator.h>
-#include <WebCore/CSSCalcSymbolTable.h>
-#include <WebCore/CSSCalcValue.h>
-#include <WebCore/CSSPrimitiveValue.h>
-#include <WebCore/CSSToLengthConversionData.h>
-#include <WebCore/CSSValueKeywords.h>
-#include <WebCore/CompositeOperation.h>
-#include <WebCore/FontSizeAdjust.h>
-#include <WebCore/GraphicsTypes.h>
-#include <WebCore/PositionTryFallback.h>
-#include <WebCore/RenderStyleConstants.h>
-#include <WebCore/SVGRenderStyleDefs.h>
-#include <WebCore/ScrollAxis.h>
-#include <WebCore/ScrollTypes.h>
-#include <WebCore/StyleScrollBehavior.h>
-#include <WebCore/StyleTextDecorationLine.h>
-#include <WebCore/StyleWebKitOverflowScrolling.h>
-#include <WebCore/StyleWebKitTouchCallout.h>
-#include <WebCore/TextFlags.h>
-#include <WebCore/ThemeTypes.h>
-#include <WebCore/TouchAction.h>
-#include <WebCore/UnicodeBidi.h>
-#include <WebCore/WritingMode.h>
+#include "AnchorPositionEvaluator.h"
+#include "CSSCalcSymbolTable.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSToLengthConversionData.h"
+#include "CSSValueKeywords.h"
+#include "CompositeOperation.h"
+#include "FontSizeAdjust.h"
+#include "GraphicsTypes.h"
+#include "PositionTryFallback.h"
+#include "RenderStyleConstants.h"
+#include "SVGRenderStyleDefs.h"
+#include "ScrollAxis.h"
+#include "ScrollTypes.h"
+#include "StyleScrollBehavior.h"
+#include "StyleTextDecorationLine.h"
+#include "StyleWebKitOverflowScrolling.h"
+#include "StyleWebKitTouchCallout.h"
+#include "TextFlags.h"
+#include "ThemeTypes.h"
+#include "TouchAction.h"
+#include "UnicodeBidi.h"
+#include "WritingMode.h"
 #include <wtf/MathExtras.h>
 
 #if ENABLE(APPLE_PAY)
-#include <WebCore/ApplePayButtonPart.h>
+#include "ApplePayButtonPart.h"
 #endif
 
 #if HAVE(CORE_MATERIAL)
-#include <WebCore/AppleVisualEffect.h>
+#include "AppleVisualEffect.h"
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -36,7 +36,6 @@
 #include "CSSBorderImageSliceValue.h"
 #include "CSSBorderImageWidthValue.h"
 #include "CSSBoxShadowPropertyValue.h"
-#include "CSSCalcValue.h"
 #include "CSSCanvasValue.h"
 #include "CSSColorSchemeValue.h"
 #include "CSSColorValue.h"
@@ -125,8 +124,6 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSBorderImageWidthValue>(*this));
     case BoxShadowProperty:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSBoxShadowPropertyValue>(*this));
-    case Calculation:
-        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCalcValue>(*this));
     case Canvas:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCanvasValue>(*this));
     case Color:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -76,7 +76,6 @@ public:
     bool isBorderImageSliceValue() const { return m_classType == ClassType::BorderImageSlice; }
     bool isBorderImageWidthValue() const { return m_classType == ClassType::BorderImageWidth; }
     bool isBoxShadowPropertyValue() const { return m_classType == ClassType::BoxShadowProperty; }
-    bool isCalcValue() const { return m_classType == ClassType::Calculation; }
     bool isCanvasValue() const { return m_classType == ClassType::Canvas; }
     bool isColor() const { return m_classType == ClassType::Color; }
 #if ENABLE(DARK_MODE_CSS)
@@ -223,7 +222,6 @@ protected:
         BorderImageSlice,
         BorderImageWidth,
         BoxShadowProperty,
-        Calculation,
         Color,
 #if ENABLE(DARK_MODE_CSS)
         ColorScheme,

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -32,8 +32,7 @@
 #pragma once
 
 #include <WebCore/CSSCalcTree.h>
-#include <WebCore/CSSValue.h>
-#include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
 #include <wtf/Ref.h>
 
 namespace WebCore {
@@ -62,20 +61,23 @@ enum CSSValueID : uint16_t;
 
 enum class CSSUnitType : uint8_t;
 
-class CSSCalcValue final : public CSSValue {
+namespace CSSCalc {
+
+// Boxes a `CSSCalc::Tree` along with the `Style::Calculation::Category` and `CSS::Range` used to construct it.
+class Value final : public RefCounted<Value> {
 public:
-    static RefPtr<CSSCalcValue> parse(CSSParserTokenRange&, CSS::PropertyParserState&, CSS::Category, CSS::Range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
+    static RefPtr<Value> parse(CSSParserTokenRange&, CSS::PropertyParserState&, CSS::Category, CSS::Range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 
-    static Ref<CSSCalcValue> create(const Style::CalculationValue&, const RenderStyle&);
-    static Ref<CSSCalcValue> create(CSS::Category, CSS::Range, CSSCalc::Tree&&);
+    static Ref<Value> create(const Style::CalculationValue&, const RenderStyle&);
+    static Ref<Value> create(CSS::Category, CSS::Range, CSSCalc::Tree&&);
 
-    ~CSSCalcValue();
+    ~Value();
 
     // Creates a copy of the CSSCalc::Tree with non-canonical dimensions and any symbols present in the provided symbol table resolved.
-    Ref<CSSCalcValue> copySimplified(const CSSToLengthConversionData&) const;
-    Ref<CSSCalcValue> copySimplified(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;
-    Ref<CSSCalcValue> copySimplified(NoConversionDataRequiredToken) const;
-    Ref<CSSCalcValue> copySimplified(NoConversionDataRequiredToken, const CSSCalcSymbolTable&) const;
+    Ref<Value> copySimplified(const CSSToLengthConversionData&) const;
+    Ref<Value> copySimplified(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;
+    Ref<Value> copySimplified(NoConversionDataRequiredToken) const;
+    Ref<Value> copySimplified(NoConversionDataRequiredToken, const CSSCalcSymbolTable&) const;
 
     CSS::Category category() const { return m_category; }
     CSS::Range range() const { return m_range; }
@@ -101,25 +103,24 @@ public:
 
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
 
-    String customCSSText(const CSS::SerializationContext&) const;
-    bool equals(const CSSCalcValue&) const;
+    String cssText(const CSS::SerializationContext&) const;
+    bool equals(const Value&) const;
 
     void dump(TextStream&) const;
 
     const CSSCalc::Tree& tree() const { return m_tree; }
 
 private:
-    explicit CSSCalcValue(CSS::Category, CSS::Range, CSSCalc::Tree&&);
+    explicit Value(CSS::Category, CSS::Range, CSSCalc::Tree&&);
 
     double clampToPermittedRange(double) const;
 
     CSS::Category m_category;
     CSS::Range m_range;
-    CSSCalc::Tree m_tree;
+    Tree m_tree;
 };
 
-TextStream& operator<<(TextStream&, const CSSCalcValue&);
+TextStream& operator<<(TextStream&, const Value&);
 
+} // namespace CSSCalc
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSCalcValue, isCalcValue())

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h
@@ -236,7 +236,7 @@ template<typename Primitive> struct FunctionConsumerForCalcValues {
         ASSERT(range.peek().type() == FunctionToken);
 
         auto rangeCopy = range;
-        if (RefPtr value = CSSCalcValue::parse(rangeCopy, state, Primitive::category, Primitive::range, WTFMove(symbolsAllowed), options)) {
+        if (RefPtr value = CSSCalc::Value::parse(rangeCopy, state, Primitive::category, Primitive::range, WTFMove(symbolsAllowed), options)) {
             range = rangeCopy;
             return {{ value.releaseNonNull() }};
         }

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -187,9 +187,8 @@ static bool mayConvertCSSValueListToSingleValue(std::optional<CSSPropertyID> pro
 
 ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& document, const CSSValue& cssValue, std::optional<CSSPropertyID> propertyID)
 {
-    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(cssValue)) {
-        if (primitiveValue->isCalculated()) {
-            auto* calcValue = primitiveValue->cssCalcValue();
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(cssValue)) {
+        if (RefPtr calcValue = primitiveValue->cssCalcValue()) {
             auto result = CSSNumericValue::reifyMathExpression(calcValue->tree());
             if (result.hasException())
                 return result.releaseException();

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -405,7 +405,7 @@ RefPtr<CSSValue> CSSUnitValue::toCSSValueWithProperty(CSSPropertyID propertyID) 
         sumChildren.append(WTFMove(*node));
         auto sum = CSSCalc::makeChild(CSSCalc::Sum { .children = WTFMove(sumChildren) }, type);
 
-        return CSSPrimitiveValue::create(CSSCalcValue::create(category, range, CSSCalc::Tree {
+        return CSSPrimitiveValue::create(CSSCalc::Value::create(category, range, CSSCalc::Tree {
             .root = WTFMove(sum),
             .type = type,
             .stage = CSSCalc::Stage::Specified,

--- a/Source/WebCore/css/typedom/numeric/CSSMathValue.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathValue.cpp
@@ -43,7 +43,7 @@ RefPtr<CSSValue> CSSMathValue::toCSSValue() const
     if (!category)
         return nullptr;
 
-    return CSSPrimitiveValue::create(CSSCalcValue::create(*category, CSS::All, CSSCalc::Tree {
+    return CSSPrimitiveValue::create(CSSCalc::Value::create(*category, CSS::All, CSSCalc::Tree {
         .root = WTFMove(*node),
         .type = type,
         .stage = CSSCalc::Stage::Specified,

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveData.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveData.h
@@ -219,14 +219,14 @@ template<Numeric N, PrimitiveKeyword... Ks> struct PrimitiveDataIndex {
 
 union PrimitiveDataPayload {
     double number;
-    CSSCalcValue* calc;
+    CSSCalc::Value* calc;
 
     PrimitiveDataPayload(double number)
         : number { number }
     {
     }
 
-    PrimitiveDataPayload(CSSCalcValue* calc)
+    PrimitiveDataPayload(CSSCalc::Value* calc)
         : calc { calc }
     {
     }

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
@@ -36,22 +36,22 @@
 namespace WebCore {
 namespace CSS {
 
-void unevaluatedCalcRef(CSSCalcValue* calc)
+void unevaluatedCalcRef(CSSCalc::Value* calc)
 {
     calc->ref();
 }
 
-void unevaluatedCalcDeref(CSSCalcValue* calc)
+void unevaluatedCalcDeref(CSSCalc::Value* calc)
 {
     calc->deref();
 }
 
-UnevaluatedCalcBase::UnevaluatedCalcBase(CSSCalcValue& value)
+UnevaluatedCalcBase::UnevaluatedCalcBase(CSSCalc::Value& value)
     : calc { value }
 {
 }
 
-UnevaluatedCalcBase::UnevaluatedCalcBase(Ref<CSSCalcValue>&& value)
+UnevaluatedCalcBase::UnevaluatedCalcBase(Ref<CSSCalc::Value>&& value)
     : calc { WTFMove(value) }
 {
 }
@@ -63,12 +63,12 @@ UnevaluatedCalcBase& UnevaluatedCalcBase::operator=(UnevaluatedCalcBase&&) = def
 
 UnevaluatedCalcBase::~UnevaluatedCalcBase() = default;
 
-Ref<CSSCalcValue> UnevaluatedCalcBase::protectedCalc() const
+Ref<CSSCalc::Value> UnevaluatedCalcBase::protectedCalc() const
 {
     return calc;
 }
 
-CSSCalcValue& UnevaluatedCalcBase::leakRef()
+CSSCalc::Value& UnevaluatedCalcBase::leakRef()
 {
     return calc.leakRef();
 }
@@ -85,17 +85,12 @@ bool UnevaluatedCalcBase::requiresConversionData() const
 
 void UnevaluatedCalcBase::serializationForCSS(StringBuilder& builder, const CSS::SerializationContext& context) const
 {
-    builder.append(protectedCalc()->customCSSText(context));
+    builder.append(protectedCalc()->cssText(context));
 }
 
 void UnevaluatedCalcBase::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
     protectedCalc()->collectComputedStyleDependencies(dependencies);
-}
-
-IterationStatus UnevaluatedCalcBase::visitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
-{
-    return func(calc);
 }
 
 UnevaluatedCalcBase UnevaluatedCalcBase::simplifyBase(const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) const

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -35,7 +35,6 @@
 namespace WebCore {
 
 class CSSCalcSymbolTable;
-class CSSCalcValue;
 class CSSToLengthConversionData;
 struct ComputedStyleDependencies;
 struct NoConversionDataRequiredToken;
@@ -44,22 +43,26 @@ namespace Style {
 class BuilderState;
 }
 
+namespace CSSCalc {
+class Value;
+}
+
 namespace CSS {
 
 enum class Category : uint8_t;
 
 // Type-erased helpers to allow for shared code.
 
-void unevaluatedCalcRef(CSSCalcValue*);
-void unevaluatedCalcDeref(CSSCalcValue*);
+void unevaluatedCalcRef(CSSCalc::Value*);
+void unevaluatedCalcDeref(CSSCalc::Value*);
 
-// `UnevaluatedCalc` annotates a `CSSCalcValue` with the raw value type that it
+// `UnevaluatedCalc` annotates a `CSSCalc::Value` with the raw value type that it
 // will be evaluated to, allowing the processing of calc in generic code.
 
 // Non-generic base type to allow code sharing and out-of-line definitions.
 struct UnevaluatedCalcBase {
-    UnevaluatedCalcBase(CSSCalcValue&);
-    UnevaluatedCalcBase(Ref<CSSCalcValue>&&);
+    UnevaluatedCalcBase(CSSCalc::Value&);
+    UnevaluatedCalcBase(Ref<CSSCalc::Value>&&);
 
     UnevaluatedCalcBase(const UnevaluatedCalcBase&);
     UnevaluatedCalcBase(UnevaluatedCalcBase&&);
@@ -67,14 +70,13 @@ struct UnevaluatedCalcBase {
     UnevaluatedCalcBase& operator=(UnevaluatedCalcBase&&);
     ~UnevaluatedCalcBase();
 
-    Ref<CSSCalcValue> protectedCalc() const;
-    CSSCalcValue& leakRef() WARN_UNUSED_RETURN;
+    Ref<CSSCalc::Value> protectedCalc() const;
+    CSSCalc::Value& leakRef() WARN_UNUSED_RETURN;
 
     bool requiresConversionData() const;
 
     void serializationForCSS(StringBuilder&, const CSS::SerializationContext&) const;
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
-    IterationStatus visitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 
     UnevaluatedCalcBase simplifyBase(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;
 
@@ -88,7 +90,7 @@ struct UnevaluatedCalcBase {
     bool equal(const UnevaluatedCalcBase&) const;
 
 private:
-    Ref<CSSCalcValue> calc;
+    Ref<CSSCalc::Value> calc;
 };
 
 template<NumericRaw RawType> struct UnevaluatedCalc : UnevaluatedCalcBase {
@@ -196,9 +198,9 @@ template<Calc T> struct ComputedStyleDependenciesCollector<T> {
 // MARK: - CSSValue Visitation
 
 template<Calc T> struct CSSValueChildrenVisitor<T> {
-    inline IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>& func, const T& value)
+    inline IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const T&)
     {
-        return value.visitChildren(func);
+        return IterationStatus::Continue;
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -264,14 +264,14 @@ template<auto R, typename V> struct ToCSS<Length<R, V>> {
 template<auto R, typename V> struct ToCSS<UnevaluatedCalculation<CSS::AnglePercentage<R, V>>> {
     auto operator()(const UnevaluatedCalculation<CSS::AnglePercentage<R, V>>& value, const RenderStyle& style) -> typename CSS::AnglePercentage<R, V>::Calc
     {
-        return typename CSS::AnglePercentage<R, V>::Calc { CSSCalcValue::create(value.protectedCalculation(), style) };
+        return typename CSS::AnglePercentage<R, V>::Calc { CSSCalc::Value::create(value.protectedCalculation(), style) };
     }
 };
 
 template<auto R, typename V> struct ToCSS<UnevaluatedCalculation<CSS::LengthPercentage<R, V>>> {
     auto operator()(const UnevaluatedCalculation<CSS::LengthPercentage<R, V>>& value, const RenderStyle& style) -> typename CSS::LengthPercentage<R, V>::Calc
     {
-        return typename CSS::LengthPercentage<R, V>::Calc { CSSCalcValue::create(value.protectedCalculation(), style) };
+        return typename CSS::LengthPercentage<R, V>::Calc { CSSCalc::Value::create(value.protectedCalculation(), style) };
     }
 };
 
@@ -287,7 +287,7 @@ template<auto R, typename V> struct ToCSS<AnglePercentage<R, V>> {
                 return typename CSS::AnglePercentage<R, V>::Raw { percentage.unit, percentage.value };
             },
             [&](const typename AnglePercentage<R, V>::Calc& calculation) -> CSS::AnglePercentage<R> {
-                return typename CSS::AnglePercentage<R, V>::Calc { CSSCalcValue::create(calculation.protectedCalculation(), style) };
+                return typename CSS::AnglePercentage<R, V>::Calc { CSSCalc::Value::create(calculation.protectedCalculation(), style) };
             }
         );
     }
@@ -308,7 +308,7 @@ template<auto R, typename V> struct ToCSS<LengthPercentage<R, V>> {
                 return typename CSS::LengthPercentage<R, V>::Raw { percentage.unit, percentage.value };
             },
             [&](const typename LengthPercentage<R, V>::Calc& calculation) -> CSS::LengthPercentage<R> {
-                return typename CSS::LengthPercentage<R, V>::Calc { CSSCalcValue::create(calculation.protectedCalculation(), style) };
+                return typename CSS::LengthPercentage<R, V>::Calc { CSSCalc::Value::create(calculation.protectedCalculation(), style) };
             }
         );
     }


### PR DESCRIPTION
#### b97486202ae26d8256d70b3484475936d24d618e
<pre>
[Style] Cleanup CSSCalcValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=300589">https://bugs.webkit.org/show_bug.cgi?id=300589</a>

Reviewed by Darin Adler.

- Renames CSSCalcValue to CSSCalc::Value for consistency with the
  rest of CSS calc() code.
- Remove inheritance from CSSValue. It serves no purpose, as it is
  never used polymorphically.
- Remove unnecessary override of customVisitChildren in CSSPrimitiveValue,
  it always returns IterationStatus::Continue.

* Source/WebCore/css/CSSPrimitiveValue.cpp:
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSValue.cpp:
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
* Source/WebCore/css/typedom/numeric/CSSMathValue.cpp:
* Source/WebCore/css/values/primitives/CSSPrimitiveData.h:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:

Canonical link: <a href="https://commits.webkit.org/301495@main">https://commits.webkit.org/301495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/177b4b7c25bf9647caa15be8e640b053e0962ef9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126152 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36608 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77950 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54349 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/132954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112841 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31024 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31246 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40635 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/135662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109058 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26571 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49690 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50302 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52803 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58637 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52131 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55476 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->