### PR TITLE
[WTF] Fix -Wc++23-lambda-attributes warnings

### DIFF
--- a/Source/JavaScriptCore/Configurations/JavaScriptCore.xcconfig
+++ b/Source/JavaScriptCore/Configurations/JavaScriptCore.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2024 Apple Inc. All rights reserved.
+// Copyright (C) 2009-2025 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -63,12 +63,15 @@ MODULE_VERIFIER_SUPPORTED_LANGUAGES_NO = objective-c;
 // FIXME: (rdar://74275135) Re-enable support for automatically verifying Objective-C and C when possible.
 MODULE_VERIFIER_SUPPORTED_LANGUAGES_YES = objective-c++ c++;
 
+MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = $(MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS_$(WK_HAS_VALID_JSC_PRIVATE_MODULE));
+MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS_YES = c++23;
+
+MODULE_VERIFIER_KIND = builtin;
+
 MODULEMAP_PRIVATE_FILE = $(MODULEMAP_PRIVATE_FILE_$(WK_HAS_VALID_JSC_PRIVATE_MODULE));
 MODULEMAP_PRIVATE_FILE_ = ;
 MODULEMAP_PRIVATE_FILE_NO = ;
 MODULEMAP_PRIVATE_FILE_YES = $(SRCROOT)/JavaScriptCore_Private.modulemap;
-
-MODULE_VERIFIER_KIND = builtin;
 
 WK_SUPPORTS_OTHER_TAPI_FLAGS_STATICLIBS = $(WK_SUPPORTS_OTHER_TAPI_FLAGS_STATICLIBS_$(WK_PLATFORM_NAME));
 WK_SUPPORTS_OTHER_TAPI_FLAGS_STATICLIBS_iphoneos = $(WK_SUPPORTS_OTHER_TAPI_FLAGS_STATICLIBS$(WK_IOS_17));


### PR DESCRIPTION
#### 1e7334780f9baf96cb63dda8a3d55571c8f34af5
<pre>
[WTF] Fix -Wc++23-lambda-attributes warnings
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=300747">https://bugs.webkit.org/show_bug.cgi?id=300747</a>&gt;
&lt;<a href="https://rdar.apple.com/162639803">rdar://162639803</a>&gt;

Reviewed by Chris Dumez.

* Source/JavaScriptCore/Configurations/JavaScriptCore.xcconfig:
(MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS): Add.
- Set variable based on the value of WK_HAS_VALID_JSC_PRIVATE_MODULE.
  This is similar to one of the changes in 301180@main for
  Source/WebKit/Configurations/WebKit.xcconfig.

Canonical link: <a href="https://commits.webkit.org/301598@main">https://commits.webkit.org/301598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8aea765c40133a812dd43a9a6b1b1d0594e451f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133379 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78166 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/22fb2f79-dc9b-474f-a24d-b218304d0382) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54670 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c84963a6-5307-45ad-bd02-9098b2124f94) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76726 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a14a6623-5915-4696-b67d-9ca06515c359) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31297 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76686 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118538 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135925 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124952 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40888 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104459 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49933 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28268 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50581 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19781 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53099 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58914 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157998 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52383 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39532 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55717 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54117 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->