### PR TITLE
Web Inspector: REGRESSION(300338@main) Sources: Breakpoints don't work

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -381,6 +381,12 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
     dataForTarget(target)
     {
+        console.assert(target.hasDomain("Debugger"), `Target of type "${target.type}" does not have "Debugger" domain.`);
+
+        // FIXME <https://webkit.org/b/298909> Add Debugger support for frame targets.
+        if (!target.hasDomain("Debugger"))
+            return null;
+
         let targetData = this._targetDebuggerDataMap.get(target);
         if (targetData)
             return targetData;

--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
@@ -292,7 +292,7 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
                     propertyNames.push(savedResultAlias + "_");
 
                 let target = WI.runtimeManager.activeExecutionContext.target;
-                let targetData = WI.debuggerManager.paused ? WI.debuggerManager.dataForTarget(target) : {};
+                let targetData = (WI.debuggerManager.paused && WI.debuggerManager.dataForTarget(target)) || {};
 
                 function shouldExposeEvent() {
                     switch (completionController.mode) {

--- a/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js
+++ b/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js
@@ -195,8 +195,11 @@ WI.OpenResourceDialog = class OpenResourceDialog extends WI.Dialog
         this._addScriptsForTarget(WI.mainTarget);
 
         for (let target of WI.targets) {
-            if (target !== WI.mainTarget)
-                this._addResourcesForTarget(target);
+            if (target !== WI.mainTarget) {
+                // FIXME <https://webkit.org/b/298909> Add Debugger support for frame targets.
+                if (!(target instanceof WI.FrameTarget))
+                    this._addResourcesForTarget(target);
+            }
         }
 
         this._addLocalResourceOverrides();
@@ -339,6 +342,10 @@ WI.OpenResourceDialog = class OpenResourceDialog extends WI.Dialog
 
     _addResource(resource, suppressFilterUpdate)
     {
+        // FIXME <https://webkit.org/b/298909> Remove this null-check after implementing the Debugger domain for frame targets.
+        if (!resource)
+            return;
+
         if (!this.representedObjectIsValid(resource))
             return;
 
@@ -396,7 +403,7 @@ WI.OpenResourceDialog = class OpenResourceDialog extends WI.Dialog
         const suppressFilterUpdate = true;
 
         let targetData = WI.debuggerManager.dataForTarget(target);
-        for (let script of targetData.scripts) {
+        for (let script of targetData?.scripts || []) {
             if (script.anonymous || script.resource || script.dynamicallyAddedScriptElement)
                 continue;
             if (!WI.settings.debugShowConsoleEvaluations.value && isWebInspectorConsoleEvaluationScript(script.sourceURL))

--- a/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
@@ -814,7 +814,7 @@ WI.SourceCodeTextEditor = class SourceCodeTextEditor extends WI.TextEditor
     _addThreadIndicatorForTarget(target)
     {
         let targetData = WI.debuggerManager.dataForTarget(target);
-        let topCallFrame = targetData.stackTrace?.callFrames[0];
+        let topCallFrame = targetData?.stackTrace?.callFrames[0];
         if (!topCallFrame)
             return;
 

--- a/Source/WebInspectorUI/UserInterface/Views/ThreadTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ThreadTreeElement.js
@@ -46,6 +46,10 @@ WI.ThreadTreeElement = class ThreadTreeElement extends WI.GeneralTreeElement
 
         let targetData = WI.debuggerManager.dataForTarget(this._target);
 
+        // FIXME <https://webkit.org/b/298909> Remove this null-check after implementing the Debugger domain for frame targets.
+        if (!targetData)
+            return;
+
         if (targetData.pausing || !targetData.stackTrace?.callFrames.length) {
             this.appendChild(this._idleTreeElement);
             this.expand();
@@ -74,10 +78,10 @@ WI.ThreadTreeElement = class ThreadTreeElement extends WI.GeneralTreeElement
     populateContextMenu(contextMenu, event)
     {
         let targetData = WI.debuggerManager.dataForTarget(this._target);
-
-        contextMenu.appendItem(WI.UIString("Resume Thread"), () => {
-            WI.debuggerManager.continueUntilNextRunLoop(this._target);
-        }, !targetData.paused);
+        if (targetData)
+            contextMenu.appendItem(WI.UIString("Resume Thread"), () => {
+                WI.debuggerManager.continueUntilNextRunLoop(this._target);
+            }, !targetData.paused);
 
         super.populateContextMenu(contextMenu, event);
     }
@@ -92,7 +96,7 @@ WI.ThreadTreeElement = class ThreadTreeElement extends WI.GeneralTreeElement
             return;
 
         let targetData = WI.debuggerManager.dataForTarget(this._target);
-        if (!targetData.paused)
+        if (!targetData?.paused)
             return;
 
         if (!this._statusButton) {


### PR DESCRIPTION
#### 8da8436c7a4aa33549884da99ba026fc982064e7
<pre>
Web Inspector: REGRESSION(300338@main) Sources: Breakpoints don&apos;t work
<a href="https://bugs.webkit.org/show_bug.cgi?id=300702">https://bugs.webkit.org/show_bug.cgi?id=300702</a>
<a href="https://rdar.apple.com/162603099">rdar://162603099</a>

Reviewed by Devin Rousso and BJ Burg.

Web Inspector operates with the assumption that all target types support
the Debugger, Console, and Runtime domains.

The newly introduced frame target, added in <a href="https://commits.webkit.org/300338@main">https://commits.webkit.org/300338@main</a>,
is part of a wider migration of logic and currently does not support the Debugger domain.
There are guards on the frontend to prevent it from being used in the meanwhile.

When a target is created, various parts of the frontend attempt to get or create a
`WI.DebuggerData` for it via `WI.debuggerManager.prototype.dataForTarget()`
without checking the capabilities of the target.

When a breakpoint hits in the page target, logic in `WI.DebuggerManager.debuggerDidPause()`
also pauses all other targets. Since the frame target does not have a Debugger domain
and associated agent, Web Inspector throws an exception trying to pause it.

This patch ensures the target supports the Debugger domain before returning an
instance of `WI.DebuggerData`. Call sites are updated to handle a `null` returnt.

* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype.dataForTarget):
* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js:
* Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js:
(WI.OpenResourceDialog.prototype._addResource):
(WI.OpenResourceDialog.prototype._addScriptsForTarget):
`WI.FrameTarget.mainResource` is currently `null` so there are no other resources hanging off of it.

* Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js:
(WI.SourceCodeTextEditor.prototype._addThreadIndicatorForTarget):
* Source/WebInspectorUI/UserInterface/Views/ThreadTreeElement.js:
(WI.ThreadTreeElement.prototype.refresh):
(WI.ThreadTreeElement.prototype.populateContextMenu):
(WI.ThreadTreeElement.prototype._updateStatus):
(WI.ThreadTreeElement):
It&apos;s the `WI.ThreadTreeElement` which creates the `WI.DebuggerData` for the frame target
which then `WI.DebuggerManager.debuggerDidPause()` finds as an &quot;otherTarget&quot; to pause.

Canonical link: <a href="https://commits.webkit.org/301521@main">https://commits.webkit.org/301521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91195f9e817fa92b31cf1b6b502e86baa7cb03e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133014 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0224a75c-60fa-48d0-ac2c-81a6026610ef) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54438 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a2f8fca-34af-464e-b70c-2f158361216a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129188 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/37245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/112910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8dd71a05-54a2-43ac-8b98-2f3e4e0cfbcf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31319 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52985 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/40703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/135713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109140 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49749 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19739 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52885 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/58716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53918 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->