### PR TITLE
[libpas] Build fails with libc implementations that lack execinfo.h

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -43,8 +43,8 @@
 #include <unistd.h>
 #endif
 
-/* PlayStation does not currently support the backtrace API. Android API versions < 33 don't, either. Windows does not either. */
-#if !PAS_PLATFORM(PLAYSTATION) && (!PAS_OS(ANDROID) || __ANDROID_API__ >= 33) && !PAS_OS(WINDOWS)
+/* PlayStation does not currently support the backtrace API. Android API versions < 33 don't, either. Windows does not either. Linux only with GLibc and not uCLibc/Musl. */
+#if (PAS_OS(ANDROID) && __ANDROID_API__ >= 33) || PAS_OS(DARWIN) || (PAS_OS(LINUX) && defined(__GLIBC__) && !defined(__UCLIBC__))
 #include <execinfo.h>
 #else
 size_t backtrace(void** buffer, size_t size)

--- a/Source/bmalloc/libpas/src/test/PGMTests.cpp
+++ b/Source/bmalloc/libpas/src/test/PGMTests.cpp
@@ -43,9 +43,9 @@
 #include "pas_report_crash.h"
 #include "pas_root.h"
 
-#if !PAS_PLATFORM(PLAYSTATION)
+#if (PAS_OS(ANDROID) && __ANDROID_API__ >= 33) || PAS_OS(DARWIN) || (PAS_OS(LINUX) && defined(__GLIBC__) && !defined(__UCLIBC__))
 #include <execinfo.h>
-#endif // !PAS_PLATFORM(PLAYSTATION)
+#endif
 
 using namespace std;
 
@@ -383,8 +383,7 @@ void testPGMMetadataVectorManagementFewDeallocations()
     pas_heap_lock_unlock();
 }
 
-/* Backtrace API is currently not supported on PlayStation. */
-#if !PAS_PLATFORM(PLAYSTATION)
+#if (PAS_OS(ANDROID) && __ANDROID_API__ >= 33) || PAS_OS(DARWIN) || (PAS_OS(LINUX) && defined(__GLIBC__) && !defined(__UCLIBC__))
 void testPGMMetadataDoubleFreeBehavior()
 {
     pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(1);
@@ -583,7 +582,7 @@ void testPGMAllocMetadataOnly()
         CHECK(!dealloc_metadata);
     }
 }
-#endif // !PAS_PLATFORM(PLAYSTATION)
+#endif
 
 } // anonymous namespace
 
@@ -598,9 +597,9 @@ void addPGMTests()
     ADD_TEST(testPGMMetadataVectorManagement());
     ADD_TEST(testPGMMetadataVectorManagementFewDeallocations());
     ADD_TEST(testPGMMetadataVectorManagementRehash());
-#if !PAS_PLATFORM(PLAYSTATION)
+#if (PAS_OS(ANDROID) && __ANDROID_API__ >= 33) || PAS_OS(DARWIN) || (PAS_OS(LINUX) && defined(__GLIBC__) && !defined(__UCLIBC__))
     ADD_TEST(testPGMMetadataDoubleFreeBehavior());
     ADD_TEST(testPGMBmallocAllocationBacktrace());
     ADD_TEST(testPGMAllocMetadataOnly());
-#endif // !PAS_PLATFORM(PLAYSTATION)
+#endif
 }


### PR DESCRIPTION
#### c78f2b76d86c862f49678bf1a7f2c8d98d9963b8
<pre>
[libpas] Build fails with libc implementations that lack execinfo.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=300701">https://bugs.webkit.org/show_bug.cgi?id=300701</a>

Reviewed by Yusuke Suzuki and Michael Catanzaro.

Change guards to use backtrace() and execinfo.h on Linux only when using
glibc as the C library. The PlayStation and Windows cases no longer need
to be matched, as they are neither Linux nor Darwin, both of which are now
explicitly listed. The Android check is kept as it was.

* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
* Source/bmalloc/libpas/src/test/PGMTests.cpp:
(addPGMTests):

Canonical link: <a href="https://commits.webkit.org/301539@main">https://commits.webkit.org/301539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/820e4bb46d7e72ba2b14b15819166919c2e81205

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132983 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77981 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54405 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64203 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31071 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76457 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118279 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135685 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124668 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104589 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53415 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109114 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104345 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26608 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49729 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28066 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50337 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52853 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157714 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52171 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39469 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->