### PR TITLE
[WebDriver] Elements references nested in arrays or objects are not extracted when executing scripts

### DIFF
--- a/Source/WebDriver/Session.h
+++ b/Source/WebDriver/Session.h
@@ -208,8 +208,10 @@ private:
     RefPtr<JSON::Object> createElement(RefPtr<JSON::Value>&&);
     Ref<JSON::Object> createElement(const String& elementID);
     RefPtr<JSON::Object> createShadowRoot(RefPtr<JSON::Value>&&);
-    RefPtr<JSON::Object> extractElement(JSON::Value&);
-    String extractElementID(JSON::Value&);
+    RefPtr<JSON::Object> extractElement(const JSON::Value&);
+    String extractElementID(const JSON::Value&);
+    Expected<Ref<JSON::Value>, CommandResult> replaceReferences(Ref<JSON::Value>&&);
+    Expected<Ref<JSON::Value>, CommandResult> replaceReferences(Ref<JSON::Value>&&, HashSet<Ref<JSON::Value>>&);
     Ref<JSON::Value> handleScriptResult(Ref<JSON::Value>&&);
     void elementIsEditable(const String& elementID, Function<void(CommandResult&&)>&&);
 

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -373,64 +373,6 @@
 
         }
     },
-    "imported/selenium/py/test/selenium/webdriver/support/relative_by_tests.py": {
-        "subtests": {
-            "test_should_be_able_to_find_elements_above_another": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_should_be_able_to_combine_filters": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_should_be_able_to_find_first_one": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_should_be_able_to_find_first_one_by_locator": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_should_be_able_to_find_elements_above_another_by_locator": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_should_be_able_to_combine_filters_by_locator": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_should_be_able_to_use_css_selectors": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_should_be_able_to_use_css_selectors_by_locator": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_should_be_able_to_use_xpath": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_should_be_able_to_use_xpath_by_locator": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_no_such_element_is_raised_rather_than_index_error": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_no_such_element_is_raised_rather_than_index_error_by_locator": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_near_locator_should_find_near_elements": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_near_locator_should_find_near_elements_by_locator": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_near_locator_should_not_find_far_elements": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_near_locator_should_not_find_far_elements_by_locator": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_near_locator_should_find_far_elements": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            },
-            "test_near_locator_should_find_far_elements_by_locator": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213451"}}
-            }
-        }
-    },
 
     "imported/w3c/webdriver/tests/classic/add_cookie/add.py": {
         "subtests": {


### PR DESCRIPTION
#### 7b619594eed45ca227b9178a5d46b1c059398e67
<pre>
[WebDriver] Elements references nested in arrays or objects are not extracted when executing scripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=300462">https://bugs.webkit.org/show_bug.cgi?id=300462</a>

Reviewed by Carlos Garcia Campos.

Currently, we are just translating/extracting the element references for
the top level arguments when evaluating JS functions. This may lead to
failures when the element reference is nested in an Array or Object,
like for Selenium&apos;s snippets for some selectors like `relative-by`

This commit traverses the arguments in a similar fashion to the &quot;JSON
deserialize&quot; algorithm [1], making sure all element references are
processed.

[1] <a href="https://www.w3.org/TR/webdriver/#dfn-json-deserialize">https://www.w3.org/TR/webdriver/#dfn-json-deserialize</a>

* Source/WebDriver/Session.cpp:
(WebDriver::Session::extractElement):
(WebDriver::Session::extractElementID):
(WebDriver::Session::replaceReferences):
(WebDriver::Session::executeScript):
* Source/WebDriver/Session.h:
* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/301445@main">https://commits.webkit.org/301445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/234e9ef024660f408a77320999c757b323235735

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36448 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54217 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/132852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112688 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35975 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30873 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135548 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40510 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104460 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108902 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26537 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49572 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27896 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50159 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58504 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52013 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->