### PR TITLE
[JSC] Move Promise.resolve and Promise.reject to C++

### DIFF
--- a/JSTests/stress/dfg-promise-resolve-fulfilled-identity.js
+++ b/JSTests/stress/dfg-promise-resolve-fulfilled-identity.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(input)
+{
+    return Promise.resolve(input);
+}
+
+async function testMain()
+{
+    for (let i = 0; i < testLoopCount; ++i) {
+        let input = new Promise((resolve, reject) => resolve(undefined));
+        let result = test(input);
+        shouldBe(result, input);
+        let res = await result;
+        shouldBe(res, undefined);
+    }
+}
+testMain().catch($vm.abort);

--- a/JSTests/stress/dfg-promise-resolve-fulfilled-then.js
+++ b/JSTests/stress/dfg-promise-resolve-fulfilled-then.js
@@ -1,0 +1,27 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(input)
+{
+    return Promise.resolve(input);
+}
+
+class DerivedPromise extends Promise {
+    then(a, b) {
+        return super.then(a, b);
+    }
+}
+
+async function testMain()
+{
+    for (let i = 0; i < testLoopCount; ++i) {
+        let promise = new DerivedPromise((resolve, reject) => resolve(undefined));
+        let result = await test(promise);
+        shouldBe(promise !== result, true);
+        let res = await result;
+        shouldBe(res, undefined);
+    }
+}
+testMain().catch($vm.abort);

--- a/JSTests/stress/dfg-promise-resolve-fulfilled.js
+++ b/JSTests/stress/dfg-promise-resolve-fulfilled.js
@@ -1,0 +1,18 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(input)
+{
+    return Promise.resolve(input);
+}
+
+async function testMain()
+{
+    for (let i = 0; i < testLoopCount; ++i) {
+        let res = await test(undefined);
+        shouldBe(res, undefined);
+    }
+}
+testMain().catch($vm.abort);

--- a/Source/JavaScriptCore/builtins/AsyncDisposableStackPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncDisposableStackPrototype.js
@@ -103,7 +103,7 @@ function disposeAsync()
         if (i) {
             var resource = stack[--i];
             try {
-                @Promise.@resolve(resource.method.@call(resource.value)).@then(loop, handleError);
+                @promiseResolve(@Promise, resource.method.@call(resource.value)).@then(loop, handleError);
             } catch (error) {
                 handleError(error);
             }

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -91,6 +91,8 @@ namespace JSC {
     macro(promiseAllOnFulfilled) \
     macro(promiseEmptyOnFulfilled) \
     macro(promiseEmptyOnRejected) \
+    macro(promiseResolve) \
+    macro(promiseReject) \
     macro(performPromiseThen) \
     macro(push) \
     macro(repeatCharacter) \

--- a/Source/JavaScriptCore/builtins/DisposableStackPrototype.js
+++ b/Source/JavaScriptCore/builtins/DisposableStackPrototype.js
@@ -38,16 +38,12 @@ function getAsyncDisposableMethod(value)
         return @undefined;
 
     return () => {
-        var promise = @newPromise();
-        var result;
         try {
-            result = method.@call(value);
+            method.@call(value);
         } catch (e) {
-            @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, e);
-            return promise;
+            return @promiseReject(@Promise, e);
         }
-        @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, @undefined);
-        return promise;
+        return @promiseResolve(@Promise, @undefined);
     };
 }
 

--- a/Source/JavaScriptCore/builtins/PromiseConstructor.js
+++ b/Source/JavaScriptCore/builtins/PromiseConstructor.js
@@ -80,7 +80,7 @@ function promiseNewOnRejected(promise)
 {
     "use strict";
 
-    return function @reject(reason) {
+    return (reason) => {
         return @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, reason);
     };
 }
@@ -324,32 +324,6 @@ function race(iterable)
     }
 
     return promise;
-}
-
-function reject(reason)
-{
-    "use strict";
-
-    if (!@isObject(this))
-        @throwTypeError("|this| is not an object");
-
-    if (this === @Promise) {
-        var promise = @newPromise();
-        @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, reason);
-        return promise;
-    }
-
-    return @promiseRejectSlow(this, reason);
-}
-
-function resolve(value)
-{
-    "use strict";
-
-    if (!@isObject(this))
-        @throwTypeError("|this| is not an object");
-
-    return @promiseResolve(this, value);
 }
 
 function try(callback /*, ...args */)

--- a/Source/JavaScriptCore/builtins/PromiseOperations.js
+++ b/Source/JavaScriptCore/builtins/PromiseOperations.js
@@ -66,53 +66,16 @@ function newPromiseCapability(constructor)
     if (constructor === @Promise) {
         var promise = @newPromise();
         var capturedPromise = promise;
-        function @resolve(resolution) {
-            return @resolvePromiseWithFirstResolvingFunctionCallCheck(capturedPromise, resolution);
-        }
-        function @reject(reason) {
-            return @rejectPromiseWithFirstResolvingFunctionCallCheck(capturedPromise, reason);
-        }
-        return { resolve: @resolve, reject: @reject, promise };
+        return {
+            resolve: (0, (value) => {
+                return @resolvePromiseWithFirstResolvingFunctionCallCheck(capturedPromise, value);
+            }),
+            reject: (0, (value) => {
+                return @rejectPromiseWithFirstResolvingFunctionCallCheck(capturedPromise, value);
+            }),
+            promise
+        };
     }
 
     return @newPromiseCapabilitySlow(constructor);
-}
-
-@linkTimeConstant
-function promiseResolve(constructor, value)
-{
-    "use strict";
-
-    if (@isPromise(value) && value.constructor === constructor)
-        return value;
-
-    if (constructor === @Promise) {
-        var promise = @newPromise();
-        @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, value);
-        return promise;
-    }
-
-    return @promiseResolveSlow(constructor, value);
-}
-
-@linkTimeConstant
-function promiseResolveSlow(constructor, value)
-{
-    "use strict";
-
-    @assert(constructor !== @Promise);
-    var promiseCapability = @newPromiseCapabilitySlow(constructor);
-    promiseCapability.resolve.@call(@undefined, value);
-    return promiseCapability.promise;
-}
-
-@linkTimeConstant
-function promiseRejectSlow(constructor, reason)
-{
-    "use strict";
-
-    @assert(constructor !== @Promise);
-    var promiseCapability = @newPromiseCapabilitySlow(constructor);
-    promiseCapability.reject.@call(@undefined, reason);
-    return promiseCapability.promise;
 }

--- a/Source/JavaScriptCore/builtins/WebAssembly.js
+++ b/Source/JavaScriptCore/builtins/WebAssembly.js
@@ -26,14 +26,14 @@
 function compileStreaming(source) {
     "use strict";
 
-    return @Promise.@resolve(source).@then(@webAssemblyCompileStreamingInternal);
+    return @promiseResolve(@Promise, source).@then(@webAssemblyCompileStreamingInternal);
 }
 
 function instantiateStreaming(source) {
     "use strict";
 
     var importObject = @argument(1);
-    return @Promise.@resolve(source).@then((source) => {
+    return @promiseResolve(@Promise, source).@then((source) => {
         return @webAssemblyInstantiateStreamingInternal(source, importObject);
     });
 }

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -71,6 +71,8 @@ class JSGlobalObject;
     v(promiseAllOnFulfilled, nullptr) \
     v(promiseEmptyOnFulfilled, nullptr) \
     v(promiseEmptyOnRejected, nullptr) \
+    v(promiseResolve, nullptr) \
+    v(promiseReject, nullptr) \
     v(performPromiseThen, nullptr) \
     v(makeTypeError, nullptr) \
     v(AggregateError, nullptr) \

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -4589,6 +4589,70 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case PromiseConstructorResolveIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            Node* constructor = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+            Node* argument = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            setResult(addToGraph(PromiseResolve, Edge(constructor, ObjectUse), Edge(argument)));
+            return CallOptimizationResult::Inlined;
+        }
+
+        case PromiseResolveIntrinsic: {
+            if (argumentCountIncludingThis < 3)
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            Node* constructor = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            Node* argument = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
+            setResult(addToGraph(PromiseResolve, Edge(constructor, ObjectUse), Edge(argument)));
+            return CallOptimizationResult::Inlined;
+        }
+
+        case PromiseConstructorRejectIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            Node* constructor = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+            Node* argument = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            setResult(addToGraph(PromiseReject, Edge(constructor, ObjectUse), Edge(argument)));
+            return CallOptimizationResult::Inlined;
+        }
+
+        case PromiseRejectIntrinsic: {
+            if (argumentCountIncludingThis < 3)
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            Node* constructor = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            Node* argument = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
+            setResult(addToGraph(PromiseReject, Edge(constructor, ObjectUse), Edge(argument)));
+            return CallOptimizationResult::Inlined;
+        }
+
         default:
             return CallOptimizationResult::DidNothing;
         }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2512,6 +2512,11 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         clobberTop();
         return;
 
+    case PromiseResolve:
+    case PromiseReject:
+        clobberTop();
+        return;
+
     case LastNodeType:
         RELEASE_ASSERT_NOT_REACHED();
         return;

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -485,6 +485,8 @@ bool doesGC(Graph& graph, Node* node)
     case ResolvePromiseFirstResolving:
     case RejectPromiseFirstResolving:
     case FulfillPromiseFirstResolving:
+    case PromiseResolve:
+    case PromiseReject:
 #else // not ASSERT_ENABLED
     // See comment at the top for why the default for all nodes should be to
     // return true.

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3552,6 +3552,8 @@ private:
         case ResolvePromiseFirstResolving:
         case RejectPromiseFirstResolving:
         case FulfillPromiseFirstResolving:
+        case PromiseResolve:
+        case PromiseReject:
             break;
 #else // not ASSERT_ENABLED
         default:

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -975,6 +975,13 @@ public:
         return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::ObjectPrototypeChainIsSaneWatchpointSet);
     }
 
+    bool isWatchingPromiseSpeciesWatchpoint(Node* node)
+    {
+        JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
+        InlineWatchpointSet& set = globalObject->promiseSpeciesWatchpointSet();
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::PromiseSpeciesWatchpointSet);
+    }
+
     Profiler::Compilation* compilation() { return m_plan.compilation(); }
 
     DesiredIdentifiers& identifiers() { return m_plan.identifiers(); }

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -58,7 +58,8 @@ JITData::JITData(unsigned stubInfoSize, unsigned poolSize, const JITCode& jitCod
         case LinkerIR::Type::ArraySpeciesWatchpointSet:
         case LinkerIR::Type::ArrayPrototypeChainIsSaneWatchpointSet:
         case LinkerIR::Type::StringPrototypeChainIsSaneWatchpointSet:
-        case LinkerIR::Type::ObjectPrototypeChainIsSaneWatchpointSet: {
+        case LinkerIR::Type::ObjectPrototypeChainIsSaneWatchpointSet:
+        case LinkerIR::Type::PromiseSpeciesWatchpointSet: {
             ++numberOfWatchpoints;
             break;
         }
@@ -198,6 +199,11 @@ bool JITData::tryInitialize(VM& vm, CodeBlock* codeBlock, const JITCode& jitCode
         case LinkerIR::Type::ObjectPrototypeChainIsSaneWatchpointSet: {
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
             success &= attemptToWatch(codeBlock, m_globalObject->objectPrototypeChainIsSaneWatchpointSet(), watchpoint);
+            break;
+        }
+        case LinkerIR::Type::PromiseSpeciesWatchpointSet: {
+            auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
+            success &= attemptToWatch(codeBlock, m_globalObject->promiseSpeciesWatchpointSet(), watchpoint);
             break;
         }
         }

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -106,6 +106,7 @@ public:
         ArrayPrototypeChainIsSaneWatchpointSet,
         StringPrototypeChainIsSaneWatchpointSet,
         ObjectPrototypeChainIsSaneWatchpointSet,
+        PromiseSpeciesWatchpointSet,
     };
 
     using Value = JITConstant<Type>;

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -638,6 +638,8 @@ namespace JSC { namespace DFG {
     macro(ResolvePromiseFirstResolving, NodeMustGenerate) \
     macro(RejectPromiseFirstResolving, NodeMustGenerate) \
     macro(FulfillPromiseFirstResolving, NodeMustGenerate) \
+    macro(PromiseResolve, NodeMustGenerate | NodeResultJS) \
+    macro(PromiseReject, NodeMustGenerate | NodeResultJS) \
 
 
 // This enum generates a monotonically increasing id for all Node types,

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1661,6 +1661,26 @@ JSC_DEFINE_JIT_OPERATION(operationFulfillPromiseFirstResolving, void, (JSGlobalO
     OPERATION_RETURN(scope);
 }
 
+JSC_DEFINE_JIT_OPERATION(operationPromiseResolve, JSObject*, (JSGlobalObject* globalObject, JSObject* constructor, EncodedJSValue encodedArgument))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue argument = JSValue::decode(encodedArgument);
+    OPERATION_RETURN(scope, JSPromise::promiseResolve(globalObject, constructor, argument));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationPromiseReject, JSObject*, (JSGlobalObject* globalObject, JSObject* constructor, EncodedJSValue encodedArgument))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue argument = JSValue::decode(encodedArgument);
+    OPERATION_RETURN(scope, JSPromise::promiseReject(globalObject, constructor, argument));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationRegExpTestString, size_t, (JSGlobalObject* globalObject, RegExpObject* regExpObject, JSString* input))
 {
     SuperSamplerScope superSamplerScope(false);

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -356,6 +356,8 @@ JSC_DECLARE_JIT_OPERATION(operationParseIntGeneric, EncodedJSValue, (JSGlobalObj
 JSC_DECLARE_JIT_OPERATION(operationResolvePromiseFirstResolving, void, (JSGlobalObject*, JSPromise*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationRejectPromiseFirstResolving, void, (JSGlobalObject*, JSPromise*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationFulfillPromiseFirstResolving, void, (JSGlobalObject*, JSPromise*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationPromiseResolve, JSObject*, (JSGlobalObject*, JSObject*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationPromiseReject, JSObject*, (JSGlobalObject*, JSObject*, EncodedJSValue));
 
 JSC_DECLARE_JIT_OPERATION(operationNewSymbol, Symbol*, (VM*));
 JSC_DECLARE_JIT_OPERATION(operationNewSymbolWithStringDescription, Symbol*, (JSGlobalObject*, JSString*));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1738,6 +1738,8 @@ private:
         case ResolvePromiseFirstResolving:
         case RejectPromiseFirstResolving:
         case FulfillPromiseFirstResolving:
+        case PromiseResolve:
+        case PromiseReject:
             break;
             
         // This gets ignored because it only pretends to produce a value.

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -782,6 +782,8 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case ResolvePromiseFirstResolving:
     case RejectPromiseFirstResolving:
     case FulfillPromiseFirstResolving:
+    case PromiseResolve:
+    case PromiseReject:
     case SetAdd:
     case MapSet:
     case MapOrSetDelete:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -17501,6 +17501,40 @@ void SpeculativeJIT::compileFulfillPromiseFirstResolving(Node* node)
     noResult(node);
 }
 
+void SpeculativeJIT::compilePromiseResolve(Node* node)
+{
+    SpeculateCellOperand constructor(this, node->child1());
+    JSValueOperand argument(this, node->child2());
+
+    GPRReg constructorGPR = constructor.gpr();
+    JSValueRegs argumentRegs = argument.jsValueRegs();
+
+    speculateObject(node->child1(), constructorGPR);
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationPromiseResolve, resultGPR, LinkableConstant::globalObject(*this, node), constructorGPR, argumentRegs);
+    cellResult(resultGPR, node);
+}
+
+void SpeculativeJIT::compilePromiseReject(Node* node)
+{
+    SpeculateCellOperand constructor(this, node->child1());
+    JSValueOperand argument(this, node->child2());
+
+    GPRReg constructorGPR = constructor.gpr();
+    JSValueRegs argumentRegs = argument.jsValueRegs();
+
+    speculateObject(node->child1(), constructorGPR);
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationPromiseReject, resultGPR, LinkableConstant::globalObject(*this, node), constructorGPR, argumentRegs);
+    cellResult(resultGPR, node);
+}
+
 unsigned SpeculativeJIT::appendExceptionHandlingOSRExit(ExitKind kind, unsigned eventStreamIndex, CodeOrigin opCatchOrigin, HandlerInfo* exceptionHandler, CallSiteIndex callSite, MacroAssembler::JumpList jumpsToFail)
 {
     if (Options::validateDFGMayExit()) [[unlikely]] {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1803,6 +1803,8 @@ public:
     void compileResolvePromiseFirstResolving(Node*);
     void compileRejectPromiseFirstResolving(Node*);
     void compileFulfillPromiseFirstResolving(Node*);
+    void compilePromiseResolve(Node*);
+    void compilePromiseReject(Node*);
 
     template<typename JSClass, typename Operation>
     void compileCreateInternalFieldObject(Node*, Operation);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -4356,6 +4356,14 @@ void SpeculativeJIT::compile(Node* node)
         compileFulfillPromiseFirstResolving(node);
         break;
 
+    case PromiseResolve:
+        compilePromiseResolve(node);
+        break;
+
+    case PromiseReject:
+        compilePromiseReject(node);
+        break;
+
     case Unreachable:
         unreachable(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -6494,6 +6494,14 @@ void SpeculativeJIT::compile(Node* node)
         compileFulfillPromiseFirstResolving(node);
         break;
 
+    case PromiseResolve:
+        compilePromiseResolve(node);
+        break;
+
+    case PromiseReject:
+        compilePromiseReject(node);
+        break;
+
 #if ENABLE(FTL_JIT)        
     case CheckTierUpInLoop: {
         Jump callTierUp = branchAdd32(PositiveOrZero, TrustedImm32(Options::ftlTierUpCounterIncrementForLoop()), Address(GPRInfo::jitDataRegister, JITData::offsetOfTierUpCounter()));

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -497,6 +497,8 @@ inline CapabilityLevel canCompile(Node* node)
     case ResolvePromiseFirstResolving:
     case RejectPromiseFirstResolving:
     case FulfillPromiseFirstResolving:
+    case PromiseResolve:
+    case PromiseReject:
         // These are OK.
         break;
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1905,6 +1905,14 @@ private:
             compileFulfillPromiseFirstResolving();
             break;
 
+        case PromiseResolve:
+            compilePromiseResolve();
+            break;
+
+        case PromiseReject:
+            compilePromiseReject();
+            break;
+
         case LoopHint: {
             compileLoopHint();
             codeGenerationResult = CodeGenerationResult::NotGenerated;
@@ -20032,6 +20040,22 @@ IGNORE_CLANG_WARNINGS_END
         LValue promise = lowCell(m_node->child1());
         LValue argument = lowJSValue(m_node->child2());
         vmCall(Void, operationFulfillPromiseFirstResolving, weakPointer(globalObject), promise, argument);
+    }
+
+    void compilePromiseResolve()
+    {
+        auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        LValue constructor = lowObject(m_node->child1());
+        LValue argument = lowJSValue(m_node->child2());
+        setJSValue(vmCall(pointerType(), operationPromiseResolve, weakPointer(globalObject), constructor, argument));
+    }
+
+    void compilePromiseReject()
+    {
+        auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        LValue constructor = lowObject(m_node->child1());
+        LValue argument = lowJSValue(m_node->child2());
+        setJSValue(vmCall(pointerType(), operationPromiseReject, weakPointer(globalObject), constructor, argument));
     }
 
     void compileLoopHint()

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -204,6 +204,10 @@ namespace JSC {
     macro(ResolvePromiseWithFirstResolvingFunctionCallCheckIntrinsic) \
     macro(RejectPromiseWithFirstResolvingFunctionCallCheckIntrinsic) \
     macro(FulfillPromiseWithFirstResolvingFunctionCallCheckIntrinsic) \
+    macro(PromiseConstructorResolveIntrinsic) \
+    macro(PromiseResolveIntrinsic) \
+    macro(PromiseConstructorRejectIntrinsic) \
+    macro(PromiseRejectIntrinsic) \
     \
     /* Getter intrinsics. */ \
     macro(TypedArrayLengthIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -358,6 +358,8 @@ static JSC_DECLARE_HOST_FUNCTION(promiseOnRejectedWithContext);
 static JSC_DECLARE_HOST_FUNCTION(promiseAllOnFulfilled);
 static JSC_DECLARE_HOST_FUNCTION(promiseEmptyOnFulfilled);
 static JSC_DECLARE_HOST_FUNCTION(promiseEmptyOnRejected);
+static JSC_DECLARE_HOST_FUNCTION(promiseResolve);
+static JSC_DECLARE_HOST_FUNCTION(promiseReject);
 static JSC_DECLARE_HOST_FUNCTION(performPromiseThen);
 #if ASSERT_ENABLED
 static JSC_DECLARE_HOST_FUNCTION(assertCall);
@@ -873,6 +875,22 @@ JSC_DEFINE_HOST_FUNCTION(promiseEmptyOnRejected, (JSGlobalObject* globalObject, 
     JSValue argument = callFrame->argument(0);
     scope.throwException(globalObject, argument);
     return encodedJSUndefined();
+}
+
+JSC_DEFINE_HOST_FUNCTION(promiseResolve, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    ASSERT(callFrame->argumentCount() == 2);
+    JSObject* constructor = jsCast<JSObject*>(callFrame->uncheckedArgument(0));
+    JSValue argument = callFrame->uncheckedArgument(1);
+    return JSValue::encode(JSPromise::promiseResolve(globalObject, constructor, argument));
+}
+
+JSC_DEFINE_HOST_FUNCTION(promiseReject, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    ASSERT(callFrame->argumentCount() == 2);
+    JSObject* constructor = jsCast<JSObject*>(callFrame->uncheckedArgument(0));
+    JSValue argument = callFrame->uncheckedArgument(1);
+    return JSValue::encode(JSPromise::promiseReject(globalObject, constructor, argument));
 }
 
 JSC_DEFINE_HOST_FUNCTION(performPromiseThen, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -1916,6 +1934,12 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::promiseEmptyOnRejected)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "promiseEmptyOnRejected"_s, promiseEmptyOnRejected, ImplementationVisibility::Private));
+        });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::promiseResolve)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "promiseResolve"_s, promiseResolve, ImplementationVisibility::Private, PromiseResolveIntrinsic));
+        });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::promiseReject)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "promiseReject"_s, promiseReject, ImplementationVisibility::Private, PromiseRejectIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::performPromiseThen)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 5, "performPromiseThen"_s, performPromiseThen, ImplementationVisibility::Private));

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -146,7 +146,8 @@ public:
     static std::tuple<JSFunction*, JSFunction*> createResolvingFunctionsWithoutPromise(VM&, JSGlobalObject*, JSValue onFulfilled, JSValue onRejected, JSValue context);
     static std::tuple<JSObject*, JSObject*, JSObject*> newPromiseCapability(JSGlobalObject*, JSValue constructor);
     static JSValue createPromiseCapability(VM&, JSGlobalObject*, JSObject* promise, JSObject* resolve, JSObject* reject);
-    static JSValue promiseResolve(JSGlobalObject*, JSValue constructor, JSValue);
+    static JSObject* promiseResolve(JSGlobalObject*, JSObject* constructor, JSValue);
+    static JSObject* promiseReject(JSGlobalObject*, JSObject* constructor, JSValue);
 
     JSValue then(JSGlobalObject*, JSValue onFulfilled, JSValue onRejected);
 

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.h
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.h
@@ -46,9 +46,6 @@ public:
 protected:
     JSPromiseConstructor(VM&, FunctionExecutable*, JSGlobalObject*, Structure*);
     void finishCreation(VM&, JSPromisePrototype*);
-
-private:
-    void addOwnInternalSlots(VM&, JSGlobalObject*);
 };
 static_assert(sizeof(JSPromiseConstructor) == sizeof(JSFunction), "Allocate JSPromiseConstructor in JSFunction IsoSubspace");
 

--- a/Source/WebCore/Modules/compression/CompressionStream.js
+++ b/Source/WebCore/Modules/compression/CompressionStream.js
@@ -45,11 +45,11 @@ function initializeCompressionStream(format)
 
     // Setup Transform and Flush Algorithms
     const startAlgorithm = () => {
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
     const transformAlgorithm = (chunk) => {
         if (!@isObject(chunk) || (!(chunk instanceof @ArrayBuffer) && !(chunk.buffer instanceof @ArrayBuffer)))
-            return @Promise.@reject(@makeTypeError("Invalid type should be ArrayBuffer"));
+            return @promiseReject(@Promise, @makeTypeError("Invalid type should be ArrayBuffer"));
 
         try {
             const encoder = @getByIdDirectPrivate(this, "CompressionStreamEncoder");
@@ -61,10 +61,10 @@ function initializeCompressionStream(format)
                 @transformStreamDefaultControllerEnqueue(controller, buffer);
             }
         } catch (e) {
-            return @Promise.@reject(@makeTypeError(e.message));
+            return @promiseReject(@Promise, @makeTypeError(e.message));
         }
 
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
     const flushAlgorithm = () => {
         const encoder = @getByIdDirectPrivate(this, "CompressionStreamEncoder");
@@ -73,7 +73,7 @@ function initializeCompressionStream(format)
         try {
             buffer = encoder.@flush();
         } catch (e) {
-            return @Promise.@reject(@makeTypeError(e.message));
+            return @promiseReject(@Promise, @makeTypeError(e.message));
         }
         if (buffer) {
             const transformStream = @getByIdDirectPrivate(this, "CompressionStreamTransform");
@@ -81,7 +81,7 @@ function initializeCompressionStream(format)
             @transformStreamDefaultControllerEnqueue(controller, buffer);
         }
 
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
 
     const [transform, readable, writable] = @createTransformStream(startAlgorithm, transformAlgorithm, flushAlgorithm);

--- a/Source/WebCore/Modules/compression/DecompressionStream.js
+++ b/Source/WebCore/Modules/compression/DecompressionStream.js
@@ -45,11 +45,11 @@ function initializeDecompressionStream(format)
 
     // Setup Transform and Flush Algorithms
     const startAlgorithm = () => {
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
     const transformAlgorithm = (chunk) => {
         if (!@isObject(chunk) || (!(chunk instanceof @ArrayBuffer) && !(chunk.buffer instanceof @ArrayBuffer)))
-            return @Promise.@reject(@makeTypeError("Invalid type should be ArrayBuffer"));
+            return @promiseReject(@Promise, @makeTypeError("Invalid type should be ArrayBuffer"));
 
         try {
             const decoder = @getByIdDirectPrivate(this, "DecompressionStreamDecoder");
@@ -61,10 +61,10 @@ function initializeDecompressionStream(format)
                 @transformStreamDefaultControllerEnqueue(controller, buffer);
             }
         } catch (e) {
-            return @Promise.@reject(@makeTypeError(e.message));
+            return @promiseReject(@Promise, @makeTypeError(e.message));
         }
 
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
     const flushAlgorithm = () => {        
         try {
@@ -77,10 +77,10 @@ function initializeDecompressionStream(format)
                 @transformStreamDefaultControllerEnqueue(controller, buffer);
             }
         } catch (e) {
-            return @Promise.@reject(@makeTypeError(e.message));
+            return @promiseReject(@Promise, @makeTypeError(e.message));
         }
 
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
 
     const [transform, readable, writable] = @createTransformStream(startAlgorithm, transformAlgorithm, flushAlgorithm);

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.js
@@ -49,10 +49,10 @@ function cancel()
     "use strict";
 
     if (!@isReadableStreamDefaultReader(this))
-        return @Promise.@reject(@makeThisTypeError("ReadableStreamDefaultReader", "cancel"));
+        return @promiseReject(@Promise, @makeThisTypeError("ReadableStreamDefaultReader", "cancel"));
 
     if (!@getByIdDirectPrivate(this, "ownerReadableStream"))
-        return @Promise.@reject(@makeTypeError("cancel() called on a reader owned by no readable stream"));
+        return @promiseReject(@Promise, @makeTypeError("cancel() called on a reader owned by no readable stream"));
 
     const reason = arguments[0];
     return @readableStreamReaderGenericCancel(this, reason);
@@ -63,9 +63,9 @@ function read()
     "use strict";
 
     if (!@isReadableStreamDefaultReader(this))
-        return @Promise.@reject(@makeThisTypeError("ReadableStreamDefaultReader", "read"));
+        return @promiseReject(@Promise, @makeThisTypeError("ReadableStreamDefaultReader", "read"));
     if (!@getByIdDirectPrivate(this, "ownerReadableStream"))
-        return @Promise.@reject(@makeTypeError("read() called on a reader owned by no readable stream"));
+        return @promiseReject(@Promise, @makeTypeError("read() called on a reader owned by no readable stream"));
 
     return @readableStreamDefaultReaderRead(this);
 }
@@ -89,7 +89,7 @@ function closed()
     "use strict";
 
     if (!@isReadableStreamDefaultReader(this))
-        return @Promise.@reject(@makeGetterTypeError("ReadableStreamDefaultReader", "closed"));
+        return @promiseReject(@Promise, @makeGetterTypeError("ReadableStreamDefaultReader", "closed"));
 
     return @getByIdDirectPrivate(this, "closedPromiseCapability").promise;
 }

--- a/Source/WebCore/Modules/streams/StreamInternals.js
+++ b/Source/WebCore/Modules/streams/StreamInternals.js
@@ -38,7 +38,7 @@ function shieldingPromiseResolve(result)
 {
     "use strict";
 
-    const promise = @Promise.@resolve(result);
+    const promise = @promiseResolve(@Promise, result);
     if (promise.@then === @undefined)
         promise.@then = @Promise.prototype.@then;
     return promise;
@@ -49,7 +49,7 @@ function promiseInvokeOrNoopMethodNoCatch(object, method, args)
     "use strict";
 
     if (method === @undefined)
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     return @shieldingPromiseResolve(method.@apply(object, args));
 }
 
@@ -68,7 +68,7 @@ function promiseInvokeOrNoopMethod(object, method, args)
         return @promiseInvokeOrNoopMethodNoCatch(object, method, args);
     }
     catch(error) {
-        return @Promise.@reject(error);
+        return @promiseReject(@Promise, error);
     }
 }
 
@@ -80,7 +80,7 @@ function promiseInvokeOrNoop(object, key, args)
         return @promiseInvokeOrNoopNoCatch(object, key, args);
     }
     catch(error) {
-        return @Promise.@reject(error);
+        return @promiseReject(@Promise, error);
     }
 }
 
@@ -95,7 +95,7 @@ function promiseInvokeOrFallbackOrNoop(object, key1, args1, key2, args2)
         return @shieldingPromiseResolve(method.@apply(object, args1));
     }
     catch(error) {
-        return @Promise.@reject(error);
+        return @promiseReject(@Promise, error);
     }
 }
 
@@ -210,7 +210,7 @@ function extractHighWaterMarkFromQueuingStrategyInit(init)
 function createFulfilledPromise(value)
 {
     const promise = @newPromise();
-    @fulfillPromise(promise, value);
+    @fulfillPromiseWithFirstResolvingFunctionCallCheck(promise, value);
     return promise;
 }
 

--- a/Source/WebCore/Modules/streams/TransformStreamInternals.js
+++ b/Source/WebCore/Modules/streams/TransformStreamInternals.js
@@ -142,7 +142,7 @@ function initializeTransformStream(stream, startPromise, writableHighWaterMark, 
     const pullAlgorithm = () => { return @transformStreamDefaultSourcePullAlgorithm(stream); };
     const cancelAlgorithm = (reason) => {
         @transformStreamErrorWritableAndUnblockWrite(stream, reason);
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
     const underlyingSource = { };
     @putByIdDirectPrivate(underlyingSource, "start", startAlgorithm);
@@ -230,11 +230,11 @@ function setUpTransformStreamDefaultControllerFromTransformer(stream, transforme
         try {
             @transformStreamDefaultControllerEnqueue(controller, chunk);
         } catch (e) {
-            return @Promise.@reject(e);
+            return @promiseReject(@Promise, e);
         }
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
-    let flushAlgorithm = () => { return @Promise.@resolve(); };
+    let flushAlgorithm = () => { return @promiseResolve(@Promise, @undefined); };
 
     if ("transform" in transformerDict)
         transformAlgorithm = (chunk) => {
@@ -366,7 +366,7 @@ function transformStreamDefaultSinkAbortAlgorithm(stream, reason)
     "use strict";
 
     @transformStreamError(stream, reason);
-    return @Promise.@resolve();
+    return @promiseResolve(@Promise, @undefined);
 }
 
 function transformStreamDefaultSinkCloseAlgorithm(stream)

--- a/Source/WebCore/Modules/streams/WritableStreamDefaultWriter.js
+++ b/Source/WebCore/Modules/streams/WritableStreamDefaultWriter.js
@@ -46,7 +46,7 @@ function closed()
     "use strict";
 
     if (!@isWritableStreamDefaultWriter(this))
-        return @Promise.@reject(@makeGetterTypeError("WritableStreamDefaultWriter", "closed"));
+        return @promiseReject(@Promise, @makeGetterTypeError("WritableStreamDefaultWriter", "closed"));
 
     return @getByIdDirectPrivate(this, "closedPromise").promise;
 }
@@ -71,7 +71,7 @@ function ready()
     "use strict";
 
     if (!@isWritableStreamDefaultWriter(this))
-        return @Promise.@reject(@makeThisTypeError("WritableStreamDefaultWriter", "ready"));
+        return @promiseReject(@Promise, @makeThisTypeError("WritableStreamDefaultWriter", "ready"));
 
     return @getByIdDirectPrivate(this, "readyPromise").promise;
 }
@@ -81,10 +81,10 @@ function abort()
     "use strict";
 
     if (!@isWritableStreamDefaultWriter(this))
-        return @Promise.@reject(@makeThisTypeError("WritableStreamDefaultWriter", "abort"));
+        return @promiseReject(@Promise, @makeThisTypeError("WritableStreamDefaultWriter", "abort"));
 
     if (@getByIdDirectPrivate(this, "stream") === @undefined)
-        return @Promise.@reject(@makeTypeError("WritableStreamDefaultWriter has no stream"));
+        return @promiseReject(@Promise, @makeTypeError("WritableStreamDefaultWriter has no stream"));
 
     const reason = arguments[0];
     return @writableStreamDefaultWriterAbort(this, reason);
@@ -95,14 +95,14 @@ function close()
     "use strict";
 
     if (!@isWritableStreamDefaultWriter(this))
-        return @Promise.@reject(@makeThisTypeError("WritableStreamDefaultWriter", "close"));
+        return @promiseReject(@Promise, @makeThisTypeError("WritableStreamDefaultWriter", "close"));
 
     const stream = @getByIdDirectPrivate(this, "stream");
     if (stream === @undefined)
-        return @Promise.@reject(@makeTypeError("WritableStreamDefaultWriter has no stream"));
+        return @promiseReject(@Promise, @makeTypeError("WritableStreamDefaultWriter has no stream"));
 
     if (@writableStreamCloseQueuedOrInFlight(stream))
-        return @Promise.@reject(@makeTypeError("WritableStreamDefaultWriter is being closed"));
+        return @promiseReject(@Promise, @makeTypeError("WritableStreamDefaultWriter is being closed"));
     
     return @writableStreamDefaultWriterClose(this);
 }
@@ -127,10 +127,10 @@ function write()
     "use strict";
 
     if (!@isWritableStreamDefaultWriter(this))
-        return @Promise.@reject(@makeThisTypeError("WritableStreamDefaultWriter", "write"));
+        return @promiseReject(@Promise, @makeThisTypeError("WritableStreamDefaultWriter", "write"));
 
     if (@getByIdDirectPrivate(this, "stream") === @undefined)
-        return @Promise.@reject(@makeTypeError("WritableStreamDefaultWriter has no stream"));
+        return @promiseReject(@Promise, @makeTypeError("WritableStreamDefaultWriter has no stream"));
 
     const chunk = arguments[0];
     return @writableStreamDefaultWriterWrite(this, chunk);

--- a/Source/WebCore/Modules/streams/WritableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/WritableStreamInternals.js
@@ -126,10 +126,10 @@ function initializeWritableStreamSlots(stream, underlyingSink)
 function writableStreamCloseForBindings(stream)
 {
     if (@isWritableStreamLocked(stream))
-        return @Promise.@reject(@makeTypeError("WritableStream.close method can only be used on non locked WritableStream"));
+        return @promiseReject(@Promise, @makeTypeError("WritableStream.close method can only be used on non locked WritableStream"));
 
     if (@writableStreamCloseQueuedOrInFlight(stream))
-        return @Promise.@reject(@makeTypeError("WritableStream.close method can only be used on a being close WritableStream"));
+        return @promiseReject(@Promise, @makeTypeError("WritableStream.close method can only be used on a being close WritableStream"));
 
     return @writableStreamClose(stream);
 }
@@ -137,7 +137,7 @@ function writableStreamCloseForBindings(stream)
 function writableStreamAbortForBindings(stream, reason)
 {
     if (@isWritableStreamLocked(stream))
-        return @Promise.@reject(@makeTypeError("WritableStream.abort method can only be used on non locked WritableStream"));
+        return @promiseReject(@Promise, @makeTypeError("WritableStream.abort method can only be used on non locked WritableStream"));
 
     return @writableStreamAbort(stream, reason);
 }
@@ -184,14 +184,14 @@ function writableStreamAbort(stream, reason)
 {
     let state = @getByIdDirectPrivate(stream, "state");
     if (state === "closed" || state === "errored")
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
 
     const controller = @getByIdDirectPrivate(stream, "controller");
     @signalAbort(@getByIdDirectPrivate(controller, "signal"), reason);
 
     state = @getByIdDirectPrivate(stream, "state");
     if (state === "closed" || state === "errored")
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
 
     const pendingAbortRequest = @getByIdDirectPrivate(stream, "pendingAbortRequest");
     if (pendingAbortRequest !== @undefined)
@@ -236,7 +236,7 @@ function writableStreamClose(stream)
 {
     const state = @getByIdDirectPrivate(stream, "state");
     if (state === "closed" || state === "errored")
-        return @Promise.@reject(@makeTypeError("Cannot close a writable stream that is closed or errored"));
+        return @promiseReject(@Promise, @makeTypeError("Cannot close a writable stream that is closed or errored"));
 
     @assert(state === "writable" || state === "erroring");
     @assert(!@writableStreamCloseQueuedOrInFlight(stream));
@@ -494,10 +494,10 @@ function writableStreamDefaultWriterCloseWithErrorPropagation(writer)
     const state = @getByIdDirectPrivate(stream, "state");
 
     if (@writableStreamCloseQueuedOrInFlight(stream) || state === "closed")
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
 
     if (state === "errored")
-        return @Promise.@reject(@getByIdDirectPrivate(stream, "storedError"));
+        return @promiseReject(@Promise, @getByIdDirectPrivate(stream, "storedError"));
 
     @assert(state === "writable" || state === "erroring");
     return @writableStreamDefaultWriterClose(writer);
@@ -574,20 +574,20 @@ function writableStreamDefaultWriterWrite(writer, chunk)
     const chunkSize = @writableStreamDefaultControllerGetChunkSize(controller, chunk);
 
     if (stream !== @getByIdDirectPrivate(writer, "stream"))
-        return @Promise.@reject(@makeTypeError("writer is not stream's writer"));
+        return @promiseReject(@Promise, @makeTypeError("writer is not stream's writer"));
 
     const state = @getByIdDirectPrivate(stream, "state");
     if (state === "errored")
-        return @Promise.@reject(@getByIdDirectPrivate(stream, "storedError"));
+        return @promiseReject(@Promise, @getByIdDirectPrivate(stream, "storedError"));
 
     if (@writableStreamCloseQueuedOrInFlight(stream) || state === "closed")
-        return @Promise.@reject(@makeTypeError("stream is closing or closed"));
+        return @promiseReject(@Promise, @makeTypeError("stream is closing or closed"));
 
     if (@writableStreamCloseQueuedOrInFlight(stream) || state === "closed")
-        return @Promise.@reject(@makeTypeError("stream is closing or closed"));
+        return @promiseReject(@Promise, @makeTypeError("stream is closing or closed"));
 
     if (state === "erroring")
-        return @Promise.@reject(@getByIdDirectPrivate(stream, "storedError"));
+        return @promiseReject(@Promise, @getByIdDirectPrivate(stream, "storedError"));
 
     @assert(state === "writable");
 
@@ -617,7 +617,7 @@ function setUpWritableStreamDefaultController(stream, controller, startAlgorithm
     const backpressure = @writableStreamDefaultControllerGetBackpressure(controller);
     @writableStreamUpdateBackpressure(stream, backpressure);
 
-    @Promise.@resolve(startAlgorithm.@call()).@then(() => {
+    @promiseResolve(@Promise, startAlgorithm()).@then(() => {
         const state = @getByIdDirectPrivate(stream, "state");
         @assert(state === "writable" || state === "erroring");
         @putByIdDirectPrivate(controller, "started", true);
@@ -635,9 +635,9 @@ function setUpWritableStreamDefaultControllerFromUnderlyingSink(stream, underlyi
     const controller = new @WritableStreamDefaultController(@isWritableStream);
 
     let startAlgorithm = () => { };
-    let writeAlgorithm = () => { return @Promise.@resolve(); };
-    let closeAlgorithm = () => { return @Promise.@resolve(); };
-    let abortAlgorithm = () => { return @Promise.@resolve(); };
+    let writeAlgorithm = () => { return @promiseResolve(@Promise, @undefined); };
+    let closeAlgorithm = () => { return @promiseResolve(@Promise, @undefined); };
+    let abortAlgorithm = () => { return @promiseResolve(@Promise, @undefined); };
 
     if ("start" in underlyingSinkDict) {
         const startMethod = underlyingSinkDict["start"];

--- a/Source/WebCore/bindings/js/JSDOMPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMPromise.h
@@ -53,7 +53,7 @@ public:
     enum class Status { Pending, Fulfilled, Rejected };
     Status status() const;
 
-    static IsCallbackRegistered whenPromiseIsSettled(JSDOMGlobalObject*, JSC::JSObject* promise, Function<void()>&&);
+    static IsCallbackRegistered whenPromiseIsSettled(JSDOMGlobalObject*, JSC::JSPromise*, Function<void()>&&);
 
 private:
     DOMPromise(JSDOMGlobalObject& globalObject, JSC::JSPromise& promise)

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -240,24 +240,12 @@ void rejectPromiseWithExceptionIfAny(JSC::JSGlobalObject& lexicalGlobalObject, J
 JSC::EncodedJSValue createRejectedPromiseWithTypeError(JSC::JSGlobalObject& lexicalGlobalObject, const String& errorMessage, RejectedPromiseWithTypeErrorCause cause)
 {
     auto& globalObject = lexicalGlobalObject;
-    auto& vm = lexicalGlobalObject.vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto promiseConstructor = globalObject.promiseConstructor();
-    auto rejectFunction = promiseConstructor->get(&lexicalGlobalObject, vm.propertyNames->builtinNames().rejectPrivateName());
-    RETURN_IF_EXCEPTION(scope, { });
     auto* rejectionValue = static_cast<ErrorInstance*>(createTypeError(&lexicalGlobalObject, errorMessage));
     if (cause == RejectedPromiseWithTypeErrorCause::NativeGetter)
         rejectionValue->setNativeGetterTypeError();
 
-    auto callData = JSC::getCallData(rejectFunction);
-    ASSERT(callData.type != CallData::Type::None);
-
-    MarkedArgumentBuffer arguments;
-    arguments.append(rejectionValue);
-    ASSERT(!arguments.hasOverflowed());
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(call(&lexicalGlobalObject, rejectFunction, callData, promiseConstructor, arguments)));
+    return JSValue::encode(JSPromise::rejectedPromise(&globalObject, rejectionValue));
 }
 
 static inline JSC::JSValue parseAsJSON(JSC::JSGlobalObject* lexicalGlobalObject, const String& data)

--- a/Source/WebCore/dom/TextDecoderStream.js
+++ b/Source/WebCore/dom/TextDecoderStream.js
@@ -31,7 +31,7 @@ function initializeTextDecoderStream()
     const options = arguments.length >= 2 ? arguments[1] : { };
 
     const startAlgorithm = () => {
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
     const transformAlgorithm = (chunk) => {
         const decoder = @getByIdDirectPrivate(this, "textDecoderStreamDecoder");
@@ -39,14 +39,14 @@ function initializeTextDecoderStream()
         try {
             buffer = decoder.@decode(chunk);
         } catch (e) {
-            return @Promise.@reject(e);
+            return @promiseReject(@Promise, e);
         }
         if (buffer) {
             const transformStream = @getByIdDirectPrivate(this, "textDecoderStreamTransform");
             const controller = @getByIdDirectPrivate(transformStream, "controller");
             @transformStreamDefaultControllerEnqueue(controller, buffer);
         }
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
     const flushAlgorithm = () => {
         const decoder = @getByIdDirectPrivate(this, "textDecoderStreamDecoder");
@@ -54,14 +54,14 @@ function initializeTextDecoderStream()
         try {
             buffer = decoder.@flush();
         } catch (e) {
-            return @Promise.@reject(e);
+            return @promiseReject(@Promise, e);
         }
         if (buffer) {
             const transformStream = @getByIdDirectPrivate(this, "textDecoderStreamTransform");
             const controller = @getByIdDirectPrivate(transformStream, "controller");
             @transformStreamDefaultControllerEnqueue(controller, buffer);
         }
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
 
     const [transform, readable, writable] = @createTransformStream(startAlgorithm, transformAlgorithm, flushAlgorithm);

--- a/Source/WebCore/dom/TextEncoderStream.js
+++ b/Source/WebCore/dom/TextEncoderStream.js
@@ -28,7 +28,7 @@ function initializeTextEncoderStream()
     "use strict";
 
     const startAlgorithm = () => {
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
     const transformAlgorithm = (chunk) => {
         const encoder = @getByIdDirectPrivate(this, "textEncoderStreamEncoder");
@@ -36,14 +36,14 @@ function initializeTextEncoderStream()
         try {
             buffer = encoder.@encode(chunk);
         } catch (e) {
-            return @Promise.@reject(e);
+            return @promiseReject(@Promise, e);
         }
         if (buffer) {
             const transformStream = @getByIdDirectPrivate(this, "textEncoderStreamTransform");
             const controller = @getByIdDirectPrivate(transformStream, "controller");
             @transformStreamDefaultControllerEnqueue(controller, buffer);
         }
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
     const flushAlgorithm = () => {
         const encoder = @getByIdDirectPrivate(this, "textEncoderStreamEncoder");
@@ -53,7 +53,7 @@ function initializeTextEncoderStream()
             const controller = @getByIdDirectPrivate(transformStream, "controller");
             @transformStreamDefaultControllerEnqueue(controller, buffer);
         }
-        return @Promise.@resolve();
+        return @promiseResolve(@Promise, @undefined);
     };
 
     const [transform, readable, writable] = @createTransformStream(startAlgorithm, transformAlgorithm, flushAlgorithm);


### PR DESCRIPTION
#### a0faddd38a6d4f20735b1404c116e79eee972275
<pre>
[JSC] Move Promise.resolve and Promise.reject to C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=300603">https://bugs.webkit.org/show_bug.cgi?id=300603</a>
<a href="https://rdar.apple.com/162500561">rdar://162500561</a>

Reviewed by Yijia Huang.

This patch moves Promise.resolve / Promise.reject implementations from
JS to C++ to improve stability and performance. Doing so will further
allow us to move more things (e.g. Promise.all) to C++ to gain
significant performance improvement.

The most difficult part of this is Promise.resolve and its optimization.
Since we were using inlined Promise.resolve and avoiding various costly
operations when we detect some input values in DFG / FTL, we cannot just
move them to C++. In this patch, we implement intrinsic for them and add
DFG nodes handling these optimizations.

1. We check Promise input and if it is fine &amp; watchpoint is fine, then
   we will just convert Promise.resolve(promise) to identity.
2. We check non object input and convert it to fulfilled promise
   allocation.
3. We check an object input without having &quot;then&quot; property and convert
   it to (2) as well with watchpoints.

Also, we expose @promiseResolve / @promiseReject abstract operations
and use tme instead of Promise.@resolve / Promise.@reject.

* JSTests/stress/dfg-promise-resolve-fulfilled-identity.js: Added.
(shouldBe):
(test):
(async testMain):
* JSTests/stress/dfg-promise-resolve-fulfilled-then.js: Added.
(shouldBe):
(test):
(DerivedPromise.prototype.then):
(DerivedPromise):
(async testMain):
* JSTests/stress/dfg-promise-resolve-fulfilled.js: Added.
(shouldBe):
(test):
(async testMain):
* Source/JavaScriptCore/builtins/AsyncDisposableStackPrototype.js:
(disposeAsync):
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/DisposableStackPrototype.js:
(linkTimeConstant.getAsyncDisposableMethod):
* Source/JavaScriptCore/builtins/PromiseConstructor.js:
(linkTimeConstant.promiseNewOnRejected):
(linkTimeConstant.promiseNewOnRejected.return.reject): Deleted.
(reject): Deleted.
(resolve): Deleted.
* Source/JavaScriptCore/builtins/PromiseOperations.js:
(linkTimeConstant.newPromiseCapability):
(linkTimeConstant.newPromiseCapability.resolve): Deleted.
(linkTimeConstant.newPromiseCapability.reject): Deleted.
(linkTimeConstant.promiseResolve): Deleted.
(linkTimeConstant.promiseResolveSlow): Deleted.
(linkTimeConstant.promiseRejectSlow): Deleted.
* Source/JavaScriptCore/builtins/WebAssembly.js:
(compileStreaming):
(instantiateStreaming):
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITData::JITData):
(JSC::DFG::JITData::tryInitialize):
* Source/JavaScriptCore/dfg/DFGJITCode.h:
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::promiseResolve):
(JSC::JSPromise::promiseReject):
* Source/JavaScriptCore/runtime/JSPromise.h:
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::JSPromiseConstructor::create):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSPromiseConstructor::addOwnInternalSlots): Deleted.
* Source/JavaScriptCore/runtime/JSPromiseConstructor.h:
* Source/WebCore/Modules/compression/CompressionStream.js:
(initializeCompressionStream):
* Source/WebCore/Modules/compression/DecompressionStream.js:
(initializeDecompressionStream):
* Source/WebCore/Modules/streams/ReadableStreamDefaultReader.js:
(cancel):
(read):
(getter.closed):
* Source/WebCore/Modules/streams/ReadableStreamInternals.js:
(readableStreamPipeToForBindings):
(readableStreamDefaultReaderClosedForBindings):
(readableStreamDefaultReaderReadForBindings):
(readableStreamDefaultReaderCancelForBindings):
(readableStreamReaderGenericInitialize):
(readableStreamPipeToWritableStream):
(const.pullAlgorithm):
(readableStreamTeePullFunction):
(readableStreamCancel):
(readableStreamClose):
(readableStreamFulfillReadRequest):
(readableStreamDefaultReaderRead):
(readableStreamDefaultReaderErrorReadRequests):
* Source/WebCore/Modules/streams/StreamInternals.js:
(shieldingPromiseResolve):
(promiseInvokeOrNoopMethodNoCatch):
(promiseInvokeOrNoopMethod):
(promiseInvokeOrNoop):
(promiseInvokeOrFallbackOrNoop):
(createFulfilledPromise):
* Source/WebCore/Modules/streams/TransformStreamInternals.js:
(initializeTransformStream):
(setUpTransformStreamDefaultControllerFromTransformer):
(transformStreamDefaultSinkAbortAlgorithm):
* Source/WebCore/Modules/streams/WritableStreamDefaultWriter.js:
(getter.closed):
(getter.ready):
(abort):
(close):
(write):
* Source/WebCore/Modules/streams/WritableStreamInternals.js:
(writableStreamCloseForBindings):
(writableStreamAbortForBindings):
(writableStreamAbort):
(writableStreamClose):
(writableStreamDefaultWriterCloseWithErrorPropagation):
(writableStreamDefaultWriterWrite):
(setUpWritableStreamDefaultController):
* Source/WebCore/bindings/js/JSDOMPromise.cpp:
(WebCore::DOMPromise::whenPromiseIsSettled):
* Source/WebCore/bindings/js/JSDOMPromise.h:
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
(WebCore::createRejectedPromiseWithTypeError):
* Source/WebCore/dom/TextDecoderStream.js:
(initializeTextDecoderStream):
* Source/WebCore/dom/TextEncoderStream.js:
(initializeTextEncoderStream):

Canonical link: <a href="https://commits.webkit.org/301423@main">https://commits.webkit.org/301423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70f215f89230ce2a208069fd3b94ab312066267b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125898 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77762 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/506c1007-d3e9-4ead-b9ca-6fd3b516351f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54118 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95920 "") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64017 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/60758679-a83b-41e4-bf93-44dcdc2a8d1c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76411 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30766 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76240 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117978 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106764 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135451 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124405 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104385 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104112 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49484 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27800 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50054 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19708 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52577 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58389 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157418 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51920 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39417 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53619 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->