### PR TITLE
Cache Headroom on NativeImage

### DIFF
--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -53,6 +53,7 @@ RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image)
 NativeImage::NativeImage(PlatformImagePtr&& platformImage)
     : m_platformImage(WTFMove(platformImage))
 {
+    computeHeadroom();
 }
 
 NativeImage::~NativeImage()
@@ -75,6 +76,13 @@ void NativeImage::replacePlatformImage(PlatformImagePtr&& platformImage)
 {
     ASSERT(platformImage);
     m_platformImage = WTFMove(platformImage);
+    computeHeadroom();
 }
+
+#if !USE(CG)
+void NativeImage::computeHeadroom()
+{
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <WebCore/ImageTypes.h>
 #include <WebCore/PlatformExportMacros.h>
 #include <WebCore/PlatformImage.h>
 #include <WebCore/RenderingResource.h>
@@ -41,7 +42,6 @@ class FloatRect;
 class GraphicsContext;
 class IntSize;
 class NativeImageBackend;
-struct Headroom;
 struct ImagePaintingOptions;
 
 class NativeImage : public ThreadSafeRefCounted<NativeImage> {
@@ -82,7 +82,10 @@ public:
 protected:
     WEBCORE_EXPORT NativeImage(PlatformImagePtr&&);
 
+    void computeHeadroom();
+
     mutable PlatformImagePtr m_platformImage;
+    mutable Headroom m_headroom { Headroom::None };
     mutable WeakHashSet<RenderingResourceObserver> m_observers;
     RenderingResourceIdentifier m_renderingResourceIdentifier { RenderingResourceIdentifier::generate() };
 };

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -78,14 +78,17 @@ DestinationColorSpace NativeImage::colorSpace() const
     return DestinationColorSpace(CGImageGetColorSpace(m_platformImage.get()));
 }
 
-Headroom NativeImage::headroom() const
+void NativeImage::computeHeadroom()
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
     float headroom = CGImageGetContentHeadroom(m_platformImage.get());
-    return Headroom(std::max<float>(headroom, Headroom::None));
-#else
-    return Headroom::None;
+    m_headroom = Headroom(std::max<float>(headroom, Headroom::None));
 #endif
+}
+
+Headroom NativeImage::headroom() const
+{
+    return m_headroom;
 }
 
 std::optional<Color> NativeImage::singlePixelSolidColor() const


### PR DESCRIPTION
#### 7ae2169425c43f66c76f1c50c7722d379cf1f0c2
<pre>
Cache Headroom on NativeImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=300650">https://bugs.webkit.org/show_bug.cgi?id=300650</a>
<a href="https://rdar.apple.com/162553270">rdar://162553270</a>

Reviewed by Said Abou-Hallawa.

Profiling shows that each call to `RenderImage::paintReplaced()` calls `NativeImage::headroom()` twice,
and this adds up to about 13% of the time under `RenderImage::paintReplaced()`; there&apos;s some CG overhead.

Avoid this by caching headroom on the NativeImage.

This is intended to offset some of the cost of implementing LargestContentfulPaint.

* Source/WebCore/platform/graphics/NativeImage.cpp:
(WebCore::NativeImage::NativeImage):
(WebCore::NativeImage::replacePlatformImage):
(WebCore::NativeImage::computeHeadroom):
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::computeHeadroom):
(WebCore::NativeImage::headroom const):

Canonical link: <a href="https://commits.webkit.org/301459@main">https://commits.webkit.org/301459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aba6ffa05ac7e1bbae6053fcc042eaa00d701fac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36483 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c44c7d01-2aef-4759-8e54-5353a0e801a5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54248 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/132874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90e56a9e-d9d9-4e9d-9613-0f7dd77f925a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112724 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ffb0054c-8c84-4762-985e-4f6a7376801b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30909 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76346 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135573 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52807 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40537 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108942 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104215 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26548 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49603 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27931 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50185 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52704 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58537 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52038 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55385 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53742 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->