### PR TITLE
Add a test for 301346@main, ensuring that loading cached PDFs succeeds

### DIFF
--- a/LayoutTests/pdf/load-pdf-twice-in-sequence-expected.txt
+++ b/LayoutTests/pdf/load-pdf-twice-in-sequence-expected.txt
@@ -1,0 +1,200 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 300.00 300.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (bounds 300.00 300.00)
+              (backgroundColor #808080)
+              (children 2
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 2
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                          (children 1
+                            (GraphicsLayer
+                              (position 34.55 38.86)
+                              (anchor 0.00 0.00)
+                              (bounds 215.91 215.91)
+                              (children 1
+                                (GraphicsLayer
+                                  (anchor 0.00 0.00)
+                                  (bounds 100.00 100.00)
+                                  (drawsContent 1)
+                                  (backgroundColor #FFFFFF)
+                                  (transform [2.16 0.00 0.00 0.00] [0.00 2.16 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 285.00 294.00)
+                          (drawsContent 1)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                        )
+                      )
+                    )
+                  )
+                )
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 300.00 300.00)
+        )
+      )
+    )
+  )
+)
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1046.00 1388.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1046.00 1388.00)
+      (contentsOpaque 1)
+      (children 4
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 300.00 300.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (bounds 300.00 300.00)
+              (backgroundColor #808080)
+              (children 2
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 2
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                          (children 1
+                            (GraphicsLayer
+                              (position 34.55 38.86)
+                              (anchor 0.00 0.00)
+                              (bounds 215.91 215.91)
+                              (children 1
+                                (GraphicsLayer
+                                  (anchor 0.00 0.00)
+                                  (bounds 100.00 100.00)
+                                  (drawsContent 1)
+                                  (backgroundColor #FFFFFF)
+                                  (transform [2.16 0.00 0.00 0.00] [0.00 2.16 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 285.00 294.00)
+                          (drawsContent 1)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                        )
+                      )
+                    )
+                  )
+                )
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 312.00 8.00)
+          (bounds 300.00 300.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (bounds 300.00 300.00)
+              (backgroundColor #808080)
+              (children 2
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 2
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                          (children 1
+                            (GraphicsLayer
+                              (position 34.55 38.86)
+                              (anchor 0.00 0.00)
+                              (bounds 215.91 215.91)
+                              (children 1
+                                (GraphicsLayer
+                                  (anchor 0.00 0.00)
+                                  (bounds 100.00 100.00)
+                                  (drawsContent 1)
+                                  (backgroundColor #FFFFFF)
+                                  (transform [2.16 0.00 0.00 0.00] [0.00 2.16 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 285.00 294.00)
+                          (drawsContent 1)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                        )
+                      )
+                    )
+                  )
+                )
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 300.00 300.00)
+        )
+        (GraphicsLayer
+          (position 312.00 8.00)
+          (bounds 300.00 300.00)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/pdf/load-pdf-twice-in-sequence.html
+++ b/LayoutTests/pdf/load-pdf-twice-in-sequence.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true PDFPluginHUDEnabled=false ] -->
+<html>
+<head>
+<style>
+embed {
+    width: 300px;
+    height: 300px;
+}
+</style>
+<script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<embed id="plugin" src="../fast/images/resources/green_rectangle.pdf"></embed>
+<embed id="plugin2"></embed>
+<pre id="layers"></pre>
+<pre id="layers2"></pre>
+<script>
+testRunner?.waitUntilDone();
+testRunner?.dumpAsText();
+internals?.registerPDFTest(async () => {
+    await UIHelper.waitForPDFFadeIn();
+    layers.textContent = internals.layerTreeAsText(document);
+    plugin2.src = "../fast/images/resources/green_rectangle.pdf";
+    internals?.registerPDFTest(async () => {
+        await UIHelper.waitForPDFFadeIn();
+        layers2.textContent = internals.layerTreeAsText(document);
+        testRunner?.notifyDone();
+    }, plugin2);
+}, plugin);
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 7c3fea2e73edc7d7c5373dda8f22bf2c44b1293e
<pre>
Add a test for 301346@main, ensuring that loading cached PDFs succeeds
<a href="https://bugs.webkit.org/show_bug.cgi?id=300662">https://bugs.webkit.org/show_bug.cgi?id=300662</a>
<a href="https://rdar.apple.com/162560992">rdar://162560992</a>

Reviewed by Sam Weinig and Abrar Rahman Protyasha.

Upon further investigation, it is trivial to make a 100% repro test
case for the bug fixed in 301346@main, where PDFPlugin would fail to
load PDFs that were already cached, so that we don&apos;t have to depend
on a rare race condition to cover that fix.

It turns out that simply waiting for PDFPlugin to itself force-cache
the loaded PDF via PDFPluginBase::addArchiveResource(), and then trying
to load the *same* PDF in another plugin, will take the archive path
(and thus the `deliverResponseAndData` path, and thus exercise the fix
from 301346@main), 100% of the time.

* LayoutTests/pdf/load-pdf-twice-in-sequence-expected.txt: Added.
* LayoutTests/pdf/load-pdf-twice-in-sequence.html: Added.

Canonical link: <a href="https://commits.webkit.org/301453@main">https://commits.webkit.org/301453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ac44fbffe0fff94238fa40426c7c5714ac243db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132858 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77849 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/19fe4cd0-9b41-49c1-b76c-c9de4c4cb18e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54226 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/563cb43f-b3ad-4b16-a68a-27dc3fab3f89) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112705 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8227d8a-9d78-4f64-af42-0a528878d3f2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30891 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76329 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135554 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104468 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104188 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26542 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49578 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27913 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50166 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52682 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52020 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55367 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53721 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->