### PR TITLE
[FairPlay] beginSimulatedHDCPError/endSimulatedHDCPError methods are unused.

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1716,18 +1716,6 @@ bool MediaPlayer::isGStreamerHolePunchingEnabled()
 }
 #endif
 
-void MediaPlayer::beginSimulatedHDCPError()
-{
-    if (RefPtr privateInterface = m_private)
-        privateInterface->beginSimulatedHDCPError();
-}
-
-void MediaPlayer::endSimulatedHDCPError()
-{
-    if (RefPtr privateInterface = m_private)
-        privateInterface->endSimulatedHDCPError();
-}
-
 String MediaPlayer::languageOfPrimaryAudioTrack() const
 {
     RefPtr playerPrivate = m_private;

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -676,9 +676,6 @@ public:
     bool isGStreamerHolePunchingEnabled();
 #endif
 
-    void beginSimulatedHDCPError();
-    void endSimulatedHDCPError();
-
     String languageOfPrimaryAudioTrack() const;
 
     size_t extraMemoryCost() const;

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -284,9 +284,6 @@ public:
     virtual void simulateAudioInterruption() { }
 #endif
 
-    virtual void beginSimulatedHDCPError() { }
-    virtual void endSimulatedHDCPError() { }
-
     virtual String languageOfPrimaryAudioTrack() const { return emptyString(); }
 
     virtual size_t extraMemoryCost() const

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -159,9 +159,6 @@ private:
 
     void cancelLoad() final;
 
-    void beginSimulatedHDCPError() final { outputObscuredDueToInsufficientExternalProtectionChanged(true); }
-    void endSimulatedHDCPError() final { outputObscuredDueToInsufficientExternalProtectionChanged(false); }
-
     void notifyTrackModeChanged() final;
     void synchronizeTextTrackState() final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -141,8 +141,6 @@ public:
 #endif
 
     void outputObscuredDueToInsufficientExternalProtectionChanged(bool);
-    void beginSimulatedHDCPError() override { outputObscuredDueToInsufficientExternalProtectionChanged(true); }
-    void endSimulatedHDCPError() override { outputObscuredDueToInsufficientExternalProtectionChanged(false); }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) || ENABLE(ENCRYPTED_MEDIA)
     void keyNeeded(const SharedBuffer&);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4596,19 +4596,6 @@ void Internals::enterViewerMode(HTMLVideoElement& element)
     element.enterFullscreen(HTMLMediaElementEnums::VideoFullscreenModeInWindow);
 }
 
-
-void Internals::beginSimulatedHDCPError(HTMLMediaElement& element)
-{
-    if (RefPtr player = element.player())
-        player->beginSimulatedHDCPError();
-}
-
-void Internals::endSimulatedHDCPError(HTMLMediaElement& element)
-{
-    if (RefPtr player = element.player())
-        player->endSimulatedHDCPError();
-}
-
 ExceptionOr<bool> Internals::mediaPlayerRenderingCanBeAccelerated(HTMLMediaElement& element)
 {
     return element.mediaPlayerRenderingCanBeAccelerated();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -800,8 +800,6 @@ public:
     void simulateAudioInterruption(HTMLMediaElement&);
     ExceptionOr<bool> mediaElementHasCharacteristic(HTMLMediaElement&, const String&);
     void enterViewerMode(HTMLVideoElement&);
-    void beginSimulatedHDCPError(HTMLMediaElement&);
-    void endSimulatedHDCPError(HTMLMediaElement&);
     ExceptionOr<bool> mediaPlayerRenderingCanBeAccelerated(HTMLMediaElement&);
 
     bool elementShouldBufferData(HTMLMediaElement&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -976,8 +976,6 @@ enum ContentsFormat {
     [Conditional=VIDEO] sequence<DOMString> mediaResponseContentRanges(HTMLMediaElement media);
     [Conditional=VIDEO] undefined simulateAudioInterruption(HTMLMediaElement element);
     [Conditional=VIDEO] boolean mediaElementHasCharacteristic(HTMLMediaElement element, DOMString characteristic);
-    [Conditional=VIDEO] undefined beginSimulatedHDCPError(HTMLMediaElement media);
-    [Conditional=VIDEO] undefined endSimulatedHDCPError(HTMLMediaElement media);
     [Conditional=VIDEO] boolean mediaPlayerRenderingCanBeAccelerated(HTMLMediaElement media);
 
     [Conditional=VIDEO] boolean elementShouldBufferData(HTMLMediaElement media);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -1123,16 +1123,6 @@ void RemoteMediaPlayerProxy::setShouldContinueAfterKeyNeeded(bool should)
 }
 #endif
 
-void RemoteMediaPlayerProxy::beginSimulatedHDCPError()
-{
-    protectedPlayer()->beginSimulatedHDCPError();
-}
-
-void RemoteMediaPlayerProxy::endSimulatedHDCPError()
-{
-    protectedPlayer()->endSimulatedHDCPError();
-}
-
 void RemoteMediaPlayerProxy::notifyActiveSourceBuffersChanged()
 {
     protectedConnection()->send(Messages::MediaPlayerPrivateRemote::ActiveSourceBuffersChanged(), m_id);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -213,9 +213,6 @@ public:
     void setShouldContinueAfterKeyNeeded(bool);
 #endif
 
-    void beginSimulatedHDCPError();
-    void endSimulatedHDCPError();
-
     void notifyActiveSourceBuffersChanged();
 
     void applicationWillResignActive();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -96,9 +96,6 @@ messages -> RemoteMediaPlayerProxy {
     [EnabledBy=LegacyEncryptedMediaAPIEnabled] SetShouldContinueAfterKeyNeeded(bool should)
 #endif
 
-    BeginSimulatedHDCPError()
-    EndSimulatedHDCPError()
-
     NotifyActiveSourceBuffersChanged()
 
     ApplicationWillResignActive()

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1510,16 +1510,6 @@ void MediaPlayerPrivateRemote::tracksChanged()
     connection().send(Messages::RemoteMediaPlayerProxy::TracksChanged(), m_id);
 }
 
-void MediaPlayerPrivateRemote::beginSimulatedHDCPError()
-{
-    connection().send(Messages::RemoteMediaPlayerProxy::BeginSimulatedHDCPError(), m_id);
-}
-
-void MediaPlayerPrivateRemote::endSimulatedHDCPError()
-{
-    connection().send(Messages::RemoteMediaPlayerProxy::EndSimulatedHDCPError(), m_id);
-}
-
 String MediaPlayerPrivateRemote::languageOfPrimaryAudioTrack() const
 {
     return m_cachedState.languageOfPrimaryAudioTrack;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -434,9 +434,6 @@ private:
 
     void tracksChanged() final;
 
-    void beginSimulatedHDCPError() final;
-    void endSimulatedHDCPError() final;
-
     String languageOfPrimaryAudioTrack() const final;
 
     size_t extraMemoryCost() const final;


### PR DESCRIPTION
#### 1d20c141591645a8c0c0bc6c1233f10ee47dd670
<pre>
[FairPlay] beginSimulatedHDCPError/endSimulatedHDCPError methods are unused.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300691">https://bugs.webkit.org/show_bug.cgi?id=300691</a>
<a href="https://rdar.apple.com/162594711">rdar://162594711</a>

Reviewed by Eric Carlson.

Those methods, initially intended for testing, have never been used.
Going forward, where the MediaPlayer will run in the content process
and the CDMInstance will run in the GPU process, they become an unnecessary
hindrance.
So we remove them
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::beginSimulatedHDCPError): Deleted.
(WebCore::MediaPlayer::endSimulatedHDCPError): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::beginSimulatedHDCPError): Deleted.
(WebCore::MediaPlayerPrivateInterface::endSimulatedHDCPError): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::beginSimulatedHDCPError): Deleted.
(WebCore::Internals::endSimulatedHDCPError): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::beginSimulatedHDCPError): Deleted.
(WebKit::RemoteMediaPlayerProxy::endSimulatedHDCPError): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::beginSimulatedHDCPError): Deleted.
(WebKit::MediaPlayerPrivateRemote::endSimulatedHDCPError): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/301501@main">https://commits.webkit.org/301501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d81ca5336f65b27e146a5a6a41f0e95aee88394

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77905 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ad873929-55b1-4650-9659-59d473f0ae41) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96038 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64130 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a8192a6-d6f9-4f48-89af-9924f422391c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129051 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76520 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c9bdbc2-f48c-4aa6-b31e-e353dfa06bc9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30977 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76386 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106928 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135621 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40592 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104548 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53317 "Hash 2d81ca53 for PR 52292 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104254 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26581 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27984 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50252 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52756 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58590 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52084 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55430 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53794 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->