### PR TITLE
Adopt LIFETIME_BOUND for WTF::CheckedPtr

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -110,9 +110,10 @@ public:
 
     ALWAYS_INLINE explicit operator bool() const { return PtrTraits::unwrap(m_ptr); }
 
-    ALWAYS_INLINE T* get() const { return PtrTraits::unwrap(m_ptr); }
-    ALWAYS_INLINE T& operator*() const { RELEASE_ASSERT(m_ptr); return *get(); }
-    ALWAYS_INLINE T* operator->() const { RELEASE_ASSERT(m_ptr); return get(); }
+    ALWAYS_INLINE T* get() const LIFETIME_BOUND { return PtrTraits::unwrap(m_ptr); }
+    ALWAYS_INLINE T* unsafeGet() const { return PtrTraits::unwrap(m_ptr); }
+    ALWAYS_INLINE T& operator*() const LIFETIME_BOUND { RELEASE_ASSERT(m_ptr); return *get(); }
+    ALWAYS_INLINE T* operator->() const LIFETIME_BOUND { RELEASE_ASSERT(m_ptr); return get(); }
 
     CheckedRef<T> releaseNonNull()
     {

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -124,7 +124,7 @@ RenderImage* toSimpleImage(RenderObject& renderer)
         return nullptr;
 #endif // ENABLE(VIDEO)
 
-    return renderImage.get();
+    return renderImage.unsafeGet();
 }
 
 // FIXME: This probably belongs on Element.

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2442,7 +2442,7 @@ static RenderObject* nearestRendererFromNode(Node& node)
     for (RefPtr ancestor = &node; ancestor && !renderer; ancestor = composedParentIgnoringDocumentFragments(*ancestor))
         renderer = ancestor->renderer();
 
-    return renderer.get();
+    return renderer.unsafeGet();
 }
 
 static int zIndexFromRenderer(RenderObject* renderer)

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -473,7 +473,7 @@ const RenderElement* ViewTimeline::stickyContainer() const
     auto scrollerRenderer = sourceScrollerRenderer();
     while (renderer && renderer != scrollerRenderer) {
         if (renderer->isStickilyPositioned())
-            return renderer.get();
+            return renderer.unsafeGet();
         renderer = renderer->containingBlock();
     }
     return nullptr;

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1440,7 +1440,7 @@ RenderText* SimplifiedBackwardsTextIterator::handleFirstLetter(int& startOffset,
     m_offset = firstLetterRenderer->caretMaxOffset();
     m_offset += collapsedSpaceLength(*firstLetterRenderer, m_offset);
 
-    return firstLetterRenderer.get();
+    return firstLetterRenderer.unsafeGet();
 }
 
 bool SimplifiedBackwardsTextIterator::handleReplacedElement()

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -655,7 +655,7 @@ auto VisiblePosition::localCaretRect() const -> LocalCaretRect
     if (!renderer)
         return { };
 
-    return { computeLocalCaretRect(*renderer, boxAndOffset), const_cast<RenderObject*>(renderer.get()) };
+    return { computeLocalCaretRect(*renderer, boxAndOffset), const_cast<RenderObject*>(renderer.unsafeGet()) };
 }
 
 IntRect VisiblePosition::absoluteCaretBounds(bool* insideFixed) const

--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -170,7 +170,7 @@ void AutoscrollController::updateDragAndDrop(Node* dropTargetNode, const IntPoin
         if (offset.isZero())
             return nullptr;
 
-        return scrollable.get();
+        return scrollable.unsafeGet();
     };
     
     CheckedPtr scrollable = findDragAndDropScroller();

--- a/Source/WebCore/platform/ios/PasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PasteboardIOS.mm
@@ -170,7 +170,7 @@ void Pasteboard::read(PasteboardPlainText& text, PlainTextURLReadingPolicy allow
 {
     auto itemIndexToQuery = itemIndex.value_or(0);
 
-    PasteboardStrategy& strategy = *platformStrategies()->pasteboardStrategy();
+    PasteboardStrategy& strategy = *platformStrategies()->pasteboardStrategy().unsafeGet();
 
     if (allowURL == PlainTextURLReadingPolicy::AllowURL) {
         text.text = strategy.readStringFromPasteboard(itemIndexToQuery, UTTypeURL.identifier, m_pasteboardName, context());
@@ -345,7 +345,7 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
         return;
     }
 
-    PasteboardStrategy& strategy = *platformStrategies()->pasteboardStrategy();
+    PasteboardStrategy& strategy = *platformStrategies()->pasteboardStrategy().unsafeGet();
 
     size_t numberOfItems = strategy.getPasteboardItemsCount(m_pasteboardName, context());
 
@@ -410,7 +410,7 @@ bool Pasteboard::respectsUTIFidelities() const
 void Pasteboard::readRespectingUTIFidelities(PasteboardWebContentReader& reader, WebContentReadingPolicy policy, std::optional<size_t> itemIndex)
 {
     ASSERT(respectsUTIFidelities());
-    auto& strategy = *platformStrategies()->pasteboardStrategy();
+    auto& strategy = *platformStrategies()->pasteboardStrategy().unsafeGet();
     for (NSUInteger index = 0, numberOfItems = strategy.getPasteboardItemsCount(m_pasteboardName, context()); index < numberOfItems; ++index) {
         if (itemIndex && index != *itemIndex)
             continue;
@@ -526,7 +526,7 @@ void Pasteboard::clear()
 
 Vector<String> Pasteboard::readPlatformValuesAsStrings(const String& domType, int64_t changeCount, const String& pasteboardName)
 {
-    auto& strategy = *platformStrategies()->pasteboardStrategy();
+    auto& strategy = *platformStrategies()->pasteboardStrategy().unsafeGet();
 
     // Grab the value off the pasteboard corresponding to the cocoaType.
     auto cocoaType = cocoaTypeFromHTMLClipboardType(domType);
@@ -590,7 +590,7 @@ void Pasteboard::writeString(const String& type, const String& data)
 Vector<String> Pasteboard::readFilePaths()
 {
     Vector<String> filePaths;
-    auto& strategy = *platformStrategies()->pasteboardStrategy();
+    auto& strategy = *platformStrategies()->pasteboardStrategy().unsafeGet();
     for (NSUInteger index = 0, numberOfItems = strategy.getPasteboardItemsCount(m_pasteboardName, context()); index < numberOfItems; ++index) {
         // Currently, drag and drop is the only case on iOS where the "pasteboard" may contain file paths.
         auto info = strategy.informationForItemAtIndex(index, m_pasteboardName, m_changeCount, context());

--- a/Source/WebCore/rendering/LayoutRepainter.cpp
+++ b/Source/WebCore/rendering/LayoutRepainter.cpp
@@ -40,7 +40,7 @@ LayoutRepainter::LayoutRepainter(RenderElement& renderer, std::optional<CheckFor
     if (!m_checkForRepaint)
         return;
 
-    m_repaintContainer = m_renderer->containerForRepaint().renderer.get();
+    m_repaintContainer = m_renderer->containerForRepaint().renderer.unsafeGet();
     m_oldRects = m_renderer->rectsForRepaintingAfterLayout(m_repaintContainer, m_repaintOutlineBounds);
 }
 

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -788,7 +788,7 @@ inline RenderBox* RenderBox::parentBox() const
 inline RenderBox* RenderBox::firstChildBox() const
 {
     if (CheckedPtr box = dynamicDowncast<RenderBox>(firstChild()))
-        return box.get();
+        return box.unsafeGet();
 
     ASSERT(!firstChild());
     return nullptr;
@@ -802,7 +802,7 @@ inline RenderBox* RenderBox::firstInFlowChildBox() const
 inline RenderBox* RenderBox::lastChildBox() const
 {
     if (CheckedPtr box = dynamicDowncast<RenderBox>(lastChild()))
-        return box.get();
+        return box.unsafeGet();
 
     ASSERT(!lastChild());
     return nullptr;
@@ -816,7 +816,7 @@ inline RenderBox* RenderBox::lastInFlowChildBox() const
 inline RenderBox* RenderBox::previousSiblingBox() const
 {
     if (CheckedPtr box = dynamicDowncast<RenderBox>(previousSibling()))
-        return box.get();
+        return box.unsafeGet();
 
     ASSERT(!previousSibling());
     return nullptr;
@@ -826,7 +826,7 @@ inline RenderBox* RenderBox::previousInFlowSiblingBox() const
 {
     for (CheckedPtr curr = previousSiblingBox(); curr; curr = curr->previousSiblingBox()) {
         if (!curr->isFloatingOrOutOfFlowPositioned())
-            return curr.get();
+            return curr.unsafeGet();
     }
     return nullptr;
 }
@@ -834,7 +834,7 @@ inline RenderBox* RenderBox::previousInFlowSiblingBox() const
 inline RenderBox* RenderBox::nextSiblingBox() const
 {
     if (CheckedPtr box = dynamicDowncast<RenderBox>(nextSibling()))
-        return box.get();
+        return box.unsafeGet();
 
     ASSERT(!nextSibling());
     return nullptr;
@@ -844,7 +844,7 @@ inline RenderBox* RenderBox::nextInFlowSiblingBox() const
 {
     for (CheckedPtr curr = nextSiblingBox(); curr; curr = curr->nextSiblingBox()) {
         if (!curr->isFloatingOrOutOfFlowPositioned())
-            return curr.get();
+            return curr.unsafeGet();
     }
     return nullptr;
 }

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -1047,7 +1047,7 @@ static RenderBlockFlow* blockContainerForLastFormattedLine(const RenderBlock& en
         if (auto* descendantRoot = blockContainerForLastFormattedLine(*blockContainer))
             return descendantRoot;
         if (CheckedPtr blockFlow = dynamicDowncast<RenderBlockFlow>(blockContainer.get()); blockFlow && blockFlow->hasLines())
-            return blockFlow.get();
+            return blockFlow.unsafeGet();
     }
     return { };
 }

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2258,7 +2258,7 @@ const RenderElement* RenderElement::pushMappingToContainer(const RenderLayerMode
 
     geometryMap.push(this, offset, false);
 
-    return container.get();
+    return container.unsafeGet();
 }
 
 RenderBoxModelObject* RenderElement::offsetParent() const

--- a/Source/WebCore/rendering/RenderFragmentContainer.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainer.cpp
@@ -443,7 +443,7 @@ RenderOverflow* RenderFragmentContainer::overflowForBox(const RenderBox& box) co
         return { };
 
     if (CheckedPtr overflow = boxInfo->overflow())
-        return overflow.get();
+        return overflow.unsafeGet();
 
     boxInfo->createOverflow(computedLayoutOverflowRectForBox(box), computedVisualOverflowRectForBox(box));
     return boxInfo->overflow();

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -821,7 +821,7 @@ void RenderFragmentedFlow::mapLocalToContainer(const RenderLayerModelObject* anc
 
         // If the repaint container is nullptr, we have to climb up to the RenderView, otherwise swap
         // it with the fragment's repaint container.
-        ancestorContainer = ancestorContainer ? fragment->containerForRepaint().renderer.get() : nullptr;
+        ancestorContainer = ancestorContainer ? fragment->containerForRepaint().renderer.unsafeGet() : nullptr;
 
         if (RenderFragmentedFlow* fragmentFragmentedFlow = fragment->enclosingFragmentedFlow()) {
             RenderFragmentContainer* startFragment = nullptr;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -437,7 +437,7 @@ RenderObject* RenderObject::traverseNext(const RenderObject* stayWithin, HeightT
             if (overflowType == OverflowHeight)
                 newFixedDepth = currentDepth;
             ASSERT(!stayWithin || child->isDescendantOf(stayWithin));
-            return child.get();
+            return child.unsafeGet();
         }
     }
 
@@ -460,7 +460,7 @@ RenderObject* RenderObject::traverseNext(const RenderObject* stayWithin, HeightT
                 if (overflowType == OverflowHeight)
                     newFixedDepth = currentDepth;
                 ASSERT(!stayWithin || !n->nextSibling() || n->nextSibling()->isDescendantOf(stayWithin));
-                return sibling.get();
+                return sibling.unsafeGet();
             }
         }
         if (!stayWithin || n->parent() != stayWithin) {
@@ -642,7 +642,7 @@ RenderElement* RenderObject::markContainingBlocksForLayout(RenderElement* layout
             if (ancestor == layoutRoot)
                 return layoutRoot;
         } else if (isLayoutBoundary(*ancestor))
-            return ancestor.get();
+            return ancestor.unsafeGet();
 
         if (auto* renderGrid = dynamicDowncast<RenderGrid>(container.get()); renderGrid && renderGrid->isExtrinsicallySized())
             simplifiedNormalFlowLayout = true;
@@ -1710,7 +1710,7 @@ static inline RenderElement* containerForElement(const RenderObject& renderer, c
             if (repaintContainerSkipped && repaintContainer == parent)
                 *repaintContainerSkipped = true;
         }
-        return parent.get();
+        return parent.unsafeGet();
     }
     for (; parent && !parent->canContainFixedPositionObjects(); parent = parent->parent()) {
         if (isInTopLayerOrBackdrop(parent->style(), parent->element())) {
@@ -1720,7 +1720,7 @@ static inline RenderElement* containerForElement(const RenderObject& renderer, c
         if (repaintContainerSkipped && repaintContainer == parent)
             *repaintContainerSkipped = true;
     }
-    return parent.get();
+    return parent.unsafeGet();
 }
 
 RenderElement* RenderObject::container() const

--- a/Source/WebCore/rendering/RenderSelectionGeometry.cpp
+++ b/Source/WebCore/rendering/RenderSelectionGeometry.cpp
@@ -38,7 +38,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderBlockSelectionGeometry);
 
 RenderSelectionGeometryBase::RenderSelectionGeometryBase(RenderObject& renderer)
     : m_renderer(renderer)
-    , m_repaintContainer(renderer.containerForRepaint().renderer.get())
+    , m_repaintContainer(renderer.containerForRepaint().renderer.unsafeGet())
     , m_state(renderer.selectionState())
 {
 }

--- a/Source/WebCore/rendering/TextBoxTrimmer.cpp
+++ b/Source/WebCore/rendering/TextBoxTrimmer.cpp
@@ -72,7 +72,7 @@ static inline RenderBlockFlow* firstFormattedLineRoot(const RenderBlockFlow& enc
         if (!blockContainer || blockContainer->createsNewFormattingContext())
             continue;
         if (blockContainer->hasLines())
-            return blockContainer.get();
+            return blockContainer.unsafeGet();
         if (auto* descendantRoot = firstFormattedLineRoot(*blockContainer))
             return descendantRoot;
         if (!shouldIgnoreAsFirstLastFormattedLineContainer(*blockContainer))
@@ -88,7 +88,7 @@ static RenderBlockFlow* lastFormattedLineRoot(const RenderBlockFlow& enclosingBl
         if (!blockContainer || blockContainer->createsNewFormattingContext())
             continue;
         if (blockContainer->hasLines())
-            return blockContainer.get();
+            return blockContainer.unsafeGet();
         if (auto* descendantRoot = lastFormattedLineRoot(*blockContainer))
             return descendantRoot;
         if (!shouldIgnoreAsFirstLastFormattedLineContainer(*blockContainer))

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -115,7 +115,7 @@ const RenderElement* RenderSVGModelObject::pushMappingToContainer(const RenderLa
     ASSERT_UNUSED(ancestorSkipped, !ancestorSkipped);
 
     pushOntoGeometryMap(geometryMap, ancestorToStopAt, container.get(), ancestorSkipped);
-    return container.get();
+    return container.unsafeGet();
 }
 
 LayoutRect RenderSVGModelObject::outlineBoundsForRepaint(const RenderLayerModelObject* repaintContainer, const RenderGeometryMap* geometryMap) const

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -202,7 +202,7 @@ static inline LegacyRenderSVGResourceContainer* paintingResourceFromSVGPaint(Tre
     if (resourceType != PatternResourceType && resourceType != LinearGradientResourceType && resourceType != RadialGradientResourceType)
         return nullptr;
 
-    return container.get();
+    return container.unsafeGet();
 }
 
 std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderElement& renderer, const RenderStyle& style)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -70,15 +70,15 @@ RenderBoxModelObject& RenderTreeBuilder::Inline::parentCandidateInContinuation(R
     CheckedPtr current = nextContinuation(&parent);
     while (current) {
         if (beforeChild && beforeChild->parent() == current)
-            return current->firstChild() == beforeChild ? *previous : *current;
+            return current->firstChild() == beforeChild ? *previous.unsafeGet() : *current.unsafeGet();
         auto next = nextContinuation(current.get());
         if (!next)
-            return !beforeChild && !current->firstChild() ? *previous : *current;
+            return !beforeChild && !current->firstChild() ? *previous.unsafeGet() : *current.unsafeGet();
         previous = current;
         current = next;
     }
     ASSERT_NOT_REACHED();
-    return *previous;
+    return *previous.unsafeGet();
 }
 
 static RenderPtr<RenderInline> cloneAsContinuation(RenderInline& renderer)

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -153,7 +153,7 @@ RenderElement* Styleable::renderer() const
 
         // Return early if we're looking for ::view-transition-group().
         if (pseudoElementIdentifier->pseudoId == PseudoId::ViewTransitionGroup)
-            return correctGroup.get();
+            return correctGroup.unsafeGet();
 
         // Go through all descendants until we find the relevant pseudo element otherwise.
         for (auto& descendant : descendantsOfType<RenderBox>(*correctGroup)) {

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
@@ -60,7 +60,7 @@ using namespace WebCore;
 
 WebResourceLoadScheduler& webResourceLoadScheduler()
 {
-    return static_cast<WebResourceLoadScheduler&>(*platformStrategies()->loaderStrategy());
+    return static_cast<WebResourceLoadScheduler&>(*platformStrategies()->loaderStrategy().unsafeGet());
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebResourceLoadScheduler);


### PR DESCRIPTION
#### 76deffade372bd76dc9d3e2223b98aad0b4b78db
<pre>
Adopt LIFETIME_BOUND for WTF::CheckedPtr
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=300705">https://bugs.webkit.org/show_bug.cgi?id=300705</a>&gt;
&lt;<a href="https://rdar.apple.com/162605637">rdar://162605637</a>&gt;

Reviewed by Geoffrey Garen.

Introduce CheckedPtr::unsafeGet() for pre-existing unsafe uses of
CheckedPtr::get().

* Source/WTF/wtf/CheckedPtr.h:
(WTF::CheckedPtr::get const):
(WTF::CheckedPtr::unsafeGet const): Add.
(WTF::CheckedPtr::operator* const):
(WTF::CheckedPtr::operator-&gt; const):

* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::toSimpleImage):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::nearestRendererFromNode):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::stickyContainer const):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::SimplifiedBackwardsTextIterator::handleFirstLetter):
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::VisiblePosition::localCaretRect const):
* Source/WebCore/page/AutoscrollController.cpp:
(WebCore::AutoscrollController::updateDragAndDrop):
* Source/WebCore/platform/ios/PasteboardIOS.mm:
(WebCore::Pasteboard::read):
(WebCore::Pasteboard::readRespectingUTIFidelities):
(WebCore::Pasteboard::readPlatformValuesAsStrings):
(WebCore::Pasteboard::readFilePaths):
* Source/WebCore/rendering/LayoutRepainter.cpp:
(WebCore::LayoutRepainter::LayoutRepainter):
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::firstChildBox const):
(WebCore::RenderBox::lastChildBox const):
(WebCore::RenderBox::previousSiblingBox const):
(WebCore::RenderBox::previousInFlowSiblingBox const):
(WebCore::RenderBox::nextSiblingBox const):
(WebCore::RenderBox::nextInFlowSiblingBox const):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::blockContainerForLastFormattedLine):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::pushMappingToContainer const):
* Source/WebCore/rendering/RenderFragmentContainer.cpp:
(WebCore::RenderFragmentContainer::overflowForBox const):
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::mapLocalToContainer const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::traverseNext const):
(WebCore::RenderObject::markContainingBlocksForLayout):
(WebCore::containerForElement):
* Source/WebCore/rendering/RenderSelectionGeometry.cpp:
(WebCore::RenderSelectionGeometryBase::RenderSelectionGeometryBase):
* Source/WebCore/rendering/TextBoxTrimmer.cpp:
(WebCore::firstFormattedLineRoot):
(WebCore::lastFormattedLineRoot):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::pushMappingToContainer const):
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::paintingResourceFromSVGPaint):
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::RenderTreeBuilder::Inline::parentCandidateInContinuation):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::renderer const):

* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp:
(webResourceLoadScheduler):

Canonical link: <a href="https://commits.webkit.org/301492@main">https://commits.webkit.org/301492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec3e3307bc5d68e9b7aec5922a160c767b66bf1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126125 "38 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132934 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77927 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89573385-1141-47a5-8db6-525202430d42) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54323 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64157 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2957adc1-0ba3-48ed-87d4-3b1f0352e8e8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76537 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3a010fd-2764-46ce-b8f2-49645e13e0e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31005 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76407 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118210 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135642 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124598 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40614 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109037 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49669 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28010 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50277 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19729 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52778 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58613 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157641 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52106 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39455 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55452 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->