### PR TITLE
[TestWebKitAPI] Fix simulated 0x08fd4dbfade2dead crash logs running DatabaseTracker tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/DatabaseTrackerTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/DatabaseTrackerTest.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -130,6 +130,7 @@ TEST(DatabaseTracker, DeleteOrigin)
     EXPECT_FALSE(FileSystem::fileExists(originPath));
 #endif
 
+    databaseTracker = nullptr;
     removeDirectoryAndAllContents(databaseDirectoryPath);
     EXPECT_FALSE(FileSystem::fileExists(databaseDirectoryPath));
 }
@@ -163,6 +164,7 @@ TEST(DatabaseTracker, DeleteOriginWhenDatabaseDoesNotExist)
     EXPECT_TRUE(databaseTracker->origins().isEmpty());
     EXPECT_TRUE(databaseTracker->databaseNames(origin).isEmpty());
 
+    databaseTracker = nullptr;
     removeDirectoryAndAllContents(databaseDirectoryPath);
     EXPECT_FALSE(FileSystem::fileExists(databaseDirectoryPath));
 }
@@ -220,6 +222,7 @@ TEST(DatabaseTracker, DeleteOriginWhenDeletingADatabaseFails)
     EXPECT_TRUE(FileSystem::deleteFile(fullWebDatabasePath));
     EXPECT_TRUE(FileSystem::deleteEmptyDirectory(originPath));
 
+    databaseTracker = nullptr;
     removeDirectoryAndAllContents(databaseDirectoryPath);
     EXPECT_FALSE(FileSystem::fileExists(databaseDirectoryPath));
 }
@@ -259,6 +262,7 @@ TEST(DatabaseTracker, DeleteOriginWithMissingEntryInDatabasesTable)
     EXPECT_TRUE(databaseTracker->origins().isEmpty());
     EXPECT_TRUE(databaseTracker->databaseNames(origin).isEmpty());
 
+    databaseTracker = nullptr;
     removeDirectoryAndAllContents(databaseDirectoryPath);
     EXPECT_FALSE(FileSystem::fileExists(databaseDirectoryPath));
 }
@@ -302,6 +306,8 @@ TEST(DatabaseTracker, DeleteDatabase)
 
     EXPECT_EQ((unsigned)1, databaseTracker->origins().size());
     EXPECT_TRUE(FileSystem::deleteEmptyDirectory(originPath));
+
+    databaseTracker = nullptr;
     removeDirectoryAndAllContents(databaseDirectoryPath);
     EXPECT_FALSE(FileSystem::fileExists(databaseDirectoryPath));
 }
@@ -332,6 +338,7 @@ TEST(DatabaseTracker, DeleteDatabaseWhenDatabaseDoesNotExist)
     EXPECT_TRUE(databaseTracker->deleteDatabase(origin, webDatabaseName));
     EXPECT_TRUE(databaseTracker->databaseNames(origin).isEmpty());
 
+    databaseTracker = nullptr;
     removeDirectoryAndAllContents(databaseDirectoryPath);
     EXPECT_FALSE(FileSystem::fileExists(databaseDirectoryPath));
 }


### PR DESCRIPTION
#### 32d23a023c4fd84f6db0cc8c796537c19f009dad
<pre>
[TestWebKitAPI] Fix simulated 0x08fd4dbfade2dead crash logs running DatabaseTracker tests
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=300720">https://bugs.webkit.org/show_bug.cgi?id=300720</a>&gt;
&lt;<a href="https://rdar.apple.com/46857255">rdar://46857255</a>&gt;

Reviewed by Sihui Liu.

Close the SQLite database before deleting database files on disk to fix
the simulated crashes.

* Tools/TestWebKitAPI/Tests/WebCore/cocoa/DatabaseTrackerTest.mm:
(TestWebKitAPI::TEST(DatabaseTracker, DeleteOrigin)):
(TestWebKitAPI::TEST(DatabaseTracker, DeleteOriginWhenDatabaseDoesNotExist)):
(TestWebKitAPI::TEST(DatabaseTracker, DeleteOriginWhenDeletingADatabaseFails)):
(TestWebKitAPI::TEST(DatabaseTracker, DeleteOriginWithMissingEntryInDatabasesTable)):
(TestWebKitAPI::TEST(DatabaseTracker, DeleteDatabase)):
(TestWebKitAPI::TEST(DatabaseTracker, DeleteDatabaseWhenDatabaseDoesNotExist)):

Canonical link: <a href="https://commits.webkit.org/301592@main">https://commits.webkit.org/301592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d209e645764b8aec0c495d87fd9fc076908782bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77959 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/966c2f0d-2f36-4631-81e4-2262ea5c551e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96068 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64188 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c72bc84e-e326-403e-a32d-ea83251d66e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76552 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb6c68f6-bc01-40b7-812f-5b7e433edfe6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31040 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76436 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135671 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104576 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109078 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104282 "Found 2 new API test failures: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/itp, WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49705 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50314 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19776 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52816 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52148 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55495 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53863 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->