### PR TITLE
Address safer cpp warnings in WKUserContentController.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -2,7 +2,6 @@ Platform/IPC/ArgumentCoders.h
 UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm
 UIProcess/API/Cocoa/WKProcessPool.mm
-UIProcess/API/Cocoa/WKUserContentController.mm
 UIProcess/API/Cocoa/WKUserScript.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/WKWebsiteDataRecord.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -50,6 +50,11 @@
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 
+static Ref<WebKit::WebUserContentControllerProxy> protectedUserContentControllerProxy(WKUserContentController *controller)
+{
+    return *controller->_userContentControllerProxy;
+}
+
 @implementation WKUserContentController
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
@@ -69,7 +74,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKUserContentController.class, self))
         return;
 
-    _userContentControllerProxy->~WebUserContentControllerProxy();
+    SUPPRESS_UNRETAINED_ARG _userContentControllerProxy->~WebUserContentControllerProxy();
 
     [super dealloc];
 }
@@ -98,32 +103,32 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (void)addUserScript:(WKUserScript *)userScript
 {
-    _userContentControllerProxy->addUserScript(*userScript->_userScript, WebKit::InjectUserScriptImmediately::No);
+    protectedUserContentControllerProxy(self)->addUserScript(Ref { *userScript->_userScript }, WebKit::InjectUserScriptImmediately::No);
 }
 
 - (void)removeAllUserScripts
 {
-    _userContentControllerProxy->removeAllUserScripts();
+    protectedUserContentControllerProxy(self)->removeAllUserScripts();
 }
 
 - (void)addContentRuleList:(WKContentRuleList *)contentRuleList
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _userContentControllerProxy->addContentRuleList(*contentRuleList->_contentRuleList);
+    protectedUserContentControllerProxy(self)->addContentRuleList(Ref { *contentRuleList->_contentRuleList });
 #endif
 }
 
 - (void)removeContentRuleList:(WKContentRuleList *)contentRuleList
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _userContentControllerProxy->removeContentRuleList(contentRuleList->_contentRuleList->name());
+    protectedUserContentControllerProxy(self)->removeContentRuleList(Ref { *contentRuleList->_contentRuleList }->name());
 #endif
 }
 
 - (void)removeAllContentRuleLists
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _userContentControllerProxy->removeAllContentRuleLists();
+    protectedUserContentControllerProxy(self)->removeAllContentRuleLists();
 #endif
 }
 
@@ -184,7 +189,7 @@ private:
 
 - (void)_addScriptMessageHandler:(WebKit::WebScriptMessageHandler&)scriptMessageHandler
 {
-    if (!_userContentControllerProxy->addUserScriptMessageHandler(scriptMessageHandler))
+    if (!protectedUserContentControllerProxy(self)->addUserScriptMessageHandler(scriptMessageHandler))
         [NSException raise:NSInvalidArgumentException format:@"Attempt to add script message handler with name '%@' when one already exists.", scriptMessageHandler.name().createNSString().get()];
 }
 
@@ -196,34 +201,34 @@ private:
 
 - (void)addScriptMessageHandler:(id <WKScriptMessageHandler>)scriptMessageHandler contentWorld:(WKContentWorld *)world name:(NSString *)name
 {
-    auto handler = WebKit::WebScriptMessageHandler::create(makeUnique<ScriptMessageHandlerDelegate>(self, scriptMessageHandler, name), name, *world->_contentWorld);
+    auto handler = WebKit::WebScriptMessageHandler::create(makeUnique<ScriptMessageHandlerDelegate>(self, scriptMessageHandler, name), name, Ref { *world->_contentWorld });
     [self _addScriptMessageHandler:handler.get()];
 }
 
 - (void)addScriptMessageHandlerWithReply:(id <WKScriptMessageHandlerWithReply>)scriptMessageHandler contentWorld:(WKContentWorld *)world name:(NSString *)name
 {
-    auto handler = WebKit::WebScriptMessageHandler::create(makeUnique<ScriptMessageHandlerDelegate>(self, scriptMessageHandler, name), name, *world->_contentWorld);
+    auto handler = WebKit::WebScriptMessageHandler::create(makeUnique<ScriptMessageHandlerDelegate>(self, scriptMessageHandler, name), name, Ref { *world->_contentWorld });
     [self _addScriptMessageHandler:handler.get()];
 }
 
 - (void)removeScriptMessageHandlerForName:(NSString *)name
 {
-    _userContentControllerProxy->removeUserMessageHandlerForName(name, API::ContentWorld::pageContentWorldSingleton());
+    protectedUserContentControllerProxy(self)->removeUserMessageHandlerForName(name, API::ContentWorld::pageContentWorldSingleton());
 }
 
 - (void)removeScriptMessageHandlerForName:(NSString *)name contentWorld:(WKContentWorld *)contentWorld
 {
-    _userContentControllerProxy->removeUserMessageHandlerForName(name, *contentWorld->_contentWorld);
+    protectedUserContentControllerProxy(self)->removeUserMessageHandlerForName(name, Ref { *contentWorld->_contentWorld });
 }
 
 - (void)removeAllScriptMessageHandlersFromContentWorld:(WKContentWorld *)contentWorld
 {
-    _userContentControllerProxy->removeAllUserMessageHandlers(*contentWorld->_contentWorld);
+    protectedUserContentControllerProxy(self)->removeAllUserMessageHandlers(Ref { *contentWorld->_contentWorld });
 }
 
 - (void)removeAllScriptMessageHandlers
 {
-    _userContentControllerProxy->removeAllUserMessageHandlers();
+    protectedUserContentControllerProxy(self)->removeAllUserMessageHandlers();
 }
 
 #pragma mark WKObject protocol implementation
@@ -239,17 +244,17 @@ private:
 
 - (void)_removeUserScript:(WKUserScript *)userScript
 {
-    _userContentControllerProxy->removeUserScript(*userScript->_userScript);
+    protectedUserContentControllerProxy(self)->removeUserScript(Ref { *userScript->_userScript });
 }
 
 - (void)_removeAllUserScriptsAssociatedWithContentWorld:(WKContentWorld *)contentWorld
 {
-    _userContentControllerProxy->removeAllUserScripts(*contentWorld->_contentWorld);
+    protectedUserContentControllerProxy(self)->removeAllUserScripts(Ref { *contentWorld->_contentWorld });
 }
 
 - (void)_addUserScriptImmediately:(WKUserScript *)userScript
 {
-    _userContentControllerProxy->addUserScript(*userScript->_userScript, WebKit::InjectUserScriptImmediately::Yes);
+    protectedUserContentControllerProxy(self)->addUserScript(Ref { *userScript->_userScript }, WebKit::InjectUserScriptImmediately::Yes);
 }
 
 #pragma clang diagnostic push
@@ -258,28 +263,28 @@ private:
 #pragma clang diagnostic pop
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _userContentControllerProxy->addContentRuleList(*userContentFilter->_contentRuleList->_contentRuleList);
+    protectedUserContentControllerProxy(self)->addContentRuleList(Ref { *userContentFilter->_contentRuleList->_contentRuleList });
 #endif
 }
 
 - (void)_addContentRuleList:(WKContentRuleList *)contentRuleList extensionBaseURL:(NSURL *)extensionBaseURL
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _userContentControllerProxy->addContentRuleList(*contentRuleList->_contentRuleList, extensionBaseURL);
+    protectedUserContentControllerProxy(self)->addContentRuleList(Ref { *contentRuleList->_contentRuleList }, extensionBaseURL);
 #endif
 }
 
 - (void)_removeUserContentFilter:(NSString *)userContentFilterName
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _userContentControllerProxy->removeContentRuleList(userContentFilterName);
+    protectedUserContentControllerProxy(self)->removeContentRuleList(userContentFilterName);
 #endif
 }
 
 - (void)_removeAllUserContentFilters
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _userContentControllerProxy->removeAllContentRuleLists();
+    protectedUserContentControllerProxy(self)->removeAllContentRuleLists();
 #endif
 }
 
@@ -290,29 +295,29 @@ private:
 
 - (void)_addUserStyleSheet:(_WKUserStyleSheet *)userStyleSheet
 {
-    _userContentControllerProxy->addUserStyleSheet(*userStyleSheet->_userStyleSheet);
+    protectedUserContentControllerProxy(self)->addUserStyleSheet(Ref { *userStyleSheet->_userStyleSheet });
 }
 
 - (void)_removeUserStyleSheet:(_WKUserStyleSheet *)userStyleSheet
 {
-    _userContentControllerProxy->removeUserStyleSheet(*userStyleSheet->_userStyleSheet);
+    protectedUserContentControllerProxy(self)->removeUserStyleSheet(Ref { *userStyleSheet->_userStyleSheet });
 }
 
 - (void)_removeAllUserStyleSheets
 {
-    _userContentControllerProxy->removeAllUserStyleSheets();
+    protectedUserContentControllerProxy(self)->removeAllUserStyleSheets();
 }
 
 - (void)_removeAllUserStyleSheetsAssociatedWithContentWorld:(WKContentWorld *)contentWorld
 {
-    _userContentControllerProxy->removeAllUserStyleSheets(*contentWorld->_contentWorld);
+    protectedUserContentControllerProxy(self)->removeAllUserStyleSheets(Ref { *contentWorld->_contentWorld });
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 - (void)_addScriptMessageHandler:(id <WKScriptMessageHandler>)scriptMessageHandler name:(NSString *)name userContentWorld:(_WKUserContentWorld *)userContentWorld
 {
-    auto handler = WebKit::WebScriptMessageHandler::create(makeUnique<ScriptMessageHandlerDelegate>(self, scriptMessageHandler, name), name, *userContentWorld->_contentWorld->_contentWorld);
-    if (!_userContentControllerProxy->addUserScriptMessageHandler(handler.get()))
+    auto handler = WebKit::WebScriptMessageHandler::create(makeUnique<ScriptMessageHandlerDelegate>(self, scriptMessageHandler, name), name, Ref { *userContentWorld->_contentWorld->_contentWorld });
+    if (!protectedUserContentControllerProxy(self)->addUserScriptMessageHandler(handler.get()))
         [NSException raise:NSInvalidArgumentException format:@"Attempt to add script message handler with name '%@' when one already exists.", name];
 }
 
@@ -323,12 +328,12 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
 - (void)_removeScriptMessageHandlerForName:(NSString *)name userContentWorld:(_WKUserContentWorld *)userContentWorld
 {
-    _userContentControllerProxy->removeUserMessageHandlerForName(name, *userContentWorld->_contentWorld->_contentWorld);
+    protectedUserContentControllerProxy(self)->removeUserMessageHandlerForName(name, Ref { *userContentWorld->_contentWorld->_contentWorld });
 }
 
 - (void)_removeAllScriptMessageHandlersAssociatedWithUserContentWorld:(_WKUserContentWorld *)userContentWorld
 {
-    _userContentControllerProxy->removeAllUserMessageHandlers(*userContentWorld->_contentWorld->_contentWorld);
+    protectedUserContentControllerProxy(self)->removeAllUserMessageHandlers(Ref { *userContentWorld->_contentWorld->_contentWorld });
 }
 ALLOW_DEPRECATED_DECLARATIONS_END
 


### PR DESCRIPTION
#### db3521ca884e45db98473c635b8601f69935a9a3
<pre>
Address safer cpp warnings in WKUserContentController.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=300676">https://bugs.webkit.org/show_bug.cgi?id=300676</a>

Reviewed by Darin Adler.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
(protectedUserContentControllerProxy):
(-[WKUserContentController dealloc]):
(-[WKUserContentController addUserScript:]):
(-[WKUserContentController removeAllUserScripts]):
(-[WKUserContentController addContentRuleList:]):
(-[WKUserContentController removeContentRuleList:]):
(-[WKUserContentController removeAllContentRuleLists]):
(-[WKUserContentController _addScriptMessageHandler:]):
(-[WKUserContentController addScriptMessageHandler:contentWorld:name:]):
(-[WKUserContentController addScriptMessageHandlerWithReply:contentWorld:name:]):
(-[WKUserContentController removeScriptMessageHandlerForName:]):
(-[WKUserContentController removeScriptMessageHandlerForName:contentWorld:]):
(-[WKUserContentController removeAllScriptMessageHandlersFromContentWorld:]):
(-[WKUserContentController removeAllScriptMessageHandlers]):
(-[WKUserContentController _removeUserScript:]):
(-[WKUserContentController _removeAllUserScriptsAssociatedWithContentWorld:]):
(-[WKUserContentController _addUserScriptImmediately:]):
(-[WKUserContentController _addUserContentFilter:]):
(-[WKUserContentController _addContentRuleList:extensionBaseURL:]):
(-[WKUserContentController _removeUserContentFilter:]):
(-[WKUserContentController _removeAllUserContentFilters]):
(-[WKUserContentController _addUserStyleSheet:]):
(-[WKUserContentController _removeUserStyleSheet:]):
(-[WKUserContentController _removeAllUserStyleSheets]):
(-[WKUserContentController _removeAllUserStyleSheetsAssociatedWithContentWorld:]):
(-[WKUserContentController _addScriptMessageHandler:name:userContentWorld:]):
(-[WKUserContentController _removeScriptMessageHandlerForName:userContentWorld:]):
(-[WKUserContentController _removeAllScriptMessageHandlersAssociatedWithUserContentWorld:]):

Canonical link: <a href="https://commits.webkit.org/301514@main">https://commits.webkit.org/301514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59bc5ba0fda11572d492a1b084707b4147ee2595

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36679 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/46532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54411 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/132989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129155 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/46532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/112888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/46532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/46532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31295 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52959 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/40679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/135692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109107 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26594 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49730 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52859 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/58692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53892 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->