### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE for Model/ModelDDInlineConverters

### DIFF
--- a/Source/WebCore/Modules/Model/ModelDDInlineConverters.h
+++ b/Source/WebCore/Modules/Model/ModelDDInlineConverters.h
@@ -29,6 +29,7 @@
 #include <WebCore/DDMeshDescriptor.h>
 #include <WebCore/DDUpdateMeshDescriptor.h>
 #include <WebCore/ModelDDTypes.h>
+#include <wtf/cocoa/VectorCocoa.h>
 
 namespace WebCore {
 static DDModel::DDVertexAttributeFormat toCpp(WebDDVertexAttributeFormat *format)
@@ -86,16 +87,6 @@ static Vector<DDModel::DDFloat4x4> toVector(WebChainedFloat4x4 *input)
     return result;
 }
 
-static Vector<uint8_t> toVector(NSData *input)
-{
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    Vector<uint8_t> result;
-    for (NSUInteger i = 0; i < input.length; ++i)
-        result.append(((const uint8_t*)input.bytes)[i]);
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-    return result;
-}
 
 static Vector<KeyValuePair<int32_t, uint64_t>> toCpp(NSArray<WebSetRenderFlags *> *renderFlags)
 {
@@ -130,7 +121,7 @@ static DDModel::DDReplaceVertices toCpp(WebReplaceVertices *a)
 {
     return DDModel::DDReplaceVertices {
         .bufferIndex = static_cast<int32_t>(a.bufferIndex),
-        .buffer = toVector(a.buffer)
+        .buffer = makeVector(a.buffer)
     };
 }
 
@@ -159,7 +150,7 @@ static WebCore::DDModel::DDUpdateMeshDescriptor toCpp(WebUpdateMeshRequest *upda
         .parts = toCpp(update.parts),
         .renderFlags = toCpp(update.renderFlags),
         .vertices = toCpp(update.vertices),
-        .indices = toVector(update.indices),
+        .indices = makeVector(update.indices),
         .transform = update.transform,
         .instanceTransforms4x4 = toVector(update.instanceTransforms),
         .materialIds = toCpp(update.materialIds)


### PR DESCRIPTION
#### 8881c147ee99b7a30a27f297b9e20faf85972078
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE for Model/ModelDDInlineConverters
<a href="https://bugs.webkit.org/show_bug.cgi?id=300669">https://bugs.webkit.org/show_bug.cgi?id=300669</a>
<a href="https://rdar.apple.com/problem/162566712">rdar://problem/162566712</a>

Reviewed by Chris Dumez.

* Source/WebCore/Modules/Model/ModelDDInlineConverters.h:
(WebCore::toVector):

Canonical link: <a href="https://commits.webkit.org/301473@main">https://commits.webkit.org/301473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3c5ceab8042fcbd9e00a8ddfc8952f061fd560a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132876 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77867 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95997 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64095 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76486 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30911 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76348 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135575 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104484 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104204 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26560 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49605 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27933 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50187 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52706 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58539 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53744 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->