### PR TITLE
Use EnumSet for BoxSides

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2503,8 +2503,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         return blendSourceOver(pageBackgroundColor, color);
     };
 
-    for (auto sideFlag : sides) {
-        auto side = boxSideFromFlag(sideFlag);
+    for (auto side : sides) {
         auto result = findFixedContainer(side, IgnoreCSSPointerEvents::Yes);
         if (result.retryHonoringPointerEvents)
             result = findFixedContainer(side, IgnoreCSSPointerEvents::No);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5438,22 +5438,21 @@ void Page::updateFixedContainerEdges(BoxSideSet sides)
             || document->parsing();
 
         if (scrollOffset.y() < minimumOffset.y() || !canSampleTopEdge)
-            sidesToSample.remove(BoxSideFlag::Top);
+            sidesToSample.remove(BoxSide::Top);
 
         if (scrollOffset.y() > maximumOffset.y())
-            sidesToSample.remove(BoxSideFlag::Bottom);
+            sidesToSample.remove(BoxSide::Bottom);
 
         if (scrollOffset.x() < minimumOffset.x())
-            sidesToSample.remove(BoxSideFlag::Left);
+            sidesToSample.remove(BoxSide::Left);
 
         if (scrollOffset.x() > maximumOffset.x())
-            sidesToSample.remove(BoxSideFlag::Right);
+            sidesToSample.remove(BoxSide::Right);
 
         return sidesToSample;
     }());
 
-    for (auto sideFlag : sides) {
-        auto side = boxSideFromFlag(sideFlag);
+    for (auto side : sides) {
         if (!edges.hasFixedEdge(side) || (!edges.predominantColor(side).isVisible() && fixedContainerEdges().predominantColor(side).isVisible())) {
             WeakPtr lastElement = m_fixedContainerEdgesAndElements.second.at(side);
             if (!lastElement)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -242,7 +242,6 @@ using SharedStringHash = uint32_t;
 enum class ActivityState : uint16_t;
 enum class AdvancedPrivacyProtections : uint16_t;
 enum class BoxSide : uint8_t;
-enum class BoxSideFlag : uint8_t;
 enum class CanWrap : bool;
 enum class ContentSecurityPolicyModeForExtension : uint8_t;
 enum class DidWrap : bool;
@@ -934,7 +933,7 @@ public:
     WEBCORE_EXPORT Color pageExtendedBackgroundColor() const;
     WEBCORE_EXPORT Color sampledPageTopColor() const;
 
-    WEBCORE_EXPORT void updateFixedContainerEdges(OptionSet<BoxSideFlag>);
+    WEBCORE_EXPORT void updateFixedContainerEdges(EnumSet<BoxSide>);
     const FixedContainerEdges& fixedContainerEdges() const { return m_fixedContainerEdgesAndElements.first; }
     Element* lastFixedContainer(BoxSide) const;
 

--- a/Source/WebCore/platform/BoxSides.h
+++ b/Source/WebCore/platform/BoxSides.h
@@ -32,6 +32,7 @@
 
 #include <WebCore/WritingMode.h>
 #include <array>
+#include <wtf/EnumSet.h>
 
 namespace WebCore {
 
@@ -44,26 +45,10 @@ enum class LogicalBoxAxis : uint8_t {
 
 enum class BoxAxis : uint8_t {
     Horizontal,
-    Vertical
-};
+    Vertical,
 
-// FIXME: BoxAxis etc. should just be OptionSet friendly types themselves.
-enum class BoxAxisFlag : uint8_t {
-    Horizontal = 1 << 0,
-    Vertical = 1 << 1
+    HighestEnumValue = Vertical
 };
-
-constexpr BoxAxisFlag boxAxisToFlag(BoxAxis axis)
-{
-    switch (axis) {
-    case BoxAxis::Horizontal:
-        return BoxAxisFlag::Horizontal;
-    case BoxAxis::Vertical:
-        return BoxAxisFlag::Vertical;
-    }
-    ASSERT_NOT_REACHED();
-    return BoxAxisFlag::Horizontal;
-}
 
 constexpr BoxAxis mapAxisLogicalToPhysical(const WritingMode, const LogicalBoxAxis);
 constexpr LogicalBoxAxis mapAxisPhysicalToLogical(const WritingMode, const BoxAxis);
@@ -93,14 +78,9 @@ enum class BoxSide : uint8_t {
     Top,
     Right,
     Bottom,
-    Left
-};
+    Left,
 
-enum class BoxSideFlag : uint8_t {
-    Top     = 1 << static_cast<unsigned>(BoxSide::Top),
-    Right   = 1 << static_cast<unsigned>(BoxSide::Right),
-    Bottom  = 1 << static_cast<unsigned>(BoxSide::Bottom),
-    Left    = 1 << static_cast<unsigned>(BoxSide::Left)
+    HighestEnumValue = Left
 };
 
 constexpr std::array<BoxSide, 4> allBoxSides = {
@@ -110,23 +90,7 @@ constexpr std::array<BoxSide, 4> allBoxSides = {
     BoxSide::Left
 };
 
-constexpr BoxSide boxSideFromFlag(BoxSideFlag flag)
-{
-    switch (flag) {
-    case BoxSideFlag::Top:
-        return BoxSide::Top;
-    case BoxSideFlag::Right:
-        return BoxSide::Right;
-    case BoxSideFlag::Bottom:
-        return BoxSide::Bottom;
-    case BoxSideFlag::Left:
-        return BoxSide::Left;
-    }
-    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
-    return BoxSide::Left;
-}
-
-using BoxSideSet = OptionSet<BoxSideFlag>;
+using BoxSideSet = EnumSet<BoxSide>;
 
 constexpr BoxSide mapSideLogicalToPhysical(const WritingMode, const LogicalBoxSide);
 constexpr LogicalBoxSide mapSidePhysicalToLogical(const WritingMode, const BoxSide);

--- a/Source/WebCore/platform/FixedContainerEdges.cpp
+++ b/Source/WebCore/platform/FixedContainerEdges.cpp
@@ -44,14 +44,10 @@ bool FixedContainerEdges::hasFixedEdge(BoxSide side) const
 BoxSideSet FixedContainerEdges::fixedEdges() const
 {
     BoxSideSet edges;
-    if (hasFixedEdge(BoxSide::Top))
-        edges.add(BoxSideFlag::Top);
-    if (hasFixedEdge(BoxSide::Left))
-        edges.add(BoxSideFlag::Left);
-    if (hasFixedEdge(BoxSide::Bottom))
-        edges.add(BoxSideFlag::Bottom);
-    if (hasFixedEdge(BoxSide::Right))
-        edges.add(BoxSideFlag::Right);
+    for (auto boxSide : allBoxSides) {
+        if (hasFixedEdge(boxSide))
+            edges.add(boxSide);
+    }
     return edges;
 }
 

--- a/Source/WebCore/rendering/BorderEdge.h
+++ b/Source/WebCore/rendering/BorderEdge.h
@@ -75,14 +75,12 @@ BorderEdges borderEdges(const RenderStyle&, float deviceScaleFactor, RectEdges<b
 BorderEdges borderEdgesForOutline(const RenderStyle&, BorderStyle, float deviceScaleFactor);
 
 inline bool edgesShareColor(const BorderEdge& firstEdge, const BorderEdge& secondEdge) { return equalIgnoringSemanticColor(firstEdge.color(), secondEdge.color()); }
-inline BoxSideFlag edgeFlagForSide(BoxSide side) { return static_cast<BoxSideFlag>(1 << static_cast<unsigned>(side)); }
-inline bool includesEdge(OptionSet<BoxSideFlag> flags, BoxSide side) { return flags.contains(edgeFlagForSide(side)); }
 
-inline bool includesAdjacentEdges(OptionSet<BoxSideFlag> flags)
+inline bool includesAdjacentEdges(EnumSet<BoxSide> sides)
 {
     // The set includes adjacent edges if and only if it contains at least one horizontal and one vertical edge.
-    return flags.containsAny({ BoxSideFlag::Top, BoxSideFlag::Bottom })
-        && flags.containsAny({ BoxSideFlag::Left, BoxSideFlag::Right });
+    return sides.containsAny({ BoxSide::Top, BoxSide::Bottom })
+        && sides.containsAny({ BoxSide::Left, BoxSide::Right });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -412,7 +412,7 @@ void BorderPainter::paintSides(const BorderShape& borderShape, const Sides& side
         auto& currEdge = sides.edges.at(boxSide);
 
         if (currEdge.shouldRender())
-            edgesToDraw.add(edgeFlagForSide(boxSide));
+            edgesToDraw.add(boxSide);
 
         if (currEdge.presentButInvisible()) {
             --numEdgesVisible;
@@ -592,7 +592,7 @@ void BorderPainter::paintTranslucentBorderSides(const BorderShape& borderShape, 
 
         BoxSideSet commonColorEdgeSet;
         for (auto side : paintOrderSides) {
-            if (!edgesToDraw.contains(edgeFlagForSide(side)))
+            if (!edgesToDraw.contains(side))
                 continue;
 
             auto& edge = sides.edges.at(side);
@@ -604,7 +604,7 @@ void BorderPainter::paintTranslucentBorderSides(const BorderShape& borderShape, 
                 includeEdge = equalIgnoringSemanticColor(edge.color(), commonColor);
 
             if (includeEdge)
-                commonColorEdgeSet.add(edgeFlagForSide(side));
+                commonColorEdgeSet.add(side);
         }
 
         bool useTransparencyLayer = includesAdjacentEdges(commonColorEdgeSet) && !commonColor.isOpaque();
@@ -628,10 +628,10 @@ static inline bool borderStyleHasUnmatchedColorsAtCorner(BorderStyle style, BoxS
 {
     // These styles match at the top/left and bottom/right.
     if (style == BorderStyle::Inset || style == BorderStyle::Groove || style == BorderStyle::Ridge || style == BorderStyle::Outset) {
-        BoxSideSet topRightSides = { BoxSideFlag::Top, BoxSideFlag::Right };
-        BoxSideSet bottomLeftSides = { BoxSideFlag::Bottom, BoxSideFlag::Left };
+        BoxSideSet topRightSides = { BoxSide::Top, BoxSide::Right };
+        BoxSideSet bottomLeftSides = { BoxSide::Bottom, BoxSide::Left };
 
-        BoxSideSet usedSides { edgeFlagForSide(side), edgeFlagForSide(adjacentSide) };
+        BoxSideSet usedSides { side, adjacentSide };
         return usedSides == topRightSides || usedSides == bottomLeftSides;
     }
     return false;
@@ -748,7 +748,7 @@ void BorderPainter::paintBorderSides(const BorderShape& borderShape, const Sides
 
     auto paintOneSide = [&](BoxSide side, BoxSide adjacentSide1, BoxSide adjacentSide2) {
         auto& edge = sides.edges.at(side);
-        if (!edge.shouldRender() || !edgeSet.contains(edgeFlagForSide(side)))
+        if (!edge.shouldRender() || !edgeSet.contains(side))
             return;
 
         LayoutRect sideRect = borderShape.borderRect();

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -66,11 +66,11 @@ namespace InlineIterator {
 class InlineBoxIterator;
 };
 
-enum class BoxSideFlag : uint8_t;
+enum class BoxSide : uint8_t;
 enum class DecodingMode : uint8_t;
 enum class InterpolationQuality : uint8_t;
 
-using BoxSideSet = OptionSet<BoxSideFlag>;
+using BoxSideSet = EnumSet<BoxSide>;
 using BorderEdges = RectEdges<BorderEdge>;
 
 // This class is the base for all objects that adhere to the CSS box model as described

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -95,7 +95,6 @@ enum class BlockStepRound : uint8_t;
 enum class BorderCollapse : bool;
 enum class BorderStyle : uint8_t;
 enum class BoxAlignment : uint8_t;
-enum class BoxAxisFlag : uint8_t;
 enum class BoxDecorationBreak : bool;
 enum class BoxDirection : bool;
 enum class BoxLines : bool;
@@ -530,8 +529,8 @@ public:
     bool useTreeCountingFunctions() const { return m_nonInheritedFlags.useTreeCountingFunctions; }
     void setUsesAnchorFunctions();
     bool usesAnchorFunctions() const;
-    void setAnchorFunctionScrollCompensatedAxes(OptionSet<BoxAxisFlag>);
-    OptionSet<BoxAxisFlag> anchorFunctionScrollCompensatedAxes() const;
+    void setAnchorFunctionScrollCompensatedAxes(EnumSet<BoxAxis>);
+    EnumSet<BoxAxis> anchorFunctionScrollCompensatedAxes() const;
 
     void setIsPopoverInvoker();
     bool isPopoverInvoker() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -899,7 +899,7 @@ inline bool RenderStyle::isInSubtreeWithBlendMode() const { return m_rareInherit
 inline bool RenderStyle::isForceHidden() const { return m_rareInheritedData->isForceHidden; }
 inline Isolation RenderStyle::isolation() const { return static_cast<Isolation>(m_nonInheritedData->rareData->isolation); }
 inline bool RenderStyle::usesAnchorFunctions() const { return m_nonInheritedData->rareData->usesAnchorFunctions; }
-inline OptionSet<BoxAxisFlag> RenderStyle::anchorFunctionScrollCompensatedAxes() const { return OptionSet<BoxAxisFlag>::fromRaw(m_nonInheritedData->rareData->anchorFunctionScrollCompensatedAxes); }
+inline EnumSet<BoxAxis> RenderStyle::anchorFunctionScrollCompensatedAxes() const { return EnumSet<BoxAxis>::fromRaw(m_nonInheritedData->rareData->anchorFunctionScrollCompensatedAxes); }
 
 inline bool RenderStyle::isPopoverInvoker() const { return m_nonInheritedData->rareData->isPopoverInvoker; }
 

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -334,7 +334,7 @@ inline void RenderStyle::setTransformStyle3D(TransformStyle3D b) { SET_NESTED(m_
 inline void RenderStyle::setTransformStyleForcedToFlat(bool b) { SET_NESTED(m_nonInheritedData, rareData, transformStyleForcedToFlat, static_cast<unsigned>(b)); }
 inline void RenderStyle::setTranslate(Style::Translate&& translate) { SET_NESTED(m_nonInheritedData, rareData, translate, WTFMove(translate)); }
 inline void RenderStyle::setUsesAnchorFunctions() { SET_NESTED(m_nonInheritedData, rareData, usesAnchorFunctions, true); }
-inline void RenderStyle::setAnchorFunctionScrollCompensatedAxes(OptionSet<BoxAxisFlag> axes) { SET_NESTED(m_nonInheritedData, rareData, anchorFunctionScrollCompensatedAxes, axes.toRaw()); }
+inline void RenderStyle::setAnchorFunctionScrollCompensatedAxes(EnumSet<BoxAxis> axes) { SET_NESTED(m_nonInheritedData, rareData, anchorFunctionScrollCompensatedAxes, axes.toRaw()); }
 inline void RenderStyle::setIsPopoverInvoker() { SET_NESTED(m_nonInheritedData, rareData, isPopoverInvoker, true); }
 inline void RenderStyle::setUsedZIndex(Style::ZIndex index) { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_hasAutoUsedZIndex, static_cast<uint8_t>(index.m_isAuto), m_usedZIndexValue, index.m_value); }
 inline void RenderStyle::setUserDrag(UserDrag value) { SET_NESTED(m_nonInheritedData, miscData, userDrag, static_cast<unsigned>(value)); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -267,7 +267,7 @@ public:
 #endif
     PREFERRED_TYPE(ScrollbarWidth) unsigned scrollbarWidth : 2;
     PREFERRED_TYPE(bool) unsigned usesAnchorFunctions : 1;
-    PREFERRED_TYPE(OptionSet<BoxAxisFlag>) unsigned anchorFunctionScrollCompensatedAxes : 2;
+    PREFERRED_TYPE(EnumSet<BoxAxis>) unsigned anchorFunctionScrollCompensatedAxes : 2;
     PREFERRED_TYPE(bool) unsigned usesTreeCountingFunctions : 1;
     PREFERRED_TYPE(bool) unsigned isPopoverInvoker : 1;
     PREFERRED_TYPE(bool) unsigned useSVGZoomRulesForLength : 1;

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -82,8 +82,8 @@ AnchorScrollAdjuster::AnchorScrollAdjuster(RenderBox& anchored, const RenderBoxM
     auto& style = anchored.style();
 
     auto compensatedAxes = style.anchorFunctionScrollCompensatedAxes();
-    m_needsXAdjustment = compensatedAxes.contains(BoxAxisFlag::Horizontal);
-    m_needsYAdjustment = compensatedAxes.contains(BoxAxisFlag::Vertical);
+    m_needsXAdjustment = compensatedAxes.contains(BoxAxis::Horizontal);
+    m_needsYAdjustment = compensatedAxes.contains(BoxAxis::Vertical);
 
     auto containingWritingMode = anchored.container()->style().writingMode();
     if (auto positionArea = style.positionArea()) {
@@ -462,7 +462,7 @@ void AnchorPositionEvaluator::addAnchorFunctionScrollCompensatedAxis(RenderStyle
         return;
 
     auto axes = style.anchorFunctionScrollCompensatedAxes();
-    axes.add(boxAxisToFlag(axis));
+    axes.add(axis);
     style.setAnchorFunctionScrollCompensatedAxes(axes);
 }
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -254,13 +254,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     auto sidesWithInsets = [](UIEdgeInsets insets) {
         WebCore::BoxSideSet sides;
         if (insets.top > 0)
-            sides.add(WebCore::BoxSideFlag::Top);
+            sides.add(WebCore::BoxSide::Top);
         if (insets.left > 0)
-            sides.add(WebCore::BoxSideFlag::Left);
+            sides.add(WebCore::BoxSide::Left);
         if (insets.bottom > 0)
-            sides.add(WebCore::BoxSideFlag::Bottom);
+            sides.add(WebCore::BoxSide::Bottom);
         if (insets.right > 0)
-            sides.add(WebCore::BoxSideFlag::Right);
+            sides.add(WebCore::BoxSide::Right);
         return sides;
     };
     BOOL updateFixedColorExtensionViews = sidesWithInsets(_obscuredInsets) != sidesWithInsets(obscuredInsets);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1382,16 +1382,16 @@ BoxSideSet WebPage::sidesRequiringFixedContainerEdges() const
     auto sides = m_page->fixedContainerEdges().fixedEdges();
 
     if ((additionalHeight + obscuredInsets.top()) > 0)
-        sides.add(BoxSideFlag::Top);
+        sides.add(BoxSide::Top);
 
     if (obscuredInsets.left() > 0)
-        sides.add(BoxSideFlag::Left);
+        sides.add(BoxSide::Left);
 
     if (obscuredInsets.right() > 0)
-        sides.add(BoxSideFlag::Right);
+        sides.add(BoxSide::Right);
 
     if (obscuredInsets.bottom() > 0)
-        sides.add(BoxSideFlag::Bottom);
+        sides.add(BoxSide::Bottom);
 
     return sides;
 }


### PR DESCRIPTION
#### 3dd2b46fd2d83abdd41f1ee7670252b3684d6fd7
<pre>
Use EnumSet for BoxSides
<a href="https://bugs.webkit.org/show_bug.cgi?id=300680">https://bugs.webkit.org/show_bug.cgi?id=300680</a>
<a href="https://rdar.apple.com/162581907">rdar://162581907</a>

Reviewed by Tim Nguyen.

Eliminate the now-unnecessary BoxSideFlag enum.
We can also remove various conversion functions as a result.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateFixedContainerEdges):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/BoxSides.h:
(WebCore::boxAxisToFlag): Deleted.

Also remoe BoxAxisFlag enum.

(WebCore::boxSideFromFlag): Deleted.
* Source/WebCore/platform/FixedContainerEdges.cpp:
(WebCore::FixedContainerEdges::fixedEdges const):
* Source/WebCore/rendering/BorderEdge.h:
(WebCore::edgesShareColor):
(WebCore::includesAdjacentEdges):
(WebCore::edgeFlagForSide): Deleted.
(WebCore::includesEdge): Deleted.
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::paintSides const):
(WebCore::BorderPainter::paintTranslucentBorderSides const):
(WebCore::borderStyleHasUnmatchedColorsAtCorner):
(WebCore::BorderPainter::paintBorderSides const):
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::anchorFunctionScrollCompensatedAxes const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setAnchorFunctionScrollCompensatedAxes):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::AnchorScrollAdjuster::AnchorScrollAdjuster):
(WebCore::Style::AnchorPositionEvaluator::addAnchorFunctionScrollCompensatedAxis):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setObscuredInsetsInternal:]):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::sidesRequiringFixedContainerEdges const):

Canonical link: <a href="https://commits.webkit.org/301472@main">https://commits.webkit.org/301472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72c3fdf8671387ecfc3b2d7dc129d555f920ca46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132896 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77887 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54282 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64117 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112765 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76510 "1 api test failed or timed out") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30947 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76368 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135603 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104525 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104238 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26559 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49633 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27961 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50223 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58571 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52065 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55411 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53775 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->