### PR TITLE
Fix the JavaScriptCore build in some configurations

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -240,7 +240,7 @@ PAS_API PAS_NO_RETURN PAS_NEVER_INLINE void pas_reallocation_did_fail(const char
 static PAS_ALWAYS_INLINE PAS_NO_RETURN void pas_assertion_failed(
     const char* filename, int line, const char* function, const char* expression)
 {
-    asm volatile("" : "=r"(filename), "=r"(line), "=r"(function), "=r"(expression));
+    __asm__ volatile("" : "=r"(filename), "=r"(line), "=r"(function), "=r"(expression));
     __builtin_unreachable();
 }
 
@@ -264,7 +264,7 @@ static PAS_ALWAYS_INLINE PAS_NO_RETURN void pas_assertion_failed(
 {
 #if PAS_COMPILER(GCC) || PAS_COMPILER(CLANG)
     // Force each assertion crash site to be unique.
-    asm volatile("" : "=r"(filename), "=r"(line), "=r"(function), "=r"(expression));
+    __asm__ volatile("" : "=r"(filename), "=r"(line), "=r"(function), "=r"(expression));
 #endif
     __builtin_trap();
 }
@@ -537,7 +537,7 @@ static inline unsigned pas_reverse(unsigned value)
 {
 #if PAS_ARM64
     unsigned result;
-    asm ("rbit %w0, %w1"
+    __asm__ ("rbit %w0, %w1"
          : "=r"(result)
          : "r"(value));
     return result;
@@ -554,7 +554,7 @@ static inline uint64_t pas_reverse64(uint64_t value)
 {
 #if PAS_ARM64
     uint64_t result;
-    asm ("rbit %0, %1"
+    __asm__ ("rbit %0, %1"
          : "=r"(result)
          : "r"(value));
     return result;
@@ -575,7 +575,7 @@ static inline uint64_t pas_make_mask64(uint64_t num_bits)
 static inline void pas_atomic_store_uint8(uint8_t* ptr, uint8_t value)
 {
 #if PAS_COMPILER(ARM64_ATOMICS_LL_SC)
-    asm volatile (
+    __asm__ volatile (
         "stlrb %w[value], [%x[ptr]]\t\n"
         /* outputs */  :
         /* inputs  */  : [value]"r"(value), [ptr]"r"(ptr)
@@ -595,7 +595,7 @@ static inline bool pas_compare_and_swap_uint8_weak(uint8_t* ptr, uint8_t old_val
 #if PAS_COMPILER(ARM64_ATOMICS_LL_SC)
     uint32_t value = 0;
     uint32_t cond = 0;
-    asm volatile (
+    __asm__ volatile (
         "ldxrb %w[value], [%x[ptr]]\t\n"
         "cmp %w[value], %w[old_value], uxtb\t\n"
         "b.ne 1f\t\n"
@@ -628,7 +628,7 @@ static inline uint8_t pas_compare_and_swap_uint8_strong(uint8_t* ptr, uint8_t ol
 #if PAS_COMPILER(ARM64_ATOMICS_LL_SC)
     uint32_t value = 0;
     uint32_t cond = 0;
-    asm volatile (
+    __asm__ volatile (
     "0:\t\n"
         "ldxrb %w[value], [%x[ptr]]\t\n"
         "cmp %w[value], %w[old_value], uxtb\t\n"
@@ -659,7 +659,7 @@ static inline bool pas_compare_and_swap_uint16_weak(uint16_t* ptr, uint16_t old_
 #if PAS_COMPILER(ARM64_ATOMICS_LL_SC)
     uint32_t value = 0;
     uint32_t cond = 0;
-    asm volatile (
+    __asm__ volatile (
         "ldxrh %w[value], [%x[ptr]]\t\n"
         "cmp %w[value], %w[old_value], uxth\t\n"
         "b.ne 1f\t\n"
@@ -692,7 +692,7 @@ static inline bool pas_compare_and_swap_uint32_weak(uint32_t* ptr, uint32_t old_
 #if PAS_COMPILER(ARM64_ATOMICS_LL_SC)
     uint32_t value = 0;
     uint32_t cond = 0;
-    asm volatile (
+    __asm__ volatile (
         "ldxr %w[value], [%x[ptr]]\t\n"
         "cmp %w[value], %w[old_value]\t\n"
         "b.ne 1f\t\n"
@@ -725,7 +725,7 @@ static inline uint32_t pas_compare_and_swap_uint32_strong(uint32_t* ptr, uint32_
 #if PAS_COMPILER(ARM64_ATOMICS_LL_SC)
     uint32_t value = 0;
     uint32_t cond = 0;
-    asm volatile (
+    __asm__ volatile (
     "0:\t\n"
         "ldxr %w[value], [%x[ptr]]\t\n"
         "cmp %w[value], %w[old_value]\t\n"
@@ -756,7 +756,7 @@ static inline bool pas_compare_and_swap_uint64_weak(uint64_t* ptr, uint64_t old_
 #if PAS_COMPILER(ARM64_ATOMICS_LL_SC)
     uint64_t value = 0;
     uint64_t cond = 0;
-    asm volatile (
+    __asm__ volatile (
         "ldxr %x[value], [%x[ptr]]\t\n"
         "cmp %x[value], %x[old_value]\t\n"
         "b.ne 1f\t\n"
@@ -789,7 +789,7 @@ static inline uint64_t pas_compare_and_swap_uint64_strong(uint64_t* ptr, uint64_
 #if PAS_COMPILER(ARM64_ATOMICS_LL_SC)
     uint64_t value = 0;
     uint64_t cond = 0;
-    asm volatile (
+    __asm__ volatile (
     "0:\t\n"
         "ldxr %x[value], [%x[ptr]]\t\n"
         "cmp %x[value], %x[old_value]\t\n"
@@ -867,14 +867,14 @@ static PAS_ALWAYS_INLINE void pas_fence_after_load(void)
 static PAS_ALWAYS_INLINE void pas_store_store_fence(void)
 {
     if (PAS_ARM)
-        asm volatile ("dmb ishst" : : : "memory");
+        __asm__ volatile ("dmb ishst" : : : "memory");
     else
         pas_compiler_fence();
 }
 
 static PAS_ALWAYS_INLINE uintptr_t pas_opaque(uintptr_t value)
 {
-    asm volatile ("" : "+r"(value) : : "memory");
+    __asm__ volatile ("" : "+r"(value) : : "memory");
     return value;
 }
 
@@ -939,7 +939,7 @@ static inline bool pas_compare_and_swap_pair_weak(void* raw_ptr,
     uintptr_t new_high = pas_pair_high(new_value);
     uintptr_t cond = 0;
     uintptr_t temp = 0;
-    asm volatile (
+    __asm__ volatile (
         "ldxp %x[low], %x[high], [%x[ptr]]\t\n"
         "eor %x[cond], %x[high], %x[old_high]\t\n"
         "eor %x[temp], %x[low], %x[old_low]\t\n"
@@ -986,7 +986,7 @@ static inline pas_pair pas_compare_and_swap_pair_strong(void* raw_ptr,
     uintptr_t new_high = pas_pair_high(new_value);
     uintptr_t cond = 0;
     uintptr_t temp = 0;
-    asm volatile (
+    __asm__ volatile (
     "0:\t\n"
         "ldxp %x[low], %x[high], [%x[ptr]]\t\n"
         "eor %x[cond], %x[high], %x[old_high]\t\n"
@@ -1037,7 +1037,7 @@ static inline void pas_atomic_store_pair(void* raw_ptr, pas_pair value)
     uintptr_t low = pas_pair_low(value);
     uintptr_t high = pas_pair_high(value);
     uintptr_t cond = 0;
-    asm volatile (
+    __asm__ volatile (
     "0:\t\n"
         "ldxp xzr, %x[cond], [%x[ptr]]\t\n"
         "stlxp %w[cond], %x[low], %x[high], [%x[ptr]]\t\n"
@@ -1073,7 +1073,7 @@ static PAS_ALWAYS_INLINE bool pas_compare_ptr_opaque(uintptr_t a, uintptr_t b)
 #if PAS_COMPILER(CLANG)
 #if PAS_ARM64
     uint32_t cond = 0;
-    asm volatile (
+    __asm__ volatile (
         "cmp %x[a], %x[b]\t\n"
         "cset %w[cond], eq\t\n"
         /* outputs */  : [cond]"=&r"(cond)

--- a/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h
@@ -97,16 +97,16 @@ static inline __pas_size_t __pas_round_up_to_power_of_2(__pas_size_t size, __pas
 
 static __PAS_ALWAYS_INLINE void __pas_compiler_fence(void)
 {
-    asm volatile("" ::: "memory");
+    __asm__ volatile("" ::: "memory");
 }
 
 static __PAS_ALWAYS_INLINE void __pas_fence(void)
 {
 #if !__PAS_ARM && !__PAS_RISCV
     if (sizeof(void*) == 8)
-        asm volatile("lock; orl $0, (%%rsp)" ::: "memory");
+        __asm__ volatile("lock; orl $0, (%%rsp)" ::: "memory");
     else
-        asm volatile("lock; orl $0, (%%esp)" ::: "memory");
+        __asm__ volatile("lock; orl $0, (%%esp)" ::: "memory");
 #else
     __atomic_thread_fence(__ATOMIC_SEQ_CST);
 #endif
@@ -126,13 +126,13 @@ static __PAS_ALWAYS_INLINE unsigned __pas_depend_impl(unsigned long input, int c
     // dependent loads in their store order without the reader using a barrier
     // or an acquire load.
     __PAS_UNUSED_PARAM(cpu_only);
-    asm volatile ("eor %w[out], %w[in], %w[in]"
+    __asm__ volatile ("eor %w[out], %w[in], %w[in]"
                   : [out] "=r"(output)
                   : [in] "r"(input)
                   : "memory");
 #elif __PAS_ARM
     __PAS_UNUSED_PARAM(cpu_only);
-    asm volatile ("eor %[out], %[in], %[in]"
+    __asm__ volatile ("eor %[out], %[in], %[in]"
                   : [out] "=r"(output)
                   : [in] "r"(input)
                   : "memory");


### PR DESCRIPTION
#### b79359af12175bca7258e35b49c98208eca3cbf2
<pre>
Fix the JavaScriptCore build in some configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=300635">https://bugs.webkit.org/show_bug.cgi?id=300635</a>
<a href="https://rdar.apple.com/162411683">rdar://162411683</a>

Reviewed by Keith Miller.

First, some background:

1. The `asm` keyword is a supported keyword in C++, and GNU C. Notably however, it does not exist in non-GNU C standards.
Instead, the alternative keyword `__asm__` exists to serve the same purpose.

2. The bmalloc module map consists of a `pas` submodule, which participates in header fusion. This means that if a client
uses any of the headers in it, it implicitly imports all the other headers. This is expected and desired behavior.

3. The JavaScriptCore private module map defines a submodule &quot;PASReportCrashPrivate&quot; which contains the associated header,
and PASReportCrashPrivate.h transitively depends on at least one of the headers in the `bmalloc.pas` modules.

4. Within the bmalloc.pas module is pas_utils.h and pas_utils_prefix.h, both of which use the `asm` keyword.

As a result of all of these, the JavaScriptCore private module map depends on the existence of the `asm` keyword in all cases,
whereas before it was limited to the inclusion of specific headers. Consequently, any non-GNU C clients of the JavaScriptCore private
module will fail to compile because `asm` does not exist.

Fix by moving to `__asm__` which is available everywhere.

* Source/bmalloc/libpas/src/libpas/pas_utils.h:
(pas_assertion_failed):
(pas_reverse):
(pas_reverse64):
(pas_atomic_store_uint8):
(pas_compare_and_swap_uint8_weak):
(pas_compare_and_swap_uint8_strong):
(pas_compare_and_swap_uint16_weak):
(pas_compare_and_swap_uint32_weak):
(pas_compare_and_swap_uint32_strong):
(pas_compare_and_swap_uint64_weak):
(pas_compare_and_swap_uint64_strong):
(pas_store_store_fence):
(pas_opaque):
(pas_compare_and_swap_pair_weak):
(pas_compare_and_swap_pair_strong):
(pas_atomic_store_pair):
(pas_compare_ptr_opaque):
* Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h:
(__pas_compiler_fence):
(__pas_fence):
(__pas_depend_impl):

Canonical link: <a href="https://commits.webkit.org/301429@main">https://commits.webkit.org/301429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8cceee4ed9e55479006767f793065998c0d7e22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125943 "18 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132812 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77802 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51df10ed-e06d-4fa0-aaed-5acbc5b734a6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54162 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64048 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7f5a00a-23be-44e2-b220-7c9d1b7afc96) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76445 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/322f4ebb-414b-402c-bed5-5400b35f5ab7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30822 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76282 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118023 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135497 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124450 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40458 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104433 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108848 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104153 "Found 1 new API test failure: WebKitGTK/TestLoaderClient:/webkit/WebKitWebPage/get-uri (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26521 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49523 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27851 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50105 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52621 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157463 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51966 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39428 "Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-slow-memory (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55314 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53663 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->