### PR TITLE
[JSC] Add getCallDataInline in JSC

### DIFF
--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -84,7 +84,7 @@ inline void* handleHostCall(VM& vm, JSCell* owner, CallFrame* calleeFrame, JSVal
     calleeFrame->setCodeBlock(nullptr);
 
     if (callLinkInfo->specializationKind() == CodeSpecializationKind::CodeForCall) {
-        auto callData = JSC::getCallData(callee);
+        auto callData = JSC::getCallDataInline(callee);
         ASSERT(callData.type != CallData::Type::JS);
 
         if (callData.type == CallData::Type::Native) {

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1215,7 +1215,7 @@ JSValue Interpreter::executeProgram(const SourceCode& source, JSGlobalObject*, J
             case JSONPPathEntryTypeCall: {
                 JSValue function = baseObject.get(globalObject, ident);
                 RETURN_IF_EXCEPTION(throwScope, JSValue());
-                auto callData = JSC::getCallData(function);
+                auto callData = JSC::getCallDataInline(function);
                 if (callData.type == CallData::Type::None)
                     return throwException(globalObject, throwScope, createNotAFunctionError(globalObject, function));
                 MarkedArgumentBuffer jsonArg;
@@ -1305,7 +1305,7 @@ JSValue Interpreter::executeBoundCall(VM& vm, JSBoundFunction* function, JSCell*
 
     JSObject* targetFunction = function->targetFunction();
     JSValue boundThis = function->boundThis();
-    auto callData = JSC::getCallData(targetFunction);
+    auto callData = JSC::getCallDataInline(targetFunction);
     ASSERT(callData.type != CallData::Type::None);
 
     RELEASE_AND_RETURN(scope, executeCallImpl(vm, targetFunction, callData, boundThis, context, combinedArgs));
@@ -1400,7 +1400,7 @@ JSValue Interpreter::executeCall(JSObject* function, const CallData& callData, J
         // Let's just replace and get unwrapped functions again.
         JSObject* targetFunction = boundFunction->targetFunction();
         JSValue boundThis = boundFunction->boundThis();
-        auto targetFunctionCallData = JSC::getCallData(targetFunction);
+        auto targetFunctionCallData = JSC::getCallDataInline(targetFunction);
         ASSERT(targetFunctionCallData.type != CallData::Type::None);
         return executeCallImpl(vm, targetFunction, targetFunctionCallData, boundThis, context, args);
     }

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2064,7 +2064,7 @@ static UGPRPair handleHostCall(CallFrame* calleeFrame, JSValue callee, CodeSpeci
     calleeFrame->clearReturnPC();
 
     if (kind == CodeSpecializationKind::CodeForCall) {
-        auto callData = JSC::getCallData(callee);
+        auto callData = JSC::getCallDataInline(callee);
         ASSERT(callData.type != CallData::Type::JS);
 
         if (callData.type == CallData::Type::Native) {

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -267,7 +267,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncToString, (JSGlobalObject* globalObject, 
         RETURN_IF_EXCEPTION(scope, { });
 
         // 3. If IsCallable(func) is false, then let func be the standard built-in method Object.prototype.toString (15.2.4.2).
-        auto callData = JSC::getCallData(function);
+        auto callData = JSC::getCallDataInline(function);
         if (callData.type == CallData::Type::None) [[unlikely]]
             RELEASE_AND_RETURN(scope, JSValue::encode(objectPrototypeToString(globalObject, thisObject)));
 
@@ -288,7 +288,7 @@ static JSString* toLocaleString(JSGlobalObject* globalObject, JSValue value, JSV
     JSValue toLocaleStringMethod = value.get(globalObject, vm.propertyNames->toLocaleString);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto callData = JSC::getCallData(toLocaleStringMethod);
+    auto callData = JSC::getCallDataInline(toLocaleStringMethod);
     if (callData.type == CallData::Type::None) {
         throwTypeError(globalObject, scope, "toLocaleString is not callable"_s);
         return { };
@@ -903,7 +903,7 @@ static ALWAYS_INLINE std::span<EncodedJSValue> sortStableSort(JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto callData = JSC::getCallData(comparator);
+    auto callData = JSC::getCallDataInline(comparator);
     ASSERT(callData.type != CallData::Type::None);
 
     if (callData.type == CallData::Type::JS) [[likely]] {

--- a/Source/JavaScriptCore/runtime/CallData.cpp
+++ b/Source/JavaScriptCore/runtime/CallData.cpp
@@ -47,7 +47,7 @@ JSValue call(JSGlobalObject* globalObject, JSValue functionObject, JSValue thisV
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto callData = JSC::getCallData(functionObject);
+    auto callData = JSC::getCallDataInline(functionObject);
     if (callData.type == CallData::Type::None)
         return throwTypeError(globalObject, scope, errorMessage);
 
@@ -88,7 +88,7 @@ JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObject, JSVa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto callData = JSC::getCallData(functionObject);
+    auto callData = JSC::getCallDataInline(functionObject);
     if (callData.type == CallData::Type::None)
         return throwTypeError(globalObject, scope, errorMessage);
 

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -928,7 +928,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToJSON, (JSGlobalObject* globalObject, Cal
     JSValue toISOValue = object->get(globalObject, vm.propertyNames->toISOString);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-    auto callData = JSC::getCallData(toISOValue);
+    auto callData = JSC::getCallDataInline(toISOValue);
     if (callData.type == CallData::Type::None)
         return throwVMTypeError(globalObject, scope, "toISOString is not a function"_s);
 

--- a/Source/JavaScriptCore/runtime/GetterSetter.cpp
+++ b/Source/JavaScriptCore/runtime/GetterSetter.cpp
@@ -56,7 +56,7 @@ JSValue GetterSetter::callGetter(JSGlobalObject* globalObject, JSValue thisValue
 
     JSObject* getter = this->getter();
 
-    auto callData = JSC::getCallData(getter);
+    auto callData = JSC::getCallDataInline(getter);
     RELEASE_AND_RETURN(scope, call(globalObject, getter, callData, thisValue, ArgList()));
 }
 
@@ -74,7 +74,7 @@ bool GetterSetter::callSetter(JSGlobalObject* globalObject, JSValue thisValue, J
     args.append(value);
     ASSERT(!args.hasOverflowed());
 
-    auto callData = JSC::getCallData(setter);
+    auto callData = JSC::getCallDataInline(setter);
     scope.release();
     call(globalObject, setter, callData, thisValue, args);
     return true;

--- a/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -43,7 +43,7 @@ JSValue iteratorNext(JSGlobalObject* globalObject, IterationRecord iterationReco
     JSValue iterator = iterationRecord.iterator;
     JSValue nextFunction = iterationRecord.nextMethod;
 
-    auto nextFunctionCallData = JSC::getCallData(nextFunction);
+    auto nextFunctionCallData = JSC::getCallDataInline(nextFunction);
     if (nextFunctionCallData.type == CallData::Type::None)
         return throwTypeError(globalObject, scope);
 
@@ -67,7 +67,7 @@ JSValue iteratorNextWithCachedCall(JSGlobalObject* globalObject, IterationRecord
 
     JSValue iterator = iterationRecord.iterator;
 
-    ASSERT(JSC::getCallData(iterationRecord.nextMethod).type == CallData::Type::JS);
+    ASSERT(JSC::getCallDataInline(iterationRecord.nextMethod).type == CallData::Type::JS);
 
     JSValue result;
     if (argument)
@@ -149,7 +149,7 @@ void iteratorClose(JSGlobalObject* globalObject, JSValue iterator)
         return;
     }
 
-    auto returnFunctionCallData = JSC::getCallData(returnFunction);
+    auto returnFunctionCallData = JSC::getCallDataInline(returnFunction);
     if (returnFunctionCallData.type == CallData::Type::None) {
         if (exception)
             throwException(globalObject, throwScope, exception);
@@ -231,7 +231,7 @@ IterationRecord iteratorForIterable(JSGlobalObject* globalObject, JSObject* obje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto iteratorMethodCallData = JSC::getCallData(iteratorMethod);
+    auto iteratorMethodCallData = JSC::getCallDataInline(iteratorMethod);
     if (iteratorMethodCallData.type == CallData::Type::None) {
         throwTypeError(globalObject, scope);
         return { };
@@ -260,7 +260,7 @@ IterationRecord iteratorForIterable(JSGlobalObject* globalObject, JSValue iterab
     JSValue iteratorFunction = iterable.get(globalObject, vm.propertyNames->iteratorSymbol);
     RETURN_IF_EXCEPTION(scope, { });
     
-    auto iteratorFunctionCallData = JSC::getCallData(iteratorFunction);
+    auto iteratorFunctionCallData = JSC::getCallDataInline(iteratorFunction);
     if (iteratorFunctionCallData.type == CallData::Type::None) {
         throwTypeError(globalObject, scope);
         return { };

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -172,7 +172,7 @@ ALWAYS_INLINE void forEachInIterationRecord(JSGlobalObject* globalObject, Iterat
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue nextMethod = iterationRecord.nextMethod;
-    auto callData = getCallData(nextMethod);
+    auto callData = getCallDataInline(nextMethod);
 
     std::optional<CachedCall> cachedCallHolder;
     CachedCall* cachedCall = nullptr;
@@ -278,7 +278,7 @@ void forEachInIterable(JSGlobalObject& globalObject, JSObject* iterable, JSValue
     RETURN_IF_EXCEPTION(scope, void());
 
     JSValue nextMethod = iterationRecord.nextMethod;
-    auto callData = getCallData(nextMethod);
+    auto callData = getCallDataInline(nextMethod);
 
     std::optional<CachedCall> cachedCallHolder;
     CachedCall* cachedCall = nullptr;

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
@@ -64,7 +64,7 @@ JSC_DEFINE_HOST_FUNCTION(boundThisNoArgsFunctionCall, (JSGlobalObject* globalObj
         // Force the executable to cache its arity entrypoint.
         executable->entrypointFor(CodeSpecializationKind::CodeForCall, ArityCheckMode::MustCheckArity);
     }
-    auto callData = JSC::getCallData(targetFunction);
+    auto callData = JSC::getCallDataInline(targetFunction);
     ASSERT(callData.type != CallData::Type::None);
     return JSValue::encode(call(globalObject, targetFunction, callData, boundFunction->boundThis(), args));
 }
@@ -95,7 +95,7 @@ JSC_DEFINE_HOST_FUNCTION(boundFunctionCall, (JSGlobalObject* globalObject, CallF
     }
 
     JSObject* targetFunction = boundFunction->targetFunction();
-    auto callData = JSC::getCallData(targetFunction);
+    auto callData = JSC::getCallDataInline(targetFunction);
     ASSERT(callData.type != CallData::Type::None);
     RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, targetFunction, callData, boundFunction->boundThis(), args)));
 }

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.h
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.h
@@ -133,7 +133,7 @@ public:
 
     static bool canSkipNameAndLengthMaterialization(JSGlobalObject*, Structure*);
 
-    DECLARE_INFO;
+    DECLARE_EXPORT_INFO;
 
     DECLARE_VISIT_CHILDREN;
 

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -312,25 +312,7 @@ DEFINE_VISIT_CHILDREN(JSFunction);
 
 CallData JSFunction::getCallData(JSCell* cell)
 {
-    // Keep this function OK for invocation from concurrent compilers.
-    CallData callData;
-
-    JSFunction* thisObject = jsCast<JSFunction*>(cell);
-    if (thisObject->isHostFunction()) {
-        callData.type = CallData::Type::Native;
-        callData.native.function = thisObject->nativeFunction();
-        callData.native.isBoundFunction = thisObject->inherits<JSBoundFunction>();
-        callData.native.isWasm = false;
-#if ENABLE(WEBASSEMBLY)
-        callData.native.isWasm = thisObject->inherits<WebAssemblyFunction>();
-#endif
-    } else {
-        callData.type = CallData::Type::JS;
-        callData.js.functionExecutable = thisObject->jsExecutable();
-        callData.js.scope = thisObject->scope();
-    }
-
-    return callData;
+    return getCallDataInline(cell);
 }
 
 static constexpr unsigned prototypeAttributesForNonClass = PropertyAttribute::DontEnum | PropertyAttribute::DontDelete;

--- a/Source/JavaScriptCore/runtime/JSFunction.h
+++ b/Source/JavaScriptCore/runtime/JSFunction.h
@@ -124,6 +124,7 @@ public:
 
     JS_EXPORT_PRIVATE static CallData getConstructData(JSCell*);
     JS_EXPORT_PRIVATE static CallData getCallData(JSCell*);
+    static CallData getCallDataInline(JSCell*);
 
     static constexpr ptrdiff_t offsetOfExecutableOrRareData()
     {

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -774,7 +774,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncForEach(VM& vm, JSGlo
     size_t length = thisObject->length();
 
     JSValue functorValue = callFrame->argument(0);
-    auto callData = JSC::getCallData(functorValue);
+    auto callData = JSC::getCallDataInline(functorValue);
     if (callData.type == CallData::Type::None) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.forEach callback must be a function"_s);
 
@@ -834,7 +834,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncMap(VM& vm, JSGlobalO
     size_t length = thisObject->length();
 
     JSValue functorValue = callFrame->argument(0);
-    auto callData = JSC::getCallData(functorValue);
+    auto callData = JSC::getCallDataInline(functorValue);
     if (callData.type == CallData::Type::None) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.map callback must be a function"_s);
 
@@ -941,7 +941,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFilter(VM& vm, JSGlob
     size_t length = thisObject->length();
 
     JSValue functorValue = callFrame->argument(0);
-    auto callData = JSC::getCallData(functorValue);
+    auto callData = JSC::getCallDataInline(functorValue);
     if (callData.type == CallData::Type::None) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.filter callback must be a function"_s);
 
@@ -1034,7 +1034,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFind(VM& vm, JSGlobal
     size_t length = thisObject->length();
 
     JSValue functorValue = callFrame->argument(0);
-    auto callData = JSC::getCallData(functorValue);
+    auto callData = JSC::getCallDataInline(functorValue);
     if (callData.type == CallData::Type::None) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.find callback must be a function"_s);
 
@@ -1107,7 +1107,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFindIndex(VM& vm, JSG
     size_t length = thisObject->length();
 
     JSValue functorValue = callFrame->argument(0);
-    auto callData = JSC::getCallData(functorValue);
+    auto callData = JSC::getCallDataInline(functorValue);
     if (callData.type == CallData::Type::None) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.findIndex callback must be a function"_s);
 
@@ -1180,7 +1180,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFindLast(VM& vm, JSGl
     size_t length = thisObject->length();
 
     JSValue functorValue = callFrame->argument(0);
-    auto callData = JSC::getCallData(functorValue);
+    auto callData = JSC::getCallDataInline(functorValue);
     if (callData.type == CallData::Type::None) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.findLast callback must be a function"_s);
 
@@ -1253,7 +1253,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFindLastIndex(VM& vm,
     size_t length = thisObject->length();
 
     JSValue functorValue = callFrame->argument(0);
-    auto callData = JSC::getCallData(functorValue);
+    auto callData = JSC::getCallDataInline(functorValue);
     if (callData.type == CallData::Type::None) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.findLastIndex callback must be a function"_s);
 
@@ -1326,7 +1326,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncEvery(VM& vm, JSGloba
     size_t length = thisObject->length();
 
     JSValue functorValue = callFrame->argument(0);
-    auto callData = JSC::getCallData(functorValue);
+    auto callData = JSC::getCallDataInline(functorValue);
     if (callData.type == CallData::Type::None) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.every callback must be a function"_s);
 
@@ -1399,7 +1399,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSome(VM& vm, JSGlobal
     size_t length = thisObject->length();
 
     JSValue functorValue = callFrame->argument(0);
-    auto callData = JSC::getCallData(functorValue);
+    auto callData = JSC::getCallDataInline(functorValue);
     if (callData.type == CallData::Type::None) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.some callback must be a function"_s);
 
@@ -1523,7 +1523,7 @@ static ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSortImpl(VM& v
         return JSValue::encode(thisObject);
     }
 
-    auto callData = JSC::getCallData(comparatorValue);
+    auto callData = JSC::getCallDataInline(comparatorValue);
 
     size_t length = thisObject->length();
     if (length < 2)

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -172,7 +172,7 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncForEach, (JSGlobalObject* globalObject
         return throwVMTypeError(globalObject, scope, "Iterator.prototype.forEach requires the callback argument to be callable."_s);
     }
 
-    auto callData = JSC::getCallData(callbackArg);
+    auto callData = JSC::getCallDataInline(callbackArg);
     ASSERT(callData.type != CallData::Type::None);
 
     uint64_t counter = 0;

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -73,7 +73,7 @@ static void promiseResolveThenableJobFastSlow(JSGlobalObject* globalObject, JSPr
     MarkedArgumentBuffer arguments;
     arguments.append(error);
     ASSERT(!arguments.hasOverflowed());
-    auto callData = JSC::getCallData(reject);
+    auto callData = JSC::getCallDataInline(reject);
     call(globalObject, reject, callData, jsUndefined(), arguments);
     EXCEPTION_ASSERT(scope.exception() || true);
 }
@@ -102,7 +102,7 @@ static void promiseResolveThenableJobWithoutPromiseFastSlow(JSGlobalObject* glob
     MarkedArgumentBuffer arguments;
     arguments.append(error);
     ASSERT(!arguments.hasOverflowed());
-    auto callData = JSC::getCallData(reject);
+    auto callData = JSC::getCallDataInline(reject);
     call(globalObject, reject, callData, jsUndefined(), arguments);
     EXCEPTION_ASSERT(scope.exception() || true);
 }

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -2492,7 +2492,7 @@ static ALWAYS_INLINE JSValue callToPrimitiveFunction(JSGlobalObject* globalObjec
             return JSValue();
     }
 
-    auto callData = JSC::getCallData(function);
+    auto callData = JSC::getCallDataInline(function);
     if (callData.type == CallData::Type::None) {
         if constexpr (key == CachedSpecialPropertyKey::ToPrimitive)
             throwTypeError(globalObject, scope, "Symbol.toPrimitive is not a function, undefined, or null"_s);
@@ -2608,7 +2608,7 @@ bool JSObject::hasInstance(JSGlobalObject* globalObject, JSValue value, JSValue 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!hasInstanceValue.isUndefinedOrNull() && hasInstanceValue != globalObject->functionProtoHasInstanceSymbolFunction()) {
-        auto callData = JSC::getCallData(hasInstanceValue);
+        auto callData = JSC::getCallDataInline(hasInstanceValue);
         if (callData.type == CallData::Type::None) {
             throwException(globalObject, scope, createInvalidInstanceofParameterErrorHasInstanceValueNotFunction(globalObject, this));
             return false;
@@ -4146,7 +4146,7 @@ JSValue JSObject::getMethod(JSGlobalObject* globalObject, CallData& callData, co
         return jsUndefined();
     }
 
-    callData = JSC::getCallData(method.asCell());
+    callData = JSC::getCallDataInline(method.asCell());
     if (callData.type == CallData::Type::None) {
         throwVMTypeError(globalObject, scope, errorMessage);
         return jsUndefined();

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -749,9 +749,25 @@ ALWAYS_INLINE CallData getCallData(JSCell* cell)
 
 inline CallData getCallData(JSValue value)
 {
-    if (!value.isCell()) 
+    if (!value.isCell())
         return { };
     return getCallData(value.asCell());
+}
+
+ALWAYS_INLINE CallData getCallDataInline(JSCell* cell)
+{
+    if (cell->type() == JSFunctionType)
+        return JSFunction::getCallDataInline(cell);
+    CallData result = cell->methodTable()->getCallData(cell);
+    ASSERT(result.type == CallData::Type::None || cell->isValidCallee());
+    return result;
+}
+
+ALWAYS_INLINE CallData getCallDataInline(JSValue value)
+{
+    if (!value.isCell())
+        return { };
+    return getCallDataInline(value.asCell());
 }
 
 inline CallData getConstructData(JSValue value)

--- a/Source/JavaScriptCore/runtime/MapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/MapConstructor.cpp
@@ -92,7 +92,7 @@ JSC_DEFINE_HOST_FUNCTION(constructMap, (JSGlobalObject* globalObject, CallFrame*
         adderFunction = map->JSObject::get(globalObject, vm.propertyNames->set);
         RETURN_IF_EXCEPTION(scope, { });
 
-        adderFunctionCallData = JSC::getCallData(adderFunction);
+        adderFunctionCallData = JSC::getCallDataInline(adderFunction);
         if (adderFunctionCallData.type == CallData::Type::None) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "'set' property of a Map should be callable."_s);
     }

--- a/Source/JavaScriptCore/runtime/MapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/MapPrototype.cpp
@@ -219,7 +219,7 @@ JSC_DEFINE_HOST_FUNCTION(mapProtoFuncGetOrInsertComputed, (JSGlobalObject* globa
 
     key = normalizeMapKey(key);
     RELEASE_AND_RETURN(scope, JSValue::encode(map->getOrInsert(globalObject, key, [&] {
-        auto callData = JSC::getCallData(valueCallback);
+        auto callData = JSC::getCallDataInline(valueCallback);
         ASSERT(callData.type != CallData::Type::None);
 
         if (callData.type == CallData::Type::JS) [[likely]] {

--- a/Source/JavaScriptCore/runtime/ObjectPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectPrototype.cpp
@@ -332,7 +332,7 @@ JSC_DEFINE_HOST_FUNCTION(objectProtoFuncToLocaleString, (JSGlobalObject* globalO
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     // If IsCallable(toString) is false, throw a TypeError exception.
-    auto callData = JSC::getCallData(toString);
+    auto callData = JSC::getCallDataInline(toString);
     if (callData.type == CallData::Type::None)
         return throwVMTypeError(globalObject, scope);
 

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -99,7 +99,7 @@ JSObject* ProxyObject::getHandlerTrap(JSGlobalObject* globalObject, JSObject* ha
         if (value.isUndefinedOrNull())
             return nullptr;
 
-        callData = JSC::getCallData(value);
+        callData = JSC::getCallDataInline(value);
         if (callData.type == CallData::Type::None) {
             throwTypeError(globalObject, scope, makeString('\'', String(ident.impl()), "' property of a Proxy's handler should be callable"_s));
             return nullptr;
@@ -620,7 +620,7 @@ JSC_DEFINE_HOST_FUNCTION(performProxyCall, (JSGlobalObject* globalObject, CallFr
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     JSObject* target = proxy->target();
     if (applyMethod.isUndefined()) {
-        auto callData = JSC::getCallData(target);
+        auto callData = JSC::getCallDataInline(target);
         RELEASE_ASSERT(callData.type != CallData::Type::None);
         RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, target, callData, callFrame->thisValue(), ArgList(callFrame))));
     }

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -106,7 +106,7 @@ static inline JSValue regExpExec(JSGlobalObject* globalObject, JSValue thisValue
 
     JSValue match;
     if (regExpExec != regExpBuiltinExec && regExpExec.isCallable()) [[unlikely]] {
-        auto callData = JSC::getCallData(regExpExec);
+        auto callData = JSC::getCallDataInline(regExpExec);
         ASSERT(callData.type != CallData::Type::None);
         if (callData.type == CallData::Type::JS) [[likely]] {
             CachedCall cachedCall(globalObject, jsCast<JSFunction*>(regExpExec), 1);
@@ -125,7 +125,7 @@ static inline JSValue regExpExec(JSGlobalObject* globalObject, JSValue thisValue
             return { };
         }
     } else {
-        auto callData = JSC::getCallData(regExpBuiltinExec);
+        auto callData = JSC::getCallDataInline(regExpBuiltinExec);
         MarkedArgumentBuffer args;
         args.append(str);
         ASSERT(!args.hasOverflowed());

--- a/Source/JavaScriptCore/runtime/SetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/SetConstructor.cpp
@@ -87,7 +87,7 @@ JSC_DEFINE_HOST_FUNCTION(constructSet, (JSGlobalObject* globalObject, CallFrame*
         adderFunction = set->JSObject::get(globalObject, vm.propertyNames->add);
         RETURN_IF_EXCEPTION(scope, { });
 
-        adderFunctionCallData = JSC::getCallData(adderFunction);
+        adderFunctionCallData = JSC::getCallDataInline(adderFunction);
         if (adderFunctionCallData.type == CallData::Type::None) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "'add' property of a Set should be callable."_s);
     }

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -298,7 +298,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
 
         auto* storage = jsCast<JSSet::Storage*>(storageCell);
         JSSet::Helper::Entry entry = 0;
-        CallData hasCallData = JSC::getCallData(has);
+        CallData hasCallData = JSC::getCallDataInline(has);
 
         std::optional<CachedCall> cachedHasCall;
         if (hasCallData.type == CallData::Type::JS) [[likely]] {
@@ -335,7 +335,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
             }
         }
     } else {
-        CallData keysCallData = JSC::getCallData(keys);
+        CallData keysCallData = JSC::getCallDataInline(keys);
         MarkedArgumentBuffer args;
         ASSERT(!args.hasOverflowed());
         JSValue iterator = call(globalObject, keys, keysCallData, otherValue, args);
@@ -422,7 +422,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncUnion, (JSGlobalObject* globalObject, CallF
     if (!keys.isCallable()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Set.prototype.union expects other.keys to be callable"_s);
 
-    CallData keysCallData = JSC::getCallData(keys);
+    CallData keysCallData = JSC::getCallDataInline(keys);
     MarkedArgumentBuffer args;
     ASSERT(!args.hasOverflowed());
     JSValue iterator = call(globalObject, keys, keysCallData, otherValue, args);
@@ -557,7 +557,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
         if (resultStorageCell == vm.orderedHashTableSentinel())
             return JSValue::encode(result);
 
-        CallData hasCallData = JSC::getCallData(has);
+        CallData hasCallData = JSC::getCallDataInline(has);
         std::optional<CachedCall> cachedHasCall;
         if (hasCallData.type == CallData::Type::JS) [[likely]] {
             cachedHasCall.emplace(globalObject, jsCast<JSFunction*>(has), 1);
@@ -598,7 +598,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
             resultStorage = currentStorage;
         }
     } else {
-        CallData keysCallData = JSC::getCallData(keys);
+        CallData keysCallData = JSC::getCallDataInline(keys);
         MarkedArgumentBuffer keysArgs;
         ASSERT(!keysArgs.hasOverflowed());
         JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, keysArgs);
@@ -609,7 +609,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
         if (!nextMethod.isCallable()) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "Set.prototype.difference expects other.keys().next to be callable"_s);
 
-        CallData nextCallData = JSC::getCallData(nextMethod);
+        CallData nextCallData = JSC::getCallDataInline(nextMethod);
 
         std::optional<CachedCall> cachedNextCall;
         if (nextCallData.type == CallData::Type::JS) [[likely]] {
@@ -727,7 +727,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncSymmetricDifference, (JSGlobalObject* globa
     if (!keys.isCallable()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Set.prototype.symmetricDifference expects other.keys to be callable"_s);
 
-    CallData keysCallData = JSC::getCallData(keys);
+    CallData keysCallData = JSC::getCallDataInline(keys);
     MarkedArgumentBuffer keysArgs;
     ASSERT(!keysArgs.hasOverflowed());
     JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, keysArgs);
@@ -741,7 +741,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncSymmetricDifference, (JSGlobalObject* globa
     JSSet* result = thisSet->clone(globalObject, vm, globalObject->setStructure());
     RETURN_IF_EXCEPTION(scope, { });
 
-    CallData nextCallData = JSC::getCallData(nextMethod);
+    CallData nextCallData = JSC::getCallDataInline(nextMethod);
 
     std::optional<CachedCall> cachedNextCall;
     if (nextCallData.type == CallData::Type::JS) [[likely]] {
@@ -825,7 +825,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSubsetOf, (JSGlobalObject* globalObject, 
     if (thisSet->size() > otherSize)
         return JSValue::encode(jsBoolean(false));
 
-    CallData hasCallData = JSC::getCallData(has);
+    CallData hasCallData = JSC::getCallDataInline(has);
     JSCell* thisStorageCell = thisSet->storageOrSentinel(vm);
     if (thisStorageCell == vm.orderedHashTableSentinel())
         return JSValue::encode(jsBoolean(true));
@@ -944,7 +944,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSupersetOf, (JSGlobalObject* globalObject
     if (thisSet->size() < otherSize)
         return JSValue::encode(jsBoolean(false));
 
-    CallData keysCallData = JSC::getCallData(keys);
+    CallData keysCallData = JSC::getCallDataInline(keys);
     MarkedArgumentBuffer keysArgs;
     ASSERT(!keysArgs.hasOverflowed());
     JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, keysArgs);
@@ -955,7 +955,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSupersetOf, (JSGlobalObject* globalObject
     if (!nextMethod.isCallable()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Set.prototype.isSupersetOf expects other.keys().next to be callable"_s);
 
-    CallData nextCallData = JSC::getCallData(nextMethod);
+    CallData nextCallData = JSC::getCallDataInline(nextMethod);
 
     std::optional<CachedCall> cachedNextCall;
     if (nextCallData.type == CallData::Type::JS) [[likely]] {
@@ -1080,7 +1080,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
         auto* thisStorage = jsCast<JSSet::Storage*>(thisStorageCell);
         JSSet::Helper::Entry entry = 0;
 
-        CallData hasCallData = JSC::getCallData(has);
+        CallData hasCallData = JSC::getCallDataInline(has);
         std::optional<CachedCall> cachedHasCall;
         if (hasCallData.type == CallData::Type::JS) [[likely]] {
             cachedHasCall.emplace(globalObject, jsCast<JSFunction*>(has), 1);
@@ -1116,7 +1116,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
             thisStorage = currentStorage;
         }
     } else {
-        CallData keysCallData = JSC::getCallData(keys);
+        CallData keysCallData = JSC::getCallDataInline(keys);
         MarkedArgumentBuffer keysArgs;
         ASSERT(!keysArgs.hasOverflowed());
         JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, keysArgs);
@@ -1127,7 +1127,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
         if (!nextMethod.isCallable()) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "Set.prototype.isDisjointFrom expects other.keys().next to be callable"_s);
 
-        CallData nextCallData = JSC::getCallData(nextMethod);
+        CallData nextCallData = JSC::getCallDataInline(nextMethod);
 
         std::optional<CachedCall> cachedNextCall;
         if (nextCallData.type == CallData::Type::JS) [[likely]] {

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -397,7 +397,7 @@ inline JSString* replaceUsingStringSearch(VM& vm, JSGlobalObject* globalObject, 
         replaceString = asString(replaceValue)->value(globalObject);
         RETURN_IF_EXCEPTION(scope, nullptr);
     } else {
-        callData = JSC::getCallData(replaceValue);
+        callData = JSC::getCallDataInline(replaceValue);
         if (callData.type == CallData::Type::None) {
             replaceString = replaceValue.toWTFString(globalObject);
             RETURN_IF_EXCEPTION(scope, nullptr);
@@ -1514,7 +1514,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     String replacementString;
-    auto callData = JSC::getCallData(replaceValue);
+    auto callData = JSC::getCallDataInline(replaceValue);
     if (callData.type == CallData::Type::None) {
         replacementString = replaceValue.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, nullptr);

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1323,7 +1323,7 @@ void VM::callPromiseRejectionCallback(Strong<JSPromise>& promise)
 
     auto scope = DECLARE_CATCH_SCOPE(*this);
 
-    auto callData = JSC::getCallData(callback);
+    auto callData = JSC::getCallDataInline(callback);
     ASSERT(callData.type != CallData::Type::None);
 
     MarkedArgumentBuffer args;

--- a/Source/JavaScriptCore/runtime/WeakMapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapConstructor.cpp
@@ -73,7 +73,7 @@ JSC_DEFINE_HOST_FUNCTION(constructWeakMap, (JSGlobalObject* globalObject, CallFr
     JSValue adderFunction = weakMap->JSObject::get(globalObject, vm.propertyNames->set);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-    auto adderFunctionCallData = JSC::getCallData(adderFunction);
+    auto adderFunctionCallData = JSC::getCallDataInline(adderFunction);
     if (adderFunctionCallData.type == CallData::Type::None)
         return throwVMTypeError(globalObject, scope, "'set' property of a WeakMap should be callable."_s);
 

--- a/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
@@ -178,7 +178,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapGetOrInsertComputed, (JSGlobalObject* g
         return throwVMTypeError(globalObject, scope, WeakMapInvalidKeyError);
 
     JSValue valueCallback = callFrame->argument(1);
-    auto callData = JSC::getCallData(valueCallback);
+    auto callData = JSC::getCallDataInline(valueCallback);
     if (callData.type == CallData::Type::None) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "WeakMap.prototype.getOrInsertComputed requires the callback argument to be callable."_s);
 

--- a/Source/JavaScriptCore/runtime/WeakSetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakSetConstructor.cpp
@@ -74,7 +74,7 @@ JSC_DEFINE_HOST_FUNCTION(constructWeakSet, (JSGlobalObject* globalObject, CallFr
     JSValue adderFunction = weakSet->JSObject::get(globalObject, vm.propertyNames->add);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-    auto adderFunctionCallData = JSC::getCallData(adderFunction);
+    auto adderFunctionCallData = JSC::getCallDataInline(adderFunction);
     if (adderFunctionCallData.type == CallData::Type::None)
         return throwVMTypeError(globalObject, scope, "'add' property of a WeakSet should be callable."_s);
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -965,7 +965,7 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
     ASSERT(!exception);
 
     if (JSObject* startFunction = m_startFunction.get()) {
-        auto callData = JSC::getCallData(startFunction);
+        auto callData = JSC::getCallDataInline(startFunction);
         call(globalObject, startFunction, callData, jsUndefined(), *vm.emptyList);
         RETURN_IF_EXCEPTION(scope, { });
     }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
@@ -101,7 +101,7 @@ JSC_DEFINE_HOST_FUNCTION(callWebAssemblyWrapperFunction, (JSGlobalObject* global
     auto scope = DECLARE_THROW_SCOPE(vm);
     WebAssemblyWrapperFunction* wasmFunction = jsCast<WebAssemblyWrapperFunction*>(callFrame->jsCallee());
     JSObject* function = wasmFunction->function();
-    auto callData = JSC::getCallData(function);
+    auto callData = JSC::getCallDataInline(function);
     RELEASE_ASSERT(callData.type != CallData::Type::None);
     RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, function, callData, jsUndefined(), ArgList(callFrame))));
 }


### PR DESCRIPTION
#### 771c848b972e5866774dcc73abdcbaabd3335a27
<pre>
[JSC] Add getCallDataInline in JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=300776">https://bugs.webkit.org/show_bug.cgi?id=300776</a>
<a href="https://rdar.apple.com/162660814">rdar://162660814</a>

Reviewed by Tadeu Zagallo.

JSFunction::getCallData is JS_EXPORT_PRIVATE. So unfortunately it is not
inlined. But this getCallData is really hot so we need to make sure it
is inlined. This patch adds JSFunction::getCallDataInline, and
JSC::getCallDataInline and use them in a hot code.

* Source/JavaScriptCore/bytecode/RepatchInlines.h:
(JSC::handleHostCall):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeProgram):
(JSC::Interpreter::executeBoundCall):
(JSC::Interpreter::executeCall):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::handleHostCall):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::toLocaleString):
(JSC::sortStableSort):
* Source/JavaScriptCore/runtime/CallData.cpp:
(JSC::call):
(JSC::callMicrotask):
* Source/JavaScriptCore/runtime/DatePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/GetterSetter.cpp:
(JSC::GetterSetter::callGetter):
(JSC::GetterSetter::callSetter):
* Source/JavaScriptCore/runtime/IteratorOperations.cpp:
(JSC::iteratorNext):
(JSC::iteratorNextWithCachedCall):
(JSC::iteratorClose):
(JSC::iteratorForIterable):
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInIterationRecord):
(JSC::forEachInIterable):
* Source/JavaScriptCore/runtime/JSBoundFunction.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSBoundFunction.h:
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::getCallData):
* Source/JavaScriptCore/runtime/JSFunction.h:
* Source/JavaScriptCore/runtime/JSFunctionInlines.h:
(JSC::JSFunction::getCallDataInline):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncForEach):
(JSC::genericTypedArrayViewProtoFuncMap):
(JSC::genericTypedArrayViewProtoFuncFilter):
(JSC::genericTypedArrayViewProtoFuncFind):
(JSC::genericTypedArrayViewProtoFuncFindIndex):
(JSC::genericTypedArrayViewProtoFuncFindLast):
(JSC::genericTypedArrayViewProtoFuncFindLastIndex):
(JSC::genericTypedArrayViewProtoFuncEvery):
(JSC::genericTypedArrayViewProtoFuncSome):
(JSC::genericTypedArrayViewProtoFuncSortImpl):
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::promiseResolveThenableJobFastSlow):
(JSC::promiseResolveThenableJobWithoutPromiseFastSlow):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::callToPrimitiveFunction):
(JSC::JSObject::hasInstance):
(JSC::JSObject::getMethod):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::getCallData):
(JSC::getCallDataInline):
* Source/JavaScriptCore/runtime/MapConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/MapPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ObjectPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::ProxyObject::getHandlerTrap):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::regExpExec):
* Source/JavaScriptCore/runtime/SetConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::replaceUsingStringSearch):
(JSC::replaceUsingRegExpSearch):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::callPromiseRejectionCallback):
* Source/JavaScriptCore/runtime/WeakMapConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakMapPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakSetConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::evaluate):
* Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/301595@main">https://commits.webkit.org/301595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd4d0291928f26112aeb123c0bf3a92e5fe3890d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37043 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3bcbca24-8e23-489e-be47-af96a93e201c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54669 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/133378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c15c2f23-da46-4f88-a53b-e9e305ac62fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129434 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/37408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/113118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aa1bfc1a-8106-45ba-b7b8-510179936430) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31295 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76685 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118537 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135924 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124951 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40887 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109438 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49932 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50580 "Hash fd4d0291 for PR 52370 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19779 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53098 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58913 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157997 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52382 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39531 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55716 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54116 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->