### PR TITLE
Safari Technology Preview 226 breaks espn.com title bar

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/html.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/html.idl
@@ -1817,7 +1817,7 @@ interface Window : EventTarget {
   attribute DOMString name;
   [PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
   readonly attribute History history;
-  readonly attribute Navigation navigation;
+  [Replaceable] readonly attribute Navigation navigation;
   readonly attribute CustomElementRegistry customElements;
   [Replaceable] readonly attribute BarProp locationbar;
   [Replaceable] readonly attribute BarProp menubar;

--- a/LayoutTests/navigation-api/navigation-object-is-replaceable-expected.txt
+++ b/LayoutTests/navigation-api/navigation-object-is-replaceable-expected.txt
@@ -1,0 +1,11 @@
+This tests that the Navigation object is replaceable
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS navigation is not "foo"
+PASS navigation is "foo"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-object-is-replaceable.html
+++ b/LayoutTests/navigation-api/navigation-object-is-replaceable.html
@@ -1,0 +1,12 @@
+<script src="../resources/js-test.js"></script>
+
+<script>
+description("This tests that the Navigation object is replaceable");
+
+window.onload = () => {
+    shouldNotBe("navigation", "\"foo\"");
+    navigation = "foo";
+    shouldBe("navigation", "\"foo\"");
+}
+
+</script>

--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -66,7 +66,7 @@
     [LegacyUnforgeable] readonly attribute Document document;
     attribute [AtomString] DOMString name;
     readonly attribute History history;
-    [EnabledBySetting=NavigationAPIEnabled] readonly attribute Navigation navigation;
+    [EnabledBySetting=NavigationAPIEnabled, Replaceable] readonly attribute Navigation navigation;
     [ImplementedAs=ensureCustomElementRegistry] readonly attribute CustomElementRegistry customElements;
     [Replaceable] readonly attribute BarProp locationbar;
     [Replaceable] readonly attribute BarProp menubar;


### PR DESCRIPTION
#### ae143edf7fbed31bd11942eabc075be75ad98f72
<pre>
Safari Technology Preview 226 breaks espn.com title bar
<a href="https://bugs.webkit.org/show_bug.cgi?id=297721">https://bugs.webkit.org/show_bug.cgi?id=297721</a>
<a href="https://rdar.apple.com/158951219">rdar://158951219</a>

Reviewed by Chris Dumez and Anne van Kesteren.

With the Navigation API enabled, the ESPN title bar is empty instead of
containing the tab buttons like it should.

The issue is that espn.com re-assigns the &quot;navigation&quot; variable to hold
these items in this function:

preRender: function(type, navCached, defaultNavData) {
    ...
    navigation = defaultNavData.navigation
    ...
    espn_ui.Helpers.nav.items = navigation.items
    ...
}

But with the Navigation API enabled, the &quot;navigation&quot; variable is reserved
for accessing that API and is not replaceable. So this re-assignment fails
and the title bar ends up empty.

The spec does not say that &quot;navigation&quot; should be replaceable. But this is
breaking a live site and Chrome does allow it to be replaceable, so we fix this
by making it replaceable in WebKit too. I have confirmed that this does fix
the ESPN title bar locally.

Associated spec issue: <a href="https://github.com/whatwg/html/pull/11786">https://github.com/whatwg/html/pull/11786</a>

I&apos;ve added a new layout test to check this:
navigation-api/navigation-object-is-replaceable.html

* LayoutTests/imported/w3c/web-platform-tests/interfaces/html.idl:
* LayoutTests/imported/w3c/web-platform-tests/interfaces/html.idl:
* LayoutTests/navigation-api/navigation-object-is-replaceable-expected.txt: Added.
* LayoutTests/navigation-api/navigation-object-is-replaceable.html: Added.
* Source/WebCore/page/DOMWindow.idl:

Canonical link: <a href="https://commits.webkit.org/301607@main">https://commits.webkit.org/301607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4107f16fdb11a2eec6da49efa413d3539eeddd40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78142 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4a91c6a-9eee-4dda-a9c3-8282f5f360e0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54635 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96231 "Failed to checkout and rebase branch from PR 52313") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec6f256f-37bc-4c54-8bbd-62920073db0a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113084 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76704 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21534d7f-16ba-47ab-b298-f431c756af88) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36281 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31261 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76660 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135890 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40860 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104732 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53629 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104432 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49906 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28234 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50552 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19784 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53066 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58883 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52357 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55692 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->