### PR TITLE
[WIP] For testing, assert zero extension always

### DIFF
--- a/JSTests/wasm/stress/simd-const-relaxed-f32-madd.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f32-madd.js
@@ -1,5 +1,8 @@
 //@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// FIXME: remove --useWasmIPIntSIMD=0 and don't skip no-jit once IPInt support is implemented
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js
@@ -1,5 +1,8 @@
 //@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// FIXME: remove --useWasmIPIntSIMD=0 and don't skip no jit modes once IPInt support is implemented
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-const-relaxed-f64-madd.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f64-madd.js
@@ -1,5 +1,8 @@
 //@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// FIXME: remove --useWasmIPIntSIMD=0 and don't skip no jit modes once IPInt support is implemented
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js
@@ -1,5 +1,8 @@
 //@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// FIXME: remove --useWasmIPIntSIMD=0 and don't skip no jit modes once IPInt support is implemented
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-const-relaxed-lane-select.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-lane-select.js
@@ -1,5 +1,8 @@
 //@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// FIXME: remove --useWasmIPIntSIMD=0 and don't skip no jit modes once IPInt support is implemented
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-const-relaxed-swizzle.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-swizzle.js
@@ -1,5 +1,8 @@
 //@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+// FIXME: remove --useWasmIPIntSIMD=0 and don't skip no jit modes once IPInt support is implemented
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/Source/JavaScriptCore/jit/OperationResult.h
+++ b/Source/JavaScriptCore/jit/OperationResult.h
@@ -55,10 +55,15 @@ concept canMakeExceptionOperationResult =
 #if USE(JSVALUE64)
 
 template<typename T>
+concept shouldZeroExtendInExceptionResult = sizeof(T) < sizeof(UCPURegister) && std::is_integral_v<T>;
+
+template<typename T>
 struct ExceptionOperationResult {
     using ResultType = T;
     static_assert(assertNotOperationSignature<T>);
-    T value;
+    // Use UCPURegister for small integral types to ensure full register width is written,
+    // avoiding garbage in upper bits of return register. This matches the JSVALUE32_64 behavior.
+    std::conditional_t<shouldZeroExtendInExceptionResult<T>, UCPURegister, T> value;
     Exception* exception;
 };
 
@@ -99,7 +104,16 @@ struct ExceptionOperationImplicitResult {
     {
         // For whatever reason aggregate initialization doesn't seem to work here.
         ExceptionOperationResult<To> result;
-        result.value = value;
+        // For small integral types, explicitly zero-extend to match JSVALUE32_64 behavior.
+        // We cast to the corresponding unsigned type first to ensure zero-extension rather than sign-extension.
+        // Special case bool since std::make_unsigned_t doesn't work with bool.
+        if constexpr (shouldZeroExtendInExceptionResult<From>) {
+            if constexpr (std::is_same_v<From, bool>)
+                result.value = static_cast<UCPURegister>(value);
+            else
+                result.value = static_cast<std::make_unsigned_t<From>>(value);
+        } else
+            result.value = value;
         result.exception = exception;
         return result;
     }

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -1063,7 +1063,6 @@ end
     cCall4(_operationWasmToJSExitMarshalArguments)
     btpnz r1, .oom
 
-if ASSERT_ENABLED
     # Assert that upper bits of r0 are clean (bool should only use low byte)
     # On X86_64, r0 is t0/RAX. We check that bits 8-31 are zero.
     move r0, t2
@@ -1071,7 +1070,6 @@ if ASSERT_ENABLED
     bieq t2, 0, .upperBitsClean
     break
 .upperBitsClean:
-end
 
     bineq r0, 0, .safe
     move wasmInstance, a0

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -1063,9 +1063,19 @@ end
     cCall4(_operationWasmToJSExitMarshalArguments)
     btpnz r1, .oom
 
+if ASSERT_ENABLED
+    # Assert that upper bits of r0 are clean (bool should only use low byte)
+    # On X86_64, r0 is t0/RAX. We check that bits 8-31 are zero.
+    move r0, t2
+    rshifti 8, t2
+    bieq t2, 0, .upperBitsClean
+    break
+.upperBitsClean:
+end
+
     bineq r0, 0, .safe
-    move wasmInstance, r0
-    move (constexpr Wasm::ExceptionType::TypeErrorInvalidValueUse), r1
+    move wasmInstance, a0
+    move (constexpr Wasm::ExceptionType::TypeErrorInvalidValueUse), a1
     cCall2(_operationWasmToJSException)
     jumpToException()
     break

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -624,7 +624,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useWasmIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues"_s) \
     v(Bool, useWasmIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during loop iterations"_s) \
     v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues"_s) \
-    v(Bool, useWasmIPIntSIMD, false, Normal, "Allow IPInt to interpret SIMD code"_s) \
+    v(Bool, useWasmIPIntSIMD, true, Normal, "Allow IPInt to interpret SIMD code"_s) \
     v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing."_s) \
     v(Bool, useOMGInlining, true, Normal, "Use OMG inlining"_s) \
     v(Bool, freeRetiredWasmCode, true, Normal, "free BBQ/OMG-OSR wasm code once it's no longer reachable."_s) \

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1917,8 +1917,7 @@ def runWebAssemblySuite(*optionalTestSpecificOptions)
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
         run("wasm-bbq", "--useWasmIPInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-bbq-no-consts", "--useWasmIPInt=false", "--disableBBQConsts=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
-        # FIXME: this is a hacky way to check if we use SIMD rdar://138436830
-        if $runJITlessWasm and not $testSpecificRequiredOptions.include? "--useWasmSIMD=1"
+        if $runJITlessWasm
           run("wasm-no-jit", "--useJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?("wasm-no-jit".to_sym)
           run("wasm-no-wasm-jit", "--useBBQJIT=false", "--useOMGJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?("wasm-no-wasm-jit".to_sym)
         end
@@ -1951,8 +1950,7 @@ def runV8WebAssemblySuite(*optionalTestSpecificOptions)
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
         run("wasm-bbq", "--useWasmIPInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-bbq-no-consts", "--useWasmIPInt=false", "--disableBBQConsts=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
-        # FIXME: this is a hacky way to check if we use SIMD rdar://138436830
-        if $runJITlessWasm and not $testSpecificRequiredOptions.include? "--useWasmSIMD=1"
+        if $runJITlessWasm
           run("wasm-no-jit", "--useJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?("wasm-no-jit".to_sym)
           run("wasm-no-wasm-jit", "--useBBQJIT=false", "--useOMGJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?("wasm-no-wasm-jit".to_sym)
         end
@@ -2031,8 +2029,7 @@ def runWebAssemblyEmscripten(mode)
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *FTL_OPTIONS)
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *FTL_OPTIONS) if shouldCollectContinuously?
         run("wasm-bbq", "--useWasmIPInt=false", *FTL_OPTIONS) # Doesn't actually depend on FTL, but we enable it on the same platforms for now.
-        # FIXME: this is a hacky way to check if we use SIMD rdar://138436830
-        if $runJITlessWasm and not $testSpecificRequiredOptions.include? "--useWasmSIMD=1"
+        if $runJITlessWasm
           run("wasm-no-jit", "--useJIT=false" *FTL_OPTIONS) unless $skipModes.include?("wasm-no-jit".to_sym)
           run("wasm-no-wasm-jit", "--useBBQJIT=false", "--useOMGJIT=false" *FTL_OPTIONS) unless $skipModes.include?("wasm-no-wasm-jit".to_sym)
         end


### PR DESCRIPTION
#### a93406863a3bc05c4d649e2894663ef99b4ca0c2
<pre>
For testing, assert zero extension always
</pre>
----------------------------------------------------------------------
#### 21fff7c66b774cb790c718e942d11006be9183d4
<pre>
Fix operations returning bool and argument registers
</pre>
----------------------------------------------------------------------
#### 28728696b1a886c8e3aaab93694a85da664d8861
<pre>
[JSC] WASM IPInt SIMD: enable by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=300666">https://bugs.webkit.org/show_bug.cgi?id=300666</a>
<a href="https://rdar.apple.com/162563158">rdar://162563158</a>

Reviewed by NOBODY (OOPS!).

Enable Wasm SIMD support in InPlaceInterpreter by default.

Remove the hack in run-jsc-stress-tests that was used to skip the
JIT-less modes for SIMD tests. Explicitly skip JIT-less modes for
the handful of relaxed SIMD tests that are exercising the off-by-default
relaxed SIMD instructions currently implemented by BBQ/OMG.

* JSTests/wasm/stress/simd-const-relaxed-f32-madd.js:
* JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js:
* JSTests/wasm/stress/simd-const-relaxed-f64-madd.js:
* JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js:
* JSTests/wasm/stress/simd-const-relaxed-lane-select.js:
* JSTests/wasm/stress/simd-const-relaxed-swizzle.js:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Tools/Scripts/run-jsc-stress-tests:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a93406863a3bc05c4d649e2894663ef99b4ca0c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78009 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4fb2670d-ca2f-4100-b152-35853ffca4e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128112 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54439 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96122 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/core/simd/simd_select.wast.js.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6fef4373-73c2-4b4b-b583-12bda8174846) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76602 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41e477d0-f3e2-406d-8051-1dbd4fc4b9c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31094 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76486 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118316 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107036 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31325 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/core/simd/simd_select.wast.js.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135714 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124706 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52986 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40702 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/core/simd/simd_select.wast.js.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104624 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/core/simd/simd_select.wast.js.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104324 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49753 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28087 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/core/simd/simd_select.wast.js.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50369 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52886 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58717 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157755 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52203 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39477 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55547 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53919 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->