### PR TITLE
[SaferC++] Improve memory safety in WebCoreSupport and InjectedBundle code

### DIFF
--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -62,11 +62,13 @@ public:
 
     void setInnerNonSharedNode(Node*);
     Node* innerNonSharedNode() const { return m_innerNonSharedNode.get(); }
+    RefPtr<Node> protectedInnerNonSharedNode() const { return m_innerNonSharedNode.get(); }
 
     WEBCORE_EXPORT Element* innerNonSharedElement() const;
 
     void setURLElement(Element*);
     Element* URLElement() const { return m_innerURLElement.get(); }
+    RefPtr<Element> protectedURLElement() const { return m_innerURLElement.get(); }
 
     void setScrollbar(RefPtr<Scrollbar>&&);
     Scrollbar* scrollbar() const { return m_scrollbar.get(); }

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -63,10 +63,7 @@ WebProcess/InjectedBundle/API/mac/WKDOMText.mm
 WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
-WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
-WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 WebProcess/Inspector/WebInspectorUI.cpp
-WebProcess/WebCoreSupport/WebChromeClient.cpp
 WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 WebProcess/WebPage/Cocoa/TextAnimationController.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
@@ -59,7 +59,7 @@ InjectedBundleDOMWindowExtension* InjectedBundleDOMWindowExtension::get(DOMWindo
 }
 
 InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension(WebFrame* frame, InjectedBundleScriptWorld* world)
-    : m_coreExtension(DOMWindowExtension::create(frame->coreLocalFrame() ? frame->coreLocalFrame()->window() : nullptr, world->coreWorld()))
+    : m_coreExtension(DOMWindowExtension::create(frame->coreLocalFrame() ? frame->protectedCoreLocalFrame()->protectedWindow() : nullptr, world->protectedCoreWorld()))
 {
     allExtensions().add(m_coreExtension.get(), *this);
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
@@ -52,12 +52,12 @@ Ref<InjectedBundleHitTestResult> InjectedBundleHitTestResult::create(const HitTe
 
 RefPtr<InjectedBundleNodeHandle> InjectedBundleHitTestResult::nodeHandle() const
 {
-    return InjectedBundleNodeHandle::getOrCreate(m_hitTestResult.innerNonSharedNode());
+    return InjectedBundleNodeHandle::getOrCreate(m_hitTestResult.protectedInnerNonSharedNode().get());
 }
 
 RefPtr<InjectedBundleNodeHandle> InjectedBundleHitTestResult::urlElementHandle() const
 {
-    return InjectedBundleNodeHandle::getOrCreate(m_hitTestResult.URLElement());
+    return InjectedBundleNodeHandle::getOrCreate(m_hitTestResult.protectedURLElement().get());
 }
 
 RefPtr<WebFrame> InjectedBundleHitTestResult::frame() const
@@ -156,7 +156,7 @@ IntRect InjectedBundleHitTestResult::imageRect() const
     if (!coreFrame)
         return imageRect;
     
-    auto* view = coreFrame->view();
+    RefPtr view = coreFrame->view();
     if (!view)
         return imageRect;
     

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -328,7 +328,7 @@ void WebChromeClient::focusedElementChanged(Element* element, LocalFrame* frame,
     RefPtr webFrame = coreFrame ? WebFrame::fromCoreFrame(*coreFrame) : nullptr;
     RefPtr page = m_page.get();
     if (page && broadcast == BroadcastFocusedElement::Yes)
-        WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::FocusedElementChanged(webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt, options), page->identifier());
+        WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::FocusedElementChanged(webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt, options), page->identifier());
 
     RefPtr inputElement = dynamicDowncast<HTMLInputElement>(element);
     if (!inputElement || !inputElement->isText())


### PR DESCRIPTION
#### 907d0b02a3e874a0c4b3ea9814537318e25698e8
<pre>
[SaferC++] Improve memory safety in WebCoreSupport and InjectedBundle code
<a href="https://bugs.webkit.org/show_bug.cgi?id=300750">https://bugs.webkit.org/show_bug.cgi?id=300750</a>
<a href="https://rdar.apple.com/162643379">rdar://162643379</a>

Reviewed by NOBODY (OOPS!).

Apply SaferC++ guidelines to the following files:

* Source/WebCore/rendering/HitTestResult.h:
(WebCore::HitTestResult::protectedInnerNonSharedNode const):
(WebCore::HitTestResult::protectedURLElement const):
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp:
(WebKit::InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp:
(WebKit::InjectedBundleHitTestResult::nodeHandle const):
(WebKit::InjectedBundleHitTestResult::urlElementHandle const):
(WebKit::InjectedBundleHitTestResult::imageRect const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::focusedElementChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/907d0b02a3e874a0c4b3ea9814537318e25698e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126243 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45899 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36719 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133017 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78011 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/370857b2-b905-4017-9d0f-0864a6222185) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128114 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46559 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54441 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/133017 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/78011 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a12f05b-ad8b-4994-b55e-6ccdd3f5c4c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129191 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/46559 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/36719 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/133017 "Hash 907d0b02 for PR 52344 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d41ea30d-1e18-4889-9928-4831a3c08c53) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/46559 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/36719 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76488 "Hash 907d0b02 for PR 52344 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/46559 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/36719 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135716 "Hash 907d0b02 for PR 52344 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52988 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/54441 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/135716 "Hash 907d0b02 for PR 52344 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53450 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/36719 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/135716 "Hash 907d0b02 for PR 52344 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/36719 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50371 "Hash 907d0b02 for PR 52344 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52888 "Hash 907d0b02 for PR 52344 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58719 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52205 "Hash 907d0b02 for PR 52344 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55549 "Hash 907d0b02 for PR 52344 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53921 "Hash 907d0b02 for PR 52344 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->