### PR TITLE
Remove various supportsFloatingPoint MacroAssembler methods that are always true

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -2791,10 +2791,6 @@ public:
 
     // Floating-point operations:
 
-    static bool supportsFloatingPoint() { return true; }
-    static bool supportsFloatingPointTruncate() { return true; }
-    static bool supportsFloatingPointSqrt() { return true; }
-    static bool supportsFloatingPointAbs() { return true; }
     static bool supportsFloatingPointRounding() { return true; }
     static bool supportsCountPopulation() { return true; }
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -1862,10 +1862,6 @@ public:
 
     // Floating-point operations:
 
-    static bool supportsFloatingPoint() { return true; }
-    static bool supportsFloatingPointTruncate() { return true; }
-    static bool supportsFloatingPointSqrt() { return true; }
-    static bool supportsFloatingPointAbs() { return true; }
     static bool supportsFloatingPointRounding() { return false; }
     static bool supportsFloat16() { return false; }
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -115,10 +115,6 @@ public:
         return { m_allowScratchRegister };
     }
 
-    static bool supportsFloatingPoint() { return true; }
-    static bool supportsFloatingPointTruncate() { return true; }
-    static bool supportsFloatingPointSqrt() { return true; }
-    static bool supportsFloatingPointAbs() { return true; }
     static bool supportsFloatingPointRounding() { return true; }
     static bool supportsFloat16() { return false; }
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -4663,10 +4663,6 @@ protected:
     }
 
 private:
-    // Only MacroAssemblerX86 should be using the following method; SSE2 is always available on
-    // x86_64, and clients & subclasses of MacroAssembler should be using 'supportsFloatingPoint()'.
-    friend class MacroAssemblerX86;
-
     ALWAYS_INLINE void generateTest32(Address address, TrustedImm32 mask = TrustedImm32(-1))
     {
         if (mask.m_value == -1)
@@ -9228,10 +9224,6 @@ public:
 
     // Misc helper functions.
 
-    static bool supportsFloatingPoint() { return true; }
-    static bool supportsFloatingPointTruncate() { return true; }
-    static bool supportsFloatingPointSqrt() { return true; }
-    static bool supportsFloatingPointAbs() { return true; }
     static bool supportsFloat16() { return false; }
 
     template<PtrTag resultTag, PtrTag locationTag>

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2559,9 +2559,6 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
                 return CallOptimizationResult::Inlined;
             }
 
-            if (!MacroAssembler::supportsFloatingPointAbs())
-                return CallOptimizationResult::DidNothing;
-
             insertChecks();
             Node* node = addToGraph(ArithAbs, get(virtualRegisterForArgumentIncludingThis(1, registerOffset)));
             if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, Overflow))

--- a/Source/JavaScriptCore/dfg/DFGCapabilities.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCapabilities.cpp
@@ -40,7 +40,7 @@ namespace JSC { namespace DFG {
 
 bool isSupported()
 {
-    return Options::useDFGJIT() && MacroAssembler::supportsFloatingPoint();
+    return Options::useDFGJIT();
 }
 
 bool isSupportedForInlining(CodeBlock* codeBlock)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -6513,18 +6513,10 @@ void SpeculativeJIT::compileArithSqrt(Node* node)
 {
     if (node->child1().useKind() == DoubleRepUse) {
         SpeculateDoubleOperand op1(this, node->child1());
-        FPRReg op1FPR = op1.fpr();
 
-        if (!supportsFloatingPointSqrt() || !Options::useArchitectureSpecificOptimizations()) {
-            flushRegisters();
-            FPRResult result(this);
-            callOperationWithoutExceptionCheck(Math::sqrtDouble, result.fpr(), op1FPR);
-            doubleResult(result.fpr(), node);
-        } else {
-            FPRTemporary result(this, op1);
-            sqrtDouble(op1.fpr(), result.fpr());
-            doubleResult(result.fpr(), node);
-        }
+        FPRTemporary result(this, op1);
+        sqrtDouble(op1.fpr(), result.fpr());
+        doubleResult(result.fpr(), node);
         return;
     }
 

--- a/Source/JavaScriptCore/jit/JITAddGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITAddGenerator.cpp
@@ -103,11 +103,6 @@ bool JITAddGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
         jit.boxInt32(scratch, m_result);
         endJumpList.append(jit.jump());
 
-        if (!jit.supportsFloatingPoint()) {
-            slowPathJumpList.append(notInt32);
-            return true;
-        }
-
         // Try to do doubleVar + double(intConstant).
         notInt32.link(&jit);
         if (!varOpr.definitelyIsNumber())
@@ -136,13 +131,6 @@ bool JITAddGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
 
         jit.boxInt32(scratch, m_result);
         endJumpList.append(jit.jump());
-
-
-        if (!jit.supportsFloatingPoint()) {
-            slowPathJumpList.append(leftNotInt);
-            slowPathJumpList.append(rightNotInt);
-            return true;
-        }
 
         leftNotInt.link(&jit);
         if (!m_leftOperand.definitelyIsNumber())

--- a/Source/JavaScriptCore/jit/JITArithmetic.cpp
+++ b/Source/JavaScriptCore/jit/JITArithmetic.cpp
@@ -403,19 +403,17 @@ void JIT::emit_compareSlowImpl(VirtualRegister op1, VirtualRegister op2, size_t 
             return false;
         linkAllSlowCases(iter);
 
-        if (supportsFloatingPoint()) {
-            Jump fail1 = branchIfNotNumber(jsReg2, regT4);
-            unboxDouble(jsReg2, fpReg2);
+        Jump fail1 = branchIfNotNumber(jsReg2, regT4);
+        unboxDouble(jsReg2, fpReg2);
 
-            move(Imm32(getConstantOperand(op).asInt32()), jsReg1.payloadGPR());
-            convertInt32ToDouble(jsReg1.payloadGPR(), fpReg1);
+        move(Imm32(getConstantOperand(op).asInt32()), jsReg1.payloadGPR());
+        convertInt32ToDouble(jsReg1.payloadGPR(), fpReg1);
 
-            emitDoubleCompare(fpRegT0, fpRegT1);
+        emitDoubleCompare(fpRegT0, fpRegT1);
 
-            emitJumpSlowToHot(jump(), instructionSize);
+        emitJumpSlowToHot(jump(), instructionSize);
 
-            fail1.link(this);
-        }
+        fail1.link(this);
 
         emitGetVirtualRegister(op, jsReg1);
         loadGlobalObject(regT4);
@@ -431,21 +429,19 @@ void JIT::emit_compareSlowImpl(VirtualRegister op1, VirtualRegister op2, size_t 
 
     linkSlowCase(iter); // LHS is not Int.
 
-    if (supportsFloatingPoint()) {
-        Jump fail1 = branchIfNotNumber(jsRegT10, regT4);
-        Jump fail2 = branchIfNotNumber(jsRegT32, regT4);
-        Jump fail3 = branchIfInt32(jsRegT32);
-        unboxDouble(jsRegT10, fpRegT0);
-        unboxDouble(jsRegT32, fpRegT1);
+    Jump fail1 = branchIfNotNumber(jsRegT10, regT4);
+    Jump fail2 = branchIfNotNumber(jsRegT32, regT4);
+    Jump fail3 = branchIfInt32(jsRegT32);
+    unboxDouble(jsRegT10, fpRegT0);
+    unboxDouble(jsRegT32, fpRegT1);
 
-        emitDoubleCompare(fpRegT0, fpRegT1);
+    emitDoubleCompare(fpRegT0, fpRegT1);
 
-        emitJumpSlowToHot(jump(), instructionSize);
+    emitJumpSlowToHot(jump(), instructionSize);
 
-        fail1.link(this);
-        fail2.link(this);
-        fail3.link(this);
-    }
+    fail1.link(this);
+    fail2.link(this);
+    fail3.link(this);
 
     linkSlowCase(iter); // RHS is not Int.
     loadGlobalObject(regT4);

--- a/Source/JavaScriptCore/jit/JITDivGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITDivGenerator.cpp
@@ -72,8 +72,6 @@ void JITDivGenerator::generateFastPath(CCallHelpers& jit)
 #endif
 
     ASSERT(!m_didEmitFastPath);
-    if (!jit.supportsFloatingPoint())
-        return;
     if (!m_leftOperand.mightBeNumber() || !m_rightOperand.mightBeNumber())
         return;
 

--- a/Source/JavaScriptCore/jit/JITMulGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITMulGenerator.cpp
@@ -47,9 +47,6 @@ JITMathICInlineResult JITMulGenerator::generateInline(CCallHelpers& jit, MathICG
         return JITMathICInlineResult::DontGenerate;
 
     if (lhs.isOnlyNumber() && rhs.isOnlyNumber() && !m_leftOperand.isConst() && !m_rightOperand.isConst()) {
-        if (!jit.supportsFloatingPoint())
-            return JITMathICInlineResult::DontGenerate;
-
         ASSERT(m_left);
         ASSERT(m_right);
         if (!m_leftOperand.definitelyIsNumber())
@@ -123,11 +120,6 @@ bool JITMulGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
         jit.boxInt32(multiplyResultGPR, m_result);
         endJumpList.append(jit.jump());
 
-        if (!jit.supportsFloatingPoint()) {
-            slowPathJumpList.append(notInt32);
-            return true;
-        }
-
         // Try to do doubleVar * double(intConstant).
         notInt32.link(&jit);
         if (!varOpr.definitelyIsNumber())
@@ -155,12 +147,6 @@ bool JITMulGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
 
         jit.boxInt32(m_scratchGPR, m_result);
         endJumpList.append(jit.jump());
-
-        if (!jit.supportsFloatingPoint()) {
-            slowPathJumpList.append(leftNotInt);
-            slowPathJumpList.append(rightNotInt);
-            return true;
-        }
 
         leftNotInt.link(&jit);
         if (!m_leftOperand.definitelyIsNumber())

--- a/Source/JavaScriptCore/jit/JITSubGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITSubGenerator.cpp
@@ -47,9 +47,6 @@ JITMathICInlineResult JITSubGenerator::generateInline(CCallHelpers& jit, MathICG
         return JITMathICInlineResult::DontGenerate;
 
     if (lhs.isOnlyNumber() && rhs.isOnlyNumber()) {
-        if (!jit.supportsFloatingPoint())
-            return JITMathICInlineResult::DontGenerate;
-
         if (!m_leftOperand.definitelyIsNumber())
             state.slowPathJumps.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
         if (!m_rightOperand.definitelyIsNumber())
@@ -102,12 +99,6 @@ bool JITSubGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
     jit.boxInt32(m_scratchGPR, m_result);
 
     endJumpList.append(jit.jump());
-
-    if (!jit.supportsFloatingPoint()) {
-        slowPathJumpList.append(leftNotInt);
-        slowPathJumpList.append(rightNotInt);
-        return true;
-    }
 
     leftNotInt.link(&jit);
     if (!m_leftOperand.definitelyIsNumber())


### PR DESCRIPTION
#### 10992fea97ad7dc3d96dc91825013d8b8efef62b
<pre>
Remove various supportsFloatingPoint MacroAssembler methods that are always true
<a href="https://bugs.webkit.org/show_bug.cgi?id=300641">https://bugs.webkit.org/show_bug.cgi?id=300641</a>
<a href="https://rdar.apple.com/162542638">rdar://162542638</a>

Reviewed by Dan Hecht and Yusuke Suzuki.

Many of the supportsFloatingPoint* methods are true for all platforms we have a MacroAssembler
for. We should just remove these checks and the various uses of them since I don&apos;t expect to
support a CPU without those in the foreseeable future.

No new tests, removing dead code.

Canonical link: <a href="https://commits.webkit.org/304190@main">https://commits.webkit.org/304190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67aa11fb2b95c100090754c4b99512325a343e23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77822 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e40587bd-c6a2-43ea-8fbe-2ccf274061d4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54187 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95968 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64059 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/22104c3c-e2b8-46af-97cf-53f27cfa4daf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76457 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eef89700-c20b-4603-935b-863cff5721c1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35954 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118049 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135520 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124484 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104441 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104161 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28350 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49546 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108878 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50129 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52645 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27875 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157496 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51987 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58467 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39436 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->