### PR TITLE
Speculation Rules: do not cache unsuccessful responses

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-http-cache-interference.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-http-cache-interference.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Check that the HTTP cache doesn't cache when the server conditionally responds with 503 for prefetch requests. assert_equals: Should use the non-prefetched 200, instead of the prefetched 503 expected "200" but got "503"
+PASS Check that the HTTP cache doesn't cache when the server conditionally responds with 503 for prefetch requests.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=400&should_prefetch=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=400&should_prefetch=false-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Check that only prefetched requests with status in 200-299 range are used. assert_equals: Prefetch should not work for request statue:400. expected (undefined) undefined but got (string) "prefetch"
+PASS Check that only prefetched requests with status in 200-299 range are used.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=500&should_prefetch=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=500&should_prefetch=false-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Check that only prefetched requests with status in 200-299 range are used. assert_equals: Prefetch should not work for request statue:500. expected (undefined) undefined but got (string) "prefetch"
+PASS Check that only prefetched requests with status in 200-299 range are used.
 

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -34,6 +34,7 @@
 #include "DocumentLoader.h"
 #include "Frame.h"
 #include "FrameLoader.h"
+#include "MemoryCache.h"
 #include "ReferrerPolicy.h"
 #include "ResourceRequest.h"
 #include "SecurityOrigin.h"
@@ -161,6 +162,11 @@ void DocumentPrefetcher::notifyFinished(CachedResource& resource, const NetworkL
     auto it = m_prefetchedData.find(resourceURL);
     if (it != m_prefetchedData.end())
         it->value.metrics = Box<NetworkLoadMetrics>::create(metrics);
+
+    if (!resource.response().isSuccessful()) {
+        m_prefetchedData.remove(resourceURL);
+        MemoryCache::singleton().remove(resource);
+    }
 
     if (resource.hasClient(*this))
         resource.removeClient(*this);


### PR DESCRIPTION
#### c83dad436f35ea948b07714d2a22490316b59aea
<pre>
Speculation Rules: do not cache unsuccessful responses
<a href="https://bugs.webkit.org/show_bug.cgi?id=300624">https://bugs.webkit.org/show_bug.cgi?id=300624</a>

Reviewed by Alex Christensen.

This PR ensures that non-successful HTTP responses to prefetched resources do not get served from the memory cache, by removing them as part of notifyFinished.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-http-cache-interference.https-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=400&amp;should_prefetch=false-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=500&amp;should_prefetch=false-expected.txt: Progression.
* Source/WebCore/loader/DocumentPrefetcher.cpp:
(WebCore::DocumentPrefetcher::notifyFinished): Remove non-successful responses from the memory cache.

Canonical link: <a href="https://commits.webkit.org/302649@main">https://commits.webkit.org/302649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/099f982d8b12a1ccf701e8666a4d69c1e8e2e08c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81241 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98859 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66679 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34358 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80433 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139643 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1707 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107365 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107240 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27301 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1478 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31063 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54594 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1899 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65268 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->