### PR TITLE
[iOS][WebContent] Block iopolicysys syscall in sandbox

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.Development.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.Development.sb.in
@@ -306,7 +306,3 @@
         (require-any
             (apply subpath issue-extension-secondary-paths))))
 #endif
-
-#if __has_include(<WebKitAdditions/WebContentSandbox-ios.defs>)
-#include <WebKitAdditions/WebContentSandbox-ios.defs>
-#endif

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -44,6 +44,9 @@
 
 (deny file-write-mount file-write-unmount)
 
+(deny process-iopolicy-get (with telemetry))
+(deny process-iopolicy-set (with telemetry))
+
 (allow file-read-metadata
     (vnode-type DIRECTORY))
 
@@ -537,8 +540,4 @@
         (extension-class "com.apple.mediaserverd.read")
         (require-any
             (apply subpath issue-extension-secondary-paths))))
-#endif
-
-#if __has_include(<WebKitAdditions/WebContentSandbox-ios.defs>)
-#include <WebKitAdditions/WebContentSandbox-ios.defs>
 #endif

--- a/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
@@ -391,7 +391,6 @@
     (syscall-number
         SYS_fgetxattr
         SYS_getxattr
-        SYS_iopolicysys
         SYS_psynch_rw_wrlock
 #if ASAN_ENABLED
         SYS_sigaltstack


### PR DESCRIPTION
#### 6b5ffb6a2a25216611c0ab417f928921d371578a
<pre>
[iOS][WebContent] Block iopolicysys syscall in sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=300630">https://bugs.webkit.org/show_bug.cgi?id=300630</a>
<a href="https://rdar.apple.com/162528753">rdar://162528753</a>

Reviewed by Brent Fulgham.

This syscall is rarely used, and the client is handling the blocking gracefully, so it can be blocked.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.Development.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb:

Canonical link: <a href="https://commits.webkit.org/301474@main">https://commits.webkit.org/301474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2118730e89dfd00984b1a279d79e8218a0b320ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77792 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/749a919c-a22d-4ae7-a0cc-39380bc29493) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95946 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64040 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47d7e0d9-5320-4c16-9f90-9ae3c27ff4dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76435 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2910848e-50c1-4a46-af3a-9c94b42bb5f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35921 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76273 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106795 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135488 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104418 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104138 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49513 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27839 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50098 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19719 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52612 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58424 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51956 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55305 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53654 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->