### PR TITLE
[JSC] WASM IPInt SIMD: enable by default

### DIFF
--- a/JSTests/wasm/stress/simd-const-relaxed-f32-madd.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f32-madd.js
@@ -1,5 +1,8 @@
 //@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// FIXME: remove --useWasmIPIntSIMD=0 and don't skip no-jit once IPInt support is implemented
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js
@@ -1,5 +1,8 @@
 //@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// FIXME: remove --useWasmIPIntSIMD=0 and don't skip no jit modes once IPInt support is implemented
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-const-relaxed-f64-madd.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f64-madd.js
@@ -1,5 +1,8 @@
 //@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// FIXME: remove --useWasmIPIntSIMD=0 and don't skip no jit modes once IPInt support is implemented
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js
@@ -1,5 +1,8 @@
 //@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// FIXME: remove --useWasmIPIntSIMD=0 and don't skip no jit modes once IPInt support is implemented
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-const-relaxed-lane-select.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-lane-select.js
@@ -1,5 +1,8 @@
 //@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// FIXME: remove --useWasmIPIntSIMD=0 and don't skip no jit modes once IPInt support is implemented
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-const-relaxed-swizzle.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-swizzle.js
@@ -1,5 +1,8 @@
 //@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// FIXME: remove --useWasmIPIntSIMD=0 and don't skip no jit modes once IPInt support is implemented
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -624,7 +624,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useWasmIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues"_s) \
     v(Bool, useWasmIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during loop iterations"_s) \
     v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues"_s) \
-    v(Bool, useWasmIPIntSIMD, false, Normal, "Allow IPInt to interpret SIMD code"_s) \
+    v(Bool, useWasmIPIntSIMD, true, Normal, "Allow IPInt to interpret SIMD code"_s) \
     v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing."_s) \
     v(Bool, useOMGInlining, true, Normal, "Use OMG inlining"_s) \
     v(Bool, freeRetiredWasmCode, true, Normal, "free BBQ/OMG-OSR wasm code once it's no longer reachable."_s) \

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1917,8 +1917,7 @@ def runWebAssemblySuite(*optionalTestSpecificOptions)
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
         run("wasm-bbq", "--useWasmIPInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-bbq-no-consts", "--useWasmIPInt=false", "--disableBBQConsts=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
-        # FIXME: this is a hacky way to check if we use SIMD rdar://138436830
-        if $runJITlessWasm and not $testSpecificRequiredOptions.include? "--useWasmSIMD=1"
+        if $runJITlessWasm
           run("wasm-no-jit", "--useJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?("wasm-no-jit".to_sym)
           run("wasm-no-wasm-jit", "--useBBQJIT=false", "--useOMGJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?("wasm-no-wasm-jit".to_sym)
         end
@@ -1951,8 +1950,7 @@ def runV8WebAssemblySuite(*optionalTestSpecificOptions)
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
         run("wasm-bbq", "--useWasmIPInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-bbq-no-consts", "--useWasmIPInt=false", "--disableBBQConsts=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
-        # FIXME: this is a hacky way to check if we use SIMD rdar://138436830
-        if $runJITlessWasm and not $testSpecificRequiredOptions.include? "--useWasmSIMD=1"
+        if $runJITlessWasm
           run("wasm-no-jit", "--useJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?("wasm-no-jit".to_sym)
           run("wasm-no-wasm-jit", "--useBBQJIT=false", "--useOMGJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?("wasm-no-wasm-jit".to_sym)
         end
@@ -2031,8 +2029,7 @@ def runWebAssemblyEmscripten(mode)
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *FTL_OPTIONS)
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *FTL_OPTIONS) if shouldCollectContinuously?
         run("wasm-bbq", "--useWasmIPInt=false", *FTL_OPTIONS) # Doesn't actually depend on FTL, but we enable it on the same platforms for now.
-        # FIXME: this is a hacky way to check if we use SIMD rdar://138436830
-        if $runJITlessWasm and not $testSpecificRequiredOptions.include? "--useWasmSIMD=1"
+        if $runJITlessWasm
           run("wasm-no-jit", "--useJIT=false" *FTL_OPTIONS) unless $skipModes.include?("wasm-no-jit".to_sym)
           run("wasm-no-wasm-jit", "--useBBQJIT=false", "--useOMGJIT=false" *FTL_OPTIONS) unless $skipModes.include?("wasm-no-wasm-jit".to_sym)
         end


### PR DESCRIPTION
#### 3e8c9d3d75eb57df2980f0009b5c002a303d81a4
<pre>
[JSC] WASM IPInt SIMD: enable by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=300666">https://bugs.webkit.org/show_bug.cgi?id=300666</a>
<a href="https://rdar.apple.com/162563158">rdar://162563158</a>

Reviewed by Yusuke Suzuki and Daniel Liu.

Enable Wasm SIMD support in InPlaceInterpreter by default.

Remove the hack in run-jsc-stress-tests that was used to skip the
JIT-less modes for SIMD tests. Explicitly skip JIT-less modes for
the handful of relaxed SIMD tests that are exercising the off-by-default
relaxed SIMD instructions currently implemented by BBQ/OMG.

* JSTests/wasm/stress/simd-const-relaxed-f32-madd.js:
* JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js:
* JSTests/wasm/stress/simd-const-relaxed-f64-madd.js:
* JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js:
* JSTests/wasm/stress/simd-const-relaxed-lane-select.js:
* JSTests/wasm/stress/simd-const-relaxed-swizzle.js:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/301576@main">https://commits.webkit.org/301576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b57d33f5e50bb982223bfc2b86f6f04f2a66241

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36903 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133318 "Hash 8b57d33f for PR 52269 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78102 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77483ba6-44a7-4c6f-a428-671f326276af) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54571 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/133318 "Hash 8b57d33f for PR 52269 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cedb0472-c1b0-4e55-9db1-782aec177b95) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113042 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/133318 "Hash 8b57d33f for PR 52269 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b197ca7-d099-4ef0-9db2-3a6333f8260b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36239 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31218 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76604 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118438 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135837 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124837 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40811 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53568 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104401 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49859 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28193 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50494 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19766 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53005 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58834 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157885 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52309 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39508 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55649 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54032 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->