### PR TITLE
[CSS Zoom] Apply zoom factor to text-shadow, box-shadow, and drop-shadow

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7588,7 +7588,6 @@ imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html [ 
 imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom.sub.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/list-style-image.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/relative-units-from-parent.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-viewport/zoom/text-shadow.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/border.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/bottom.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>CSS zoom applies to box-shadow when specified and inherited</title>
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+
+<style>
+body {
+  --scale: 1;
+  --shadowScaleOffsetX: 1;
+  --shadowScaleOffsetY: 1;
+  --shadowScaleBlurRadius: 1;
+}
+div {
+  font-size: calc(1rem * var(--scale));
+  box-shadow: calc(5px * var(--shadowScaleOffsetX)) calc(5px * var(--shadowScaleOffsetY)) calc(2px * var(--shadowScaleBlurRadius)) black;
+}
+.zoomFont {
+  --scale: 2;
+}
+.zoomShadow {
+  --shadowScaleOffsetX: 2;
+  --shadowScaleOffsetY: 2;
+  --shadowScaleBlurRadius: 2;
+}
+</style>
+<div>unzoomed</div>
+<div class="zoomFont zoomShadow">zoomed</div>
+<div class="zoomFont">zoomed inherited</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS zoom applies to box-shadow when specified and inherited</title>
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/box-shadow-ref.html">
+
+<style>
+
+.shadow {
+  box-shadow: 5px 5px 2px black;
+}
+.zoom {
+  zoom: 2;
+}
+</style>
+
+<div class="shadow">unzoomed</div>
+<div class="zoom"><div class="shadow">zoomed</div></div>
+<div class="shadow"><div class="zoom">zoomed inherited</div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-drop-shadow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-drop-shadow-expected.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>CSS zoom applies to drop-shadow when specified and inherited</title>
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<style>
+body {
+    --scale: 1;
+}
+.container {
+    filter: drop-shadow(calc(5px * var(--scale)) calc(5px * var(--scale)) calc(5px * var(--scale)) black);
+    padding: calc(20px * var(--scale));
+}
+.circle-mask {
+    border-radius: calc(80px * var(--scale));;
+    overflow: hidden;
+    width: calc(100px * var(--scale));
+    height: calc(100px * var(--scale));
+}
+.green-box {
+    width: calc(100px * var(--scale));
+    height: calc(100px * var(--scale));
+    background-color: green;
+    font-size: calc(1rem * var(--scale));
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+.zoom {
+    --scale: 2;
+}
+</style>
+<div class="container">
+  <div class="circle-mask">
+    <div class="green-box">unzoomed</div>
+  </div>
+</div>
+<div class="container">
+  <div class="circle-mask zoom">
+    <div class="green-box">zoomed</div>
+  </div>
+</div>
+<div class="container zoom">
+  <div class="circle-mask">
+    <div class="green-box">zoomed inherited</div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-drop-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-drop-shadow.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<title>CSS zoom applies to drop-shadow when specified and inherited</title>
+<link rel="author" title="Stephen White" href="mailto:senorblanco@chromium.org">
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#FilterProperty">
+<link rel="match" href="reference/filters-drop-shadow-ref.html">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-862" />
+<meta name="assert" content="Check that clipping gets correctly applied on children of a container with a drop-shadow filter in effect."/>
+
+<style>
+.container {
+    filter: drop-shadow(5px 5px 5px black);
+    padding: 20px;
+}
+.circle-mask {
+    border-radius: 80px;
+    overflow: hidden;
+    width: 100px;
+    height: 100px;
+}
+.green-box {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+.zoom {
+  zoom: 2;
+}
+</style>
+<div class="container">
+  <div class="circle-mask">
+    <div class="green-box">unzoomed</div>
+  </div>
+</div>
+<div class="container">
+  <div class="circle-mask zoom">
+    <div class="green-box">zoomed</div>
+  </div>
+</div>
+<div class="container zoom">
+  <div class="circle-mask">
+    <div class="green-box">zoomed inherited</div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/box-shadow-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/box-shadow-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>CSS zoom applies to box-shadow when specified and inherited</title>
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+
+<style>
+body {
+  --scale: 1;
+  --shadowScaleOffsetX: 1;
+  --shadowScaleOffsetY: 1;
+  --shadowScaleBlurRadius: 1;
+}
+div {
+  font-size: calc(1rem * var(--scale));
+  box-shadow: calc(5px * var(--shadowScaleOffsetX)) calc(5px * var(--shadowScaleOffsetY)) calc(2px * var(--shadowScaleBlurRadius)) black;
+}
+.zoomFont {
+  --scale: 2;
+}
+.zoomShadow {
+  --shadowScaleOffsetX: 2;
+  --shadowScaleOffsetY: 2;
+  --shadowScaleBlurRadius: 2;
+}
+</style>
+<div>unzoomed</div>
+<div class="zoomFont zoomShadow">zoomed</div>
+<div class="zoomFont">zoomed inherited</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/filters-drop-shadow-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/filters-drop-shadow-ref.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>CSS zoom applies to drop-shadow when specified and inherited</title>
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<style>
+body {
+    --scale: 1;
+}
+.container {
+    filter: drop-shadow(calc(5px * var(--scale)) calc(5px * var(--scale)) calc(5px * var(--scale)) black);
+    padding: calc(20px * var(--scale));
+}
+.circle-mask {
+    border-radius: calc(80px * var(--scale));;
+    overflow: hidden;
+    width: calc(100px * var(--scale));
+    height: calc(100px * var(--scale));
+}
+.green-box {
+    width: calc(100px * var(--scale));
+    height: calc(100px * var(--scale));
+    background-color: green;
+    font-size: calc(1rem * var(--scale));
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+.zoom {
+    --scale: 2;
+}
+</style>
+<div class="container">
+  <div class="circle-mask">
+    <div class="green-box">unzoomed</div>
+  </div>
+</div>
+<div class="container">
+  <div class="circle-mask zoom">
+    <div class="green-box">zoomed</div>
+  </div>
+</div>
+<div class="container zoom">
+  <div class="circle-mask">
+    <div class="green-box">zoomed inherited</div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style-expected.txt
@@ -11,6 +11,22 @@ PASS Property border-width value 'inherit' no zoom
 PASS Property border-width value '5px 10px' zoom: 2
 PASS Property border-width value '2px 4px 6px 8px' zoom: 2
 PASS Property border-width value 'inherit' zoom: 2
+PASS Property box-shadow value 'rgb(0, 0, 0) 10px 10px 10px 0px' no zoom
+PASS Property box-shadow value 'inherit' no zoom
+PASS Property box-shadow value 'rgb(0, 0, 0) 10px 10px 10px 0px' zoom: 2
+PASS Property box-shadow value 'inherit' zoom: 2
+PASS Property filter value 'drop-shadow(rgb(0, 0, 0) 10px 10px 10px)' no zoom
+PASS Property filter value 'inherit' no zoom
+PASS Property filter value 'drop-shadow(rgb(0, 0, 0) 10px 10px 10px)' zoom: 2
+PASS Property filter value 'inherit' zoom: 2
+PASS Property line-height value '13px' no zoom
+PASS Property line-height value 'inherit' no zoom
+PASS Property line-height value '13px' zoom: 2
+PASS Property line-height value 'inherit' zoom: 2
+PASS Property text-shadow value 'rgb(0, 0, 0) 10px 10px 0px' no zoom
+PASS Property text-shadow value 'inherit' no zoom
+PASS Property text-shadow value 'rgb(0, 0, 0) 10px 10px 0px' zoom: 2
+PASS Property text-shadow value 'inherit' zoom: 2
 PASS Property text-underline-offset value '4px' no zoom
 PASS Property text-underline-offset value 'inherit' no zoom
 PASS Property text-underline-offset value '4px' zoom: 2
@@ -19,8 +35,4 @@ PASS Property -webkit-text-stroke-width value '4px' no zoom
 PASS Property -webkit-text-stroke-width value 'inherit' no zoom
 PASS Property -webkit-text-stroke-width value '4px' zoom: 2
 PASS Property -webkit-text-stroke-width value 'inherit' zoom: 2
-PASS Property line-height value '13px' no zoom
-PASS Property line-height value 'inherit' no zoom
-PASS Property line-height value '13px' zoom: 2
-PASS Property line-height value 'inherit' zoom: 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html
@@ -24,6 +24,22 @@
       "otherValues": ["5px 10px", "2px 4px 6px 8px"],
       "requiredProperties": { "border-style": "solid" }
     },
+    "box-shadow": {
+      "value": "rgb(0, 0, 0) 5px 5px 5px 0px",
+      "otherValues": ["rgb(0, 0, 0) 10px 10px 10px 0px"]
+    },
+    "filter": {
+      "value": "drop-shadow(rgb(0, 0, 0) 5px 5px 5px)",
+      "otherValues": ["drop-shadow(rgb(0, 0, 0) 10px 10px 10px)"]
+    },
+    "line-height" : {
+      "value": "7px",
+      "otherValues": ["13px"]
+    },
+    "text-shadow": {
+      "value": "rgb(0, 0, 0) 5px 5px 0px",
+      "otherValues": ["rgb(0, 0, 0) 10px 10px 0px"]
+    },
     "text-underline-offset": {
       "value": "2px",
       "otherValues": ["4px"]
@@ -32,10 +48,6 @@
       "value": "2px",
       "otherValues": ["4px"]
     },
-    "line-height" : {
-      "value": "7px",
-      "otherValues": ["13px"]
-    }
   };
 
   for (const [property, {value, otherValues, requiredProperties}] of Object.entries(properties)) {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -355,10 +355,10 @@ static std::optional<CSS::BoxShadow> consumeSingleUnresolvedBoxShadow(CSSParserT
     auto rangeCopy = range;
 
     std::optional<CSS::Color> color;
-    std::optional<CSS::Length<>> x;
-    std::optional<CSS::Length<>> y;
-    std::optional<CSS::Length<CSS::Nonnegative>> blur;
-    std::optional<CSS::Length<>> spread;
+    std::optional<CSS::Length<CSS::AllUnzoomed>> x;
+    std::optional<CSS::Length<CSS::AllUnzoomed>> y;
+    std::optional<CSS::Length<CSS::NonnegativeUnzoomed>> blur;
+    std::optional<CSS::Length<CSS::AllUnzoomed>> spread;
     std::optional<CSS::Keyword::Inset> inset;
 
     for (size_t i = 0; i < 3; i++) {
@@ -397,10 +397,10 @@ static std::optional<CSS::BoxShadow> consumeSingleUnresolvedBoxShadow(CSSParserT
             return { };
         }
 
-        x = MetaConsumer<CSS::Length<>>::consume(rangeCopy, state);
+        x = MetaConsumer<CSS::Length<CSS::AllUnzoomed>>::consume(rangeCopy, state);
         if (!x)
             return { };
-        y = MetaConsumer<CSS::Length<>>::consume(rangeCopy, state);
+        y = MetaConsumer<CSS::Length<CSS::AllUnzoomed>>::consume(rangeCopy, state);
         if (!y)
             return { };
 
@@ -409,13 +409,13 @@ static std::optional<CSS::BoxShadow> consumeSingleUnresolvedBoxShadow(CSSParserT
         // The explicit check for calc() is unfortunate. This is ensuring that we only fail
         // parsing if there is a length, but it fails the range check.
         if (token.type() == DimensionToken || token.type() == NumberToken || (token.type() == FunctionToken && CSSCalc::isCalcFunction(token.functionId()))) {
-            blur = MetaConsumer<CSS::Length<CSS::Nonnegative>>::consume(rangeCopy, state);
+            blur = MetaConsumer<CSS::Length<CSS::NonnegativeUnzoomed>>::consume(rangeCopy, state);
             if (!blur)
                 return { };
         }
 
         if (blur)
-            spread = MetaConsumer<CSS::Length<>>::consume(rangeCopy, state);
+            spread = MetaConsumer<CSS::Length<CSS::AllUnzoomed>>::consume(rangeCopy, state);
     }
 
     if (!y)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -137,9 +137,9 @@ static std::optional<CSS::DropShadowFunction> consumeFilterDropShadow(CSSParserT
     auto args = consumeFunction(range);
 
     std::optional<CSS::Color> color;
-    std::optional<CSS::Length<>> x;
-    std::optional<CSS::Length<>> y;
-    std::optional<CSS::Length<CSS::Nonnegative>> stdDeviation;
+    std::optional<CSS::Length<CSS::AllUnzoomed>> x;
+    std::optional<CSS::Length<CSS::AllUnzoomed>> y;
+    std::optional<CSS::Length<CSS::NonnegativeUnzoomed>> stdDeviation;
 
     auto consumeOptionalColor = [&] -> bool {
         if (color)
@@ -154,14 +154,14 @@ static std::optional<CSS::DropShadowFunction> consumeFilterDropShadow(CSSParserT
     auto consumeLengths = [&] -> bool {
         if (x)
             return false;
-        x = MetaConsumer<CSS::Length<>>::consume(args, state);
+        x = MetaConsumer<CSS::Length<CSS::AllUnzoomed>>::consume(args, state);
         if (!x)
             return false;
-        y = MetaConsumer<CSS::Length<>>::consume(args, state);
+        y = MetaConsumer<CSS::Length<CSS::AllUnzoomed>>::consume(args, state);
         if (!y)
             return false;
 
-        stdDeviation = MetaConsumer<CSS::Length<CSS::Nonnegative>>::consume(args, state);
+        stdDeviation = MetaConsumer<CSS::Length<CSS::NonnegativeUnzoomed>>::consume(args, state);
         return true;
     };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+TextDecoration.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+TextDecoration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,9 +55,9 @@ static std::optional<CSS::TextShadow> consumeSingleUnresolvedTextShadow(CSSParse
     auto rangeCopy = range;
 
     std::optional<CSS::Color> color;
-    std::optional<CSS::Length<>> x;
-    std::optional<CSS::Length<>> y;
-    std::optional<CSS::Length<CSS::Nonnegative>> blur;
+    std::optional<CSS::Length<CSS::AllUnzoomed>> x;
+    std::optional<CSS::Length<CSS::AllUnzoomed>> y;
+    std::optional<CSS::Length<CSS::NonnegativeUnzoomed>> blur;
 
     auto consumeOptionalColor = [&] -> bool {
         if (color)
@@ -72,14 +72,14 @@ static std::optional<CSS::TextShadow> consumeSingleUnresolvedTextShadow(CSSParse
     auto consumeLengths = [&] -> bool {
         if (x)
             return false;
-        x = MetaConsumer<CSS::Length<>>::consume(rangeCopy, state);
+        x = MetaConsumer<CSS::Length<CSS::AllUnzoomed>>::consume(rangeCopy, state);
         if (!x)
             return false;
-        y = MetaConsumer<CSS::Length<>>::consume(rangeCopy, state);
+        y = MetaConsumer<CSS::Length<CSS::AllUnzoomed>>::consume(rangeCopy, state);
         if (!y)
             return false;
 
-        blur = MetaConsumer<CSS::Length<CSS::Nonnegative>>::consume(rangeCopy, state);
+        blur = MetaConsumer<CSS::Length<CSS::NonnegativeUnzoomed>>::consume(rangeCopy, state);
         return true;
     };
 

--- a/Source/WebCore/css/values/borders/CSSBoxShadow.h
+++ b/Source/WebCore/css/values/borders/CSSBoxShadow.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,9 +35,9 @@ namespace CSS {
 // https://drafts.csswg.org/css-backgrounds-3/#typedef-shadow
 struct BoxShadow {
     Markable<Color> color;
-    SpaceSeparatedPoint<Length<>> location;
-    Markable<Length<Nonnegative>> blur;
-    Markable<Length<>> spread;
+    SpaceSeparatedPoint<Length<CSS::AllUnzoomed>> location;
+    Markable<Length<CSS::NonnegativeUnzoomed>> blur;
+    Markable<Length<CSS::AllUnzoomed>> spread;
     std::optional<Keyword::Inset> inset;
     bool isWebkitBoxShadow;
 

--- a/Source/WebCore/css/values/filter-effects/CSSDropShadowFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSDropShadowFunction.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,8 +35,8 @@ namespace CSS {
 // https://drafts.fxtf.org/filter-effects/#funcdef-filter-drop-shadow
 struct DropShadow {
     Markable<Color> color;
-    SpaceSeparatedPoint<Length<>> location;
-    Markable<Length<Nonnegative>> stdDeviation;
+    SpaceSeparatedPoint<Length<CSS::AllUnzoomed>> location;
+    Markable<Length<CSS::NonnegativeUnzoomed>> stdDeviation;
 
     bool operator==(const DropShadow&) const = default;
 };

--- a/Source/WebCore/css/values/text-decoration/CSSTextShadow.h
+++ b/Source/WebCore/css/values/text-decoration/CSSTextShadow.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,8 +35,8 @@ namespace CSS {
 // https://drafts.csswg.org/css-text-decor-3/#propdef-text-shadow
 struct TextShadow {
     Markable<Color> color;
-    SpaceSeparatedPoint<Length<>> location;
-    Markable<Length<Nonnegative>> blur;
+    SpaceSeparatedPoint<Length<CSS::AllUnzoomed>> location;
+    Markable<Length<CSS::NonnegativeUnzoomed>> blur;
 
     bool operator==(const TextShadow&) const = default;
 };

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4604,10 +4604,11 @@ FontAttributes Editor::fontAttributesAtSelectionStart()
             return FontShadow { };
         },
         [&](const auto& shadows) {
+            const auto& zoomFactor = style->usedZoomForLength();
             return FontShadow {
                 style->colorWithColorFilter(shadows[0].color),
-                { shadows[0].location.x().resolveZoom(Style::ZoomNeeded { }), shadows[0].location.y().resolveZoom(Style::ZoomNeeded { }) },
-                shadows[0].blur.resolveZoom(Style::ZoomNeeded { })
+                { shadows[0].location.x().resolveZoom(zoomFactor), shadows[0].location.y().resolveZoom(zoomFactor) },
+                shadows[0].blur.resolveZoom(zoomFactor)
             };
         }
     );

--- a/Source/WebCore/editing/FontAttributeChanges.cpp
+++ b/Source/WebCore/editing/FontAttributeChanges.cpp
@@ -94,9 +94,9 @@ static RefPtr<CSSValue> cssValueForTextShadow(const FontShadow& shadow)
         return nullptr;
 
     auto color = CSS::Color { CSS::ResolvedColor { shadow.color } };
-    auto width = CSS::Length<> { CSS::LengthUnit::Px, shadow.offset.width() };
-    auto height = CSS::Length<> { CSS::LengthUnit::Px, shadow.offset.height() };
-    auto blur = CSS::Length<CSS::Nonnegative> { CSS::LengthUnit::Px, shadow.blurRadius };
+    auto width = CSS::Length<CSS::AllUnzoomed> { CSS::LengthUnit::Px, shadow.offset.width() };
+    auto height = CSS::Length<CSS::AllUnzoomed> { CSS::LengthUnit::Px, shadow.offset.height() };
+    auto blur = CSS::Length<CSS::NonnegativeUnzoomed> { CSS::LengthUnit::Px, shadow.blurRadius };
 
     CSS::TextShadowProperty::List list {
         CSS::TextShadow {

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -125,8 +125,8 @@ static inline bool computeInkOverflowForInlineLevelBox(const RenderStyle& style,
 
     auto inflateWithBoxShadow = [&] {
         // FIXME: Use `Style::shadowOutsetExtent` to get all 4 extents at once after static cast to `int` in `shadowVerticalExtent` is understood.
-        auto [topBoxShadow, bottomBoxShadow] = Style::shadowVerticalExtent(style.boxShadow());
-        auto [leftBoxShadow, rightBoxShadow] = Style::shadowHorizontalExtent(style.boxShadow());
+        auto [topBoxShadow, bottomBoxShadow] = Style::shadowVerticalExtent(style.boxShadow(), style.usedZoomForLength());
+        auto [leftBoxShadow, rightBoxShadow] = Style::shadowHorizontalExtent(style.boxShadow(), style.usedZoomForLength());
         if (!topBoxShadow && !bottomBoxShadow && !leftBoxShadow && !rightBoxShadow)
             return;
         inkOverflow.inflate(-leftBoxShadow.toFloat(), -topBoxShadow.toFloat(), rightBoxShadow.toFloat(), bottomBoxShadow.toFloat());
@@ -190,7 +190,7 @@ void InlineDisplayContentBuilder::appendTextDisplayBox(const Line::Run& lineRun,
         addStrokeOverflow();
 
         auto addTextShadow = [&] {
-            auto textShadow = Style::shadowOutsetExtent(style.textShadow());
+            auto textShadow = Style::shadowOutsetExtent(style.textShadow(), style.usedZoomForLength());
             inkOverflow.inflate(-textShadow.top(), textShadow.right(), textShadow.bottom(), -textShadow.left());
         };
         addTextShadow();

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2005 Allan Sandfeld Jensen (kde@carewolf.com)
  *           (C) 2005, 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2010-2013 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -181,8 +181,9 @@ static void applyBoxShadowForBackground(GraphicsContext& context, const RenderSt
         if (shadow.inset)
             continue;
 
-        FloatSize shadowOffset(shadow.location.x().resolveZoom(Style::ZoomNeeded { }), shadow.location.y().resolveZoom(Style::ZoomNeeded { }));
-        context.setDropShadow({ shadowOffset, shadow.blur.resolveZoom(Style::ZoomNeeded { }), style.colorWithColorFilter(shadow.color), shadow.isWebkitBoxShadow ? ShadowRadiusMode::Legacy : ShadowRadiusMode::Default });
+        const auto& zoomFactor = style.usedZoomForLength();
+        FloatSize shadowOffset(shadow.location.x().resolveZoom(zoomFactor), shadow.location.y().resolveZoom(zoomFactor));
+        context.setDropShadow({ shadowOffset, shadow.blur.resolveZoom(zoomFactor), style.colorWithColorFilter(shadow.color), shadow.isWebkitBoxShadow ? ShadowRadiusMode::Legacy : ShadowRadiusMode::Default });
         break;
     }
 }
@@ -856,14 +857,15 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Render
     float deviceScaleFactor = document().deviceScaleFactor();
 
     bool hasOpaqueBackground = style.visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor).isOpaque();
+    const auto& zoomFactor = style.usedZoomForLength();
     for (const auto& shadow : style.boxShadow()) {
         if (Style::shadowStyle(shadow) != shadowStyle)
             continue;
 
-        LayoutSize shadowOffset(shadow.location.x().resolveZoom(Style::ZoomNeeded { }), shadow.location.y().resolveZoom(Style::ZoomNeeded { }));
-        LayoutUnit shadowPaintingExtent = Style::paintingExtent(shadow);
-        LayoutUnit shadowSpread = LayoutUnit(shadow.spread.resolveZoom(Style::ZoomNeeded { }));
-        auto shadowRadius = shadow.blur.resolveZoom(Style::ZoomNeeded { });
+        LayoutSize shadowOffset(shadow.location.x().resolveZoom(zoomFactor), shadow.location.y().resolveZoom(zoomFactor));
+        LayoutUnit shadowPaintingExtent = Style::paintingExtent(shadow, zoomFactor);
+        LayoutUnit shadowSpread = LayoutUnit(shadow.spread.resolveZoom(zoomFactor));
+        auto shadowRadius = shadow.blur.resolveZoom(zoomFactor);
 
         if (shadowOffset.isZero() && !shadowRadius && !shadowSpread)
             continue;

--- a/Source/WebCore/rendering/EllipsisBoxPainter.cpp
+++ b/Source/WebCore/rendering/EllipsisBoxPainter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,7 +72,8 @@ void EllipsisBoxPainter::paint()
             return false;
         },
         [&](const auto& shadows) {
-            context.setDropShadow({ LayoutSize(shadows[0].location.x().resolveZoom(Style::ZoomNeeded { }), shadows[0].location.y().resolveZoom(Style::ZoomNeeded { })), shadows[0].blur.resolveZoom(Style::ZoomNeeded { }), style.colorWithColorFilter(shadows[0].color), ShadowRadiusMode::Default });
+            const auto& zoomFactor = style.usedZoomForLength();
+            context.setDropShadow({ LayoutSize(shadows[0].location.x().resolveZoom(zoomFactor), shadows[0].location.y().resolveZoom(zoomFactor)), shadows[0].blur.resolveZoom(zoomFactor), style.colorWithColorFilter(shadows[0].color), ShadowRadiusMode::Default });
             return true;
         }
     );

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -221,12 +221,12 @@ inline void LegacyInlineFlowBox::addTextBoxVisualOverflow(LegacyInlineTextBox& t
     // applied to the right, so this is not an issue with left overflow.
     rightGlyphOverflow -= std::min(0, (int)lineStyle.fontCascade().letterSpacing());
 
-    auto [textShadowLogicalTop, textShadowLogicalBottom] = Style::shadowBlockDirectionExtent(lineStyle.textShadow(), writingMode);
+    auto [textShadowLogicalTop, textShadowLogicalBottom] = Style::shadowBlockDirectionExtent(lineStyle.textShadow(), writingMode, lineStyle.usedZoomForLength());
 
     auto childOverflowLogicalTop = std::min<LayoutUnit>(textShadowLogicalTop + topGlyphOverflow, topGlyphOverflow);
     auto childOverflowLogicalBottom = std::max<LayoutUnit>(textShadowLogicalBottom + bottomGlyphOverflow, bottomGlyphOverflow);
 
-    auto [textShadowLogicalLeft, textShadowLogicalRight] = Style::shadowInlineDirectionExtent(lineStyle.textShadow(), writingMode);
+    auto [textShadowLogicalLeft, textShadowLogicalRight] = Style::shadowInlineDirectionExtent(lineStyle.textShadow(), writingMode, lineStyle.usedZoomForLength());
 
     auto childOverflowLogicalLeft = std::min<LayoutUnit>(textShadowLogicalLeft + leftGlyphOverflow, leftGlyphOverflow);
     auto childOverflowLogicalRight = std::max<LayoutUnit>(textShadowLogicalRight + rightGlyphOverflow, rightGlyphOverflow);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4514,7 +4514,7 @@ LayoutRect RenderBox::applyVisualEffectOverflow(const LayoutRect& borderBox) con
     
     // Compute box-shadow overflow first.
     if (style().hasBoxShadow()) {
-        auto shadowOutsets = Style::shadowOutsetExtent(style().boxShadow());
+        auto shadowOutsets = Style::shadowOutsetExtent(style().boxShadow(), style().usedZoomForLength());
         // Box-shadow extent's left and top are negative when extends to left and top, respectively, so negate to convert to outsets.
         shadowOutsets.left() = -shadowOutsets.left();
         shadowOutsets.top() = -shadowOutsets.top();

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1497,10 +1497,10 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
     const RenderStyle& outlineStyle = outlineStyleForRepaint();
     auto& style = this->style();
     auto outlineWidth = LayoutUnit { outlineStyle.outlineSize() };
-    auto insetShadowExtent = Style::shadowInsetExtent(style.boxShadow());
+    auto insetShadowExtent = Style::shadowInsetExtent(style.boxShadow(), style.usedZoomForLength());
     auto sizeDelta = LayoutSize { absoluteValue(newOutlineBoundsRect.width() - oldOutlineBoundsRect.width()), absoluteValue(newOutlineBoundsRect.height() - oldOutlineBoundsRect.height()) };
     if (sizeDelta.width()) {
-        auto [shadowLeft, shadowRight] = Style::shadowHorizontalExtent(style.boxShadow());
+        auto [shadowLeft, shadowRight] = Style::shadowHorizontalExtent(style.boxShadow(), style.usedZoomForLength());
 
         auto insetExtent = [&] {
             // Inset "content" is inside the border box (e.g. border, negative outline and box shadow).
@@ -1544,7 +1544,7 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
         }
     }
     if (sizeDelta.height()) {
-        auto [shadowTop, shadowBottom] = Style::shadowVerticalExtent(style.boxShadow());
+        auto [shadowTop, shadowBottom] = Style::shadowVerticalExtent(style.boxShadow(), style.usedZoomForLength());
 
         auto insetExtent = [&] {
             // Inset "content" is inside the border box (e.g. border, negative outline and box shadow).

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,7 +53,7 @@ public:
 
     void paint();
 
-    static inline FloatSize rotateShadowOffset(const SpaceSeparatedPoint<Style::Length<>>& offset, WritingMode);
+    static inline FloatSize rotateShadowOffset(const SpaceSeparatedPoint<Style::Length<CSS::AllUnzoomed>>& offset, WritingMode, const Style::ZoomFactor&);
 
 protected:
     auto& textBox() const { return m_textBox; }
@@ -116,25 +116,25 @@ protected:
     bool m_compositionWithCustomUnderlines { false };
 };
 
-inline FloatSize TextBoxPainter::rotateShadowOffset(const SpaceSeparatedPoint<Style::Length<>>& offset, WritingMode writingMode)
+inline FloatSize TextBoxPainter::rotateShadowOffset(const SpaceSeparatedPoint<Style::Length<CSS::AllUnzoomed>>& offset, WritingMode writingMode, const Style::ZoomFactor& zoomFactor)
 {
     if (writingMode.isHorizontal()) {
         return {
-            offset.x().resolveZoom(Style::ZoomNeeded { }),
-            offset.y().resolveZoom(Style::ZoomNeeded { }),
+            offset.x().resolveZoom(zoomFactor),
+            offset.y().resolveZoom(zoomFactor),
         };
     }
 
     if (writingMode.isLineOverLeft()) { // sideways-lr
         return {
-            -offset.y().resolveZoom(Style::ZoomNeeded { }),
-             offset.x().resolveZoom(Style::ZoomNeeded { }),
+            -offset.y().resolveZoom(zoomFactor),
+             offset.x().resolveZoom(zoomFactor),
         };
     }
 
     return {
-         offset.y().resolveZoom(Style::ZoomNeeded { }),
-        -offset.x().resolveZoom(Style::ZoomNeeded { }),
+         offset.y().resolveZoom(zoomFactor),
+        -offset.x().resolveZoom(zoomFactor),
     };
 }
 

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -1,7 +1,7 @@
 /*
  * (C) 1999 Lars Knoll (knoll@kde.org)
  * (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -232,11 +232,12 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
     bool clipping = m_shadow.size() > 1 && !areLinesOpaque;
     if (clipping) {
         auto clipRect = FloatRect { boxOrigin, FloatSize { decorationGeometry.textBoxWidth, decorationGeometry.clippingOffset } };
+        const auto& zoomFactor = style.usedZoomForLength();
         for (const auto& shadow : m_shadow) {
-            auto shadowExtent = Style::paintingExtent(shadow);
+            auto shadowExtent = Style::paintingExtent(shadow, zoomFactor);
             auto shadowRect = clipRect;
             shadowRect.inflate(shadowExtent);
-            auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow.location, m_writingMode);
+            auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow.location, m_writingMode, zoomFactor);
             shadowRect.move(shadowOffset);
             clipRect.unite(shadowRect);
             extraOffset = std::max(extraOffset, std::max(0.f, shadowOffset.height()) + shadowExtent);
@@ -269,6 +270,7 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
     if (m_shadow.isNone())
         draw(nullptr);
     else {
+        const auto& zoomFactor = style.usedZoomForLength();
         for (const auto& shadow : m_shadow) {
             if (&shadow == &m_shadow.last()) {
                 // The last set of lines paints normally inside the clip.
@@ -279,9 +281,9 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
 
             m_shadowColorFilter.transformColor(shadowColor);
 
-            auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow.location, m_writingMode);
+            auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow.location, m_writingMode, zoomFactor);
             shadowOffset.expand(0, -extraOffset);
-            m_context.setDropShadow({ shadowOffset, shadow.blur.resolveZoom(Style::ZoomNeeded { }), shadowColor, ShadowRadiusMode::Default });
+            m_context.setDropShadow({ shadowOffset, shadow.blur.resolveZoom(zoomFactor), shadowColor, ShadowRadiusMode::Default });
 
             draw(&shadow);
         }

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -1,7 +1,7 @@
 /*
  * (C) 1999 Lars Knoll (knoll@kde.org)
  * (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
@@ -54,8 +54,9 @@ ShadowApplier::ShadowApplier(const RenderStyle& style, GraphicsContext& context,
         return;
     }
 
-    auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow->location, ignoreWritingMode ? WritingMode() : style.writingMode());
-    auto shadowRadius = shadow->blur.resolveZoom(Style::ZoomNeeded { });
+    const auto& zoomFactor = style.usedZoomForLength();
+    auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow->location, ignoreWritingMode ? WritingMode() : style.writingMode(), zoomFactor);
+    auto shadowRadius = shadow->blur.resolveZoom(zoomFactor);
     auto shadowColor = style.colorResolvingCurrentColor(shadow->color);
 
     colorFilter.transformColor(shadowColor);
@@ -65,7 +66,7 @@ ShadowApplier::ShadowApplier(const RenderStyle& style, GraphicsContext& context,
     // often draw the *last* shadow and the text itself in a single call.
     if (m_onlyDrawsShadow) {
         FloatRect shadowRect(textRect);
-        shadowRect.inflate(Style::paintingExtent(*shadow) + 3 * textRect.height());
+        shadowRect.inflate(Style::paintingExtent(*shadow, zoomFactor) + 3 * textRect.height());
         shadowRect.move(shadowOffset);
         context.save();
         context.clip(shadowRect);

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
@@ -136,7 +136,7 @@ void RenderSVGBlock::computeOverflow(LayoutUnit oldClientAfterEdge, bool recompu
         return;
 
     auto borderRect = borderBoxRect();
-    Style::adjustRectForShadow(borderRect, textShadow);
+    Style::adjustRectForShadow(borderRect, textShadow, style().usedZoomForLength());
     addVisualOverflow(snappedIntRect(borderRect));
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -944,7 +944,7 @@ FloatRect RenderSVGText::repaintRectInLocalCoordinates(RepaintRectCalculation re
         auto repaintRect = SVGBoundingBoxComputation::computeRepaintBoundingBox(*this);
 
         if (auto& textShadow = style().textShadow(); !textShadow.isNone())
-            Style::adjustRectForShadow(repaintRect, textShadow);
+            Style::adjustRectForShadow(repaintRect, textShadow, style().usedZoomForLength());
 
         return repaintRect;
     }
@@ -953,7 +953,7 @@ FloatRect RenderSVGText::repaintRectInLocalCoordinates(RepaintRectCalculation re
     SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintRect, repaintRectCalculation);
 
     if (auto& textShadow = style().textShadow(); !textShadow.isNone())
-        Style::adjustRectForShadow(repaintRect, textShadow);
+        Style::adjustRectForShadow(repaintRect, textShadow, style().usedZoomForLength());
 
     return repaintRect;
 }
@@ -971,7 +971,7 @@ void RenderSVGText::updatePositionAndOverflow(const FloatRect& boundaries)
 
         auto overflowRect = visualOverflowRectEquivalent();
         if (auto& textShadow = style().textShadow(); !textShadow.isNone())
-            Style::adjustRectForShadow(overflowRect, textShadow);
+            Style::adjustRectForShadow(overflowRect, textShadow, style().usedZoomForLength());
 
         addVisualOverflow(overflowRect);
         return;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -89,11 +89,11 @@ const RenderElement* LegacyRenderSVGModelObject::pushMappingToContainer(const Re
     return SVGRenderSupport::pushMappingToContainer(*this, ancestorToStopAt, geometryMap);
 }
 
-static void adjustRectForOutlineAndShadow(const LegacyRenderSVGModelObject& renderer, LayoutRect& rect)
+static void adjustRectForOutlineAndShadow(const LegacyRenderSVGModelObject& renderer, LayoutRect& rect, const Style::ZoomFactor& zoomFactor)
 {
     auto shadowRect = rect;
     if (auto& boxShadow = renderer.style().boxShadow(); !boxShadow.isNone())
-        Style::adjustRectForShadow(shadowRect, boxShadow);
+        Style::adjustRectForShadow(shadowRect, boxShadow, zoomFactor);
 
     auto outlineRect = rect;
     auto outlineSize = LayoutUnit { renderer.outlineStyleForRepaint().outlineSize() };
@@ -109,7 +109,7 @@ static void adjustRectForOutlineAndShadow(const LegacyRenderSVGModelObject& rend
 LayoutRect LegacyRenderSVGModelObject::outlineBoundsForRepaint(const RenderLayerModelObject* repaintContainer, const RenderGeometryMap*) const
 {
     LayoutRect box = enclosingLayoutRect(repaintRectInLocalCoordinates());
-    adjustRectForOutlineAndShadow(*this, box);
+    adjustRectForOutlineAndShadow(*this, box, style().usedZoomForLength());
 
     FloatQuad containerRelativeQuad = localToContainerQuad(FloatRect(box), repaintContainer);
     return LayoutRect(snapRectToDevicePixels(LayoutRect(containerRelativeQuad.boundingBox()), document().deviceScaleFactor()));

--- a/Source/WebCore/style/values/borders/StyleBoxShadow.h
+++ b/Source/WebCore/style/values/borders/StyleBoxShadow.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,9 +36,9 @@ namespace Style {
 
 struct BoxShadow {
     Color color;
-    SpaceSeparatedPoint<Length<>> location;
-    Length<CSS::Nonnegative> blur;
-    Length<> spread;
+    SpaceSeparatedPoint<Length<CSS::AllUnzoomed>> location;
+    Length<CSS::NonnegativeUnzoomed> blur;
+    Length<CSS::AllUnzoomed> spread;
     std::optional<CSS::Keyword::Inset> inset;
     bool isWebkitBoxShadow;
 
@@ -102,9 +103,9 @@ inline bool isInset(const BoxShadow& shadow)
     return shadow.inset.has_value();
 }
 
-inline LayoutUnit paintingSpread(const BoxShadow& shadow)
+inline LayoutUnit paintingSpread(const BoxShadow& shadow, const Style::ZoomFactor& zoomFactor)
 {
-    return LayoutUnit { shadow.spread.resolveZoom(Style::ZoomNeeded { }) };
+    return LayoutUnit { shadow.spread.resolveZoom(zoomFactor) };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/text-decoration/StyleTextShadow.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextShadow.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,7 +56,7 @@ auto ToStyle<CSS::TextShadow>::operator()(const CSS::TextShadow& value, const Bu
     return {
         .color = value.color ? toStyle(*value.color, state) : Color::currentColor(),
         .location = toStyle(value.location, state),
-        .blur = value.blur ? toStyle(*value.blur, state) : Length<CSS::Nonnegative> { 0 },
+        .blur = value.blur ? toStyle(*value.blur, state) : Length<CSS::NonnegativeUnzoomed> { 0 },
     };
 }
 

--- a/Source/WebCore/style/values/text-decoration/StyleTextShadow.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextShadow.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,8 +35,8 @@ namespace Style {
 
 struct TextShadow {
     Color color;
-    SpaceSeparatedPoint<Length<>> location;
-    Length<CSS::Nonnegative> blur;
+    SpaceSeparatedPoint<Length<CSS::AllUnzoomed>> location;
+    Length<CSS::NonnegativeUnzoomed> blur;
 
     bool operator==(const TextShadow&) const = default;
 };
@@ -94,7 +95,7 @@ constexpr bool isInset(const TextShadow&)
     return false;
 }
 
-constexpr LayoutUnit paintingSpread(const TextShadow&)
+constexpr LayoutUnit paintingSpread(const TextShadow&, const Style::ZoomFactor&)
 {
     return LayoutUnit();
 }


### PR DESCRIPTION
#### a797d90e51ab84dde8d6cb343ac13ee43df735d2
<pre>
[CSS Zoom] Apply zoom factor to text-shadow, box-shadow, and drop-shadow
<a href="https://bugs.webkit.org/show_bug.cgi?id=300577">https://bugs.webkit.org/show_bug.cgi?id=300577</a>
<a href="https://rdar.apple.com/162463179">rdar://162463179</a>

Reviewed by Tim Nguyen.

Update TextShadow, BoxShadow, and DropShadow to use the new strong type system,
and apply zoom factor at evaluation-time.

This change consists of changing Length&lt;&gt; to Length&lt;CSS:UnzoomedAll&gt; in shadow
related data, Length&lt;Nonnegative&gt; to Length&lt;CSS::NonnegativeUnzoomed&gt; in blur
related data, and threading the Style zoom state through more of the callstack.

Test: imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow.html
      imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-drop-shadow.html
      imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html
      imported/w3c/web-platform-tests/css/css-viewport/zoom/text-shadow.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-drop-shadow-expected.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-drop-shadow.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/box-shadow-ref.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/filters-drop-shadow-ref.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp:
(WebCore::CSSPropertyParserHelpers::consumeSingleUnresolvedBoxShadow):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFilterDropShadow):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+TextDecoration.cpp:
(WebCore::CSSPropertyParserHelpers::consumeSingleUnresolvedTextShadow):
* Source/WebCore/css/values/borders/CSSBoxShadow.h:
* Source/WebCore/css/values/filter-effects/CSSDropShadowFunction.h:
* Source/WebCore/css/values/text-decoration/CSSTextShadow.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::fontAttributesAtSelectionStart):
* Source/WebCore/editing/FontAttributeChanges.cpp:
(WebCore::cssValueForTextShadow):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::computeInkOverflowForInlineLevelBox):
(WebCore::Layout::InlineDisplayContentBuilder::appendTextDisplayBox):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::applyBoxShadowForBackground):
(WebCore::BackgroundPainter::paintBoxShadow const):
* Source/WebCore/rendering/EllipsisBoxPainter.cpp:
(WebCore::EllipsisBoxPainter::paint):
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::addTextBoxVisualOverflow):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::applyVisualEffectOverflow const):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintAfterLayoutIfNeeded):
* Source/WebCore/rendering/TextBoxPainter.h:
(WebCore::TextBoxPainter::rotateShadowOffset):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::TextDecorationPainter::paintBackgroundDecorations):
* Source/WebCore/rendering/TextPainter.cpp:
* Source/WebCore/rendering/svg/RenderSVGBlock.cpp:
(WebCore::RenderSVGBlock::computeOverflow):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::repaintRectInLocalCoordinates const):
(WebCore::RenderSVGText::updatePositionAndOverflow):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::adjustRectForOutlineAndShadow):
(WebCore::LegacyRenderSVGModelObject::outlineBoundsForRepaint const):
* Source/WebCore/style/values/borders/StyleBoxShadow.h:
(WebCore::Style::paintingSpread):
* Source/WebCore/style/values/borders/StyleShadow.h:
(WebCore::Style::requires):
(WebCore::Style::paintingExtent):
(WebCore::Style::paintingExtentAndSpread):
(WebCore::Style::shadowOutsetExtent):
(WebCore::Style::shadowInsetExtent):
(WebCore::Style::shadowHorizontalExtent):
(WebCore::Style::shadowVerticalExtent):
(WebCore::Style::shadowBlockDirectionExtent):
(WebCore::Style::shadowInlineDirectionExtent):
(WebCore::Style::adjustRectForShadow):
* Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp:
(WebCore::Style::toCSSDropShadow):
(WebCore::Style::createFilterOperation):
* Source/WebCore/style/values/text-decoration/StyleTextShadow.cpp:
(WebCore::Style::ToStyle&lt;CSS::TextShadow&gt;::operator):
* Source/WebCore/style/values/text-decoration/StyleTextShadow.h:
(WebCore::Style::paintingSpread):

Canonical link: <a href="https://commits.webkit.org/301596@main">https://commits.webkit.org/301596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f91a19d67b0a31e56f78472f8007734eea92e0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126458 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133361 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78148 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b02ef45-a222-40ec-8444-06fca5959457) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54644 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e429c0b6-8771-43d5-af2e-4bc07b729cf2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113095 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/640b081e-d23f-417a-92b3-0945d90be394) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31272 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76667 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135898 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40866 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109408 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104445 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26642 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49914 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28243 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50560 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53074 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58891 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52364 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55698 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54095 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->