### PR TITLE
[WebGPU Swift] 1 crash and 3 text failures with Swift backend

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -44,6 +44,8 @@
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
 
+IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
+
 // FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
 // annotating incomplete types
 struct SWIFT_SHARED_REFERENCE(wgpuBufferReference, wgpuBufferRelease) WGPUBufferImpl {
@@ -140,7 +142,7 @@ private:
     Buffer(Device&);
 
     bool validateGetMappedRange(size_t offset, size_t rangeSize) const;
-    NSString* errorValidatingMapAsync(WGPUMapModeFlags, size_t offset, size_t rangeSize) const;
+    NSString * _Nullable errorValidatingMapAsync(WGPUMapModeFlags, size_t offset, size_t rangeSize) const;
     bool validateUnmap() const;
     void setState(State);
     void incrementBufferMapCount();
@@ -149,8 +151,8 @@ private:
     void takeSlowIndirectValidationPath(CommandBuffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
 
     id<MTLBuffer> m_buffer { nil };
-    id<MTLBuffer> m_indirectBuffer { nil };
-    id<MTLBuffer> m_indirectIndexedBuffer { nil };
+    id<MTLBuffer> _Nullable m_indirectBuffer { nil };
+    id<MTLBuffer> _Nullable m_indirectIndexedBuffer { nil };
 
     // https://gpuweb.github.io/gpuweb/#buffer-interface
 
@@ -202,3 +204,5 @@ inline void derefBuffer(WebGPU::Buffer* obj)
 {
     WTF::deref(obj);
 }
+
+IGNORE_CLANG_WARNINGS_END

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -322,7 +322,7 @@ std::span<uint8_t> Buffer::getBufferContents()
     return span<uint8_t>(m_buffer);
 }
 
-NSString* Buffer::errorValidatingMapAsync(WGPUMapModeFlags mode, size_t offset, size_t rangeSize) const
+NSString *Buffer::errorValidatingMapAsync(WGPUMapModeFlags mode, size_t offset, size_t rangeSize) const
 {
 #define ERROR_STRING(x) (@"GPUBuffer.mapAsync: " x)
     if (!isValid())

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -41,8 +41,10 @@
 #import <wtf/Vector.h>
 #import <wtf/WeakPtr.h>
 
+IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
+
 @interface TextureAndClearColor : NSObject
-- (instancetype)initWithTexture:(id<MTLTexture>)texture NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithTexture:(id<MTLTexture> _Nonnull)texture NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 @property (nonatomic) id<MTLTexture> texture;
 @property (nonatomic) MTLClearColor clearColor;
@@ -113,7 +115,7 @@ public:
 #if ENABLE(WEBGPU_SWIFT)
     void setEncoderState(EncoderState state) { m_state = state; }
     EncoderState getEncoderState() { return m_state; }
-    NSString * encoderStateNameWrapper() { return encoderStateName(); }
+    NSString * _Nullable encoderStateNameWrapper() { return encoderStateName(); }
 #endif
 
     id<MTLBlitCommandEncoder> ensureBlitCommandEncoder();
@@ -136,7 +138,7 @@ public:
     void addTexture(id<MTLTexture>);
     void addTexture(const Texture&);
     void addSampler(const Sampler&);
-    id<MTLCommandBuffer> commandBuffer() const;
+    id<MTLCommandBuffer> _Nullable commandBuffer() const;
     void setExistingEncoder(id<MTLCommandEncoder>);
     void generateInvalidEncoderStateError();
     bool validateClearBuffer(const Buffer&, uint64_t offset, uint64_t size);
@@ -144,7 +146,7 @@ public:
     static void trackEncoder(CommandEncoder&, HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>&);
     static size_t computeSize(Vector<uint64_t>&, const Device&);
     uint64_t uniqueId() const { return m_uniqueId; }
-    NSMutableSet<id<MTLCounterSampleBuffer>> *timestampBuffers() const { return m_retainedTimestampBuffers; };
+    NSMutableSet<id<MTLCounterSampleBuffer>> * _Nullable timestampBuffers() const { return m_retainedTimestampBuffers; };
     void addOnCommitHandler(Function<bool(CommandBuffer&, CommandEncoder&)>&&);
 #if ENABLE(WEBGPU_BY_DEFAULT)
     bool useResidencySet(id<MTLResidencySet>);
@@ -158,41 +160,41 @@ private:
 
     bool validatePopDebugGroup() const;
 
-    NSString* validateFinishError() const;
-    NSString* errorValidatingCopyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, const Buffer& destination, uint64_t destinationOffset, uint64_t size);
-    NSString* errorValidatingComputePassDescriptor(const WGPUComputePassDescriptor&) const;
-    NSString* errorValidatingRenderPassDescriptor(const WGPURenderPassDescriptor&) const;
-    NSString* errorValidatingImageCopyBuffer(const WGPUImageCopyBuffer&) const;
-    NSString* errorValidatingCopyBufferToTexture(const WGPUImageCopyBuffer&, const WGPUImageCopyTexture&, const WGPUExtent3D&) const;
-    NSString* errorValidatingCopyTextureToBuffer(const WGPUImageCopyTexture&, const WGPUImageCopyBuffer&, const WGPUExtent3D&) const;
-    NSString* errorValidatingCopyTextureToTexture(const WGPUImageCopyTexture& source, const WGPUImageCopyTexture& destination, const WGPUExtent3D& copySize) const;
+    NSString * _Nullable validateFinishError() const;
+    NSString * _Nullable errorValidatingCopyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, const Buffer& destination, uint64_t destinationOffset, uint64_t size);
+    NSString * _Nullable errorValidatingComputePassDescriptor(const WGPUComputePassDescriptor&) const;
+    NSString * _Nullable errorValidatingRenderPassDescriptor(const WGPURenderPassDescriptor&) const;
+    NSString * _Nullable errorValidatingImageCopyBuffer(const WGPUImageCopyBuffer&) const;
+    NSString * _Nullable errorValidatingCopyBufferToTexture(const WGPUImageCopyBuffer&, const WGPUImageCopyTexture&, const WGPUExtent3D&) const;
+    NSString * _Nullable errorValidatingCopyTextureToBuffer(const WGPUImageCopyTexture&, const WGPUImageCopyBuffer&, const WGPUExtent3D&) const;
+    NSString * _Nullable errorValidatingCopyTextureToTexture(const WGPUImageCopyTexture& source, const WGPUImageCopyTexture& destination, const WGPUExtent3D& copySize) const;
 
     void discardCommandBuffer();
     RefPtr<CommandBuffer> protectedCachedCommandBuffer() const { return m_cachedCommandBuffer.get(); }
     void retainTimestampsForOneUpdateLoop();
 
-    id<MTLCommandBuffer> m_commandBuffer { nil };
-    id<MTLCommandEncoder> m_existingCommandEncoder { nil };
-    id<MTLBlitCommandEncoder> m_blitCommandEncoder { nil };
-    NSString* m_lastErrorString { nil };
+    id<MTLCommandBuffer> _Nullable m_commandBuffer { nil };
+    id<MTLCommandEncoder> _Nullable m_existingCommandEncoder { nil };
+    id<MTLBlitCommandEncoder> _Nullable m_blitCommandEncoder { nil };
+    NSString* _Nullable m_lastErrorString { nil };
     uint64_t m_debugGroupStackSize { 0 };
     ThreadSafeWeakPtr<CommandBuffer> m_cachedCommandBuffer;
 #if CPU(X86_64) && (PLATFORM(MAC) || PLATFORM(MACCATALYST))
-    NSMutableSet<id<MTLTexture>> *m_managedTextures { nil };
-    NSMutableSet<id<MTLBuffer>> *m_managedBuffers { nil };
+    NSMutableSet<id<MTLTexture>> * _Nullable m_managedTextures { nil };
+    NSMutableSet<id<MTLBuffer>> * _Nullable m_managedBuffers { nil };
 #endif
 private:
-    NSMutableSet<id<MTLIndirectCommandBuffer>> *m_retainedICBs { nil };
-    NSMutableSet<id<MTLTexture>> *m_retainedTextures { nil };
-    NSMutableSet<id<MTLBuffer>> *m_retainedBuffers { nil };
+    NSMutableSet<id<MTLIndirectCommandBuffer>> * _Nullable m_retainedICBs { nil };
+    NSMutableSet<id<MTLTexture>> * _Nullable m_retainedTextures { nil };
+    NSMutableSet<id<MTLBuffer>> * _Nullable m_retainedBuffers { nil };
     HashSet<RefPtr<const Sampler>> m_retainedSamplers;
-    NSMutableSet<id<MTLCounterSampleBuffer>> *m_retainedTimestampBuffers { nil };
+    NSMutableSet<id<MTLCounterSampleBuffer>> * _Nullable m_retainedTimestampBuffers { nil };
     Vector<Function<bool(CommandBuffer&, CommandEncoder&)>> m_onCommitHandlers;
     HashMap<uint64_t, Vector<DrawIndexCacheContainerValue>, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_skippedDrawIndexedValidationKeys;
     Vector<RefPtr<const BindGroup>> m_bindGroups;
     int m_bufferMapCount { 0 };
     bool m_makeSubmitInvalid { false };
-    id<MTLSharedEvent> m_sharedEvent { nil };
+    id<MTLSharedEvent> _Nullable m_sharedEvent { nil };
     uint64_t m_sharedEventSignalValue { 0 };
     const Ref<Device> m_device;
     uint64_t m_uniqueId;
@@ -212,3 +214,5 @@ inline void derefCommandEncoder(WebGPU::CommandEncoder* obj)
 {
     WTF::deref(obj);
 }
+
+IGNORE_CLANG_WARNINGS_END

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -374,7 +374,7 @@ extension WebGPU.CommandEncoder {
                 mtlAttachment?.slice = 0
                 mtlAttachment?.depthPlane = Int(textureAndClearColor.depthPlane)
             }
-            clearRenderCommandEncoder = m_commandBuffer.makeRenderCommandEncoder(descriptor: clearDescriptor)
+            clearRenderCommandEncoder = m_commandBuffer?.makeRenderCommandEncoder(descriptor: clearDescriptor)
             setExistingEncoder(clearRenderCommandEncoder)
         }
 
@@ -833,7 +833,7 @@ extension WebGPU.CommandEncoder {
             return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), error)
         }
 
-        guard m_commandBuffer.status.rawValue < MTLCommandBufferStatus.enqueued.rawValue else {
+        if m_commandBuffer != nil && m_commandBuffer!.status.rawValue >= MTLCommandBufferStatus.enqueued.rawValue {
             return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "command buffer has already been committed")
         }
 
@@ -1196,7 +1196,7 @@ extension WebGPU.CommandEncoder {
             return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "GPUDevice was invalid, this will be an error submitting the command buffer")
         }
 
-        let mtlRenderCommandEncoder = m_commandBuffer.makeRenderCommandEncoder(descriptor: mtlDescriptor)
+        let mtlRenderCommandEncoder = m_commandBuffer?.makeRenderCommandEncoder(descriptor: mtlDescriptor)
         if m_existingCommandEncoder != nil {
             assertionFailure("!m_existingCommandEncoder")
         }
@@ -1880,8 +1880,8 @@ extension WebGPU.CommandEncoder {
             self.finalizeBlitCommandEncoder()
             let workaround: MTLSharedEvent = m_device.ptr().resolveTimestampsSharedEvent()
             // The signal value does not matter, the event alone prevents reordering
-            m_commandBuffer.encodeSignalEvent(workaround, value: 1)
-            m_commandBuffer.encodeWaitForEvent(workaround, value: 1)
+            m_commandBuffer?.encodeSignalEvent(workaround, value: 1)
+            m_commandBuffer?.encodeWaitForEvent(workaround, value: 1)
             guard ensureBlitCommandEncoder() != nil else {
                 return
             }
@@ -1891,7 +1891,7 @@ extension WebGPU.CommandEncoder {
             guard let counterSampleBuffer else {
                 return
             }
-            unsafe m_blitCommandEncoder.resolveCounters(
+            unsafe m_blitCommandEncoder?.resolveCounters(
                 counterSampleBuffer,
                 range: Range(uncheckedBounds: (Int(firstQuery + counterSampleBufferOffset), Int(firstQuery + counterSampleBufferOffset + queryCount))),
                 destinationBuffer: destination.buffer(),
@@ -2121,7 +2121,7 @@ extension WebGPU.CommandEncoder {
             return WebGPU.ComputePassEncoder.createInvalid(self, m_device.ptr(), String(error!))
         }
 
-        guard m_commandBuffer.status.rawValue < MTLCommandBufferStatus.enqueued.rawValue else {
+        if m_commandBuffer != nil && m_commandBuffer!.status.rawValue >= MTLCommandBufferStatus.enqueued.rawValue {
             return WebGPU.ComputePassEncoder.createInvalid(self, m_device.ptr(), "command buffer has already been committed")
         }
 
@@ -2150,7 +2150,7 @@ extension WebGPU.CommandEncoder {
                 m_device.ptr().trackTimestampsBuffer(m_commandBuffer, counterSampleBuffer);
             }
         }
-        guard let computeCommandEncoder = m_commandBuffer.makeComputeCommandEncoder(descriptor: computePassDescriptor) else {
+        guard let computeCommandEncoder = m_commandBuffer?.makeComputeCommandEncoder(descriptor: computePassDescriptor) else {
             return WebGPU.ComputePassEncoder.createInvalid(self, m_device.ptr(), "computeCommandEncoder is null")
         }
 

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -51,6 +51,8 @@
 #import <wtf/Vector.h>
 #import <wtf/text/WTFString.h>
 
+IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
+
 struct WGPUDeviceImpl {
 };
 
@@ -153,7 +155,7 @@ public:
     const Vector<WGPUFeatureName>& features() const { return m_capabilities.features; }
     const HardwareCapabilities::BaseCapabilities& baseCapabilities() const { return m_capabilities.baseCapabilities; }
 
-    id<MTLDevice> device() const { return m_device; }
+    id<MTLDevice> _Nullable device() const { return m_device; }
     void generateAValidationError(NSString * message);
     void generateAValidationError(String&& message);
     void generateAnOutOfMemoryError(String&& message);
@@ -194,14 +196,13 @@ public:
     id<MTLTexture> placeholderTexture(WGPUTextureFormat) const;
     bool isDestroyed() const;
     NSString *errorValidatingTextureCreation(const WGPUTextureDescriptor&, const Vector<WGPUTextureFormat>& viewFormats);
-    id<MTLBuffer> dispatchCallBuffer();
-    id<MTLComputePipelineState> dispatchCallPipelineState(id<MTLFunction>);
-    id<MTLRenderPipelineState> indexBufferClampPipeline(MTLIndexType, NSUInteger rasterSampleCount);
-    id<MTLRenderPipelineState> indexedIndirectBufferClampPipeline(NSUInteger rasterSampleCount);
-    id<MTLRenderPipelineState> indirectBufferClampPipeline(NSUInteger rasterSampleCount);
-    id<MTLRenderPipelineState> icbCommandClampPipeline(MTLIndexType, NSUInteger rasterSampleCount);
+    id<MTLBuffer> _Nullable dispatchCallBuffer();
+    id<MTLComputePipelineState> _Nullable dispatchCallPipelineState(id<MTLFunction>);
+    id<MTLRenderPipelineState> _Nullable indexBufferClampPipeline(MTLIndexType, NSUInteger rasterSampleCount);
+    id<MTLRenderPipelineState> _Nullable indexedIndirectBufferClampPipeline(NSUInteger rasterSampleCount);
+    id<MTLRenderPipelineState> _Nullable indirectBufferClampPipeline(NSUInteger rasterSampleCount);
+    id<MTLRenderPipelineState> _Nullable icbCommandClampPipeline(MTLIndexType, NSUInteger rasterSampleCount);
     id<MTLFunction> icbCommandClampFunction(MTLIndexType);
-    id<MTLRenderPipelineState> copyIndexIndirectArgsPipeline(NSUInteger rasterSampleCount);
     id<MTLBuffer> safeCreateBuffer(NSUInteger length, MTLStorageMode, bool skipMemoryAttribution = false, MTLCPUCacheMode = MTLCPUCacheModeDefaultCache, MTLHazardTrackingMode = MTLHazardTrackingModeDefault) const;
     id<MTLBuffer> safeCreateBuffer(NSUInteger, bool skipMemoryAttribution = false) const;
     template<typename T>
@@ -215,15 +216,15 @@ public:
     int bufferIndexForICBContainer() const;
     void setOwnerWithIdentity(id<MTLResource>) const;
     struct ExternalTextureData {
-        id<MTLTexture> texture0 { nil };
-        id<MTLTexture> texture1 { nil };
+        id<MTLTexture> _Nullable texture0 { nil };
+        id<MTLTexture> _Nullable texture1 { nil };
         simd::float3x2 uvRemappingMatrix;
         simd::float4x3 colorSpaceConversionMatrix;
     };
     ExternalTextureData createExternalTextureFromPixelBuffer(CVPixelBufferRef, WGPUColorSpace) const;
     RefPtr<XRSubImage> getXRViewSubImage(XRProjectionLayer&);
     RefPtr<XRSubImage> getXRViewSubImage() const;
-    id<MTLTexture> getXRViewSubImageDepthTexture() const;
+    id<MTLTexture> _Nullable getXRViewSubImageDepthTexture() const;
     const std::optional<const MachSendRight> webProcessID() const;
 #if CPU(X86_64)
     bool isIntel() const { return [m_device.name localizedCaseInsensitiveContainsString:@"intel"]; }
@@ -264,7 +265,6 @@ public:
     }
     void removeBufferFromCache(uint64_t address) { m_bufferMap.remove(address); }
     uint32_t appleGPUFamily() const { return m_appleGPUFamily; }
-    id<MTLRasterizationRateMap> rasterizationMapForTexture(MTLResourceID, uint32_t) const;
     void setRasterizationMapsForTexture(MTLResourceID, id<MTLRasterizationRateMap> left, id<MTLRasterizationRateMap> right);
     static id<MTLFunction> nopVertexFunction(id<MTLDevice>);
 
@@ -280,7 +280,7 @@ private:
     bool validateRenderPipeline(const WGPURenderPipelineDescriptor&);
 
     void makeInvalid();
-    NSString* addPipelineLayouts(Vector<Vector<WGPUBindGroupLayoutEntry>>&, const std::optional<WGSL::PipelineLayout>&);
+    NSString * _Nullable addPipelineLayouts(Vector<Vector<WGPUBindGroupLayoutEntry>>&, const std::optional<WGSL::PipelineLayout>&);
     Ref<PipelineLayout> generatePipelineLayout(const Vector<Vector<WGPUBindGroupLayoutEntry>> &bindGroupEntries);
 
     void captureFrameIfNeeded() const;
@@ -294,7 +294,7 @@ private:
         std::optional<Error> error;
         const WGPUErrorFilter filter;
     };
-    id<MTLDevice> m_device { nil };
+    id<MTLDevice> _Nullable m_device { nil };
     const Ref<Queue> m_defaultQueue;
 
     Function<void(WGPUErrorType, String&&)> m_uncapturedErrorCallback;
@@ -311,24 +311,24 @@ private:
     id<MTLBuffer> m_placeholderBuffer { };
     id<MTLTexture> m_placeholderTexture { nil };
     id<MTLTexture> m_placeholderDepthStencilTexture { nil };
-    id<MTLBuffer> m_dispatchCallBuffer { nil };
-    id<MTLComputePipelineState> m_dispatchCallPipelineState { nil };
+    id<MTLBuffer> _Nullable m_dispatchCallBuffer { nil };
+    id<MTLComputePipelineState> _Nullable m_dispatchCallPipelineState { nil };
 
-    id<MTLRenderPipelineState> m_indexBufferClampUintPSO { nil };
-    id<MTLRenderPipelineState> m_indexBufferClampUshortPSO { nil };
-    id<MTLRenderPipelineState> m_indexBufferClampUintPSOMS { nil };
-    id<MTLRenderPipelineState> m_indexBufferClampUshortPSOMS { nil };
+    id<MTLRenderPipelineState> _Nullable m_indexBufferClampUintPSO { nil };
+    id<MTLRenderPipelineState> _Nullable m_indexBufferClampUshortPSO { nil };
+    id<MTLRenderPipelineState> _Nullable m_indexBufferClampUintPSOMS { nil };
+    id<MTLRenderPipelineState> _Nullable m_indexBufferClampUshortPSOMS { nil };
 
-    id<MTLRenderPipelineState> m_indexedIndirectBufferClampPSO { nil };
-    id<MTLRenderPipelineState> m_indexedIndirectBufferClampPSOMS { nil };
+    id<MTLRenderPipelineState> _Nullable m_indexedIndirectBufferClampPSO { nil };
+    id<MTLRenderPipelineState> _Nullable m_indexedIndirectBufferClampPSOMS { nil };
 
-    id<MTLRenderPipelineState> m_indirectBufferClampPSO { nil };
-    id<MTLRenderPipelineState> m_indirectBufferClampPSOMS { nil };
+    id<MTLRenderPipelineState> _Nullable m_indirectBufferClampPSO { nil };
+    id<MTLRenderPipelineState> _Nullable m_indirectBufferClampPSOMS { nil };
 
-    id<MTLRenderPipelineState> m_icbCommandClampUintPSO { nil };
-    id<MTLRenderPipelineState> m_icbCommandClampUshortPSO { nil };
-    id<MTLRenderPipelineState> m_icbCommandClampUintPSOMS { nil };
-    id<MTLRenderPipelineState> m_icbCommandClampUshortPSOMS { nil };
+    id<MTLRenderPipelineState> _Nullable m_icbCommandClampUintPSO { nil };
+    id<MTLRenderPipelineState> _Nullable m_icbCommandClampUshortPSO { nil };
+    id<MTLRenderPipelineState> _Nullable m_icbCommandClampUintPSOMS { nil };
+    id<MTLRenderPipelineState> _Nullable m_icbCommandClampUshortPSOMS { nil };
 
     const Ref<Adapter> m_adapter;
     const ThreadSafeWeakPtr<Instance> m_instance;
@@ -337,7 +337,7 @@ private:
 #endif
     NSMapTable<id<MTLCommandBuffer>, NSMutableArray<id<MTLCounterSampleBuffer>>*>* m_sampleCounterBuffers;
     NSMapTable<id<MTLCommandBuffer>, NSMutableArray<id<MTLBuffer>>*>* m_resolvedSampleCounterBuffers;
-    id<MTLSharedEvent> m_resolveTimestampsSharedEvent { nil };
+    id<MTLSharedEvent> _Nullable m_resolveTimestampsSharedEvent { nil };
     HashMap<uint64_t, CommandEncoder*, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_commandEncoderMap;
     HashMap<uint64_t, Buffer*, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_bufferMap;
     mutable HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_bindGroupCompatibilityCache;
@@ -364,3 +364,5 @@ inline void derefDevice(WebGPU::Device* obj)
 {
     WTF::deref(obj);
 }
+
+IGNORE_CLANG_WARNINGS_END

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -37,6 +37,8 @@
 #import <wtf/Vector.h>
 #import <wtf/WeakPtr.h>
 
+IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
+
 struct WGPUQueueImpl {
 };
 
@@ -81,11 +83,11 @@ public:
 
     const Device& device() const SWIFT_RETURNS_INDEPENDENT_VALUE;
     void clearTextureIfNeeded(const WGPUImageCopyTexture&, NSUInteger);
-    id<MTLCommandBuffer> commandBufferWithDescriptor(MTLCommandBufferDescriptor*);
+    id<MTLCommandBuffer> _Nullable commandBufferWithDescriptor(MTLCommandBufferDescriptor*);
     void commitMTLCommandBuffer(id<MTLCommandBuffer>);
     void removeMTLCommandBuffer(id<MTLCommandBuffer>);
     void setEncoderForBuffer(id<MTLCommandBuffer>, id<MTLCommandEncoder>);
-    id<MTLCommandEncoder> encoderForBuffer(id<MTLCommandBuffer>) const;
+    id<MTLCommandEncoder> _Nullable encoderForBuffer(id<MTLCommandBuffer>) const;
     void clearTextureViewIfNeeded(TextureView&);
     void clearTextureViewIfNeeded(Texture&);
     static bool writeWillCompletelyClear(WGPUTextureDimension, uint32_t widthForMetal, uint32_t logicalSizeWidth, uint32_t heightForMetal, uint32_t logicalSizeHeight, uint32_t depthForMetal, uint32_t logicalSizeDepthOrArrayLayers);
@@ -102,13 +104,13 @@ public:
     void waitForAllCommitedWorkToComplete();
     void synchronizeResourceAndWait(id<MTLBuffer>);
     id<MTLIndirectCommandBuffer> trimICB(id<MTLIndirectCommandBuffer> dest, id<MTLIndirectCommandBuffer> src, NSUInteger newSize);
-    id<MTLDevice> metalDevice() const;
+    id<MTLDevice> _Nullable metalDevice() const;
 
 private:
     Queue(id<MTLCommandQueue>, Adapter&, Device&);
     Queue(Adapter&, Device&);
 
-    NSString* errorValidatingSubmit(const Vector<Ref<WebGPU::CommandBuffer>>&) const;
+    NSString * _Nullable errorValidatingSubmit(const Vector<Ref<WebGPU::CommandBuffer>>&) const;
     bool validateWriteBuffer(const Buffer&, uint64_t bufferOffset, size_t) const;
 
 
@@ -117,13 +119,13 @@ private:
     void removeMTLCommandBufferInternal(id<MTLCommandBuffer>);
     void clearTextureIfNeeded(Texture&, uint32_t mipLevelCount, uint32_t arrayLayerCount, uint32_t baseMipLevel, uint32_t baseArrayLayer);
 
-    NSString* errorValidatingWriteTexture(const WGPUImageCopyTexture&, const WGPUTextureDataLayout&, const WGPUExtent3D&, size_t, const Texture&) const;
+    NSString * _Nullable errorValidatingWriteTexture(const WGPUImageCopyTexture&, const WGPUTextureDataLayout&, const WGPUExtent3D&, size_t, const Texture&) const;
 
     std::pair<id<MTLBuffer>, uint64_t> newTemporaryBufferWithBytes(std::span<uint8_t> data, bool noCopy);
 
-    id<MTLCommandQueue> m_commandQueue { nil };
-    id<MTLCommandBuffer> m_commandBuffer { nil };
-    id<MTLBlitCommandEncoder> m_blitCommandEncoder { nil };
+    id<MTLCommandQueue> _Nullable m_commandQueue { nil };
+    id<MTLCommandBuffer> _Nullable m_commandBuffer { nil };
+    id<MTLBlitCommandEncoder> _Nullable m_blitCommandEncoder { nil };
     ThreadSafeWeakPtr<Device> m_device; // The only kind of queues that exist right now are default queues, which are owned by Devices.
     uint64_t m_submittedCommandBufferCount { 0 };
     uint64_t m_completedCommandBufferCount { 0 };
@@ -132,13 +134,13 @@ private:
     HashMap<uint64_t, OnSubmittedWorkScheduledCallbacks, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_onSubmittedWorkScheduledCallbacks;
     using OnSubmittedWorkDoneCallbacks = Vector<WTF::Function<void(WGPUQueueWorkDoneStatus)>>;
     HashMap<uint64_t, OnSubmittedWorkDoneCallbacks, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_onSubmittedWorkDoneCallbacks;
-    NSMutableDictionary<NSNumber*, NSMutableSet<id<MTLCounterSampleBuffer>>*>* m_retainedCounterSampleBuffers;
-    NSMutableOrderedSet<id<MTLCommandBuffer>> *m_createdNotCommittedBuffers { nil };
-    NSMutableOrderedSet<id<MTLCommandBuffer>> *m_committedNotCompletedBuffers WTF_GUARDED_BY_LOCK(m_committedNotCompletedBuffersLock) { nil };
+    NSMutableDictionary<NSNumber*, NSMutableSet<id<MTLCounterSampleBuffer>>*> * _Nullable m_retainedCounterSampleBuffers;
+    NSMutableOrderedSet<id<MTLCommandBuffer>> * _Nullable m_createdNotCommittedBuffers { nil };
+    NSMutableOrderedSet<id<MTLCommandBuffer>> * _Nullable m_committedNotCompletedBuffers WTF_GUARDED_BY_LOCK(m_committedNotCompletedBuffersLock) { nil };
     Lock m_committedNotCompletedBuffersLock;
-    NSMapTable<id<MTLCommandBuffer>, id<MTLCommandEncoder>> *m_openCommandEncoders;
+    NSMapTable<id<MTLCommandBuffer>, id<MTLCommandEncoder>> * _Nullable m_openCommandEncoders;
     const ThreadSafeWeakPtr<Instance> m_instance;
-    id<MTLBuffer> m_temporaryBuffer;
+    id<MTLBuffer> _Nullable m_temporaryBuffer;
     uint64_t m_temporaryBufferOffset;
 } SWIFT_SHARED_REFERENCE(refQueue, derefQueue) SWIFT_PRIVATE_FILEID("WebGPU/Queue.swift");
 
@@ -154,3 +156,4 @@ inline void derefQueue(WebGPU::Queue* obj)
     WTF::deref(obj);
 }
 
+IGNORE_CLANG_WARNINGS_END


### PR DESCRIPTION
#### 71e9079abf4ae7217886c6a9f3eac966ec738e7a
<pre>
[WebGPU Swift] 1 crash and 3 text failures with Swift backend
<a href="https://bugs.webkit.org/show_bug.cgi?id=300732">https://bugs.webkit.org/show_bug.cgi?id=300732</a>
<a href="https://rdar.apple.com/162639798">rdar://162639798</a>

Reviewed by Mike Wyrzykowski.

Converting from Objective-C to Swift changes a nil dereference from a no-op to
a crash. (That&apos;s bad! <a href="https://rdar.apple.com/159961640">rdar://159961640</a>)

I manually adopted nullability annotations for data members and return
values in our Objective-C++ classes that have partial Swift implementations. This
makes it a compile-time error to forget the null check in Swift, at least for the
values I&apos;ve so-annotated.

I had to disable -Wnullability-completeness in the same files because once you
do any nullability annotation clang requires you to do them all, which is too
much change in one patch, and also totally useless since it would mean adding
nullability annotations to C++-only interfaces, which get no enforcement.

Canonical link: <a href="https://commits.webkit.org/301553@main">https://commits.webkit.org/301553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bec18a5387e8626dbcb8f0f8b465fc55d1141ec5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126278 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133049 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78038 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a60f3a91-5c9a-4c07-a1bf-8ea66cb290ca) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96136 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a22714d7-0beb-4d43-93d5-75a9ae23abd4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37269 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76615 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70d0f8dc-cc0d-4c78-8010-a1793a2e4b89) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36169 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76518 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107052 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135746 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40729 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104632 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104333 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49780 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50401 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19754 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52920 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58749 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52235 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55579 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53951 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->