### PR TITLE
Address safer cpp warnings in WKNSURLAuthenticationChallenge.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,7 +1,6 @@
 AutomationProtocolObjects.h
 Shared/API/c/cf/WKStringCF.mm
 Shared/API/c/cf/WKURLCF.mm
-UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
 WebDriverBidiProtocolObjects.h
 WebProcess/GPU/graphics/Model/ModelDowncastConvertToBackingContext.cpp
 WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
@@ -38,7 +38,7 @@
 
 - (NSObject *)_web_createTarget
 {
-    Ref challenge = *reinterpret_cast<WebKit::AuthenticationChallengeProxy*>(&self._apiObject);
+    Ref challenge = downcast<WebKit::AuthenticationChallengeProxy>(self._apiObject);
 
     static dispatch_once_t token;
     static NeverDestroyed<RetainPtr<WKNSURLAuthenticationChallengeSender>> sender;
@@ -51,7 +51,7 @@
 
 - (WebKit::AuthenticationChallengeProxy&)_web_authenticationChallengeProxy
 {
-    return *reinterpret_cast<WebKit::AuthenticationChallengeProxy*>(&self._apiObject);
+    return downcast<WebKit::AuthenticationChallengeProxy>(self._apiObject);
 }
 
 @end


### PR DESCRIPTION
#### 0084566e6c289118c09888dc30ee024e31542d88
<pre>
Address safer cpp warnings in WKNSURLAuthenticationChallenge.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=300752">https://bugs.webkit.org/show_bug.cgi?id=300752</a>

Reviewed by Darin Adler.

* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm:
(-[WKNSURLAuthenticationChallenge _web_createTarget]):
(-[WKNSURLAuthenticationChallenge _web_authenticationChallengeProxy]):

Canonical link: <a href="https://commits.webkit.org/301541@main">https://commits.webkit.org/301541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dac809179ef47eeffd3bd2057ddbf5ac6c313322

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78016 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c8e6f26-c2a7-4bbd-be17-8f09aa2db188) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96113 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0cd9990-6d1d-438d-a93b-6ecb9705d6d5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76594 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f85f4b30-10f3-4f45-89c5-2eaa243caad2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36147 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76493 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135721 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104613 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104314 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26610 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49757 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28098 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50376 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52893 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58724 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52210 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55554 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53926 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->