### PR TITLE
AX: Pressing the up or down arrow key from the year field of a date input should start from the current year, not zero

### DIFF
--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/up-down-arrow-starts-at-current-year-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/up-down-arrow-starts-at-current-year-expected.txt
@@ -1,0 +1,11 @@
+Tests that pressing the up or down arrow on the year field of a date input starts the value at the current year.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS new Date(input1.value).getFullYear() === currentYear + 1 is true
+PASS new Date(input2.value).getFullYear() === currentYear - 1 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/up-down-arrow-starts-at-current-year.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/up-down-arrow-starts-at-current-year.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/common.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input id="input1" type="datetime-local" />
+<input id="input2" type="datetime-local" />
+
+<script>
+window.jsTestIsAsync = true;
+
+var currentYear = new Date().getFullYear();
+
+addEventListener("load", async () => {
+    description("Tests that pressing the up or down arrow on the year field of a date input starts the value at the current year.");
+
+    const numberOfFieldsInDatetimeLocal = 6;
+    for (let i = 0; i < numberOfFieldsInDatetimeLocal; i++) {
+        UIHelper.keyDown("\t", ["altKey"]);
+        UIHelper.keyDown("upArrow");
+        UIHelper.keyDown("upArrow");
+    }
+    shouldBeTrue("new Date(input1.value).getFullYear() === currentYear + 1");
+
+    for (let i = 0; i < numberOfFieldsInDatetimeLocal; i++) {
+        UIHelper.keyDown("\t", ["altKey"]);
+        UIHelper.keyDown("downArrow");
+        UIHelper.keyDown("downArrow");
+    }
+    shouldBeTrue("new Date(input2.value).getFullYear() === currentYear - 1");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/html/shadow/DateTimeFieldElements.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElements.cpp
@@ -364,4 +364,29 @@ void DateTimeYearFieldElement::setValueAsDate(const DateComponents& date)
     setValueAsInteger(date.fullYear());
 }
 
+static int currentYear()
+{
+    GregorianDateTime date;
+    date.setToCurrentLocalTime();
+    return date.year();
+}
+
+void DateTimeYearFieldElement::stepDown()
+{
+    if (!hasValue()) {
+        setValueAsInteger(currentYear());
+        return;
+    }
+    DateTimeNumericFieldElement::stepDown();
+}
+
+void DateTimeYearFieldElement::stepUp()
+{
+    if (!hasValue()) {
+        setValueAsInteger(currentYear());
+        return;
+    }
+    DateTimeNumericFieldElement::stepUp();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/DateTimeFieldElements.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElements.h
@@ -162,6 +162,9 @@ class DateTimeYearFieldElement final : public DateTimeNumericFieldElement {
 public:
     static Ref<DateTimeYearFieldElement> create(Document&, DateTimeFieldElementFieldOwner&);
 
+    void stepDown() final;
+    void stepUp() final;
+
 private:
     DateTimeYearFieldElement(Document&, DateTimeFieldElementFieldOwner&);
 

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.h
@@ -54,8 +54,8 @@ protected:
     bool hasValue() const final;
     void setEmptyValue(EventBehavior = DispatchNoEvent) final;
     void setValueAsInteger(int, EventBehavior = DispatchNoEvent) final;
-    void stepDown() final;
-    void stepUp() final;
+    void stepDown() override;
+    void stepUp() override;
     int valueAsInteger() const final { return m_hasValue ? m_value : -1; }
     int placeholderValueAsInteger() const final { return m_placeholderValue; }
 


### PR DESCRIPTION
#### 62d1c2262decd1597d5cf498a6448bbbacd8001a
<pre>
AX: Pressing the up or down arrow key from the year field of a date input should start from the current year, not zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=300700">https://bugs.webkit.org/show_bug.cgi?id=300700</a>
<a href="https://rdar.apple.com/162601959">rdar://162601959</a>

Reviewed by Joshua Hoffman and Aditya Keerthi.

Starting from the current year provides a better user experience, as starting from zero as done prior to this commit
means we jump to year 0001 on arrow down, or year 275760 on arrow up, neither of which are likely to be what a user
actually wanted.

Test: fast/forms/datetimelocal/datetimelocal-editable-components/up-down-arrow-starts-at-current-year.html

* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/up-down-arrow-starts-at-current-year-expected.txt: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/up-down-arrow-starts-at-current-year.html: Added.
* Source/WebCore/html/shadow/DateTimeFieldElements.cpp:
(WebCore::currentYear):
(WebCore::DateTimeYearFieldElement::stepDown):
(WebCore::DateTimeYearFieldElement::stepUp):
* Source/WebCore/html/shadow/DateTimeFieldElements.h:
* Source/WebCore/html/shadow/DateTimeNumericFieldElement.h:

Canonical link: <a href="https://commits.webkit.org/301608@main">https://commits.webkit.org/301608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5c6242f6d490c1bd7cc7ca4518f0a5a93bdb067

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133313 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78099 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf058bf1-273c-45e9-afd5-e09659d0f091) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96203 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64289 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d51534e4-e71d-4a70-b6e4-6c7845e2d028) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113035 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76677 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2749758d-c86a-47a7-ad6a-439e8a2c9592) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76597 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107156 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135832 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104697 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53564 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104398 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26650 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49849 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28186 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50490 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53000 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58828 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52305 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55645 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54028 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->