### PR TITLE
Fix editing/pasteboard tests' CSS borders

### DIFF
--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-custom.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-custom.html
@@ -13,7 +13,7 @@ html, body {
 }
 
 #destination {
-    border: 1px blue green;
+    border: 1px solid green;
     height: 1024px;
 }
 

--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-plain-text.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-plain-text.html
@@ -12,7 +12,7 @@ html, body {
 }
 
 #destination {
-    border: 1px blue green;
+    border: 1px solid green;
     height: 1024px;
 }
 

--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-rich-text.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-rich-text.html
@@ -12,7 +12,7 @@ html, body {
 }
 
 #destination {
-    border: 1px blue green;
+    border: 1px solid green;
     height: 1024px;
 }
 

--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-url.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-url.html
@@ -12,7 +12,7 @@ html, body {
 }
 
 #destination {
-    border: 1px blue green;
+    border: 1px solid green;
     height: 1024px;
 }
 

--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-custom.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-custom.html
@@ -13,7 +13,7 @@ html, body {
 }
 
 #destination {
-    border: 1px blue green;
+    border: 1px solid green;
     height: 1024px;
 }
 

--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-plain-text.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-plain-text.html
@@ -12,7 +12,7 @@ html, body {
 }
 
 #destination {
-    border: 1px blue green;
+    border: 1px solid green;
     height: 1024px;
 }
 

--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-rich-text.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-rich-text.html
@@ -12,7 +12,7 @@ html, body {
 }
 
 #destination {
-    border: 1px blue green;
+    border: 1px solid green;
     height: 1024px;
 }
 


### PR DESCRIPTION
#### 69e5d1d07eebaf676b01e82b0cfbeefd6b7c7dc4
<pre>
Fix editing/pasteboard tests&apos; CSS borders
<a href="https://bugs.webkit.org/show_bug.cgi?id=300609">https://bugs.webkit.org/show_bug.cgi?id=300609</a>
<a href="https://rdar.apple.com/162502426">rdar://162502426</a>

Reviewed by Wenson Hsieh.

These tests used `border: 1px blue green;`, but it doesn&apos;t make sense to
have two colors.
Also the default line-style is `none`, so these were useless to show the
drag&amp;drop destination boxes.

Changed `blue` to `solid`, so we now show a solid green border.

* LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-custom.html:
* LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-plain-text.html:
* LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-rich-text.html:
* LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-url.html:
* LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-custom.html:
* LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-plain-text.html:
* LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-rich-text.html:

Canonical link: <a href="https://commits.webkit.org/301428@main">https://commits.webkit.org/301428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90d504357a14ae1ef9939774a6b5fb91a4cd8908

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77734 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/778c7acd-3b30-41ad-8c75-063ad20dd76d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95888 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63992 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cfef905f-f568-4f85-9397-d361a1201175) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36947 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112555 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIScripting.ErrorsRegisteredContentScript (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76379 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b7267024-7785-4104-a6c2-c629cdf6c8f8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30739 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76206 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135416 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52650 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104354 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104082 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26522 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49450 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27777 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50015 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52544 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51891 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55240 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53587 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->