### PR TITLE
[Screen Time] Element fullscreen displays a blank view in macOS SwiftUI apps

### DIFF
--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -40,6 +40,7 @@ DECLARE_SYSTEM_HEADER
 #import <AppKit/NSMenu_Private.h>
 #import <AppKit/NSPreviewRepresentingActivityItem_Private.h>
 #import <AppKit/NSTextInputClient_Private.h>
+#import <AppKit/NSView_Layout.h>
 #import <AppKit/NSWindow_Private.h>
 #import <AppKit/NSScrollViewSeparatorTrackingAdapter_Private.h>
 
@@ -120,6 +121,10 @@ typedef NS_ENUM(NSInteger, NSScrollPocketEdge) {
 @property NSScrollPocketStyle style;
 @property (copy, nullable) NSColor *captureColor;
 @property (readonly, strong) NSView *captureView;
+@end
+
+@interface NSView (NSConstraintBasedLayout)
+- (void)_setHostsAutolayoutEngine:(BOOL)flag;
 @end
 
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -458,6 +458,9 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
     RetainPtr screenTimeView = [_screenTimeWebpageController view];
 
     if ([_configuration showsSystemScreenTimeBlockingView]) {
+#if PLATFORM(MAC)
+        [screenTimeView _setHostsAutolayoutEngine:YES];
+#endif
         [screenTimeView setFrame:self.bounds];
         [self addSubview:screenTimeView.get()];
     }

--- a/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
+++ b/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
@@ -38,6 +38,7 @@ DECLARE_SYSTEM_HEADER
 #import <AppKit/NSMenu_Private.h>
 #import <AppKit/NSScrollViewSeparatorTrackingAdapter_Private.h>
 #import <AppKit/NSTextInputClient_Private.h>
+#import <AppKit/NSView_UnifiedLayout.h>
 #import <AppKit/NSWindow_Private.h>
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
@@ -114,6 +115,10 @@ NSString * const NSInspectorBarTextAlignmentItemIdentifier = @"NSInspectorBarTex
 
 @interface NSImage (SPI)
 @property (readonly, getter=_isSymbolImage) BOOL _symbolImage;
+@end
+
+@interface NSView (_NSConstraintBasedLayoutEmbedding)
+@property (readonly) BOOL _wantsConstraintBasedLayout;
 @end
 
 #endif


### PR DESCRIPTION
#### 39b1eedf5498b3e06a762a64f834f5f6de6efb6d
<pre>
[Screen Time] Element fullscreen displays a blank view in macOS SwiftUI apps
<a href="https://bugs.webkit.org/show_bug.cgi?id=300660">https://bugs.webkit.org/show_bug.cgi?id=300660</a>
<a href="https://rdar.apple.com/157888558">rdar://157888558</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

With the introduction of Screen Time in WebKit, `WKWebView` now contains an
`STWebpageView` subview. `STWebpageView` contains an `NSRemoteView`, which uses
Auto Layout to size itself. The addition of this view is the first time `WKWebView`
has Auto Layout use (that is not from autoresizing mask constaints) in its
hierarchy.

SwiftUI apps have long used `WKWebView` via `NSViewRepresentable`, relying on
SwiftUI&apos;s &quot;view hosting&quot; implementation. Even the recently added `WebView` API
relies on view hosting under the hood. SwiftUI&apos;s view hosting implementation
takes control of the hosted view&apos;s layout. More specifically, SwiftUI checks
`-[NSView _wantsConstraintBasedLayout]` on the hosted view (in this case, a
`WKWebView`). If true, SwiftUI sets `translatesAutoresizingMaskIntoConstraints`
to false, and adds constraints to size the hosted view to match its container
(referred to as the view host in SwiftUI).

With the addition of `STWebpageView` into the `WKWebView` hierarchy,
`-[NSView _wantsConstraintBasedLayout]` now evaluates to true. This is because
`_wantsConstraintBasedLayout` recursively checks subviews to see if they are
using Auto Layout. Consequently, with Screen Time enablement, all `WKWebView`s
in a SwiftUI context have `translatesAutoresizingMaskIntoConstraints` set to
false.

Finally, WebKit&apos;s fullscreen implementation works by removing the `WKWebView`
out of its original hierarchy and adding to a WebKit-owned fullscreen window.
As part of this implementation, all constraints are removed from the web view,
and restored on fullscreen exit. Since all constraints are removed in fullscreen,
and the `WKWebView` has translatesAutoresizingMaskIntoConstraints` set to false
as described above, there is nothing to size the web view. Consequently, a blank
view is shown in fullscreen.

Simply forcing `translatesAutoresizingMaskIntoConstraints` to true does not fix
the issue, as SwiftUI still takes control of the frame of the hosted view. That
approach yields a partial fix where the web view now has a defined size, but the
size is still incorrect. Other fixes could involve SwiftUI, including only
setting `translatesAutoresizingMaskIntoConstraints` to false if the hosted view
directly has non-TAMIC constraints, and avoiding updating the frame if the hosted
view is no longer a descendant of the hosting view. However, these fixes were
deemed too risky at this time. Finally, an ideal solution would be to rearchitect
WebKit&apos;s fullscreen implementation to avoid ripping the web view out of its
original view hierarchy.

To fix, mark the Screen Time view as hosting an Auto Layout engine prior to
adding it to the `WKWebView`&apos;s hierarchy. This results in `-[NSView _wantsConstraintBasedLayout]`
on the `WKWebView` itself returning false, since descendants that host their own
engine are skipped. Ultimately, this prevents SwiftUI from setting
`translatesAutoresizingMaskIntoConstraints` to false when the `WKWebView` contains
the Screen Time view.

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _installScreenTimeWebpageControllerIfNeeded]):
* Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(TEST(ScreenTime, FullscreenWithSystemBlockingViewInHierarchy)):

Canonical link: <a href="https://commits.webkit.org/301481@main">https://commits.webkit.org/301481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dfe200c01d324172da1de6fa25385e9382c06a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77923 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8e941044-cc98-49cc-8430-780e1f964514) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54319 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64147 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a229c308-6e26-4e27-845b-6fc8bec0517c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112810 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07b04e17-4a57-4cfa-9d47-7864341d21dd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30996 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76403 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31213 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40608 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/135639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109026 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49663 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50273 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19723 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52774 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58608 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52102 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55448 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53812 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->