### PR TITLE
Animation not updated when Container Query units are used

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-animation-expected.txt
@@ -1,14 +1,26 @@
 
-PASS Animation using cqw unit
-PASS Animation using cqw unit responds to changing container size
-PASS Animation using cqh unit
-PASS Animation using cqh unit responds to changing container size
-PASS Animation using cqi unit
-PASS Animation using cqi unit responds to changing container size
-PASS Animation using cqb unit
-PASS Animation using cqb unit responds to changing container size
-PASS Animation using cqmin unit
-PASS Animation using cqmin unit responds to changing container size
-PASS Animation using cqmax unit
-PASS Animation using cqmax unit responds to changing container size
+PASS CSS Animation using cqw unit
+PASS CSS Animation using cqw unit responds to changing container size
+PASS CSS Animation using cqh unit
+PASS CSS Animation using cqh unit responds to changing container size
+PASS CSS Animation using cqi unit
+PASS CSS Animation using cqi unit responds to changing container size
+PASS CSS Animation using cqb unit
+PASS CSS Animation using cqb unit responds to changing container size
+PASS CSS Animation using cqmin unit
+PASS CSS Animation using cqmin unit responds to changing container size
+PASS CSS Animation using cqmax unit
+PASS CSS Animation using cqmax unit responds to changing container size
+PASS Web Animation using cqw unit
+PASS Web Animation using cqw unit responds to changing container size
+PASS Web Animation using cqh unit
+PASS Web Animation using cqh unit responds to changing container size
+PASS Web Animation using cqi unit
+PASS Web Animation using cqi unit responds to changing container size
+PASS Web Animation using cqb unit
+PASS Web Animation using cqb unit responds to changing container size
+PASS Web Animation using cqmin unit
+PASS Web Animation using cqmin unit responds to changing container size
+PASS Web Animation using cqmax unit
+PASS Web Animation using cqmax unit responds to changing container size
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-animation.html
@@ -18,28 +18,35 @@
   @keyframes anim_cqmin { from { top: 20cqmin; } to { top: 40cqmin; } }
   @keyframes anim_cqmax { from { top: 20cqmax; } to { top: 40cqmax; } }
 
-  #container > div {
+  #container > div.css-animation {
     animation-delay: -5s;
     animation-play-state: paused;
     animation-duration: 10s;
     animation-timing-function: linear;
   }
 
-  #element_cqw { animation-name: anim_cqw; }
-  #element_cqh { animation-name: anim_cqh; }
-  #element_cqi { animation-name: anim_cqi; }
-  #element_cqb { animation-name: anim_cqb; }
-  #element_cqmin { animation-name: anim_cqmin; }
-  #element_cqmax { animation-name: anim_cqmax; }
+  .css-animation.cqw { animation-name: anim_cqw; }
+  .css-animation.cqh { animation-name: anim_cqh; }
+  .css-animation.cqi { animation-name: anim_cqi; }
+  .css-animation.cqb { animation-name: anim_cqb; }
+  .css-animation.cqmin { animation-name: anim_cqmin; }
+  .css-animation.cqmax { animation-name: anim_cqmax; }
 
 </style>
 <div id=container>
-  <div id=element_cqw></div>
-  <div id=element_cqh></div>
-  <div id=element_cqi></div>
-  <div id=element_cqb></div>
-  <div id=element_cqmin></div>
-  <div id=element_cqmax></div>
+  <div class="css-animation cqw"></div>
+  <div class="css-animation cqh"></div>
+  <div class="css-animation cqi"></div>
+  <div class="css-animation cqb"></div>
+  <div class="css-animation cqmin"></div>
+  <div class="css-animation cqmax"></div>
+
+  <div class="web-animation cqw"></div>
+  <div class="web-animation cqh"></div>
+  <div class="web-animation cqi"></div>
+  <div class="web-animation cqb"></div>
+  <div class="web-animation cqmin"></div>
+  <div class="web-animation cqmax"></div>
 </div>
 <script>
   setup(() => assert_implements_size_container_queries());
@@ -48,12 +55,12 @@
 
   for (let unit of units) {
     test(() => {
-      let element = document.getElementById(`element_${unit}`)
+      let element = document.querySelector(`.css-animation.${unit}`)
       assert_equals(getComputedStyle(element).top, '60px');
-    }, `Animation using ${unit} unit`);
+    }, `CSS Animation using ${unit} unit`);
 
     test(() => {
-      let element = document.getElementById(`element_${unit}`)
+      let element = document.querySelector(`.css-animation.${unit}`)
       assert_equals(getComputedStyle(element).top, '60px');
       try {
         container.style.width = '300px';
@@ -64,7 +71,42 @@
       }
 
       assert_equals(getComputedStyle(element).top, '60px');
-    }, `Animation using ${unit} unit responds to changing container size`);
+    }, `CSS Animation using ${unit} unit responds to changing container size`);
+  }
+
+  const keyframes = {
+    "cqw" : { top: ["20cqw", "40cqw"] },
+    "cqh" : { top: ["20cqh", "40cqh"] },
+    "cqi" : { top: ["20cqi", "40cqi"] },
+    "cqb" : { top: ["20cqb", "40cqb"] },
+    "cqmin" : { top: ["20cqmin", "40cqmin"] },
+    "cqmax" : { top: ["20cqmax", "40cqmax"] }
+  };
+
+  for (const unit in keyframes) {
+    const target = document.querySelector(`.web-animation.${unit}`);
+    const assert_top = expected => assert_equals(getComputedStyle(target).top, expected);
+
+    const animation = target.animate(keyframes[unit], 10 * 1000);
+    animation.currentTime = 5 * 1000;
+    animation.pause();
+
+    test(() => {
+      assert_top('60px');
+    }, `Web Animation using ${unit} unit`);
+
+    test(() => {
+      assert_top('60px');
+      try {
+        container.style.width = '300px';
+        container.style.height = '300px';
+        assert_top('90px');
+      } finally {
+        container.style = '';
+      }
+
+      assert_top('60px');
+    }, `Web Animation using ${unit} unit responds to changing container size`);
   }
 
 </script>

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -395,7 +395,7 @@ void CSSAnimation::keyframesRuleDidChange()
     if (!owningElement)
         return;
 
-    keyframeEffect->keyframesRuleDidChange();
+    keyframeEffect->recomputeKeyframesAtNextOpportunity();
     owningElement->keyframesRuleDidChange();
 }
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1088,9 +1088,8 @@ ExceptionOr<void> KeyframeEffect::setKeyframes(JSGlobalObject& lexicalGlobalObje
     return processKeyframesResult;
 }
 
-void KeyframeEffect::keyframesRuleDidChange()
+void KeyframeEffect::recomputeKeyframesAtNextOpportunity()
 {
-    ASSERT(is<CSSAnimation>(animation()));
     clearBlendingKeyframes();
     invalidate();
 }

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -140,6 +140,7 @@ public:
     void transformRelatedPropertyDidChange();
     enum class RecomputationReason : uint8_t { LogicalPropertyChange, Other };
     std::optional<RecomputationReason> recomputeKeyframesIfNecessary(const RenderStyle* previousUnanimatedStyle, const RenderStyle& unanimatedStyle, const Style::ResolutionContext&);
+    void recomputeKeyframesAtNextOpportunity();
     void applyPendingAcceleratedActions();
     void applyPendingAcceleratedActionsOrUpdateTimingProperties();
 
@@ -176,7 +177,6 @@ public:
     bool requiresPseudoElement() const;
     bool hasImplicitKeyframes() const;
 
-    void keyframesRuleDidChange();
     void customPropertyRegistrationDidChange(const AtomString&);
 
     bool canBeAccelerated() const;

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -972,13 +972,14 @@ void Styleable::queryContainerDidChange() const
     auto* animations = this->animations();
     if (!animations)
         return;
-    for (auto animation : *animations) {
-        auto* cssAnimation = dynamicDowncast<CSSAnimation>(animation.get());
-        if (!cssAnimation)
-            continue;
-        auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(cssAnimation->effect());
-        if (keyframeEffect && keyframeEffect->blendingKeyframes().usesContainerUnits())
-            cssAnimation->keyframesRuleDidChange();
+    for (auto& animation : *animations) {
+        RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect());
+        if (keyframeEffect && keyframeEffect->blendingKeyframes().usesContainerUnits()) {
+            if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation))
+                cssAnimation->keyframesRuleDidChange();
+            else
+                keyframeEffect->recomputeKeyframesAtNextOpportunity();
+        }
     }
 }
 


### PR DESCRIPTION
#### 1fab1713b7b7bc38ba4ed653e1181e2e021b1461
<pre>
Animation not updated when Container Query units are used
<a href="https://bugs.webkit.org/show_bug.cgi?id=299952">https://bugs.webkit.org/show_bug.cgi?id=299952</a>
<a href="https://rdar.apple.com/162194744">rdar://162194744</a>

Reviewed by Antti Koivisto and Anne van Kesteren.

Recompute keyframes when container query units are used for all types of animations,
not just CSS Animations.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-animation.html:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::keyframesRuleDidChange):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::recomputeKeyframesAtNextOpportunity):
(WebCore::KeyframeEffect::keyframesRuleDidChange): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::queryContainerDidChange const):

Canonical link: <a href="https://commits.webkit.org/301584@main">https://commits.webkit.org/301584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/142e6758c4194f9efe45e807a85dd2d4b99064fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78103 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b5ee46f-314c-47a4-a2ef-af6326827027) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96204 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ceb01b4-c8de-4442-bd4c-c36322046ba9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113044 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76680 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/184cd742-7d7d-478d-912a-6db21876d183) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36237 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31220 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76606 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135839 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104698 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104399 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49851 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28195 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Passed layout tests; 2 flakes 1 failures; Uploaded test results; 8 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50496 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19769 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58836 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52310 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55650 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54033 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->