### PR TITLE
REGRESSION(298715@main): SVG animation with finite 'max' and indefinite 'repeatDur` causes the web page to jetsam

### DIFF
--- a/LayoutTests/svg/animations/smil-max-finite-repeatDur-indefinite-crash-expected.txt
+++ b/LayoutTests/svg/animations/smil-max-finite-repeatDur-indefinite-crash-expected.txt
@@ -1,0 +1,3 @@
+Passes if it does not crash.
+
+

--- a/LayoutTests/svg/animations/smil-max-finite-repeatDur-indefinite-crash.html
+++ b/LayoutTests/svg/animations/smil-max-finite-repeatDur-indefinite-crash.html
@@ -1,0 +1,21 @@
+<body>
+    <p>Passes if it does not crash.</p>
+    <svg id="svg">
+        <rect width="100" height="100" fill="green">
+            <set attributeName="transform" begin="200ms" max="200ms" dur="2s" repeatDur="indefinite" onend="handleEndEvent()"/>
+        </rect>
+    </svg>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        svg.setCurrentTime(0.5);
+
+        function handleEndEvent(event) {
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+    </script>
+</body>


### PR DESCRIPTION
#### 9e3f17d2eca9adac7441eab4e473cf76495ec806
<pre>
REGRESSION(298715@main): SVG animation with finite &apos;max&apos; and indefinite &apos;repeatDur` causes the web page to jetsam
<a href="https://bugs.webkit.org/show_bug.cgi?id=299047">https://bugs.webkit.org/show_bug.cgi?id=299047</a>
<a href="https://rdar.apple.com/160099991">rdar://160099991</a>

Reviewed by Nikolas Zimmermann.

Re-landing 300165@main after confirming it did not cause a memory regression.

When the SMIL ends because the elapsed time is greater than the intervalEnd, we
should not use repeatingDuration to calculate &apos;repeat&apos; value unless its value is
finite. If it is value isIndefinite, we should use the duration since the begin
of the animation.

Test: svg/animations/smil-max-finite-repeatDur-indefinite-crash.html

* LayoutTests/svg/animations/smil-max-finite-repeatDur-indefinite-crash-expected.txt: Added.
* LayoutTests/svg/animations/smil-max-finite-repeatDur-indefinite-crash.html: Added.
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::calculateAnimationPercentAndRepeat const):

Canonical link: <a href="https://commits.webkit.org/301404@main">https://commits.webkit.org/301404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc7565c4f44bf304a7f209566c55514b9cc4131a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132721 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77721 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9366853b-d2ab-4308-b967-99c2e61b42d2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95878 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63986 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7972047b-d1a1-4800-9c56-b81e63d5b6fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76369 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e967802-067a-4066-bef0-1a92d1094965) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30725 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76192 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135402 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104342 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104070 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26508 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27764 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49992 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52530 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58341 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51878 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53573 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->