### PR TITLE
Crash in LabelsNodeList::~LabelsNodeList

### DIFF
--- a/Source/WebCore/dom/LiveNodeList.h
+++ b/Source/WebCore/dom/LiveNodeList.h
@@ -48,6 +48,7 @@ public:
 
     NodeListInvalidationType invalidationType() const { return m_invalidationType; }
     ContainerNode& ownerNode() const { return m_ownerNode; }
+    ContainerNode& rootNode() const;
     void invalidateCacheForAttribute(const QualifiedName& attributeName) const;
     virtual void invalidateCacheForDocument(Document&) const = 0;
     inline void invalidateCache() const;
@@ -60,7 +61,6 @@ protected:
 
     inline Document& document() const;
     inline Ref<Document> protectedDocument() const;
-    ContainerNode& rootNode() const;
 
 private:
     bool isLiveNodeList() const final { return true; }
@@ -71,7 +71,7 @@ private:
     bool m_isRegisteredForInvalidationAtDocument { false };
 };
 
-template <class NodeListType>
+template <class NodeListType, CollectionTraversalType traversalType = CollectionTraversalType::Descendants>
 class CachedLiveNodeList : public LiveNodeList {
     WTF_MAKE_TZONE_OR_ISO_NON_HEAP_ALLOCATABLE(CachedLiveNodeList);
 public:
@@ -81,7 +81,7 @@ public:
     inline Node* item(unsigned offset) const final;
 
     // For CollectionIndexCache
-    using Traversal = CollectionTraversal<CollectionTraversalType::Descendants>;
+    using Traversal = CollectionTraversal<traversalType>;
     using Iterator = Traversal::Iterator;
     inline Iterator collectionBegin() const;
     inline Iterator collectionLast() const;

--- a/Source/WebCore/dom/LiveNodeListInlines.h
+++ b/Source/WebCore/dom/LiveNodeListInlines.h
@@ -84,69 +84,69 @@ inline ContainerNode& LiveNodeList::rootNode() const
     return m_ownerNode;
 }
 
-template <class NodeListType>
-CachedLiveNodeList<NodeListType>::CachedLiveNodeList(ContainerNode& ownerNode, NodeListInvalidationType invalidationType)
+template <class NodeListType, CollectionTraversalType traversalType>
+CachedLiveNodeList<NodeListType, traversalType>::CachedLiveNodeList(ContainerNode& ownerNode, NodeListInvalidationType invalidationType)
     : LiveNodeList(ownerNode, invalidationType)
 {
 }
 
-template <class NodeListType>
-CachedLiveNodeList<NodeListType>::~CachedLiveNodeList()
+template <class NodeListType, CollectionTraversalType traversalType>
+CachedLiveNodeList<NodeListType, traversalType>::~CachedLiveNodeList()
 {
     if (m_indexCache.hasValidCache())
         protectedDocument()->unregisterNodeListForInvalidation(*this);
 }
 
-template <class NodeListType>
-unsigned CachedLiveNodeList<NodeListType>::length() const
+template <class NodeListType, CollectionTraversalType traversalType>
+unsigned CachedLiveNodeList<NodeListType, traversalType>::length() const
 {
     return m_indexCache.nodeCount(nodeList());
 }
 
-template <class NodeListType>
-Node* CachedLiveNodeList<NodeListType>::item(unsigned offset) const
+template <class NodeListType, CollectionTraversalType traversalType>
+Node* CachedLiveNodeList<NodeListType, traversalType>::item(unsigned offset) const
 {
     return m_indexCache.nodeAt(nodeList(), offset);
 }
 
-template <class NodeListType>
-auto CachedLiveNodeList<NodeListType>::collectionBegin() const -> Iterator
+template <class NodeListType, CollectionTraversalType traversalType>
+auto CachedLiveNodeList<NodeListType, traversalType>::collectionBegin() const -> Iterator
 {
     return Traversal::begin(nodeList(), rootNode());
 }
 
-template <class NodeListType>
-auto CachedLiveNodeList<NodeListType>::collectionLast() const -> Iterator
+template <class NodeListType, CollectionTraversalType traversalType>
+auto CachedLiveNodeList<NodeListType, traversalType>::collectionLast() const -> Iterator
 {
     return Traversal::last(nodeList(), rootNode());
 }
 
-template <class NodeListType>
-void CachedLiveNodeList<NodeListType>::collectionTraverseForward(Iterator& current, unsigned count, unsigned& traversedCount) const
+template <class NodeListType, CollectionTraversalType traversalType>
+void CachedLiveNodeList<NodeListType, traversalType>::collectionTraverseForward(Iterator& current, unsigned count, unsigned& traversedCount) const
 {
     Traversal::traverseForward(nodeList(), current, count, traversedCount);
 }
 
-template <class NodeListType>
-void CachedLiveNodeList<NodeListType>::collectionTraverseBackward(Iterator& current, unsigned count) const
+template <class NodeListType, CollectionTraversalType traversalType>
+void CachedLiveNodeList<NodeListType, traversalType>::collectionTraverseBackward(Iterator& current, unsigned count) const
 {
     Traversal::traverseBackward(nodeList(), current, count);
 }
 
-template <class NodeListType>
-bool CachedLiveNodeList<NodeListType>::collectionCanTraverseBackward() const
+template <class NodeListType, CollectionTraversalType traversalType>
+bool CachedLiveNodeList<NodeListType, traversalType>::collectionCanTraverseBackward() const
 {
     return true;
 }
 
-template <class NodeListType>
-void CachedLiveNodeList<NodeListType>::willValidateIndexCache() const
+template <class NodeListType, CollectionTraversalType traversalType>
+void CachedLiveNodeList<NodeListType, traversalType>::willValidateIndexCache() const
 {
     protectedDocument()->registerNodeListForInvalidation(const_cast<CachedLiveNodeList&>(*this));
 }
 
-template <class NodeListType>
-void CachedLiveNodeList<NodeListType>::invalidateCacheForDocument(Document& document) const
+template <class NodeListType, CollectionTraversalType traversalType>
+void CachedLiveNodeList<NodeListType, traversalType>::invalidateCacheForDocument(Document& document) const
 {
     if (m_indexCache.hasValidCache()) {
         document.unregisterNodeListForInvalidation(const_cast<NodeListType&>(nodeList()));

--- a/Source/WebCore/html/CollectionTraversal.h
+++ b/Source/WebCore/html/CollectionTraversal.h
@@ -28,10 +28,12 @@
 #include <WebCore/CollectionType.h>
 #include <WebCore/ElementChildIterator.h>
 #include <WebCore/TypedElementDescendantIterator.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class ContainerNode;
+class WeakPtrImplWithEventTargetData;
 
 template <CollectionTraversalType traversalType>
 struct CollectionTraversal { };
@@ -39,6 +41,23 @@ struct CollectionTraversal { };
 template <>
 struct CollectionTraversal<CollectionTraversalType::Descendants> {
     using Iterator = ElementDescendantIterator<Element>;
+
+    template <typename CollectionClass>
+    static inline Iterator begin(const CollectionClass&, ContainerNode& rootNode);
+
+    template <typename CollectionClass>
+    static inline Iterator last(const CollectionClass&, ContainerNode& rootNode);
+
+    template <typename CollectionClass>
+    static inline void traverseForward(const CollectionClass&, Iterator& current, unsigned count, unsigned& traversedCount);
+
+    template <typename CollectionClass>
+    static inline void traverseBackward(const CollectionClass&, Iterator& current, unsigned count);
+};
+
+template <>
+struct CollectionTraversal<CollectionTraversalType::WeakPtrDescendants> {
+    using Iterator = WeakPtr<Element, WeakPtrImplWithEventTargetData>;
 
     template <typename CollectionClass>
     static inline Iterator begin(const CollectionClass&, ContainerNode& rootNode);
@@ -89,5 +108,10 @@ struct CollectionTraversal<CollectionTraversalType::CustomForwardOnly> {
     static inline void traverseBackward(const CollectionClass&, Element*&, unsigned count);
 };
 
-
 } // namespace WebCore
+
+namespace std {
+
+template<> struct iterator_traits<WeakPtr<WebCore::Element, WebCore::WeakPtrImplWithEventTargetData>> { using value_type = WebCore::Element; };
+
+}

--- a/Source/WebCore/html/CollectionTraversalInlines.h
+++ b/Source/WebCore/html/CollectionTraversalInlines.h
@@ -82,6 +82,70 @@ inline void CollectionTraversal<CollectionTraversalType::Descendants>::traverseB
     }
 }
 
+// CollectionTraversal::WeakPtrDescendants
+
+template <typename CollectionClass>
+inline auto CollectionTraversal<CollectionTraversalType::WeakPtrDescendants>::begin(const CollectionClass& collection, ContainerNode& rootNode) -> Iterator
+{
+    auto it = descendantsOfType<Element>(rootNode).begin();
+    while (it && !collection.elementMatches(*it))
+        ++it;
+    if (!it)
+        return nullptr;
+    return WeakPtr { *it };
+}
+
+template <typename CollectionClass>
+inline auto CollectionTraversal<CollectionTraversalType::WeakPtrDescendants>::last(const CollectionClass& collection, ContainerNode& rootNode) -> Iterator
+{
+    ElementDescendantIterator<Element> it { rootNode, ElementTraversal::lastWithin(rootNode) };
+    while (it && !collection.elementMatches(*it))
+        --it;
+    if (!it)
+        return nullptr;
+    return WeakPtr { *it };
+}
+
+template <typename CollectionClass>
+inline void CollectionTraversal<CollectionTraversalType::WeakPtrDescendants>::traverseForward(const CollectionClass& collection, Iterator& current, unsigned count, unsigned& traversedCount)
+{
+    ASSERT(collection.elementMatches(*current));
+    ElementDescendantIterator<Element> iterator { collection.rootNode(), current.get() };
+    for (traversedCount = 0; traversedCount < count; ++traversedCount) {
+        do {
+            ++iterator;
+            if (!iterator) {
+                current = nullptr;
+                return;
+            }
+        } while (!collection.elementMatches(*iterator));
+    }
+    if (iterator)
+        current = *iterator;
+    else
+        current = nullptr;
+}
+
+template <typename CollectionClass>
+inline void CollectionTraversal<CollectionTraversalType::WeakPtrDescendants>::traverseBackward(const CollectionClass& collection, Iterator& current, unsigned count)
+{
+    ASSERT(collection.elementMatches(*current));
+    ElementDescendantIterator<Element> iterator { collection.rootNode(), current.get() };
+    for (; count; --count) {
+        do {
+            --iterator;
+            if (!iterator) {
+                current = nullptr;
+                return;
+            }
+        } while (!collection.elementMatches(*iterator));
+    }
+    if (iterator)
+        current = *iterator;
+    else
+        current = nullptr;
+}
+
 // CollectionTraversal::ChildrenOnly
 
 template <typename CollectionClass>

--- a/Source/WebCore/html/CollectionType.h
+++ b/Source/WebCore/html/CollectionType.h
@@ -59,7 +59,7 @@ enum class CollectionType : uint8_t {
     AllDescendants
 };
 
-enum class CollectionTraversalType : uint8_t { Descendants, ChildrenOnly, CustomForwardOnly };
+enum class CollectionTraversalType : uint8_t { Descendants, WeakPtrDescendants, ChildrenOnly, CustomForwardOnly };
 template<CollectionType collectionType>
 struct CollectionTypeTraits {
     static const CollectionTraversalType traversalType = CollectionTraversalType::Descendants;

--- a/Source/WebCore/html/LabelsNodeList.h
+++ b/Source/WebCore/html/LabelsNodeList.h
@@ -30,7 +30,7 @@ namespace WebCore {
 
 class HTMLElement;
 
-class LabelsNodeList final : public CachedLiveNodeList<LabelsNodeList> {
+class LabelsNodeList final : public CachedLiveNodeList<LabelsNodeList, CollectionTraversalType::WeakPtrDescendants> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(LabelsNodeList);
 public:
     static Ref<LabelsNodeList> create(HTMLElement&, const AtomString&);


### PR DESCRIPTION
#### 74aabff89f46e7f6f25643f5c40eeceb4851d4ef
<pre>
Crash in LabelsNodeList::~LabelsNodeList
<a href="https://bugs.webkit.org/show_bug.cgi?id=300692">https://bugs.webkit.org/show_bug.cgi?id=300692</a>
&lt;<a href="https://rdar.apple.com/162254579">rdar://162254579</a>&gt;

Reviewed by Chris Dumez.

Fix the crash by using WeakPtr instead of CheckedPtr in LabelsNodeList.

No new tests since we don&apos;t have a reproduction.

* Source/WebCore/dom/LiveNodeList.h:
* Source/WebCore/html/CollectionTraversal.h:
* Source/WebCore/html/CollectionTraversalInlines.h:
(WebCore::CollectionTraversal&lt;CollectionTraversalType::WeakPtrDescendants&gt;::begin):
(WebCore::CollectionTraversal&lt;CollectionTraversalType::WeakPtrDescendants&gt;::last):
(WebCore::CollectionTraversal&lt;CollectionTraversalType::WeakPtrDescendants&gt;::traverseForward):
(WebCore::CollectionTraversal&lt;CollectionTraversalType::WeakPtrDescendants&gt;::traverseBackward):
* Source/WebCore/html/CollectionType.h:

Canonical link: <a href="https://commits.webkit.org/301516@main">https://commits.webkit.org/301516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/309555c207b4eb604c8305f935829db1cd11e9bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126190 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77974 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c214828-7521-4c02-968c-e090d5245ecf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54397 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7b2599a-02af-494c-b516-e0ba5075bf6f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112878 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5988fa9f-d519-44a9-a5bc-59b3cb5079c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36114 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76450 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31284 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40664 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/135680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109096 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49716 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28053 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50329 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19736 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52845 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58678 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52164 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55510 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53878 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->