### PR TITLE
[webkitapipy] Add allowlist escape hatch for declarations that may be dead-stripped

### DIFF
--- a/Source/JavaScriptCore/Configurations/AllowedSPI-legacy.toml
+++ b/Source/JavaScriptCore/Configurations/AllowedSPI-legacy.toml
@@ -31,8 +31,7 @@ symbols = [
 
 [[legacy]]
 symbols = ["dyld_get_program_sdk_version"]
-requires = ["!USE_APPLE_INTERNAL_SDK"]
+# In internal builds, usage may be dead-stripped depending on WebKitAdditions
+# code in RuntimeApplicationChecks.
+allow-unused = true
 
-[[legacy]]
-symbols = ["dyld_get_program_sdk_version"]
-requires = ["!NDEBUG"]

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/allow.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/allow.py
@@ -51,6 +51,7 @@ class AllowedSPI:
     selectors: list[Selector]
     classes: list[str]
     requires: list[str] = field(default_factory=list)
+    allow_unused: bool = False
 
     class Selector(NamedTuple):
         name: str
@@ -108,8 +109,10 @@ class AllowList:
 
                 bugs = AllowedSPI.Bugs(entry.pop('request', None),
                                        entry.pop('cleanup', None))
+                allow_unused = bool(entry.pop('allow-unused', False))
                 allow = AllowedSPI(reason=reason, bugs=bugs, symbols=syms,
-                                   selectors=sels, classes=clss, requires=reqs)
+                                   selectors=sels, classes=clss, requires=reqs,
+                                   allow_unused=allow_unused)
 
                 if reason == AllowedReason.TEMPORARY_USAGE:
                     if not bugs.cleanup:

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
@@ -59,6 +59,15 @@ A = AllowList.from_dict({'temporary-usage': [
 ]})
 A_File = Path('/allowed.toml')
 A_Hash = 23456
+A_ExplicitlyAllowUnused = AllowList.from_dict({'temporary-usage': [
+    {'request': 'rdar://12345',
+     'cleanup': 'rdar://12346',
+     'classes': ['WKDoesntExist'],
+     'selectors': [{'name': 'initWithData:', 'class': '?'}],
+     'symbols': ['WKDoesntExistLibraryVersion'],
+     'allow-unused': True}
+]})
+
 A_UnusedAllow = UnusedAllowedName(name='WKDoesntExist', file=A_File,
                                   kind=OBJC_CLS)
 A_AllowedAPI = UnnecessaryAllowedName(name='WKDoesntExist', file=A_File,
@@ -274,6 +283,15 @@ class TestSDKDB(TestCase):
 
     def test_audit_unused_allow_from_loaded_allowlist(self):
         self.add_allowlist()
+        self.assertIn(A_UnusedAllow, self.sdkdb.audit())
+
+    def test_audit_no_unused_when_explicitly_allowed(self):
+        self.add_allowlist(A_ExplicitlyAllowUnused)
+        self.assertNotIn(A_UnusedAllow, self.sdkdb.audit())
+
+    def test_audit_unused_allow_from_conflicting_allow_unused_keys(self):
+        self.add_allowlist()
+        self.add_allowlist(A_ExplicitlyAllowUnused)
         self.assertIn(A_UnusedAllow, self.sdkdb.audit())
 
     def test_audit_no_unused_allow_from_unloaded_allowlist(self):


### PR DESCRIPTION
#### 85036d0b733804971a7d2206118ee45d2e1a8054
<pre>
[webkitapipy] Add allowlist escape hatch for declarations that may be dead-stripped
<a href="https://bugs.webkit.org/show_bug.cgi?id=300717">https://bugs.webkit.org/show_bug.cgi?id=300717</a>
<a href="https://rdar.apple.com/162153981">rdar://162153981</a>

Reviewed by Sam Sneddon.

Some SPI usage (such as dyld_program_sdk_at_least in
RuntimeApplicationChecksCocoa.mm) may be stripped out by the linker
depending on some relatively complex program analysis relating to
underlying OS headers. There isn&apos;t a good `requires` clause that we
could write to only activate the allowlist entry when it is needed.

For this and future cases, add an optional `allow-unused` field to the
allowlist format. Entries with this key will not emit an
UnusedAllowedName diagnostic when they are detected.

We still want the default audit-spi behavior to enforce cleaning up old
allowlist entries, and restricting them with requirements, to better
document when allowed SPI is actually in use.

* Source/JavaScriptCore/Configurations/AllowedSPI-legacy.toml:
* Tools/Scripts/libraries/webkitapipy/webkitapipy/allow.py:
(AllowedSPI):
(AllowList.from_dict):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py:
(SDKDB._initialize_db):
(SDKDB.InsertionKind.statement):
(SDKDB._add_allowlist):
(SDKDB.audit):
(SDKDB._add_symbol):
(SDKDB._add_objc_class):
(SDKDB._add_objc_selector):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py:
(TestSDKDB.test_audit_no_unused_when_explicitly_allowed):
(TestSDKDB):
(TestSDKDB.test_audit_no_unused_from_multiple_allowlists):

Canonical link: <a href="https://commits.webkit.org/301508@main">https://commits.webkit.org/301508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/918d8c38920a928850514836eb2242753258d52c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77953 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90a46db0-9a84-46f0-b21a-ab522e719b82) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54353 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd5a0549-a45e-4101-82c9-a09aad21d9eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112851 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/366b8f28-c1e3-459c-84a5-7888e2aebfc1) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/125509 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31033 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76431 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118238 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135665 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124626 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40639 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109069 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26588 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49694 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28036 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50306 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52807 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58641 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157672 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52135 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39464 "Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-slow-memory (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55480 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53845 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->