### PR TITLE
media/modern-media-controls/volume-support/volume-support-drag-to-mute.html is a constant timeout

### DIFF
--- a/LayoutTests/media/modern-media-controls/volume-support/volume-support-drag-to-mute.html
+++ b/LayoutTests/media/modern-media-controls/volume-support/volume-support-drag-to-mute.html
@@ -78,7 +78,7 @@ function dragVolumeSlider(fromVolume, toVolume)
     eventSender.mouseMoveTo(centerX, dragStartY);
     eventSender.mouseDown();
     for (let i = 1; i <= iterations; ++i)
-        eventSender.mouseMoveTo(dragVolumeSlider, dragStartY + i * Math.sign(delta));
+        eventSender.mouseMoveTo(centerX, dragStartY + i * Math.sign(delta));
     eventSender.mouseUp();
 }
 


### PR DESCRIPTION
#### d12924d35c74e2183fc4538530c5636871317f9a
<pre>
media/modern-media-controls/volume-support/volume-support-drag-to-mute.html is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=300741">https://bugs.webkit.org/show_bug.cgi?id=300741</a>
<a href="https://rdar.apple.com/162324754">rdar://162324754</a>

Reviewed by NOBODY (OOPS!).

Pass an actual number as the x coordinate to `eventSender.mouseMoveTo` (rather than an element).
Prior to <a href="https://commits.webkit.org/299237@main">299237@main</a>, this resulted in an integer value `0` being used as the x offset, but aftter
the change, this results in `nan` which causes the whole event dispatch to fail.

* LayoutTests/media/modern-media-controls/volume-support/volume-support-drag-to-mute.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d12924d35c74e2183fc4538530c5636871317f9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126219 "Failed to checkout and rebase branch from PR 52337") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45875 "Failed to checkout and rebase branch from PR 52337") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36691 "Failed to checkout and rebase branch from PR 52337") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/46539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/54420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/132997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129167 "Failed to checkout and rebase branch from PR 52337") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/46539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/36691 "Failed to checkout and rebase branch from PR 52337") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/46539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/36691 "Failed to checkout and rebase branch from PR 52337") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/46539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/36691 "Failed to checkout and rebase branch from PR 52337") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/52968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/54420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/135698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/53430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/36691 "Failed to checkout and rebase branch from PR 52337") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/36691 "Failed to checkout and rebase branch from PR 52337") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/52868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/53901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->