### PR TITLE
[GPU] ImageBufferCGPDFDocumentBackend::create() should validate its parameters

### DIFF
--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
@@ -45,6 +45,10 @@ size_t ImageBufferCGPDFDocumentBackend::calculateMemoryCost(const Parameters& pa
 
 std::unique_ptr<ImageBufferCGPDFDocumentBackend> ImageBufferCGPDFDocumentBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
 {
+    IntSize backendSize = parameters.backendSize;
+    if (backendSize.isEmpty())
+        return nullptr;
+
     auto data = adoptCF(CFDataCreateMutable(kCFAllocatorDefault, 0));
     if (!data)
         return nullptr;
@@ -53,7 +57,6 @@ std::unique_ptr<ImageBufferCGPDFDocumentBackend> ImageBufferCGPDFDocumentBackend
     if (!dataConsumer)
         return nullptr;
 
-    auto backendSize = parameters.backendSize;
     auto mediaBox = CGRectMake(0, 0, backendSize.width(), backendSize.height());
 
     auto pdfContext = adoptCF(CGPDFContextCreate(dataConsumer.get(), &mediaBox, nullptr));


### PR DESCRIPTION
#### d91d227a67b4785617d8f5e39e547d886794586a
<pre>
[GPU] ImageBufferCGPDFDocumentBackend::create() should validate its parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=300487">https://bugs.webkit.org/show_bug.cgi?id=300487</a>
<a href="https://rdar.apple.com/162342884">rdar://162342884</a>

Reviewed by Said Abou-Hallawa.

ImageBufferCGPDFDocumentBackend::create() should validate its
parameters, and refuse to create the backend if they are not valid.

* Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp:
(WebCore::ImageBufferCGPDFDocumentBackend::create):

Canonical link: <a href="https://commits.webkit.org/301661@main">https://commits.webkit.org/301661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12c0c62fa877d5bcced562f04b66e1bb8176497b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77998 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6fc3cc3-bacc-43c7-bd2b-f5f40760902e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96100 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64213 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/200179be-026c-4fc2-835d-f30d9444d743) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76582 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fdb13fb5-a228-48f8-b9a2-be02de4f74ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36135 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31080 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76474 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107018 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135703 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104603 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104305 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26673 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49739 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50357 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58705 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52190 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55535 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53907 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->