### PR TITLE
Resync Navigation API WPT Tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6978,10 +6978,10 @@ imported/w3c/web-platform-tests/navigation-api/scroll-behavior/ [ Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/opaque-origin.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-forward-opaque-origin.html [ Skip ]
 
-webkit.org/b/300005 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate.html [ Skip ]
 webkit.org/b/300006 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault.html [ Skip ]
 
 # Out of target of Interop 2025.
+imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-infinite.optional.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-history-pushState.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-location.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-redirect.html?currententrychange [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT A cross-origin traversal does not fire the navigate event Test timed out
+PASS A cross-origin traversal does not fire the navigate event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate.html
@@ -6,11 +6,11 @@
 <script>
 promise_test(async t => {
   // Open a cross-origin window.
-  let w = window.open(get_host_info().HTTP_REMOTE_ORIGIN + "/navigation-api/navigate-event/resources/opener-postMessage-onload.html");
+  let w = window.open(get_host_info().HTTP_REMOTE_ORIGIN + "/navigation-api/navigate-event/resources/opener-postMessage-onpageshow.html");
   await new Promise(resolve => window.onmessage = resolve);
 
   // Navigate the opened window to this origin.
-  w.location = get_host_info().ORIGIN + "/navigation-api/navigate-event/resources/opener-postMessage-onload.html";
+  w.location = get_host_info().ORIGIN + "/navigation-api/navigate-event/resources/opener-postMessage-onpageshow.html";
   await new Promise(resolve => window.onmessage = resolve);
   assert_equals(w.navigation.entries().length, 1);
   assert_equals(w.navigation.currentEntry.index, 0);

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.back() cross-document cannot be cancelled with the navigate event Test timed out
+FAIL navigation.back() cross-document cannot be cancelled with the navigate event assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault.html
@@ -8,10 +8,10 @@
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  let w = window.open("resources/opener-postMessage-onload.html");
+  let w = window.open("resources/opener-postMessage-onpageshow.html");
   await new Promise(resolve => window.onmessage = resolve);
   // Navigate to a url that will notify us when the navigation is complete.
-  w.navigation.navigate("opener-postMessage-onload.html?1");
+  w.navigation.navigate("opener-postMessage-onpageshow.html?1");
 
   await new Promise(resolve => window.onmessage = resolve);
   assert_equals(w.navigation.entries().length, 2);

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-infinite.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-infinite.optional-expected.txt
@@ -1,0 +1,5 @@
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT infinite replaceState inside a navigate event for navigation.back() Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-infinite.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-infinite.optional.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../navigation-methods/return-value/resources/helpers.js"></script>
+<script>
+promise_test(async t => {
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await navigation.navigate("#push").finished;
+  let { reject, promise } = Promise.withResolvers();
+  navigation.addEventListener("navigate", () => {
+    try {
+      history.replaceState(null, "", "#");
+    } catch (e) {
+      reject(e);
+    }
+  });
+  await Promise.all([
+    promise_rejects_dom(t, "SecurityError", promise, "Infinite recursion in replaceState"),
+    assertBothRejectDOM(t, navigation.back(), "AbortError")]);
+}, "infinite replaceState inside a navigate event for navigation.back()");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler.html
@@ -9,7 +9,7 @@ promise_test(async t => {
   await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   await navigation.navigate("#push").finished;
-  navigation.onnavigate = () => history.replaceState(null, "", "#");
+  navigation.addEventListener("navigate", () => history.replaceState(null, "", "#"), {once: true});
   await assertBothRejectDOM(t, navigation.back(), "AbortError");
 }, "replaceState inside a navigate event for navigation.back()");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/opener-postMessage-onload.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/opener-postMessage-onload.html
@@ -1,6 +1,0 @@
-<!doctype html>
-<head>
-<script>
-window.onload = () => opener.postMessage("onload", "*");
-</script>
-</head>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/opener-postMessage-onpageshow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/opener-postMessage-onpageshow.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<head>
+<script>
+window.onpageshow = () => opener.postMessage("onpageshow", "*");
+</script>
+</head>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/w3c-import.log
@@ -17,4 +17,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/cross-origin-redirect-on-second-visit.py
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/meta-refresh.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/navigatesuccess-cross-document-helper.html
-/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/opener-postMessage-onload.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/opener-postMessage-onpageshow.html

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/w3c-import.log
@@ -89,6 +89,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-navigates-top-and-same-doc-child-and-cross-doc-child.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-same-document-preventDefault-multiple-windows.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-top-cancels-cross-document-child.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-infinite.optional.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/same-url-replace-cross-document.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/same-url-replace-same-document.html


### PR DESCRIPTION
#### 97dbaf6e551f5f66d0eed08ec0d012b705301757
<pre>
Resync Navigation API WPT Tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=300731">https://bugs.webkit.org/show_bug.cgi?id=300731</a>
<a href="https://rdar.apple.com/162633755">rdar://162633755</a>

Reviewed by Basuke Suzuki.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/04b92eb9e5e00a4c9a2f3a87369fc42a5139a321">https://github.com/web-platform-tests/wpt/commit/04b92eb9e5e00a4c9a2f3a87369fc42a5139a321</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-infinite.optional-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-infinite.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/opener-postMessage-onload.html: Removed.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/opener-postMessage-onpageshow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/301532@main">https://commits.webkit.org/301532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc93dab95bc964a8a78b8b71e00d2de9865dedd9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132981 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77979 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dfb30f31-937f-44c1-9a86-ec783b3e075c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96083 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64197 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f85a8f2-5306-4431-af33-45e208830350) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76565 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d85491ec-963e-4507-93ef-e1f9234312e2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36122 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31067 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76455 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135683 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104584 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104289 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49720 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28055 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50334 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19746 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52850 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52169 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55515 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53883 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->