### PR TITLE
[ safaridriver ] dblclick not being issued

### DIFF
--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
@@ -513,7 +513,11 @@ void SimulatedInputDispatcher::finishDispatching(std::optional<AutomationCommand
     m_keyframes.clear();
     m_keyframeIndex = 0;
     m_inputSourceStateIndex = 0;
-
+#if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
+    // It is unclear if this is desirable; see
+    // https://github.com/w3c/webdriver/issues/1772 for ongoing discussion:
+    m_client.clearDoubleClicks();
+#endif
     finish(error);
 }
 

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
@@ -136,6 +136,7 @@ public:
         virtual ~Client() { }
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
         virtual void simulateMouseInteraction(WebPageProxy&, MouseInteraction, MouseButton, const WebCore::IntPoint& locationInView, const String& pointerType, AutomationCompletionHandler&&) = 0;
+        virtual void clearDoubleClicks() = 0;
 #endif
 #if ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
         virtual void simulateTouchInteraction(WebPageProxy&, TouchInteraction, const WebCore::IntPoint& locationInView, std::optional<Seconds> duration, AutomationCompletionHandler&&) = 0;

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -953,7 +953,7 @@ void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame, st
         }
 
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
-        resetClickCount();
+        resetMouseState();
 #endif
     } else {
         if (auto callback = m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame.take(frame.frameID())) {
@@ -1971,24 +1971,44 @@ void WebAutomationSession::viewportInViewCenterPointOfElement(WebPageProxy& page
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
 void WebAutomationSession::updateClickCount(MouseButton button, const WebCore::IntPoint& position, Seconds maxTime, int maxDistance)
 {
-    auto now = MonotonicTime::now();
-    if (now - m_lastClickTime < maxTime && button == m_lastClickButton && m_lastClickPosition.distanceSquaredToPoint(position) < maxDistance) {
-        m_clickCount++;
-        m_lastClickTime = now;
+    if (button != MouseButton::Left) {
+        m_lastClickPosition.reset();
+        m_clickCount = 1;
         return;
     }
 
-    m_clickCount = 1;
+    auto now = MonotonicTime::now();
+    if (!m_lastClickPosition || m_lastClickPosition->distanceSquaredToPoint(position) > maxDistance || now - m_lastClickTime > maxTime) {
+        m_lastClickPosition = position;
+        m_lastClickTime = now;
+        m_clickCount = 1;
+        return;
+    }
+
     m_lastClickTime = now;
-    m_lastClickButton = button;
-    m_lastClickPosition = position;
+    ++m_clickCount;
 }
 
-void WebAutomationSession::resetClickCount()
+void WebAutomationSession::updateLastPosition(const WebCore::IntPoint& position, int maxDistance)
+{
+    // Cancel multiple clicks if mouse strays too far:
+    if (m_lastClickPosition && m_lastClickPosition->distanceSquaredToPoint(position) > maxDistance)
+        m_lastClickPosition.reset();
+
+    m_lastPosition = position;
+}
+
+void WebAutomationSession::resetMouseState()
 {
     m_clickCount = 1;
-    m_lastClickButton = MouseButton::None;
-    m_lastClickPosition = { };
+    m_lastPosition.reset();
+    m_lastClickPosition.reset();
+}
+
+void WebAutomationSession::clearDoubleClicks()
+{
+    m_clickCount = 1;
+    m_lastClickPosition.reset();
 }
 
 void WebAutomationSession::simulateMouseInteraction(WebPageProxy& page, MouseInteraction interaction, MouseButton mouseButton, const WebCore::IntPoint& locationInViewport, const String& pointerType, CompletionHandler<void(std::optional<AutomationCommandError>)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -200,6 +200,7 @@ public:
     // SimulatedInputDispatcher::Client API
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
     void simulateMouseInteraction(WebPageProxy&, MouseInteraction, MouseButton, const WebCore::IntPoint& locationInView, const String& pointerType, AutomationCompletionHandler&&) override;
+    void clearDoubleClicks() override;
 #endif
 #if ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
     void simulateTouchInteraction(WebPageProxy&, TouchInteraction, const WebCore::IntPoint& locationInView, std::optional<Seconds> duration, AutomationCompletionHandler&&) override;
@@ -328,8 +329,9 @@ private:
 
     // Platform-dependent implementations.
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
-    void updateClickCount(MouseButton, const WebCore::IntPoint&, Seconds maxTime = 1_s, int maxDistance = 0);
-    void resetClickCount();
+    void resetMouseState();
+    void updateClickCount(MouseButton, const WebCore::IntPoint&, Seconds maxTime = 0.5_s, int maxDistance = 0);
+    void updateLastPosition(const WebCore::IntPoint&, int maxDistance = 0);
     void platformSimulateMouseInteraction(WebPageProxy&, MouseInteraction, MouseButton, const WebCore::IntPoint& locationInViewport, OptionSet<WebEventModifier>, const String& pointerType);
     static OptionSet<WebEventModifier> platformWebModifiersFromRaw(WebPageProxy&, unsigned modifiers);
 #endif
@@ -427,9 +429,9 @@ private:
 #endif
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
     MonotonicTime m_lastClickTime;
-    MouseButton m_lastClickButton { MouseButton::None };
     HashMap<MouseButton, bool, WTF::IntHash<MouseButton>, WTF::StrongEnumHashTraits<MouseButton>> m_mouseButtonsCurrentlyDown;
-    WebCore::IntPoint m_lastClickPosition;
+    std::optional<WebCore::IntPoint> m_lastPosition;
+    std::optional<WebCore::IntPoint> m_lastClickPosition;
     unsigned m_clickCount { 1 };
 #endif
 


### PR DESCRIPTION
#### 2f785577a3363c8fa048b02413e926b1fcc45ccb
<pre>
[ safaridriver ] dblclick not being issued
<a href="https://bugs.webkit.org/show_bug.cgi?id=299551">https://bugs.webkit.org/show_bug.cgi?id=299551</a>
<a href="https://rdar.apple.com/161399867">rdar://161399867</a>

Reviewed by BJ Burg.

Simulated MouseUps and MouseDowns through WebDriver now contain the
correct value for clickCount, triggering the doubleclick detection
downstream. This required a code change to make sure m_clickCount
always has the correct value.

This patch introduces m_lastPosition and updateLastPosition() to
decouple mouse delta calculation and multiple click detection.
Previously, m_lastClickPosition and updateClickCount() were overloaded,
being used to detect multiple clicks on GTK and to calculate mouse
deltas on Mac. On Mac, updateClickCount() had to be called on every
simulated mouse event (instead of only on mousedowns), which would
result in a clobbered m_clickCount.

This patch causes the following tests to pass:

* wpt/event-timing/dblclick.html
* wpt/tests/classic/perform_actions/pointer_dblclick.py::test_dblclick_at_coordinates[0]
* wpt/tests/classic/perform_actions/pointer_dblclick.py::test_dblclick_at_coordinates[200]
* wpt/tests/classic/perform_actions/pointer_pause_dblclick.py::test_dblclick_with_pause_after_second_pointerdown

This is a do-over of 300900@main, which was reverted because it broke
the following:

* wpt/tests/classic/perform_actions/pointer_pause_dblclick.py::test_no_dblclick :
    broke because the doubleclick delay was too large; fixed by changing
    the default delay from 1s to 500ms. (test exercises 640ms)
* wpt/tests/classic/release_actions/sequence.py::test_release_mouse_sequence_resets_dblclick_state[with release actions]
* wpt/tests/classic/release_actions/sequence.py::test_release_mouse_sequence_resets_dblclick_state[without release actions] :
    enforce that safaridriver doesn&apos;t issue double clicks when each click
    happens in a separate action chain. These are confusingly named - the
    presence of the release action is irrelevant to the expected output. See
    <a href="https://github.com/w3c/webdriver/issues/1772">https://github.com/w3c/webdriver/issues/1772</a> for ongoing discussion.
    Were fixed by the addition of WebAutomationSession::clearDoubleClicks(),
    which is called on SimulatedInputDispatcher::finishDispatching()

Canonical link: <a href="https://commits.webkit.org/301726@main">https://commits.webkit.org/301726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de9490e194d072d64ecf77f18e29d619a9ee9235

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132982 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77980 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96084 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64202 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76571 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36121 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76456 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135684 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104587 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104291 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26714 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49726 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28058 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50336 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58685 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52170 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53885 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->