### PR TITLE
[Liquid Glass] Scroll pocket can get stuck with previous color if its style is changed from hard to soft

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3189,6 +3189,7 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
         // or it should match the scroll view background color anyways.
         // When using a hard pocket (iPad), the top scroll pocket capture color must be set to ensure
         // that glass elements overlaying the pocket adapt correctly.
+        [_scrollView _setInternalTopPocketColor:nil];
         return;
     }
 

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -664,6 +664,9 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
 
 - (void)_setInternalTopPocketColor:(UIColor *)color
 {
+    if ([_topPocketColorSetInternally isEqual:color] || _topPocketColorSetInternally == color)
+        return;
+
     _topPocketColorSetInternally = color;
 
     [self _updateTopPocketColor];

--- a/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
@@ -824,9 +824,17 @@ TEST(WKScrollViewTests, TopScrollPocketCaptureColorAfterSettingHardStyle)
     [scrollView topEdgeEffect].style = UIScrollEdgeEffectStyle.hardStyle;
     [webView waitForNextPresentationUpdate];
 
-    auto topPocketColor = WebCore::colorFromCocoaColor([scrollView _pocketColorForEdge:UIRectEdgeTop]);
-    EXPECT_WK_STREQ("rgb(255, 99, 71)", WebCore::serializationForCSS(topPocketColor));
+    auto topHardPocketColor = WebCore::colorFromCocoaColor([scrollView _pocketColorForEdge:UIRectEdgeTop]);
+    EXPECT_WK_STREQ("rgb(255, 99, 71)", WebCore::serializationForCSS(topHardPocketColor));
     EXPECT_TRUE([scrollView _prefersSolidColorHardPocketForEdge:UIRectEdgeTop]);
+
+    [scrollView topEdgeEffect].style = UIScrollEdgeEffectStyle.softStyle;
+
+    // Removing the top fixed element should also remove the top color extension.
+    [webView objectByEvaluatingJavaScript:@"document.querySelector('header').remove()"];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_NULL([scrollView _pocketColorForEdge:UIRectEdgeTop]);
 }
 
 #endif // HAVE(LIQUID_GLASS)


### PR DESCRIPTION
#### 5823931432ec3a8d8e9f6f9f1cced841f723a61d
<pre>
[Liquid Glass] Scroll pocket can get stuck with previous color if its style is changed from hard to soft
<a href="https://bugs.webkit.org/show_bug.cgi?id=300770">https://bugs.webkit.org/show_bug.cgi?id=300770</a>
<a href="https://rdar.apple.com/162558490">rdar://162558490</a>

Reviewed by Abrar Rahman Protyasha.

In the case where the top scroll pocket (scroll edge effect) is changing from `.hard` to `.soft`
style, our current logic in `-_updateTopScrollPocketCaptureColor` to update the internal top pocket
color will just bail instead of making any changes to the scroll pocket.

As a result, if the top scroll pocket starts out as a hard pocket and the website contains a fixed
position header that triggers top fixed color extension and then later becomes a soft pocket, and
then the fixed header is removed, the pocket will get stuck with its old pocket color from when the
header was in the DOM.

Fix this by resetting `_internalTopPocketColor` to `nil` when the pocket style changes to soft.

Test: added to WKScrollViewTests.TopScrollPocketCaptureColorAfterSettingHardStyle

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateTopScrollPocketCaptureColor]):
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _setInternalTopPocketColor:]):

Additionally bail if the incoming internal top pocket color is exactly equal to the current value,
to avoid calling into UIKit to update the pocket unnecessarily.

* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(TestWebKitAPI::TEST(WKScrollViewTests, TopScrollPocketCaptureColorAfterSettingHardStyle)):

Augment an existing API test to verify that if the pocket style changes to `Soft` and the fixed
header is removed, the top pocket color correctly resets to `nil` to reflect this.

Canonical link: <a href="https://commits.webkit.org/301556@main">https://commits.webkit.org/301556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe7aa7b7020abe96d73c0778f0631e41127f93fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133052 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78040 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/87ca60c7-31ac-4489-a2f8-f4e4e6611524) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96141 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76619 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ec84db5-eaa1-4b80-8ffc-59fc85dd2b25) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36178 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31129 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76520 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135748 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104635 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104335 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26623 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49781 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28118 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50403 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52922 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58751 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52237 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55581 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53953 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->