### PR TITLE
Address Safer CPP warnings in Cocoa API classes

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,11 +1,7 @@
 Platform/IPC/ArgumentCoders.h
 UIProcess/API/C/mac/WKPagePrivateMac.mm
-UIProcess/API/Cocoa/WKContentWorld.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm
-UIProcess/API/Cocoa/WKOpenPanelParameters.mm
 UIProcess/API/Cocoa/WKProcessPool.mm
-UIProcess/API/Cocoa/WKScriptMessage.mm
-UIProcess/API/Cocoa/WKURLSchemeTask.mm
 UIProcess/API/Cocoa/WKUserContentController.mm
 UIProcess/API/Cocoa/WKUserScript.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
@@ -67,7 +67,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKContentWorld.class, self))
         return;
 
-    _contentWorld->~ContentWorld();
+    SUPPRESS_UNCOUNTED_ARG _contentWorld->~ContentWorld();
 
     [super dealloc];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -38,12 +38,17 @@
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
+- (Ref<API::FrameInfo>)_protectedFrameInfo
+{
+    return *_frameInfo;
+}
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKFrameInfo.class, self))
         return;
 
-    _frameInfo->~FrameInfo();
+    SUPPRESS_UNCOUNTED_ARG self._protectedFrameInfo->~FrameInfo();
 
     [super dealloc];
 }
@@ -72,7 +77,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKWebView *)webView
 {
-    RefPtr page = _frameInfo->page();
+    RefPtr page = self._protectedFrameInfo->page();
     return page ? page->cocoaView().autorelease() : nil;
 }
 
@@ -94,12 +99,12 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (_WKFrameHandle *)_handle
 {
-    return wrapper(_frameInfo->handle()).autorelease();
+    return wrapper(self._protectedFrameInfo->handle()).autorelease();
 }
 
 - (_WKFrameHandle *)_parentFrameHandle
 {
-    return wrapper(_frameInfo->parentFrameHandle()).autorelease();
+    return wrapper(self._protectedFrameInfo->parentFrameHandle()).autorelease();
 }
 
 - (NSUUID *)_documentIdentifier
@@ -129,7 +134,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSString *)_title
 {
-    return _frameInfo->title().createNSString().autorelease();
+    return self._protectedFrameInfo->title().createNSString().autorelease();
 }
 
 - (BOOL)_isScrollable

--- a/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.mm
@@ -53,17 +53,17 @@
 
 - (NSArray<NSString *> *)_acceptedMIMETypes
 {
-    return wrapper(_openPanelParameters->acceptMIMETypes()).autorelease();
+    return wrapper(Ref { *_openPanelParameters }->acceptMIMETypes()).autorelease();
 }
 
 - (NSArray<NSString *> *)_acceptedFileExtensions
 {
-    return wrapper(_openPanelParameters->acceptFileExtensions()).autorelease();
+    return wrapper(Ref { *_openPanelParameters }->acceptFileExtensions()).autorelease();
 }
 
 - (NSArray<NSString *> *)_allowedFileExtensions
 {
-    return wrapper(_openPanelParameters->allowedFileExtensions()).autorelease();
+    return wrapper(Ref { *_openPanelParameters }->allowedFileExtensions()).autorelease();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.mm
@@ -38,7 +38,7 @@
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKScriptMessage.class, self))
         return;
 
-    _scriptMessage->~ScriptMessage();
+    SUPPRESS_UNCOUNTED_ARG _scriptMessage->~ScriptMessage();
 
     [super dealloc];
 }
@@ -50,7 +50,7 @@
 
 - (WKWebView *)webView
 {
-    if (RefPtr page = _scriptMessage->page())
+    if (RefPtr page = Ref { *_scriptMessage }->page())
         return page->cocoaView().autorelease();
     return nil;
 }
@@ -62,7 +62,7 @@
 
 - (NSString *)name
 {
-    return _scriptMessage->cocoaName().unsafeGet();
+    return Ref { *_scriptMessage }->cocoaName().unsafeGet();
 }
 
 - (WKContentWorld *)world

--- a/Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeTask.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeTask.mm
@@ -80,28 +80,33 @@ static void raiseExceptionIfNecessary(WebKit::WebURLSchemeTask::ExceptionType ex
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+- (Ref<WebKit::WebURLSchemeTask>)_protectedURLSchemeTask
+{
+    return *_urlSchemeTask;
+}
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKURLSchemeTaskImpl.class, self))
         return;
-    _urlSchemeTask->WebURLSchemeTask::~WebURLSchemeTask();
+    SUPPRESS_UNCOUNTED_ARG _urlSchemeTask->WebURLSchemeTask::~WebURLSchemeTask();
     [super dealloc];
 }
 
 - (NSURLRequest *)request
 {
-    return _urlSchemeTask->nsRequest();
+    return self._protectedURLSchemeTask->nsRequest();
 }
 
 - (BOOL)_requestOnlyIfCached
 {
-    return _urlSchemeTask->nsRequest().cachePolicy == NSURLRequestReturnCacheDataDontLoad;
+    return self._protectedURLSchemeTask->nsRequest().cachePolicy == NSURLRequestReturnCacheDataDontLoad;
 }
 
 - (void)_willPerformRedirection:(NSURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest *))completionHandler
 {
     auto function = [strongSelf = retainPtr(self), self, response = retainPtr(response), request = retainPtr(request), handler = makeBlockPtr(completionHandler)] () mutable {
-        return _urlSchemeTask->willPerformRedirection(response.get(), request.get(), [handler = WTFMove(handler)] (WebCore::ResourceRequest&& actualNewRequest) {
+        return self._protectedURLSchemeTask->willPerformRedirection(response.get(), request.get(), [handler = WTFMove(handler)] (WebCore::ResourceRequest&& actualNewRequest) {
             handler.get()(actualNewRequest.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody));
         });
     };
@@ -113,7 +118,7 @@ static void raiseExceptionIfNecessary(WebKit::WebURLSchemeTask::ExceptionType ex
 - (void)didReceiveResponse:(NSURLResponse *)response
 {
     auto function = [strongSelf = retainPtr(self), self, response = retainPtr(response)] {
-        return _urlSchemeTask->didReceiveResponse(response.get());
+        return self._protectedURLSchemeTask->didReceiveResponse(response.get());
     };
 
     auto result = getExceptionTypeFromMainRunLoop(WTFMove(function));
@@ -123,7 +128,7 @@ static void raiseExceptionIfNecessary(WebKit::WebURLSchemeTask::ExceptionType ex
 - (void)didReceiveData:(NSData *)data
 {
     auto function = [strongSelf = retainPtr(self), self, data = retainPtr(data)] () mutable {
-        return _urlSchemeTask->didReceiveData(WebCore::SharedBuffer::create(data.get()));
+        return self._protectedURLSchemeTask->didReceiveData(WebCore::SharedBuffer::create(data.get()));
     };
 
     auto result = getExceptionTypeFromMainRunLoop(WTFMove(function));
@@ -133,7 +138,7 @@ static void raiseExceptionIfNecessary(WebKit::WebURLSchemeTask::ExceptionType ex
 - (void)didFinish
 {
     auto function = [strongSelf = retainPtr(self), self] {
-        return _urlSchemeTask->didComplete({ });
+        return self._protectedURLSchemeTask->didComplete({ });
     };
 
     auto result = getExceptionTypeFromMainRunLoop(WTFMove(function));
@@ -143,7 +148,7 @@ static void raiseExceptionIfNecessary(WebKit::WebURLSchemeTask::ExceptionType ex
 - (void)didFailWithError:(NSError *)error
 {
     auto function = [strongSelf = retainPtr(self), self, error = retainPtr(error)] {
-        return _urlSchemeTask->didComplete(error.get());
+        return self._protectedURLSchemeTask->didComplete(error.get());
     };
 
     auto result = getExceptionTypeFromMainRunLoop(WTFMove(function));
@@ -153,7 +158,7 @@ static void raiseExceptionIfNecessary(WebKit::WebURLSchemeTask::ExceptionType ex
 - (void)_didPerformRedirection:(NSURLResponse *)response newRequest:(NSURLRequest *)request
 {
     auto function = [strongSelf = retainPtr(self), self, response = retainPtr(response), request = retainPtr(request)] {
-        return _urlSchemeTask->didPerformRedirection(response.get(), request.get());
+        return self._protectedURLSchemeTask->didPerformRedirection(response.get(), request.get());
     };
 
     auto result = getExceptionTypeFromMainRunLoop(WTFMove(function));


### PR DESCRIPTION
#### 7024a77812532c2ad5107ac5647aa719d5875819
<pre>
Address Safer CPP warnings in Cocoa API classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=300698">https://bugs.webkit.org/show_bug.cgi?id=300698</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm:
(-[WKContentWorld dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(-[WKFrameInfo _protectedFrameInfo]):
(-[WKFrameInfo dealloc]):
(-[WKFrameInfo webView]):
(-[WKFrameInfo _handle]):
(-[WKFrameInfo _parentFrameHandle]):
(-[WKFrameInfo _title]):
* Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.mm:
(-[WKOpenPanelParameters _acceptedMIMETypes]):
(-[WKOpenPanelParameters _acceptedFileExtensions]):
(-[WKOpenPanelParameters _allowedFileExtensions]):
* Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.mm:
(-[WKScriptMessage dealloc]):
(-[WKScriptMessage webView]):
(-[WKScriptMessage name]):
* Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeTask.mm:
(-[WKURLSchemeTaskImpl _protectedURLSchemeTask]):
(-[WKURLSchemeTaskImpl dealloc]):
(-[WKURLSchemeTaskImpl request]):
(-[WKURLSchemeTaskImpl _requestOnlyIfCached]):
(-[WKURLSchemeTaskImpl _willPerformRedirection:newRequest:completionHandler:]):
(-[WKURLSchemeTaskImpl didReceiveResponse:]):
(-[WKURLSchemeTaskImpl didReceiveData:]):
(-[WKURLSchemeTaskImpl didFinish]):
(-[WKURLSchemeTaskImpl didFailWithError:]):
(-[WKURLSchemeTaskImpl _didPerformRedirection:newRequest:]):

Canonical link: <a href="https://commits.webkit.org/301504@main">https://commits.webkit.org/301504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9381477bfa5c391e1551a6ca44acd163aff57a04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126112 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132922 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77914 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96041 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64141 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76524 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36054 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76395 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106933 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135631 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104554 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53326 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104262 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26586 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49656 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27995 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50264 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52765 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58611 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52093 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55439 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->