### PR TITLE
[CSS Zoom] Apply zoom factor to text-decoration-thickness

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/text-decoration-thickness-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/text-decoration-thickness-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>CSS zoom applies to text-decoration-thickness when specified and inherited</title>
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+
+<style>
+body {
+  --scale: 1;
+}
+div {
+  font-size: calc(1rem * var(--scale));
+  text-decoration: underline blue;
+  text-decoration-thickness: calc(5px * var(--scale));
+}
+.zoom {
+  --scale: 2;
+}
+</style>
+
+<div>unzoomed</div>
+<div class="zoom">zoomed</div>
+<div class="zoom">zoomed inherited</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style-expected.txt
@@ -23,6 +23,10 @@ PASS Property line-height value '13px' no zoom
 PASS Property line-height value 'inherit' no zoom
 PASS Property line-height value '13px' zoom: 2
 PASS Property line-height value 'inherit' zoom: 2
+PASS Property text-decoration-thickness value '4px' no zoom
+PASS Property text-decoration-thickness value 'inherit' no zoom
+PASS Property text-decoration-thickness value '4px' zoom: 2
+PASS Property text-decoration-thickness value 'inherit' zoom: 2
 PASS Property text-shadow value 'rgb(0, 0, 0) 10px 10px 0px' no zoom
 PASS Property text-shadow value 'inherit' no zoom
 PASS Property text-shadow value 'rgb(0, 0, 0) 10px 10px 0px' zoom: 2

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html
@@ -36,6 +36,10 @@
       "value": "7px",
       "otherValues": ["13px"]
     },
+    "text-decoration-thickness": {
+      "value": "2px",
+      "otherValues": ["4px"]
+    },
     "text-shadow": {
       "value": "rgb(0, 0, 0) 5px 5px 0px",
       "otherValues": ["rgb(0, 0, 0) 10px 10px 0px"]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/text-decoration-thickness-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/text-decoration-thickness-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>CSS zoom applies to text-decoration-thickness when specified and inherited</title>
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+
+<style>
+body {
+  --scale: 1;
+}
+div {
+  font-size: calc(1rem * var(--scale));
+  text-decoration: underline blue;
+  text-decoration-thickness: calc(5px * var(--scale));
+}
+.zoom {
+  --scale: 2;
+}
+</style>
+
+<div>unzoomed</div>
+<div class="zoom">zoomed</div>
+<div class="zoom">zoomed inherited</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/text-decoration-thickness.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/text-decoration-thickness.html
@@ -1,0 +1,21 @@
+<title>CSS zoom applies to text-decoration-thickness when specified and inherited</title>
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/text-decoration-thickness-ref.html">
+
+<style>
+.decoration-thickness {
+  text-decoration: underline blue;
+  text-decoration-thickness: 5px; 
+}
+.zoom {
+  zoom: 2;
+}
+#zoomed-inherited {
+  text-decoration-thickness: inherit;
+}
+</style>
+
+<div id="unzoomed" class="decoration-thickness">unzoomed</div>
+<div class="zoom"><div id="zoomed" class="decoration-thickness">zoomed</div></div>
+<div class="decoration-thickness"><div id="zoomed-inherited" class="zoom">zoomed inherited</div></div>

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -727,12 +727,12 @@ TextDecorationPainter TextBoxPainter::createDecorationPainter(const StyledMarked
 
 static inline float computedTextDecorationThickness(const RenderStyle& styleToUse, float deviceScaleFactor)
 {
-    return ceilToDevicePixel(styleToUse.textDecorationThickness().resolve(styleToUse.computedFontSize(), styleToUse.metricsOfPrimaryFont()), deviceScaleFactor);
+    return ceilToDevicePixel(styleToUse.textDecorationThickness().resolve(styleToUse), deviceScaleFactor);
 }
 
 static inline float computedAutoTextDecorationThickness(const RenderStyle& styleToUse, float deviceScaleFactor)
 {
-    return ceilToDevicePixel(Style::TextDecorationThickness { CSS::Keyword::Auto { } }.resolve(styleToUse.computedFontSize(), styleToUse.metricsOfPrimaryFont()), deviceScaleFactor);
+    return ceilToDevicePixel(Style::TextDecorationThickness { CSS::Keyword::Auto { } }.resolve(styleToUse), deviceScaleFactor);
 }
 
 static inline float computedLinethroughCenter(const RenderStyle& styleToUse, float textDecorationThickness, float autoTextDecorationThickness)

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -195,7 +195,7 @@ static GlyphOverflow computedInkOverflowForDecorations(const RenderStyle& lineSt
     if (decoration.isNone())
         return GlyphOverflow();
 
-    float strokeThickness = lineStyle.textDecorationThickness().resolve(lineStyle.computedFontSize(), lineStyle.metricsOfPrimaryFont());
+    float strokeThickness = lineStyle.textDecorationThickness().resolve(lineStyle);
     WavyStrokeParameters wavyStrokeParameters;
     float wavyOffset = 0;
 
@@ -224,7 +224,7 @@ static GlyphOverflow computedInkOverflowForDecorations(const RenderStyle& lineSt
     }
     if (decoration.hasOverline()) {
         FloatRect rect(FloatPoint(), FloatSize(1, strokeThickness));
-        float autoTextDecorationThickness = Style::TextDecorationThickness { CSS::Keyword::Auto { } }.resolve(lineStyle.computedFontSize(), lineStyle.metricsOfPrimaryFont());
+        float autoTextDecorationThickness = Style::TextDecorationThickness { CSS::Keyword::Auto { } }.resolve(lineStyle);
         rect.move(0, autoTextDecorationThickness - strokeThickness - wavyOffset);
         if (decorationStyle == TextDecorationStyle::Wavy) {
             FloatBoxExtent wavyExpansion;
@@ -237,7 +237,7 @@ static GlyphOverflow computedInkOverflowForDecorations(const RenderStyle& lineSt
     }
     if (decoration.hasLineThrough()) {
         FloatRect rect(FloatPoint(), FloatSize(1, strokeThickness));
-        float autoTextDecorationThickness = Style::TextDecorationThickness { CSS::Keyword::Auto { } }.resolve(lineStyle.computedFontSize(), lineStyle.metricsOfPrimaryFont());
+        float autoTextDecorationThickness = Style::TextDecorationThickness { CSS::Keyword::Auto { } }.resolve(lineStyle);
         auto center = 2 * lineStyle.metricsOfPrimaryFont().ascent() / 3 + autoTextDecorationThickness / 2;
         rect.move(0, center - strokeThickness / 2);
         if (decorationStyle == TextDecorationStyle::Wavy) {

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,22 +50,7 @@ float TextDecorationThickness::resolve(const RenderStyle& style) const
             return style.metricsOfPrimaryFont().underlineThickness().value_or(0);
         },
         [&](const TextDecorationThicknessLength& length) {
-            return Style::evaluate<float>(length, style.computedFontSize(), Style::ZoomNeeded { });
-        }
-    );
-}
-
-float TextDecorationThickness::resolve(float fontSize, const FontMetrics& metrics) const
-{
-    return WTF::switchOn(m_value,
-        [&](const CSS::Keyword::Auto&) {
-            return fontSize / textDecorationBaseFontSize;
-        },
-        [&](const CSS::Keyword::FromFont&) {
-            return metrics.underlineThickness().value_or(0);
-        },
-        [&](const TextDecorationThicknessLength& length) {
-            return Style::evaluate<float>(length, fontSize, Style::ZoomNeeded { });
+            return Style::evaluate<float>(length, style.computedFontSize(), style.usedZoomForLength());
         }
     );
 }

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,7 +34,7 @@ class FontMetrics;
 
 namespace Style {
 
-struct TextDecorationThicknessLength : LengthWrapperBase<LengthPercentage<>> {
+struct TextDecorationThicknessLength : LengthWrapperBase<LengthPercentage<CSS::AllUnzoomed>> {
     using Base::Base;
 };
 
@@ -61,7 +61,6 @@ struct TextDecorationThickness {
     bool isLength() const { return WTF::holdsAlternative<TextDecorationThicknessLength>(m_value); }
 
     float resolve(const RenderStyle&) const;
-    float resolve(float fontSize, const FontMetrics&) const;
 
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {


### PR DESCRIPTION
#### a4b32d383c7bc91cd7b8e124788afc0184eae260
<pre>
[CSS Zoom] Apply zoom factor to text-decoration-thickness
<a href="https://bugs.webkit.org/show_bug.cgi?id=300642">https://bugs.webkit.org/show_bug.cgi?id=300642</a>
&lt;<a href="https://rdar.apple.com/problem/162543798">rdar://problem/162543798</a>&gt;

Reviewed by Tim Nguyen.

Adapt the text-decoration-thickness logic to the new CSS Zoom architecture.

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/text-decoration-thickness.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/text-decoration-thickness-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/text-decoration-thickness-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/text-decoration-thickness.html: Added.
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::computedTextDecorationThickness):
(WebCore::computedAutoTextDecorationThickness):
* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::computedInkOverflowForDecorations):
* Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp:
(WebCore::Style::TextDecorationThickness::resolve const):
* Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.h:

Canonical link: <a href="https://commits.webkit.org/301664@main">https://commits.webkit.org/301664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9068cabb9bab4cda1a54a1f270e43c34b9ad9818

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133634 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78323 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54851 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fc57cb96-b097-4a0b-bd09-258122c19491) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113293 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/92c70478-cfba-4cf0-9f65-344003fd41ca) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31478 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77030 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136208 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53356 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/41053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109652 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26676 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50100 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28435 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50791 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53290 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59086 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52550 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55886 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54290 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->