### PR TITLE
AX: Pressing VO-Space does not open the date picker for date inputs

### DIFF
--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/accessibility-opens-picker-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/accessibility-opens-picker-expected.txt
@@ -1,0 +1,10 @@
+Tests that an accessibility press can activate the date picker.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS showingPicker is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/accessibility-opens-picker.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/accessibility-opens-picker.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/common.js"></script>
+<script src="../../../../resources/accessibility-helper.js.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input id="input" type="datetime-local" value="2020-09-16T10:45"/>
+
+<script>
+window.jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Tests that an accessibility press can activate the date picker.");
+
+    // Press via the accessibility API.
+    accessibilityController.accessibleElementById("input").press();
+
+    while (!(await UIHelper.isShowingDateTimePicker()))
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+    UIHelper.keyDown("escape");
+    await UIHelper.ensurePresentationUpdate();
+    showingPicker = await UIHelper.isShowingDateTimePicker();
+    shouldBeFalse("showingPicker");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -1513,7 +1513,7 @@ static RefPtr<Element> nodeActionElement(Node& node)
 {
     auto elementName = WebCore::elementName(node);
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(node)) {
-        if (!input->isDisabledFormControl() && (input->isRadioButton() || input->isCheckbox() || input->isTextButton() || input->isFileUpload() || input->isImageButton() || input->isTextField()))
+        if (!input->isDisabledFormControl() && (input->isRadioButton() || input->isCheckbox() || input->isTextButton() || input->isFileUpload() || input->isImageButton() || input->isTextField() || input->isDateField() || input->isDateTimeLocalField()))
             return input;
     } else if (elementName == ElementName::HTML_button || elementName == ElementName::HTML_select)
         return &downcast<Element>(node);

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -418,6 +418,9 @@
 /* Day label in date picker */
 "DAY (Date picker for extra zoom mode)" = "DAY";
 
+/* Base accessibility text for the window containing the date picker of <input type='date'> */
+"Date Picker Window Accessibility Title" = "date picker";
+
 /* Phishing warning title */
 "Deceptive Website Warning" = "Deceptive Website Warning";
 

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -339,6 +339,23 @@ void BaseDateAndTimeInputType::handleDOMActivateEvent(Event& event)
     showPicker();
 }
 
+void BaseDateAndTimeInputType::handleAccessibilityActivation()
+{
+    RefPtr element = this->element();
+    if (!element || !element->renderer() || !element->isMutable())
+        return;
+
+    // Consider accessibility activations to be keyboard activations for the purpose of
+    // moving focus into the picker when it's displayed.
+    m_pickerWasActivatedByKeyboard = true;
+
+    if (m_dateTimeChooser)
+        return;
+
+    m_didTransferFocusToPicker = true;
+    showPicker();
+}
+
 void BaseDateAndTimeInputType::showPicker()
 {
     if (!element()->renderer())

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -119,6 +119,7 @@ private:
     bool isMouseFocusable() const final;
 
     void handleDOMActivateEvent(Event&) override;
+    void handleAccessibilityActivation() final;
     void createShadowSubtree() final;
     void removeShadowSubtree() final;
     void updateInnerTextValue() final;

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -279,6 +279,7 @@ public:
     virtual void willDispatchClick(InputElementClickState&) { }
     virtual void didDispatchClick(Event&, const InputElementClickState&) { }
     virtual void handleDOMActivateEvent(Event&) { }
+    virtual void handleAccessibilityActivation() { }
 
     virtual bool allowsShowPickerAcrossFrames();
     virtual void showPicker();

--- a/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
@@ -212,6 +212,8 @@ void WebDateTimePickerMac::didChooseDate(StringView date)
     _enclosingWindow = adoptNS([[WKDateTimePickerWindow alloc] initWithContentRect:NSZeroRect styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:NO]);
     [_enclosingWindow setFrame:windowRect display:YES];
     [[_enclosingWindow contentView] setFocusRingType:NSFocusRingTypeNone];
+    RetainPtr title = WEB_UI_NSSTRING(@"Date Picker Window Accessibility Title", "Base accessibility text for the window containing the date picker of <input type='date'>");
+    [_enclosingWindow setAccessibilityTitle:title.get()];
 
     // Setting _setSharesParentFirstResponder is necessary because AppKit normally disallows
     // a view from one window (in our case, _datePicker belonging to _enclosingWindow) to be


### PR DESCRIPTION
#### 346e54f156c66e01123f52529656f61d6758502c
<pre>
AX: Pressing VO-Space does not open the date picker for date inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=300665">https://bugs.webkit.org/show_bug.cgi?id=300665</a>
<a href="https://rdar.apple.com/162562248">rdar://162562248</a>

Reviewed by Joshua Hoffman.

We need to consider date inputs to be an AccessibilityNodeObject::actionElement(), and ensure that accessibility
activations set the BaseDateAndTimeInputType::m_pickerWasActivatedByKeyboard flag so that focus moves into the picker.

Test: fast/forms/datetimelocal/datetimelocal-editable-components/accessibility-opens-picker.html

* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/accessibility-opens-picker-expected.txt: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/accessibility-opens-picker.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::nodeActionElement):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::press):
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::handleAccessibilityActivation):
* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/InputType.h:
(WebCore::InputType::handleAccessibilityActivation):
* Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm:
(-[WKDateTimePicker initWithParams:inView:]):

Canonical link: <a href="https://commits.webkit.org/301528@main">https://commits.webkit.org/301528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae090e82cbdb6145f1d89f40aef293d6c181d07b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132973 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77971 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28e05063-acc1-4279-a926-e907eff5e0e6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96077 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64191 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb2379eb-4620-4666-aa18-f6cc725e0c64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112871 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76559 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36022cc7-e6dc-4802-a2a6-5ef7873c9fb9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31051 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76447 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135678 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40663 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104588 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53404 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109089 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26601 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49719 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28049 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50326 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52842 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58672 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52161 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55507 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53875 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->