### PR TITLE
Adopt LIFETIME_BOUND for WTF::RetainPtr

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -123,9 +123,10 @@ public:
     id bridgingAutorelease();
 #endif
 
-    constexpr PtrType get() const { return m_ptr; }
-    constexpr PtrType operator->() const { return m_ptr; }
-    constexpr explicit operator PtrType() const { return m_ptr; }
+    constexpr PtrType get() const LIFETIME_BOUND { return m_ptr; }
+    constexpr PtrType unsafeGet() const { return m_ptr; } // FIXME: Replace with get() then remove.
+    constexpr PtrType operator->() const LIFETIME_BOUND { return m_ptr; }
+    constexpr explicit operator PtrType() const LIFETIME_BOUND { return m_ptr; }
     constexpr explicit operator bool() const { return m_ptr; }
 
     constexpr bool operator!() const { return !m_ptr; }

--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -86,11 +86,9 @@ bool hasEntitlementValueInArray(audit_token_t token, ASCIILiteral entitlement, A
         return false;
 
     auto string = entitlement.createCFString();
-    auto entitlementValue = adoptCF(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)).get();
-    if (!entitlementValue || CFGetTypeID(entitlementValue) != CFArrayGetTypeID())
+    RetainPtr array = adoptCF(dynamic_cf_cast<CFArrayRef>(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)));
+    if (!array)
         return false;
-
-    RetainPtr<CFArrayRef> array = static_cast<CFArrayRef>(entitlementValue);
 
     for (CFIndex i = 0; i < CFArrayGetCount(array.get()); ++i) {
         RetainPtr element = dynamic_cf_cast<CFStringRef>(CFArrayGetValueAtIndex(array.get(), i));

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -201,7 +201,7 @@ void AXRemoteFrame::initializePlatformElementWithRemoteToken(std::span<const uin
     m_processIdentifier = processIdentifier;
 
     RetainPtr nsToken = WTF::toNSData(token);
-    NSDictionary *tokenDictionary = nsToken ? unarchivedTokenForData(nsToken).get() : nil;
+    NSDictionary *tokenDictionary = nsToken ? unarchivedTokenForData(nsToken).unsafeGet() : nil;
     if (!tokenDictionary)
         return;
 

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -357,7 +357,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
         return nil;
 
     if (RetainPtr remoteElement = axObject->remoteFramePlatformElement())
-        return remoteElement.get();
+        return remoteElement.unsafeGet();
 
     // If this is a good accessible object to return, no extra work is required.
     if ([axObject->wrapper() accessibilityCanFuzzyHitTest])
@@ -398,7 +398,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     for (const auto& child : self.axBackingObject->unignoredChildren()) {
         auto* wrapper = child->wrapper();
         if (child->isRemoteFrame()) {
-            if (id platformRemoteFrame = child->remoteFramePlatformElement().get())
+            if (id platformRemoteFrame = child->remoteFramePlatformElement().unsafeGet())
                 [array addObject:platformRemoteFrame];
         } else if (child->isAttachment()) {
             if (id attachmentView = [wrapper attachmentView])
@@ -450,7 +450,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
         if (id attachmentView = [wrapper attachmentView])
             return attachmentView;
     } else if (children[elementIndex]->isRemoteFrame()) {
-        if (id remoteFramePlatformElement = children[elementIndex]->remoteFramePlatformElement().get())
+        if (id remoteFramePlatformElement = children[elementIndex]->remoteFramePlatformElement().unsafeGet())
             return remoteFramePlatformElement;
     }
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1811,7 +1811,7 @@ Widget* AXIsolatedObject::widget() const
 PlatformWidget AXIsolatedObject::platformWidget() const
 {
 #if PLATFORM(COCOA)
-    return propertyValue<RetainPtr<NSView>>(AXProperty::PlatformWidget).get();
+    return propertyValue<RetainPtr<NSView>>(AXProperty::PlatformWidget).unsafeGet();
 #else
     return m_platformWidget;
 #endif

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -264,9 +264,9 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
         // otherwise, we get palindrome errors in the AX hierarchy.
         if (child->isAttachment()) {
             if (RetainPtr<id> attachmentView = wrapper.attachmentView)
-                return attachmentView.get();
+                return attachmentView.unsafeGet();
         } else if (child->isRemoteFrame() && returnPlatformElements)
-            return child->remoteFramePlatformElement().get();
+            return child->remoteFramePlatformElement().unsafeGet();
 
         return wrapper;
     }).autorelease();

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -964,14 +964,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
     if ([additionalAttributes count])
         objectAttributes = [objectAttributes arrayByAddingObjectsFromArray:additionalAttributes];
 
-    return objectAttributes.get();
+    return objectAttributes.unsafeGet();
 }
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (id)remoteAccessibilityParentObject
 {
     RefPtr<AXCoreObject> backingObject = self.axBackingObject;
-    return backingObject ? backingObject->remoteParent().get() : nil;
+    return backingObject ? backingObject->remoteParent().unsafeGet() : nil;
 }
 
 static void convertToVector(NSArray* array, AccessibilityObject::AccessibilityChildrenVector& vector)
@@ -1083,7 +1083,7 @@ static NSArray *transformSpecialChildrenCases(AXCoreObject& backingObject, const
 
     if (!unignoredChildren.size()) {
         if (RetainPtr widgetChildren = renderWidgetChildren(backingObject))
-            return widgetChildren.get();
+            return widgetChildren.unsafeGet();
     }
     return nil;
 }
@@ -1093,7 +1093,7 @@ static NSArray *children(AXCoreObject& backingObject)
     const auto& unignoredChildren = backingObject.unignoredChildren();
     RetainPtr<NSArray> specialChildren = transformSpecialChildrenCases(backingObject, unignoredChildren);
     if ([specialChildren count])
-        return specialChildren.get();
+        return specialChildren.unsafeGet();
 
     // The tree's (AXOutline) children are supposed to be its rows and columns.
     // The ARIA spec doesn't have columns, so we just need rows.
@@ -1160,7 +1160,7 @@ static id scrollViewParent(AXCoreObject& axObject)
     if (RetainPtr platformWidget = axObject.platformWidget())
         return NSAccessibilityUnignoredAncestor(platformWidget.get());
 
-    return axObject.remoteParent().get();
+    return axObject.remoteParent().unsafeGet();
 }
 
 - (id)windowElement:(NSString *)attributeName
@@ -1202,7 +1202,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
     if ([attributeName isEqualToString: NSAccessibilityParentAttribute]) {
         // This will return the parent of the AXScrollArea, if this is a AccessibilityScrollView.
         if (RetainPtr scrollView = scrollViewParent(*backingObject))
-            return scrollView.get();
+            return scrollView.unsafeGet();
 
         // Tree item (changed to AXRows) can only report the tree (AXOutline) as its parent.
         if (backingObject->isTreeItem()) {
@@ -2105,7 +2105,7 @@ id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString 
                 return attachmentView;
         } else if (axObject->isRemoteFrame()) {
             if (returnPlatformElements)
-                return axObject->remoteFramePlatformElement().get();
+                return axObject->remoteFramePlatformElement().unsafeGet();
         } else if (axObject->isWidget()) {
             // Only call out to the main-thread if this object has a backing widget to query.
             hit = Accessibility::retrieveAutoreleasedValueFromMainThread<id>([axObject, &point] () -> RetainPtr<id> {
@@ -3096,7 +3096,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
                 NSUInteger includedChildrenCount = std::min([remoteFrameChildren count], NSUInteger(criteria.resultsLimit));
                 widgetChildren = [remoteFrameChildren subarrayWithRange:NSMakeRange(0, includedChildrenCount)];
                 if ([widgetChildren count] >= criteria.resultsLimit)
-                    return remoteFrameChildren.get();
+                    return remoteFrameChildren.unsafeGet();
                 criteria.resultsLimit -= [widgetChildren count];
             }
         }
@@ -3210,7 +3210,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
             if (id attachmentView = [wrapper attachmentView])
                 return attachmentView;
         }
-        return wrapper.get();
+        return wrapper.unsafeGet();
     }
 
     if ([attribute isEqualToString:NSAccessibilityTextMarkerRangeForUIElementAttribute]) {

--- a/Source/WebCore/editing/cocoa/AlternativeTextContextController.mm
+++ b/Source/WebCore/editing/cocoa/AlternativeTextContextController.mm
@@ -51,7 +51,7 @@ void AlternativeTextContextController::replaceAlternatives(PlatformTextAlternati
 
 PlatformTextAlternatives *AlternativeTextContextController::alternativesForContext(DictationContext context) const
 {
-    return m_alternatives.get(context).get();
+    return m_alternatives.get(context).unsafeGet();
 }
 
 void AlternativeTextContextController::removeAlternativesForContext(DictationContext context)

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -240,14 +240,14 @@ inline static RetainPtr<NSParagraphStyle> reconstructStyle(const ParagraphStyle&
 
     if (!style.textTableBlockIDs.isEmpty()) {
         RetainPtr blocks = createNSArray(style.textTableBlockIDs, [&] (auto& object) -> id {
-            return tableBlocks.get(object).get();
+            return tableBlocks.get(object).unsafeGet();
         });
         [mutableStyle setTextBlocks:blocks.get()];
     }
 
     if (!style.textListIDs.isEmpty()) {
         RetainPtr textLists = createNSArray(style.textListIDs, [&] (auto& object) -> id {
-            return lists.get(object).get();
+            return lists.get(object).unsafeGet();
         });
         [mutableStyle setTextLists:textLists.get()];
     }

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -1140,7 +1140,7 @@ NSDictionary* HTMLConverter::aggregatedAttributesForElementAndItsAncestors(Eleme
     [attributesForAncestors addEntriesFromDictionary:attributesForCurrentElement];
     m_aggregatedAttributesForElements.set(&element, attributesForAncestors);
 
-    return attributesForAncestors.get();
+    return attributesForAncestors.unsafeGet();
 }
 
 void HTMLConverter::_newParagraphForElement(Element& element, NSString *tag, BOOL flag, BOOL suppressTrailingSpace)

--- a/Source/WebCore/page/cocoa/DataDetectionResultsStorage.h
+++ b/Source/WebCore/page/cocoa/DataDetectionResultsStorage.h
@@ -47,7 +47,7 @@ public:
     void setDocumentLevelResults(NSArray *results) { m_documentLevelResults = results; }
     NSArray *documentLevelResults() const { return m_documentLevelResults.get(); }
 
-    DDScannerResult *imageOverlayDataDetectionResult(ImageOverlayDataDetectionResultIdentifier identifier) { return m_imageOverlayResults.get(identifier).get(); }
+    DDScannerResult *imageOverlayDataDetectionResult(ImageOverlayDataDetectionResultIdentifier identifier) { return m_imageOverlayResults.get(identifier).unsafeGet(); }
     ImageOverlayDataDetectionResultIdentifier addImageOverlayDataDetectionResult(DDScannerResult *result)
     {
         auto newIdentifier = ImageOverlayDataDetectionResultIdentifier::generate();

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
@@ -150,7 +150,7 @@ static WebAVPictureInPicturePlayerLayerView *WebAVPlayerLayerView_pictureInPictu
 
     auto pipView = adoptNS([allocWebAVPictureInPicturePlayerLayerViewInstance() initWithFrame:CGRectZero]);
     [playerLayerView setValue:pipView.get() forKey:pictureInPicturePlayerLayerViewKey];
-    return pipView.get();
+    return pipView.unsafeGet();
 }
 #endif // HAVE(PICTUREINPICTUREPLAYERLAYERVIEW)
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h
@@ -60,7 +60,7 @@ public:
     TargetType targetType() const final { return TargetType::AVFoundation; }
     const MediaPlaybackTargetContext& targetContext() const final { return m_context; }
 
-    AVOutputContext* outputContext() { return m_context.outputContext().get(); }
+    AVOutputContext* outputContext() { return m_context.outputContext().unsafeGet(); }
 
 private:
     explicit MediaPlaybackTargetCocoa(MediaPlaybackTargetContextCocoa&&);

--- a/Source/WebCore/platform/ios/wak/WAKWindow.mm
+++ b/Source/WebCore/platform/ios/wak/WAKWindow.mm
@@ -613,7 +613,7 @@ static RetainPtr<WebEvent>& currentEvent()
 {
     if (!_tileCache)
         return NULL;
-    return _tileCache->contentReplacementImage().get();
+    return _tileCache->contentReplacementImage().unsafeGet();
 }
 
 - (void)displayRect:(NSRect)rect

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -104,7 +104,7 @@ static NSScreen *screen(Widget* widget)
     // If the widget is in a window, use that, otherwise use the display ID from the host window.
     // First case is for when the NSWindow is in the same process, second case for when it's not.
     if (RetainPtr<NSScreen> screenFromWindow = [protectedWindow(widget) screen])
-        return screenFromWindow.get();
+        return screenFromWindow.unsafeGet();
     return screen(displayID(widget));
 }
 

--- a/Source/WebCore/platform/mac/WebCoreFullScreenPlaceholderView.mm
+++ b/Source/WebCore/platform/mac/WebCoreFullScreenPlaceholderView.mm
@@ -76,7 +76,7 @@
 
 - (NSResponder *)target
 {
-    return _target.get().get();
+    return _target.get().unsafeGet();
 }
 
 - (void)setTarget:(NSResponder *)target

--- a/Source/WebCore/platform/mac/WidgetMac.mm
+++ b/Source/WebCore/platform/mac/WidgetMac.mm
@@ -176,7 +176,7 @@ NSView *Widget::outerView() const
         ASSERT(view);
     }
 
-    return view.get();
+    return view.unsafeGet();
 }
 
 RetainPtr<NSView> Widget::protectedOuterView() const

--- a/Source/WebCore/platform/text/cocoa/LocalizedDateCache.mm
+++ b/Source/WebCore/platform/text/cocoa/LocalizedDateCache.mm
@@ -75,7 +75,7 @@ NSDateFormatter *LocalizedDateCache::formatterForDateType(DateComponentsType typ
 {
     int key = static_cast<int>(type);
     if (m_formatterMap.contains(key))
-        return m_formatterMap.get(key).get();
+        return m_formatterMap.get(key).unsafeGet();
 
     auto dateFormatter = createFormatterForType(type);
     m_formatterMap.set(key, dateFormatter.get());

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1508,7 +1508,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RELEASE_ASSERT(storageSession);
 
     RetainPtr<NSHTTPCookieStorage> cookieStorage;
-    if (CFHTTPCookieStorageRef storage = storageSession->cookieStorage().get()) {
+    if (CFHTTPCookieStorageRef storage = storageSession->cookieStorage().unsafeGet()) {
         cookieStorage = adoptNS([[NSHTTPCookieStorage alloc] _initWithCFHTTPCookieStorage:storage]);
         configuration.get().HTTPCookieStorage = cookieStorage.get();
     } else

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -124,7 +124,7 @@ static NSArray<NSHTTPCookie *> *cookiesBySettingPartition(NSArray<NSHTTPCookie *
         if (partitionedCookie)
             [partitionedCookies addObject:partitionedCookie.get()];
     }
-    return partitionedCookies.get();
+    return partitionedCookies.unsafeGet();
 }
 #endif
 

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -114,7 +114,7 @@ inline std::optional<String> toOptional(NSString *maybeNil)
 
 inline CocoaImage *toCocoaImage(RefPtr<WebCore::Icon> icon)
 {
-    return icon ? icon->image().get() : nil;
+    return icon ? icon->image().unsafeGet() : nil;
 }
 
 enum class JSONOptions {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
@@ -309,7 +309,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (id <WKDownloadDelegate>)delegate
 {
-    return _delegate.get().get();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)setDelegate:(id<WKDownloadDelegatePrivate>)delegate

--- a/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.mm
@@ -62,7 +62,7 @@
 
 - (NSString *)name
 {
-    return _scriptMessage->cocoaName().get();
+    return _scriptMessage->cocoaName().unsafeGet();
 }
 
 - (WKContentWorld *)world

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1131,7 +1131,7 @@ struct WKWebsiteData {
 
 - (id <_WKWebsiteDataStoreDelegate>)_delegate
 {
-    return _delegate.get().get();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)set_delegate:(id <_WKWebsiteDataStoreDelegate>)delegate

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm
@@ -129,7 +129,7 @@ private:
     RefPtr page = _dataTask->page();
     if (!page)
         return nil;
-    return page->cocoaView().get();
+    return page->cocoaView().unsafeGet();
 }
 
 - (id <_WKDataTaskDelegate>)delegate

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
@@ -90,7 +90,7 @@ private:
 
 - (id <_WKInspectorDelegate>)delegate
 {
-    return _delegate.get().get();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)setDelegate:(id<_WKInspectorDelegate>)delegate

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm
@@ -43,7 +43,7 @@
 - (NSData *)data
 {
     if (auto messageData = self._protectedMessage->data())
-        return toNSData(*messageData).get();
+        return toNSData(*messageData).unsafeGet();
 
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm
@@ -46,17 +46,17 @@
 
 - (NSData *)applicationServerKey
 {
-    return toNSData(self._protectedData->applicationServerKey()).get();
+    return toNSData(self._protectedData->applicationServerKey()).unsafeGet();
 }
 
 - (NSData *)authenticationSecret
 {
-    return toNSData(self._protectedData->sharedAuthenticationSecret()).get();
+    return toNSData(self._protectedData->sharedAuthenticationSecret()).unsafeGet();
 }
 
 - (NSData *)ecdhPublicKey
 {
-    return toNSData(self._protectedData->clientECDHPublicKey()).get();
+    return toNSData(self._protectedData->clientECDHPublicKey()).unsafeGet();
 }
 
 - (API::Object&)_apiObject

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -247,7 +247,7 @@ void ApplicationStateTracker::setWindow(UIWindow *window)
     case ApplicationType::ViewService: {
         UIViewController *serviceViewController = nil;
 
-        for (UIView *view = m_view.get().get(); view; view = view.superview) {
+        for (UIView *view = m_view.get().unsafeGet(); view; view = view.superview) {
             auto viewController = WebCore::viewController(view);
 
             if (viewController._hostProcessIdentifier) {

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -159,7 +159,7 @@ ASVInlinePreview * ModelElementController::previewForModelIdentifier(ModelIdenti
     if (!webPageProxy || !webPageProxy->protectedPreferences()->modelElementEnabled())
         return nullptr;
 
-    return m_inlinePreviews.get(modelIdentifier.uuid).get();
+    return m_inlinePreviews.get(modelIdentifier.uuid).unsafeGet();
 }
 
 void ModelElementController::modelElementCreateRemotePreview(String uuid, WebCore::FloatSize size, CompletionHandler<void(Expected<std::pair<String, uint32_t>, WebCore::ResourceError>)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -318,7 +318,7 @@ UIDelegate::UIClient::~UIClient() = default;
 
 id<WKUIDelegatePrivate> UIDelegate::UIClient::uiDelegatePrivate()
 {
-    return m_uiDelegate ? (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get() : nil;
+    return m_uiDelegate ? (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get().unsafeGet() : nil;
 }
 
 RetainPtr<id<WKUIDelegatePrivate>> UIDelegate::UIClient::protectedUIDelegatePrivate()

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
@@ -135,7 +135,7 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
 
 - (id<WKContactPickerDelegate>)delegate
 {
-    return _delegate.get().get();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)setDelegate:(id<WKContactPickerDelegate>)delegate

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -237,7 +237,7 @@ static RetainPtr<LPLinkMetadata> placeholderMetadataWithFileURL(NSURL *url)
 
 - (id<WKShareSheetDelegate>)delegate
 {
-    return _delegate.get().get();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)setDelegate:(id<WKShareSheetDelegate>)delegate

--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
@@ -223,7 +223,7 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
 
 - (id<WKDigitalCredentialsPickerDelegate>)delegate
 {
-    return _delegate.get().get();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)setDelegate:(id<WKDigitalCredentialsPickerDelegate>)delegate

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -243,7 +243,7 @@ static void* const safeAreaInsetsKVOContext = (void*)&safeAreaInsetsKVOContext;
         return nil;
 
     if (RefPtr inspectedPage = _inspectedPage.get())
-        return inspectedPage->cocoaView().get();
+        return inspectedPage->cocoaView().unsafeGet();
 
     return nil;
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -313,14 +313,14 @@ static Class scrollViewScrollIndicatorClassSingleton()
         if ([view isKindOfClass:[WKChildScrollView class]]) {
             if (WebKit::isScrolledBy((WKChildScrollView *)view.get(), viewsAtPoint.last().get())) {
                 LOG_WITH_STREAM(UIHitTesting, stream << " " << (void*)view.get() << " is child scroll view and scrolled by " << (void*)viewsAtPoint.last().get());
-                return view.get();
+                return view.unsafeGet();
             }
         }
 
         if ([view isKindOfClass:WebKit::scrollViewScrollIndicatorClassSingleton()] && [[view superview] isKindOfClass:WKChildScrollView.class]) {
             if (WebKit::isScrolledBy((WKChildScrollView *)[view superview], viewsAtPoint.last().get())) {
                 LOG_WITH_STREAM(UIHitTesting, stream << " " << (void*)view.get() << " is the scroll indicator of child scroll view, which is scrolled by " << (void*)viewsAtPoint.last().get());
-                return view.get();
+                return view.unsafeGet();
             }
         }
 

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -200,12 +200,12 @@ void DragDropInteractionState::addDefaultDropPreview(UIDragItem *item, UITargete
 
 UITargetedDragPreview *DragDropInteractionState::defaultDropPreview(UIDragItem *item) const
 {
-    return m_defaultDropPreviews.get(item).get();
+    return m_defaultDropPreviews.get(item).unsafeGet();
 }
 
 UITargetedDragPreview *DragDropInteractionState::finalDropPreview(UIDragItem *item) const
 {
-    return m_finalDropPreviews.get(item).get();
+    return m_finalDropPreviews.get(item).unsafeGet();
 }
 
 void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, UIView *previewContainer, RefPtr<WebCore::TextIndicator>&& textIndicator)

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -233,7 +233,7 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
 {
     for (RetainPtr parent = [self superview]; parent; parent = [parent superview]) {
         if (RetainPtr scrollView = dynamic_objc_cast<UIScrollView>(parent.get()))
-            return scrollView.get();
+            return scrollView.unsafeGet();
     }
     return nil;
 }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12803,12 +12803,12 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
 - (CGImageRef)copySubjectResultForImageContextMenu
 {
-    return valueOrDefault(_imageAnalysisContextMenuActionData).copySubjectResult.get();
+    return valueOrDefault(_imageAnalysisContextMenuActionData).copySubjectResult.unsafeGet();
 }
 
 - (UIMenu *)machineReadableCodeSubMenuForImageContextMenu
 {
-    return valueOrDefault(_imageAnalysisContextMenuActionData).machineReadableCodeMenu.get();
+    return valueOrDefault(_imageAnalysisContextMenuActionData).machineReadableCodeMenu.unsafeGet();
 }
 
 #if USE(QUICK_LOOK)
@@ -14238,7 +14238,7 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
             if (enclosingView != selectedView && ![enclosingView _wk_isAncestorOf:selectedView])
                 return self;
         }
-        return enclosingView.get();
+        return enclosingView.unsafeGet();
     }();
 
     ASSERT(_cachedSelectionContainerView);

--- a/Source/WebKit/UIProcess/ios/WKHighlightLongPressGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKHighlightLongPressGestureRecognizer.mm
@@ -52,7 +52,7 @@
 
 - (UIScrollView *)lastTouchedScrollView
 {
-    return _lastTouchedScrollView.get().get();
+    return _lastTouchedScrollView.get().unsafeGet();
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -617,7 +617,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollView:self scrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Top]);
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Top, wrapper);
     }
-    return wrapper.get();
+    return wrapper.unsafeGet();
 }
 
 - (WKUIScrollEdgeEffect *)_wk_leftEdgeEffect
@@ -631,7 +631,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollView:self scrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Left]);
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Left, wrapper);
     }
-    return wrapper.get();
+    return wrapper.unsafeGet();
 }
 
 - (WKUIScrollEdgeEffect *)_wk_rightEdgeEffect
@@ -645,7 +645,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollView:self scrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Right]);
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Right, wrapper);
     }
-    return wrapper.get();
+    return wrapper.unsafeGet();
 }
 
 - (WKUIScrollEdgeEffect *)_wk_bottomEdgeEffect
@@ -659,7 +659,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollView:self scrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Bottom]);
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Bottom, wrapper);
     }
-    return wrapper.get();
+    return wrapper.unsafeGet();
 }
 
 - (void)_setInternalTopPocketColor:(UIColor *)color

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -169,7 +169,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HideEditMenuScope);
 
     for (id<UIInteraction> interaction in _view.interactions) {
         if (RetainPtr selectionInteraction = dynamic_objc_cast<UITextSelectionDisplayInteraction>(interaction))
-            return selectionInteraction.get();
+            return selectionInteraction.unsafeGet();
     }
 
     return nil;
@@ -235,7 +235,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HideEditMenuScope);
                 return nil;
 
             if ([foundView superview] == newContainer)
-                return foundView.get();
+                return foundView.unsafeGet();
         }
 
         return nil;

--- a/Source/WebKit/UIProcess/ios/forms/WKFocusedFormControlView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFocusedFormControlView.mm
@@ -176,7 +176,7 @@ static UIBezierPath *pathWithRoundedRectInFrame(CGRect rect, CGFloat borderRadiu
 
 - (id <WKFocusedFormControlViewDelegate>)delegate
 {
-    return _delegate.get().get();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)setDelegate:(id <WKFocusedFormControlViewDelegate>)delegate

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -262,7 +262,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (id<WKFullScreenViewControllerDelegate>)delegate
 {
-    return _delegate.get().get();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)setDelegate:(id<WKFullScreenViewControllerDelegate>)delegate

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -148,7 +148,7 @@ IntSize PageClientImpl::viewSize()
 NSView *PageClientImpl::activeView() const
 {
     CheckedPtr impl = m_impl.get();
-    return (impl && impl->thumbnailView()) ? (NSView *)impl->thumbnailView() : m_view.getAutoreleased();
+    return (impl && impl->thumbnailView()) ? impl->thumbnailView().unsafeGet() : m_view.getAutoreleased();
 }
 
 NSWindow *PageClientImpl::activeWindow() const

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3831,7 +3831,7 @@ void WebViewImpl::accessibilityRegisterUIProcessTokens()
 id WebViewImpl::accessibilityFocusedUIElement()
 {
     enableAccessibilityIfNecessary();
-    return remoteAccessibilityChildIfNotSuspended().get();
+    return remoteAccessibilityChildIfNotSuspended().unsafeGet();
 }
 
 id WebViewImpl::accessibilityHitTest(CGPoint)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -148,7 +148,7 @@ static const int defaultScrollMagnitudeThresholdForPageFlip = 20;
             }
         });
     }
-    return protectedSelf->_parent.get().get();
+    return protectedSelf->_parent.get().unsafeGet();
 }
 
 - (void)setParent:(NSObject *)parent

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -230,7 +230,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             }
         });
     }
-    return protectedSelf->_parent.get().get();
+    return protectedSelf->_parent.get().unsafeGet();
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
@@ -517,7 +517,7 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
         if (properties.animations.size()) {
             [animationGroup setAnimations:createNSArray(properties.animations, [&] (auto& animationProperties) -> CAAnimation * {
                 if (PlatformCAAnimation::isValidKeyPath(properties.keyPath, properties.animationType))
-                    return createAnimation(layer, layerTreeHost, animationProperties).get();
+                    return createAnimation(layer, layerTreeHost, animationProperties).unsafeGet();
                 ASSERT_NOT_REACHED();
                 return nil;
             }).get()];

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -203,16 +203,16 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     if ([attribute isEqualToString:NSAccessibilityParentAttribute])
-        return [self accessibilityAttributeParentValue].get();
+        return [self accessibilityAttributeParentValue].unsafeGet();
 
     if ([attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
         return @(screenHeight.load());
 
     if ([attribute isEqualToString:NSAccessibilityWindowAttribute])
-        return [self accessibilityAttributeWindowValue].get();
+        return [self accessibilityAttributeWindowValue].unsafeGet();
 
     if ([attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute])
-        return [self accessibilityAttributeTopLevelUIElementValue].get();
+        return [self accessibilityAttributeTopLevelUIElementValue].unsafeGet();
 
     return nil;
 }

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
@@ -147,7 +147,7 @@ static _WKMockUserNotificationCenter *centersByBundleIdentifier(NSString *bundle
 {
     RetainPtr settings = [UNMutableNotificationSettings emptySettings];
     [settings setAuthorizationStatus:m_hasPermission ? UNAuthorizationStatusAuthorized : UNAuthorizationStatusNotDetermined];
-    return settings.get();
+    return settings.unsafeGet();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/History/WebHistory.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistory.mm
@@ -188,7 +188,7 @@ static inline WebHistoryDateKey dateKey(NSTimeInterval date)
     ASSERT_ARG(entry, entry != nil);
     ASSERT(_entriesByDate->contains(dateKey));
 
-    NSMutableArray *entriesForDate = _entriesByDate->get(dateKey).get();
+    NSMutableArray *entriesForDate = _entriesByDate->get(dateKey).unsafeGet();
     NSTimeInterval entryDate = [entry lastVisitedTimeInterval];
 
     unsigned count = [entriesForDate count];
@@ -452,7 +452,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WebHistoryDateKey dateKey;
     if (![self findKey:&dateKey forDay:[date timeIntervalSinceReferenceDate]])
         return nil;
-    return _entriesByDate->get(dateKey).get();
+    return _entriesByDate->get(dateKey).unsafeGet();
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -879,7 +879,7 @@ WebHistoryWriter::WebHistoryWriter(DateToEntriesMap* entriesByDate)
 void WebHistoryWriter::writeHistoryItems(BinaryPropertyListObjectStream& stream)
 {
     for (int dateIndex = m_dateKeys.size() - 1; dateIndex >= 0; dateIndex--) {
-        NSArray *entries = m_entriesByDate->get(m_dateKeys[dateIndex]).get();
+        NSArray *entries = m_entriesByDate->get(m_dateKeys[dateIndex]).unsafeGet();
         NSUInteger entryCount = [entries count];
         for (NSUInteger entryIndex = 0; entryIndex < entryCount; ++entryIndex)
             writeHistoryItem(stream, [entries objectAtIndex:entryIndex]);

--- a/Source/WebKitLegacy/mac/Misc/WebSharingServicePickerController.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebSharingServicePickerController.mm
@@ -238,12 +238,12 @@ RetainPtr<NSImage> WebSharingServicePickerClient::imageForCurrentSharingServiceP
     if (!_pickerClient)
         return nil;
 
-    return _pickerClient->imageForCurrentSharingServicePickerItem(*self).get();
+    return _pickerClient->imageForCurrentSharingServicePickerItem(*self).unsafeGet();
 }
 
 - (NSWindow *)sharingService:(NSSharingService *)sharingService sourceWindowForShareItems:(NSArray *)items sharingContentScope:(NSSharingContentScope *)sharingContentScope
 {
-    return _pickerClient->windowForSharingServicePicker(*self).get();
+    return _pickerClient->windowForSharingServicePicker(*self).unsafeGet();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
@@ -161,7 +161,7 @@ void WebDragClient::startDrag(DragItem dragItem, DataTransfer& dataTransfer, Fra
     [topHTMLView _stopAutoscrollTimer];
     NSPasteboard *pasteboard = [NSPasteboard pasteboardWithName:dataTransfer.pasteboard().name().createNSString().get()];
 
-    NSImage *dragNSImage = dragImage.get().get();
+    NSImage *dragNSImage = dragImage.get().unsafeGet();
     WebHTMLView *sourceHTMLView = htmlView.get();
 
     IntSize size([dragNSImage size]);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -404,7 +404,7 @@ void WebInspectorFrontendClient::save(Vector<InspectorFrontendClient::SaveData>&
     auto suggestedURL = saveDatas[0].url;
     ASSERT(!suggestedURL.isEmpty());
 
-    NSURL *platformURL = m_suggestedToActualURLMap.get(suggestedURL).get();
+    NSURL *platformURL = m_suggestedToActualURLMap.get(suggestedURL).unsafeGet();
     if (!platformURL) {
         platformURL = [NSURL URLWithString:suggestedURL.createNSString().get()];
         // The user must confirm new filenames before we can save to them.
@@ -562,7 +562,7 @@ void WebInspectorFrontendClient::save(Vector<InspectorFrontendClient::SaveData>&
     [window setTitlebarAppearsTransparent:YES];
 
     [self setWindow:window.get()];
-    return window.get();
+    return window.unsafeGet();
 }
 
 // MARK: -

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm
@@ -74,7 +74,7 @@ bool WebNotificationClient::show(ScriptExecutionContext&, NotificationData&& not
 
 void WebNotificationClient::cancel(NotificationData&& notification)
 {
-    WebNotification *webNotification = m_notificationMap.get(notification.notificationID).get();
+    WebNotification *webNotification = m_notificationMap.get(notification.notificationID).unsafeGet();
     if (!webNotification)
         return;
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1879,7 +1879,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
 - (void)_startDrag:(const WebCore::DragItem&)dragItem
 {
     auto& dragImage = dragItem.image;
-    auto image = dragImage.get().get();
+    auto image = dragImage.get().unsafeGet();
     RefPtr<WebCore::TextIndicator> textIndicator = dragImage.textIndicator();
 
     if (textIndicator)
@@ -8634,7 +8634,7 @@ FORWARD(toggleUnderline)
 
 - (id)_objectForIdentifier:(unsigned long)identifier
 {
-    return _private->identifierMap.get(identifier).get();
+    return _private->identifierMap.get(identifier).unsafeGet();
 }
 
 - (void)_removeObjectForIdentifier:(unsigned long)identifier

--- a/Tools/DumpRenderTree/mac/DumpRenderTreePasteboard.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTreePasteboard.mm
@@ -74,7 +74,7 @@ static RetainPtr<NSMutableDictionary> localPasteboards WTF_GUARDED_BY_LOCK(local
         return pasteboard;
     auto pasteboard = adoptNS([[LocalPasteboard alloc] initWithName:name]);
     [localPasteboards setObject:pasteboard.get() forKey:name];
-    return pasteboard.get();
+    return pasteboard.unsafeGet();
 }
 
 + (void)releaseLocalPasteboards
@@ -219,13 +219,13 @@ static RetainPtr<CFStringRef> toUTI(NSString *type)
 
 - (NSData *)dataForType:(NSString *)dataType
 {
-    if (NSData *data = (__bridge NSData *)_data.get(toUTI(dataType).get()).get())
+    if (NSData *data = (__bridge NSData *)_data.get(toUTI(dataType).get()).unsafeGet())
         return data;
 
     if (_owner && [_owner respondsToSelector:@selector(pasteboard:provideDataForType:)])
         [_owner pasteboard:self provideDataForType:dataType];
 
-    return (__bridge NSData *)_data.get(toUTI(dataType).get()).get();
+    return (__bridge NSData *)_data.get(toUTI(dataType).get()).unsafeGet();
 }
 
 - (BOOL)setPropertyList:(id)propertyList forType:(NSString *)dataType

--- a/Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm
@@ -65,12 +65,12 @@
 
 - (NSString *)lastStateChange
 {
-    return std::exchange(_lastStateChange, @"").get();
+    return std::exchange(_lastStateChange, @"").unsafeGet();
 }
 
 - (NSString *)lastMethodCalled
 {
-    return std::exchange(_lastMethodCalled, @"").get();
+    return std::exchange(_lastMethodCalled, @"").unsafeGet();
 }
 
 - (NSString *)identifier

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
@@ -762,7 +762,7 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeaders)
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().get();
+    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
     webView.get().navigationDelegate = delegate;
     __block bool receivedActionNotification { false };
     __block Vector<String> urls;
@@ -848,7 +848,7 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereAppendWin
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().get();
+    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
     webView.get().navigationDelegate = delegate;
     __block bool receivedActionNotification { false };
     __block Vector<String> urls;
@@ -937,7 +937,7 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereSetWins)
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().get();
+    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
     webView.get().navigationDelegate = delegate;
     __block bool receivedActionNotification { false };
     __block Vector<String> urls;
@@ -1003,7 +1003,7 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereRemoveWin
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().get();
+    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
     webView.get().navigationDelegate = delegate;
     __block bool receivedActionNotification { false };
     __block Vector<String> urls;
@@ -1075,7 +1075,7 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithMultipleRuleLists)
     [[configuration userContentController] addContentRuleList:secondList.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().get();
+    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
     webView.get().navigationDelegate = delegate;
     __block bool receivedActionNotification { false };
     __block Vector<String> urls;
@@ -1195,7 +1195,7 @@ TEST_F(WKContentRuleListStoreTest, Redirect)
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"othertestscheme"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().get();
+    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
     webView.get().navigationDelegate = delegate;
     __block bool receivedActionNotification { false };
     __block Vector<String> urlsFromCallback;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
@@ -252,7 +252,7 @@ TEST(WKWebView, SnapshotImageEmptyWithOutOfScopeCompletionHandler)
 
     EXPECT_NULL([snapshotWrapper error]);
 
-    auto image = [snapshotWrapper image].get();
+    auto image = [snapshotWrapper image].unsafeGet();
     EXPECT_EQ(0UL, CGImageGetWidth(image));
     EXPECT_EQ(0UL, CGImageGetHeight(image));
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -1180,12 +1180,12 @@ public:
 
     _WKNotificationData *mostRecentNotification()
     {
-        return m_delegate.get().mostRecentNotification.get();
+        return m_delegate.get().mostRecentNotification.unsafeGet();
     }
 
     NSURL *mostRecentActionURL()
     {
-        return m_delegate.get().mostRecentActionURL.get();
+        return m_delegate.get().mostRecentActionURL.unsafeGet();
     }
 
     std::optional<uint64_t> mostRecentAppBadge()

--- a/Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm
@@ -243,7 +243,7 @@ static WebView *webViewAfterPerformingDragOperation(NSPasteboard *pasteboard)
     [[destination mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"full-page-contenteditable" withExtension:@"html"]]];
 
     TestWebKitAPI::Util::run(&isDone);
-    return destination.get();
+    return destination.unsafeGet();
 }
 
 TEST(LegacyDragAndDropTests, DropUTF8PlainText)

--- a/Tools/TestWebKitAPI/Tests/mac/WKWebViewForTestingImmediateActions.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WKWebViewForTestingImmediateActions.mm
@@ -64,7 +64,7 @@ static NSPoint swizzledImmediateActionLocationInView(id, SEL, NSView *)
 {
     for (NSGestureRecognizer *gesture in [self gestureRecognizers]) {
         if (RetainPtr immediateActionGesture = dynamic_objc_cast<NSImmediateActionGestureRecognizer>(gesture))
-            return immediateActionGesture.get();
+            return immediateActionGesture.unsafeGet();
     }
     return nil;
 }

--- a/Tools/TestWebKitAPI/cocoa/TestContextMenuDriver.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestContextMenuDriver.mm
@@ -35,7 +35,7 @@
 
 - (id<_UIClickInteractionDriverDelegate>)delegate
 {
-    return _delegate.get().get();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)setDelegate:(id<_UIClickInteractionDriverDelegate>)delegate
@@ -45,7 +45,7 @@
 
 - (UIView *)view
 {
-    return _view.get().get();
+    return _view.get().unsafeGet();
 }
 
 - (void)setView:(UIView *)view

--- a/Tools/TestWebKitAPI/mac/TestDraggingInfo.mm
+++ b/Tools/TestWebKitAPI/mac/TestDraggingInfo.mm
@@ -73,7 +73,7 @@
 
 - (id)draggingSource
 {
-    return _source.get().get();
+    return _source.get().unsafeGet();
 }
 
 - (void)setDraggingSource:(id)draggingSource

--- a/Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.mm
+++ b/Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.mm
@@ -73,7 +73,7 @@
 
 - (id)draggingSource
 {
-    return _draggingSource.get().get();
+    return _draggingSource.get().unsafeGet();
 }
 
 - (void)setDraggingSource:(id)draggingSource

--- a/Tools/TestWebKitAPI/mac/TestInspectorBar.mm
+++ b/Tools/TestWebKitAPI/mac/TestInspectorBar.mm
@@ -46,7 +46,7 @@
 
 - (TestInspectorBar *)inspectorBar
 {
-    return _testInspectorBar.get().get();
+    return _testInspectorBar.get().unsafeGet();
 }
 
 - (void)updateSelectedAttributes
@@ -156,7 +156,7 @@
 
 - (TestInspectorBarItemController *)itemController
 {
-    return _testItemController.get().get();
+    return _testItemController.get().unsafeGet();
 }
 
 - (void)setItemController:(TestInspectorBarItemController *)itemController

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -791,7 +791,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::allAttributes()
             continue;
 
         if ([attribute isEqualToString:@"AXVisibleCharacterRange"]) {
-            id value = attributeValue(NSAccessibilityRoleAttribute).get();
+            id value = attributeValue(NSAccessibilityRoleAttribute).unsafeGet();
             NSString *role = [value isKindOfClass:[NSString class]] ? (NSString *)value : nil;
             if (role == nil || [role isEqualToString:@"AXList"] || [role isEqualToString:@"AXLink"] || [role isEqualToString:@"AXGroup"] || [role isEqualToString:@"AXRow"] || [role isEqualToString:@"AXColumn"] || [role isEqualToString:@"AXTable"] || [role isEqualToString:@"AXWebArea"]) {
                 // For some roles, behavior with ITM on and ITM off differ for this API in ways
@@ -1766,7 +1766,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::horizontalScrollbar() con
         return nullptr;
 
     BEGIN_AX_OBJC_EXCEPTIONS
-    if (id scrollbar = attributeValue(NSAccessibilityHorizontalScrollBarAttribute).get())
+    if (id scrollbar = attributeValue(NSAccessibilityHorizontalScrollBarAttribute).unsafeGet())
         return AccessibilityUIElement::create(scrollbar);
     END_AX_OBJC_EXCEPTIONS
 
@@ -1779,7 +1779,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::verticalScrollbar() const
         return nullptr;
 
     BEGIN_AX_OBJC_EXCEPTIONS
-    if (id scrollbar = attributeValue(NSAccessibilityVerticalScrollBarAttribute).get())
+    if (id scrollbar = attributeValue(NSAccessibilityVerticalScrollBarAttribute).unsafeGet())
         return AccessibilityUIElement::create(scrollbar);
     END_AX_OBJC_EXCEPTIONS
 
@@ -2101,7 +2101,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::popupValue() const
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::focusableAncestor()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    if (id ancestor = attributeValue(@"AXFocusableAncestor").get())
+    if (id ancestor = attributeValue(@"AXFocusableAncestor").unsafeGet())
         return AccessibilityUIElement::create(ancestor);
     END_AX_OBJC_EXCEPTIONS
 
@@ -2111,7 +2111,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::focusableAncestor()
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::editableAncestor()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    if (id ancestor = attributeValue(@"AXEditableAncestor").get())
+    if (id ancestor = attributeValue(@"AXEditableAncestor").unsafeGet())
         return AccessibilityUIElement::create(ancestor);
     END_AX_OBJC_EXCEPTIONS
 
@@ -2121,7 +2121,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::editableAncestor()
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::highestEditableAncestor()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    if (id ancestor = attributeValue(@"AXHighestEditableAncestor").get())
+    if (id ancestor = attributeValue(@"AXHighestEditableAncestor").unsafeGet())
         return AccessibilityUIElement::create(ancestor);
     END_AX_OBJC_EXCEPTIONS
 

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -91,7 +91,7 @@ SOFT_LINK_CLASS(UIKit, UIPhysicalKeyboardEvent)
     for (UIView *subview in self.subviews.reverseObjectEnumerator) {
         CGPoint convertedPoint = [subview convertPoint:point fromView:self];
         if (RetainPtr frontmostView = [subview _wtr_frontmostViewAtPoint:convertedPoint])
-            return frontmostView.get();
+            return frontmostView.unsafeGet();
     }
 
     if (![self.layer.presentationLayer containsPoint:point])


### PR DESCRIPTION
#### 4e4112627e57f523a8e1734a0f71269def888235
<pre>
Adopt LIFETIME_BOUND for WTF::RetainPtr
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=300594">https://bugs.webkit.org/show_bug.cgi?id=300594</a>&gt;
&lt;<a href="https://rdar.apple.com/162489676">rdar://162489676</a>&gt;

Reviewed by Geoffrey Garen.

Introduce RetainPtr::unsafeGet() for pre-existing unsafe uses of
RetainPtr::get().

* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtr::unsafeGet const):
(WTF::RetainPtr::get const): Deleted.
(WTF::RetainPtr::operator-&gt; const): Deleted.
(WTF::RetainPtr::operator PtrType const): Deleted.
* Source/WTF/wtf/cocoa/Entitlements.mm:
(WTF::hasEntitlementValueInArray):
- Avoid switching to unsafeGet() and remove C-style cast by switching to
  dynamic_cf_cast&lt;CFArrayRef&gt;() first.

* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::AXRemoteFrame::initializePlatformElementWithRemoteToken):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityHitTest:]):
(-[WebAccessibilityObjectWrapper accessibilityElements]):
(-[WebAccessibilityObjectWrapper accessibilityElementAtIndex:]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::platformWidget const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(makeNSArray):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeNames]):
(-[WebAccessibilityObjectWrapper remoteAccessibilityParentObject]):
(transformSpecialChildrenCases):
(children):
(scrollViewParent):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):
(-[WebAccessibilityObjectWrapper _accessibilityHitTest:returnPlatformElements:]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
* Source/WebCore/editing/cocoa/AlternativeTextContextController.mm:
(WebCore::AlternativeTextContextController::alternativesForContext const):
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::reconstructStyle):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(HTMLConverter::aggregatedAttributesForElementAndItsAncestors):
* Source/WebCore/page/cocoa/DataDetectionResultsStorage.h:
(WebCore::DataDetectionResultsStorage::imageOverlayDataDetectionResult):
* Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm:
(WebCore::WebAVPlayerLayerView_pictureInPicturePlayerLayerView):
* Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h:
* Source/WebCore/platform/ios/wak/WAKWindow.mm:
(-[WAKWindow contentReplacementImage]):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::screen):
* Source/WebCore/platform/mac/WebCoreFullScreenPlaceholderView.mm:
(-[WebCoreFullScreenPlaceholderView target]):
* Source/WebCore/platform/mac/WidgetMac.mm:
(WebCore::Widget::outerView const):
* Source/WebCore/platform/text/cocoa/LocalizedDateCache.mm:
(WebCore::LocalizedDateCache::formatterForDateType):

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
(WebKit::toCocoaImage):
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
(-[WKDownload delegate]):
* Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.mm:
(-[WKScriptMessage name]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _delegate]):
* Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm:
(-[_WKDataTask webView]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm:
(-[_WKInspector delegate]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm:
(-[_WKWebPushMessage data]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm:
(-[_WKWebPushSubscriptionData applicationServerKey]):
(-[_WKWebPushSubscriptionData authenticationSecret]):
(-[_WKWebPushSubscriptionData ecdhPublicKey]):
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(WebKit::ApplicationStateTracker::setWindow):
* Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm:
(WebKit::ModelElementController::previewForModelIdentifier):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::uiDelegatePrivate):
* Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm:
(-[WKContactPicker delegate]):
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(-[WKShareSheet delegate]):
* Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm:
(-[WKDigitalCredentialsPicker delegate]):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController _horizontallyAttachedInspectedWebView]):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(-[UIView _web_findDescendantViewAtPoint:withEvent:]):
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::defaultDropPreview const):
(WebKit::DragDropInteractionState::finalDropPreview const):
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIView _wk_parentScrollView]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView copySubjectResultForImageContextMenu]):
(-[WKContentView machineReadableCodeSubMenuForImageContextMenu]):
(-[WKContentView _selectionContainerViewInternal]):
* Source/WebKit/UIProcess/ios/WKHighlightLongPressGestureRecognizer.mm:
(-[WKHighlightLongPressGestureRecognizer lastTouchedScrollView]):
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _wk_topEdgeEffect]):
(-[WKScrollView _wk_leftEdgeEffect]):
(-[WKScrollView _wk_rightEdgeEffect]):
(-[WKScrollView _wk_bottomEdgeEffect]):
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper textSelectionDisplayInteraction]):
(-[WKTextInteractionWrapper prepareToMoveSelectionContainer:]):
* Source/WebKit/UIProcess/ios/forms/WKFocusedFormControlView.mm:
(-[WKFocusedFormControlView delegate]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController delegate]):
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::activeView const):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::accessibilityFocusedUIElement):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(-[WKPDFPluginAccessibilityObject parent]):
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm:
(-[WKAccessibilityPDFDocumentObject accessibilityParent]):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm:
(WebKit::createAnimation):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityAttributeValue:]):
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
(-[_WKMockUserNotificationCenter notificationSettings]):

* Source/WebKitLegacy/mac/History/WebHistory.mm:
(-[WebHistoryPrivate insertItem:forDateKey:]):
(-[WebHistoryPrivate orderedItemsLastVisitedOnDay:]):
(WebHistoryWriter::writeHistoryItems):
* Source/WebKitLegacy/mac/Misc/WebSharingServicePickerController.mm:
(-[WebSharingServicePickerController sharingService:transitionImageForShareItem:contentRect:]):
(-[WebSharingServicePickerController sharingService:sourceWindowForShareItems:sharingContentScope:]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm:
(WebDragClient::startDrag):
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:
(WebInspectorFrontendClient::save):
(-[WebInspectorWindowController window]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm:
(WebNotificationClient::cancel):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _startDrag:]):
(-[WebView _objectForIdentifier:]):

* Tools/DumpRenderTree/mac/DumpRenderTreePasteboard.mm:
(+[DumpRenderTreePasteboard _pasteboardWithName:]):
(-[LocalPasteboard dataForType:]):
* Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm:
(-[_WKMockMediaSessionCoordinator lastStateChange]):
(-[_WKMockMediaSessionCoordinator lastMethodCalled]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(TEST_F(WKContentRuleListStoreTest, ModifyHeaders)):
(TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereAppendWins)):
(TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereSetWins)):
(TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereRemoveWins)):
(TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithMultipleRuleLists)):
(TEST_F(WKContentRuleListStoreTest, Redirect)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm:
(TestWebKitAPI::TEST(WKWebView, SnapshotImageEmptyWithOutOfScopeCompletionHandler)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
* Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm:
(TestWebKitAPI::webViewAfterPerformingDragOperation):
* Tools/TestWebKitAPI/Tests/mac/WKWebViewForTestingImmediateActions.mm:
(-[WKWebViewForTestingImmediateActions immediateActionGesture]):
* Tools/TestWebKitAPI/cocoa/TestContextMenuDriver.mm:
(-[TestContextMenuDriver delegate]):
(-[TestContextMenuDriver view]):
* Tools/TestWebKitAPI/mac/TestDraggingInfo.mm:
(-[TestDraggingInfo draggingSource]):
* Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.mm:
(-[TestFilePromiseReceiver draggingSource]):
* Tools/TestWebKitAPI/mac/TestInspectorBar.mm:
(-[TestInspectorBarItemController inspectorBar]):
(-[TestInspectorBar itemController]):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElement::allAttributes):
(WTR::AccessibilityUIElement::horizontalScrollbar const):
(WTR::AccessibilityUIElement::verticalScrollbar const):
(WTR::AccessibilityUIElement::focusableAncestor):
(WTR::AccessibilityUIElement::editableAncestor):
(WTR::AccessibilityUIElement::highestEditableAncestor):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(-[UIView _wtr_frontmostViewAtPoint:]):

Canonical link: <a href="https://commits.webkit.org/301419@main">https://commits.webkit.org/301419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56f5aeeda0a6f629589a7e99cfd0361c233c0ea9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125936 "114 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77795 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/970710d0-f197-44ee-b244-2e9a4fca9ad6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54156 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/041f9f74-07fb-4971-8646-03148091ba44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76438 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41009a2c-43d9-4cf2-9cd0-c6172f9e4998) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30817 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76276 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118016 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135491 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124443 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40454 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108842 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49517 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27846 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50099 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19706 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52615 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58427 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157456 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51959 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39425 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55308 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53657 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->