### PR TITLE
Address safer cpp warnings in WKWebsiteDataStore.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -6,7 +6,6 @@ UIProcess/API/Cocoa/WKUserContentController.mm
 UIProcess/API/Cocoa/WKUserScript.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
-UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 UIProcess/API/Cocoa/WKWindowFeatures.mm
 UIProcess/API/Cocoa/_WKAttachment.mm
 UIProcess/API/Cocoa/_WKAutomationSession.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -28,7 +28,6 @@ UIProcess/API/Cocoa/WKURLSchemeTask.mm
 UIProcess/API/Cocoa/WKUserScript.mm
 UIProcess/API/Cocoa/WKWebViewConfiguration.mm
 UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
-UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 UIProcess/API/Cocoa/_WKApplicationManifest.mm
 UIProcess/API/Cocoa/_WKArchiveConfiguration.mm
 UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,6 +1,5 @@
 [ iOS ] Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
 [ iOS ] Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
-[ iOS ] UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 [ iOS ] UIProcess/API/Cocoa/_WKElementAction.mm
 [ iOS ] UIProcess/API/Cocoa/_WKTouchEventGenerator.mm
 [ iOS ] UIProcess/API/ios/WKWebViewIOS.mm

--- a/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
@@ -79,7 +79,7 @@ std::optional<WebPushMessage> WebPushMessage::fromDictionary(NSDictionary *dicti
     return message;
 }
 
-NSDictionary *WebPushMessage::toDictionary() const
+RetainPtr<NSDictionary> WebPushMessage::toDictionary() const
 {
     RetainPtr<NSData> nsData;
     if (pushData)

--- a/Source/WebKit/Shared/WebPushMessage.h
+++ b/Source/WebKit/Shared/WebPushMessage.h
@@ -51,7 +51,7 @@ struct WebPushMessage {
 
 #if PLATFORM(COCOA)
     static std::optional<WebPushMessage> fromDictionary(NSDictionary *);
-    NSDictionary *toDictionary() const;
+    RetainPtr<NSDictionary> toDictionary() const;
 #endif
 };
 


### PR DESCRIPTION
#### ae85c58c8611fc7e6bfce3fb58121f5ab60efa9a
<pre>
Address safer cpp warnings in WKWebsiteDataStore.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=300674">https://bugs.webkit.org/show_bug.cgi?id=300674</a>

Reviewed by Darin Adler.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm:
(WebKit::WebPushMessage::toDictionary const):
* Source/WebKit/Shared/WebPushMessage.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(protectedWebsiteDataStore):
(-[WKWebsiteDataStore dealloc]):
(-[WKWebsiteDataStore httpCookieStore]):
(-[WKWebsiteDataStore removeDataOfTypes:modifiedSince:completionHandler:]):
(-[WKWebsiteDataStore removeDataOfTypes:forDataRecords:completionHandler:]):
(-[WKWebsiteDataStore setProxyConfigurations:]):
(-[WKWebsiteDataStore fetchDataOfTypes:completionHandler:]):
(-[WKWebsiteDataStore restoreData:completionHandler:]):
(-[WKWebsiteDataStore _initWithConfiguration:]):
(-[WKWebsiteDataStore _fetchDataRecordsOfTypes:withOptions:completionHandler:]):
(-[WKWebsiteDataStore _resourceLoadStatisticsEnabled]):
(-[WKWebsiteDataStore _setResourceLoadStatisticsEnabled:]):
(-[WKWebsiteDataStore _resourceLoadStatisticsDebugMode]):
(-[WKWebsiteDataStore _setResourceLoadStatisticsDebugMode:]):
(-[WKWebsiteDataStore _setPrivateClickMeasurementDebugModeEnabled:]):
(-[WKWebsiteDataStore _setStorageSiteValidationEnabled:]):
(-[WKWebsiteDataStore _setPersistedSites:]):
(-[WKWebsiteDataStore _setResourceLoadStatisticsTestingCallback:]):
(-[WKWebsiteDataStore _setStorageAccessPromptQuirkForTesting:withSubFrameDomains:withTriggerPages:completionHandler:]):
(-[WKWebsiteDataStore _grantStorageAccessForTesting:withSubFrameDomains:completionHandler:]):
(-[WKWebsiteDataStore _setResourceLoadStatisticsTimeAdvanceForTesting:completionHandler:]):
(-[WKWebsiteDataStore _loadedSubresourceDomainsFor:completionHandler:]):
(-[WKWebsiteDataStore _clearLoadedSubresourceDomainsFor:]):
(-[WKWebsiteDataStore _scheduleCookieBlockingUpdate:]):
(-[WKWebsiteDataStore _logUserInteraction:completionHandler:]):
(-[WKWebsiteDataStore _setPrevalentDomain:completionHandler:]):
(-[WKWebsiteDataStore _getIsPrevalentDomain:completionHandler:]):
(-[WKWebsiteDataStore _clearPrevalentDomain:completionHandler:]):
(-[WKWebsiteDataStore _clearResourceLoadStatistics:]):
(-[WKWebsiteDataStore _closeDatabases:]):
(-[WKWebsiteDataStore _getResourceLoadStatisticsDataSummary:]):
(-[WKWebsiteDataStore _isRelationshipOnlyInDatabaseOnce:thirdParty:completionHandler:]):
(-[WKWebsiteDataStore _isRegisteredAsSubresourceUnderFirstParty:thirdParty:completionHandler:]):
(-[WKWebsiteDataStore _statisticsDatabaseHasAllTables:]):
(-[WKWebsiteDataStore _processStatisticsAndDataRecords:]):
(-[WKWebsiteDataStore _setThirdPartyCookieBlockingMode:onlyOnSitesWithoutUserInteraction:completionHandler:]):
(-[WKWebsiteDataStore _renameOrigin:to:forDataOfTypes:completionHandler:]):
(-[WKWebsiteDataStore _networkProcessHasEntitlementForTesting:]):
(-[WKWebsiteDataStore _setUserAgentStringQuirkForTesting:withUserAgent:completionHandler:]):
(-[WKWebsiteDataStore _setPrivateTokenIPCForTesting:]):
(-[WKWebsiteDataStore set_delegate:]):
(-[WKWebsiteDataStore _trustServerForLocalPCMTesting:]):
(-[WKWebsiteDataStore _setPrivateClickMeasurementDebugModeEnabledForTesting:]):
(-[WKWebsiteDataStore _terminateNetworkProcess]):
(-[WKWebsiteDataStore _sendNetworkProcessPrepareToSuspend:]):
(-[WKWebsiteDataStore _sendNetworkProcessWillSuspendImminently]):
(-[WKWebsiteDataStore _sendNetworkProcessDidResume]):
(-[WKWebsiteDataStore _synthesizeAppIsBackground:]):
(-[WKWebsiteDataStore _networkProcessIdentifier]):
(-[WKWebsiteDataStore _countNonDefaultSessionSets:]):
(-[WKWebsiteDataStore _hasServiceWorkerBackgroundActivityForTesting]):
(-[WKWebsiteDataStore _getPendingPushMessage:]):
(-[WKWebsiteDataStore _getPendingPushMessages:]):
(-[WKWebsiteDataStore _processPushMessage:completionHandler:]):
(-[WKWebsiteDataStore _processWebCorePersistentNotificationClick:completionHandler:]):
(-[WKWebsiteDataStore _processWebCorePersistentNotificationClose:completionHandler:]):
(-[WKWebsiteDataStore _getAllBackgroundFetchIdentifiers:]):
(-[WKWebsiteDataStore _getBackgroundFetchState:completionHandler:]):
(-[WKWebsiteDataStore _abortBackgroundFetch:completionHandler:]):
(-[WKWebsiteDataStore _pauseBackgroundFetch:completionHandler:]):
(-[WKWebsiteDataStore _resumeBackgroundFetch:completionHandler:]):
(-[WKWebsiteDataStore _clickBackgroundFetch:completionHandler:]):
(-[WKWebsiteDataStore _storeServiceWorkerRegistrations:]):
(-[WKWebsiteDataStore _scopeURL:hasPushSubscriptionForTesting:]):
(-[WKWebsiteDataStore _originDirectoryForTesting:topOrigin:type:completionHandler:]):
(-[WKWebsiteDataStore _setCompletionHandlerForRemovalFromNetworkProcess:]):
(-[WKWebsiteDataStore _setRestrictedOpenerTypeForTesting:forDomain:]):
(-[WKWebsiteDataStore _getAppBadgeForTesting:]):
(-[WKWebsiteDataStore _runningOrTerminatingServiceWorkerCountForTesting:]):

Canonical link: <a href="https://commits.webkit.org/301511@main">https://commits.webkit.org/301511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b92982a397c2158ef57c53fafed01999e84622e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132897 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77888 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b252588-3f85-4e19-a624-3c1784c7a87a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54284 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96010 "Failed to checkout and rebase branch from PR 52278") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64111 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a73e714-a1cf-4302-bc18-dc6c71c67708) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76499 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36028 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76369 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135604 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104514 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104231 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26589 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49634 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27963 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50225 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52739 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58573 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52067 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55413 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53777 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->