### PR TITLE
[css-anchor-position-1] Invalidate all remembered last successful position option when @position-try mutates

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Starts rendering with --try
 PASS No successful position, keep --try
-FAIL No successful position, last successful invalidated by @position-try change assert_equals: expected 0 but got 200
+PASS No successful position, last successful invalidated by @position-try change
 

--- a/Source/WebCore/css/CSSPositionTryDescriptors.h
+++ b/Source/WebCore/css/CSSPositionTryDescriptors.h
@@ -124,6 +124,10 @@ public:
 private:
     CSSPositionTryDescriptors(MutableStyleProperties&, CSSPositionTryRule&);
 
+    // Override this to invalidate all remembered last-successful position options
+    // when property value changes.
+    ExceptionOr<void> setPropertyInternal(CSSPropertyID, const String& value, IsImportant) override;
+
     StyleRuleType ruleType() const final;
 };
 

--- a/Source/WebCore/css/PropertySetCSSDescriptors.h
+++ b/Source/WebCore/css/PropertySetCSSDescriptors.h
@@ -78,7 +78,7 @@ protected:
 
     // CSSPropertyID versions of the CSSOM functions to support bindings.
     String getPropertyValueInternal(CSSPropertyID) const;
-    ExceptionOr<void> setPropertyInternal(CSSPropertyID, const String& value, IsImportant);
+    virtual ExceptionOr<void> setPropertyInternal(CSSPropertyID, const String& value, IsImportant);
 
     CSSParserContext cssParserContext() const;
     Ref<MutableStyleProperties> protectedPropertySet() const;


### PR DESCRIPTION
#### 095e0991651ff2c57d9f3ccf57d1b0d447f62b47
<pre>
[css-anchor-position-1] Invalidate all remembered last successful position option when @position-try mutates
<a href="https://rdar.apple.com/162555785">rdar://162555785</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300657">https://bugs.webkit.org/show_bug.cgi?id=300657</a>

Reviewed by Antti Koivisto.

This patch invalidates all remembered last successful position option when a
property inside @position-try rule mutates, per spec. This is done by making
PropertySetCSSDescriptors::setPropertyInternal virtual, and providing an override
in CSSPositionTryDescriptors that invalidates the remembered position options.
This is the bare minimum needed to pass the test.

Test: LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule-expected.txt:
* Source/WebCore/css/CSSPositionTryDescriptors.cpp:
(WebCore::CSSPositionTryDescriptors::setPropertyInternal):
* Source/WebCore/css/CSSPositionTryDescriptors.h:
* Source/WebCore/css/PropertySetCSSDescriptors.h:

Canonical link: <a href="https://commits.webkit.org/301617@main">https://commits.webkit.org/301617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/919fbe2d60387545a3919deb638ba8e74805506c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133375 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78162 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a5d9fca7-1f08-4610-94ca-0888d0f71450) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96248 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a76b7c5e-2432-44f5-80a4-fede5e551370) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76721 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c1f9755c-d790-46cd-8328-80bdf144122e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36294 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31285 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76682 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135919 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104755 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104456 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26655 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49926 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28256 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50577 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53093 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58910 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52379 "Hash 919fbe2d for PR 52263 does not build (failure)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55713 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54113 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->