### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for MediaPlayerClient

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -207,8 +207,20 @@ static const std::optional<Vector<FourCC>>& nullOptionalFourCCVector()
 
 class NullMediaPlayerClient final
     : public MediaPlayerClient
+    , public RefCounted<NullMediaPlayerClient>
     , public Identified<MediaPlayerClientIdentifier> {
+public:
+    static Ref<NullMediaPlayerClient> create()
+    {
+        return adoptRef(*new NullMediaPlayerClient);
+    }
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
+    NullMediaPlayerClient() = default;
+
 #if !RELEASE_LOG_DISABLED
     const Logger& mediaPlayerLogger() final
     {
@@ -259,7 +271,7 @@ const Vector<ContentType>& MediaPlayerClient::mediaContentTypesRequiringHardware
 
 static MediaPlayerClient& nullMediaPlayerClient()
 {
-    static NeverDestroyed<NullMediaPlayerClient> client;
+    static NeverDestroyed<Ref<NullMediaPlayerClient>> client = NullMediaPlayerClient::create();
     return client.get();
 }
 
@@ -595,7 +607,7 @@ const MediaPlayerFactory* MediaPlayer::nextBestMediaEngine(const MediaPlayerFact
 
 void MediaPlayer::reloadAndResumePlaybackIfNeeded()
 {
-    client().mediaPlayerReloadAndResumePlaybackIfNeeded();
+    protectedClient()->mediaPlayerReloadAndResumePlaybackIfNeeded();
 }
 
 void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
@@ -615,7 +627,7 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
 
     ASSERT(!m_initializingMediaEngine);
     m_initializingMediaEngine = true;
-    client().mediaPlayerWillInitializeMediaEngine();
+    protectedClient()->mediaPlayerWillInitializeMediaEngine();
 
     const MediaPlayerFactory* engine = nullptr;
 
@@ -637,7 +649,7 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
         RefPtr playerPrivate = engine->createMediaEnginePlayer(this);
         m_private = playerPrivate;
         if (playerPrivate) {
-            client().mediaPlayerEngineUpdated();
+            protectedClient()->mediaPlayerEngineUpdated();
             playerPrivate->setMessageClientForTesting(m_internalMessageClient);
 
             if (m_pageIsVisible)
@@ -660,8 +672,9 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
         }
     }
 
+    Ref client = this->client();
     if (RefPtr playerPrivate = m_private) {
-        playerPrivate->setShouldCheckHardwareSupport(client().mediaPlayerShouldCheckHardwareSupport());
+        playerPrivate->setShouldCheckHardwareSupport(client->mediaPlayerShouldCheckHardwareSupport());
 
 #if ENABLE(MEDIA_SOURCE)
         if (RefPtr mediaSource = m_mediaSource.get())
@@ -681,19 +694,19 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
             && (nextBestMediaEngine(m_currentMediaEngine) || nextMediaEngine(m_currentMediaEngine)))
             m_reloadTimer.startOneShot(0_s);
         else {
-            client().mediaPlayerEngineUpdated();
-            client().mediaPlayerResourceNotSupported();
+            client->mediaPlayerEngineUpdated();
+            client->mediaPlayerResourceNotSupported();
         }
     }
 
     m_initializingMediaEngine = false;
-    client().mediaPlayerDidInitializeMediaEngine();
+    client->mediaPlayerDidInitializeMediaEngine();
 }
 
 void MediaPlayer::queueTaskOnEventLoop(Function<void()>&& task)
 {
     ASSERT(isMainThread());
-    client().mediaPlayerQueueTaskOnEventLoop(WTFMove(task));
+    protectedClient()->mediaPlayerQueueTaskOnEventLoop(WTFMove(task));
 }
 
 bool MediaPlayer::hasAvailableVideoFrame() const
@@ -848,7 +861,7 @@ void MediaPlayer::seekWhenPossible(const MediaTime& time)
 
 void MediaPlayer::seeked(const MediaTime& time)
 {
-    client().mediaPlayerSeeked(time);
+    protectedClient()->mediaPlayerSeeked(time);
 }
 
 bool MediaPlayer::paused() const
@@ -940,7 +953,7 @@ void MediaPlayer::setVideoFullscreenMode(MediaPlayer::VideoFullscreenMode mode)
 
 MediaPlayer::VideoFullscreenMode MediaPlayer::fullscreenMode() const
 {
-    return client().mediaPlayerFullscreenMode();
+    return protectedClient()->mediaPlayerFullscreenMode();
 }
 
 void MediaPlayer::videoFullscreenStandbyChanged()
@@ -950,20 +963,20 @@ void MediaPlayer::videoFullscreenStandbyChanged()
 
 bool MediaPlayer::isVideoFullscreenStandby() const
 {
-    return client().mediaPlayerIsVideoFullscreenStandby();
+    return protectedClient()->mediaPlayerIsVideoFullscreenStandby();
 }
 
 #endif
 
 FloatSize MediaPlayer::videoLayerSize() const
 {
-    return client().mediaPlayerVideoLayerSize();
+    return protectedClient()->mediaPlayerVideoLayerSize();
 }
 
 #if PLATFORM(IOS_FAMILY)
 bool MediaPlayer::canShowWhileLocked() const
 {
-    return client().canShowWhileLocked();
+    return protectedClient()->canShowWhileLocked();
 }
 
 void MediaPlayer::setSceneIdentifier(const String& identifier)
@@ -977,7 +990,7 @@ void MediaPlayer::setSceneIdentifier(const String& identifier)
 
 void MediaPlayer::videoLayerSizeDidChange(const FloatSize& size)
 {
-    client().mediaPlayerVideoLayerSizeDidChange(size);
+    protectedClient()->mediaPlayerVideoLayerSizeDidChange(size);
 }
 
 void MediaPlayer::setVideoLayerSizeFenced(const FloatSize& size, WTF::MachSendRightAnnotated&& fence)
@@ -1069,7 +1082,7 @@ double MediaPlayer::effectiveRate() const
 
 double MediaPlayer::requestedRate() const
 {
-    return client().mediaPlayerRequestedPlaybackRate();
+    return protectedClient()->mediaPlayerRequestedPlaybackRate();
 }
 
 bool MediaPlayer::preservesPitch() const
@@ -1124,12 +1137,12 @@ double MediaPlayer::seekableTimeRangesLastModifiedTime()
 
 void MediaPlayer::bufferedTimeRangesChanged()
 {
-    client().mediaPlayerBufferedTimeRangesChanged();
+    protectedClient()->mediaPlayerBufferedTimeRangesChanged();
 }
 
 void MediaPlayer::seekableTimeRangesChanged()
 {
-    client().mediaPlayerSeekableTimeRangesChanged();
+    protectedClient()->mediaPlayerSeekableTimeRangesChanged();
 }
 
 double MediaPlayer::liveUpdateInterval()
@@ -1293,7 +1306,7 @@ void MediaPlayer::setWirelessVideoPlaybackDisabled(bool disabled)
 
 void MediaPlayer::currentPlaybackTargetIsWirelessChanged(bool isCurrentPlaybackTargetWireless)
 {
-    client().mediaPlayerCurrentPlaybackTargetIsWirelessChanged(isCurrentPlaybackTargetWireless);
+    protectedClient()->mediaPlayerCurrentPlaybackTargetIsWirelessChanged(isCurrentPlaybackTargetWireless);
 }
 
 bool MediaPlayer::canPlayToWirelessPlaybackTarget() const
@@ -1452,10 +1465,11 @@ void MediaPlayer::networkStateChanged()
     RefPtr playerPrivate = m_private;
     if (playerPrivate->networkState() >= MediaPlayer::NetworkState::FormatError)
         m_lastErrorMessage = playerPrivate->errorMessage();
+    Ref client = this->client();
     // If more than one media engine is installed and this one failed before finding metadata,
     // let the next engine try.
     if (playerPrivate->networkState() >= MediaPlayer::NetworkState::FormatError && playerPrivate->readyState() < MediaPlayer::ReadyState::HaveMetadata) {
-        client().mediaPlayerEngineFailedToLoad();
+        client->mediaPlayerEngineFailedToLoad();
         if (!m_activeEngineIdentifier
             && installedMediaEngines().size() > 1
             && (nextBestMediaEngine(m_currentMediaEngine) || nextMediaEngine(m_currentMediaEngine))) {
@@ -1463,12 +1477,12 @@ void MediaPlayer::networkStateChanged()
             return;
         }
     }
-    client().mediaPlayerNetworkStateChanged();
+    client->mediaPlayerNetworkStateChanged();
 }
 
 void MediaPlayer::readyStateChanged()
 {
-    client().mediaPlayerReadyStateChanged();
+    protectedClient()->mediaPlayerReadyStateChanged();
     if (m_pendingSeekRequest && protectedPrivate()->readyState() == MediaPlayer::ReadyState::HaveMetadata)
         seekToTime(*std::exchange(m_pendingSeekRequest, std::nullopt));
 }
@@ -1481,7 +1495,7 @@ void MediaPlayer::volumeChanged(double newVolume)
 #else
     m_volume = newVolume;
 #endif
-    client().mediaPlayerVolumeChanged();
+    protectedClient()->mediaPlayerVolumeChanged();
 }
 
 void MediaPlayer::muteChanged(bool newMuted)
@@ -1490,47 +1504,47 @@ void MediaPlayer::muteChanged(bool newMuted)
         return;
 
     m_muted = newMuted;
-    client().mediaPlayerMuteChanged();
+    protectedClient()->mediaPlayerMuteChanged();
 }
 
 void MediaPlayer::timeChanged()
 {
-    client().mediaPlayerTimeChanged();
+    protectedClient()->mediaPlayerTimeChanged();
 }
 
 void MediaPlayer::sizeChanged()
 {
-    client().mediaPlayerSizeChanged();
+    protectedClient()->mediaPlayerSizeChanged();
 }
 
 void MediaPlayer::repaint()
 {
-    client().mediaPlayerRepaint();
+    protectedClient()->mediaPlayerRepaint();
 }
 
 void MediaPlayer::durationChanged()
 {
-    client().mediaPlayerDurationChanged();
+    protectedClient()->mediaPlayerDurationChanged();
 }
 
 void MediaPlayer::rateChanged()
 {
-    client().mediaPlayerRateChanged();
+    protectedClient()->mediaPlayerRateChanged();
 }
 
 void MediaPlayer::playbackStateChanged()
 {
-    client().mediaPlayerPlaybackStateChanged();
+    protectedClient()->mediaPlayerPlaybackStateChanged();
 }
 
 void MediaPlayer::firstVideoFrameAvailable()
 {
-    client().mediaPlayerFirstVideoFrameAvailable();
+    protectedClient()->mediaPlayerFirstVideoFrameAvailable();
 }
 
 void MediaPlayer::characteristicChanged()
 {
-    client().mediaPlayerCharacteristicChanged();
+    protectedClient()->mediaPlayerCharacteristicChanged();
 }
 
 #if ENABLE(WEB_AUDIO)
@@ -1546,17 +1560,17 @@ AudioSourceProvider* MediaPlayer::audioSourceProvider()
 
 RefPtr<ArrayBuffer> MediaPlayer::cachedKeyForKeyId(const String& keyId) const
 {
-    return client().mediaPlayerCachedKeyForKeyId(keyId);
+    return protectedClient()->mediaPlayerCachedKeyForKeyId(keyId);
 }
 
 void MediaPlayer::keyNeeded(const SharedBuffer& initData)
 {
-    client().mediaPlayerKeyNeeded(initData);
+    protectedClient()->mediaPlayerKeyNeeded(initData);
 }
 
 String MediaPlayer::mediaKeysStorageDirectory() const
 {
-    return client().mediaPlayerMediaKeysStorageDirectory();
+    return protectedClient()->mediaPlayerMediaKeysStorageDirectory();
 }
 
 #endif
@@ -1565,12 +1579,12 @@ String MediaPlayer::mediaKeysStorageDirectory() const
 
 void MediaPlayer::initializationDataEncountered(const String& initDataType, RefPtr<ArrayBuffer>&& initData)
 {
-    client().mediaPlayerInitializationDataEncountered(initDataType, WTFMove(initData));
+    protectedClient()->mediaPlayerInitializationDataEncountered(initDataType, WTFMove(initData));
 }
 
 void MediaPlayer::waitingForKeyChanged()
 {
-    client().mediaPlayerWaitingForKeyChanged();
+    protectedClient()->mediaPlayerWaitingForKeyChanged();
 }
 
 bool MediaPlayer::waitingForKey() const
@@ -1583,12 +1597,12 @@ bool MediaPlayer::waitingForKey() const
 
 String MediaPlayer::referrer() const
 {
-    return client().mediaPlayerReferrer();
+    return protectedClient()->mediaPlayerReferrer();
 }
 
 String MediaPlayer::userAgent() const
 {
-    return client().mediaPlayerUserAgent();
+    return protectedClient()->mediaPlayerUserAgent();
 }
 
 String MediaPlayer::engineDescription() const
@@ -1607,45 +1621,45 @@ long MediaPlayer::platformErrorCode() const
 
 CachedResourceLoader* MediaPlayer::cachedResourceLoader()
 {
-    return client().mediaPlayerCachedResourceLoader();
+    return protectedClient()->mediaPlayerCachedResourceLoader();
 }
 
 Ref<PlatformMediaResourceLoader> MediaPlayer::mediaResourceLoader()
 {
     if (!m_mediaResourceLoader)
-        m_mediaResourceLoader = client().mediaPlayerCreateResourceLoader();
+        m_mediaResourceLoader = protectedClient()->mediaPlayerCreateResourceLoader();
 
     return *m_mediaResourceLoader;
 }
 
 void MediaPlayer::addAudioTrack(AudioTrackPrivate& track)
 {
-    client().mediaPlayerDidAddAudioTrack(track);
+    protectedClient()->mediaPlayerDidAddAudioTrack(track);
 }
 
 void MediaPlayer::removeAudioTrack(AudioTrackPrivate& track)
 {
-    client().mediaPlayerDidRemoveAudioTrack(track);
+    protectedClient()->mediaPlayerDidRemoveAudioTrack(track);
 }
 
 void MediaPlayer::addTextTrack(InbandTextTrackPrivate& track)
 {
-    client().mediaPlayerDidAddTextTrack(track);
+    protectedClient()->mediaPlayerDidAddTextTrack(track);
 }
 
 void MediaPlayer::removeTextTrack(InbandTextTrackPrivate& track)
 {
-    client().mediaPlayerDidRemoveTextTrack(track);
+    protectedClient()->mediaPlayerDidRemoveTextTrack(track);
 }
 
 void MediaPlayer::addVideoTrack(VideoTrackPrivate& track)
 {
-    client().mediaPlayerDidAddVideoTrack(track);
+    protectedClient()->mediaPlayerDidAddVideoTrack(track);
 }
 
 void MediaPlayer::removeVideoTrack(VideoTrackPrivate& track)
 {
-    client().mediaPlayerDidRemoveVideoTrack(track);
+    protectedClient()->mediaPlayerDidRemoveVideoTrack(track);
 }
 
 void MediaPlayer::setTextTrackRepresentation(TextTrackRepresentation* representation)
@@ -1671,7 +1685,7 @@ void MediaPlayer::notifyTrackModeChanged()
 
 Vector<RefPtr<PlatformTextTrack>> MediaPlayer::outOfBandTrackSources()
 {
-    return client().outOfBandTrackSources();
+    return protectedClient()->outOfBandTrackSources();
 }
 
 void MediaPlayer::resetMediaEngines()
@@ -1698,7 +1712,7 @@ void MediaPlayer::simulateAudioInterruption()
 
 bool MediaPlayer::isGStreamerHolePunchingEnabled()
 {
-    return client().isGStreamerHolePunchingEnabled();
+    return protectedClient()->isGStreamerHolePunchingEnabled();
 }
 #endif
 
@@ -1728,7 +1742,7 @@ size_t MediaPlayer::extraMemoryCost() const
 
 void MediaPlayer::reportGPUMemoryFootprint(uint64_t footPrint) const
 {
-    client().mediaPlayerDidReportGPUMemoryFootprint(footPrint);
+    protectedClient()->mediaPlayerDidReportGPUMemoryFootprint(footPrint);
 }
 
 unsigned long long MediaPlayer::fileSize() const
@@ -1764,12 +1778,12 @@ Ref<MediaPlayer::VideoPlaybackQualityMetricsPromise> MediaPlayer::asyncVideoPlay
 
 String MediaPlayer::sourceApplicationIdentifier() const
 {
-    return client().mediaPlayerSourceApplicationIdentifier();
+    return protectedClient()->mediaPlayerSourceApplicationIdentifier();
 }
 
 Vector<String> MediaPlayer::preferredAudioCharacteristics() const
 {
-    return client().mediaPlayerPreferredAudioCharacteristics();
+    return protectedClient()->mediaPlayerPreferredAudioCharacteristics();
 }
 
 void MediaPlayerFactorySupport::callRegisterMediaEngine(MediaEngineRegister registerMediaEngine)
@@ -1779,18 +1793,18 @@ void MediaPlayerFactorySupport::callRegisterMediaEngine(MediaEngineRegister regi
 
 bool MediaPlayer::doesHaveAttribute(const AtomString& attribute, AtomString* value) const
 {
-    return client().doesHaveAttribute(attribute, value);
+    return protectedClient()->doesHaveAttribute(attribute, value);
 }
 
 #if PLATFORM(IOS_FAMILY)
 String MediaPlayer::mediaPlayerNetworkInterfaceName() const
 {
-    return client().mediaPlayerNetworkInterfaceName();
+    return protectedClient()->mediaPlayerNetworkInterfaceName();
 }
 
 void MediaPlayer::getRawCookies(const URL& url, MediaPlayerClient::GetRawCookiesCallback&& completionHandler) const
 {
-    client().mediaPlayerGetRawCookies(url, WTFMove(completionHandler));
+    protectedClient()->mediaPlayerGetRawCookies(url, WTFMove(completionHandler));
 }
 #endif
 
@@ -1802,7 +1816,7 @@ void MediaPlayer::setShouldDisableSleep(bool flag)
 
 bool MediaPlayer::shouldDisableSleep() const
 {
-    return client().mediaPlayerShouldDisableSleep();
+    return protectedClient()->mediaPlayerShouldDisableSleep();
 }
 
 String MediaPlayer::contentMIMEType() const
@@ -1822,32 +1836,32 @@ bool MediaPlayer::contentMIMETypeWasInferredFromExtension() const
 
 const Vector<ContentType>& MediaPlayer::mediaContentTypesRequiringHardwareSupport() const
 {
-    return client().mediaContentTypesRequiringHardwareSupport();
+    return protectedClient()->mediaContentTypesRequiringHardwareSupport();
 }
 
 const std::optional<Vector<String>>& MediaPlayer::allowedMediaContainerTypes() const
 {
-    return client().allowedMediaContainerTypes();
+    return protectedClient()->allowedMediaContainerTypes();
 }
 
 const std::optional<Vector<String>>& MediaPlayer::allowedMediaCodecTypes() const
 {
-    return client().allowedMediaCodecTypes();
+    return protectedClient()->allowedMediaCodecTypes();
 }
 
 const std::optional<Vector<FourCC>>& MediaPlayer::allowedMediaVideoCodecIDs() const
 {
-    return client().allowedMediaVideoCodecIDs();
+    return protectedClient()->allowedMediaVideoCodecIDs();
 }
 
 const std::optional<Vector<FourCC>>& MediaPlayer::allowedMediaAudioCodecIDs() const
 {
-    return client().allowedMediaAudioCodecIDs();
+    return protectedClient()->allowedMediaAudioCodecIDs();
 }
 
 const std::optional<Vector<FourCC>>& MediaPlayer::allowedMediaCaptionFormatTypes() const
 {
-    return client().allowedMediaCaptionFormatTypes();
+    return protectedClient()->allowedMediaCaptionFormatTypes();
 }
 
 void MediaPlayer::applicationWillResignActive()
@@ -1886,12 +1900,12 @@ void MediaPlayer::isLoopingChanged()
 
 void MediaPlayer::remoteEngineFailedToLoad()
 {
-    client().mediaPlayerEngineFailedToLoad();
+    protectedClient()->mediaPlayerEngineFailedToLoad();
 }
 
 SecurityOriginData MediaPlayer::documentSecurityOrigin() const
 {
-    return client().documentSecurityOrigin();
+    return protectedClient()->documentSecurityOrigin();
 }
 
 void MediaPlayer::setPreferredDynamicRangeMode(DynamicRangeMode mode)
@@ -1953,13 +1967,13 @@ void MediaPlayer::playerContentBoxRectChanged(const LayoutRect& rect)
 #if PLATFORM(COCOA)
 void MediaPlayer::onNewVideoFrameMetadata(VideoFrameMetadata&& metadata, RetainPtr<CVPixelBufferRef>&& buffer)
 {
-    client().mediaPlayerOnNewVideoFrameMetadata(WTFMove(metadata), WTFMove(buffer));
+    protectedClient()->mediaPlayerOnNewVideoFrameMetadata(WTFMove(metadata), WTFMove(buffer));
 }
 #endif
 
 String MediaPlayer::elementId() const
 {
-    return client().mediaPlayerElementId();
+    return protectedClient()->mediaPlayerElementId();
 }
 
 bool MediaPlayer::supportsPlayAtHostTime() const
@@ -2033,7 +2047,7 @@ void MediaPlayer::setPrefersSpatialAudioExperience(bool value)
 
 auto MediaPlayer::soundStageSize() const -> SoundStageSize
 {
-    return client().mediaPlayerSoundStageSize();
+    return protectedClient()->mediaPlayerSoundStageSize();
 }
 
 void MediaPlayer::soundStageSizeDidChange()
@@ -2065,7 +2079,7 @@ bool MediaPlayer::supportsLinearMediaPlayer() const
 #if !RELEASE_LOG_DISABLED
 const Logger& MediaPlayer::mediaPlayerLogger()
 {
-    return client().mediaPlayerLogger();
+    return protectedClient()->mediaPlayerLogger();
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -46,6 +46,7 @@
 #include <WebCore/Timer.h>
 #include <WebCore/VideoPlaybackQualityMetrics.h>
 #include <WebCore/VideoTarget.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
@@ -62,13 +63,11 @@ OBJC_CLASS AVPlayer;
 OBJC_CLASS NSArray;
 
 namespace WebCore {
-class MediaPlayerClient;
 class MediaPlayerFactory;
 }
 
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaPlayerClient> : std::true_type { };
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaPlayerFactory> : std::true_type { };
 }
 
@@ -186,7 +185,7 @@ struct MediaPlayerLoadOptions {
     VideoRendererPreferences videoRendererPreferences { };
 };
 
-class MediaPlayerClient : public CanMakeWeakPtr<MediaPlayerClient> {
+class MediaPlayerClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaPlayerClient> {
 public:
     virtual ~MediaPlayerClient() = default;
 
@@ -531,7 +530,7 @@ public:
 
     double volume() const;
     void setVolume(double);
-    bool platformVolumeConfigurationRequired() const { return client().mediaPlayerPlatformVolumeConfigurationRequired(); }
+    bool platformVolumeConfigurationRequired() const { return protectedClient()->mediaPlayerPlatformVolumeConfigurationRequired(); }
 
     bool muted() const;
     void setMuted(bool);
@@ -716,7 +715,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& mediaPlayerLogger();
-    uint64_t mediaPlayerLogIdentifier() { return client().mediaPlayerLogIdentifier(); }
+    uint64_t mediaPlayerLogIdentifier() { return protectedClient()->mediaPlayerLogIdentifier(); }
 #endif
 
     void applicationWillResignActive();
@@ -730,18 +729,18 @@ public:
 
     bool shouldIgnoreIntrinsicSize();
 
-    bool renderingCanBeAccelerated() const { return client().mediaPlayerRenderingCanBeAccelerated(); }
-    void renderingModeChanged() const  { client().mediaPlayerRenderingModeChanged(); }
-    bool acceleratedCompositingEnabled() { return client().mediaPlayerAcceleratedCompositingEnabled(); }
-    void activeSourceBuffersChanged() { client().mediaPlayerActiveSourceBuffersChanged(); }
-    LayoutRect playerContentBoxRect() const { return client().mediaPlayerContentBoxRect(); }
-    float playerContentsScale() const { return client().mediaPlayerContentsScale(); }
-    bool shouldUsePersistentCache() const { return client().mediaPlayerShouldUsePersistentCache(); }
-    const String& mediaCacheDirectory() const { return client().mediaPlayerMediaCacheDirectory(); }
-    bool isVideoPlayer() const { return client().mediaPlayerIsVideo(); }
-    void mediaEngineUpdated() { client().mediaPlayerEngineUpdated(); }
-    void resourceNotSupported() { client().mediaPlayerResourceNotSupported(); }
-    bool isLooping() const { return client().mediaPlayerIsLooping(); }
+    bool renderingCanBeAccelerated() const { return protectedClient()->mediaPlayerRenderingCanBeAccelerated(); }
+    void renderingModeChanged() const  { protectedClient()->mediaPlayerRenderingModeChanged(); }
+    bool acceleratedCompositingEnabled() { return protectedClient()->mediaPlayerAcceleratedCompositingEnabled(); }
+    void activeSourceBuffersChanged() { protectedClient()->mediaPlayerActiveSourceBuffersChanged(); }
+    LayoutRect playerContentBoxRect() const { return protectedClient()->mediaPlayerContentBoxRect(); }
+    float playerContentsScale() const { return protectedClient()->mediaPlayerContentsScale(); }
+    bool shouldUsePersistentCache() const { return protectedClient()->mediaPlayerShouldUsePersistentCache(); }
+    const String& mediaCacheDirectory() const { return protectedClient()->mediaPlayerMediaCacheDirectory(); }
+    bool isVideoPlayer() const { return protectedClient()->mediaPlayerIsVideo(); }
+    void mediaEngineUpdated() { protectedClient()->mediaPlayerEngineUpdated(); }
+    void resourceNotSupported() { protectedClient()->mediaPlayerResourceNotSupported(); }
+    bool isLooping() const { return protectedClient()->mediaPlayerIsLooping(); }
     void isLoopingChanged();
 
     void remoteEngineFailedToLoad();
@@ -775,7 +774,7 @@ public:
     void renderVideoWillBeDestroyed();
 
     void setShouldDisableHDR(bool);
-    bool shouldDisableHDR() const { return client().mediaPlayerShouldDisableHDR(); }
+    bool shouldDisableHDR() const { return protectedClient()->mediaPlayerShouldDisableHDR(); }
 
     void setResourceOwner(const ProcessIdentity&);
 
@@ -800,8 +799,8 @@ public:
     void setInFullscreenOrPictureInPicture(bool);
     bool isInFullscreenOrPictureInPicture() const;
 
-    PlatformVideoTarget videoTarget() const { return client().mediaPlayerVideoTarget(); }
-    MediaPlayerClientIdentifier clientIdentifier() const { return client().mediaPlayerClientIdentifier(); }
+    PlatformVideoTarget videoTarget() const { return protectedClient()->mediaPlayerVideoTarget(); }
+    MediaPlayerClientIdentifier clientIdentifier() const { return protectedClient()->mediaPlayerClientIdentifier(); }
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool supportsLinearMediaPlayer() const;
@@ -823,6 +822,7 @@ private:
     MediaPlayer(MediaPlayerClient&, MediaPlayerEnums::MediaEngineIdentifier);
 
     MediaPlayerClient& client() const { return *m_client; }
+    Ref<MediaPlayerClient> protectedClient() const { return client(); }
 
     RefPtr<MediaPlayerPrivateInterface> protectedPrivate() const;
 
@@ -922,12 +922,14 @@ public:
 
 inline String MediaPlayer::audioOutputDeviceId() const
 {
-    return m_client ? m_client->audioOutputDeviceId() : String { };
+    RefPtr client = m_client.get();
+    return client ? client->audioOutputDeviceId() : String { };
 }
 
 inline String MediaPlayer::audioOutputDeviceIdOverride() const
 {
-    return m_client ? m_client->audioOutputDeviceIdOverride() : String { };
+    RefPtr client = m_client.get();
+    return client ? client->audioOutputDeviceIdOverride() : String { };
 }
 
 inline bool MediaPlayer::hasMediaEngine() const


### PR DESCRIPTION
#### cfc8b667285b151954c745b5f7bcecbf20039b0e
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for MediaPlayerClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=300615">https://bugs.webkit.org/show_bug.cgi?id=300615</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::nullMediaPlayerClient):
(WebCore::MediaPlayer::reloadAndResumePlaybackIfNeeded):
(WebCore::MediaPlayer::loadWithNextMediaEngine):
(WebCore::MediaPlayer::queueTaskOnEventLoop):
(WebCore::MediaPlayer::seeked):
(WebCore::MediaPlayer::fullscreenMode const):
(WebCore::MediaPlayer::isVideoFullscreenStandby const):
(WebCore::MediaPlayer::videoLayerSize const):
(WebCore::MediaPlayer::canShowWhileLocked const):
(WebCore::MediaPlayer::videoLayerSizeDidChange):
(WebCore::MediaPlayer::requestedRate const):
(WebCore::MediaPlayer::bufferedTimeRangesChanged):
(WebCore::MediaPlayer::seekableTimeRangesChanged):
(WebCore::MediaPlayer::currentPlaybackTargetIsWirelessChanged):
(WebCore::MediaPlayer::networkStateChanged):
(WebCore::MediaPlayer::readyStateChanged):
(WebCore::MediaPlayer::volumeChanged):
(WebCore::MediaPlayer::muteChanged):
(WebCore::MediaPlayer::timeChanged):
(WebCore::MediaPlayer::sizeChanged):
(WebCore::MediaPlayer::repaint):
(WebCore::MediaPlayer::durationChanged):
(WebCore::MediaPlayer::rateChanged):
(WebCore::MediaPlayer::playbackStateChanged):
(WebCore::MediaPlayer::firstVideoFrameAvailable):
(WebCore::MediaPlayer::characteristicChanged):
(WebCore::MediaPlayer::cachedKeyForKeyId const):
(WebCore::MediaPlayer::keyNeeded):
(WebCore::MediaPlayer::mediaKeysStorageDirectory const):
(WebCore::MediaPlayer::initializationDataEncountered):
(WebCore::MediaPlayer::waitingForKeyChanged):
(WebCore::MediaPlayer::referrer const):
(WebCore::MediaPlayer::userAgent const):
(WebCore::MediaPlayer::cachedResourceLoader):
(WebCore::MediaPlayer::mediaResourceLoader):
(WebCore::MediaPlayer::addAudioTrack):
(WebCore::MediaPlayer::removeAudioTrack):
(WebCore::MediaPlayer::addTextTrack):
(WebCore::MediaPlayer::removeTextTrack):
(WebCore::MediaPlayer::addVideoTrack):
(WebCore::MediaPlayer::removeVideoTrack):
(WebCore::MediaPlayer::outOfBandTrackSources):
(WebCore::MediaPlayer::isGStreamerHolePunchingEnabled):
(WebCore::MediaPlayer::reportGPUMemoryFootprint const):
(WebCore::MediaPlayer::sourceApplicationIdentifier const):
(WebCore::MediaPlayer::preferredAudioCharacteristics const):
(WebCore::MediaPlayer::doesHaveAttribute const):
(WebCore::MediaPlayer::mediaPlayerNetworkInterfaceName const):
(WebCore::MediaPlayer::getRawCookies const):
(WebCore::MediaPlayer::shouldDisableSleep const):
(WebCore::MediaPlayer::mediaContentTypesRequiringHardwareSupport const):
(WebCore::MediaPlayer::allowedMediaContainerTypes const):
(WebCore::MediaPlayer::allowedMediaCodecTypes const):
(WebCore::MediaPlayer::allowedMediaVideoCodecIDs const):
(WebCore::MediaPlayer::allowedMediaAudioCodecIDs const):
(WebCore::MediaPlayer::allowedMediaCaptionFormatTypes const):
(WebCore::MediaPlayer::remoteEngineFailedToLoad):
(WebCore::MediaPlayer::documentSecurityOrigin const):
(WebCore::MediaPlayer::onNewVideoFrameMetadata):
(WebCore::MediaPlayer::elementId const):
(WebCore::MediaPlayer::soundStageSize const):
(WebCore::MediaPlayer::mediaPlayerLogger):
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayer::audioOutputDeviceId const):
(WebCore::MediaPlayer::audioOutputDeviceIdOverride const):

Canonical link: <a href="https://commits.webkit.org/301441@main">https://commits.webkit.org/301441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38be87e08a1e421d64dff0549959769c3cf0ea74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125915 "18 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132786 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77778 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55faa01e-84d1-486e-bf2f-b1d8f5378cdb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95933 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64026 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55907d57-f3f4-4af3-af39-913117b6a34f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76424 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31561387-358b-43a6-8c6a-4e28c9cb50aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35904 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30788 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76257 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135468 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104404 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104128 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26532 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49500 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27821 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50073 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52594 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58406 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157435 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51937 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/157435 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55288 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53636 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->