### PR TITLE
AX: Increment/Decrement actions on spinbuttons should default to arrow key behavior if implemented

### DIFF
--- a/LayoutTests/accessibility/contenteditable-spinbutton-uses-arrow-keys-expected.txt
+++ b/LayoutTests/accessibility/contenteditable-spinbutton-uses-arrow-keys-expected.txt
@@ -1,0 +1,13 @@
+This test ensures that increment and decrement simulate up and down keypresses for ARIA spinbuttons when they have the contenteditable attribute set.
+
+#spinbutton initial value: AXValue: 2022
+Key event received: {keyIdentifier: Up, key: ArrowUp, keyCode: 38}
+#spinbutton value after increment: AXValue: 2023
+
+Key event received: {keyIdentifier: Down, key: ArrowDown, keyCode: 40}
+#spinbutton value after decrement: AXValue: 2022
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+2022

--- a/LayoutTests/accessibility/contenteditable-spinbutton-uses-arrow-keys.html
+++ b/LayoutTests/accessibility/contenteditable-spinbutton-uses-arrow-keys.html
@@ -1,0 +1,66 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- MaterialUI uses this pattern (role=spinbutton + contenteditable) for their date picker components. -->
+
+<span role="spinbutton"
+     aria-valuenow="2022"
+     aria-valuemin="2000"
+     aria-valuemax="2040"
+     aria-label="Year"
+     contenteditable="true"
+     id="spinbutton">
+    2022
+</span>
+
+<script>
+var output = "This test ensures that increment and decrement simulate up and down keypresses for ARIA spinbuttons when they have the contenteditable attribute set.\n\n";
+
+function handleKeyDown(event) {
+	output += `Key event received: {keyIdentifier: ${event.keyIdentifier}, key: ${event.key}, keyCode: ${event.keyCode}}\n`;
+
+	const spinbutton = document.getElementById("spinbutton");
+	if (event.keyIdentifier === "Up")
+		spinbutton.ariaValueNow = Number(spinbutton.ariaValueNow) + 1;
+	else if (event.keyIdentifier === "Down")
+		spinbutton.ariaValueNow = Number(spinbutton.ariaValueNow) - 1;
+	else
+		debug(`FAIL: Unexpected keypress ${event.keyIdentifier}`);
+
+	event.preventDefault();
+	event.stopPropagation();
+}
+
+if (window.accessibilityController) {
+	window.jsTestIsAsync = true;
+
+	document.getElementById("spinbutton").addEventListener("keydown", handleKeyDown);
+	var axSpinbutton = accessibilityController.accessibleElementById("spinbutton");
+	
+	document.getElementById("spinbutton").focus();
+	
+	let lastKnownValue = axSpinbutton.stringValue;
+	output += `#spinbutton initial value: ${lastKnownValue}\n`;
+
+	axSpinbutton.increment();
+	setTimeout(async () => {
+		await waitFor(() => axSpinbutton.stringValue !== lastKnownValue);
+		lastKnownValue = axSpinbutton.stringValue;
+
+		output += `#spinbutton value after increment: ${lastKnownValue}\n\n`;
+		axSpinbutton.decrement();
+		await waitFor(() => axSpinbutton.stringValue !== lastKnownValue);
+		output += `#spinbutton value after decrement: ${axSpinbutton.stringValue}\n`;
+
+		debug(output);
+		finishJSTest();
+	}, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1013,6 +1013,9 @@ accessibility/datetime/input-time-field-labels-and-value-changes.html [ Skip ] #
 # -webkit-overflow-scrolling (ENABLE_WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY) is only for iOS
 fast/repaint/overflow-scroll-touch-repaint.html [ Skip ]
 
+# On GTK, arrow keys are incrementing date fields by 2 steps, both with and without this change, so this test doesn't need to run since the code is guarded with PLATFORM(COCOA).
+accessibility/contenteditable-spinbutton-uses-arrow-keys.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Accessibility-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -1689,6 +1689,19 @@ void AccessibilityNodeObject::alterRangeValue(StepAction stepAction)
     if (!element || element->isDisabledFormControl())
         return;
 
+#if PLATFORM(COCOA)
+    if (role() == AccessibilityRole::SpinButton) {
+        // First try a keyboard event to see if that affects the value of the spinbutton, since authors are supposed to handle up/down keys.
+        // We can't check the event listeners directly here since those may be on an ancestor or the document.
+        float beforeValue = valueForRange();
+        postKeyboardKeysForValueChange(stepAction);
+        if (beforeValue != valueForRange()) {
+            // Performing a keyboard action (up/down arrow) resulted in a value change, so return early to avoid doubly-modifing the value.
+            return;
+        }
+    }
+#endif
+
     if (!getAttribute(stepAttr).isEmpty())
         changeValueByStep(stepAction);
     else


### PR DESCRIPTION
#### 69c08ffd8fb483090d7e86b8d778d00733fdce9e
<pre>
AX: Increment/Decrement actions on spinbuttons should default to arrow key behavior if implemented
<a href="https://bugs.webkit.org/show_bug.cgi?id=300727">https://bugs.webkit.org/show_bug.cgi?id=300727</a>
<a href="https://rdar.apple.com/161667991">rdar://161667991</a>

Reviewed by Tyler Wilcock.

Spinbuttons (per the spec <a href="https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/)">https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/)</a>, are meant
to support up/down arrow key events. These event handlers are often responsible for making
sure the value of these inputs move up by a particular step amount, and other such state.

In many cases (e.g., when spinbuttons are not text inputs), we fallback to sending these key
events when incrementing/decrementing via ATs. But, when a spinbutton is a text input (in
the case of contenteditable, for example), we don&apos;t send simulated up/down arrow key events
and just insert an updated value through simulated typing.

This PR changes our behavior for spinbuttons so that we always try an arrow key event first,
and if it actually changes the value of the input, don&apos;t do anything else. This will help
make the experience more uniform between AT and keyboard events.

Test: accessibility/contenteditable-spinbutton-uses-arrow-keys.html

* LayoutTests/accessibility/contenteditable-spinbutton-uses-arrow-keys-expected.txt: Added.
* LayoutTests/accessibility/contenteditable-spinbutton-uses-arrow-keys.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::alterRangeValue):

Canonical link: <a href="https://commits.webkit.org/301689@main">https://commits.webkit.org/301689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2237dc8c148594acebaaa83434e43efa2ea6c77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133656 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78341 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a6cbe2a8-e733-4987-bd70-c0f8f49fae7e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96410 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a9f65894-49ad-49a2-8520-920fb495b7b8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113312 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76935 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/070a6013-6968-4325-bff6-5e165aabb3d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36472 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31496 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77053 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107402 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.PostMessageWithMessagePorts (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136231 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104925 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104626 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26689 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50118 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28453 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50843 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53303 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59106 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52569 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55905 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54311 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->