### PR TITLE
[CSS Zoom] Evaluate container queries against unzoomed sizes.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7590,7 +7590,6 @@ imported/w3c/web-platform-tests/css/css-viewport/zoom/list-style-image.html [ Im
 imported/w3c/web-platform-tests/css/css-viewport/zoom/relative-units-from-parent.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/border.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/bottom.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/height.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/inherited-length.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/left.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-block-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-block-size-expected.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<style>
+  .container {
+    container-type: size;
+    width: 100px;
+    height: 200px;
+    writing-mode: vertical-lr;
+  }
+  .child {
+    background-color: green;
+    height: 50px;
+    width: 50px;
+}
+</style>
+<p>All boxes below should be green.</p>
+<div class="container">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="nested" style="zoom: 2">
+    <div class="child"></div>
+  </div>
+</div>
+<div class="outer" style="zoom: 2">
+  <div class="container">
+    <div class="child"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-block-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-block-size.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/container-queries-block-size-ref.html">
+<style>
+  .container {
+    container-type: size;
+    width: 100px;
+    height: 200px;
+    writing-mode: vertical-lr;
+  }
+  .child {
+    background-color: green;
+    height: 50px;
+    width: 50px;
+    @container (block-size > 120px) {
+      background-color: red;
+    }
+  }
+</style>
+<p>All boxes below should be green.</p>
+<div class="container">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="nested" style="zoom: 2">
+    <div class="child"></div>
+  </div>
+</div>
+<div class="outer" style="zoom: 2">
+  <div class="container">
+    <div class="child"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-height-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-height-expected.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<style>
+  .container {
+    container-type: size;
+    width: 100px;
+    height: 100px;
+  }
+  .child {
+    background-color: green;
+    height: 50px;
+    width: 50px;
+}
+</style>
+<p>All boxes below should be green.</p>
+<div class="container">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="nested" style="zoom: 2">
+    <div class="child"></div>
+  </div>
+</div>
+<div class="outer" style="zoom: 2">
+  <div class="container">
+    <div class="child"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-height.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-height.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/container-queries-height-ref.html">
+<style>
+  .container {
+    container-type: size;
+    width: 100px;
+    height: 100px;
+  }
+  .child {
+    background-color: green;
+    height: 50px;
+    width: 50px;
+    @container (height > 120px) {
+      background-color: red;
+    }
+  }
+</style>
+<p>All boxes below should be green.</p>
+<div class="container">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="nested" style="zoom: 2">
+    <div class="child"></div>
+  </div>
+</div>
+<div class="outer" style="zoom: 2">
+  <div class="container">
+    <div class="child"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-inline-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-inline-size-expected.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<style>
+  .container {
+    container-type: inline-size;
+    width: 100px;
+    height: 100px;
+    writing-mode: vertical-lr;
+  }
+  .child {
+    background-color: green;
+    height: 50px;
+    width: 50px;
+}
+</style>
+<p>All boxes below should be green.</p>
+<div class="container">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="nested" style="zoom: 2">
+    <div class="child"></div>
+  </div>
+</div>
+<div class="outer" style="zoom: 2">
+  <div class="container">
+    <div class="child"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-inline-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-inline-size.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/container-queries-inline-size-ref.html">
+<style>
+  .container {
+    container-type: inline-size;
+    width: 200px;
+    height: 100px;
+    writing-mode: vertical-lr;
+  }
+  .child {
+    background-color: green;
+    height: 50px;
+    width: 50px;
+    @container (inline-size > 120px) {
+      background-color: red;
+    }
+  }
+</style>
+<p>All boxes below should be green.</p>
+<div class="container">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="nested" style="zoom: 2">
+    <div class="child"></div>
+  </div>
+</div>
+<div class="outer" style="zoom: 2">
+  <div class="container">
+    <div class="child"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/container-queries-block-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/container-queries-block-size-ref.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<style>
+  .container {
+    container-type: size;
+    width: 100px;
+    height: 100px;
+    writing-mode: vertical-lr;
+  }
+  .child {
+    background-color: green;
+    height: 50px;
+    width: 50px;
+}
+</style>
+<p>All boxes below should be green.</p>
+<div class="container">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="nested" style="zoom: 2">
+    <div class="child"></div>
+  </div>
+</div>
+<div class="outer" style="zoom: 2">
+  <div class="container">
+    <div class="child"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/container-queries-height-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/container-queries-height-ref.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<style>
+  .container {
+    container-type: size;
+    width: 100px;
+    height: 100px;
+  }
+  .child {
+    background-color: green;
+    height: 50px;
+    width: 50px;
+}
+</style>
+<p>All boxes below should be green.</p>
+<div class="container">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="nested" style="zoom: 2">
+    <div class="child"></div>
+  </div>
+</div>
+<div class="outer" style="zoom: 2">
+  <div class="container">
+    <div class="child"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/container-queries-inline-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/container-queries-inline-size-ref.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<style>
+  .container {
+    container-type: inline-size;
+    width: 100px;
+    height: 100px;
+    writing-mode: vertical-lr;
+  }
+  .child {
+    background-color: green;
+    height: 50px;
+    width: 50px;
+}
+</style>
+<p>All boxes below should be green.</p>
+<div class="container">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="child"></div>
+</div>
+<div class="container" style="zoom: 2">
+  <div class="nested" style="zoom: 2">
+    <div class="child"></div>
+  </div>
+</div>
+<div class="outer" style="zoom: 2">
+  <div class="container">
+    <div class="child"></div>
+  </div>
+</div>

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -42,6 +42,13 @@ namespace WebCore::CQ {
 
 using namespace MQ;
 
+static LayoutUnit unscaledSizeForPrincipleBox(const Style::PreferredSize& computedSize, LayoutUnit usedSize, UsesSVGZoomRulesForLength usesSVGZoomRulesForLength, float usedZoom)
+{
+    if (usesSVGZoomRulesForLength == UsesSVGZoomRulesForLength::Yes || !computedSize.isFixed())
+        return usedSize;
+    return LayoutUnit { usedSize / usedZoom };
+}
+
 struct SizeFeatureSchema : public FeatureSchema {
     SizeFeatureSchema(const AtomString& name, Type type, ValueType valueType, OptionSet<MediaQueryDynamicDependency> dependencies, FixedVector<CSSValueID>&& valueIdentifiers = { })
         : FeatureSchema(name, type, valueType, dependencies, WTFMove(valueIdentifiers))
@@ -79,7 +86,11 @@ struct WidthFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        return evaluateLengthFeature(feature, renderer.contentBoxWidth(), conversionData);
+        auto& renderStyle = renderer.style();
+        auto usesSVGZoomRulesForLength = renderStyle.useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
+
+        auto width = unscaledSizeForPrincipleBox(renderStyle.width(), renderer.contentBoxWidth(), usesSVGZoomRulesForLength, renderStyle.usedZoom());
+        return evaluateLengthFeature(feature, width, conversionData);
     }
 };
 
@@ -93,7 +104,11 @@ struct HeightFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        return evaluateLengthFeature(feature, renderer.contentBoxHeight(), conversionData);
+        auto& renderStyle = renderer.style();
+        auto usesSVGZoomRulesForLength = renderStyle.useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
+
+        auto height = unscaledSizeForPrincipleBox(renderStyle.height(), renderer.contentBoxHeight(), usesSVGZoomRulesForLength, renderStyle.usedZoom());
+        return evaluateLengthFeature(feature, height, conversionData);
     }
 };
 
@@ -107,7 +122,11 @@ struct InlineSizeFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        return evaluateLengthFeature(feature, renderer.contentBoxLogicalWidth(), conversionData);
+        auto& renderStyle = renderer.style();
+        auto usesSVGZoomRulesForLength = renderStyle.useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
+
+        auto logicalWidth = unscaledSizeForPrincipleBox(renderStyle.logicalWidth(), renderer.contentBoxLogicalWidth(), usesSVGZoomRulesForLength, renderStyle.usedZoom());
+        return evaluateLengthFeature(feature, logicalWidth, conversionData);
     }
 };
 
@@ -121,7 +140,11 @@ struct BlockSizeFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        return evaluateLengthFeature(feature, renderer.contentBoxLogicalHeight(), conversionData);
+        auto& renderStyle = renderer.style();
+        auto usesSVGZoomRulesForLength = renderStyle.useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
+
+        auto logicalHeight = unscaledSizeForPrincipleBox(renderStyle.logicalHeight(), renderer.contentBoxLogicalHeight(), usesSVGZoomRulesForLength, renderStyle.usedZoom());
+        return evaluateLengthFeature(feature, logicalHeight, conversionData);
     }
 };
 

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1293,6 +1293,8 @@ CSSBoxType transformBoxToCSSBoxType(TransformBox);
 
 constexpr float defaultMiterLimit = 4;
 
+enum class UsesSVGZoomRulesForLength : bool { No, Yes };
+
 WTF::TextStream& operator<<(WTF::TextStream&, AnimationDirection);
 WTF::TextStream& operator<<(WTF::TextStream&, AnimationFillMode);
 WTF::TextStream& operator<<(WTF::TextStream&, AnimationPlayState);


### PR DESCRIPTION
#### 819df563a4f63736b23e5617bdf7f3320f90bed6
<pre>
[CSS Zoom] Evaluate container queries against unzoomed sizes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300066">https://bugs.webkit.org/show_bug.cgi?id=300066</a>
<a href="https://rdar.apple.com/161861142">rdar://161861142</a>

Reviewed by Antti Koivisto, Sam Weinig, and Matthieu Dubet.

There was a CSSWG resolution which clarified the behavior between the
zoom property and resolving container queries in terms of what size
values the container query should use. The resolution was to use the
unscaled dimensions of the principle box.

<a href="https://github.com/w3c/csswg-drafts/issues/10268">https://github.com/w3c/csswg-drafts/issues/10268</a>

This patch aligns WebKit with other engines by removing the scale from
the principle box when evaluating a container query since we apply zoom
to the renderer&apos;s sizes during layout. There are two exceptions we use
to decide not to apply this logic:

1.) If the computed value of the propery is a non-fixed value.
Technically the spec only calls out the auto or percent cases but it
seems other engines also do not apply zoom to other non-fixed values
(e.g. intrinsic keywords).

2.) If the RenderStyle associated with the principle box has the
useSVGZoomRulesForLength bit set. This is because we handle zoom
differently since we seem to scale the entire document. This may be
correct but I opt for the safest case here which is to not change
functionality.

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-block-size.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-height.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries-inline-size.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/container-queries-block-size-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/container-queries-height-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/container-queries-inline-size-ref.html
I also added a few more tests to cover container queries against the
container height and also make sure we are checking the inline/block
dimensions correctly.

Canonical link: <a href="https://commits.webkit.org/301639@main">https://commits.webkit.org/301639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3853bf1b4d90bb1016ffccb14f3d7895a0f4f2b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133336 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78121 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a441266-490b-4457-8044-97b6f9dbf782) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96224 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64317 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76697 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/750d3a2e-b1e5-4000-ab02-448e5b946d5f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31239 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76632 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135862 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104718 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53596 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104417 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26665 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49878 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50520 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53034 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58858 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52334 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54058 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->