### PR TITLE
Drop DataLoadToken as it doesn't seem to do anything

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -838,10 +838,8 @@ bool DocumentLoader::tryLoadingSubstituteData()
         handleSubstituteDataLoadNow();
     else {
         auto loadData = [weakThis = WeakPtr { *this }] {
-            if (RefPtr protectedThis = weakThis.get()) {
-                protectedThis->m_dataLoadToken.clear();
+            if (RefPtr protectedThis = weakThis.get())
                 protectedThis->handleSubstituteDataLoadNow();
-            }
         };
 
 #if USE(COCOA_EVENT_LOOP)
@@ -2348,8 +2346,6 @@ void DocumentLoader::cancelMainResourceLoad(const ResourceError& resourceError, 
     ResourceError error = resourceError.isNull() ? protectedFrameLoader()->cancelledError(m_request) : resourceError;
 
     DOCUMENTLOADER_RELEASE_LOG("cancelMainResourceLoad: (type=%d, code=%d)", static_cast<int>(error.type()), error.errorCode());
-
-    m_dataLoadToken.clear();
 
     cancelPolicyCheckIfNeeded();
 

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -75,15 +75,6 @@
 #endif
 
 namespace WebCore {
-class DataLoadToken;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::DataLoadToken> : std::true_type { };
-}
-
-namespace WebCore {
 
 class ApplicationManifestLoader;
 class Archive;
@@ -183,11 +174,6 @@ enum class InlineMediaPlaybackPolicy : uint8_t {
 
 enum class ContentExtensionDefaultEnablement : bool { Disabled, Enabled };
 using ContentExtensionEnablement = std::pair<ContentExtensionDefaultEnablement, HashSet<String>>;
-
-class DataLoadToken : public CanMakeWeakPtr<DataLoadToken> {
-public:
-    void clear() { weakPtrFactory().revokeAll(); }
-};
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DocumentLoader);
 class DocumentLoader
@@ -726,8 +712,6 @@ private:
     DocumentLoadTiming m_loadTiming;
 
     Markable<ResourceLoaderIdentifier> m_identifierForLoadWithoutResourceLoader;
-
-    DataLoadToken m_dataLoadToken;
 
     HashMap<uint64_t, LinkIcon> m_iconsPendingLoadDecision;
     HashMap<std::unique_ptr<IconLoader>, CompletionHandler<void(FragmentedSharedBuffer*)>> m_iconLoaders;


### PR DESCRIPTION
#### aa980d1ecc5149952a9b381633b1704d15be75c5
<pre>
Drop DataLoadToken as it doesn&apos;t seem to do anything
<a href="https://bugs.webkit.org/show_bug.cgi?id=300613">https://bugs.webkit.org/show_bug.cgi?id=300613</a>

Reviewed by Darin Adler.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::tryLoadingSubstituteData):
(WebCore::DocumentLoader::cancelMainResourceLoad):
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DataLoadToken::clear): Deleted.

Canonical link: <a href="https://commits.webkit.org/301439@main">https://commits.webkit.org/301439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7692ce691a6b47423783d434757dd849596c6add

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77747 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aaa82d8f-1277-4b7f-8645-6f45da4f0642) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95898 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64007 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a8e5d65-6f4c-4388-888c-351678b3d08f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76389 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bdd07de5-1e72-4089-9985-e8b86e4b82a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30746 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76221 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106741 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135431 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52664 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104368 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104095 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26530 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49464 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27782 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50031 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58370 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51904 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55253 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53601 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->