### PR TITLE
Refactor Model GraphicsLayer attaching

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -643,6 +643,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/model-element/ModelPlayerAccessibilityChildren.h
     Modules/model-element/ModelPlayerAnimationState.h
     Modules/model-element/ModelPlayerClient.h
+    Modules/model-element/ModelPlayerGraphicsLayerConfiguration.h
     Modules/model-element/ModelPlayerIdentifier.h
     Modules/model-element/ModelPlayerProvider.h
     Modules/model-element/ModelPlayerTransformState.h

--- a/Source/WebCore/Modules/model-element/DDModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/DDModelPlayer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,8 +63,7 @@ private:
     // ModelPlayer overrides.
     void load(Model&, LayoutSize) override;
     void sizeDidChange(LayoutSize) override;
-    CALayer *layer() override;
-    std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() override;
+    void configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&) override;
     void enterFullscreen() override;
     void handleMouseDown(const LayoutPoint&, MonotonicTime) override;
     void handleMouseMove(const LayoutPoint&, MonotonicTime) override;
@@ -82,8 +82,8 @@ private:
     void setIsMuted(bool, CompletionHandler<void(bool success)>&&) override;
     ModelPlayerAccessibilityChildren accessibilityChildren() override;
 
-    const MachSendRight* displayBuffer() const override;
-    GraphicsLayerContentsDisplayDelegate* contentsDisplayDelegate() override;
+    const MachSendRight* displayBuffer() const;
+    GraphicsLayerContentsDisplayDelegate* contentsDisplayDelegate();
     void ensureOnMainThreadWithProtectedThis(Function<void(Ref<DDModelPlayer>)>&& task);
 
     WeakPtr<ModelPlayerClient> m_client;

--- a/Source/WebCore/Modules/model-element/DDModelPlayer.mm
+++ b/Source/WebCore/Modules/model-element/DDModelPlayer.mm
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +36,7 @@
 #import "HTMLModelElement.h"
 #import "ModelDDInlineConverters.h"
 #import "ModelDDTypes.h"
+#import "ModelPlayerGraphicsLayerConfiguration.h"
 #import "Navigator.h"
 #import "Page.h"
 #import "PlatformCALayer.h"
@@ -214,16 +216,6 @@ void DDModelPlayer::sizeDidChange(LayoutSize)
 {
 }
 
-PlatformLayer* DDModelPlayer::layer()
-{
-    return nullptr;
-}
-
-std::optional<LayerHostingContextIdentifier> DDModelPlayer::layerHostingContextIdentifier()
-{
-    return std::nullopt;
-}
-
 void DDModelPlayer::enterFullscreen()
 {
 }
@@ -302,6 +294,11 @@ WebCore::ModelPlayerIdentifier DDModelPlayer::identifier() const
     return m_id;
 }
 
+void DDModelPlayer::configureGraphicsLayer(GraphicsLayer& graphicsLayer, ModelPlayerGraphicsLayerConfiguration&&)
+{
+    graphicsLayer.setContentsDisplayDelegate(contentsDisplayDelegate(), GraphicsLayer::ContentsLayerPurpose::Canvas);
+}
+
 const MachSendRight* DDModelPlayer::displayBuffer() const
 {
     if (m_currentTexture >= m_displayBuffers.size())
@@ -333,9 +330,9 @@ void DDModelPlayer::update()
         RefPtr { m_contentsDisplayDelegate }->setDisplayBuffer(*machSendRight);
 
     if (RefPtr client = m_client.get())
-        client->didUpdateDisplayDelegate(*this);
+        client->didUpdate(*this);
 }
 
-}
+} // namespace WebCore
 
 #endif

--- a/Source/WebCore/Modules/model-element/ModelPlayerClient.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerClient.h
@@ -35,6 +35,7 @@
 namespace WebCore {
 
 class FloatPoint3D;
+class GraphicsLayer;
 class HTMLModelElement;
 class ModelPlayer;
 class ResourceError;
@@ -43,12 +44,6 @@ class WEBCORE_EXPORT ModelPlayerClient : public AbstractRefCountedAndCanMakeWeak
 public:
     virtual ~ModelPlayerClient();
 
-    virtual void didUpdateLayerHostingContextIdentifier(ModelPlayer&, LayerHostingContextIdentifier) = 0;
-#if ENABLE(GPU_PROCESS_MODEL)
-    // FIXME: Merge with `didUpdateLayerHostingContextIdentifier`, as both just want to trigger `renderer->updateFromElement()` and mean the same thing semantically.
-    virtual void didUpdateDisplayDelegate(ModelPlayer&) const = 0;
-#endif
-
     virtual void didFinishLoading(ModelPlayer&) = 0;
     virtual void didFailLoading(ModelPlayer&, const ResourceError&) = 0;
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
@@ -56,6 +51,7 @@ public:
     virtual void didFinishEnvironmentMapLoading(ModelPlayer&, bool succeeded) = 0;
 #endif
     virtual void didUnload(ModelPlayer&) = 0;
+    virtual void didUpdate(ModelPlayer&) = 0;
 
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
     virtual void didUpdateEntityTransform(ModelPlayer&, const TransformationMatrix&) = 0;
@@ -64,9 +60,9 @@ public:
     virtual void didUpdateBoundingBox(ModelPlayer&, const FloatPoint3D&, const FloatPoint3D&) = 0;
 #endif
 
-    virtual std::optional<PlatformLayerIdentifier> modelContentsLayerID() const = 0;
+    virtual RefPtr<GraphicsLayer> graphicsLayer() const = 0;
+
     virtual bool isVisible() const = 0;
-    virtual bool isIntersectingViewport() const = 0;
     virtual void logWarning(ModelPlayer&, const String& warningMessage) = 0;
 };
 

--- a/Source/WebCore/Modules/model-element/ModelPlayerGraphicsLayerConfiguration.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerGraphicsLayerConfiguration.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MODEL_ELEMENT)
+
+#include <WebCore/Color.h>
+#include <WebCore/LayoutSize.h>
+#include <WebCore/Model.h>
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+struct ModelPlayerGraphicsLayerConfiguration {
+    RefPtr<Model> model;
+    LayoutSize contentSize;
+    Color backgroundColor;
+    bool isInteractive;
+#if ENABLE(MODEL_ELEMENT_PORTAL)
+    bool hasPortal;
+#endif
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +30,7 @@
 #include "FloatPoint3D.h"
 #include "Logging.h"
 #include "Model.h"
+#include "ModelPlayerGraphicsLayerConfiguration.h"
 #include "ModelPlayerTransformState.h"
 #include "TransformationMatrix.h"
 #include <wtf/CompletionHandler.h>
@@ -202,14 +204,9 @@ void PlaceholderModelPlayer::setStageMode(WebCore::StageModeOperation stageModeO
 #endif
 
 // Empty implementation
-PlatformLayer* PlaceholderModelPlayer::layer()
-{
-    return nullptr;
-}
 
-std::optional<LayerHostingContextIdentifier> PlaceholderModelPlayer::layerHostingContextIdentifier()
+void PlaceholderModelPlayer::configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&)
 {
-    return std::nullopt;
 }
 
 void PlaceholderModelPlayer::sizeDidChange(LayoutSize)
@@ -285,20 +282,6 @@ void PlaceholderModelPlayer::setIsMuted(bool, CompletionHandler<void(bool succes
 ModelPlayerAccessibilityChildren PlaceholderModelPlayer::accessibilityChildren()
 {
     return { };
-}
-
-#endif
-
-#if ENABLE(GPU_PROCESS_MODEL)
-
-const MachSendRight* PlaceholderModelPlayer::displayBuffer() const
-{
-    return nullptr;
-}
-
-GraphicsLayerContentsDisplayDelegate* PlaceholderModelPlayer::contentsDisplayDelegate()
-{
-    return nullptr;
 }
 
 #endif

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,9 +78,8 @@ private:
 #endif
 
     // Empty implementation
+    void configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&) final;
     void sizeDidChange(LayoutSize) final;
-    PlatformLayer* layer() final;
-    std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() final;
     void enterFullscreen() final;
     void handleMouseDown(const LayoutPoint&, MonotonicTime) final;
     void handleMouseMove(const LayoutPoint&, MonotonicTime) final;
@@ -99,10 +99,6 @@ private:
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
     ModelPlayerAccessibilityChildren accessibilityChildren() final;
 #endif
-#if ENABLE(GPU_PROCESS_MODEL)
-    const MachSendRight* displayBuffer() const override;
-    GraphicsLayerContentsDisplayDelegate* contentsDisplayDelegate() override;
-#endif
 
     std::optional<bool> m_lastPausedStateIfSuspended;
     ModelPlayerAnimationState m_animationState;
@@ -110,4 +106,4 @@ private:
     ModelPlayerIdentifier m_id;
 };
 
-}
+} // namespace WebCore

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +28,7 @@
 #include "DummyModelPlayer.h"
 
 #include "Model.h"
+#include "ModelPlayerGraphicsLayerConfiguration.h"
 #include "ResourceError.h"
 
 namespace WebCore {
@@ -50,14 +52,8 @@ void DummyModelPlayer::load(Model& model, LayoutSize)
         client->didFailLoading(*this, ResourceError { errorDomainWebKitInternal, 0, model.url(), "Trying to load model via DummyModelPlayer"_s });
 }
 
-PlatformLayer* DummyModelPlayer::layer()
+void DummyModelPlayer::configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&)
 {
-    return nullptr;
-}
-
-std::optional<LayerHostingContextIdentifier> DummyModelPlayer::layerHostingContextIdentifier()
-{
-    return std::nullopt;
 }
 
 void DummyModelPlayer::sizeDidChange(LayoutSize)
@@ -128,23 +124,13 @@ void DummyModelPlayer::setIsMuted(bool, CompletionHandler<void(bool success)>&&)
 {
 }
 
-#if PLATFORM(COCOA)
+#if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
+
 ModelPlayerAccessibilityChildren DummyModelPlayer::accessibilityChildren()
 {
     return { };
 }
+
 #endif
 
-#if ENABLE(GPU_PROCESS_MODEL)
-const MachSendRight* DummyModelPlayer::displayBuffer() const
-{
-    return nullptr;
-}
-
-GraphicsLayerContentsDisplayDelegate* DummyModelPlayer::contentsDisplayDelegate()
-{
-    return nullptr;
-}
-#endif
-
-}
+} // namespace WebCore

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,9 +46,8 @@ private:
     // ModelPlayer overrides.
     ModelPlayerIdentifier identifier() const final { return m_id; }
     void load(Model&, LayoutSize) override;
+    void configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&) override;
     void sizeDidChange(LayoutSize) override;
-    PlatformLayer* layer() override;
-    std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() override;
     void enterFullscreen() override;
     void handleMouseDown(const LayoutPoint&, MonotonicTime) override;
     void handleMouseMove(const LayoutPoint&, MonotonicTime) override;
@@ -66,10 +66,6 @@ private:
     void setIsMuted(bool, CompletionHandler<void(bool success)>&&) override;
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
     ModelPlayerAccessibilityChildren accessibilityChildren() override;
-#endif
-#if ENABLE(GPU_PROCESS_MODEL)
-    const MachSendRight* displayBuffer() const override;
-    GraphicsLayerContentsDisplayDelegate* contentsDisplayDelegate() override;
 #endif
 
     WeakPtr<ModelPlayerClient> m_client;

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,9 +57,8 @@ private:
     // ModelPlayer overrides.
     ModelPlayerIdentifier identifier() const override;
     void load(Model&, LayoutSize) override;
+    void configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&) override;
     void sizeDidChange(LayoutSize) override;
-    CALayer *layer() override;
-    std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() override;
     void enterFullscreen() override;
     void handleMouseDown(const LayoutPoint&, MonotonicTime) override;
     void handleMouseMove(const LayoutPoint&, MonotonicTime) override;

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +30,8 @@
 
 #import "SceneKitModelPlayer.h"
 
+#import "GraphicsLayer.h"
+#import "ModelPlayerGraphicsLayerConfiguration.h"
 #import "SceneKitModel.h"
 #import "SceneKitModelLoader.h"
 #import <pal/spi/cocoa/SceneKitSPI.h>
@@ -83,14 +86,9 @@ void SceneKitModelPlayer::sizeDidChange(LayoutSize)
 {
 }
 
-PlatformLayer* SceneKitModelPlayer::layer()
+void SceneKitModelPlayer::configureGraphicsLayer(GraphicsLayer& graphicsLayer, ModelPlayerGraphicsLayerConfiguration&&)
 {
-    return m_layer.get();
-}
-
-std::optional<LayerHostingContextIdentifier> SceneKitModelPlayer::layerHostingContextIdentifier()
-{
-    return std::nullopt;
+    graphicsLayer.setContentsToPlatformLayer(m_layer.get(), GraphicsLayer::ContentsLayerPurpose::Model);
 }
 
 void SceneKitModelPlayer::enterFullscreen()

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,8 +102,7 @@ public:
     WebCore::ModelPlayerIdentifier identifier() const final { return m_id; }
     void load(WebCore::Model&, WebCore::LayoutSize) final;
     void sizeDidChange(WebCore::LayoutSize) final;
-    PlatformLayer* layer() final;
-    std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier() final;
+    void configureGraphicsLayer(WebCore::GraphicsLayer&, WebCore::ModelPlayerGraphicsLayerConfiguration&&) final;
     void setEntityTransform(WebCore::TransformationMatrix) final;
     void enterFullscreen() final;
     bool supportsMouseInteraction() final;
@@ -159,6 +159,7 @@ private:
     void notifyModelPlayerOfEntityTransformChange();
     void applyDefaultIBL();
     void updateForCurrentStageMode();
+    std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier();
 
     WebCore::ModelPlayerIdentifier m_id;
     bool m_isVisible { true };

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +42,7 @@
 #import <WebCore/Color.h>
 #import <WebCore/LayerHostingContextIdentifier.h>
 #import <WebCore/Model.h>
+#import <WebCore/ModelPlayerGraphicsLayerConfiguration.h>
 #import <WebCore/ResourceError.h>
 #import <WebKitAdditions/REModel.h>
 #import <WebKitAdditions/REModelLoader.h>
@@ -698,9 +700,8 @@ void ModelProcessModelPlayerProxy::sizeDidChange(WebCore::LayoutSize layoutSize)
     [m_layer setFrame:CGRectMake(0, 0, width, height)];
 }
 
-PlatformLayer* ModelProcessModelPlayerProxy::layer()
+void ModelProcessModelPlayerProxy::configureGraphicsLayer(WebCore::GraphicsLayer&, WebCore::ModelPlayerGraphicsLayerConfiguration&&)
 {
-    return nullptr;
 }
 
 std::optional<WebCore::LayerHostingContextIdentifier> ModelProcessModelPlayerProxy::layerHostingContextIdentifier()

--- a/Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.h
@@ -53,8 +53,6 @@ private:
     // WebCore::ModelPlayer overrides.
     void load(WebCore::Model&, WebCore::LayoutSize) override;
     void sizeDidChange(WebCore::LayoutSize) override;
-    PlatformLayer* layer() override;
-    std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier() override;
     void enterFullscreen() override;
     void getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&) override;
     void setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) override;

--- a/Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.mm
@@ -55,16 +55,6 @@ void ARKitInlinePreviewModelPlayer::sizeDidChange(LayoutSize)
 {
 }
 
-PlatformLayer* ARKitInlinePreviewModelPlayer::layer()
-{
-    return nullptr;
-}
-
-std::optional<WebCore::LayerHostingContextIdentifier> ARKitInlinePreviewModelPlayer::layerHostingContextIdentifier()
-{
-    return std::nullopt;
-}
-
 void ARKitInlinePreviewModelPlayer::enterFullscreen()
 {
 }

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,7 +89,7 @@ private:
     void reload(WebCore::Model&, WebCore::LayoutSize, WebCore::ModelPlayerAnimationState&, std::unique_ptr<WebCore::ModelPlayerTransformState>&&) final;
     void visibilityStateDidChange() final;
     void sizeDidChange(WebCore::LayoutSize) final;
-    PlatformLayer* layer() final;
+    void configureGraphicsLayer(WebCore::GraphicsLayer&, WebCore::ModelPlayerGraphicsLayerConfiguration&&) final;
     void handleMouseDown(const WebCore::LayoutPoint&, MonotonicTime) final;
     void handleMouseMove(const WebCore::LayoutPoint&, MonotonicTime) final;
     void handleMouseUp(const WebCore::LayoutPoint&, MonotonicTime) final;

--- a/Source/WebKit/WebProcess/Model/ios/ARKitInlinePreviewModelPlayerIOS.h
+++ b/Source/WebKit/WebProcess/Model/ios/ARKitInlinePreviewModelPlayerIOS.h
@@ -49,6 +49,7 @@ private:
     static ARKitInlinePreviewModelPlayerIOS* modelPlayerForPageAndLayerID(WebPage&, WebCore::PlatformLayerIdentifier);
 
     // WebCore::ModelPlayer overrides.
+    void configureGraphicsLayer(WebCore::GraphicsLayer&, WebCore::ModelPlayerGraphicsLayerConfiguration&&) override;
     void enterFullscreen() override;
     void setInteractionEnabled(bool) override;
     void handleMouseDown(const WebCore::LayoutPoint&, MonotonicTime) override;

--- a/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.h
+++ b/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.h
@@ -52,8 +52,8 @@ private:
 
     // WebCore::ModelPlayer overrides.
     void load(WebCore::Model&, WebCore::LayoutSize) override;
+    void configureGraphicsLayer(WebCore::GraphicsLayer&, WebCore::ModelPlayerGraphicsLayerConfiguration&&) override;
     void sizeDidChange(WebCore::LayoutSize) override;
-    PlatformLayer* layer() override;
     bool supportsMouseInteraction() override;
     bool supportsDragging() override;
     void handleMouseDown(const WebCore::LayoutPoint&, MonotonicTime) override;

--- a/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
+++ b/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
@@ -33,7 +33,9 @@
 #import "MessageSenderInlines.h"
 #import "WebPage.h"
 #import "WebPageProxyMessages.h"
+#import <WebCore/GraphicsLayer.h>
 #import <WebCore/Model.h>
+#import <WebCore/ModelPlayerGraphicsLayerConfiguration.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/mac/SystemPreviewSPI.h>
 #import <wtf/FileHandle.h>
@@ -269,9 +271,9 @@ void ARKitInlinePreviewModelPlayerMac::sizeDidChange(WebCore::LayoutSize size)
     page->sendWithAsyncReply(Messages::WebPageProxy::ModelElementSizeDidChange(uuid, size), WTFMove(completionHandler));
 }
 
-PlatformLayer* ARKitInlinePreviewModelPlayerMac::layer()
+void ARKitInlinePreviewModelPlayerMac::configureGraphicsLayer(WebCore::GraphicsLayer& graphicsLayer, WebCore::ModelPlayerGraphicsLayerConfiguration&&)
 {
-    return [m_inlinePreview layer];
+    graphicsLayer.setContentsToPlatformLayer([m_inlinePreview layer], WebCore::GraphicsLayer::ContentsLayerPurpose::Model);
 }
 
 bool ARKitInlinePreviewModelPlayerMac::supportsMouseInteraction()


### PR DESCRIPTION
#### 7929b2727d5204bb59fa2639b182a0c152ac0a61
<pre>
Refactor Model GraphicsLayer attaching
<a href="https://bugs.webkit.org/show_bug.cgi?id=300644">https://bugs.webkit.org/show_bug.cgi?id=300644</a>

Reviewed by Mike Wyrzykowski.

Refactors how &lt;model&gt; elements attach their backends to the GraphicsLayer
tree, replacing backend specific code in RenderLayerBacking with a single
configuration point.

Now, ModelPlayer implementations implement a new `ModelPlayer::configureGraphicsLayer(...)`
function to setup the GraphicsLayer however is needed.

* Source/WebCore/Modules/model-element/DDModelPlayer.h:
* Source/WebCore/Modules/model-element/DDModelPlayer.mm:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/ModelPlayerClient.h:
* Source/WebCore/Modules/model-element/ModelPlayerGraphicsLayerConfiguration.h: Added.
* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp:
* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h:
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp:
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h:
* Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.h:
* Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
* Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.h:
* Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.mm:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
* Source/WebKit/WebProcess/Model/ios/ARKitInlinePreviewModelPlayerIOS.h:
* Source/WebKit/WebProcess/Model/ios/ARKitInlinePreviewModelPlayerIOS.mm:
* Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.h:
* Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm:

Canonical link: <a href="https://commits.webkit.org/301958@main">https://commits.webkit.org/301958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70e84c2e04262896f7eeb547c7ac6ab05e02d907

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134889 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55796 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130566 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/38299 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114312 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/77624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78248 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137370 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41832 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105666 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105317 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26851 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50834 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54214 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60386 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/53448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/55207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->