### PR TITLE
Speculation Rules - fire error events when rules are invalid

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/inline-speculation-rules-errors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/inline-speculation-rules-errors-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT A script with invalid JSON should fire error events on the element and window Test timed out
+PASS A script with invalid JSON should fire error events on the element and window
 

--- a/Source/WebCore/loader/SpeculationRules.cpp
+++ b/Source/WebCore/loader/SpeculationRules.cpp
@@ -364,9 +364,8 @@ bool SpeculationRules::parseSpeculationRules(const StringView& text, const URL& 
     }
 
     auto prefetch = parseRules(*jsonObject, "prefetch"_s, rulesetLevelTag, rulesetBaseURL, documentBaseURL);
-    if (!prefetch)
-        return false;
-    m_prefetchRules.appendVector(WTFMove(*prefetch));
+    if (prefetch)
+        m_prefetchRules.appendVector(WTFMove(*prefetch));
     return true;
 }
 


### PR DESCRIPTION
#### 11f4ab9a5edd429ea3a381152a14ff35fda5c283
<pre>
Speculation Rules - fire error events when rules are invalid
<a href="https://bugs.webkit.org/show_bug.cgi?id=300622">https://bugs.webkit.org/show_bug.cgi?id=300622</a>

Reviewed by Alex Christensen.

When invalid speculation rules are encountered, this PR triggers an error event on the speculation rules script element, as well as a global one.
This aligns the implementation with the spec, and gets the relevant test to pass.

No new tests, but an existing test expectation is fixed.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/inline-speculation-rules-errors-expected.txt: Progression.
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::reportSpeculationRulesError): <a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception</a>
(WebCore::ScriptElement::registerSpeculationRules): Report errors if registration failed.
* Source/WebCore/loader/SpeculationRules.cpp:
(WebCore::SpeculationRules::parseSpeculationRules):

Canonical link: <a href="https://commits.webkit.org/302629@main">https://commits.webkit.org/302629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3991e6f15c3fc755a630538e82cc587064689f0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132791 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77781 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95936 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64029 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76427 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30789 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106781 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135473 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104407 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104131 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27291 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49501 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27822 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50078 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52599 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58411 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51942 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55292 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->