### PR TITLE
Provide support for WTF::String in WebExtension JavaScript APIs

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "WebExtensionUtilities.h"
+#include "JSWebExtensionWrapper.h"
 #include <wtf/text/MakeString.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS)
@@ -204,6 +205,11 @@ ALLOW_NONLITERAL_FORMAT_END
         return formatString("Invalid call to %s. %s.", callingAPIName.utf8().data(), uppercaseFirst(formattedUnderlyingErrorString).utf8().data());
 
     return formattedUnderlyingErrorString;
+}
+
+JSObjectRef toJSError(JSContextRef context, const String& callingAPIName, const String& sourceKey, const String& underlyingErrorString)
+{
+    return toJSError(context, toErrorString(callingAPIName, sourceKey, underlyingErrorString));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
@@ -64,6 +64,9 @@ Unexpected<WebExtensionError> toWebExtensionError(const String& callingAPIName, 
     return makeUnexpected(toErrorString(callingAPIName, sourceKey, underlyingErrorString, std::forward<Args>(args)...));
 }
 
+/// Returns an error object that combines the provided information into a single, descriptive message.
+JSObjectRef toJSError(JSContextRef, const String& callingAPIName, const String& sourceKey, const String& underlyingErrorString);
+
 #ifdef __OBJC__
 
 /// Verifies that a dictionary:
@@ -85,9 +88,6 @@ bool validateDictionary(NSDictionary<NSString *, id> *, NSString *sourceKey, NSA
 ///  - The `callingAPIName` and `sourceKey` parameters are used to reference the object within a larger context. When an error occurs, this key helps identify the source of the problem in the `outExceptionString`.
 /// If the object is valid, returns `YES`. Otherwise returns `NO` and sets `outExceptionString` to a message describing what validation failed.
 bool validateObject(NSObject *, NSString *sourceKey, id valueTypes, NSString **outExceptionString);
-
-/// Returns an error object that combines the provided information into a single, descriptive message.
-JSObjectRef toJSError(JSContextRef, NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString);
 
 /// Returns a rejected Promise object that combines the provided information into a single, descriptive error message.
 JSObjectRef toJSRejectedPromise(JSContextRef, NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString);

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -316,11 +316,6 @@ bool validateObject(NSObject *object, NSString *sourceKey, id expectedValueType,
     return !errorString;
 }
 
-JSObjectRef toJSError(JSContextRef context, NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString)
-{
-    return toJSError(context, toErrorString(callingAPIName, sourceKey, underlyingErrorString).createNSString().get());
-}
-
 JSObjectRef toJSRejectedPromise(JSContextRef context, NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString)
 {
     auto *error = toJSValue(context, toJSError(context, callingAPIName, sourceKey, underlyingErrorString));

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -121,7 +121,7 @@ void WebExtensionAPIPort::setError(JSValue *error)
     m_error = error;
 }
 
-void WebExtensionAPIPort::postMessage(WebFrame& frame, NSString *message, NSString **outExceptionString)
+void WebExtensionAPIPort::postMessage(WebFrame& frame, const String& message, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port#postmessage
 
@@ -130,7 +130,7 @@ void WebExtensionAPIPort::postMessage(WebFrame& frame, NSString *message, NSStri
         return;
     }
 
-    if (message.length > webExtensionMaxMessageLength) {
+    if (message.length() > webExtensionMaxMessageLength) {
         *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length").createNSString().autorelease();
         return;
     }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -973,7 +973,7 @@ void WebExtensionAPITabs::captureVisibleTab(WebPageProxyIdentifier webPageProxyI
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::sendMessage(WebFrame& frame, double tabID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::sendMessage(WebFrame& frame, double tabID, const String& messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/sendMessage
 
@@ -981,7 +981,7 @@ void WebExtensionAPITabs::sendMessage(WebFrame& frame, double tabID, NSString *m
     if (!isValid(tabIdentifer, outExceptionString))
         return;
 
-    if (messageJSON.length > webExtensionMaxMessageLength) {
+    if (messageJSON.length() > webExtensionMaxMessageLength) {
         *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length").createNSString().autorelease();
         return;
     }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
@@ -42,8 +42,8 @@ class WebExtensionAPIAction : public WebExtensionAPIObject, public JSWebExtensio
 
 public:
 #if PLATFORM(COCOA)
-    void getTitle(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void setTitle(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getTitle(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, String& outExceptionString);
+    void setTitle(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, String& outExceptionString);
 
     void getBadgeText(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void setBadgeText(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
@@ -75,7 +75,7 @@ private:
     static NSArray *parseIconVariants(NSArray *, const URL& baseURL, NSString *inputKey, NSString **outExceptionString);
 #endif
 
-    static bool parseActionDetails(NSDictionary *, std::optional<WebExtensionWindowIdentifier>&, std::optional<WebExtensionTabIdentifier>&, NSString **outExceptionString);
+    static Expected<void, String> parseActionDetails(NSDictionary *, std::optional<WebExtensionWindowIdentifier>&, std::optional<WebExtensionTabIdentifier>&);
 
     RefPtr<WebExtensionAPIEvent> m_onClicked;
 #endif

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -55,7 +55,7 @@ public:
     std::optional<WebPageProxyIdentifier> owningPageProxyIdentifier() const { return m_owningPageProxyIdentifier; }
     const std::optional<WebExtensionMessageSenderParameters>& senderParameters() const { return m_senderParameters; }
 
-    void postMessage(WebFrame&, NSString *, NSString **outExceptionString);
+    void postMessage(WebFrame&, const String&, NSString **outExceptionString);
     void disconnect();
 
     bool isDisconnected() const { return m_disconnected; }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -44,8 +44,8 @@ class WebExtensionAPIRuntime;
 
 class WebExtensionAPIRuntimeBase : public JSWebExtensionWrappable {
 public:
-    JSValue *reportError(NSString *errorMessage, JSGlobalContextRef, NOESCAPE const Function<void()>& = nullptr);
-    JSValue *reportError(NSString *errorMessage, WebExtensionCallbackHandler&);
+    JSValue *reportError(String errorMessage, JSGlobalContextRef, NOESCAPE const Function<void()>& = nullptr);
+    JSValue *reportError(const String& errorMessage, WebExtensionCallbackHandler&);
 
 private:
     friend class WebExtensionAPIRuntime;
@@ -66,9 +66,9 @@ public:
 #if PLATFORM(COCOA)
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
 
-    NSURL *getURL(NSString *resourcePath, NSString **outExceptionString);
+    NSURL *getURL(const String& resourcePath, NSString **outExceptionString);
     NSDictionary *getManifest();
-    NSString *getVersion();
+    String getVersion();
     void getPlatformInfo(Ref<WebExtensionCallbackHandler>&&);
     void getBackgroundPage(Ref<WebExtensionCallbackHandler>&&);
     double getFrameId(JSValue *);
@@ -78,15 +78,15 @@ public:
     void openOptionsPage(Ref<WebExtensionCallbackHandler>&&);
     void reload();
 
-    NSString *runtimeIdentifier();
+    String runtimeIdentifier();
 
     JSValue *lastError();
 
-    void sendMessage(WebPageProxyIdentifier, WebFrame&, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    RefPtr<WebExtensionAPIPort> connect(WebPageProxyIdentifier, WebFrame&, JSContextRef, NSString *extensionID, NSDictionary *options, NSString **outExceptionString);
+    void sendMessage(WebPageProxyIdentifier, WebFrame&, const String& extensionID, const String& messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    RefPtr<WebExtensionAPIPort> connect(WebPageProxyIdentifier, WebFrame&, JSContextRef, const String& extensionID, NSDictionary *options, NSString **outExceptionString);
 
-    void sendNativeMessage(WebFrame&, NSString *applicationID, NSString *messageJSON, Ref<WebExtensionCallbackHandler>&&);
-    RefPtr<WebExtensionAPIPort> connectNative(WebPageProxyIdentifier, JSContextRef, NSString *applicationID);
+    void sendNativeMessage(WebFrame&, const String& applicationID, const String& messageJSON, Ref<WebExtensionCallbackHandler>&&);
+    RefPtr<WebExtensionAPIPort> connectNative(WebPageProxyIdentifier, JSContextRef, const String& applicationID);
 
     WebExtensionAPIEvent& onConnect();
     WebExtensionAPIEvent& onInstalled();
@@ -98,7 +98,7 @@ public:
 private:
     friend class WebExtensionAPIWebPageRuntime;
 
-    static bool parseConnectOptions(NSDictionary *, std::optional<String>& name, NSString *sourceKey, NSString **outExceptionString);
+    static bool parseConnectOptions(NSDictionary *, std::optional<String>& name, const String& sourceKey, NSString **outExceptionString);
 
     RefPtr<WebExtensionAPIEvent> m_onConnect;
     RefPtr<WebExtensionAPIEvent> m_onInstalled;
@@ -116,8 +116,8 @@ public:
     WebExtensionAPIWebPageRuntime& runtime() const final { return const_cast<WebExtensionAPIWebPageRuntime&>(*this); }
 
 #if PLATFORM(COCOA)
-    void sendMessage(WebPage&, WebFrame&, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    RefPtr<WebExtensionAPIPort> connect(WebPage&, WebFrame&, JSContextRef, NSString *extensionID, NSDictionary *options, NSString **outExceptionString);
+    void sendMessage(WebPage&, WebFrame&, const String& extensionID, const String& messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    RefPtr<WebExtensionAPIPort> connect(WebPage&, WebFrame&, JSContextRef, const String& extensionID, NSDictionary *options, NSString **outExceptionString);
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -75,7 +75,7 @@ public:
     void toggleReaderMode(WebPageProxyIdentifier, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void captureVisibleTab(WebPageProxyIdentifier, double windowID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void sendMessage(WebFrame&, double tabID, NSString *message, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void sendMessage(WebFrame&, double tabID, const String& message, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     RefPtr<WebExtensionAPIPort> connect(WebFrame&, JSContextRef, double tabID, NSDictionary *options, NSString **outExceptionString);
 
     void executeScript(WebPageProxyIdentifier, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -35,8 +35,6 @@
 #endif
 #include <wtf/WeakPtr.h>
 
-OBJC_CLASS NSString;
-
 #if JSC_OBJC_API_ENABLED && defined(__OBJC__)
 
 @interface JSValue (WebKitExtras)
@@ -81,11 +79,11 @@ public:
 
     ~WebExtensionCallbackHandler();
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) && defined(__OBJC__)
     JSGlobalContextRef globalContext() const { return m_globalContext.get(); }
     JSValue *callbackFunction() const;
 
-    void reportError(NSString *);
+    void reportError(const String&);
 
     id call();
     id call(id argument);
@@ -94,7 +92,9 @@ public:
 #endif
 
 private:
+#ifdef __OBJC__
     WebExtensionCallbackHandler(JSValue *callbackFunction);
+#endif
     WebExtensionCallbackHandler(JSContextRef, JSObjectRef resolveFunction, JSObjectRef rejectFunction);
     WebExtensionCallbackHandler(JSContextRef, JSObjectRef callbackFunction, WebExtensionAPIRuntimeBase&);
     WebExtensionCallbackHandler(JSContextRef, WebExtensionAPIRuntimeBase&);
@@ -160,10 +160,20 @@ inline Ref<WebExtensionCallbackHandler> toJSErrorCallbackHandler(JSContextRef co
 
 RefPtr<WebExtensionCallbackHandler> toJSCallbackHandler(JSContextRef, JSValueRef callback, WebExtensionAPIRuntimeBase&);
 
+String toString(JSContextRef, JSValueRef, NullStringPolicy = NullStringPolicy::NullAndUndefinedAsNullString);
+
+String toString(JSStringRef);
+
+JSObjectRef toJSError(JSContextRef, const String&);
+
+JSRetainPtr<JSStringRef> toJSString(const String&);
+
+JSValueRef deserializeJSONString(JSContextRef, const String& jsonString);
+String serializeJSObject(JSContextRef, JSValueRef, JSValueRef* exception);
+
 #ifdef __OBJC__
 
 id toNSObject(JSContextRef, JSValueRef, Class containingObjectsOfClass = Nil, NullValuePolicy = NullValuePolicy::NotAllowed, ValuePolicy = ValuePolicy::Recursive);
-NSString *toNSString(JSContextRef, JSValueRef, NullStringPolicy = NullStringPolicy::NullAndUndefinedAsNullString);
 NSDictionary *toNSDictionary(JSContextRef, JSValueRef, NullValuePolicy = NullValuePolicy::NotAllowed, ValuePolicy = ValuePolicy::Recursive);
 
 JSContext *toJSContext(JSContextRef);
@@ -176,19 +186,10 @@ JSValue *toWindowObject(JSContextRef, WebPage&);
 
 JSValueRef toJSValueRef(JSContextRef, id);
 
-JSValueRef toJSValueRef(JSContextRef, NSString *, NullOrEmptyString = NullOrEmptyString::NullStringAsEmptyString);
+JSValueRef toJSValueRef(JSContextRef, const String&, NullOrEmptyString = NullOrEmptyString::NullStringAsEmptyString);
 JSValueRef toJSValueRef(JSContextRef, NSURL *, NullOrEmptyString = NullOrEmptyString::NullStringAsEmptyString);
 
 JSValueRef toJSValueRefOrJSNull(JSContextRef, id);
-
-NSString *toNSString(JSStringRef);
-
-JSObjectRef toJSError(JSContextRef, NSString *);
-
-JSRetainPtr<JSStringRef> toJSString(NSString *);
-
-JSValueRef deserializeJSONString(JSContextRef, NSString *jsonString);
-NSString *serializeJSObject(JSContextRef, JSValueRef, JSValueRef* exception);
 
 inline bool isDictionary(JSContextRef context, JSValueRef value) { return toJSValue(context, value)._isDictionary; }
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
@@ -121,6 +121,9 @@
         "RaisesException": {
             "contextsAllowed": ["operation"]
         },
+        "RaisesStringException": {
+            "contextsAllowed": ["operation"]
+        },
         "ReturnsPromiseWhenCallbackIsOmitted": {
             "contextsAllowed": ["interface", "operation"]
         },
@@ -130,6 +133,9 @@
         },
         "SetProperty": {
             "contextsAllowed": ["operation"]
+        },
+        "String": {
+            "contextsAllowed": ["argument"]
         },
         "URL": {
             "contextsAllowed": ["argument", "attribute", "operation"]

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -65,7 +65,11 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
     auto context = frame.jsContextForWorld(world);
     auto globalObject = JSContextGetGlobalObject(context);
 
-    auto namespaceObject = JSObjectGetProperty(context, globalObject, toJSString("browser").get(), nullptr);
+    JSRetainPtr browserString = toJSString("browser");
+    if (!browserString)
+        return;
+
+    auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
     if (namespaceObject && JSValueIsObject(context, namespaceObject))
         return;
 
@@ -85,8 +89,10 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
 
     namespaceObject = toJS(context, WebExtensionAPINamespace::create(contentWorldType, *extension).ptr());
 
-    JSObjectSetProperty(context, globalObject, toJSString("browser").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
-    JSObjectSetProperty(context, globalObject, toJSString("chrome").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+
+    if (JSRetainPtr chromeString = toJSString("chrome"))
+        JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
 }
 
 void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(WebPage& page, WebFrame& frame, DOMWrapperWorld& world)
@@ -100,7 +106,11 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
     auto context = frame.jsContextForServiceWorkerWorld(world);
     auto globalObject = JSContextGetGlobalObject(context);
 
-    auto namespaceObject = JSObjectGetProperty(context, globalObject, toJSString("browser").get(), nullptr);
+    JSRetainPtr browserString = toJSString("browser");
+    if (!browserString)
+        return;
+
+    auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
     if (namespaceObject && JSValueIsObject(context, namespaceObject))
         return;
 
@@ -108,8 +118,9 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
 
     namespaceObject = toJS(context, WebExtensionAPINamespace::create(WebExtensionContentWorldType::Main, *extension).ptr());
 
-    JSObjectSetProperty(context, globalObject, toJSString("browser").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
-    JSObjectSetProperty(context, globalObject, toJSString("chrome").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    if (JSRetainPtr chromeString = toJSString("chrome"))
+        JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
 }
 
 void WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary(WebFrame& frame, DOMWrapperWorld& world)
@@ -117,13 +128,17 @@ void WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary(WebFrame&
     auto context = frame.jsContextForWorld(world);
     auto globalObject = JSContextGetGlobalObject(context);
 
-    auto namespaceObject = JSObjectGetProperty(context, globalObject, toJSString("browser").get(), nullptr);
+    JSRetainPtr browserString = toJSString("browser");
+    if (!browserString)
+        return;
+
+    auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
     if (namespaceObject && JSValueIsObject(context, namespaceObject))
         return;
 
     namespaceObject = toJS(context, WebExtensionAPIWebPageNamespace::create(WebExtensionContentWorldType::WebPage).ptr());
 
-    JSObjectSetProperty(context, globalObject, toJSString("browser").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
 }
 
 static WebExtensionFrameParameters toFrameParameters(WebFrame& frame, const URL& url, bool includeDocumentIdentifier = true)

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl
@@ -29,8 +29,8 @@
     ReturnsPromiseWhenCallbackIsOmitted,
 ] interface WebExtensionAPIAction {
 
-    [RaisesException] void getTitle([Optional, NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
-    [RaisesException] void setTitle([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+    [RaisesStringException] void getTitle([Optional, NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+    [RaisesStringException] void setTitle([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
 
     [RaisesException] void getBadgeText([Optional, NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
     [RaisesException] void setBadgeText([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);


### PR DESCRIPTION
#### 01f5315190c9623c7a03e449865a45d21554520e
<pre>
Provide support for WTF::String in WebExtension JavaScript APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=300606">https://bugs.webkit.org/show_bug.cgi?id=300606</a>

Reviewed by Timothy Hatcher.

This implements support for WTF::String in WebExtension’s JavaScript
APIs. While nothing is ported to C++, this provides a good starting point
for porting the APIs.

NSString is still supported in the JavaScript APIs, and most APIs still
use NSString at the moment, with the exception of the Action APIs, which
have been ported to using WTF::String.

No new tests are required, all existing WebExtension JavaScript tests
will test these changes.

* Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp:
(WebKit::toJSError):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.h:
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::toJSError): Deleted.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::parseActionDetails):
(WebKit::WebExtensionAPIAction::getTitle):
(WebKit::WebExtensionAPIAction::setTitle):
(WebKit::WebExtensionAPIAction::getBadgeText):
(WebKit::WebExtensionAPIAction::setBadgeText):
(WebKit::WebExtensionAPIAction::getBadgeBackgroundColor):
(WebKit::WebExtensionAPIAction::setBadgeBackgroundColor):
(WebKit::WebExtensionAPIAction::isEnabled):
(WebKit::WebExtensionAPIAction::setIcon):
(WebKit::WebExtensionAPIAction::getPopup):
(WebKit::WebExtensionAPIAction::setPopup):
(WebKit::WebExtensionAPIAction::openPopup):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
(WebKit::WebExtensionAPIPort::postMessage):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntimeBase::reportError):
(WebKit::WebExtensionAPIRuntime::parseConnectOptions):
(WebKit::WebExtensionAPIRuntime::getURL):
(WebKit::WebExtensionAPIRuntime::getVersion):
(WebKit::WebExtensionAPIRuntime::runtimeIdentifier):
(WebKit::WebExtensionAPIRuntime::sendMessage):
(WebKit::WebExtensionAPIRuntime::connect):
(WebKit::WebExtensionAPIRuntime::sendNativeMessage):
(WebKit::WebExtensionAPIRuntime::connectNative):
(WebKit::WebExtensionAPIWebPageRuntime::sendMessage):
(WebKit::WebExtensionAPIWebPageRuntime::connect):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::sendMessage):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::WebExtensionCallbackHandler::reportError):
(WebKit::toString):
(WebKit::toNSDictionary):
(WebKit::toJSValueRef):
(WebKit::deserializeJSONString):
(WebKit::serializeJSObject):
(WebKit::toJSError):
(WebKit::toJSString):
(WebKit::toNSString): Deleted.
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
(_installArgumentTypeExceptions):
(_installAutomaticExceptions):
(_platformType):
(_platformTypeConstructor):
(_platformTypeVariableDeclaration):
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json:
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
(WebKit::WebExtensionControllerProxy::globalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary):
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl:

Canonical link: <a href="https://commits.webkit.org/301649@main">https://commits.webkit.org/301649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae42568e11835e1ce7e2a5e7c34e68a44b4fbc38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78214 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96295 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113168 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76837 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36343 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76737 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107260 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135977 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104805 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104506 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28316 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50645 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19806 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53151 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58964 "Found 11 new failures in WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm, WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52433 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55767 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->