### PR TITLE
[GTK][WPE] Make ANGLE WebGL context not current before its destruction

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -107,20 +107,14 @@ GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
             bool result = EGL_DestroySync(m_displayObj, sync);
             ASSERT_UNUSED(result, !!result);
         }
-#if PLATFORM(WIN)
         EGL_MakeCurrent(m_displayObj, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-#endif
         EGL_DestroyContext(m_displayObj, m_contextObj);
     }
 
-#if !PLATFORM(WIN)
+    // On GTK and WPE ports, we need to destroy the ANGLE sharingContext as it's not a singleton. We don't need
+    // an ifdef for the Windows port here because m_angleSharingContextObj is always nullptr for that port.
     if (m_angleSharingContextObj)
         EGL_DestroyContext(m_displayObj, m_angleSharingContextObj);
-
-    // Ideally this should go before the m_contextObj destruction, but there are platforms where it breaks
-    // the destruction m_contextObj. Putting it here works for all the platforms that I've tested.
-    EGL_MakeCurrent(m_displayObj, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-#endif
 
     if (m_surfaceObj)
         EGL_DestroySurface(m_displayObj, m_surfaceObj);
@@ -316,8 +310,11 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitializeContext()
     eglContextAttributes.append(EGL_NONE);
 
 #if PLATFORM(WIN)
+    // On the Windows port, the ANGLE sharingContext is a singleton.
     m_contextObj = EGL_CreateContext(m_displayObj, m_configObj, sharedDisplay.angleSharingGLContext(), eglContextAttributes.span().data());
 #else
+    // On GTK and WPE ports, the ANGLE sharingContext is not a singleton, so we need to check whether it's properly
+    // created and keep a reference to it for destruction.
     m_angleSharingContextObj = sharedDisplay.angleSharingGLContext();
     if (m_angleSharingContextObj == EGL_NO_CONTEXT) {
         LOG(WebGL, "ANGLE sharing EGLContext Initialization failed.");


### PR DESCRIPTION
#### 7d9718365dbfed57f6005c72ca9f6f38c22679b0
<pre>
[GTK][WPE] Make ANGLE WebGL context not current before its destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=300614">https://bugs.webkit.org/show_bug.cgi?id=300614</a>

Reviewed by NOBODY (OOPS!).

Make the ANGLE context not current before its destruction. Also add some comments to clarify
that GTK/WPE ports don&apos;t use a singleton ANGLE sharingContext, while the Windows port does.
This means that GTK/WPE need to destroy the sharingContext while Windows doesn&apos;t need to do it.

* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::~GraphicsContextGLANGLE):
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitializeContext):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d9718365dbfed57f6005c72ca9f6f38c22679b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132771 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77765 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54121 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95917 "Found 3 new test failures: webgl/2.0.y/conformance/extensions/ext-texture-mirror-clamp-to-edge.html webgl/2.0.y/conformance2/samplers/sampler-drawing-test.html webgl/2.0.y/conformance2/samplers/samplers.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64020 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76408 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30770 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76243 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135454 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40419 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104388 "Found 1 new test failure: webgl/2.0.y/conformance2/misc/expando-loss-2.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104115 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49487 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27804 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50057 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52580 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58392 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51923 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55274 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->