### PR TITLE
[Safer CPP] Unskip files that are now passing on the bot

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -61,7 +61,6 @@ html/track/TrackBase.h
 inspector/InspectorController.h
 [ Mac ] inspector/InspectorFrontendHost.h
 inspector/InspectorInstrumentation.h
-inspector/InspectorOverlay.h
 inspector/InspectorStyleSheet.h
 inspector/InstrumentingAgents.h
 inspector/UserGestureEmulationScope.h

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -38,9 +38,6 @@ WebProcess/cocoa/WebProcessCocoa.mm
 [ Mac ] Platform/cocoa/_WKWebViewTextInputNotifications.mm
 [ Mac ] UIProcess/API/Cocoa/_WKInspectorExtension.mm
 [ Mac ] UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
-[ Mac ] UIProcess/API/mac/WKWebViewTestingMac.mm
-[ Mac ] UIProcess/mac/WKTextAnimationManagerMac.mm
-[ Mac ] UIProcess/mac/WebViewImpl.mm
 [ Mac ] WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
 [ Mac ] WebProcess/WebPage/MomentumEventDispatcher.cpp
 [ Mac ] WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm


### PR DESCRIPTION
#### 866fcf91485ea203bc6b68568ab56a8db24d723c
<pre>
[Safer CPP] Unskip files that are now passing on the bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=300743">https://bugs.webkit.org/show_bug.cgi?id=300743</a>

Unreviewed, unskip files that are now passing on the safer cpp bot.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/301513@main">https://commits.webkit.org/301513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/414cbc4c407b041b08b56e5839dd558820736f60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126217 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/45873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36689 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128088 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/46537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/54418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/132995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129165 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/46537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/112895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/46537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/46537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/31303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/52966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/54418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/135696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/53428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/109118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19734 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/52866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/58697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/53899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->