### PR TITLE
Address safer cpp warnings in _WKWebPushAction.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -25,7 +25,6 @@ UIProcess/API/Cocoa/_WKWebPushMessage.h
 [ iOS ] UIProcess/API/Cocoa/_WKTextManipulationConfiguration.h
 [ iOS ] UIProcess/API/Cocoa/_WKTextManipulationToken.h
 [ iOS ] UIProcess/API/Cocoa/_WKTouchEventGeneratorInternal.h
-[ iOS ] UIProcess/API/Cocoa/_WKWebPushAction.mm
 [ iOS ] UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h
 [ iOS ] UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
 [ iOS ] UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -51,7 +51,6 @@ UIProcess/API/Cocoa/_WKTextManipulationToken.mm
 [ Mac ] UIProcess/API/Cocoa/_WKThumbnailView.mm
 UIProcess/API/Cocoa/_WKUserInitiatedAction.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
-UIProcess/API/Cocoa/_WKWebPushAction.mm
 [ Mac ] UIProcess/Automation/mac/WebAutomationSessionMac.mm
 [ Mac ] UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
 [ Mac ] UIProcess/Inspector/mac/WKInspectorViewController.mm

--- a/Source/WebKit/Shared/WebPushDaemonConstants.h
+++ b/Source/WebKit/Shared/WebPushDaemonConstants.h
@@ -52,22 +52,22 @@ enum class MessageType : uint8_t {
 static constexpr unsigned long pushActionSetting = 0x8054000;
 
 #ifdef __OBJC__
-inline NSString *pushActionVersionKey()
+inline NSString *pushActionVersionKeySingleton()
 {
     return @"WebPushActionVersion";
 }
 
-inline NSNumber *currentPushActionVersion()
+inline NSNumber *currentPushActionVersionSingleton()
 {
     return @1;
 }
 
-inline NSString *pushActionPartitionKey()
+inline NSString *pushActionPartitionKeySingleton()
 {
     return @"WebPushActionPartition";
 }
 
-inline NSString *pushActionTypeKey()
+inline NSString *pushActionTypeKeySingleton()
 {
     return @"WebPushActionType";
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm
@@ -63,19 +63,19 @@ static RetainPtr<NSUUID> uuidFromPushPartition(NSString *pushPartition)
 
 - (void)dealloc
 {
-    [_version release];
-    [_webClipIdentifier release];
-    [_type release];
+    SUPPRESS_UNRETAINED_ARG [_version release];
+    SUPPRESS_UNRETAINED_ARG [_webClipIdentifier release];
+    SUPPRESS_UNRETAINED_ARG [_type release];
     [super dealloc];
 }
 
 + (_WKWebPushAction *)webPushActionWithDictionary:(NSDictionary *)dictionary
 {
-    NSNumber *version = dictionary[WebKit::WebPushD::pushActionVersionKey()];
+    NSNumber *version = dictionary[WebKit::WebPushD::pushActionVersionKeySingleton()];
     if (!version || ![version isKindOfClass:[NSNumber class]])
         return nil;
 
-    NSString *pushPartition = dictionary[WebKit::WebPushD::pushActionPartitionKey()];
+    NSString *pushPartition = dictionary[WebKit::WebPushD::pushActionPartitionKeySingleton()];
     if (!pushPartition || ![pushPartition isKindOfClass:[NSString class]])
         return nil;
 
@@ -83,7 +83,7 @@ static RetainPtr<NSUUID> uuidFromPushPartition(NSString *pushPartition)
     if (!uuid)
         return nil;
 
-    NSString *type = dictionary[WebKit::WebPushD::pushActionTypeKey()];
+    NSString *type = dictionary[WebKit::WebPushD::pushActionTypeKeySingleton()];
     if (!type || ![type isKindOfClass:[NSString class]])
         return nil;
 
@@ -132,11 +132,12 @@ static RetainPtr<NSUUID> uuidFromPushPartition(NSString *pushPartition)
 
 - (NSString *)_nameForBackgroundTaskAndLogging
 {
-    if ([_type isEqualToString:_WKWebPushActionTypePushEvent])
+    RetainPtr type = _type;
+    if ([type isEqualToString:_WKWebPushActionTypePushEvent])
         return @"Web Push Event";
-    if ([_type isEqualToString:_WKWebPushActionTypeNotificationClick])
+    if ([type isEqualToString:_WKWebPushActionTypeNotificationClick])
         return @"Web Notification Click";
-    if ([_type isEqualToString:_WKWebPushActionTypeNotificationClose])
+    if ([type isEqualToString:_WKWebPushActionTypeNotificationClose])
         return @"Web Notification Close";
 
     return @"Unknown Web Push event";

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -644,9 +644,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     NSDictionary *settingsInfo = @{
-        pushActionVersionKey(): currentPushActionVersion(),
-        pushActionPartitionKey(): subscriptionSetIdentifier.pushPartition.createNSString().get(),
-        pushActionTypeKey(): _WKWebPushActionTypePushEvent
+        pushActionVersionKeySingleton(): currentPushActionVersionSingleton(),
+        pushActionPartitionKeySingleton(): subscriptionSetIdentifier.pushPartition.createNSString().get(),
+        pushActionTypeKeySingleton(): _WKWebPushActionTypePushEvent
     };
     RetainPtr<BSMutableSettings> bsSettings = adoptNS([[BSMutableSettings alloc] init]);
     [bsSettings setObject:settingsInfo forSetting:WebKit::WebPushD::pushActionSetting];


### PR DESCRIPTION
#### e579f7a5992e0a12717624da570540fcf83dceed
<pre>
Address safer cpp warnings in _WKWebPushAction.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=300679">https://bugs.webkit.org/show_bug.cgi?id=300679</a>

Reviewed by Darin Adler.

* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/Shared/WebPushDaemonConstants.h:
(WebKit::WebPushD::pushActionVersionKeySingleton):
(WebKit::WebPushD::currentPushActionVersionSingleton):
(WebKit::WebPushD::pushActionPartitionKeySingleton):
(WebKit::WebPushD::pushActionTypeKeySingleton):
(WebKit::WebPushD::pushActionVersionKey): Deleted.
(WebKit::WebPushD::currentPushActionVersion): Deleted.
(WebKit::WebPushD::pushActionPartitionKey): Deleted.
(WebKit::WebPushD::pushActionTypeKey): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm:
(-[_WKWebPushAction dealloc]):
(+[_WKWebPushAction webPushActionWithDictionary:]):
(-[_WKWebPushAction _nameForBackgroundTaskAndLogging]):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::notifyClientPushMessageIsAvailable):

Canonical link: <a href="https://commits.webkit.org/301512@main">https://commits.webkit.org/301512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e3fa65107967c54571358958ceb690c4fb75e25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126082 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77885 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec35b814-40af-4f3f-8e5b-b92d0b63505d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96008 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64110 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9fd8c37-5e82-4ded-885c-c4485dba7ac9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112758 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76497 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8e2de251-06f9-4ce2-b168-0be2067004c9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36025 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76366 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135601 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104511 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104229 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26591 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49630 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27956 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50221 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52735 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58569 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52063 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55409 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53773 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->