### PR TITLE
Remove bypass for RemoteDOMWindow $vm property access

### DIFF
--- a/LayoutTests/http/tests/security/cross-origin-window-property-access-expected.txt
+++ b/LayoutTests/http/tests/security/cross-origin-window-property-access-expected.txt
@@ -16,6 +16,7 @@ PASS Object.getOwnPropertyDescriptor(window.__proto__, "constructor").get.call(c
 PASS crossOriginWindow.constructor threw exception SecurityError: Blocked a frame with origin "http://127.0.0.1:8000" from accessing a cross-origin frame. Protocols, domains, and ports must match..
 PASS Object.getOwnPropertyDescriptor(crossOriginWindow.__proto__, "constructor").value threw exception SecurityError: Blocked a frame with origin "http://127.0.0.1:8000" from accessing a cross-origin frame. Protocols, domains, and ports must match..
 PASS Object.getOwnPropertyDescriptor(window, "location").get.call(crossOriginWindow) === crossOriginWindow.location is true
+PASS crossOriginWindow.$vm threw exception SecurityError: Blocked a frame with origin "http://127.0.0.1:8000" from accessing a cross-origin frame. Protocols, domains, and ports must match..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/security/cross-origin-window-property-access.html
+++ b/LayoutTests/http/tests/security/cross-origin-window-property-access.html
@@ -37,6 +37,7 @@ async function runTest()
     shouldThrowErrorName('crossOriginWindow.constructor', 'SecurityError');
     shouldThrowErrorName('Object.getOwnPropertyDescriptor(crossOriginWindow.__proto__, "constructor").value', 'SecurityError');
     shouldBeTrue('Object.getOwnPropertyDescriptor(window, "location").get.call(crossOriginWindow) === crossOriginWindow.location');
+    shouldThrowErrorName('crossOriginWindow.$vm', 'SecurityError');
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/site-isolation/remotedomwindow-property-access-security-checks-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/remotedomwindow-property-access-security-checks-expected.txt
@@ -1,0 +1,29 @@
+ALERT: PASS: Accessing document threw SecurityError
+ALERT: PASS: Accessing $vm threw SecurityError
+ALERT: PASS: Accessing navigator threw SecurityError
+ALERT: PASS: Accessing screen threw SecurityError
+ALERT: PASS: Accessing history threw SecurityError
+ALERT: PASS: Accessing innerHeight threw SecurityError
+ALERT: PASS: Accessing innerWidth threw SecurityError
+ALERT: PASS: Accessing scrollX threw SecurityError
+ALERT: PASS: Accessing scrollY threw SecurityError
+ALERT: PASS: Accessing name threw SecurityError
+ALERT: PASS: Accessing menubar threw SecurityError
+ALERT: PASS: Accessing toolbar threw SecurityError
+ALERT: PASS: Accessing localStorage threw SecurityError
+ALERT: PASS: Accessing sessionStorage threw SecurityError
+ALERT: PASS: Accessing alert threw SecurityError
+ALERT: PASS: Accessing confirm threw SecurityError
+ALERT: PASS: Accessing prompt threw SecurityError
+ALERT: PASS: Accessing print threw SecurityError
+ALERT: PASS: Accessing open threw SecurityError
+ALERT: PASS: Accessing constructor threw SecurityError
+ALERT: PASS: Accessing fetch threw SecurityError
+ALERT: PASS: Accessing location did not throw
+ALERT: PASS: postMessage did not throw
+ALERT: PASS: blur() did not throw
+ALERT: PASS: focus() did not throw
+ALERT: PASS: close() did not throw
+This test verifies RemoteDOMWindow property access security checks
+
+

--- a/LayoutTests/http/tests/site-isolation/remotedomwindow-property-access-security-checks.html
+++ b/LayoutTests/http/tests/site-isolation/remotedomwindow-property-access-security-checks.html
@@ -1,0 +1,68 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test verifies RemoteDOMWindow property access security checks</p>
+<iframe id="child"></iframe>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function shouldBlock(targetWindow, property) {
+    try {
+        const value = targetWindow[property];
+        alert("FAIL: Accessing " + property + " should have thrown SecurityError");
+    } catch (e) {
+        if (e.name === 'SecurityError')
+            alert("PASS: Accessing " + property + " threw SecurityError");
+        else
+            alert("FAIL: Accessing " + property + " threw " + e.name + " instead of SecurityError");
+    }
+}
+
+function shouldAllow(targetWindow, property, isMethod) {
+    try {
+        if (isMethod)
+            targetWindow[property]();
+        else
+            var value = targetWindow[property];
+        alert("PASS: " + (isMethod ? property + "()" : "Accessing " + property) + " did not throw");
+    } catch (e) {
+        alert("FAIL: " + (isMethod ? property + "()" : "Accessing " + property) + " threw " + e.name);
+    }
+}
+
+const iframe = document.getElementById('child');
+iframe.onload = function() {
+    const crossOriginWindow = iframe.contentWindow;
+
+    const blockedProperties = ['document', '$vm', 'navigator', 'screen', 'history', 'innerHeight', 'innerWidth',
+                                'scrollX', 'scrollY', 'name', 'menubar', 'toolbar',
+                                'localStorage', 'sessionStorage', 'alert', 'confirm',
+                                'prompt', 'print', 'open', 'constructor', 'fetch'];
+    blockedProperties.forEach(function(property) {
+        shouldBlock(crossOriginWindow, property);
+    });
+
+    shouldAllow(crossOriginWindow, 'location', false);
+
+    try {
+        crossOriginWindow.postMessage('test', '*');
+        alert("PASS: postMessage did not throw");
+    } catch (e) {
+        alert("FAIL: postMessage threw " + e.name);
+    }
+
+    shouldAllow(crossOriginWindow, 'blur', true);
+    shouldAllow(crossOriginWindow, 'focus', true);
+    shouldAllow(crossOriginWindow, 'close', true);
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+};
+iframe.src = 'http://localhost:8000/security/resources/blank.html';
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -3069,7 +3069,8 @@ DEFINE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE, JSGlobalObject);
 SUPPRESS_ASAN void JSGlobalObject::exposeDollarVM(VM& vm)
 {
     RELEASE_ASSERT(g_jscConfig.restrictedOptionsEnabled && Options::useDollarVM());
-    if (hasOwnProperty(this, vm.propertyNames->builtinNames().dollarVMPrivateName()))
+    PropertySlot slot(this, PropertySlot::InternalMethodType::VMInquiry, &vm);
+    if (getOwnPropertySlot(this, this, vm.propertyNames->builtinNames().dollarVMPrivateName(), slot))
         return;
 
     JSDollarVM* dollarVM = JSDollarVM::create(vm, JSDollarVM::createStructure(vm, this, m_objectPrototype.get()));

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -198,10 +198,6 @@ bool JSDOMWindow::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexicalGl
 
     ASSERT(lexicalGlobalObject->vm().currentThreadIsHoldingAPILock());
 
-    // FIXME (rdar://115751655): This should be replaced with a same-origin check between the active and target document.
-    if (!is<LocalDOMWindow>(thisObject->wrapped()) && propertyName == "$vm"_s) [[unlikely]]
-        return true;
-
     // Hand off all cross-domain access to jsDOMWindowGetOwnPropertySlotRestrictedAccess.
     String errorMessage;
     if (!BindingSecurity::shouldAllowAccessToDOMWindow(*lexicalGlobalObject, thisObject->wrapped(), errorMessage))


### PR DESCRIPTION
#### 4ad3bb8b572370d20751a00b43c4922ee8071123
<pre>
Remove bypass for RemoteDOMWindow $vm property access
<a href="https://bugs.webkit.org/show_bug.cgi?id=300773">https://bugs.webkit.org/show_bug.cgi?id=300773</a>
<a href="https://rdar.apple.com/115751655">rdar://115751655</a>

Reviewed by Yusuke Suzuki and Keith Miller.

While <a href="https://commits.webkit.org/277560@main">https://commits.webkit.org/277560@main</a> fixed the majority of RemoteDOMWindow property access
security checks, $vm still has a hack/bypass. This PR removes that bypass and allows $vm to go thru
the same correct security checks that other properties do.

exposeDollarVM() currently uses hasOwnProperty() to check if $vm has already been exposed. With the
changes in this PR, this causes a SecurityError and a resulting assert because RemoteDOMWindow
is not allowed to access $vm. To solve this, we replace this check with getOwnPropertySlot().

We adjust the existing cross origin property access test to include $vm to ensure we don&apos;t regress
any existing behavior. Lastly, we add a new SI test to ensure that with SI on, all RemoteDOMWindow property
access security checks go thru correctly (including $vm).

Test: http/tests/site-isolation/remotedomwindow-property-access-security-checks.html
* LayoutTests/http/tests/security/cross-origin-window-property-access-expected.txt:
* LayoutTests/http/tests/security/cross-origin-window-property-access.html:
* LayoutTests/http/tests/site-isolation/remotedomwindow-property-access-security-checks-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/remotedomwindow-property-access-security-checks.html: Added.
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::exposeDollarVM):
* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::JSDOMWindow::getOwnPropertySlot):

Canonical link: <a href="https://commits.webkit.org/301696@main">https://commits.webkit.org/301696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d02d99641e9a860cc4a38fe76ff3058cb3819ceb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78192 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c322115-879e-4637-b32a-413b785e086d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96274 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64379 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7ac10544-0a04-4069-9cbb-b03d98f476f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113145 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76748 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/06bc4dce-c118-4583-b4ef-934c60a477f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31323 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76714 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118567 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107236 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135954 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124982 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104781 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53694 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104483 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26694 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28292 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50616 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53128 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58941 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158027 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52410 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39540 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55744 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54145 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->