### PR TITLE
Address safer CPP warnings in WKDownload

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,7 +1,6 @@
 Platform/IPC/ArgumentCoders.h
 UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKContentWorld.mm
-UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm
 UIProcess/API/Cocoa/WKOpenPanelParameters.mm
 UIProcess/API/Cocoa/WKPreferences.mm
@@ -21,7 +20,6 @@ UIProcess/API/Cocoa/_WKContentRuleListAction.mm
 [ Mac ] UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
 UIProcess/API/Cocoa/_WKCustomHeaderFields.mm
 UIProcess/API/Cocoa/_WKDataTask.mm
-UIProcess/API/Cocoa/_WKDownload.mm
 UIProcess/API/Cocoa/_WKFeature.mm
 UIProcess/API/Cocoa/_WKFrameTreeNode.mm
 UIProcess/API/Cocoa/_WKInspector.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -19,7 +19,6 @@ Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
 UIProcess/API/C/mac/WKNotificationPrivateMac.mm
 UIProcess/API/C/mac/WKProtectionSpaceNS.mm
 [ Mac ] UIProcess/API/Cocoa/NSAttributedString.mm
-UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm
 UIProcess/API/Cocoa/WKNavigationAction.mm
 UIProcess/API/Cocoa/WKNavigationResponse.mm

--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -110,6 +110,7 @@ template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectCla
 
 namespace API {
 
+using WebKit::protectedWrapper;
 using WebKit::wrapper;
 
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
@@ -57,7 +57,7 @@ IGNORE_WARNINGS_END
 {
     if (!(self = [super init]))
         return nil;
-    _download = download;
+    lazyInitialize(_download, retainPtr(download));
     return self;
 }
 
@@ -72,14 +72,14 @@ IGNORE_WARNINGS_END
 
 - (void)cancel
 {
-    _download->_download->cancel([download = Ref { *_download->_download }] (auto*) {
-        download->client().legacyDidCancel(download.get());
+    Ref { *_download->_download }->cancel([download = Ref { *_download->_download }] (auto*) {
+        download->protectedClient()->legacyDidCancel(download.get());
     });
 }
 
 - (void)publishProgressAtURL:(NSURL *)URL
 {
-    _download->_download->publishProgress(URL);
+    Ref { *_download->_download }->publishProgress(URL);
 }
 
 - (NSURLRequest *)request
@@ -89,7 +89,7 @@ IGNORE_WARNINGS_END
 
 - (WKWebView *)originatingWebView
 {
-    RefPtr page = _download->_download->originatingPage();
+    RefPtr page = Ref { *_download->_download }->originatingPage();
     return page ? page->cocoaView().autorelease() : nil;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h
@@ -32,6 +32,6 @@
 
 @interface _WKDownload () <WKObject> {
 @package
-    RetainPtr<WKDownload> _download;
+    const RetainPtr<WKDownload> _download;
 }
 @end

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -110,6 +110,8 @@ public:
     API::FrameInfo& frameInfo() { return m_frameInfo.get(); }
 
     API::DownloadClient& client() { return m_client.get(); }
+    Ref<API::DownloadClient> protectedClient() const;
+
     void setClient(Ref<API::DownloadClient>&&);
     void setDidStartCallback(CompletionHandler<void(DownloadProxy*)>&& callback) { m_didStartCallback = WTFMove(callback); }
     void setSuggestedFilename(const String& suggestedFilename) { m_suggestedFilename = suggestedFilename; }
@@ -133,7 +135,6 @@ public:
 private:
     explicit DownloadProxy(DownloadProxyMap&, WebsiteDataStore&, API::DownloadClient&, const WebCore::ResourceRequest&, const std::optional<FrameInfoData>&, WebPageProxy*);
 
-    Ref<API::DownloadClient> protectedClient() const;
     RefPtr<WebsiteDataStore> protectedDataStore() { return m_dataStore; }
 
     // IPC::MessageReceiver


### PR DESCRIPTION
#### 443f5cba747191382d00c39c2aa8fc36081529cd
<pre>
Address safer CPP warnings in WKDownload
<a href="https://bugs.webkit.org/show_bug.cgi?id=300598">https://bugs.webkit.org/show_bug.cgi?id=300598</a>

Reviewed by Darin Adler.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/Shared/Cocoa/WKObject.h:
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
(-[WKDownload protectedDownload]):
(-[WKDownload cancel:]):
(-[WKDownload webView]):
(-[WKDownload setDelegate:]):
(-[WKDownload progress]):
(-[WKDownload dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm:
(-[_WKDownload initWithDownload2:]):
(-[_WKDownload cancel]):
(-[_WKDownload publishProgressAtURL:]):
(-[_WKDownload originatingWebView]):
* Source/WebKit/UIProcess/API/Cocoa/_WKDownloadInternal.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:

Canonical link: <a href="https://commits.webkit.org/301443@main">https://commits.webkit.org/301443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c17b20a472a4c8b36dc2e4fc9c97e27c0a210d89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132750 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77748 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/76330310-4c78-4ef5-ac7a-f953b55e0f37) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95899 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64003 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c66a7ba-14b8-4968-bee9-f2becc5086ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76390 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d69f62b5-1ba7-4ccc-ba91-bb44e81b9cd2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35869 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76222 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135432 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52665 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104365 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108768 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104092 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49465 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27779 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50032 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52559 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58371 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51909 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55254 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53602 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->