### PR TITLE
Ask for testcase to be attached on WebKit Bugzilla

### DIFF
--- a/Websites/bugs.webkit.org/template/en/custom/bug/create/create.html.tmpl
+++ b/Websites/bugs.webkit.org/template/en/custom/bug/create/create.html.tmpl
@@ -154,8 +154,11 @@ TUI_hide_default('attachment_text_field');
     </div>
     [% END %]
     
-    <p><em>Note: If you are reporting an intermittent issue that WebKit developers may not be able to easily reproduce, please also file a <a href="https://feedbackassistant.apple.com">Feedback Assistant</a> report to <a href="https://developer.apple.com/bug-reporting/profiles-and-logs/?name=sysdiagnose">include a sysdiagnose</a>.</em></p>
-
+    <ul>
+      <li>Please add testcases as an attachment or quote problematic code in the bug report even when providing a link for convenience to guarantee WebKit engineers can review buggy behavior, as linked pages can change or be unavailable later.</li>
+      <li>If you are reporting an intermittent issue that WebKit developers may not be able to easily reproduce, please also file a <a href="https://feedbackassistant.apple.com">Feedback Assistant</a> report to <a href="https://developer.apple.com/bug-reporting/profiles-and-logs/?name=sysdiagnose">include a sysdiagnose</a>.</li>
+    </ul>
+    
     <p><input type="submit" id="submitbug" value="Submit [% terms.Bug %]"></p>
 </section>
 


### PR DESCRIPTION
#### 338c064cd2dd6f9212b67530ff4c62d359c2ff4e
<pre>
Ask for testcase to be attached on WebKit Bugzilla
<a href="https://bugs.webkit.org/show_bug.cgi?id=298033">https://bugs.webkit.org/show_bug.cgi?id=298033</a>
rdar://159850044
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/338c064cd2dd6f9212b67530ff4c62d359c2ff4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78493 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fa7ecb1b-d659-4171-b0b0-3e44c6ca20f2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96573 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64581 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7b44425f-cc1c-4450-b024-c7ba22df2f0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77087 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b5669e39-5fd9-4463-8d42-8292b0f6d314) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36608 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77303 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136434 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105086 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104781 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50291 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28635 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51047 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53499 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52745 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56079 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54499 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->