### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for MessagePortChannelProvider

### DIFF
--- a/Source/WebCore/dom/MessageChannel.cpp
+++ b/Source/WebCore/dom/MessageChannel.cpp
@@ -53,7 +53,7 @@ MessageChannel::MessageChannel(ScriptExecutionContext& context)
     if (!context.activeDOMObjectsAreStopped()) {
         ASSERT(!port1().isDetached());
         ASSERT(!port2().isDetached());
-        MessagePortChannelProvider::fromContext(context).createNewMessagePortChannel(port1().identifier(), port2().identifier(), context.settingsValues().siteIsolationEnabled);
+        MessagePortChannelProvider::protectedFromContext(context)->createNewMessagePortChannel(port1().identifier(), port2().identifier(), context.settingsValues().siteIsolationEnabled);
     } else {
         ASSERT(port1().isDetached());
         ASSERT(port2().isDetached());

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -138,7 +138,7 @@ MessagePort::~MessagePort()
 
 void MessagePort::entangle()
 {
-    MessagePortChannelProvider::fromContext(*protectedScriptExecutionContext()).entangleLocalPortInThisProcessToRemote(m_identifier, m_remoteIdentifier);
+    MessagePortChannelProvider::protectedFromContext(*protectedScriptExecutionContext())->entangleLocalPortInThisProcessToRemote(m_identifier, m_remoteIdentifier);
 }
 
 ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
@@ -172,7 +172,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
 
     LOG(MessagePorts, "Actually posting message to port %s (to be received by port %s)", m_identifier.logString().utf8().data(), m_remoteIdentifier.logString().utf8().data());
 
-    MessagePortChannelProvider::fromContext(*protectedScriptExecutionContext()).postMessageToRemote(WTFMove(message), m_remoteIdentifier);
+    MessagePortChannelProvider::protectedFromContext(*protectedScriptExecutionContext())->postMessageToRemote(WTFMove(message), m_remoteIdentifier);
     return { };
 }
 
@@ -182,7 +182,7 @@ TransferredMessagePort MessagePort::disentangle()
     m_entangled = false;
 
     Ref context = *scriptExecutionContext();
-    MessagePortChannelProvider::fromContext(context).messagePortDisentangled(m_identifier);
+    MessagePortChannelProvider::protectedFromContext(context)->messagePortDisentangled(m_identifier);
 
     // We can't receive any messages or generate any events after this, so remove ourselves from the list of active ports.
     context->destroyedMessagePort(*this);
@@ -287,7 +287,7 @@ void MessagePort::dispatchMessages()
         }
     };
 
-    MessagePortChannelProvider::fromContext(*context).takeAllMessagesForPort(m_identifier, WTFMove(messagesTakenHandler));
+    MessagePortChannelProvider::protectedFromContext(*context)->takeAllMessagesForPort(m_identifier, WTFMove(messagesTakenHandler));
 }
 
 void MessagePort::dispatchEvent(Event& event)

--- a/Source/WebCore/dom/messageports/MessagePortChannelProvider.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProvider.cpp
@@ -35,9 +35,9 @@
 
 namespace WebCore {
 
-static WeakPtr<MessagePortChannelProvider>& globalProvider()
+static RefPtr<MessagePortChannelProvider>& globalProvider()
 {
-    static MainThreadNeverDestroyed<WeakPtr<MessagePortChannelProvider>> globalProvider;
+    static MainThreadNeverDestroyed<RefPtr<MessagePortChannelProvider>> globalProvider;
     return globalProvider;
 }
 
@@ -46,7 +46,7 @@ MessagePortChannelProvider& MessagePortChannelProvider::singleton()
     ASSERT(isMainThread());
     auto& globalProvider = WebCore::globalProvider();
     if (!globalProvider)
-        globalProvider = new MessagePortChannelProviderImpl;
+        globalProvider = MessagePortChannelProviderImpl::create();
     return *globalProvider;
 }
 

--- a/Source/WebCore/dom/messageports/MessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProvider.h
@@ -26,17 +26,9 @@
 #pragma once
 
 #include <WebCore/ProcessIdentifier.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Vector.h>
-
-namespace WebCore {
-class MessagePortChannelProvider;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MessagePortChannelProvider> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -44,9 +36,10 @@ class ScriptExecutionContext;
 struct MessagePortIdentifier;
 struct MessageWithMessagePorts;
 
-class MessagePortChannelProvider : public CanMakeWeakPtr<MessagePortChannelProvider> {
+class MessagePortChannelProvider : public AbstractRefCountedAndCanMakeWeakPtr<MessagePortChannelProvider> {
 public:
     static MessagePortChannelProvider& fromContext(ScriptExecutionContext&);
+    static Ref<MessagePortChannelProvider> protectedFromContext(ScriptExecutionContext& context) { return fromContext(context); }
     static MessagePortChannelProvider& singleton();
     WEBCORE_EXPORT static void setSharedProvider(MessagePortChannelProvider&);
 

--- a/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp
@@ -32,6 +32,11 @@
 
 namespace WebCore {
 
+Ref<MessagePortChannelProviderImpl> MessagePortChannelProviderImpl::create()
+{
+    return adoptRef(*new MessagePortChannelProviderImpl);
+}
+
 MessagePortChannelProviderImpl::MessagePortChannelProviderImpl() = default;
 
 MessagePortChannelProviderImpl::~MessagePortChannelProviderImpl()

--- a/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.h
@@ -27,15 +27,21 @@
 
 #include "MessagePortChannelProvider.h"
 #include "MessagePortChannelRegistry.h"
+#include <wtf/RefCounted.h>
 
 namespace WebCore {
 
-class MessagePortChannelProviderImpl final : public MessagePortChannelProvider {
+class MessagePortChannelProviderImpl final : public MessagePortChannelProvider, public RefCounted<MessagePortChannelProviderImpl> {
 public:
-    MessagePortChannelProviderImpl();
+    static Ref<MessagePortChannelProviderImpl> create();
     ~MessagePortChannelProviderImpl() final;
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
+    MessagePortChannelProviderImpl();
+
     void createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote, bool siteIsolationEnabled) final;
     void entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote) final;
     void messagePortDisentangled(const MessagePortIdentifier& local) final;

--- a/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
@@ -35,14 +35,18 @@ namespace WebCore {
 
 class WorkerOrWorkletGlobalScope;
 
-class WorkerMessagePortChannelProvider final : public MessagePortChannelProvider, public CanMakeCheckedPtr<WorkerMessagePortChannelProvider> {
+class WorkerMessagePortChannelProvider final : public MessagePortChannelProvider, public RefCounted<WorkerMessagePortChannelProvider> {
     WTF_MAKE_TZONE_ALLOCATED(WorkerMessagePortChannelProvider);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerMessagePortChannelProvider);
 public:
-    explicit WorkerMessagePortChannelProvider(WorkerOrWorkletGlobalScope&);
+    static Ref<WorkerMessagePortChannelProvider> create(WorkerOrWorkletGlobalScope&);
     ~WorkerMessagePortChannelProvider();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
+    explicit WorkerMessagePortChannelProvider(WorkerOrWorkletGlobalScope&);
+
     void createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote, bool siteIsolationEnabled) final;
     void entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote) final;
     void messagePortDisentangled(const MessagePortIdentifier& local) final;
@@ -50,7 +54,7 @@ private:
     void postMessageToRemote(MessageWithMessagePorts&&, const MessagePortIdentifier& remoteTarget) final;
     void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&) final;
 
-    WeakRef<WorkerOrWorkletGlobalScope> m_scope;
+    WeakPtr<WorkerOrWorkletGlobalScope> m_scope;
 
     uint64_t m_lastCallbackIdentifier { 0 };
     HashMap<uint64_t, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, Function<void()>&&)>> m_takeAllMessagesCallbacks;

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -586,7 +586,7 @@ CacheStorageConnection& WorkerGlobalScope::cacheStorageConnection()
 MessagePortChannelProvider& WorkerGlobalScope::messagePortChannelProvider()
 {
     if (!m_messagePortChannelProvider)
-        lazyInitialize(m_messagePortChannelProvider, makeUnique<WorkerMessagePortChannelProvider>(*this));
+        lazyInitialize(m_messagePortChannelProvider, WorkerMessagePortChannelProvider::create(*this));
     return *m_messagePortChannelProvider;
 }
 

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -244,7 +244,7 @@ private:
     MemoryCompactRobinHoodHashMap<URL, WeakHashSet<ScriptBufferSourceProvider>> m_importedScriptsSourceProviders;
 
     const RefPtr<CacheStorageConnection> m_cacheStorageConnection;
-    const std::unique_ptr<WorkerMessagePortChannelProvider> m_messagePortChannelProvider;
+    const RefPtr<WorkerMessagePortChannelProvider> m_messagePortChannelProvider;
     const RefPtr<WorkerSWClientConnection> m_swClientConnection;
     std::unique_ptr<CSSValuePool> m_cssValuePool;
     std::unique_ptr<WorkerClient> m_workerClient;

--- a/Source/WebCore/worklets/WorkletGlobalScope.cpp
+++ b/Source/WebCore/worklets/WorkletGlobalScope.cpp
@@ -175,7 +175,7 @@ void WorkletGlobalScope::fetchAndInvokeScript(const URL& moduleURL, FetchRequest
 MessagePortChannelProvider& WorkletGlobalScope::messagePortChannelProvider()
 {
     if (!m_messagePortChannelProvider)
-        m_messagePortChannelProvider = makeUnique<WorkerMessagePortChannelProvider>(*this);
+        lazyInitialize(m_messagePortChannelProvider, WorkerMessagePortChannelProvider::create(*this));
     return *m_messagePortChannelProvider;
 }
 

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -120,7 +120,7 @@ private:
     JSC::RuntimeFlags m_jsRuntimeFlags;
     std::optional<ScriptSourceCode> m_code;
 
-    std::unique_ptr<WorkerMessagePortChannelProvider> m_messagePortChannelProvider;
+    const RefPtr<WorkerMessagePortChannelProvider> m_messagePortChannelProvider;
 
     SettingsValues m_settingsValues;
 };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
@@ -39,6 +39,10 @@ public:
 
     void messagePortSentToRemote(const WebCore::MessagePortIdentifier&);
 
+    // Don't do anything in ref() / deref() since this class is a singleton.
+    void ref() const { }
+    void deref() const { }
+
 private:
     WebMessagePortChannelProvider();
     ~WebMessagePortChannelProvider() final;


### PR DESCRIPTION
#### 45f52741b039cb7e1ef54a12971ed2891cf38481
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for MessagePortChannelProvider
<a href="https://bugs.webkit.org/show_bug.cgi?id=300605">https://bugs.webkit.org/show_bug.cgi?id=300605</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/MessageChannel.cpp:
(WebCore::MessageChannel::MessageChannel):
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::entangle):
(WebCore::MessagePort::postMessage):
(WebCore::MessagePort::disentangle):
(WebCore::MessagePort::dispatchMessages):
* Source/WebCore/dom/messageports/MessagePortChannelProvider.cpp:
(WebCore::globalProvider):
(WebCore::MessagePortChannelProvider::singleton):
* Source/WebCore/dom/messageports/MessagePortChannelProvider.h:
(WebCore::MessagePortChannelProvider::protectedFromContext):
* Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp:
(WebCore::MessagePortChannelProviderImpl::create):
* Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.h:
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.cpp:
(WebCore::WorkerMessagePortChannelProvider::create):
(WebCore::WorkerMessagePortChannelProvider::takeAllMessagesForPort):
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::messagePortChannelProvider):
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/worklets/WorkletGlobalScope.cpp:
(WebCore::WorkletGlobalScope::messagePortChannelProvider):
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h:

Canonical link: <a href="https://commits.webkit.org/301437@main">https://commits.webkit.org/301437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75c25aa93718a6c170e58172d95cb84c3d29f02d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77742 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25c84497-d756-4902-ab4f-022c79d5d764) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95896 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63998 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4d4f3bf-ffcd-4ed3-987d-d52870ef5c3f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76387 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2141fb89-4e5c-4d88-9d4b-682f20fad172) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30738 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76215 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135425 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104362 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104089 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26528 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49461 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50026 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52553 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58364 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51899 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55248 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53596 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->