### PR TITLE
Introduce AbstractCanMakeCheckedPtr class in WTF to reduce code duplication

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		4448265228D18CA600D916F9 /* NotificationCenterCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 4448265128D18CA600D916F9 /* NotificationCenterCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4606FEE72B1E901800D704F1 /* WeakRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 4606FEE62B1E901800D704F1 /* WeakRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		461229722ACF6B3100BB1CCC /* FastCharacterComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4628C0952E9D026A00462A50 /* AbstractCanMakeCheckedPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 4628C0942E9D026A00462A50 /* AbstractCanMakeCheckedPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46335BED2E778B1300860373 /* DispatchExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 46335BEC2E778B1300860373 /* DispatchExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		463CCFBC2B251D77009AB04E /* SingleThreadIntegralWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46449E8B2822E5680005A8BC /* WeakHashCountedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1298,6 +1299,7 @@
 		4606FEE62B1E901800D704F1 /* WeakRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakRef.h; sourceTree = "<group>"; };
 		461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FastCharacterComparison.h; sourceTree = "<group>"; };
 		46209A27266D543A007F8F4A /* CancellableTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CancellableTask.h; sourceTree = "<group>"; };
+		4628C0942E9D026A00462A50 /* AbstractCanMakeCheckedPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AbstractCanMakeCheckedPtr.h; sourceTree = "<group>"; };
 		46335BEC2E778B1300860373 /* DispatchExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DispatchExtras.h; sourceTree = "<group>"; };
 		463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingleThreadIntegralWrapper.h; sourceTree = "<group>"; };
 		46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakHashCountedSet.h; sourceTree = "<group>"; };
@@ -2275,6 +2277,7 @@
 				A8A4731B151A825B004123FF /* text */,
 				A8A47339151A825B004123FF /* threads */,
 				A8A47348151A825B004123FF /* unicode */,
+				4628C0942E9D026A00462A50 /* AbstractCanMakeCheckedPtr.h */,
 				144EB7452CBC94B100926E1B /* AbstractRefCounted.h */,
 				1404B3E42CBC954D00A7471C /* AbstractRefCountedAndCanMakeWeakPtr.h */,
 				5363861E2CFE391C0034E883 /* AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h */,
@@ -3392,6 +3395,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4628C0952E9D026A00462A50 /* AbstractCanMakeCheckedPtr.h in Headers */,
 				144EB7462CBC94B100926E1B /* AbstractRefCounted.h in Headers */,
 				1404B3E52CBC954D00A7471C /* AbstractRefCountedAndCanMakeWeakPtr.h in Headers */,
 				5363861F2CFE391C0034E883 /* AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h in Headers */,

--- a/Source/WTF/wtf/AbstractCanMakeCheckedPtr.h
+++ b/Source/WTF/wtf/AbstractCanMakeCheckedPtr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Sony Interactive Entertainment Inc.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -9,7 +9,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
  * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
@@ -25,18 +25,21 @@
 
 #pragma once
 
-#include <wtf/AbstractCanMakeCheckedPtr.h>
+namespace WTF {
 
-namespace WebCore {
-
-class CurlMultipartHandleClient : public AbstractCanMakeCheckedPtr {
+// Use this class when an abstract base class needs CheckedPtr/CheckedRef support, and the
+// CanMakeCheckedPtr implementation will be in a concrete subclass.
+class AbstractCanMakeCheckedPtr {
 public:
-    virtual void didReceiveHeaderFromMultipart(Vector<String>&&) = 0;
-    virtual void didReceiveDataFromMultipart(std::span<const uint8_t>) = 0;
-    virtual void didCompleteFromMultipart() = 0;
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 
 protected:
-    ~CurlMultipartHandleClient() { }
+    virtual ~AbstractCanMakeCheckedPtr() = default;
 };
 
-} // namespace WebCore
+} // namespace WTF
+
+using WTF::AbstractCanMakeCheckedPtr;

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -3,6 +3,7 @@ if (ENABLE_MALLOC_HEAP_BREAKDOWN AND NOT APPLE)
 endif ()
 
 set(WTF_PUBLIC_HEADERS
+    AbstractCanMakeCheckedPtr.h
     AbstractRefCounted.h
     AbstractRefCountedAndCanMakeWeakPtr.h
     AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h

--- a/Source/WebCore/Modules/badge/WorkerBadgeProxy.h
+++ b/Source/WebCore/Modules/badge/WorkerBadgeProxy.h
@@ -26,20 +26,15 @@
 #pragma once
 
 #include <optional>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 
 namespace WebCore {
 
-class WorkerBadgeProxy {
+class WorkerBadgeProxy : public AbstractCanMakeCheckedPtr {
 public:
     virtual ~WorkerBadgeProxy() = default;
 
     virtual void setAppBadge(std::optional<uint64_t>) = 0;
-
-    // CanMakeCheckedPtr.
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/push-api/PushStrategy.h
+++ b/Source/WebCore/Modules/push-api/PushStrategy.h
@@ -29,6 +29,7 @@
 #include <WebCore/PushPermissionState.h>
 #include <WebCore/PushSubscriptionData.h>
 #include <WebCore/PushSubscriptionIdentifier.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -36,7 +37,7 @@ namespace WebCore {
 
 template<typename> class ExceptionOr;
 
-class WEBCORE_EXPORT PushStrategy {
+class WEBCORE_EXPORT PushStrategy : public AbstractCanMakeCheckedPtr {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(PushStrategy);
 public:
     virtual ~PushStrategy() = default;
@@ -52,12 +53,6 @@ public:
 
     using GetPushPermissionStateCallback = CompletionHandler<void(ExceptionOr<PushPermissionState>&&)>;
     virtual void windowGetPushPermissionState(const URL& scope, GetPushPermissionStateCallback&&) = 0;
-
-    // CheckedPtr interface.
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PendingScriptClient.h
+++ b/Source/WebCore/dom/PendingScriptClient.h
@@ -25,21 +25,15 @@
 
 #pragma once
 
-#include <wtf/CheckedRef.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 
 namespace WebCore {
 
 class PendingScript;
 
-class PendingScriptClient {
+class PendingScriptClient : public AbstractCanMakeCheckedPtr {
 public:
     virtual ~PendingScriptClient() = default;
-
-    // CheckedPtr interface
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
 
     virtual void notifyFinished(PendingScript&) = 0;
 };

--- a/Source/WebCore/platform/PopupMenuClient.h
+++ b/Source/WebCore/platform/PopupMenuClient.h
@@ -25,6 +25,7 @@
 #include <WebCore/LayoutUnit.h>
 #include <WebCore/PopupMenuStyle.h>
 #include <WebCore/ScrollTypes.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -35,7 +36,7 @@ class HostWindow;
 class Scrollbar;
 class ScrollableArea;
 
-class PopupMenuClient {
+class PopupMenuClient : public AbstractCanMakeCheckedPtr {
 public:
     virtual ~PopupMenuClient() = default;
     virtual void valueChanged(unsigned listIndex, bool fireEvents = true) = 0;
@@ -74,12 +75,6 @@ public:
     virtual HostWindow* hostWindow() const = 0;
 
     virtual Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth) = 0;
-
-    // CheckedPtr interface.
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
 };
 
 }

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -51,14 +51,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollableArea);
 
-struct SameSizeAsScrollableArea : public CanMakeWeakPtr<SameSizeAsScrollableArea> {
+struct SameSizeAsScrollableArea : public CanMakeWeakPtr<SameSizeAsScrollableArea>, public AbstractCanMakeCheckedPtr {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(SameSizeAsScrollableArea);
-
-    // CheckedPtr interface
-    virtual uint32_t checkedPtrCount() const { return 0; }
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const { return 0; }
-    virtual void incrementCheckedPtrCount() const { }
-    virtual void decrementCheckedPtrCount() const { }
 
     virtual ~SameSizeAsScrollableArea() { }
     SameSizeAsScrollableArea() { }

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -32,6 +32,7 @@
 #include <WebCore/ScrollSnapOffsetsInfo.h>
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/Scrollbar.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/Platform.h>
@@ -72,15 +73,9 @@ inline int offsetForOrientation(ScrollOffset offset, ScrollbarOrientation orient
     return 0;
 }
 
-class ScrollableArea : public CanMakeWeakPtr<ScrollableArea> {
+class ScrollableArea : public CanMakeWeakPtr<ScrollableArea>, public AbstractCanMakeCheckedPtr {
     WTF_MAKE_TZONE_ALLOCATED(ScrollableArea);
 public:
-    // CheckedPtr interface
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
-
     virtual bool isScrollView() const { return false; }
     virtual bool isRenderLayer() const { return false; }
     virtual bool isListBox() const { return false; }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -31,7 +31,7 @@
 #include <WebCore/NowPlayingMetadataObserver.h>
 #include <WebCore/PlatformMediaSession.h>
 #include <WebCore/VideoReceiverEndpoint.h>
-#include <wtf/CheckedRef.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
@@ -63,17 +63,11 @@ enum class PlaybackSessionModelPlaybackState : uint8_t {
     Stalled = 1 << 1,
 };
 
-class PlaybackSessionModel : public CanMakeWeakPtr<PlaybackSessionModel> {
+class PlaybackSessionModel : public CanMakeWeakPtr<PlaybackSessionModel>, public AbstractCanMakeCheckedPtr {
 public:
     virtual ~PlaybackSessionModel() { };
     virtual void addClient(PlaybackSessionModelClient&) = 0;
     virtual void removeClient(PlaybackSessionModelClient&) = 0;
-
-    // CheckedPtr interface
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
 
     virtual void play() = 0;
     virtual void pause() = 0;
@@ -160,15 +154,9 @@ public:
 #endif
 };
 
-class PlaybackSessionModelClient : public CanMakeWeakPtr<PlaybackSessionModelClient> {
+class PlaybackSessionModelClient : public CanMakeWeakPtr<PlaybackSessionModelClient>, public AbstractCanMakeCheckedPtr {
 public:
     virtual ~PlaybackSessionModelClient() { };
-
-    // CheckedPtr interface
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
 
     virtual void durationChanged(double) { }
     virtual void currentTimeChanged(double /* currentTime */, double /* anchorTime */) { }

--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -35,6 +35,7 @@
 #include <WebCore/MediaPlayerEnums.h>
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/PlaybackSessionModel.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/WeakPtr.h>
@@ -116,15 +117,9 @@ public:
 #endif
 };
 
-class VideoPresentationModelClient : public CanMakeWeakPtr<VideoPresentationModelClient> {
+class VideoPresentationModelClient : public CanMakeWeakPtr<VideoPresentationModelClient>, public AbstractCanMakeCheckedPtr {
 public:
     virtual ~VideoPresentationModelClient() = default;
-
-    // CheckedPtr interface
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
 
     virtual void hasVideoChanged(bool) { }
     virtual void videoDimensionsChanged(const FloatSize&) { }

--- a/Source/WebCore/platform/graphics/RenderingResource.h
+++ b/Source/WebCore/platform/graphics/RenderingResource.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/RenderingResourceIdentifier.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakHashSet.h>
 
@@ -36,16 +37,10 @@ class DisplayList;
 class Gradient;
 class NativeImage;
 
-class RenderingResourceObserver {
+class RenderingResourceObserver : public AbstractCanMakeCheckedPtr {
 public:
     using WeakValueType = RenderingResourceObserver;
     virtual ~RenderingResourceObserver() = default;
-
-    // CheckedPtr interface.
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
 
     virtual void willDestroyNativeImage(const NativeImage&) = 0;
     virtual void willDestroyGradient(const Gradient&) = 0;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -48,6 +48,7 @@
 #include <WebCore/RealtimeMediaSourceFactory.h>
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
 #include <WebCore/VideoFrameTimeMetadata.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
@@ -125,15 +126,9 @@ class WEBCORE_EXPORT RealtimeMediaSource : public AbstractThreadSafeRefCountedAn
 #endif
 {
 public:
-    class AudioSampleObserver {
+    class AudioSampleObserver : public AbstractCanMakeCheckedPtr {
     public:
         virtual ~AudioSampleObserver() = default;
-
-        // CheckedPtr interface
-        virtual uint32_t checkedPtrCount() const = 0;
-        virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-        virtual void incrementCheckedPtrCount() const = 0;
-        virtual void decrementCheckedPtrCount() const = 0;
 
         // May be called on a background thread.
         virtual void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t /*numberOfFrames*/) = 0;

--- a/Source/WebCore/workers/WorkerDebuggerProxy.h
+++ b/Source/WebCore/workers/WorkerDebuggerProxy.h
@@ -30,21 +30,16 @@
 
 #pragma once
 
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class WorkerDebuggerProxy {
+class WorkerDebuggerProxy : public AbstractCanMakeCheckedPtr {
 public:
     virtual ~WorkerDebuggerProxy() = default;
     virtual void postMessageToDebugger(const String&) = 0;
     virtual void setResourceCachingDisabledByWebInspector(bool) = 0;
-
-    // CanMakeCheckedPtr.
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerLoaderProxy.h
+++ b/Source/WebCore/workers/WorkerLoaderProxy.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <WebCore/ScriptExecutionContext.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 
 namespace WebCore {
 
@@ -40,7 +41,7 @@ struct ReportingClient;
 
 // A proxy to talk to the loader context. Normally, the document on the main thread
 // provides loading services for the subordinate workers.
-class WorkerLoaderProxy {
+class WorkerLoaderProxy : public AbstractCanMakeCheckedPtr {
 public:
     virtual ~WorkerLoaderProxy() = default;
 
@@ -56,12 +57,6 @@ public:
 
     // Posts a task to the thread which runs the loading code (normally, the main thread).
     virtual void postTaskToLoader(ScriptExecutionContext::Task&&) = 0;
-
-    // CanMakeCheckedPtr.
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerReportingProxy.h
+++ b/Source/WebCore/workers/WorkerReportingProxy.h
@@ -30,13 +30,12 @@
 
 #pragma once
 
-#include <wtf/CheckedPtr.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 
 namespace WebCore {
 
-class WorkerReportingProxy : public CanMakeThreadSafeCheckedPtr<WorkerReportingProxy> {
+class WorkerReportingProxy : public AbstractCanMakeCheckedPtr {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(WorkerReportingProxy);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerReportingProxy);
 public:
     virtual ~WorkerReportingProxy() = default;
 
@@ -49,12 +48,6 @@ public:
 
     // Invoked when the thread has stopped.
     virtual void workerGlobalScopeDestroyed() = 0;
-
-    // CanMakeCheckedPtr.
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
@@ -33,6 +33,7 @@
 #include "UseDownloadPlaceholder.h"
 #include <WebCore/LocalFrameLoaderClient.h>
 #include <WebCore/NotImplemented.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/AbstractRefCounted.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
@@ -71,15 +72,9 @@ class DownloadManager : public CanMakeCheckedPtr<DownloadManager> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DownloadManager);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DownloadManager);
 public:
-    class Client : public AbstractRefCounted {
+    class Client : public AbstractRefCounted, public AbstractCanMakeCheckedPtr {
     public:
         virtual ~Client() { }
-
-        // CheckedPtr interface
-        virtual uint32_t checkedPtrCount() const = 0;
-        virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-        virtual void incrementCheckedPtrCount() const = 0;
-        virtual void decrementCheckedPtrCount() const = 0;
 
         virtual void didCreateDownload() = 0;
         virtual void didDestroyDownload() = 0;

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -27,6 +27,7 @@
 
 #include "Connection.h"
 #include <WebCore/ProcessIdentifier.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/ProcessID.h>
@@ -121,7 +122,7 @@ public:
     using ProcessType = ProcessLaunchType;
     using LaunchOptions = ProcessLaunchOptions;
 
-    class Client {
+    class Client : public AbstractCanMakeCheckedPtr {
     public:
         virtual ~Client() { }
         
@@ -137,12 +138,6 @@ public:
 #if PLATFORM(COCOA)
         virtual RefPtr<XPCEventHandler> xpcEventHandler() const { return nullptr; }
 #endif
-
-        // CanMakeCheckedPtr.
-        virtual uint32_t checkedPtrCount() const = 0;
-        virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-        virtual void incrementCheckedPtrCount() const = 0;
-        virtual void decrementCheckedPtrCount() const = 0;
     };
 
     static Ref<ProcessLauncher> create(Client* client, LaunchOptions&& launchOptions)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -33,6 +33,7 @@
 #include "RemoteImageBufferSetConfiguration.h"
 #include "RenderingUpdateID.h"
 #include "WorkQueueMessageReceiver.h"
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Identified.h>
 #include <wtf/Lock.h>
@@ -69,15 +70,9 @@ public:
     virtual bool flushAndCollectHandles(HashMap<ImageBufferSetIdentifier, std::unique_ptr<BufferSetBackendHandle>>&) = 0;
 };
 
-class ImageBufferSetClient {
+class ImageBufferSetClient : public AbstractCanMakeCheckedPtr {
 public:
     virtual ~ImageBufferSetClient() = default;
-
-    // CheckedPtr interface
-    virtual uint32_t checkedPtrCount() const = 0;
-    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
-    virtual void incrementCheckedPtrCount() const = 0;
-    virtual void decrementCheckedPtrCount() const = 0;
 
     virtual void setNeedsDisplay() = 0;
 };


### PR DESCRIPTION
#### a3663fe33eaf9d90cfe9358bc0ba29d211b096e9
<pre>
Introduce AbstractCanMakeCheckedPtr class in WTF to reduce code duplication
<a href="https://bugs.webkit.org/show_bug.cgi?id=300619">https://bugs.webkit.org/show_bug.cgi?id=300619</a>

Reviewed by Darin Adler.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/AbstractCanMakeCheckedPtr.h: Copied from Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h.
* Source/WTF/wtf/CMakeLists.txt:
* Source/WebCore/Modules/badge/WorkerBadgeProxy.h:
* Source/WebCore/Modules/push-api/PushStrategy.h:
* Source/WebCore/dom/PendingScriptClient.h:
* Source/WebCore/platform/PopupMenuClient.h:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::SameSizeAsScrollableArea::checkedPtrCount const): Deleted.
(WebCore::SameSizeAsScrollableArea::checkedPtrCountWithoutThreadCheck const): Deleted.
(WebCore::SameSizeAsScrollableArea::incrementCheckedPtrCount const): Deleted.
(WebCore::SameSizeAsScrollableArea::decrementCheckedPtrCount const): Deleted.
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
* Source/WebCore/platform/graphics/RenderingResource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h:
* Source/WebCore/workers/WorkerDebuggerProxy.h:
* Source/WebCore/workers/WorkerLoaderProxy.h:
* Source/WebCore/workers/WorkerReportingProxy.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.h:
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:

Canonical link: <a href="https://commits.webkit.org/301440@main">https://commits.webkit.org/301440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dba48a8b7e5113dc0f46f4f6855b101728d1cf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77772 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/987a8aba-cdd3-4c22-96bb-ee507e4447fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95929 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64024 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b9eecb1-5ac8-49fc-a6bd-87844e26a25f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76420 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4864b3bc-3870-4342-89eb-e4642196b70c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35900 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30780 "Found 1 new test failure: imported/w3c/web-platform-tests/encoding/streams/stringification-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76251 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117989 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135462 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124416 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104398 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104122 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26531 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49495 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27814 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50067 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52588 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58400 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157429 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51931 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39419 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55282 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53630 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->