### PR TITLE
Address safer cpp warnings in _WKInspector* classes

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -36,7 +36,6 @@ WebProcess/cocoa/PlaybackSessionManager.mm
 WebProcess/cocoa/VideoPresentationManager.mm
 WebProcess/cocoa/WebProcessCocoa.mm
 [ Mac ] Platform/cocoa/_WKWebViewTextInputNotifications.mm
-[ Mac ] UIProcess/API/Cocoa/_WKInspectorExtension.mm
 [ Mac ] UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
 [ Mac ] WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
 [ Mac ] WebProcess/WebPage/MomentumEventDispatcher.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -10,10 +10,6 @@ UIProcess/API/Cocoa/_WKContentRuleListAction.mm
 UIProcess/API/Cocoa/_WKCustomHeaderFields.mm
 UIProcess/API/Cocoa/_WKFeature.mm
 UIProcess/API/Cocoa/_WKFrameTreeNode.mm
-UIProcess/API/Cocoa/_WKInspector.mm
-UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
-UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.mm
-UIProcess/API/Cocoa/_WKInspectorTesting.mm
 UIProcess/API/Cocoa/_WKJSHandle.mm
 UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 UIProcess/API/Cocoa/_WKResourceLoadStatisticsFirstParty.mm
@@ -78,7 +74,6 @@ WebProcess/cocoa/TextTrackRepresentationCocoa.mm
 WebProcess/cocoa/VideoPresentationManager.mm
 WebProcess/cocoa/WebProcessCocoa.mm
 [ Mac ] UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
-[ Mac ] UIProcess/API/Cocoa/_WKInspectorExtension.mm
 [ Mac ] UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
 [ Mac ] WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
 [ Mac ] WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -34,8 +34,6 @@ UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.mm
 UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.mm
 UIProcess/API/Cocoa/_WKAuthenticatorResponse.mm
 UIProcess/API/Cocoa/_WKFeature.mm
-UIProcess/API/Cocoa/_WKInspector.mm
-UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
 UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 [ Mac ] UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
 UIProcess/API/Cocoa/_WKTextManipulationConfiguration.mm

--- a/Source/WebKit/UIProcess/API/APIInspectorConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIInspectorConfiguration.cpp
@@ -48,9 +48,9 @@ WebKit::WebProcessPool* InspectorConfiguration::processPool()
     return m_processPool.get();
 }
 
-void InspectorConfiguration::setProcessPool(WebKit::WebProcessPool* processPool)
+void InspectorConfiguration::setProcessPool(RefPtr<WebKit::WebProcessPool>&& processPool)
 {
-    m_processPool = processPool;
+    m_processPool = WTFMove(processPool);
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIInspectorConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIInspectorConfiguration.h
@@ -49,7 +49,7 @@ public:
     const Vector<URLSchemeHandlerPair>& urlSchemeHandlers() { return m_customURLSchemes; }
     
     WebKit::WebProcessPool* processPool();
-    void setProcessPool(WebKit::WebProcessPool*);
+    void setProcessPool(RefPtr<WebKit::WebProcessPool>&&);
 
 private:
     Vector<URLSchemeHandlerPair> m_customURLSchemes;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.mm
@@ -95,7 +95,7 @@
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKInspectorDebuggableInfo.class, self))
         return;
 
-    _debuggableInfo->~DebuggableInfo();
+    SUPPRESS_UNRETAINED_ARG _debuggableInfo->~DebuggableInfo();
 
     [super dealloc];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h
@@ -38,6 +38,8 @@ template<> struct WrapperTraits<WebInspectorUIProxy> {
 
 }
 
+Ref<WebKit::WebInspectorUIProxy> protectedInspector(_WKInspector *);
+
 @interface _WKInspector () <WKObject> {
 @package
     AlignedStorage<WebKit::WebInspectorUIProxy> _inspector;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorTesting.mm
@@ -53,13 +53,13 @@ static NSString *JavaScriptSnippetToFetchURL(NSURL *url)
 
 - (void)_fetchURLForTesting:(NSURL *)url
 {
-    _inspector->evaluateInFrontendForTesting(JavaScriptSnippetToFetchURL(url));
+    protectedInspector(self)->evaluateInFrontendForTesting(JavaScriptSnippetToFetchURL(url));
 }
 
 - (void)_openURLExternallyForTesting:(NSURL *)url useFrontendAPI:(BOOL)useFrontendAPI
 {
     if (useFrontendAPI)
-        _inspector->evaluateInFrontendForTesting(JavaScriptSnippetToOpenURLExternally(url));
+        protectedInspector(self)->evaluateInFrontendForTesting(JavaScriptSnippetToOpenURLExternally(url));
     else {
         // Force the navigation request to be handled naturally through the
         // internal NavigationDelegate of WKInspectorViewController.

--- a/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.h
@@ -36,21 +36,22 @@ class WebURLSchemeTask;
 
 class WebURLSchemeHandlerCocoa : public WebURLSchemeHandler {
 public:
-    static Ref<WebURLSchemeHandlerCocoa> create(id <WKURLSchemeHandler>);
+    static Ref<WebURLSchemeHandlerCocoa> create(id<WKURLSchemeHandler>);
 
-    id <WKURLSchemeHandler> apiHandler() const { return m_apiHandler.get(); }
+    id<WKURLSchemeHandler> apiHandler() const { return m_apiHandler.get(); }
+    RetainPtr<id<WKURLSchemeHandler>> protectedAPIHandler() const;
 
     bool isAPIHandler() final { return true; }
 
 private:
-    WebURLSchemeHandlerCocoa(id <WKURLSchemeHandler>);
+    WebURLSchemeHandlerCocoa(id<WKURLSchemeHandler>);
 
     bool isWebURLSchemeHandlerCocoa() const final { return true; }
 
     void platformStartTask(WebPageProxy&, WebURLSchemeTask&) final;
     void platformStopTask(WebPageProxy&, WebURLSchemeTask&) final;
 
-    RetainPtr<id <WKURLSchemeHandler>> m_apiHandler;
+    RetainPtr<id<WKURLSchemeHandler>> m_apiHandler;
 
 }; // class WebURLSchemeHandler
 

--- a/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.mm
@@ -36,12 +36,12 @@
 
 namespace WebKit {
 
-Ref<WebURLSchemeHandlerCocoa> WebURLSchemeHandlerCocoa::create(id <WKURLSchemeHandler> apiHandler)
+Ref<WebURLSchemeHandlerCocoa> WebURLSchemeHandlerCocoa::create(id<WKURLSchemeHandler> apiHandler)
 {
     return adoptRef(*new WebURLSchemeHandlerCocoa(apiHandler));
 }
 
-WebURLSchemeHandlerCocoa::WebURLSchemeHandlerCocoa(id <WKURLSchemeHandler> apiHandler)
+WebURLSchemeHandlerCocoa::WebURLSchemeHandlerCocoa(id<WKURLSchemeHandler> apiHandler)
     : m_apiHandler(apiHandler)
 {
 }
@@ -60,6 +60,11 @@ void WebURLSchemeHandlerCocoa::platformStopTask(WebPageProxy& page, WebURLScheme
         [m_apiHandler.get() webView:webView.get() stopURLSchemeTask:strongTask.get()];
     else
         task.suppressTaskStoppedExceptions();
+}
+
+RetainPtr<id<WKURLSchemeHandler>> WebURLSchemeHandlerCocoa::protectedAPIHandler() const
+{
+    return apiHandler();
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 712bda02056b75d600ef0101b5bfbd35c9c9903f
<pre>
Address safer cpp warnings in _WKInspector* classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=300766">https://bugs.webkit.org/show_bug.cgi?id=300766</a>

Reviewed by Darin Adler.

* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/APIInspectorConfiguration.cpp:
(API::InspectorConfiguration::setProcessPool):
* Source/WebKit/UIProcess/API/APIInspectorConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm:
(protectedInspector):
(-[_WKInspector setDelegate:]):
(-[_WKInspector isFront]):
(-[_WKInspector connect]):
(-[_WKInspector show]):
(-[_WKInspector hide]):
(-[_WKInspector close]):
(-[_WKInspector showConsole]):
(-[_WKInspector showResources]):
(-[_WKInspector showMainResourceForFrame:]):
(-[_WKInspector attach]):
(-[_WKInspector detach]):
(-[_WKInspector togglePageProfiling]):
(-[_WKInspector toggleElementSelection]):
(-[_WKInspector _setDiagnosticLoggingDelegate:]):
(-[_WKInspector dealloc]):
(-[_WKInspector registerExtensionWithID:extensionBundleIdentifier:displayName:completionHandler:]):
(-[_WKInspector unregisterExtension:completionHandler:]):
(-[_WKInspector showExtensionTabWithIdentifier:completionHandler:]):
(-[_WKInspector navigateExtensionTabWithIdentifier:toURL:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm:
(protectedConfiguration):
(-[_WKInspectorConfiguration dealloc]):
(-[_WKInspectorConfiguration setURLSchemeHandler:forURLScheme:]):
(-[_WKInspectorConfiguration setProcessPool:]):
(-[_WKInspectorConfiguration processPool]):
(-[_WKInspectorConfiguration applyToWebViewConfiguration:]):
(-[_WKInspectorConfiguration copyWithZone:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.mm:
(-[_WKInspectorDebuggableInfo dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm:
(protectedExtension):
(-[_WKInspectorExtension delegate]):
(-[_WKInspectorExtension createTabWithName:tabIconURL:sourceURL:completionHandler:]):
(-[_WKInspectorExtension evaluateScript:frameURL:contextSecurityOrigin:useContentScriptContext:completionHandler:]):
(-[_WKInspectorExtension evaluateScript:inTabWithIdentifier:completionHandler:]):
(-[_WKInspectorExtension navigateToURL:inTabWithIdentifier:completionHandler:]):
(-[_WKInspectorExtension reloadIgnoringCache:userAgent:injectedScript:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorTesting.mm:
(-[_WKInspector _fetchURLForTesting:]):
(-[_WKInspector _openURLExternallyForTesting:useFrontendAPI:]):
* Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.h:
(WebKit::WebURLSchemeHandlerCocoa::apiHandler const):
* Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.mm:
(WebKit::WebURLSchemeHandlerCocoa::create):
(WebKit::WebURLSchemeHandlerCocoa::WebURLSchemeHandlerCocoa):
(WebKit::WebURLSchemeHandlerCocoa::protectedAPIHandler const):

Canonical link: <a href="https://commits.webkit.org/301547@main">https://commits.webkit.org/301547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d63a16013b18ac46099649ac03eee5a29b258164

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133155 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78060 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92016bcf-d0b2-441d-a063-5557f7a80e8e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54505 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b2b3bd6-361e-4fa3-b29f-6efbd072a7ed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112980 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76637 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eea58256-80f4-42b1-b7ce-0b20029a2c80) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76541 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135772 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40755 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104656 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104353 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26617 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49802 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28139 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50431 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52947 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58772 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52258 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55600 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53978 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->