### PR TITLE
Address safer cpp warnings in _WKPublicKey* classes

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -37,13 +37,6 @@ UIProcess/API/Cocoa/_WKFeature.mm
 UIProcess/API/Cocoa/_WKInspector.mm
 UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
 UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
-UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.mm
-UIProcess/API/Cocoa/_WKPublicKeyCredentialDescriptor.mm
-UIProcess/API/Cocoa/_WKPublicKeyCredentialEntity.mm
-UIProcess/API/Cocoa/_WKPublicKeyCredentialParameters.mm
-UIProcess/API/Cocoa/_WKPublicKeyCredentialRelyingPartyEntity.mm
-UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.mm
-UIProcess/API/Cocoa/_WKPublicKeyCredentialUserEntity.mm
 [ Mac ] UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
 UIProcess/API/Cocoa/_WKTextManipulationConfiguration.mm
 UIProcess/API/Cocoa/_WKTextManipulationToken.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.mm
@@ -44,14 +44,14 @@
 
 - (void)dealloc
 {
-    [_relyingParty release];
-    [_user release];
-    [_publicKeyCredentialParamaters release];
-    [_timeout release];
-    [_excludeCredentials release];
-    [_authenticatorSelection release];
-    [_extensions release];
-    [_extensionsCBOR release];
+    SUPPRESS_UNRETAINED_ARG [_relyingParty release];
+    SUPPRESS_UNRETAINED_ARG [_user release];
+    SUPPRESS_UNRETAINED_ARG [_publicKeyCredentialParamaters release];
+    SUPPRESS_UNRETAINED_ARG [_timeout release];
+    SUPPRESS_UNRETAINED_ARG [_excludeCredentials release];
+    SUPPRESS_UNRETAINED_ARG [_authenticatorSelection release];
+    SUPPRESS_UNRETAINED_ARG [_extensions release];
+    SUPPRESS_UNRETAINED_ARG [_extensionsCBOR release];
     [super dealloc];
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialDescriptor.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialDescriptor.mm
@@ -39,8 +39,8 @@
 
 - (void)dealloc
 {
-    [_identifier release];
-    [_transports release];
+    SUPPRESS_UNRETAINED_ARG [_identifier release];
+    SUPPRESS_UNRETAINED_ARG [_transports release];
     [super dealloc];
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialEntity.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialEntity.mm
@@ -39,8 +39,8 @@
 
 - (void)dealloc
 {
-    [_name release];
-    [_icon release];
+    SUPPRESS_UNRETAINED_ARG [_name release];
+    SUPPRESS_UNRETAINED_ARG [_icon release];
     [super dealloc];
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialParameters.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialParameters.mm
@@ -39,7 +39,7 @@
 
 - (void)dealloc
 {
-    [_algorithm release];
+    SUPPRESS_UNRETAINED_ARG [_algorithm release];
     [super dealloc];
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialRelyingPartyEntity.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialRelyingPartyEntity.mm
@@ -37,7 +37,7 @@
 
 - (void)dealloc
 {
-    [_identifier release];
+    SUPPRESS_UNRETAINED_ARG [_identifier release];
     [super dealloc];
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.mm
@@ -40,11 +40,11 @@
 
 - (void)dealloc
 {
-    [_timeout release];
-    [_relyingPartyIdentifier release];
-    [_allowCredentials release];
-    [_extensions release];
-    [_extensionsCBOR release];
+    SUPPRESS_UNRETAINED_ARG [_timeout release];
+    SUPPRESS_UNRETAINED_ARG [_relyingPartyIdentifier release];
+    SUPPRESS_UNRETAINED_ARG [_allowCredentials release];
+    SUPPRESS_UNRETAINED_ARG [_extensions release];
+    SUPPRESS_UNRETAINED_ARG [_extensionsCBOR release];
     [super dealloc];
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialUserEntity.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialUserEntity.mm
@@ -40,8 +40,8 @@
 
 - (void)dealloc
 {
-    [_identifier release];
-    [_displayName release];
+    SUPPRESS_UNRETAINED_ARG [_identifier release];
+    SUPPRESS_UNRETAINED_ARG [_displayName release];
     [super dealloc];
 }
 


### PR DESCRIPTION
#### aedf737b7019365992f734155b59674effbd38da
<pre>
Address safer cpp warnings in _WKPublicKey* classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=300758">https://bugs.webkit.org/show_bug.cgi?id=300758</a>

Reviewed by Darin Adler.

* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.mm:
(-[_WKPublicKeyCredentialCreationOptions dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialDescriptor.mm:
(-[_WKPublicKeyCredentialDescriptor dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialEntity.mm:
(-[_WKPublicKeyCredentialEntity dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialParameters.mm:
(-[_WKPublicKeyCredentialParameters dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialRelyingPartyEntity.mm:
(-[_WKPublicKeyCredentialRelyingPartyEntity dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.mm:
(-[_WKPublicKeyCredentialRequestOptions dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialUserEntity.mm:
(-[_WKPublicKeyCredentialUserEntity dealloc]):

Canonical link: <a href="https://commits.webkit.org/301543@main">https://commits.webkit.org/301543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b136cc1cb9d85852cf7f29b99040f1f16dea77ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78024 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f167fe1-4ff6-4676-9572-7ccae1940543) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54455 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96121 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5174cdd8-9fc8-426c-8ef1-56cc489c4cff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76601 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/308ec8ba-ab1e-4309-bebc-51dbd35fba54) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36165 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76501 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135729 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40715 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104620 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104321 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26614 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28099 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50384 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52901 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58732 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52218 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55562 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53934 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->