### PR TITLE
Track and manage Opaque Data Types in CoreIPC

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -210,6 +210,8 @@ $(PROJECT_DIR)/Scripts/generate-serializers.py
 $(PROJECT_DIR)/Scripts/webkit/__init__.py
 $(PROJECT_DIR)/Scripts/webkit/messages.py
 $(PROJECT_DIR)/Scripts/webkit/model.py
+$(PROJECT_DIR)/Scripts/webkit/opaque_ipc_types.py
+$(PROJECT_DIR)/Scripts/webkit/opaque_ipc_types.tracking.in
 $(PROJECT_DIR)/Scripts/webkit/parser.py
 $(PROJECT_DIR)/Shared/API/APIArray.serialization.in
 $(PROJECT_DIR)/Shared/API/APIData.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -356,6 +356,8 @@ GENERATE_MESSAGE_RECEIVER_SCRIPTS = \
     $(WebKit2)/Scripts/webkit/messages.py \
     $(WebKit2)/Scripts/webkit/model.py \
     $(WebKit2)/Scripts/webkit/parser.py \
+    $(WebKit2)/Scripts/webkit/opaque_ipc_types.py \
+    $(WebKit2)/Scripts/webkit/opaque_ipc_types.tracking.in \
     $(WebKit2)/DerivedSources.make \
 #
 
@@ -966,8 +968,8 @@ GENERATED_SERIALIZERS_OUTPUT_FILES = \
 
 GENERATED_SERIALIZERS_OUTPUT_PATTERNS = $(call to-pattern, $(GENERATED_SERIALIZERS_OUTPUT_FILES))
 
-$(GENERATED_SERIALIZERS_OUTPUT_PATTERNS) : $(WebKit2)/Scripts/generate-serializers.py $(SERIALIZATION_DESCRIPTION_FILES) $(WebKit2)/DerivedSources.make $(WEBCORE_SERIALIZATION_DESCRIPTION_FILES_FULLPATH)
-	$(PYTHON) $(WebKit2)/Scripts/generate-serializers.py mm $(filter %.in,$^)
+$(GENERATED_SERIALIZERS_OUTPUT_PATTERNS) : $(WebKit2)/Scripts/generate-serializers.py $(SERIALIZATION_DESCRIPTION_FILES) $(WebKit2)/DerivedSources.make $(WEBCORE_SERIALIZATION_DESCRIPTION_FILES_FULLPATH) $(WebKit2)/Scripts/webkit/opaque_ipc_types.py $(WebKit2)/Scripts/webkit/opaque_ipc_types.tracking.in
+	$(PYTHON) $(WebKit2)/Scripts/generate-serializers.py mm $(filter %.serialization.in,$^)
 
 EXTENSIONS_DIR = $(WebKit2)/WebProcess/Extensions
 EXTENSIONS_SCRIPTS_DIR = $(EXTENSIONS_DIR)/Bindings/Scripts

--- a/Source/WebKit/Scripts/generate-message-receiver.py
+++ b/Source/WebKit/Scripts/generate-message-receiver.py
@@ -57,6 +57,7 @@ def main(argv):
                 receiver = webkit.parser.parse(source_file)
 
         receiver.enforce_attribute_constraints()
+        receiver.enforce_opaque_ipc_types_usage()
 
         receivers.append(receiver)
         if receiver_name != receiver.name:

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.py
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.py
@@ -1,0 +1,801 @@
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import re
+
+
+# These are by themselves opaque without a container
+OPAQUE_TYPES = {
+    "NotDispatchableFromWebContent",  # For testing message generation
+    "MachSendRight",
+    "MachSendRightAnnotated",
+    "WTF::MachSendRightAnnotated",
+    "CFDataRef",
+    "CFArrayRef",
+    "CFDictionaryRef",
+    "NSArray",
+    "NSData",
+    "NSDictionary",
+    "WebCore::SharedMemoryHandle",
+    "WebCore::SharedMemory::Handle",
+    "IPC::SharedBufferReference",
+    "WebKit::CoreIPCData",
+    "WebKit::CoreIPCPlistDictionary",
+    "WebKit::CoreIPCPlistArray"
+}
+
+# If these types are in a 'opaque container' we are concerned
+ODT_CONCERN = {
+    "char", "signed char", "unsigned char", "int8_t", "uint8_t",
+}.union(OPAQUE_TYPES)
+
+# Containers that are an ODT when they contain a type from ODT_CONCERN or OPAQUE_TYPES
+#
+# Configuration options:
+#   check_params: Which template parameters to check for opaque data
+#     - "first": Check only first parameter (e.g., Vector<T>)
+#     - "first_two": Check first two parameters (e.g., HashMap<K,V>)
+#     - "all": Check all parameters
+#     - "selective": Check specific indices (use with selective_indices)
+#
+#   special_parsing: Custom parameter extraction logic
+#     - "array_parsing": For std::array<T, N>, extract only T (ignore N)
+#
+OPAQUE_CONTAINERS = {
+    "std::span": {"check_params": "first"},
+    "std::array": {"check_params": "first", "special_parsing": "array_parsing"},
+    "Vector": {"check_params": "first"},
+    "FixedVector": {"check_params": "first"},
+}
+
+# Containers that should be decomposed to find opaque inner containers.
+#
+# These containers are "transparent" - they don't make types opaque by themselves,
+# but we traverse through them to find opaque types within.
+#
+# Configuration options:
+#   check_params: Which template parameters to check (same options as OPAQUE_CONTAINERS)
+#
+#   propagate_context: Whether opaque container context is preserved through this container
+#     - True: Simple wrappers (std::optional, RetainPtr) - preserve parent opaque context
+#              Example: Vector<std::optional<uint8_t>> is opaque because Vector creates
+#              opaque context and std::optional preserves it to uint8_t
+#     - False: Structural containers (std::pair, Variant, Expected) - reset opaque context
+#              Example: std::pair<uint8_t, String> is NOT opaque because std::pair resets
+#              context, so uint8_t is checked outside of opaque container context
+#
+TRANSPARENT_CONTAINERS = {
+    # Simple wrappers - preserve opaque context from parent
+    "std::optional": {"check_params": "first", "propagate_context": True},
+    "RetainPtr": {"check_params": "first", "propagate_context": True},
+
+    "Expected": {"check_params": "selective", "selective_indices": [0], "propagate_context": False},
+    "Variant": {"check_params": "all", "propagate_context": False},
+
+    "std::pair": {"check_params": "all", "propagate_context": False},
+    "std::tuple": {"check_params": "all", "propagate_context": False},
+    "KeyValuePair": {"check_params": "all", "propagate_context": False},
+    "OptionalTuple": {"check_params": "all", "propagate_context": False},
+    "IPC::ArrayReferenceTuple": {"check_params": "all", "propagate_context": False},
+
+    "std::unique_ptr": {"check_params": "first", "propagate_context": False},
+    "UniqueRef": {"check_params": "first", "propagate_context": False},
+    "Ref": {"check_params": "first", "propagate_context": False},
+    "RefPtr": {"check_params": "first", "propagate_context": False},
+
+    "HashMap": {"check_params": "first_two", "propagate_context": False},
+    "MemoryCompactRobinHoodHashMap": {"check_params": "first_two", "propagate_context": False},
+    "MemoryCompactLookupOnlyRobinHoodHashSet": {"check_params": "first", "propagate_context": False},
+    "HashSet": {"check_params": "first", "propagate_context": False},
+    "OptionSet": {"check_params": "first", "propagate_context": False},
+    "Markable": {"check_params": "first", "propagate_context": False},
+    "HashCountedSet": {"check_params": "first", "propagate_context": False},
+}
+
+ALL_CONTAINER_CONFIGS = {**OPAQUE_CONTAINERS, **TRANSPARENT_CONTAINERS}
+
+
+def _is_odt_concern(type_str):
+    return type_str.strip() in ODT_CONCERN
+
+
+def _remove_const_and_whitespace(type_str):
+    if not type_str:
+        return ""
+    type_str = type_str.strip()
+    if type_str.startswith("const "):
+        type_str = type_str[6:].strip()
+    return type_str
+
+
+def _split_template_parameters(param_list):
+    """Split template parameters handling nested brackets properly
+
+    Example: "Vector<uint8_t>, String, int" -> ["Vector<uint8_t>", "String", "int"]
+    """
+    if not param_list:
+        return []
+
+    parameters = []
+    current_param = ""
+    bracket_depth = 0
+
+    for char in param_list:
+        if char == '<':
+            bracket_depth += 1
+            current_param += char
+        elif char == '>':
+            bracket_depth -= 1
+            current_param += char
+        elif char == ',' and bracket_depth == 0:
+            # Found a top-level comma - end of current parameter
+            param = _remove_const_and_whitespace(current_param)
+            if param:
+                parameters.append(param)
+            current_param = ""
+        else:
+            current_param += char
+
+    # Add the last parameter
+    param = _remove_const_and_whitespace(current_param)
+    if param:
+        parameters.append(param)
+
+    return parameters
+
+
+def _array_special_parsing(param_list):
+    """Special parsing for std::array<T, N> - only return T, ignore N"""
+    params = _split_template_parameters(param_list)
+    return params[:1] if params else []
+
+
+def _get_container_info(type_str):
+    """Get container name and parameters from a type string
+    Returns: (container_name, parameters_list, is_opaque_container) or (None, None, False) if not a container
+    """
+    for container_name in ALL_CONTAINER_CONFIGS:
+        prefix = container_name + "<"
+        if type_str.startswith(prefix) and type_str.endswith(">"):
+            param_list = type_str[len(prefix):-1]
+
+            # Handle special parsing cases
+            config = ALL_CONTAINER_CONFIGS[container_name]
+            if config.get("special_parsing") == "array_parsing":
+                parameters = _array_special_parsing(param_list)
+            else:
+                parameters = _split_template_parameters(param_list)
+
+            is_opaque_container = container_name in OPAQUE_CONTAINERS
+            return container_name, parameters, is_opaque_container
+
+    return None, None, False
+
+
+def _get_parameters_to_check(container_name, parameters):
+    """Get the list of parameters to check based on container config"""
+    if not parameters:
+        return []
+
+    config = ALL_CONTAINER_CONFIGS.get(container_name, {})
+    check_params = config.get("check_params", "all")
+
+    if check_params == "first":
+        return parameters[:1]
+    elif check_params == "first_two":
+        return parameters[:2]
+    elif check_params == "all":
+        return parameters
+    elif check_params == "selective":
+        indices = config.get("selective_indices", [])
+        return [parameters[i] for i in indices if i < len(parameters)]
+    else:
+        return []
+
+
+def _contains_opaque_data(type_str, visited=None, from_opaque_container=False):
+    """Check if a type contains opaque data.
+
+    Args:
+        type_str: The type string to check
+        visited: Set of already visited types (cycle detection)
+        from_opaque_container: True if we're in an opaque container's context
+
+    Returns:
+        The ODT concern type if found, None otherwise
+    """
+    if visited is None:
+        visited = set()
+
+    # Avoid infinite recursion
+    if type_str in visited:
+        return None
+    visited.add(type_str)
+
+    clean_type = _remove_const_and_whitespace(type_str)
+
+    if clean_type in OPAQUE_TYPES:
+        return clean_type
+
+    # ODT concerns are only opaque in opaque container context
+    if _is_odt_concern(clean_type) and from_opaque_container:
+        return clean_type
+
+    # Try to parse as container (e.g., "Vector<uint8_t>" → container_name="Vector", parameters=["uint8_t"])
+    container_name, parameters, is_opaque_container = _get_container_info(clean_type)
+
+    # If not a container template, or container has no parameters, type is not opaque
+    # Examples that return None here: "String", "int", "Vector" (no <>), "Vector<>" (empty)
+    if not container_name or not parameters:
+        return None
+
+    # Get which parameters to check based on container type
+    # E.g., HashMap<K,V> checks both K and V, Expected<T,E> only checks T
+    params_to_check = _get_parameters_to_check(container_name, parameters)
+
+    # Determine opaque context for checking child parameters
+    #
+    # ODT concerns (uint8_t, char, etc.) are ONLY opaque when inside
+    # an opaque container like Vector or std::span. The context flag tracks this.
+    #
+    # Three cases:
+    #   1. Opaque containers (Vector, std::span) → always create opaque context for children
+    #   2. Simple wrappers (std::optional, RetainPtr) → preserve parent's context
+    #   3. Structural containers (std::pair, Variant) → reset context to non-opaque
+    #
+    # Examples:
+    #   Vector<uint8_t>: Vector is opaque container → next_context=True → uint8_t is opaque ✓
+    #   std::optional<uint8_t>: std::optional preserves context, parent=False → next_context=False → not opaque ✓
+    #   Vector<std::optional<uint8_t>>: Vector sets context=True, std::optional preserves it → uint8_t is opaque ✓
+    #   std::pair<uint8_t, String>: std::pair resets context → next_context=False → uint8_t not opaque ✓
+    #
+    if is_opaque_container:
+        # Opaque containers always create opaque context for their contents
+        next_context = True
+    else:
+        # Transparent containers may preserve or reset context based on configuration
+        config = ALL_CONTAINER_CONFIGS.get(container_name, {})
+        propagates = config.get("propagate_context", False)
+        next_context = from_opaque_container if propagates else False
+
+    # Check each template parameter for opaque data
+    for param in params_to_check:
+        clean_param = _remove_const_and_whitespace(param)
+
+        # Fast path: Check if parameter is an ODT concern (uint8_t, char, etc.) in opaque context
+        # This catches cases like Vector<uint8_t> without needing to recurse
+        if _is_odt_concern(clean_param) and next_context:
+            return clean_param
+
+        # Recurse to check if parameter contains opaque data
+        # Use visited.copy() to allow same type in different branches (e.g., std::pair<Foo, Foo>)
+        # while still preventing infinite loops within a single branch
+        result = _contains_opaque_data(param, visited.copy(), next_context)
+        if result is not None:
+            return result
+
+    return None
+
+
+ATTRIBUTE_FLAG_HANDLERS = {
+    'NotSentFromWebContent': ('can_webcontent_dispatch', False),
+    'SecurityGatedReply': ('security_gated_reply', True),
+    'NeedsReview': ('needs_review', True),
+    'DebugOnly': ('debug_only', True),
+    'Legacy': ('legacy', True),
+    'UnsafeWrapper': ('unsafe_wrapper', True),
+    'SafeWrapper': ('safe_wrapper', True),
+}
+
+ATTRIBUTE_KEY_VALUE_HANDLERS = {
+    'SerializationPolicyViolation': 'serialization_policy_violation',
+    'MemorySafety': 'memory_safety',
+    'Docs': 'docs',
+}
+
+
+class OpaqueIPCTypeEntry(object):
+    """Represents a single tracked opaque transport type entry"""
+
+    def __init__(self, entry_type, attributes=None,
+                 receiver=None, message=None, parameter_name=None, parameter_type=None,
+                 alias_name=None, alias_type=None,
+                 data_type=None, name_or_method=None, type=None):
+        self.entry_type = entry_type
+        self.receiver = receiver
+        self.message = message
+        self.parameter_name = parameter_name
+        self.parameter_type = parameter_type
+        self.alias_name = alias_name
+        self.alias_type = alias_type
+        self.data_type = data_type
+        self.name_or_method = name_or_method
+        self.type = type
+
+        self._parse_attributes(attributes)
+
+    def _parse_attributes(self, attributes):
+        """Parse and set attribute flags from attribute string."""
+        self.serialization_policy_violation = None
+        self.can_webcontent_dispatch = True
+        self.legacy = False
+        self.security_gated_reply = False
+        self.needs_review = False
+        self.debug_only = False
+        self.unsafe_wrapper = False
+        self.safe_wrapper = False
+        self.memory_safety = None
+        self.docs = None
+
+        if attributes is None:
+            return
+
+        for attribute in attributes.split(', '):
+            attribute = attribute.strip()
+            if '=' in attribute:
+                key, value = attribute.split('=', 1)
+                key = key.strip()
+                value = value.strip()
+
+                if key not in ATTRIBUTE_KEY_VALUE_HANDLERS:
+                    valid_attrs = ', '.join(sorted(ATTRIBUTE_KEY_VALUE_HANDLERS.keys()))
+                    raise Exception(f"Unknown attribute '{key}' in: [{attributes}]. Valid key=value attributes are: {valid_attrs}")
+
+                attr_name = ATTRIBUTE_KEY_VALUE_HANDLERS[key]
+                setattr(self, attr_name, value.strip("'\""))
+            else:
+                if attribute not in ATTRIBUTE_FLAG_HANDLERS:
+                    valid_attrs = ', '.join(sorted(ATTRIBUTE_FLAG_HANDLERS.keys()))
+                    raise Exception(f"Unknown attribute '{attribute}' in: [{attributes}]. Valid flag attributes are: {valid_attrs}")
+
+                attr_name, attr_value = ATTRIBUTE_FLAG_HANDLERS[attribute]
+                setattr(self, attr_name, attr_value)
+
+
+class OpaqueIPCTypes(object):
+    def __init__(self, tracking_file_path=None):
+        if tracking_file_path is None:
+            tracking_file_path = os.path.join(os.path.dirname(__file__), 'opaque_ipc_types.tracking.in')
+
+        self.message_params = {}
+        self.message_param_replies = {}
+        self.alias_params = {}
+        self.structure_params = {}
+
+        # State for tracking groups
+        current_group_type = None
+        current_group_attributes = None
+
+        with open(tracking_file_path, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
+
+                if line == '}':
+                    current_group_type = None
+                    current_group_attributes = None
+                    continue
+
+                group_header = self._parse_group_header(line)
+                if group_header:
+                    current_group_attributes, current_group_type = group_header
+                    continue
+
+                entry = self._parse_line(line, current_group_type, current_group_attributes)
+                if entry:
+                    self._add_entry(entry)
+
+    def _parse_group_header(self, line):
+        """Parse a group header like: [UnsafeWrapper] Vector<uint8_t> {
+        Returns: (attributes, type_name) or None if not a group header
+        """
+        match = re.match(r'^\[([^\]]*)\]\s+(.+?)\s*\{\s*$', line)
+        if match:
+            attributes = match.group(1).strip()
+            type_name = match.group(2).strip()
+            return (attributes, type_name)
+        return None
+
+    def _parse_alias_param(self, rest, group_type, attributes):
+        """Parse an AliasParam entry."""
+        if group_type:
+            alias_name = rest.strip()
+            alias_type = group_type
+        else:
+            parts = rest.split(None, 1)
+            if len(parts) < 2:
+                raise Exception(f'opaque_ipc_types.tracking.in ungrouped AliasParam missing type. Expected format: [attr] AliasParam AliasName TypeString')
+            alias_name = parts[0]
+            alias_type = parts[1]
+
+        return OpaqueIPCTypeEntry(
+            entry_type='AliasParam',
+            attributes=attributes,
+            alias_name=alias_name,
+            alias_type=alias_type
+        )
+
+    def _parse_structure_param(self, rest, group_type, attributes):
+        """Parse a StructureParam entry."""
+        if group_type:
+            parts = [rest.strip()]
+            param_type = group_type
+        else:
+            parts = rest.split(None, 1)
+            if len(parts) < 2:
+                raise Exception(f'opaque_ipc_types.tracking.in ungrouped StructureParam missing type. Expected format: [attr] StructureParam DataType.member TypeString')
+            param_type = parts[1]
+
+        if '.' in parts[0]:
+            data_type, name_or_method = parts[0].split('.', 1)
+        else:
+            data_type = parts[0]
+            name_or_method = parts[0]
+
+        return OpaqueIPCTypeEntry(
+            entry_type='StructureParam',
+            attributes=attributes,
+            data_type=data_type,
+            name_or_method=name_or_method,
+            type=param_type
+        )
+
+    def _parse_message_param(self, record_type, rest, group_type, attributes):
+        """Parse a MessageParam or MessageParamReply entry."""
+        if group_type:
+            parts = rest.split(None, 1)
+            if len(parts) < 2:
+                raise Exception(f'opaque_ipc_types.tracking.in grouped {record_type} missing parameter name. Expected format: [attr] {record_type} Receiver.Message parameterName')
+            param_type = group_type
+        else:
+            parts = rest.split(None, 2)
+            if len(parts) < 3:
+                raise Exception(f'opaque_ipc_types.tracking.in ungrouped {record_type} incomplete. Expected format: [attr] {record_type} Receiver.Message parameterName TypeString')
+            param_type = parts[2]
+
+        if '.' in parts[0]:
+            receiver, message = parts[0].split('.', 1)
+        else:
+            receiver = parts[0]
+            message = parts[0]
+
+        return OpaqueIPCTypeEntry(
+            entry_type=record_type,
+            attributes=attributes,
+            receiver=receiver,
+            message=message,
+            parameter_name=parts[1],
+            parameter_type=param_type
+        )
+
+    def _parse_line(self, line, group_type=None, group_attributes=None):
+        match = re.match(r'^\[([^\]]*)\]\s+(\S+)\s+(.+)$', line)
+        if not match:
+            if group_type:
+                raise Exception(f'opaque_ipc_types.tracking.in grouped entry malformed. Line: {line}. Expected format: [attr] RecordType ...')
+            raise Exception(f'opaque_ipc_types.tracking.in item missing attributes: {line}')
+
+        attributes, record_type, rest = match.groups()
+
+        combined_attributes = f"{group_attributes}, {attributes}" if group_attributes and attributes else (group_attributes or attributes)
+
+        if record_type == 'AliasParam':
+            return self._parse_alias_param(rest, group_type, combined_attributes)
+        elif record_type == 'StructureParam':
+            return self._parse_structure_param(rest, group_type, combined_attributes)
+        elif record_type in ('MessageParam', 'MessageParamReply'):
+            return self._parse_message_param(record_type, rest, group_type, combined_attributes)
+        else:
+            raise Exception(f'Unknown record type: {record_type}')
+
+    def _add_entry(self, entry):
+        if entry.entry_type == 'MessageParam':
+            key = (f'{entry.receiver}.{entry.message}', entry.parameter_name)
+            if key not in self.message_params:
+                self.message_params[key] = []
+            self.message_params[key].append(entry)
+        elif entry.entry_type == 'MessageParamReply':
+            key = (f'{entry.receiver}.{entry.message}', entry.parameter_name)
+            if key not in self.message_param_replies:
+                self.message_param_replies[key] = []
+            self.message_param_replies[key].append(entry)
+        elif entry.entry_type == 'AliasParam':
+            if entry.alias_name not in self.alias_params:
+                self.alias_params[entry.alias_name] = []
+            self.alias_params[entry.alias_name].append(entry)
+        elif entry.entry_type == 'StructureParam':
+            key = (entry.data_type, entry.name_or_method)
+            if key not in self.structure_params:
+                self.structure_params[key] = []
+            self.structure_params[key].append(entry)
+
+    def _query_entries(self, entry_dict, key, type_field, type_string):
+        """Generic query method for checking if an entry is tracked."""
+        if key not in entry_dict:
+            return False
+        if type_string is None:
+            return True
+        return any(getattr(e, type_field) == type_string for e in entry_dict[key])
+
+    def _is_webcontent_dispatchable(self, entry_dict, key, type_field, type_string):
+        """Generic method to check if entry allows WebContent dispatch."""
+        if key not in entry_dict:
+            return True
+        return not any(
+            getattr(e, type_field) == type_string and not e.can_webcontent_dispatch
+            for e in entry_dict[key]
+        )
+
+    def message_param_tracked(self, receiver, message, parameter_name, type_string=None):
+        key = (f'{receiver}.{message}', parameter_name)
+        return self._query_entries(self.message_params, key, 'parameter_type', type_string)
+
+    def message_param_reply_tracked(self, receiver, message, parameter_name, type_string=None):
+        key = (f'{receiver}.{message}', parameter_name)
+        return self._query_entries(self.message_param_replies, key, 'parameter_type', type_string)
+
+    def alias_param_tracked(self, alias_name, type_string=None):
+        return self._query_entries(self.alias_params, alias_name, 'alias_type', type_string)
+
+    def structure_param_tracked(self, data_type, name_or_method, type_string=None):
+        key = (data_type, name_or_method)
+        return self._query_entries(self.structure_params, key, 'type', type_string)
+
+    def webcontent_dispatchable(self, receiver, message, parameter_name, parameter_type):
+        key = (f'{receiver}.{message}', parameter_name)
+        return self._is_webcontent_dispatchable(self.message_params, key, 'parameter_type', parameter_type)
+
+    def reply_webcontent_dispatchable(self, receiver, message, parameter_name, parameter_type):
+        key = (f'{receiver}.{message}', parameter_name)
+        return self._is_webcontent_dispatchable(self.message_param_replies, key, 'parameter_type', parameter_type)
+
+    def structure_webcontent_dispatchable(self, data_type, name_or_method, type_string):
+        key = (data_type, name_or_method)
+        return self._is_webcontent_dispatchable(self.structure_params, key, 'type', type_string)
+
+
+try:
+    opaque_ipc_types = OpaqueIPCTypes()
+except FileNotFoundError as e:
+    raise Exception(f"opaque_ipc_types.tracking.in file not found: {e}")
+
+
+def is_opaque_type(type):
+    """Check if a type represents opaque data transport.
+
+    Returns True if the type is opaque:
+    1. Direct opaque types (MachSendRight, CFDataRef, etc.)
+    2. Opaque containers with ODT concerns (Vector<uint8_t>, std::span<char>, etc.)
+    3. Transparent containers containing opaque data (std::pair<Vector<uint8_t>, String>)
+
+    Returns False otherwise:
+    4. Transparent containers without opaque data (std::pair<uint8_t, String>)
+    5. Non-opaque types (String, int, etc.)
+    6. Non-containers (uint8_t, WTF::UUID, etc.)
+    """
+    return _contains_opaque_data(type) is not None
+
+
+if __name__ == '__main__':
+    import unittest
+
+    class TestOpaqueTypes(unittest.TestCase):
+
+        def test_is_odt_concern_function(self):
+            for odt_type in ODT_CONCERN:
+                self.assertTrue(_is_odt_concern(odt_type), f"Expected {odt_type} to be ODT concern")
+
+            non_odt_types = ['String', 'int', 'float', 'bool', 'WTF::UUID']
+            for non_odt_type in non_odt_types:
+                self.assertFalse(_is_odt_concern(non_odt_type), f"Expected {non_odt_type} to not be ODT concern")
+
+        def test_contains_opaque_data_function(self):
+            # Test opaque containers with ODT concerns
+            self.assertEqual(_contains_opaque_data("std::span<uint8_t>"), "uint8_t")
+            self.assertEqual(_contains_opaque_data("std::span<const uint8_t>"), "uint8_t")
+            self.assertEqual(_contains_opaque_data("Vector<char>"), "char")
+            self.assertEqual(_contains_opaque_data("Vector<const char>"), "char")
+            self.assertEqual(_contains_opaque_data("std::array<uint8_t, 24>"), "uint8_t")
+            self.assertEqual(_contains_opaque_data("std::array<const uint8_t, 16>"), "uint8_t")
+            self.assertEqual(_contains_opaque_data("RetainPtr<CFDataRef>"), "CFDataRef")
+            self.assertEqual(_contains_opaque_data("Vector<MachSendRight>"), "MachSendRight")
+
+            # Test nested containers
+            self.assertEqual(_contains_opaque_data("std::optional<Vector<uint8_t>>"), "uint8_t")
+            self.assertEqual(_contains_opaque_data("Vector<std::optional<uint8_t>>"), "uint8_t")
+            self.assertEqual(_contains_opaque_data("Vector<std::pair<Vector<uint8_t>, std::optional<WTF::UUID>>>"), "uint8_t")
+            self.assertEqual(_contains_opaque_data("Variant<Vector<uint8_t>, String>"), "uint8_t")
+
+            # Test transparent containers without opaque content
+            self.assertIsNone(_contains_opaque_data("Expected<uint8_t, String>"))
+            self.assertIsNone(_contains_opaque_data("Variant<uint8_t, String>"))
+            self.assertIsNone(_contains_opaque_data("std::pair<uint8_t, String>"))
+            self.assertIsNone(_contains_opaque_data("std::optional<uint8_t>"))
+            self.assertIsNone(_contains_opaque_data("uint8_t"))
+            self.assertIsNone(_contains_opaque_data("String"))
+
+        def test_direct_opaque_types(self):
+            self.assertTrue(is_opaque_type("MachSendRight"))
+            self.assertTrue(is_opaque_type("MachSendRightAnnotated"))
+            self.assertFalse(is_opaque_type("String"))
+            self.assertFalse(is_opaque_type("int"))
+
+        def test_container_types_with_odt_concerns(self):
+            self.assertTrue(is_opaque_type("std::optional<Vector<uint8_t>>"))
+            self.assertTrue(is_opaque_type("Vector<std::optional<uint8_t>>"))
+            self.assertTrue(is_opaque_type("std::span<uint8_t>"))
+            self.assertTrue(is_opaque_type("std::span<const uint8_t>"))
+            self.assertTrue(is_opaque_type("std::span<char>"))
+            self.assertTrue(is_opaque_type("std::span<const char>"))
+            self.assertTrue(is_opaque_type("std::array<uint8_t, 24>"))
+            self.assertTrue(is_opaque_type("std::array<const uint8_t, 16>"))
+            self.assertTrue(is_opaque_type("Vector<uint8_t>"))
+            self.assertTrue(is_opaque_type("Vector<const uint8_t>"))
+            self.assertTrue(is_opaque_type("Vector<char>"))
+            self.assertTrue(is_opaque_type("RetainPtr<CFDataRef>"))
+            self.assertTrue(is_opaque_type("RetainPtr<NSData>"))
+            self.assertTrue(is_opaque_type("std::optional<Vector<uint8_t>>"))
+            self.assertTrue(is_opaque_type("Expected<Vector<uint8_t>, String>"))
+            self.assertTrue(is_opaque_type("Variant<Vector<uint8_t>, String>"))
+            self.assertTrue(is_opaque_type("std::pair<Vector<uint8_t>, String>"))
+            self.assertTrue(is_opaque_type("std::pair<String, Vector<uint8_t>>"))
+            self.assertTrue(is_opaque_type("Vector<std::pair<Vector<uint8_t>, std::optional<WTF::UUID>>>"))
+            self.assertTrue(is_opaque_type("std::optional<Vector<std::pair<Vector<uint8_t>, String>>>"))
+            self.assertTrue(is_opaque_type("HashMap<String, FixedVector<uint8_t>>"))
+            self.assertTrue(is_opaque_type("HashSet<Vector<uint8_t>>"))
+            self.assertTrue(is_opaque_type("std::unique_ptr<Vector<uint8_t>>"))
+            self.assertTrue(is_opaque_type("KeyValuePair<Vector<uint8_t>, String>"))
+            self.assertTrue(is_opaque_type("Vector<HashMap<String, std::pair<Vector<uint8_t>, int>>>"))
+            self.assertTrue(is_opaque_type("Variant<Vector<uint8_t>, WebKit::HTTPBody::Element::FileData, String>"))
+            self.assertTrue(is_opaque_type("Expected<std::pair<Vector<uint8_t>, String>, String>"))
+            self.assertTrue(is_opaque_type("Vector<std::pair<Vector<uint8_t>, std::optional<WTF::UUID>>>"))
+            self.assertTrue(is_opaque_type("std::optional<Vector<std::pair<Vector<uint8_t>, String>>>"))
+            self.assertTrue(is_opaque_type("Variant<Vector<uint8_t>, WebKit::HTTPBody::Element::FileData, String>"))
+            self.assertTrue(is_opaque_type("Variant<Vector<uint8_t>, Ref<WebCore::SharedBuffer>, URL>"))
+
+        def test_container_types_without_odt_concerns(self):
+            self.assertFalse(is_opaque_type("std::span<String>"))
+            self.assertFalse(is_opaque_type("std::array<int, 5>"))
+            self.assertFalse(is_opaque_type("Vector<String>"))
+            self.assertFalse(is_opaque_type("std::optional<String>"))
+            self.assertFalse(is_opaque_type("std::optional<uint8_t>"))
+            self.assertFalse(is_opaque_type("Expected<uint8_t, String>"))
+            self.assertFalse(is_opaque_type("Expected<String, uint8_t>"))
+            self.assertFalse(is_opaque_type("Expected<String, int>"))
+            self.assertFalse(is_opaque_type("Variant<uint8_t, int>"))
+            self.assertFalse(is_opaque_type("Variant<String, int>"))
+            self.assertFalse(is_opaque_type("std::pair<uint8_t, String>"))
+            self.assertFalse(is_opaque_type("std::optional<std::pair<uint8_t, String>>"))
+            self.assertFalse(is_opaque_type("Vector<std::pair<uint8_t, String>>"))
+
+        def test_infinite_recursion_protection(self):
+            # Create a visited set that simulates a circular reference
+            visited = {"TestType"}
+
+            # This should return None due to the visited check, not cause infinite recursion
+            result = _contains_opaque_data("TestType", visited=visited)
+            self.assertIsNone(result)
+
+            # Test with a type that would normally be opaque but is already visited
+            visited_opaque = {"Vector<uint8_t>"}
+            result = _contains_opaque_data("Vector<uint8_t>", visited=visited_opaque)
+            self.assertIsNone(result)
+
+            # Verify normal operation still works when not visited
+            result = _contains_opaque_data("Vector<uint8_t>")
+            self.assertEqual(result, "uint8_t")
+
+        def test_bad_formatting(self):
+            self.assertFalse(is_opaque_type(""))
+            self.assertFalse(is_opaque_type("Vector<>"))
+            self.assertFalse(is_opaque_type("std::optional<>"))
+            self.assertFalse(is_opaque_type("Vector"))
+            self.assertFalse(is_opaque_type("std::optional"))
+            self.assertFalse(is_opaque_type("<uint8_t>"))
+
+        def test_context_propagation_through_simple_wrappers(self):
+            # This is opaque because Vector creates opaque context
+            self.assertTrue(is_opaque_type("Vector<std::optional<uint8_t>>"))
+
+            # This is NOT opaque because std::optional alone doesn't create context
+            self.assertFalse(is_opaque_type("std::optional<uint8_t>"))
+
+        def test_context_reset_in_structural_containers(self):
+            # uint8_t alone in pair is not opaque
+            self.assertFalse(is_opaque_type("std::pair<uint8_t, String>"))
+
+            # But Vector<uint8_t> is opaque even in pair
+            self.assertTrue(is_opaque_type("std::pair<Vector<uint8_t>, String>"))
+
+        def test_retainptr_with_direct_opaque_types(self):
+            self.assertTrue(is_opaque_type("RetainPtr<CFDataRef>"))
+            self.assertTrue(is_opaque_type("RetainPtr<NSData>"))
+            self.assertTrue(is_opaque_type("RetainPtr<MachSendRight>"))
+
+        def test_deeply_nested_types(self):
+            deep_type = "Vector<HashMap<String, std::pair<std::optional<Vector<uint8_t>>, int>>>"
+            self.assertTrue(is_opaque_type(deep_type))
+
+        def test_opaque_ipc_types_parsing(self):
+            test_file = os.path.join(os.path.dirname(__file__), 'tests', 'test_opaque_ipc_types.tracking.in')
+            if not os.path.exists(test_file):
+                self.fail(f"Test tracking file not found: {test_file}")
+
+            ot = OpaqueIPCTypes(test_file)
+
+            total_entries = sum(len(entries) for entries in ot.message_params.values())
+            total_entries += sum(len(entries) for entries in ot.message_param_replies.values())
+            total_entries += sum(len(entries) for entries in ot.alias_params.values())
+            total_entries += sum(len(entries) for entries in ot.structure_params.values())
+
+            print(f"\ntest_opaque_ipc_types.tracking.in:")
+            print(f"  Total entries: {total_entries}")
+            print(f"    MessageParam: {sum(len(e) for e in ot.message_params.values())}")
+            print(f"    MessageParamReply: {sum(len(e) for e in ot.message_param_replies.values())}")
+            print(f"    AliasParam: {sum(len(e) for e in ot.alias_params.values())}")
+            print(f"    StructureParam: {sum(len(e) for e in ot.structure_params.values())}")
+
+            self.assertGreater(total_entries, 0, "Test file should have entries")
+
+            # Specific entries which are in the test file
+            self.assertTrue(ot.message_param_tracked('TestWithLegacyReceiver', 'DidCreateWebProcessConnection', 'connectionIdentifier', 'MachSendRight'))
+            self.assertTrue(ot.message_param_tracked('TestWithStream', 'SendMachSendRight', 'a1', 'MachSendRight'))
+            self.assertTrue(ot.message_param_reply_tracked('TestWithStream', 'ReceiveMachSendRight', 'r1', 'MachSendRight'))
+            self.assertTrue(ot.alias_param_tracked('TestNamespace::TestSalt', 'std::array<uint8_t, 8>'))
+            self.assertTrue(ot.structure_param_tracked('WebKit::TestStruct', 'buffer', 'Vector<uint8_t>'))
+
+            # Check the lookup logic for non existant items
+            self.assertFalse(ot.message_param_tracked('NonExistantReceiver', 'NonExistantMessage', 'NonExistantParameterName', 'NonExistantType'))
+            self.assertFalse(ot.message_param_reply_tracked('NonExistantReceiver', 'NonExistantMessage', 'NonExistantParameterName', 'NonExistantType'))
+            self.assertFalse(ot.alias_param_tracked('NonExistantAlias', 'NonExistantType'))
+            self.assertFalse(ot.structure_param_tracked('NonExistantStruct', 'NonExistantMmember', 'NonExistantType'))
+
+            # Things WebContent can send
+            self.assertTrue(ot.structure_webcontent_dispatchable('WebKit::TestStruct', 'buffer', 'Vector<uint8_t>'))
+            self.assertFalse(ot.structure_webcontent_dispatchable('WebKit::SecureData', 'encrypted', 'Vector<uint8_t>'))
+
+            self.assertTrue(ot.webcontent_dispatchable('TestWithLegacyReceiver', 'DidCreateWebProcessConnection', 'connectionIdentifier', 'MachSendRight'))
+            self.assertFalse(ot.webcontent_dispatchable('TestWithLegacyReceiver', 'OpaqueTypeSecurityAssertion', 'param', 'NotDispatchableFromWebContentType'))
+
+            self.assertTrue(ot.reply_webcontent_dispatchable('UserInterface', 'GetUserData', 'data', 'std::span<const uint8_t>'))
+            self.assertFalse(ot.reply_webcontent_dispatchable('TestInterface', 'GetData', 'result', 'std::span<const uint8_t>'))
+
+        def test_production_tracking_file_parses(self):
+            ot = OpaqueIPCTypes()
+
+            total_entries = sum(len(e) for e in ot.message_params.values())
+            total_entries += sum(len(e) for e in ot.message_param_replies.values())
+            total_entries += sum(len(e) for e in ot.alias_params.values())
+            total_entries += sum(len(e) for e in ot.structure_params.values())
+
+            print(f"\nopaque_ipc_types.tracking.in")
+            print(f"  Total entries: {total_entries}")
+            print(f"    MessageParam: {sum(len(e) for e in ot.message_params.values())}")
+            print(f"    MessageParamReply: {sum(len(e) for e in ot.message_param_replies.values())}")
+            print(f"    AliasParam: {sum(len(e) for e in ot.alias_params.values())}")
+            print(f"    StructureParam: {sum(len(e) for e in ot.structure_params.values())}")
+
+            self.assertGreater(total_entries, 10, "opaque_ipc_types.tracking.in seems to have too few entries")
+
+    unittest.main()

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -1,0 +1,482 @@
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This file tracks Opaque Data Type usage in CoreIPC in 4 places:
+# MessageParam - in a message parameter
+# MessageParamReply - in a message reply parameter
+# AliasParam - in a using statement in a serialization.in file
+# StructureParam - in a structure in a serialization.in file
+
+# See https://en.wikipedia.org/wiki/Opaque_data_type
+
+# If you find yourself adding something to this file to ensure the build completes please consider using a
+# SafeWrapper (explained below) or well defined type which decompose to simple primitives.
+#
+# Additions or changes to this file will trigger a review with a security focus.
+
+# We introduce two concepts to model the risk from Opaque Data Types:
+#
+# SafeWrapper: 
+#     A SafeWrapper is safe because the regular use of it cannot invalidate a security property.
+#     The data is specifically constrained in usage in the implementation (e.g. data handled fully in Strictly Safe Swift)
+#     or it's usage and behavior is primitive (specific) enough for it to be deemed very low risk.
+
+# UnsafeWrapper:
+#     It's never OK for an unsafe wrapper to be sent from WebContent without additional security considerations.
+#     The IPC serialization mechanism provides no guaranteed of safety or structure.
+#     Each use of an unsafe wrapper needs to be reviewed.
+#     Where and how an UnsafeWrapper type is used is critical for security.
+# 
+# When developing IPC flows, prefer SafeWrappers and well defined types which decompose to simple primitives.
+
+# Each item in this tracking file must have one of the following attributes for justification (in square brackets):
+#
+# Legacy: This is a bootstrapping state for NeedsReview
+# NeedsReview: This item needs to be reviewed by the security team
+# SafeWrapper: The item has been reviewed and is deemed a SafeWrapper, must also include 'MemorySafety= ...'
+# UnsafeWrapper: The item has been reviewed and can only be used in the documented ways. 
+# SecurityGatedReply: The item handled after a security relevent gate (i.e user interaction)
+# NotSentFromWebContent: We can add a ASSERT(!isInWebProcess()) in the encoder. Currently no runtime checks for AliasParam
+# DebugOnly: This is compiled out in release so we don't need to worry about it
+# SerializationPolicyViolation: Items which should be UnsafeWrapper but the added ASSERTs break functionality
+
+# Additional attributes can be used for contextual information:
+# Docs= ... , Radar or https://bugs.webkit.org link for more info / documentation
+# MemorySafety= ... , Description of level (see below):
+
+# When we have an attribute describing memory safety progress, these are the progress levels:
+# - 0: Claiming that it is desired but with no current progress
+# - 1: We have specific documented fuzzing for a capability implemented in a memory unsafe language
+# - 2: We have specific documented fuzzing and all static analysis issues are resolved (e.g SaferCPP)
+# - 3: We have a Strictly Safe Swift implementation of the capability
+
+########################### Test Items ##########################################
+# To not special case running generation tests we have a small number of test items here
+# Test are run via: make -C Source/WebKit/Scripts/webkit/tests
+[UnsafeWrapper] MachSendRight {
+    [Legacy] MessageParam TestWithLegacyReceiver.DidCreateWebProcessConnection connectionIdentifier
+    [Legacy] MessageParam TestWithoutAttributes.DidCreateWebProcessConnection connectionIdentifier
+    [Legacy] MessageParam TestWithStream.SendMachSendRight a1
+    [Legacy] MessageParamReply TestWithStream.ReceiveMachSendRight r1
+    [Legacy] MessageParam TestWithStream.SendAndReceiveMachSendRight a1
+    [Legacy] MessageParamReply TestWithStream.SendAndReceiveMachSendRight r1
+}
+# NotDispatchableFromWebContent is specified as an ODT type in opaque_ipc_types.py
+[NotSentFromWebContent] StructureParam WebCore::OpaqueTypeObject.member NotDispatchableFromWebContent
+[NotSentFromWebContent] MessageParam TestWithLegacyReceiver.OpaqueTypeSecurityAssertion ping NotDispatchableFromWebContent
+[NotSentFromWebContent] MessageParam TestWithoutAttributes.OpaqueTypeSecurityAssertion ping NotDispatchableFromWebContent
+[NotSentFromWebContent] MessageParamReply TestWithLegacyReceiver.OpaqueTypeSecurityAssertion pong NotDispatchableFromWebContent
+[NotSentFromWebContent] MessageParamReply TestWithoutAttributes.OpaqueTypeSecurityAssertion pong NotDispatchableFromWebContent
+[NotSentFromWebContent] AliasParam WebCore::AliasOpaqueTypeWrapper Variant<int, Vector<uint8_t>>
+[NotSentFromWebContent] StructureParam Namespace::OtherClass.dataDetectorResults RetainPtr<NSArray>
+
+########################### Opaque Data Types in CoreIPC ##########################################
+
+[SerializationPolicyViolation='rdar://160898631 Adopt NotSentFromWebContent'] StructureParam API::Data.span() std::span<const uint8_t>
+
+# The AliasParam handling either shows the whole type if it's on one line or just the OTD if it's a multiline variant
+[Legacy] AliasParam FileSystem::Salt std::array<uint8_t, 8>
+[Legacy] AliasParam WebCore::GraphicsContextGL::ExternalSyncSource std::tuple<MachSendRight, uint64_t>
+[Legacy] AliasParam WebKit::CFObjectValue Variant<std::nullptr_t, WebKit::CoreIPCCFArray, WebKit::CoreIPCBoolean, WebKit::CoreIPCCFCharacterSet, WebKit::CoreIPCData, WebKit::CoreIPCDate, WebKit::CoreIPCCFDictionary, WebKit::CoreIPCNull, WebKit::CoreIPCNumber, WebKit::CoreIPCString, WebKit::CoreIPCCFURL, WebKit::CoreIPCSecCertificate, WebKit::CoreIPCSecTrust, WebKit::CoreIPCCGColorSpace, WebCore::Color, WebKit::CoreIPCSecAccessControl>
+[Legacy] AliasParam WebKit::CoreIPCCFDictionary::KeyType Variant<WebKit::CoreIPCCFArray, WebKit::CoreIPCBoolean, WebKit::CoreIPCCFCharacterSet, WebKit::CoreIPCData, WebKit::CoreIPCDate, WebKit::CoreIPCCFDictionary, WebKit::CoreIPCNull, WebKit::CoreIPCNumber, WebKit::CoreIPCString, WebKit::CoreIPCCFURL>
+[Legacy] AliasParam WebKit::CoreIPCNSURLRequestData::BodyParts Variant<WebKit::CoreIPCString, WebKit::CoreIPCData>
+[Legacy] AliasParam WebKit::CoreIPCSecTrustData::ExceptionType Vector<std::pair<WebKit::CoreIPCString, Variant<WebKit::CoreIPCNumber, WebKit::CoreIPCData, bool>>>
+[Legacy] AliasParam WebKit::CoreIPCSecTrustData::PolicyArrayOfData Vector<WebKit::CoreIPCData>
+[Legacy] AliasParam WebKit::ImageBufferBackendHandle Variant<WebCore::ShareableBitmapHandle, MachSendRight, WebCore::DynamicContentScalingDisplayList>
+[Legacy] AliasParam WebKit::ImageBufferBackendHandle Variant<WebCore::ShareableBitmapHandle, MachSendRight>
+[Legacy] AliasParam WebKit::ObjectValue WebKit::CoreIPCData
+[Legacy] AliasParam WebCore::SharedMemory::Handle WebCore::SharedMemoryHandle
+[Legacy] AliasParam WebKit::PlistValue Variant<WebKit::CoreIPCPlistArray, WebKit::CoreIPCPlistDictionary, WebKit::CoreIPCString, WebKit::CoreIPCNumber, WebKit::CoreIPCDate, WebKit::CoreIPCData>
+[Legacy] AliasParam WebKit::SharedVideoFrame::Buffer Variant<std::nullptr_t, WebKit::RemoteVideoFrameReadReference, MachSendRight, WebCore::IntSize>
+
+# [UnsafeWrapper] in single line format as they are all unique types
+[Legacy] MessageParamReply WebPageProxy.ModelElementSizeDidChange result Expected<MachSendRight, WebCore::ResourceError>
+[Legacy] MessageParamReply UserMediaCaptureManagerProxy.TakePhoto result Expected<std::pair<Vector<uint8_t>, String>, String>
+[Legacy] MessageParam NetworkProcess.SetProxyConfigData proxyConfigurations Vector<std::pair<Vector<uint8_t>, std::optional<WTF::UUID>>>
+[Legacy] StructureParam WebKit::HTTPBody::Element.data Variant<Vector<uint8_t>, WebKit::HTTPBody::Element::FileData, String>
+[Legacy] StructureParam WebCore::SerializedPlatformDataCueValue::Data.value Variant<std::nullptr_t, RetainPtr<NSString>, RetainPtr<NSDate>, RetainPtr<NSNumber>, RetainPtr<NSData>>
+[Legacy] StructureParam WebCore::BlobPart.m_dataOrURL Variant<Vector<uint8_t>, Ref<WebCore::SharedBuffer>, URL>
+[Legacy] StructureParam WebCore::FormDataElement.data Variant<Vector<uint8_t>, WebCore::FormDataElement::EncodedFileData, WebCore::FormDataElement::EncodedBlobData>
+[Legacy] StructureParam WebCore::FragmentedSharedBuffer.toIPCData() Variant<std::optional<WebCore::SharedMemoryHandle>, Vector<std::span<const uint8_t>>>
+[Legacy] StructureParam WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::CustomData.sendRightAnnotated std::optional<WTF::MachSendRightAnnotated>
+[Legacy] StructureParam WebKit::NetworkSessionCreationParameters.proxyConfigData std::optional<Vector<std::pair<Vector<uint8_t>, std::optional<WTF::UUID>>>>
+
+[UnsafeWrapper] std::optional<std::span<const uint8_t>> {
+    [Legacy] StructureParam WebKit::CoreIPCData.dataReference() 
+    [NotSentFromWebContent] MessageParam WebSWContextManagerConnection.FirePushEvent data
+}
+
+[UnsafeWrapper] std::span<const uint8_t> {
+    [Legacy] MessageParam LibWebRTCCodecs.CompletedEncoding data
+    [Legacy] MessageParam LibWebRTCCodecs.SetEncodingConfiguration description
+    [Legacy] MessageParam LibWebRTCCodecsProxy.DecodeFrame data
+    [Legacy] MessageParam LibWebRTCCodecsProxy.SetDecoderFormatDescription description
+
+    [Legacy] MessageParam LogStream.LogOnBehalfOfWebContent logCategory
+    [Legacy] MessageParam LogStream.LogOnBehalfOfWebContent logChannel
+    [Legacy] MessageParam LogStream.LogOnBehalfOfWebContent logString
+
+    [Legacy] MessageParam NetworkRTCProvider.SendToSocket data
+    [Legacy] MessageParam NetworkSocketChannel.SendData data
+    [Legacy] MessageParam NetworkSocketChannel.SendString message
+
+    [Legacy] MessageParam NetworkStorageManager.ExecuteCommandForWritable dataBytes
+
+    [Legacy] MessageParam NetworkTransportSession.SendDatagram datagram
+    [Legacy] MessageParam NetworkTransportSession.StreamSendBytes bytes
+
+    [Legacy] MessageParam RemoteGraphicsContextGL.BufferData1 data
+    [Legacy] MessageParam RemoteGraphicsContextGL.BufferSubData data
+    [Legacy] MessageParam RemoteGraphicsContextGL.CompressedTexImage2D0 data
+    [Legacy] MessageParam RemoteGraphicsContextGL.CompressedTexImage3D0 data
+    [Legacy] MessageParam RemoteGraphicsContextGL.CompressedTexSubImage2D0 data
+    [Legacy] MessageParam RemoteGraphicsContextGL.CompressedTexSubImage3D0 data
+    [Legacy] MessageParam RemoteGraphicsContextGL.TexImage2D0 pixels
+    [Legacy] MessageParam RemoteGraphicsContextGL.TexImage3D0 pixels
+    [Legacy] MessageParam RemoteGraphicsContextGL.TexSubImage2D0 pixels
+    [Legacy] MessageParam RemoteGraphicsContextGL.TexSubImage3D0 pixels
+
+    [Legacy] MessageParam WebPageProxy.RegisterWebProcessAccessibilityToken data
+    [Legacy] MessageParam WebPageProxy.RelayAccessibilityNotification notificationData
+    [Legacy] MessageParam WebPageProxy.DidFinishLoadingDataForCustomContentProvider data
+
+    [Legacy] MessageParam RTCDataChannelRemoteManagerProxy.ReceiveData data
+    [Legacy] MessageParam RTCDataChannelRemoteManagerProxy.SendData text
+
+    [Legacy] StructureParam WebKit::CoreIPCSecAccessControl.dataReference()
+    [Legacy] StructureParam WebKit::CoreIPCSecCertificate.dataReference()
+    [Legacy] StructureParam WebKit::CoreIPCSecKeychainItem.dataReference()
+    [Legacy] StructureParam WebKit::CoreIPCSecTrust.dataReference()
+    [Legacy] StructureParam WebKit::CoreIPCCFCharacterSet.dataReference()
+    [Legacy] StructureParam WebKit::SandboxExtensionImpl.getSerializedFormat()
+    [Legacy] StructureParam WebCore::BufferSource.span()
+    [Legacy] StructureParam WebCore::PixelBufferSourceView.bytes()
+    [Legacy] StructureParam JSC::ArrayBufferContents.span()
+
+    [SecurityGatedReply] MessageParamReply WebPage.OpenPDFWithPreview data
+    [SecurityGatedReply] MessageParamReply WebPage.SavePDF data
+    [NotSentFromWebContent] MessageParam WebTransportSession.ReceiveDatagram datagram
+    [NotSentFromWebContent] MessageParam WebTransportSession.StreamReceiveBytes bytes
+    [NotSentFromWebContent] MessageParam WebSocketChannel.DidReceiveBinaryData data
+    [NotSentFromWebContent] MessageParam RTCDataChannelRemoteManager.ReceiveData data
+    [NotSentFromWebContent] MessageParam RTCDataChannelRemoteManager.SendData text
+    [NotSentFromWebContent] MessageParam NetworkProcessProxy.DataTaskDidReceiveData data
+    [NotSentFromWebContent] MessageParam NetworkProcess.PublishDownloadProgress activityAccessToken
+    [NotSentFromWebContent] MessageParam NetworkProcess.PublishDownloadProgress bookmarkData
+    [NotSentFromWebContent] MessageParam NetworkProcess.ResumeDownload activityAccessToken
+    [NotSentFromWebContent] MessageParam NetworkProcess.ResumeDownload resumeData
+    [NotSentFromWebContent] MessageParam MediaPlayerPrivateRemote.AddDataCue data
+    [NotSentFromWebContent] MessageParam MediaPlayerPrivateRemote.InitializationDataEncountered initData
+    [NotSentFromWebContent] MessageParam MediaPlayerPrivateRemote.MediaPlayerKeyNeeded message
+    [NotSentFromWebContent] MessageParam MediaPlayerPrivateRemote.ParseWebVTTCueData data
+    [NotSentFromWebContent] MessageParamReply DownloadProxy.DecideDestinationWithSuggestedFilename activityAccessToken
+    [NotSentFromWebContent] MessageParamReply DownloadProxy.DecideDestinationWithSuggestedFilename placeholderBookmarkData
+    [NotSentFromWebContent] MessageParamReply NetworkProcess.CancelDownload resumeData
+    [NotSentFromWebContent] MessageParamReply RemoteGraphicsContextGL.GetBufferSubDataInline data
+    [NotSentFromWebContent] MessageParamReply RemoteGraphicsContextGL.ReadPixelsInline data
+    [NotSentFromWebContent] MessageParam DownloadProxy.DidFail resumeData
+    [NotSentFromWebContent] MessageParam DownloadProxy.DidReceiveFinalURL bookmarkData
+    [NotSentFromWebContent] MessageParam DownloadProxy.DidReceivePlaceholderURL bookmarkData
+    [NotSentFromWebContent] MessageParam GPUProcess.ResolveBookmarkDataForCacheDirectory bookmarkData
+    [NotSentFromWebContent] MessageParam LegacyCustomProtocolManager.DidLoadData data
+    [NotSentFromWebContent] MessageParam LibWebRTCNetwork.SignalReadPacket data
+    [NotSentFromWebContent] MessageParam WebPage.DidChooseFilesForOpenPanelWithDisplayStringAndIcon iconData
+    [NotSentFromWebContent] MessageParam WebPage.InsertMultiRepresentationHEIC data
+    [NotSentFromWebContent] MessageParam WebPage.LoadDataInFrame data
+    [NotSentFromWebContent] MessageParam WebPage.RegisterUIProcessAccessibilityTokens elementToken
+    [NotSentFromWebContent] MessageParam WebPage.RegisterUIProcessAccessibilityTokens windowToken
+    [NotSentFromWebContent] MessageParam WebPage.ReplaceImageForRemoveBackground data
+    [NotSentFromWebContent] MessageParam WebPage.ReplaceSelectionWithPasteboardData data
+    [NotSentFromWebContent] MessageParam WebProcess.BindAccessibilityFrameWithData data
+    [NotSentFromWebContent] MessageParam WebProcess.SetInjectedBundleParameter value
+    [NotSentFromWebContent] MessageParam WebProcess.SetInjectedBundleParameters parameters
+}
+
+[UnsafeWrapper] std::optional<Vector<uint8_t>> {
+    [Legacy] MessageParamReply WebPageProxy.SerializeAndWrapCryptoKey wrappedKey
+    [Legacy] MessageParamReply WebPageProxy.UnwrapCryptoKey key
+    [Legacy] MessageParamReply WebProcessProxy.SerializeAndWrapCryptoKey wrappedKey
+    [Legacy] MessageParamReply WebProcessProxy.UnwrapCryptoKey key
+    [Legacy] MessageParamReply RemoteBuffer.GetMappedRange data
+    [Legacy] StructureParam WebCore::CryptoKeyData.key
+    [Legacy] StructureParam WebKit::FrameState.stateObjectData
+    [Legacy] StructureParam WebKit::WebPushMessage.pushData
+}
+
+[UnsafeWrapper] Vector<uint8_t> {
+    [Legacy] MessageParamReply WebPage.BindRemoteAccessibilityFrames token
+    [Legacy] MessageParam NetworkConnectionToWebProcess.NavigatorSubscribeToPushService applicationServerKey
+    [Legacy] MessageParam PushClientConnection.SubscribeToPushService vapidPublicKey
+    [Legacy] MessageParam RemoteBuffer.CopyWithCopy data
+    [Legacy] MessageParam RemoteQueue.WriteBufferWithCopy data
+    [Legacy] MessageParam RemoteQueue.WriteTextureWithCopy data
+    [Legacy] MessageParam WebPageProxy.BindRemoteAccessibilityFrames dataToken
+    [Legacy] MessageParam WebSWServerConnection.SubscribeToPushService applicationServerKey
+    [Legacy] StructureParam WebKit::DDModel::DDReplaceVertices.buffer
+    [Legacy] StructureParam WebKit::DDModel::DDUpdateMeshDescriptor.indices
+    [Legacy] StructureParam WebKit::CoreIPCPKSecureElementPass.ipcData()
+    [Legacy] StructureParam WebKit::CoreIPCCFURL.toVector()
+    [Legacy] StructureParam WebKit::NetworkProcessCreationParameters.uiProcessCookieStorageIdentifier
+    [Legacy] StructureParam WebKit::WebPushD::WebPushDaemonConnectionConfiguration.hostAppAuditTokenData
+    [Legacy] StructureParam WebKit::WebsiteDataStoreParameters.uiProcessCookieStorageIdentifier
+    [Legacy] StructureParam WebCore::ContentFilterUnblockHandler.webFilterEvaluatorData()
+    [Legacy] StructureParam WebCore::FontPlatformSerializedCreationData.fontFaceData
+    [Legacy] StructureParam WebCore::FormData.m_boundary
+    [Legacy] StructureParam WebCore::NotificationData.data
+    [Legacy] StructureParam WebCore::PushSubscriptionData.clientECDHPublicKey
+    [Legacy] StructureParam WebCore::PushSubscriptionData.serverVAPIDPublicKey
+    [Legacy] StructureParam WebCore::PushSubscriptionData.sharedAuthenticationSecret
+    [Legacy] StructureParam WebCore::SerializedScriptValue::Internals.data
+    [Legacy] StructureParam WebCore::ThreadSafeDataBufferImpl.m_data
+    [Legacy] StructureParam WebCore::WebCodecsEncodedAudioChunkData.buffer
+    [Legacy] StructureParam WebCore::WebCodecsEncodedVideoChunkData.buffer
+    [Legacy] StructureParam WebCore::WrappedCryptoKey.encryptedKey
+    [Legacy] StructureParam JSC::ArrayBuffer.toVector()
+    [Legacy] StructureParam WebCore::MockWebAuthenticationConfiguration::HidConfiguration.pinProtocols
+    [Legacy] StructureParam WebCore::DDModel::DDReplaceVertices.buffer
+    [Legacy] StructureParam WebCore::DDModel::DDUpdateMeshDescriptor.indices
+    [Legacy] StructureParam WebCore::DDModel::DDImageAsset.data
+    [Legacy] StructureParam WebCore::CustomFontCreationData.fontFaceData
+
+    [NotSentFromWebContent] MessageParam WebPage.GetInformationFromImageData imageData
+    [NotSentFromWebContent] MessageParam WebPage.BindRemoteAccessibilityFrames dataToken
+    [NotSentFromWebContent] MessageParamReply WebPageProxy.BindRemoteAccessibilityFrames token
+    [NotSentFromWebContent] MessageParamReply WebPageProxy.LoadSynchronousURLSchemeTask data
+    [NotSentFromWebContent] MessageParamReply NetworkConnectionToWebProcess.PerformSynchronousLoad data
+}
+
+[UnsafeWrapper] Vector<char> {
+    [Legacy] StructureParam WebKit::RTCNetwork.description
+    [Legacy] StructureParam WebKit::RTCNetwork.name
+    [Legacy] StructureParam WebKit::WebRTCNetwork::SocketAddress.hostname
+}
+
+[UnsafeWrapper] Vector<unsigned char> {
+    [Legacy] StructureParam WebCore::SVGPathByteStream.bytes()
+}
+
+[UnsafeWrapper] std::array<uint8_t, 16> {
+    [Legacy] StructureParam WebCore::WrappedCryptoKey.tag
+}
+
+[UnsafeWrapper] std::array<uint8_t, 24> {
+    [Legacy] StructureParam WebCore::WrappedCryptoKey.wrappedKEK
+}
+
+[UnsafeWrapper] FixedVector<uint8_t> {
+    [Legacy] StructureParam WTF::MachSendRightAnnotated.data
+}
+
+[UnsafeWrapper] Vector<WebKit::CoreIPCData> {
+    [Legacy] StructureParam WebKit::CoreIPCSecTrustData.certificates
+    [Legacy] StructureParam WebKit::CoreIPCSecTrustData.chain
+}
+
+[UnsafeWrapper] std::optional<WebKit::CoreIPCData> {
+    [Legacy] StructureParam WebKit::CoreIPCNSURLRequestData.body 
+}
+
+[UnsafeWrapper] std::optional<Vector<WebKit::CoreIPCData>> {
+    [Legacy] StructureParam WebKit::CoreIPCSecTrustData.anchors
+    [Legacy] StructureParam WebKit::CoreIPCSecTrustData.responses
+    [Legacy] StructureParam WebKit::CoreIPCSecTrustData.scts
+    [Legacy] StructureParam WebKit::CoreIPCSecTrustData.trustedLogs
+    [Legacy] StructureParam WebKit::CoreIPCNSURLProtectionSpaceData.distnames
+}
+
+[SafeWrapper] StructureParam IPC::ConnectionHandle.m_handle MachSendRight
+
+[UnsafeWrapper] std::optional<MachSendRight> {
+    [Legacy] MessageParamReply RemoteMediaPlayerProxy.NativeImageForCurrentTime sendRight
+}
+
+[UnsafeWrapper] MachSendRight {
+    [Legacy] MessageParam RemoteXRProjectionLayer.StartFrame colorBuffer
+    [Legacy] MessageParam RemoteXRProjectionLayer.StartFrame completionSyncEvent
+    [Legacy] MessageParam RemoteXRProjectionLayer.StartFrame depthBuffer
+    [Legacy] MessageParam DrawingArea.UpdateGeometry fencePort
+    [Legacy] StructureParam IPC::Semaphore.createSendRight()
+    [Legacy] StructureParam IPC::SharedFileHandle.toMachSendRight()
+    [Legacy] StructureParam IPC::Signal.takeSendRight()
+    [Legacy] StructureParam PlatformXR::FrameData::ExternalTexture.handle
+    [Legacy] StructureParam PlatformXR::FrameData::LayerSetupData.completionSyncEvent
+    [Legacy] StructureParam WebKit::CoreIPCCVPixelBufferRef.m_sendRight
+    [Legacy] StructureParam WebCore::GraphicsContextGLExternalImageSourceIOSurfaceHandle.handle
+    [Legacy] StructureParam WebCore::GraphicsContextGLExternalImageSourceMTLSharedTextureHandle.handle
+    [Legacy] StructureParam WebCore::ProcessIdentity.m_taskIdToken
+    [Legacy] StructureParam WebCore::SharedMemoryHandle.m_handle
+    [Legacy] StructureParam WTF::MachSendRightAnnotated.sendRight
+
+    [NotSentFromWebContent] MessageParam WebPage.SetObscuredContentInsetsFenced machSendRight
+    [NotSentFromWebContent] MessageParamReply RemoteGraphicsContextGL.PrepareForDisplay displayBuffer
+}
+
+[UnsafeWrapper] Vector<MachSendRight> {
+    [Legacy] StructureParam WebCore::DynamicContentScalingDisplayList.takeSurfaces()
+
+    [NotSentFromWebContent] MessageParamReply RemoteCompositorIntegration.RecreateRenderBuffers renderBuffers
+    [NotSentFromWebContent] MessageParamReply RemoteGPU.CreateModelBacking renderBuffers
+}
+
+[UnsafeWrapper] std::optional<MachSendRightAnnotated> {
+    [Legacy] MessageParam GPUConnectionToWebProcess.UpdateSampleBufferDisplayLayerBoundsAndPosition fence
+    [Legacy] StructureParam WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::CustomData.sendRightAnnotated
+}
+
+[UnsafeWrapper] WTF::MachSendRightAnnotated {
+    [Legacy] StructureParam WebCore::HostingContext.sendRightAnnotated
+}
+
+[UnsafeWrapper] MachSendRightAnnotated {
+    [Legacy] MessageParam RemoteAudioVideoRendererProxyManager.SetVideoLayerSizeFenced sendRightAnnotated
+    [Legacy] MessageParam RemoteMediaPlayerProxy.SetVideoLayerSizeFenced sendRightAnnotated
+    [Legacy] StructureParam WebCore::HostingContext.sendRightAnnotated
+
+    [NotSentFromWebContent] MessageParam VideoPresentationManager.SetVideoLayerFrameFenced sendRightAnnotated
+}
+
+[UnsafeWrapper] RetainPtr<CFDictionaryRef> {
+    [Legacy] StructureParam WebKit::CoreIPCError.userInfo()
+    [Legacy] StructureParam WebKit::NetworkSessionCreationParameters.proxyConfiguration
+    [Legacy] StructureParam WebKit::SecItemRequestData.m_attributesToMatch
+    [Legacy] StructureParam WebKit::SecItemRequestData.m_queryDictionary
+    [Legacy] StructureParam WebCore::FontPlatformDataAttributes.m_attributes
+}
+
+[UnsafeWrapper] std::optional<RetainPtr<CFArrayRef>> {
+    [Legacy] StructureParam WebCore::FontPlatformSerializedAttributes.featureSettings
+}
+
+[UnsafeWrapper] std::optional<RetainPtr<CFDataRef>> {
+    [Legacy] StructureParam WebCore::FontPlatformSerializedAttributes.matrix
+}
+
+[UnsafeWrapper] RetainPtr<CFDataRef> {
+    [Legacy] StructureParam WebCore::MultiRepresentationHEICAttachmentData.data
+    [Legacy] StructureParam WebCore::TextAttachmentFileWrapper.data
+
+    [NotSentFromWebContent] StructureParam WebKit::NetworkProcessCreationParameters.networkATSContext
+    [NotSentFromWebContent] StructureParam WebKit::WebProcessCreationParameters.networkATSContext
+}
+
+[UnsafeWrapper] RetainPtr<NSData> {
+    [Legacy] StructureParam WebCore::TextRecognitionResult.imageAnalysisData
+}
+
+[UnsafeWrapper] std::span<const char> {
+    [Legacy] StructureParam WebKit::RTCPacketOptions::SerializableData.srtpAuthKey
+    [Legacy] StructureParam WTF::CString.span()
+}
+
+[UnsafeWrapper] std::optional<WebKit::CoreIPCPlistDictionary> {
+    [Legacy] StructureParam WebKit::CoreIPCNSURLRequestData.protocolProperties
+}
+
+# Shared Memory
+[SafeWrapper] StructureParam WebCore::ShareableBitmapHandle.m_handle WebCore::SharedMemoryHandle
+[SafeWrapper] StructureParam IPC::StreamServerConnectionHandle.buffer WebCore::SharedMemoryHandle
+
+[UnsafeWrapper] std::optional<IPC::SharedBufferReference> {
+    [Legacy] MessageParamReply WebPage.GetMainResourceDataOfFrame buffer
+    [Legacy] MessageParamReply WebPage.GetResourceDataFromFrame buffer
+    [Legacy] MessageParamReply WebPage.GetAccessibilityTreeData dataReference
+    [SecurityGatedReply] MessageParamReply WebPage.GetWebArchiveOfFrame dataReference
+    [SecurityGatedReply] MessageParamReply WebPage.GetWebArchiveOfFrameWithFileName dataReference
+    [SecurityGatedReply] MessageParamReply WebPage.GetWebArchiveData dataReference
+}
+
+[UnsafeWrapper] IPC::SharedBufferReference {
+    [Legacy] MessageParamReply WebPage.GetContentsAsMHTMLData data
+}
+
+[UnsafeWrapper] IPC::SharedBufferReference {
+    [Legacy] MessageParamReply WebPage.DidGetLoadDecisionForIcon iconData
+    [Legacy] MessageParam RemoteImageDecoderAVFProxy.CreateDecoder data
+    [Legacy] MessageParam RemoteImageDecoderAVFProxy.SetData data
+    [Legacy] MessageParam RemoteMediaResourceManager.DataReceived data
+    [Legacy] MessageParam RemoteSourceBufferProxy.Append data
+    [Legacy] MessageParam WebProcess.ConsumeAudioComponentRegistrations registrationData
+    [Legacy] MessageParam WebPageProxy.RegisterAttachmentIdentifierFromData data
+    [Legacy] MessageParam ServiceWorkerDownloadTask.DidReceiveData data
+    [Legacy] MessageParam ServiceWorkerFetchTask.DidReceiveData data
+
+    [NotSentFromWebContent] MessageParam WebResourceLoader.DidReceiveData data
+    [NotSentFromWebContent] MessageParam WebSWClientConnection.NotifyRecordResponseBodyChunk data
+    [NotSentFromWebContent] MessageParam GPUProcess.ConsumeAudioComponentRegistrations registrationData
+    [NotSentFromWebContent] MessageParam WebPage.UpdateAttachmentAttributes associatedElementData
+}
+
+[UnsafeWrapper] std::optional<WebCore::SharedMemoryHandle> {
+    [Legacy] StructureParam WebKit::WebHitTestResultData.getImageSharedMemoryHandle()
+    [Legacy] StructureParam WebKit::WebCompiledContentRuleListData.createDataHandle()
+    [Legacy] StructureParam WebKit::WebJSBufferData.sharedMemoryHandle()
+}
+
+[UnsafeWrapper] Vector<WebCore::SharedMemory::Handle> {
+    [NotSentFromWebContent] MessageParam WebPage.RestoreAppHighlightsAndScrollToIndex memoryHandles
+}
+
+[UnsafeWrapper] std::optional<WebCore::SharedMemory::Handle> {
+    [Legacy] MessageParamReply WebPage.DrawPagesForPrinting data
+    [Legacy] MessageParamReply WebPage.DrawPagesForPrintingDuringDOMPrintOperation data
+    [Legacy] MessageParamReply RemoteMediaResourceManager.DataReceived remoteData
+    [Legacy] MessageParam RemoteBuffer.Copy data
+    [Legacy] MessageParam RemoteQueue.WriteBuffer data
+    [Legacy] MessageParam RemoteQueue.WriteTexture dataHandle
+    [Legacy] StructureParam IPC::SharedBufferReference::SerializableBuffer.handle
+    [Legacy] StructureParam WebKit::FullScreenMediaDetails.imageHandle
+
+    [DebugOnly] MessageParamReply IPCStreamTester.SyncMessageReturningSharedMemory1 handle
+}
+
+[UnsafeWrapper] WebCore::SharedMemoryHandle {
+    [Legacy] StructureParam WebKit::ConsumerSharedCARingBufferHandle.memory
+    [Legacy] StructureParam WebCore::ShareableResourceHandle.m_handle
+}
+
+[UnsafeWrapper] WebCore::SharedMemory::Handle {
+    [Legacy] MessageParam WebPageProxy.SaveImageToLibrary handle
+    [Legacy] MessageParam WebPageProxy.SetPromisedDataForImage imageHandle
+    [Legacy] MessageParam WebPageProxy.SetPromisedDataForImage archiveHandle
+    [Legacy] MessageParam LibWebRTCCodecsProxy.SetSharedVideoFrameMemory storageHandle
+    [Legacy] MessageParam RemoteGraphicsContext.SetSharedVideoFrameMemory storageHandle
+    [Legacy] MessageParam RemoteGraphicsContextGL.SetSharedVideoFrameMemory storageHandle
+    [Legacy] MessageParam RemoteGraphicsContextGL.GetBufferSubDataSharedMemory handle
+    [Legacy] MessageParam RemoteGraphicsContextGL.ReadPixelsSharedMemory handle
+    [Legacy] MessageParam RemoteImageBuffer.GetPixelBufferWithNewMemory handle
+    [Legacy] MessageParam RemoteDevice.SetSharedVideoFrameMemory storageHandle
+    [Legacy] MessageParam RemoteSampleBufferDisplayLayer.SetSharedVideoFrameMemory storageHandle
+    [Legacy] MessageParam RemoteAudioDestinationManager.CreateAudioDestination frameCount
+    [Legacy] MessageParam RemoteVideoFrameObjectHeap.SetSharedVideoFrameMemory storageHandle
+
+    [NotSentFromWebContent] MessageParam VisitedLinkTableController.SetVisitedLinkTable handle
+    [NotSentFromWebContent] MessageParam WebSWClientConnection.SetSWOriginTableSharedMemory handle
+    [NotSentFromWebContent] MessageParam RemoteVideoFrameObjectHeapProxyProcessor.SetSharedVideoFrameMemory storageHandle
+    [NotSentFromWebContent] MessageParam SourceBufferPrivateRemoteMessageReceiver.TakeOwnershipOfMemory remoteData
+    [DebugOnly] MessageParam WebPasteboardProxy.TestIPCSharedMemory handle
+}
+
+# GTK Specific
+[Legacy] StructureParam sk_sp<SkColorSpace>.dataReference() std::span<const uint8_t>
+[Legacy] StructureParam sk_sp<SkData>.dataReference() std::span<const uint8_t>
+[Legacy] StructureParam SkString.data() std::span<const char>
+[Legacy] StructureParam WebCore::CertificateInfo.certificateChain() Vector<Vector<uint8_t>>

--- a/Source/WebKit/Scripts/webkit/parser_unittest.py
+++ b/Source/WebKit/Scripts/webkit/parser_unittest.py
@@ -186,6 +186,16 @@ _expected_model_base = {
             'conditions': (None),
         },
         {
+            'name': 'OpaqueTypeSecurityAssertion',
+            'parameters': (
+                ('NotDispatchableFromWebContent', 'ping'),
+            ),
+            'reply_parameters': (
+                ('NotDispatchableFromWebContent', 'pong'),
+            ),
+            'conditions': (None),
+        },
+        {
             'name': 'DidCreateWebProcessConnection',
             'parameters': (
                 ('MachSendRight', 'connectionIdentifier'),

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -99,6 +99,7 @@ class ScrollingStateFrameHostingNodeWithStuffAfterTuple;
 class AppKitControlSystemImage;
 #endif
 template<typename> class RectEdges;
+class OpaqueTypeObject;
 struct Amazing;
 }
 
@@ -426,6 +427,11 @@ template<> struct ArgumentCoder<WebCore::AppKitControlSystemImage> {
 template<> struct ArgumentCoder<WebCore::RectEdges<bool>> {
     static void encode(Encoder&, const WebCore::RectEdges<bool>&);
     static std::optional<WebCore::RectEdges<bool>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebCore::OpaqueTypeObject> {
+    static void encode(Encoder&, const WebCore::OpaqueTypeObject&);
+    static std::optional<WebCore::OpaqueTypeObject> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/Makefile
+++ b/Source/WebKit/Scripts/webkit/tests/Makefile
@@ -30,5 +30,6 @@ TESTS = \
 all:
 	python3 ../../generate-serializers.py cpp TestSerializedType.serialization.in
 	python3 ../../generate-message-receiver.py . $(TESTS)
+	python3 ../opaque_ipc_types.py
 	# The following are negative tests which are expected to throw exceptions.
 	python3 -c "import sys, subprocess; result = subprocess.call(['python3', '../../generate-serializers.py', 'cpp', 'TestInvalidAttributes.serialization.in'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL); sys.exit(0) if result == 1 else sys.exit(1)"

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -126,6 +126,8 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TemplateTest>(globalObject, decoder);
     case MessageName::TestWithLegacyReceiver_SetVideoLayerID:
         return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SetVideoLayerID>(globalObject, decoder);
+    case MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertion:
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertion>(globalObject, decoder);
 #if PLATFORM(MAC)
     case MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection:
         return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection>(globalObject, decoder);
@@ -146,6 +148,8 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_RunJavaScriptAlertReply>(globalObject, decoder);
     case MessageName::TestWithLegacyReceiver_GetPluginsReply:
         return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_GetPluginsReply>(globalObject, decoder);
+    case MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertionReply:
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertionReply>(globalObject, decoder);
 #if PLATFORM(MAC)
     case MessageName::TestWithLegacyReceiver_InterpretKeyEventReply:
         return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_InterpretKeyEventReply>(globalObject, decoder);
@@ -198,6 +202,8 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TemplateTest>(globalObject, decoder);
     case MessageName::TestWithoutAttributes_SetVideoLayerID:
         return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SetVideoLayerID>(globalObject, decoder);
+    case MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertion:
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertion>(globalObject, decoder);
 #if PLATFORM(MAC)
     case MessageName::TestWithoutAttributes_DidCreateWebProcessConnection:
         return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DidCreateWebProcessConnection>(globalObject, decoder);
@@ -218,6 +224,8 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_RunJavaScriptAlertReply>(globalObject, decoder);
     case MessageName::TestWithoutAttributes_GetPluginsReply:
         return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_GetPluginsReply>(globalObject, decoder);
+    case MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertionReply:
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertionReply>(globalObject, decoder);
 #if PLATFORM(MAC)
     case MessageName::TestWithoutAttributes_InterpretKeyEventReply:
         return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_InterpretKeyEventReply>(globalObject, decoder);
@@ -359,6 +367,8 @@ std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* global
         return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_GetPluginProcessConnection>(globalObject, decoder);
     case MessageName::TestWithLegacyReceiver_TestMultipleAttributes:
         return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_TestMultipleAttributes>(globalObject, decoder);
+    case MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertion:
+        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertion>(globalObject, decoder);
 #if PLATFORM(MAC)
     case MessageName::TestWithLegacyReceiver_InterpretKeyEvent:
         return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_InterpretKeyEvent>(globalObject, decoder);
@@ -375,6 +385,8 @@ std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* global
         return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_GetPluginProcessConnection>(globalObject, decoder);
     case MessageName::TestWithoutAttributes_TestMultipleAttributes:
         return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_TestMultipleAttributes>(globalObject, decoder);
+    case MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertion:
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertion>(globalObject, decoder);
 #if PLATFORM(MAC)
     case MessageName::TestWithoutAttributes_InterpretKeyEvent:
         return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_InterpretKeyEvent>(globalObject, decoder);
@@ -742,6 +754,10 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
         return Vector<ArgumentDescription> {
             { "videoLayerID"_s, "WebCore::PlatformLayerIdentifier"_s },
         };
+    case MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertion:
+        return Vector<ArgumentDescription> {
+            { "ping"_s, "NotDispatchableFromWebContent"_s },
+        };
 #if PLATFORM(MAC)
     case MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection:
         return Vector<ArgumentDescription> {
@@ -774,6 +790,10 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
     case MessageName::TestWithLegacyReceiver_GetPluginsReply:
         return Vector<ArgumentDescription> {
             { "plugins"_s, "Vector<WebCore::PluginInfo>"_s },
+        };
+    case MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertionReply:
+        return Vector<ArgumentDescription> {
+            { "pong"_s, "NotDispatchableFromWebContent"_s },
         };
 #if PLATFORM(MAC)
     case MessageName::TestWithLegacyReceiver_InterpretKeyEventReply:
@@ -871,6 +891,10 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
         return Vector<ArgumentDescription> {
             { "videoLayerID"_s, "WebCore::PlatformLayerIdentifier"_s },
         };
+    case MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertion:
+        return Vector<ArgumentDescription> {
+            { "ping"_s, "NotDispatchableFromWebContent"_s },
+        };
 #if PLATFORM(MAC)
     case MessageName::TestWithoutAttributes_DidCreateWebProcessConnection:
         return Vector<ArgumentDescription> {
@@ -903,6 +927,10 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
     case MessageName::TestWithoutAttributes_GetPluginsReply:
         return Vector<ArgumentDescription> {
             { "plugins"_s, "Vector<WebCore::PluginInfo>"_s },
+        };
+    case MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertionReply:
+        return Vector<ArgumentDescription> {
+            { "pong"_s, "NotDispatchableFromWebContent"_s },
         };
 #if PLATFORM(MAC)
     case MessageName::TestWithoutAttributes_InterpretKeyEventReply:
@@ -1139,6 +1167,10 @@ std::optional<Vector<ArgumentDescription>> messageReplyArgumentDescriptions(Mess
         };
     case MessageName::TestWithLegacyReceiver_TestMultipleAttributes:
         return Vector<ArgumentDescription> { };
+    case MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertion:
+        return Vector<ArgumentDescription> {
+            { "pong"_s, "NotDispatchableFromWebContent"_s },
+        };
 #if PLATFORM(MAC)
     case MessageName::TestWithLegacyReceiver_InterpretKeyEvent:
         return Vector<ArgumentDescription> {
@@ -1163,6 +1195,10 @@ std::optional<Vector<ArgumentDescription>> messageReplyArgumentDescriptions(Mess
         };
     case MessageName::TestWithoutAttributes_TestMultipleAttributes:
         return Vector<ArgumentDescription> { };
+    case MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertion:
+        return Vector<ArgumentDescription> {
+            { "pong"_s, "NotDispatchableFromWebContent"_s },
+        };
 #if PLATFORM(MAC)
     case MessageName::TestWithoutAttributes_InterpretKeyEvent:
         return Vector<ArgumentDescription> {

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -77,6 +77,8 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithLegacyReceiver_LoadSomethingElse"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
     MessageDescription { "TestWithLegacyReceiver_LoadURL"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithLegacyReceiver_OpaqueTypeSecurityAssertion"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithLegacyReceiver_OpaqueTypeSecurityAssertionReply"_s, ReceiverName::TestWithLegacyReceiver, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_PreferencesDidChange"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_RunJavaScriptAlert"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_RunJavaScriptAlertReply"_s, ReceiverName::TestWithLegacyReceiver, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
@@ -153,6 +155,8 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithoutAttributes_LoadSomethingElse"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
     MessageDescription { "TestWithoutAttributes_LoadURL"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithoutAttributes_OpaqueTypeSecurityAssertion"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithoutAttributes_OpaqueTypeSecurityAssertionReply"_s, ReceiverName::TestWithoutAttributes, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutAttributes_PreferencesDidChange"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutAttributes_RunJavaScriptAlert"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutAttributes_RunJavaScriptAlertReply"_s, ReceiverName::TestWithoutAttributes, false, false, true, ProcessName::Unknown, ProcessName::Unknown },

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -121,6 +121,8 @@ enum class MessageName : uint16_t {
     TestWithLegacyReceiver_LoadSomethingElse,
 #endif
     TestWithLegacyReceiver_LoadURL,
+    TestWithLegacyReceiver_OpaqueTypeSecurityAssertion,
+    TestWithLegacyReceiver_OpaqueTypeSecurityAssertionReply,
     TestWithLegacyReceiver_PreferencesDidChange,
     TestWithLegacyReceiver_RunJavaScriptAlert,
     TestWithLegacyReceiver_RunJavaScriptAlertReply,
@@ -197,6 +199,8 @@ enum class MessageName : uint16_t {
     TestWithoutAttributes_LoadSomethingElse,
 #endif
     TestWithoutAttributes_LoadURL,
+    TestWithoutAttributes_OpaqueTypeSecurityAssertion,
+    TestWithoutAttributes_OpaqueTypeSecurityAssertionReply,
     TestWithoutAttributes_PreferencesDidChange,
     TestWithoutAttributes_RunJavaScriptAlert,
     TestWithoutAttributes_RunJavaScriptAlertReply,

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -65,6 +65,7 @@
 #include <WebCore/InheritsFrom.h>
 #include <WebCore/MoveOnlyBaseClass.h>
 #include <WebCore/MoveOnlyDerivedClass.h>
+#include <WebCore/OpaqueTypeObject.h>
 #if USE(APPKIT)
 #include <WebCore/ScrollbarTrackCornerSystemImageMac.h>
 #endif
@@ -96,6 +97,9 @@ static_assert(std::is_same_v<WTF::ProcessID,
     pid_t
 >);
 #endif
+static_assert(std::is_same_v<WebCore::AliasOpaqueTypeWrapper,
+    Variant<int, Vector<uint8_t>>
+>);
 static_assert(std::is_same_v<WebCore::ConditionalVariant,
     Variant<
         int,
@@ -560,6 +564,12 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "left()"_s
             },
         } },
+        { "WebCore::OpaqueTypeObject"_s, {
+            {
+                "NotDispatchableFromWebContent"_s,
+                "member"_s
+            },
+        } },
 #if USE(PASSKIT)
         { "PKPaymentMethod"_s, {
             { "WebKit::CoreIPCPKPaymentMethod"_s, "wrapper"_s }
@@ -592,6 +602,11 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             , "alias"_s }
         } },
 #endif
+        { "WebCore::AliasOpaqueTypeWrapper"_s, {
+        {
+            "Variant<int, Vector<uint8_t>>"_s
+            , "alias"_s }
+        } },
         { "WebCore::ConditionalVariant"_s, {
         {
             "Variant<"

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -355,6 +355,12 @@ NSNull wrapped by CoreIPCNull
     bool left();
 }
 
+class WebCore::OpaqueTypeObject {
+    NotDispatchableFromWebContent member
+}
+
+using WebCore::AliasOpaqueTypeWrapper = Variant<int, Vector<uint8_t>>
+
 using WebCore::ConditionalVariant = Variant<
     int,
 #if USE(CHAR)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiver.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiver.messages.in
@@ -60,6 +60,8 @@ messages -> TestWithLegacyReceiver {
 
     SetVideoLayerID(WebCore::PlatformLayerIdentifier videoLayerID)
 
+    OpaqueTypeSecurityAssertion(NotDispatchableFromWebContent ping) -> (NotDispatchableFromWebContent pong)
+
 #if PLATFORM(MAC)
     DidCreateWebProcessConnection(MachSendRight connectionIdentifier, OptionSet<WebKit::SelectionFlags> flags)
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
@@ -139,6 +139,10 @@ void TestWithLegacyReceiver::didReceiveMessage(IPC::Connection& connection, IPC:
         IPC::handleMessage<Messages::TestWithLegacyReceiver::SetVideoLayerID>(connection, decoder, this, &TestWithLegacyReceiver::setVideoLayerID);
         return;
     }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::OpaqueTypeSecurityAssertion::name()) {
+        IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::OpaqueTypeSecurityAssertion>(connection, decoder, this, &TestWithLegacyReceiver::opaqueTypeSecurityAssertion);
+        return;
+    }
 #if PLATFORM(MAC)
     if (decoder.messageName() == Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::name()) {
         IPC::handleMessage<Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection>(connection, decoder, this, &TestWithLegacyReceiver::didCreateWebProcessConnection);
@@ -291,6 +295,14 @@ template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::Tes
 {
     return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::SetVideoLayerID::Arguments>(globalObject, decoder);
 }
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertion>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::OpaqueTypeSecurityAssertion::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertion>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::OpaqueTypeSecurityAssertion::ReplyArguments>(globalObject, decoder);
+}
 #if PLATFORM(MAC)
 template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
 {
@@ -328,6 +340,10 @@ template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::Tes
 template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_GetPluginsReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
 {
     return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::GetPluginsReply::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertionReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::OpaqueTypeSecurityAssertionReply::Arguments>(globalObject, decoder);
 }
 #if PLATFORM(MAC)
 template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_InterpretKeyEventReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
@@ -559,6 +559,37 @@ private:
     const WebCore::PlatformLayerIdentifier& m_videoLayerID;
 };
 
+class OpaqueTypeSecurityAssertion {
+public:
+    using Arguments = std::tuple<NotDispatchableFromWebContent>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertion; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr bool deferSendingIfSuspended = false;
+
+    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertionReply; }
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<NotDispatchableFromWebContent>;
+    using Reply = CompletionHandler<void(NotDispatchableFromWebContent&&)>;
+    using Promise = WTF::NativePromise<NotDispatchableFromWebContent, IPC::Error>;
+    explicit OpaqueTypeSecurityAssertion(const NotDispatchableFromWebContent& ping)
+        : m_ping(ping)
+    {
+    }
+
+    template<typename Encoder>
+    void encode(Encoder& encoder)
+    {
+        ASSERT(!isInWebProcess());
+        SUPPRESS_FORWARD_DECL_ARG encoder << m_ping;
+    }
+
+private:
+    SUPPRESS_FORWARD_DECL_MEMBER const NotDispatchableFromWebContent& m_ping;
+};
+
 #if PLATFORM(MAC)
 class DidCreateWebProcessConnection {
 public:
@@ -745,6 +776,32 @@ public:
 
 private:
     SUPPRESS_FORWARD_DECL_MEMBER const Vector<WebCore::PluginInfo>& m_plugins;
+};
+
+class OpaqueTypeSecurityAssertionReply {
+public:
+    using Arguments = std::tuple<NotDispatchableFromWebContent>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertionReply; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr bool deferSendingIfSuspended = false;
+
+    explicit OpaqueTypeSecurityAssertionReply(const NotDispatchableFromWebContent& pong)
+        : m_pong(pong)
+    {
+    }
+
+    template<typename Encoder>
+    void encode(Encoder& encoder)
+    {
+        ASSERT(!isInWebProcess());
+        SUPPRESS_FORWARD_DECL_ARG encoder << m_pong;
+    }
+
+private:
+    SUPPRESS_FORWARD_DECL_MEMBER const NotDispatchableFromWebContent& m_pong;
 };
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributes.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributes.messages.in
@@ -67,6 +67,8 @@ messages -> TestWithoutAttributes {
 
     SetVideoLayerID(WebCore::PlatformLayerIdentifier videoLayerID)
 
+    OpaqueTypeSecurityAssertion(NotDispatchableFromWebContent ping) -> (NotDispatchableFromWebContent pong)
+
 #if PLATFORM(MAC)
     DidCreateWebProcessConnection(MachSendRight connectionIdentifier, OptionSet<WebKit::SelectionFlags> flags)
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
@@ -139,6 +139,10 @@ void TestWithoutAttributes::didReceiveMessage(IPC::Connection& connection, IPC::
         IPC::handleMessage<Messages::TestWithoutAttributes::SetVideoLayerID>(connection, decoder, this, &TestWithoutAttributes::setVideoLayerID);
         return;
     }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::OpaqueTypeSecurityAssertion::name()) {
+        IPC::handleMessageAsync<Messages::TestWithoutAttributes::OpaqueTypeSecurityAssertion>(connection, decoder, this, &TestWithoutAttributes::opaqueTypeSecurityAssertion);
+        return;
+    }
 #if PLATFORM(MAC)
     if (decoder.messageName() == Messages::TestWithoutAttributes::DidCreateWebProcessConnection::name()) {
         IPC::handleMessage<Messages::TestWithoutAttributes::DidCreateWebProcessConnection>(connection, decoder, this, &TestWithoutAttributes::didCreateWebProcessConnection);
@@ -291,6 +295,14 @@ template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::Tes
 {
     return jsValueForDecodedArguments<Messages::TestWithoutAttributes::SetVideoLayerID::Arguments>(globalObject, decoder);
 }
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertion>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::OpaqueTypeSecurityAssertion::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertion>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::OpaqueTypeSecurityAssertion::ReplyArguments>(globalObject, decoder);
+}
 #if PLATFORM(MAC)
 template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DidCreateWebProcessConnection>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
 {
@@ -328,6 +340,10 @@ template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::Tes
 template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_GetPluginsReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
 {
     return jsValueForDecodedArguments<Messages::TestWithoutAttributes::GetPluginsReply::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertionReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::OpaqueTypeSecurityAssertionReply::Arguments>(globalObject, decoder);
 }
 #if PLATFORM(MAC)
 template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_InterpretKeyEventReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
@@ -559,6 +559,37 @@ private:
     const WebCore::PlatformLayerIdentifier& m_videoLayerID;
 };
 
+class OpaqueTypeSecurityAssertion {
+public:
+    using Arguments = std::tuple<NotDispatchableFromWebContent>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertion; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr bool deferSendingIfSuspended = false;
+
+    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertionReply; }
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<NotDispatchableFromWebContent>;
+    using Reply = CompletionHandler<void(NotDispatchableFromWebContent&&)>;
+    using Promise = WTF::NativePromise<NotDispatchableFromWebContent, IPC::Error>;
+    explicit OpaqueTypeSecurityAssertion(const NotDispatchableFromWebContent& ping)
+        : m_ping(ping)
+    {
+    }
+
+    template<typename Encoder>
+    void encode(Encoder& encoder)
+    {
+        ASSERT(!isInWebProcess());
+        SUPPRESS_FORWARD_DECL_ARG encoder << m_ping;
+    }
+
+private:
+    SUPPRESS_FORWARD_DECL_MEMBER const NotDispatchableFromWebContent& m_ping;
+};
+
 #if PLATFORM(MAC)
 class DidCreateWebProcessConnection {
 public:
@@ -745,6 +776,32 @@ public:
 
 private:
     SUPPRESS_FORWARD_DECL_MEMBER const Vector<WebCore::PluginInfo>& m_plugins;
+};
+
+class OpaqueTypeSecurityAssertionReply {
+public:
+    using Arguments = std::tuple<NotDispatchableFromWebContent>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertionReply; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr bool deferSendingIfSuspended = false;
+
+    explicit OpaqueTypeSecurityAssertionReply(const NotDispatchableFromWebContent& pong)
+        : m_pong(pong)
+    {
+    }
+
+    template<typename Encoder>
+    void encode(Encoder& encoder)
+    {
+        ASSERT(!isInWebProcess());
+        SUPPRESS_FORWARD_DECL_ARG encoder << m_pong;
+    }
+
+private:
+    SUPPRESS_FORWARD_DECL_MEMBER const NotDispatchableFromWebContent& m_pong;
 };
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/Scripts/webkit/tests/test_opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/tests/test_opaque_ipc_types.tracking.in
@@ -1,0 +1,70 @@
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# See opaque_transports.tracking.in for format documentation
+
+[UnsafeWrapper] MachSendRight {
+    [Legacy] MessageParam TestWithLegacyReceiver.DidCreateWebProcessConnection connectionIdentifier
+    [Legacy] MessageParam TestWithStream.SendMachSendRight a1
+    [Legacy] MessageParamReply TestWithStream.ReceiveMachSendRight r1
+}
+
+[UnsafeWrapper] NotDispatchableFromWebContentType {
+    [NotSentFromWebContent] MessageParam TestWithLegacyReceiver.OpaqueTypeSecurityAssertion param
+    [MemorySafety=1, Docs=rdar://123445] MessageParam TestWithoutAttributes.OpaqueTypeSecurityAssertion param
+    [SecurityGatedReply] MessageParamReply SomeInterface.GetHighRiskDataFromWebContent result
+}
+
+[UnsafeWrapper] Vector<uint8_t> {
+    [Legacy] StructureParam WebKit::TestStruct.buffer
+    [Legacy] StructureParam WebCore::TestData.content
+    [NotSentFromWebContent] StructureParam WebKit::SecureData.encrypted
+}
+
+[UnsafeWrapper] std::span<const uint8_t> {
+    [Legacy] MessageParam TestInterface.ProcessData data
+    [NotSentFromWebContent] MessageParamReply TestInterface.GetData result
+}
+
+[UnsafeWrapper] TestUnsafeType {
+    [Legacy] MessageParam Test.Method param
+}
+
+[SerializationPolicyViolation='rdar://12345 Test violation'] StructureParam PolicyTest.data std::span<const uint8_t>
+[MemorySafety=1, Docs=rdar://123445] MessageParam CompoundTest.Method param Vector<uint8_t>
+
+[UnsafeWrapper] std::optional<Vector<std::pair<Vector<uint8_t>, String>>> {
+    [Legacy] StructureParam ComplexTest.complexData
+}
+
+[Legacy] AliasParam TestNamespace::TestSalt std::array<uint8_t, 8>
+[Legacy] AliasParam TestType::Handle MachSendRight
+[Legacy] MessageParam TestReceiver.TestMessage testParam MachSendRight
+[Legacy] MessageParamReply TestReceiver.GetTestData result Vector<uint8_t>
+[Legacy] StructureParam TestStruct.testMember Vector<uint8_t>
+[NotSentFromWebContent] MessageParam SecureReceiver.SecureMessage secureData Vector<uint8_t>
+[SecurityGatedReply] MessageParamReply UserInterface.GetUserData data std::span<const uint8_t>
+[NeedsReview] MessageParam ReviewTest.Method param MachSendRight
+[DebugOnly] MessageParam DebugTest.Method param Vector<uint8_t>
+[SafeWrapper] StructureParam IPC::ConnectionHandle.m_handle MachSendRight
+[Legacy] StructureParam WebKit::VeryLongNamespace::VeryLongClassName::VeryLongMethodName Vector<uint8_t>
+[Legacy] StructureParam TestClass.getData() Vector<uint8_t>

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2450,6 +2450,7 @@
 		F411457D2CD94161004CDBD1 /* _WKTouchEventGeneratorInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F411457C2CD94161004CDBD1 /* _WKTouchEventGeneratorInternal.h */; };
 		F416F1C02C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F416F1BE2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h */; };
 		F41795A62AC61B78007F5F12 /* CompactContextMenuPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = F41795A42AC619A2007F5F12 /* CompactContextMenuPresenter.h */; };
+		F422427A2E8C389800C1143F /* opaque_ipc_types.py in Copy Message Generation Scripts */ = {isa = PBXBuildFile; fileRef = F42242782E8C37AB00C1143F /* opaque_ipc_types.py */; };
 		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
 		F42A04712CA1B328000D3118 /* _WKTextRunInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F42A04702CA1B328000D3118 /* _WKTextRunInternal.h */; };
 		F42A04722CA1B3FC000D3118 /* _WKTextRun.h in Headers */ = {isa = PBXBuildFile; fileRef = F42A046C2CA1B2A4000D3118 /* _WKTextRun.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2510,6 +2511,7 @@
 		F4B021E72D0BAC2D00D9145E /* CoreIPCSecTrust.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4B021E62D0BAB6D00D9145E /* CoreIPCSecTrust.mm */; };
 		F4B24AA72D5ED4D300725993 /* CoreIPCAVOutputContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4B24AA62D5ED3CD00725993 /* CoreIPCAVOutputContext.mm */; };
 		F4B24AA82D5ED4DE00725993 /* CoreIPCAVOutputContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F4B24AA52D5ED3CD00725993 /* CoreIPCAVOutputContext.h */; };
+		F4B8E3282ECBD62E00A9A484 /* opaque_ipc_types.tracking.in in Copy Message Generation Scripts */ = {isa = PBXBuildFile; fileRef = F4B8E3272ECBD61000A9A484 /* opaque_ipc_types.tracking.in */; };
 		F4BA33F225757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */; };
 		F4BCBBEC2AC332AA00C1858D /* WKFormAccessoryView.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BCBBE62AC3295300C1858D /* WKFormAccessoryView.h */; };
 		F4BE0D7727AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BE0D7627AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h */; };
@@ -3132,6 +3134,8 @@
 				1A07D2F81919B3A900ECDA16 /* __init__.py in Copy Message Generation Scripts */,
 				1A07D2F91919B3A900ECDA16 /* messages.py in Copy Message Generation Scripts */,
 				1A07D2FA1919B3A900ECDA16 /* model.py in Copy Message Generation Scripts */,
+				F422427A2E8C389800C1143F /* opaque_ipc_types.py in Copy Message Generation Scripts */,
+				F4B8E3282ECBD62E00A9A484 /* opaque_ipc_types.tracking.in in Copy Message Generation Scripts */,
 				1A07D2FB1919B3A900ECDA16 /* parser.py in Copy Message Generation Scripts */,
 			);
 			name = "Copy Message Generation Scripts";
@@ -8593,6 +8597,7 @@
 		F41795A52AC619A2007F5F12 /* CompactContextMenuPresenter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CompactContextMenuPresenter.mm; sourceTree = "<group>"; };
 		F4217F1C2E8EFF8A0036AAC1 /* TextExtractionToStringConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextExtractionToStringConversion.h; sourceTree = "<group>"; };
 		F4217F1D2E8EFF8A0036AAC1 /* TextExtractionToStringConversion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextExtractionToStringConversion.cpp; sourceTree = "<group>"; };
+		F42242782E8C37AB00C1143F /* opaque_ipc_types.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; name = opaque_ipc_types.py; path = webkit/opaque_ipc_types.py; sourceTree = "<group>"; };
 		F425374F2AF9A25A00873864 /* InteractionInformationRequest.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = InteractionInformationRequest.serialization.in; path = ios/InteractionInformationRequest.serialization.in; sourceTree = "<group>"; };
 		F4299506270E234C0032298B /* StreamMessageReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamMessageReceiver.h; sourceTree = "<group>"; };
 		F42A046C2CA1B2A4000D3118 /* _WKTextRun.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTextRun.h; sourceTree = "<group>"; };
@@ -8696,6 +8701,7 @@
 		F4B24AA62D5ED3CD00725993 /* CoreIPCAVOutputContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCAVOutputContext.mm; sourceTree = "<group>"; };
 		F4B378D021DDBBAB0095A378 /* WebUndoStepID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebUndoStepID.h; sourceTree = "<group>"; };
 		F4B63E162C49586700BC59EF /* CoreIPCPlist.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPlist.serialization.in; sourceTree = "<group>"; };
+		F4B8E3272ECBD61000A9A484 /* opaque_ipc_types.tracking.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = opaque_ipc_types.tracking.in; path = webkit/opaque_ipc_types.tracking.in; sourceTree = "<group>"; };
 		F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKImageAnalysisGestureRecognizer.h; sourceTree = "<group>"; };
 		F4BA33F125757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKImageAnalysisGestureRecognizer.mm; sourceTree = "<group>"; };
 		F4BCBBE62AC3295300C1858D /* WKFormAccessoryView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKFormAccessoryView.h; sourceTree = "<group>"; };
@@ -16791,6 +16797,8 @@
 				5CD4F01C28B6ADDB00F9ECEA /* generate-serializers.py */,
 				0FC0856F187CE0A900780D86 /* messages.py */,
 				0FC08570187CE0A900780D86 /* model.py */,
+				F42242782E8C37AB00C1143F /* opaque_ipc_types.py */,
+				F4B8E3272ECBD61000A9A484 /* opaque_ipc_types.tracking.in */,
 				0FC08571187CE0A900780D86 /* parser.py */,
 				53B1640F2203715000EC4166 /* process-entitlements.sh */,
 			);


### PR DESCRIPTION
#### b21c169a1e5eac2379544b133ea2ee7a038c979a
<pre>
Track and manage Opaque Data Types in CoreIPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=299055">https://bugs.webkit.org/show_bug.cgi?id=299055</a>
<a href="https://rdar.apple.com/160811093">rdar://160811093</a>

Reviewed by Alex Christensen and Mike Wyrzykowski.

The goal of this change is to track and manage Opaque Data Types (which represent a sandbox escape risk) in the CoreIPC flows.

Tracking of Opaque Data Types is done via Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in

What is considered an Opaque Data Type can be seen in Source/WebKit/Scripts/webkit/opaque_ipc_types.py.

Test: Source/WebKit/Scripts/webkit/opaque_ipc_types.py
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Scripts/generate-message-receiver.py:
(main):
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.enforce_opaque_ipc_types_usage):
(UsingStatement.enforce_opaque_ipc_types_usage):
(encode_type):
(main):
* Source/WebKit/Scripts/webkit/messages.py:
(message_to_struct_declaration):
* Source/WebKit/Scripts/webkit/model.py:
(MessageReceiver.enforce_opaque_ipc_types_usage):
* Source/WebKit/Scripts/webkit/opaque_ipc_types.py: Added.
(_is_odt_concern):
(_remove_const_and_whitespace):
(_split_template_parameters):
(_array_special_parsing):
(_get_container_info):
(_get_parameters_to_check):
(_contains_opaque_data):
(OpaqueIPCTypeEntry):
(OpaqueIPCTypeEntry.__init__):
(OpaqueIPCTypeEntry._parse_attributes):
(OpaqueIPCTypes):
(OpaqueIPCTypes.__init__):
(OpaqueIPCTypes._parse_group_header):
(OpaqueIPCTypes._parse_alias_param):
(OpaqueIPCTypes._parse_structure_param):
(OpaqueIPCTypes._parse_message_param):
(OpaqueIPCTypes._parse_line):
(OpaqueIPCTypes._add_entry):
(OpaqueIPCTypes._query_entries):
(OpaqueIPCTypes._is_webcontent_dispatchable):
(OpaqueIPCTypes.message_param_tracked):
(OpaqueIPCTypes.message_param_reply_tracked):
(OpaqueIPCTypes.alias_param_tracked):
(OpaqueIPCTypes.structure_param_tracked):
(OpaqueIPCTypes.webcontent_dispatchable):
(OpaqueIPCTypes.reply_webcontent_dispatchable):
(OpaqueIPCTypes.structure_webcontent_dispatchable):
(is_opaque_type):
(TestOpaqueTypes):
(TestOpaqueTypes.test_is_odt_concern_function):
(TestOpaqueTypes.test_contains_opaque_data_function):
(TestOpaqueTypes.test_direct_opaque_types):
(TestOpaqueTypes.test_container_types_with_odt_concerns):
(TestOpaqueTypes.test_container_types_without_odt_concerns):
(TestOpaqueTypes.test_infinite_recursion_protection):
(TestOpaqueTypes.test_bad_formatting):
(TestOpaqueTypes.test_context_propagation_through_simple_wrappers):
(TestOpaqueTypes.test_context_reset_in_structural_containers):
(TestOpaqueTypes.test_retainptr_with_direct_opaque_types):
(TestOpaqueTypes.test_deeply_nested_types):
(TestOpaqueTypes.test_opaque_ipc_types_parsing):
(TestOpaqueTypes.test_production_tracking_file_parses):
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in: Added.
* Source/WebKit/Scripts/webkit/parser_unittest.py:
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::OpaqueTypeObject&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::OpaqueTypeObject&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/Makefile:
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::jsValueForArguments):
(IPC::jsValueForReplyArguments):
(IPC::messageArgumentDescriptions):
(IPC::messageReplyArgumentDescriptions):
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiver.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp:
(WebKit::TestWithLegacyReceiver::didReceiveMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertion&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertion&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_OpaqueTypeSecurityAssertionReply&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h:
(Messages::TestWithLegacyReceiver::OpaqueTypeSecurityAssertion::name):
(Messages::TestWithLegacyReceiver::OpaqueTypeSecurityAssertion::asyncMessageReplyName):
(Messages::TestWithLegacyReceiver::OpaqueTypeSecurityAssertion::OpaqueTypeSecurityAssertion):
(Messages::TestWithLegacyReceiver::OpaqueTypeSecurityAssertion::encode):
(Messages::TestWithLegacyReceiver::OpaqueTypeSecurityAssertionReply::name):
(Messages::TestWithLegacyReceiver::OpaqueTypeSecurityAssertionReply::OpaqueTypeSecurityAssertionReply):
(Messages::TestWithLegacyReceiver::OpaqueTypeSecurityAssertionReply::encode):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributes.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp:
(WebKit::TestWithoutAttributes::didReceiveMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertion&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertion&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_OpaqueTypeSecurityAssertionReply&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h:
(Messages::TestWithoutAttributes::OpaqueTypeSecurityAssertion::name):
(Messages::TestWithoutAttributes::OpaqueTypeSecurityAssertion::asyncMessageReplyName):
(Messages::TestWithoutAttributes::OpaqueTypeSecurityAssertion::OpaqueTypeSecurityAssertion):
(Messages::TestWithoutAttributes::OpaqueTypeSecurityAssertion::encode):
(Messages::TestWithoutAttributes::OpaqueTypeSecurityAssertionReply::name):
(Messages::TestWithoutAttributes::OpaqueTypeSecurityAssertionReply::OpaqueTypeSecurityAssertionReply):
(Messages::TestWithoutAttributes::OpaqueTypeSecurityAssertionReply::encode):
* Source/WebKit/Scripts/webkit/tests/test_opaque_ipc_types.tracking.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/303390@main">https://commits.webkit.org/303390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76df893b2298655f9e2a480059dbab0d344ad0ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84041 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8a1c928c-62b4-4d47-bc95-f99c4f9f6f31) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101000 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d2a491a7-3050-4bb1-9bac-35d84c0e8ad5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135071 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/3342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118345 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81791 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0587736b-3619-47b4-a463-c0ee1d9192dc) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/131474 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82859 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124188 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/112046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142286 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130632 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4287 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109374 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109549 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27774 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3256 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114620 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57533 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4341 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33013 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163599 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4172 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67787 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42518 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4432 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4300 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->