### PR TITLE
[FairPlay/MSE] HDCP status is no longer reported properly back to the CDMInstance

### DIFF
--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -94,6 +94,9 @@ public:
     virtual WebCore::FloatSize videoLayerSize() const { return { }; }
     virtual void notifyVideoLayerSizeChanged(Function<void(const MediaTime&, FloatSize)>&&) { }
     virtual void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRightAnnotated&&) { }
+#if ENABLE(ENCRYPTED_MEDIA)
+    virtual void notifyInsufficientExternalProtectionChanged(Function<void(bool)>&&) { }
+#endif
 };
 
 class VideoFullscreenInterface {

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -138,6 +138,9 @@ public:
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() final;
     PlatformLayer* platformVideoLayer() const final;
     void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRightAnnotated&&) final;
+#if ENABLE(ENCRYPTED_MEDIA)
+    void notifyInsufficientExternalProtectionChanged(Function<void(bool)>&&) final;
+#endif
 
     // VideoFullscreenInterface
     void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&&) final;
@@ -254,6 +257,9 @@ private:
     Function<void()> m_notifyWhenRequiresFlushToResume;
     Function<void()> m_renderingModeChangedCallback;
     Function<void(const MediaTime&, FloatSize)> m_sizeChangedCallback;
+#if ENABLE(ENCRYPTED_MEDIA)
+    Function<void(bool)> m_insufficientExternalProtectionChangedCallback;
+#endif
 
     RetainPtr<id> m_currentTimeObserver;
     RetainPtr<id> m_performTaskObserver;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -170,6 +170,13 @@ MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC(Media
         }
     });
 
+#if ENABLE(ENCRYPTED_MEDIA)
+    m_renderer->notifyInsufficientExternalProtectionChanged([weakThis = WeakPtr { *this }](bool obscured) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->outputObscuredDueToInsufficientExternalProtectionChanged(obscured);
+    });
+#endif
+
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     if (RetainPtr videoTarget = player->videoTarget())
         m_renderer->setVideoTarget(videoTarget.get());


### PR DESCRIPTION
#### 6d5d627497f53765a44885f28e4c574f52c2289c
<pre>
[FairPlay/MSE] HDCP status is no longer reported properly back to the CDMInstance
<a href="https://bugs.webkit.org/show_bug.cgi?id=300687">https://bugs.webkit.org/show_bug.cgi?id=300687</a>
<a href="https://rdar.apple.com/162590434">rdar://162590434</a>

Reviewed by Eric Carlson.

In 301011@main we treated all errors from the AVSBDL as a decoding error.
But if it&apos;s an HDCP error, it actually contains the HDCP obscured information.

We add a new AudioVideoRenderer callback that will contain the obscured
value so that it can be passed to the CDMInstance if any.

Covered by existing test: http/tests/media/fairplay/legacy-fairplay-mse-muxed-av-nowait.html
which would otherwise report on error.
* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
(WebCore::VideoInterface::notifyInsufficientExternalProtectionChanged):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::notifyInsufficientExternalProtectionChanged):
(WebCore::AudioVideoRendererAVFObjC::setVideoRenderer): Set the callback listener.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):

Canonical link: <a href="https://commits.webkit.org/301500@main">https://commits.webkit.org/301500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9244911b59d59ce8e6ec251a7f6bb78d38c31c3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77903 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e389bd74-6f48-4d45-9968-1da075c60900) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54299 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96024 "Failed to checkout and rebase branch from PR 52289") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64128 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8ab5a70-96d3-4be7-a10b-08ff7115a2ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76514 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51a7e918-08e7-49fe-8dd7-1c1e24ed3c36) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30970 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76384 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106923 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135619 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104532 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104247 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26580 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27976 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50249 "Hash 9244911b for PR 52289 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52754 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58588 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52082 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55428 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53792 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->