### PR TITLE
[WPE] Use HybridPaintingStrategy::GPUAffineRendering by default

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -139,7 +139,7 @@ RenderingMode SkiaPaintingEngine::decideHybridRenderingMode(const IntRect& dirty
         return RenderingMode::Unaccelerated;
     };
 
-    // Combined strategy: default for WPE, "hybrid mode", saturates CPU painting, before using GPU.
+    // Combined strategy: saturates CPU painting, before using GPU.
     auto handleCPUAffineRendering = [&]() -> RenderingMode {
         // If there is a non-identity scaling applied, prefer GPU rendering.
         if (contentsScale != 1)
@@ -156,7 +156,7 @@ RenderingMode SkiaPaintingEngine::decideHybridRenderingMode(const IntRect& dirty
         return handleMinimumFractionOfTasksUsingGPU();
     };
 
-    // Combined strategy: default for Gtk, useful mode for high-end GPUs, saturates GPU painting, before using CPU.
+    // Combined strategy: saturates GPU painting, before using CPU.
     auto handleGPUAffineRendering = [&]() -> RenderingMode {
         // If there is a non-identity scaling applied, prefer GPU rendering.
         if (contentsScale != 1)
@@ -384,11 +384,7 @@ SkiaPaintingEngine::HybridPaintingStrategy SkiaPaintingEngine::hybridPaintingStr
     static HybridPaintingStrategy strategy;
 
     std::call_once(onceFlag, [] {
-#if PLATFORM(WPE)
-        strategy = HybridPaintingStrategy::CPUAffineRendering; // Saturate CPU, before using GPU.
-#else
         strategy = HybridPaintingStrategy::GPUAffineRendering; // Saturate GPU, before using CPU.
-#endif
 
         if (const char* envString = getenv("WEBKIT_SKIA_HYBRID_PAINTING_MODE_STRATEGY")) {
             auto envStringView = StringView::fromLatin1(envString);


### PR DESCRIPTION
#### dd0dd6de3e6a3220d0eceea8c260aebe78932a53
<pre>
[WPE] Use HybridPaintingStrategy::GPUAffineRendering by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=300689">https://bugs.webkit.org/show_bug.cgi?id=300689</a>

Reviewed by Nikolas Zimmermann.

When GPU rendering is enabled, the layer tiles sizes are optimized for
the GPU, so prefer to use the GPU if possible.

Canonical link: <a href="https://commits.webkit.org/301526@main">https://commits.webkit.org/301526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fddfece9c84611f980fa04898d21995890abe16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132910 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77902 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96021 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64127 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76512 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76383 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135627 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104550 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104258 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49648 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27980 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50248 "Hash 5fddfece for PR 52290 does not build (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19742 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52753 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58587 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52081 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55427 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53791 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->