### PR TITLE
[World Leaks] Fix leaks in LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/

### DIFF
--- a/LayoutTests/webgl/webgl-worker.html
+++ b/LayoutTests/webgl/webgl-worker.html
@@ -12,6 +12,8 @@ function runTest() {
         testRunner.waitUntilDone();
         testRunner.dumpAsText();
     }
+    if (window !== window.parent)
+        window.parent.postMessage("InTest", "*");
 
     const worker = new Worker("./resources/webgl-worker.js");
     worker.addEventListener("message", (e) => {

--- a/LayoutTests/webgl/worker-does-not-leak-expected.txt
+++ b/LayoutTests/webgl/worker-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that creating Workers does not leak the Document object
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/worker-does-not-leak.html
+++ b/LayoutTests/webgl/worker-does-not-leak.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/document-leak-test.js"></script>
+<script>
+    description("Tests that creating Workers does not leak the Document object");
+    onload = () => runDocumentLeakTest({ frameURL: "webgl-worker.html", framesToCreate: 20 });
+</script>
+</body>
+</html>

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -92,6 +92,5 @@ style/values/primitives/StylePrimitiveKeyword+CSSValueCreation.h
 style/values/primitives/StylePrimitiveKeyword+Serialization.h
 [ Mac ] testing/MockMediaSessionCoordinator.cpp
 workers/Worker.cpp
-workers/WorkerMessagingProxy.cpp
 workers/WorkerOrWorkletThread.cpp
 workers/shared/SharedWorkerObjectConnection.cpp

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -200,12 +200,16 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequest(ResourceRequest&& re
 {
     ASSERT(m_options.mode == FetchOptions::Mode::Cors);
 
+    RefPtr document = m_document.get();
+    if (!document)
+        return;
+
     if ((m_options.preflightPolicy == PreflightPolicy::Consider && isSimpleCrossOriginAccessRequest(request.httpMethod(), request.httpHeaderFields())) || m_options.preflightPolicy == PreflightPolicy::Prevent || shouldPerformSecurityChecks()) {
         if (checkURLSchemeAsCORSEnabled(request.url()))
             makeSimpleCrossOriginAccessRequest(WTFMove(request));
     } else {
         if (m_options.serviceWorkersMode == ServiceWorkersMode::All && m_async) {
-            if (m_options.serviceWorkerRegistrationIdentifier || document().activeServiceWorker()) {
+            if (m_options.serviceWorkerRegistrationIdentifier || document->activeServiceWorker()) {
                 ASSERT(!m_bypassingPreflightForServiceWorkerRequest);
                 m_bypassingPreflightForServiceWorkerRequest = WTFMove(request);
                 m_options.serviceWorkersMode = ServiceWorkersMode::Only;
@@ -217,7 +221,7 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequest(ResourceRequest&& re
             return;
 
         m_simpleRequest = false;
-        if (RefPtr page = document().page(); page && CrossOriginPreflightResultCache::singleton().canSkipPreflight(page->sessionID(), document().clientOrigin(), request.url(), m_options.storedCredentialsPolicy, request.httpMethod(), request.httpHeaderFields()))
+        if (RefPtr page = document->page(); page && CrossOriginPreflightResultCache::singleton().canSkipPreflight(page->sessionID(), document->clientOrigin(), request.url(), m_options.storedCredentialsPolicy, request.httpMethod(), request.httpHeaderFields()))
             preflightSuccess(WTFMove(request));
         else
             makeCrossOriginAccessRequestWithPreflight(WTFMove(request));
@@ -255,9 +259,12 @@ void DocumentThreadableLoader::cancel()
 
     // Cancel can re-enter and m_resource might be null here as a result.
     if (m_client && m_resource) {
+        RefPtr document = m_document.get();
+        if (!document)
+            return;
         // FIXME: This error is sent to the client in didFail(), so it should not be an internal one. Use LocalFrameLoaderClient::cancelledError() instead.
         ResourceError error(errorDomainWebKitInternal, 0, m_resource->url(), "Load cancelled"_s, ResourceError::Type::Cancellation);
-        m_client->didFail(m_document->identifier(), error); // May destroy the client.
+        m_client->didFail(document->identifier(), error); // May destroy the client.
     }
     clearResource();
     m_client = nullptr;
@@ -386,6 +393,15 @@ void DocumentThreadableLoader::dataSent(CachedResource& resource, unsigned long 
 void DocumentThreadableLoader::responseReceived(const CachedResource& resource, const ResourceResponse& response, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT_UNUSED(resource, &resource == m_resource);
+
+    if (!m_client) {
+        if (completionHandler)
+            completionHandler();
+        return;
+    }
+
+    Ref protectedThis { *this };
+
     ResourceResponse responseWithCorrectFragmentIdentifier;
     if (response.source() != ResourceResponse::Source::ServiceWorker && response.url().fragmentIdentifier() != m_responseURL.fragmentIdentifier()) {
         responseWithCorrectFragmentIdentifier = response;
@@ -406,6 +422,11 @@ void DocumentThreadableLoader::responseReceived(const CachedResource& resource, 
 void DocumentThreadableLoader::didReceiveResponse(ResourceLoaderIdentifier identifier, ResourceResponse&& response)
 {
     ASSERT(m_client);
+
+    RefPtr document = m_document.get();
+    if (!document)
+        return;
+
     ASSERT(response.type() != ResourceResponse::Type::Error);
 
     // https://fetch.spec.whatwg.org/commit-snapshots/6257e220d70f560a037e46f1b4206325400db8dc/#main-fetch step 17.
@@ -416,27 +437,27 @@ void DocumentThreadableLoader::didReceiveResponse(ResourceLoaderIdentifier ident
         }
     }
 
-    InspectorInstrumentation::didReceiveThreadableLoaderResponse(document(), *this, identifier);
+    InspectorInstrumentation::didReceiveThreadableLoaderResponse(*document, *this, identifier);
 
     if (m_delayCallbacksForIntegrityCheck)
         return;
 
     if (options().filteringPolicy == ResponseFilteringPolicy::Disable) {
-        m_client->didReceiveResponse(m_document->identifier(), identifier, WTFMove(response));
+        m_client->didReceiveResponse(document->identifier(), identifier, WTFMove(response));
         return;
     }
 
     if (response.type() == ResourceResponse::Type::Default) {
-        m_client->didReceiveResponse(m_document->identifier(), identifier, ResourceResponse::filter(response, m_options.credentials == FetchOptions::Credentials::Include ? ResourceResponse::PerformExposeAllHeadersCheck::No : ResourceResponse::PerformExposeAllHeadersCheck::Yes));
+        m_client->didReceiveResponse(document->identifier(), identifier, ResourceResponse::filter(response, m_options.credentials == FetchOptions::Credentials::Include ? ResourceResponse::PerformExposeAllHeadersCheck::No : ResourceResponse::PerformExposeAllHeadersCheck::Yes));
         if (response.tainting() == ResourceResponse::Tainting::Opaque) {
             clearResource();
             if (m_client)
-                m_client->didFinishLoading(m_document->identifier(), identifier, { });
+                m_client->didFinishLoading(document->identifier(), identifier, { });
         }
         return;
     }
     ASSERT(response.type() == ResourceResponse::Type::Opaqueredirect || response.source() == ResourceResponse::Source::ServiceWorker || response.source() == ResourceResponse::Source::MemoryCache);
-    m_client->didReceiveResponse(m_document->identifier(), identifier, WTFMove(response));
+    m_client->didReceiveResponse(document->identifier(), identifier, WTFMove(response));
 }
 
 void DocumentThreadableLoader::dataReceived(CachedResource& resource, const SharedBuffer& buffer)
@@ -466,6 +487,9 @@ void DocumentThreadableLoader::finishedTimingForWorkerLoad(CachedResource& resou
 void DocumentThreadableLoader::finishedTimingForWorkerLoad(const ResourceTiming& resourceTiming)
 {
     ASSERT(m_options.initiatorContext == InitiatorContext::Worker);
+
+    if (!m_client)
+        return;
 
     m_client->didFinishTiming(resourceTiming);
 }
@@ -555,21 +579,32 @@ void DocumentThreadableLoader::preflightSuccess(ResourceRequest&& request)
 
 void DocumentThreadableLoader::preflightFailure(std::optional<ResourceLoaderIdentifier> identifier, const ResourceError& error)
 {
+    if (!m_client)
+        return;
+
+    RefPtr document = m_document.get();
+    if (!document)
+        return;
+
     m_preflightChecker = std::nullopt;
 
-    RefPtr frame = m_document->frame();
+    RefPtr frame = document->frame();
     if (identifier)
         InspectorInstrumentation::didFailLoading(frame.get(), frame->loader().protectedDocumentLoader().get(), *identifier, error);
 
     if (m_shouldLogError == ShouldLogError::Yes)
-        logError(protectedDocument(), error, m_options.initiatorType);
+        logError(*document, error, m_options.initiatorType);
 
-    m_client->didFail(m_document->identifier(), error);
+    m_client->didFail(document->identifier(), error);
 }
 
 void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCheckPolicy securityCheck)
 {
     Ref<DocumentThreadableLoader> protectedThis(*this);
+
+    RefPtr document = m_document.get();
+    if (!document)
+        return;
 
     // Any credential should have been removed from the cross-site requests.
     m_responseURL = request.url();
@@ -586,7 +621,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
         options.loadedFromFetch = m_options.initiatorType == cachedResourceRequestInitiatorTypes().fetch ? LoadedFromFetch::Yes : LoadedFromFetch::No;
         options.clientCredentialPolicy = m_sameOriginRequest ? ClientCredentialPolicy::MayAskClientForCredentials : ClientCredentialPolicy::CannotAskClientForCredentials;
         options.contentSecurityPolicyImposition = ContentSecurityPolicyImposition::SkipPolicyCheck;
-        
+
         // If there is integrity metadata to validate, we must buffer.
         if (!m_options.integrity.isEmpty())
             options.dataBufferingPolicy = DataBufferingPolicy::BufferData;
@@ -600,7 +635,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
         if (CachedResourceHandle resource = std::exchange(m_resource, nullptr))
             resource->removeClient(*this);
 
-        auto cachedResource = m_document->protectedCachedResourceLoader()->requestRawResource(WTFMove(newRequest));
+        auto cachedResource = document->protectedCachedResourceLoader()->requestRawResource(WTFMove(newRequest));
         m_resource = cachedResource.value_or(nullptr);
         if (CachedResourceHandle resource = m_resource)
             resource->addClient(*this);
@@ -616,7 +651,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     loadTiming.markStartTime();
 
     // FIXME: ThreadableLoaderOptions.sniffContent is not supported for synchronous requests.
-    RefPtr frame = m_document->frame();
+    RefPtr frame = document->frame();
     if (!frame)
         return;
 
@@ -690,7 +725,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     if (options().initiatorContext == InitiatorContext::Worker)
         finishedTimingForWorkerLoad(resourceTiming);
     else {
-        if (RefPtr window = document().window())
+        if (RefPtr window = document->window())
             window->protectedPerformance()->addResourceTiming(WTFMove(resourceTiming));
     }
 
@@ -728,12 +763,18 @@ bool DocumentThreadableLoader::isAllowedRedirect(const URL& url)
 
 SecurityOrigin& DocumentThreadableLoader::securityOrigin() const
 {
-    return m_origin ? *m_origin : m_document->securityOrigin();
+    if (m_origin)
+        return *m_origin;
+    RefPtr document = m_document.get();
+    ASSERT(document);
+    return document->securityOrigin();
 }
 
 Ref<SecurityOrigin> DocumentThreadableLoader::topOrigin() const
 {
-    return m_document->topOrigin();
+    RefPtr document = m_document.get();
+    ASSERT(document);
+    return document->topOrigin();
 }
 
 Ref<SecurityOrigin> DocumentThreadableLoader::protectedSecurityOrigin() const
@@ -745,8 +786,10 @@ const ContentSecurityPolicy& DocumentThreadableLoader::contentSecurityPolicy() c
 {
     if (m_contentSecurityPolicy)
         return *m_contentSecurityPolicy.get();
-    ASSERT(m_document->contentSecurityPolicy());
-    return *m_document->contentSecurityPolicy();
+    RefPtr document = m_document.get();
+    ASSERT(document);
+    ASSERT(document->contentSecurityPolicy());
+    return *document->contentSecurityPolicy();
 }
 
 CheckedRef<const ContentSecurityPolicy> DocumentThreadableLoader::checkedContentSecurityPolicy() const
@@ -758,7 +801,9 @@ const CrossOriginEmbedderPolicy& DocumentThreadableLoader::crossOriginEmbedderPo
 {
     if (m_crossOriginEmbedderPolicy)
         return *m_crossOriginEmbedderPolicy;
-    return m_document->crossOriginEmbedderPolicy();
+    RefPtr document = m_document.get();
+    ASSERT(document);
+    return document->crossOriginEmbedderPolicy();
 }
 
 void DocumentThreadableLoader::reportRedirectionWithBadScheme(const URL& url)
@@ -783,15 +828,18 @@ void DocumentThreadableLoader::reportIntegrityMetadataError(const CachedResource
 
 void DocumentThreadableLoader::logErrorAndFail(const ResourceError& error)
 {
+    RefPtr document = m_document.get();
+    if (!document)
+        return;
+
     if (m_shouldLogError == ShouldLogError::Yes) {
-        Ref document = *m_document;
         if (error.isAccessControl() && error.domain() != InspectorNetworkAgent::errorDomain() && !error.localizedDescription().isEmpty())
             document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, error.localizedDescription());
-        logError(document, error, m_options.initiatorType);
+        logError(*document, error, m_options.initiatorType);
     }
     ASSERT(m_client);
     if (m_client)
-        m_client->didFail(m_document->identifier(), error); // May cause the client to get destroyed.
+        m_client->didFail(document->identifier(), error); // May cause the client to get destroyed.
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -111,14 +111,14 @@ static ScriptExecutionContextIdentifier loaderContextIdentifierFromContext(const
 }
 
 WorkerMessagingProxy::WorkerMessagingProxy(Worker& workerObject)
-    : m_scriptExecutionContext(workerObject.scriptExecutionContext())
-    , m_scriptExecutionContextIdentifier(m_scriptExecutionContext ? std::optional { m_scriptExecutionContext->identifier() } : std::nullopt)
-    , m_loaderContextIdentifier(loaderContextIdentifierFromContext(*workerObject.protectedScriptExecutionContext()))
+    : m_loaderContextIdentifier(loaderContextIdentifierFromContext(*workerObject.protectedScriptExecutionContext()))
+    , m_workerContextIdentifier(workerObject.protectedScriptExecutionContext()->identifier())
     , m_inspectorProxy(WorkerInspectorProxy::create(workerObject.identifier()))
     , m_workerObject(&workerObject)
 {
-    ASSERT((is<Document>(*m_scriptExecutionContext) && isMainThread())
-        || (is<WorkerGlobalScope>(*m_scriptExecutionContext) && downcast<WorkerGlobalScope>(*m_scriptExecutionContext).thread()->thread() == &Thread::currentSingleton()));
+    RefPtr scriptExecutionContext = workerObject.scriptExecutionContext();
+    ASSERT((is<Document>(*scriptExecutionContext) && isMainThread())
+        || (is<WorkerGlobalScope>(*scriptExecutionContext) && downcast<WorkerGlobalScope>(*scriptExecutionContext).thread()->thread() == &Thread::currentSingleton()));
 
     // Nobody outside this class ref counts this object. The original ref
     // is balanced by the deref in workerGlobalScopeDestroyedInternal.
@@ -127,9 +127,6 @@ WorkerMessagingProxy::WorkerMessagingProxy(Worker& workerObject)
 WorkerMessagingProxy::~WorkerMessagingProxy()
 {
     ASSERT(!m_workerObject);
-    ASSERT(!m_scriptExecutionContext
-        || (is<Document>(*m_scriptExecutionContext) && isMainThread())
-        || (is<WorkerGlobalScope>(*m_scriptExecutionContext) && downcast<WorkerGlobalScope>(*m_scriptExecutionContext).thread()->thread() == &Thread::currentSingleton()));
 
     if (RefPtr workerThread = m_workerThread)
         workerThread->clearProxies();
@@ -137,10 +134,14 @@ WorkerMessagingProxy::~WorkerMessagingProxy()
 
 void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::SessionID sessionID, const String& name, WorkerInitializationData&& initializationData, const ScriptBuffer& sourceCode, const ContentSecurityPolicyResponseHeaders& contentSecurityPolicyResponseHeaders, bool shouldBypassMainWorldContentSecurityPolicy, const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy, MonotonicTime timeOrigin, ReferrerPolicy referrerPolicy, WorkerType workerType, FetchRequestCredentials credentials, JSC::RuntimeFlags runtimeFlags)
 {
-    RefPtr scriptExecutionContext = m_scriptExecutionContext;
+    RefPtr workerObject = m_workerObject;
+    if (!workerObject)
+        return;
+
+    RefPtr scriptExecutionContext = workerObject->scriptExecutionContext();
     if (!scriptExecutionContext)
         return;
-    
+
     if (m_askedToTerminate) {
         // Worker.terminate() could be called from JS before the thread was created.
         return;
@@ -169,7 +170,7 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
         parentWorkerGlobalScope->thread()->addChildThread(thread);
         if (auto* parentWorkerClient = parentWorkerGlobalScope->workerClient())
             thread->setWorkerClient(parentWorkerClient->createNestedWorkerClient(thread.get()).moveToUniquePtr());
-    } else if (RefPtr document = dynamicDowncast<Document>(*scriptExecutionContext)) {
+    } else if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext.get())) {
         if (RefPtr page = document->page()) {
             if (auto workerClient = page->chrome().createWorkerClient(thread.get()))
                 thread->setWorkerClient(WTFMove(workerClient));
@@ -184,14 +185,11 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
 
 void WorkerMessagingProxy::postMessageToWorkerObject(MessageWithMessagePorts&& message)
 {
-    if (!m_scriptExecutionContextIdentifier)
-        return;
-
-    // Pass a RefPtr to the WorkerUserGestureForwarder, if present, into the main thread
+    // Pass a RefPtr to the WorkerUserGestureForwarder, if present, into the worker object's thread
     // task; the m_userGestureForwarder ivar may be cleared after this function returns.
-    ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this, message = WTFMove(message), userGestureForwarder = m_userGestureForwarder](auto& context) mutable {
-        RefPtr workerObject = this->workerObject();
-        if (!workerObject || askedToTerminate())
+    ScriptExecutionContext::postTaskTo(m_workerContextIdentifier, [protectedThis = Ref { *this }, message = WTFMove(message), userGestureForwarder = m_userGestureForwarder] (auto& context) mutable {
+        RefPtr workerObject = protectedThis->workerObject();
+        if (!workerObject || protectedThis->askedToTerminate())
             return;
 
         auto ports = MessagePort::entanglePorts(context, WTFMove(message.transferredPorts));
@@ -220,12 +218,9 @@ void WorkerMessagingProxy::postMessageToWorkerObject(MessageWithMessagePorts&& m
 
 void WorkerMessagingProxy::postTaskToWorkerObject(Function<void(Worker&)>&& function)
 {
-    if (!m_scriptExecutionContextIdentifier)
-        return;
-
-    ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this, function = WTFMove(function)](auto&) mutable {
-        RefPtr workerObject = this->workerObject();
-        if (!workerObject || askedToTerminate())
+    ScriptExecutionContext::postTaskTo(m_workerContextIdentifier, [protectedThis = Ref { *this }, function = WTFMove(function)](auto&) mutable {
+        RefPtr workerObject = protectedThis->workerObject();
+        if (!workerObject || protectedThis->askedToTerminate())
             return;
         function(*workerObject);
     });
@@ -307,10 +302,11 @@ void WorkerMessagingProxy::postTaskToLoader(ScriptExecutionContext::Task&& task)
 RefPtr<CacheStorageConnection> WorkerMessagingProxy::createCacheStorageConnection()
 {
     ASSERT(isMainThread());
-    if (!m_scriptExecutionContext)
+    RefPtr workerObject = m_workerObject;
+    if (!workerObject)
         return nullptr;
 
-    RefPtr document = dynamicDowncast<Document>(*m_scriptExecutionContext);
+    RefPtr document = dynamicDowncast<Document>(workerObject->scriptExecutionContext());
     ASSERT(document);
     if (!document || !document->page())
         return nullptr;
@@ -320,7 +316,11 @@ RefPtr<CacheStorageConnection> WorkerMessagingProxy::createCacheStorageConnectio
 RefPtr<RTCDataChannelRemoteHandlerConnection> WorkerMessagingProxy::createRTCDataChannelRemoteHandlerConnection()
 {
     ASSERT(isMainThread());
-    RefPtr document = dynamicDowncast<Document>(*m_scriptExecutionContext);
+    RefPtr workerObject = m_workerObject;
+    if (!workerObject)
+        return nullptr;
+
+    RefPtr document = dynamicDowncast<Document>(workerObject->scriptExecutionContext());
     ASSERT(document);
     if (!document || !document->page())
         return nullptr;
@@ -329,11 +329,8 @@ RefPtr<RTCDataChannelRemoteHandlerConnection> WorkerMessagingProxy::createRTCDat
 
 void WorkerMessagingProxy::postExceptionToWorkerObject(const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL)
 {
-    if (!m_scriptExecutionContextIdentifier)
-        return;
-
-    ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this, errorMessage = errorMessage.isolatedCopy(), sourceURL = sourceURL.isolatedCopy(), lineNumber, columnNumber](auto&) {
-        RefPtr workerObject = this->workerObject();
+    ScriptExecutionContext::postTaskTo(m_workerContextIdentifier, [protectedThis = Ref { *this }, errorMessage = errorMessage.isolatedCopy(), sourceURL = sourceURL.isolatedCopy(), lineNumber, columnNumber] (ScriptExecutionContext&) {
+        RefPtr workerObject = protectedThis->workerObject();
         if (!workerObject)
             return;
 
@@ -345,11 +342,8 @@ void WorkerMessagingProxy::postExceptionToWorkerObject(const String& errorMessag
 
 void WorkerMessagingProxy::reportErrorToWorkerObject(const String& errorMessage)
 {
-    if (!m_scriptExecutionContextIdentifier)
-        return;
-
-    ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this,  errorMessage =  errorMessage.isolatedCopy()] (auto&) {
-        if (RefPtr workerObject = this->workerObject())
+    ScriptExecutionContext::postTaskTo(m_workerContextIdentifier, [protectedThis = Ref { *this }, errorMessage = errorMessage.isolatedCopy()] (auto&) {
+        if (RefPtr workerObject = protectedThis->workerObject())
             workerObject->reportError(errorMessage);
     });
 }
@@ -389,15 +383,12 @@ void WorkerMessagingProxy::workerThreadCreated(DedicatedWorkerThread& workerThre
 void WorkerMessagingProxy::workerObjectDestroyed()
 {
     m_workerObject = nullptr;
-    if (!m_scriptExecutionContextIdentifier)
-        return;
-
-    ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this, protectedThis = Ref { *this }](auto&) {
-        m_mayBeDestroyed = true;
-        if (m_workerThread)
-            terminateWorkerGlobalScope();
+    ScriptExecutionContext::postTaskTo(m_workerContextIdentifier, [protectedThis = Ref { *this }] (ScriptExecutionContext&) {
+        protectedThis->m_mayBeDestroyed = true;
+        if (protectedThis->m_workerThread)
+            protectedThis->terminateWorkerGlobalScope();
         else
-            workerGlobalScopeDestroyedInternal();
+            protectedThis->workerGlobalScopeDestroyedInternal();
     });
 }
 
@@ -418,21 +409,15 @@ void WorkerMessagingProxy::notifyNetworkStateChange(bool isOnline)
 
 void WorkerMessagingProxy::workerGlobalScopeDestroyed()
 {
-    if (!m_scriptExecutionContextIdentifier)
-        return;
-
-    ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this](auto&) {
-        workerGlobalScopeDestroyedInternal();
+    ScriptExecutionContext::postTaskTo(m_workerContextIdentifier, [protectedThis = Ref { *this }] (ScriptExecutionContext&) {
+        protectedThis->workerGlobalScopeDestroyedInternal();
     });
 }
 
 void WorkerMessagingProxy::workerGlobalScopeClosed()
 {
-    if (!m_scriptExecutionContextIdentifier)
-        return;
-
-    ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this](auto&) {
-        terminateWorkerGlobalScope();
+    ScriptExecutionContext::postTaskTo(m_workerContextIdentifier, [protectedThis = Ref { *this }] (ScriptExecutionContext&) {
+        protectedThis->terminateWorkerGlobalScope();
     });
 }
 
@@ -444,14 +429,17 @@ void WorkerMessagingProxy::workerGlobalScopeDestroyedInternal()
 
     m_inspectorProxy->workerTerminated();
 
-    if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(m_scriptExecutionContext); workerGlobalScope && m_workerThread)
-        workerGlobalScope->thread()->removeChildThread(Ref { *m_workerThread });
+    if (RefPtr workerObject = m_workerObject) {
+        if (RefPtr scriptExecutionContext = workerObject->scriptExecutionContext()) {
+            if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(*scriptExecutionContext)) {
+                if (RefPtr workerThread = m_workerThread)
+                    workerGlobalScope->thread()->removeChildThread(*workerThread);
+            }
+        }
+    }
 
     if (RefPtr workerThread = std::exchange(m_workerThread, nullptr))
         workerThread->clearProxies();
-
-    m_scriptExecutionContext = nullptr;
-    m_scriptExecutionContextIdentifier = std::nullopt;
 
     // This balances the original ref in construction.
     if (m_mayBeDestroyed)
@@ -468,18 +456,11 @@ void WorkerMessagingProxy::terminateWorkerGlobalScope()
 
     if (RefPtr workerThread = m_workerThread)
         workerThread->stop(nullptr);
-    else {
-        m_scriptExecutionContext = nullptr;
-        m_scriptExecutionContextIdentifier = std::nullopt;
-    }
 }
 
 void WorkerMessagingProxy::setAppBadge(std::optional<uint64_t> badge)
 {
     ASSERT(!isMainThread());
-
-    if (!m_scriptExecutionContext)
-        return;
 
     postTaskToLoader([badge = WTFMove(badge), this, protectedThis = Ref { *this }] (auto& context) {
         ASSERT(isMainThread());

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -98,10 +98,9 @@ private:
 
     // WorkerBadgeProxy
     void setAppBadge(std::optional<uint64_t>) final;
-    
-    RefPtr<ScriptExecutionContext> m_scriptExecutionContext;
-    Markable<ScriptExecutionContextIdentifier> m_scriptExecutionContextIdentifier;
+
     ScriptExecutionContextIdentifier m_loaderContextIdentifier;
+    ScriptExecutionContextIdentifier m_workerContextIdentifier;
     const Ref<WorkerInspectorProxy> m_inspectorProxy;
     RefPtr<WorkerUserGestureForwarder> m_userGestureForwarder;
     Worker* m_workerObject;


### PR DESCRIPTION
#### 0a860f64ff147509758d2219946eee0fa8f4dec5
<pre>
[World Leaks] Fix leaks in LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/
<a href="https://bugs.webkit.org/show_bug.cgi?id=300526">https://bugs.webkit.org/show_bug.cgi?id=300526</a>
<a href="https://rdar.apple.com/162395265">rdar://162395265</a>

Reviewed by NOBODY (OOPS!).

We encounter leaks in a selection of tests from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/
and worker-module.http-rp/ and some corresponding tests in
LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/ and
LayoutTests/imported/w3c/web-platform-tests/workers/ which total approximately 15
leaky tests. This patch resolves those leaks by removing the strong
Ref&lt;ScriptExecutionContext&gt; previously held by WorkerMessagingProxy::m_scriptExecutionContext.

Test: webgl/worker-does-not-leak.html

* LayoutTests/webgl/webgl-worker.html:
* LayoutTests/webgl/worker-does-not-leak-expected.txt: Added.
* LayoutTests/webgl/worker-does-not-leak.html: Added.
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::makeCrossOriginAccessRequest):
(WebCore::DocumentThreadableLoader::cancel):
(WebCore::DocumentThreadableLoader::responseReceived):
(WebCore::DocumentThreadableLoader::didReceiveResponse):
(WebCore::DocumentThreadableLoader::finishedTimingForWorkerLoad):
(WebCore::DocumentThreadableLoader::preflightFailure):
(WebCore::DocumentThreadableLoader::loadRequest):
(WebCore::DocumentThreadableLoader::securityOrigin const):
(WebCore::DocumentThreadableLoader::topOrigin const):
(WebCore::DocumentThreadableLoader::contentSecurityPolicy const):
(WebCore::DocumentThreadableLoader::crossOriginEmbedderPolicy const):
(WebCore::DocumentThreadableLoader::logErrorAndFail):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::WorkerMessagingProxy):
(WebCore::WorkerMessagingProxy::~WorkerMessagingProxy):
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
(WebCore::WorkerMessagingProxy::postMessageToWorkerObject):
(WebCore::WorkerMessagingProxy::postTaskToWorkerObject):
(WebCore::WorkerMessagingProxy::createCacheStorageConnection):
(WebCore::WorkerMessagingProxy::createRTCDataChannelRemoteHandlerConnection):
(WebCore::WorkerMessagingProxy::postExceptionToWorkerObject):
(WebCore::WorkerMessagingProxy::reportErrorToWorkerObject):
(WebCore::WorkerMessagingProxy::workerObjectDestroyed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeClosed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyedInternal):
(WebCore::WorkerMessagingProxy::terminateWorkerGlobalScope):
(WebCore::WorkerMessagingProxy::setAppBadge):
(WebCore::m_workerObject): Deleted.
* Source/WebCore/workers/WorkerMessagingProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a860f64ff147509758d2219946eee0fa8f4dec5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81535 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99042 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66841 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1675 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116456 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79742 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1593 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34581 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80691 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110118 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139898 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107550 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107443 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1657 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54914 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2152 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65521 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1968 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2001 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2075 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->