### PR TITLE
Find in Page doesn’t correctly highlight results after revealing content on iOS/iPadOS

### DIFF
--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -63,9 +63,9 @@ public:
 
     void detach();
 
-    WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarkerType, const DocumentMarker::Data& = { });
-    void addMarker(Node&, unsigned startOffset, unsigned length, DocumentMarkerType, DocumentMarker::Data&& = { });
-    WEBCORE_EXPORT void addMarker(Node&, DocumentMarker&&);
+    WEBCORE_EXPORT bool addMarker(const SimpleRange&, DocumentMarkerType, const DocumentMarker::Data& = { });
+    bool addMarker(Node&, unsigned startOffset, unsigned length, DocumentMarkerType, DocumentMarker::Data&& = { });
+    WEBCORE_EXPORT bool addMarker(Node&, DocumentMarker&&);
     void addDraggedContentMarker(const SimpleRange&);
     WEBCORE_EXPORT void addTransparentContentMarker(const SimpleRange&, WTF::UUID);
 

--- a/Source/WebCore/dom/FindRevealAlgorithms.h
+++ b/Source/WebCore/dom/FindRevealAlgorithms.h
@@ -29,6 +29,6 @@ namespace WebCore {
 
 class Node;
 
-WEBCORE_EXPORT void revealClosedDetailsAndHiddenUntilFoundAncestors(Node&);
+WEBCORE_EXPORT bool revealClosedDetailsAndHiddenUntilFoundAncestors(Node&);
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
@@ -106,6 +106,7 @@ private:
 
     HashMap<WebFoundTextRange, std::optional<WebCore::WeakSimpleRange>> m_cachedFoundRanges;
     HashMap<WebFoundTextRange, FindDecorationStyle> m_decoratedRanges;
+    HashSet<WebFoundTextRange> m_unhighlightedFoundRanges;
 
     RefPtr<WebCore::TextIndicator> m_textIndicator;
 };


### PR DESCRIPTION
#### 5b38850ca53e0cecf0fbdef20fc3b1974f1a649c
<pre>
Find in Page doesn’t correctly highlight results after revealing content on iOS/iPadOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=300744">https://bugs.webkit.org/show_bug.cgi?id=300744</a>
<a href="https://rdar.apple.com/159801954">rdar://159801954</a>

Reviewed by Aditya Keerthi.

The issue is that the `FindDecorationStyle::Found` markers are issued before the content was revealed in the `FindDecorationStyle::Highlighted` branch of `decorateTextRangeWithStyle`.

This leads to the found markers failing to be added.

Since we can&apos;t change the order for which UIKit issues these markers, we instead:
1. store the markers that fail to be added into a set
2. re-attempt to add those markers if some content got expanded

Not testable, highlights are hard to test since they are cutouts in a layer and there is no existing testing infrastructure for them.

* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::addMarker):
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/dom/FindRevealAlgorithms.cpp:
(WebCore::revealClosedDetailsAndHiddenUntilFoundAncestors):
* Source/WebCore/dom/FindRevealAlgorithms.h:
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::decorateTextRangeWithStyle):
(WebKit::WebFoundTextRangeController::clearAllDecoratedFoundText):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h:

Canonical link: <a href="https://commits.webkit.org/301751@main">https://commits.webkit.org/301751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03c59963d5b79bf5773320ade493b3dab28cf0a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133930 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/28f65a41-164e-4c86-9947-963c3cb666af) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96585 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/afdc0fac-0d24-4fd2-aec0-6aab1ecc6098) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113529 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/77099 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/96b9d4a1-591a-42b6-a61c-355dd0e5ae37) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77324 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136455 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41256 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105101 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104793 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26723 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50308 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28646 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51066 "Hash 03c59963 for PR 52340 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59387 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52760 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56094 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54518 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->