### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for CachedResourceClient

### DIFF
--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -53,9 +53,9 @@ NavigatorBeacon::~NavigatorBeacon()
         beacon->removeClient(*this);
 }
 
-NavigatorBeacon* NavigatorBeacon::from(Navigator& navigator)
+CheckedPtr<NavigatorBeacon> NavigatorBeacon::from(Navigator& navigator)
 {
-    auto* supplement = static_cast<NavigatorBeacon*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    CheckedPtr supplement = static_cast<NavigatorBeacon*>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorBeacon>(navigator);
         supplement = newSupplement.get();

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.h
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.h
@@ -41,8 +41,9 @@ class Navigator;
 class ResourceError;
 template<typename> class ExceptionOr;
 
-class NavigatorBeacon final : public Supplement<Navigator>, private CachedRawResourceClient {
+class NavigatorBeacon final : public Supplement<Navigator>, private CachedRawResourceClient, public CanMakeCheckedPtr<NavigatorBeacon> {
     WTF_MAKE_TZONE_ALLOCATED(NavigatorBeacon);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NavigatorBeacon);
 public:
     explicit NavigatorBeacon(Navigator&);
     ~NavigatorBeacon();
@@ -50,7 +51,14 @@ public:
 
     size_t inflightBeaconsCount() const { return m_inflightBeacons.size(); }
 
-    WEBCORE_EXPORT static NavigatorBeacon* from(Navigator&);
+    WEBCORE_EXPORT static CheckedPtr<NavigatorBeacon> from(Navigator&);
+
+    // CachedRawResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     ExceptionOr<bool> sendBeacon(Document&, const String& url, std::optional<FetchBody::Init>&&);

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.h
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.h
@@ -48,7 +48,7 @@ struct MediaImage;
 
 using MediaSessionMetadata = MediaMetadataInit;
 
-class ArtworkImageLoader final : public CachedImageClient {
+class ArtworkImageLoader final : public CachedImageClient, public CanMakeCheckedPtr<ArtworkImageLoader> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ArtworkImageLoader, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ArtworkImageLoader);
 public:
@@ -59,6 +59,13 @@ public:
     WEBCORE_EXPORT ~ArtworkImageLoader();
 
     WEBCORE_EXPORT void requestImageResource();
+
+    // CachedImageClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 protected:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -546,7 +546,7 @@ void MediaSession::updateNowPlayingInfo(NowPlayingInfo& info)
 
     if (!m_defaultArtworkAttempted && (!m_metadata || m_metadata->artwork().isEmpty())) {
         m_defaultArtworkAttempted = true;
-        if (auto images = fallbackArtwork(protectedDocument() ? protectedDocument()->loader() : nullptr); images.size())
+        if (auto images = fallbackArtwork(protectedDocument() ? protectedDocument()->protectedLoader().get() : nullptr); images.size())
             m_defaultMetadata = MediaMetadata::create(*this, WTFMove(images));
     }
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -86,6 +86,13 @@ public:
     void ref() const final { HTMLElement::ref(); }
     void deref() const final { HTMLElement::deref(); }
 
+    // CachedRawResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(HTMLElement);
+    uint32_t virtualCheckedPtrCount() const final { return HTMLElement::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return HTMLElement::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { HTMLElement::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { HTMLElement::decrementCheckedPtrCount(); }
+
     // VisibilityChangeClient.
     void visibilityStateChanged() final;
 

--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp
@@ -37,8 +37,11 @@
 #include "ScriptController.h"
 #include "ScriptModuleLoader.h"
 #include "ScriptSourceCode.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CachedModuleScriptLoader);
 
 Ref<CachedModuleScriptLoader> CachedModuleScriptLoader::create(ModuleScriptLoaderClient& client, DeferredPromise& promise, CachedScriptFetcher& scriptFetcher, RefPtr<JSC::ScriptFetchParameters>&& parameters)
 {

--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
@@ -29,6 +29,7 @@
 #include <WebCore/CachedResourceHandle.h>
 #include <WebCore/CachedScriptFetcher.h>
 #include <WebCore/ModuleScriptLoader.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -45,11 +46,20 @@ class DeferredPromise;
 class Document;
 class JSDOMGlobalObject;
 
-class CachedModuleScriptLoader final : public ModuleScriptLoader, private CachedResourceClient {
+class CachedModuleScriptLoader final : public ModuleScriptLoader, private CachedResourceClient, public CanMakeCheckedPtr<CachedModuleScriptLoader> {
+    WTF_MAKE_TZONE_ALLOCATED(CachedModuleScriptLoader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CachedModuleScriptLoader);
 public:
     static Ref<CachedModuleScriptLoader> create(ModuleScriptLoaderClient&, DeferredPromise&, CachedScriptFetcher&, RefPtr<JSC::ScriptFetchParameters>&&);
 
     virtual ~CachedModuleScriptLoader();
+
+    // CachedResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     bool load(Document&, URL&& sourceURL, std::optional<ServiceWorkersMode>);
 

--- a/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
@@ -30,18 +30,27 @@
 #include "CachedScript.h"
 #include "CachedScriptFetcher.h"
 #include <JavaScriptCore/SourceProvider.h>
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
-class CachedScriptSourceProvider final : public JSC::SourceProvider, public CachedResourceClient {
+class CachedScriptSourceProvider final : public JSC::SourceProvider, public CachedResourceClient, public CanMakeCheckedPtr<CachedScriptSourceProvider> {
     WTF_MAKE_TZONE_ALLOCATED(CachedScriptSourceProvider);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CachedScriptSourceProvider);
 public:
     static Ref<CachedScriptSourceProvider> create(CachedScript* cachedScript, JSC::SourceProviderSourceType sourceType, Ref<CachedScriptFetcher>&& scriptFetcher) { return adoptRef(*new CachedScriptSourceProvider(cachedScript, sourceType, WTFMove(scriptFetcher))); }
 
-    virtual ~CachedScriptSourceProvider()
+    ~CachedScriptSourceProvider()
     {
         m_cachedScript->removeClient(*this);
     }
+
+    // CachedResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     unsigned hash() const override;
     StringView source() const override;

--- a/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
@@ -34,12 +34,14 @@
 #include "CachedScriptFetcher.h"
 #include "SharedBuffer.h"
 #include <JavaScriptCore/SourceProvider.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/RefPtr.h>
 
 namespace WebCore {
 
-class WebAssemblyCachedScriptSourceProvider final : public JSC::BaseWebAssemblySourceProvider, public CachedResourceClient {
+class WebAssemblyCachedScriptSourceProvider final : public JSC::BaseWebAssemblySourceProvider, public CachedResourceClient, public CanMakeCheckedPtr<WebAssemblyCachedScriptSourceProvider> {
     WTF_MAKE_TZONE_ALLOCATED(WebAssemblyCachedScriptSourceProvider);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebAssemblyCachedScriptSourceProvider);
 public:
     static Ref<WebAssemblyCachedScriptSourceProvider> create(CachedScript* cachedScript, Ref<CachedScriptFetcher>&& scriptFetcher)
     {
@@ -50,6 +52,13 @@ public:
     {
         m_cachedScript->removeClient(*this);
     }
+
+    // CachedResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     unsigned hash() const final { return m_cachedScript->scriptHash(); }
     StringView source() const final { return m_cachedScript->script(); }

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -113,7 +113,7 @@ std::unique_ptr<FontLoadRequest> CSSFontFaceSrcResourceValue::fontLoadRequest(Sc
     }
 
     auto request = context.fontLoadRequest(m_location.resolved.string(), isFormatSVG, isInitiatingElementInUserAgentShadowTree, m_location.modifiers.loadedFromOpaqueSource);
-    if (auto* cachedRequest = dynamicDowncast<CachedFontLoadRequest>(request.get()))
+    if (CheckedPtr cachedRequest = dynamicDowncast<CachedFontLoadRequest>(request.get()))
         m_cachedFont = &cachedRequest->cachedFont();
 
     return request;

--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -33,9 +33,12 @@
 #include "SecurityOrigin.h"
 #include "StyleSheetContents.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleImport);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StyleRuleImport::ImportedStyleSheetClient);
 
 Ref<StyleRuleImport> StyleRuleImport::create(const String& href, MQ::MediaQueryList&& mediaQueries, std::optional<CascadeLayerName>&& cascadeLayerName, SupportsCondition&& supportsCondition)
 {

--- a/Source/WebCore/css/StyleRuleImport.h
+++ b/Source/WebCore/css/StyleRuleImport.h
@@ -70,7 +70,9 @@ public:
 private:
     // NOTE: We put the CachedStyleSheetClient in a member instead of inheriting from it
     // to avoid adding a vptr to StyleRuleImport.
-    class ImportedStyleSheetClient final : public CachedStyleSheetClient {
+    class ImportedStyleSheetClient final : public CachedStyleSheetClient, public CanMakeCheckedPtr<ImportedStyleSheetClient> {
+        WTF_MAKE_TZONE_ALLOCATED(ImportedStyleSheetClient);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ImportedStyleSheetClient);
     public:
         ImportedStyleSheetClient(StyleRuleImport* ownerRule) : m_ownerRule(ownerRule) { }
         virtual ~ImportedStyleSheetClient() = default;
@@ -78,6 +80,14 @@ private:
         {
             m_ownerRule->setCSSStyleSheet(href, baseURL, charset, sheet);
         }
+
+        // CachedStyleSheetClient.
+        USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+        uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+        uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+        void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+        void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+
     private:
         StyleRuleImport* m_ownerRule;
     };

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -63,7 +63,7 @@ namespace WebCore {
 
 #if ENABLE(DRAG_SUPPORT)
 
-class DragImageLoader final : public CachedImageClient {
+class DragImageLoader final : public CachedImageClient, public CanMakeCheckedPtr<DragImageLoader> {
     WTF_MAKE_TZONE_ALLOCATED(DragImageLoader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DragImageLoader);
     WTF_MAKE_NONCOPYABLE(DragImageLoader);
@@ -72,6 +72,13 @@ public:
     void startLoading(CachedResourceHandle<CachedImage>&);
     void stopLoading(CachedResourceHandle<CachedImage>&);
     void moveToDataTransfer(DataTransfer&);
+
+    // CachedImageClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     void imageChanged(CachedImage*, const IntRect*) override;

--- a/Source/WebCore/dom/LoadableClassicScript.cpp
+++ b/Source/WebCore/dom/LoadableClassicScript.cpp
@@ -34,10 +34,14 @@
 #include "ScriptSourceCode.h"
 #include "SubresourceIntegrity.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringImpl.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LoadableNonModuleScriptBase);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LoadableClassicScript);
 
 LoadableNonModuleScriptBase::LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriority,  const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
     : LoadableScript(nonce, policy, fetchPriority, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)

--- a/Source/WebCore/dom/LoadableClassicScript.h
+++ b/Source/WebCore/dom/LoadableClassicScript.h
@@ -41,9 +41,18 @@ class WeakPtrImplWithEventTargetData;
 // A CachedResourceHandle alone does not prevent the underlying CachedResource
 // from purging its data buffer. This class holds a client until this class is
 // destroyed in order to guarantee that the data buffer will not be purged.
-class LoadableNonModuleScriptBase : public LoadableScript, protected CachedResourceClient {
+class LoadableNonModuleScriptBase : public LoadableScript, protected CachedResourceClient, public CanMakeCheckedPtr<LoadableNonModuleScriptBase> {
+    WTF_MAKE_TZONE_ALLOCATED(LoadableNonModuleScriptBase);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LoadableNonModuleScriptBase);
 public:
     virtual ~LoadableNonModuleScriptBase();
+
+    // CachedResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     bool isLoaded() const final;
     bool hasError() const final;
@@ -75,6 +84,8 @@ protected:
 
 
 class LoadableClassicScript final : public LoadableNonModuleScriptBase {
+    WTF_MAKE_TZONE_ALLOCATED(LoadableClassicScript);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LoadableClassicScript);
 public:
     static Ref<LoadableClassicScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 

--- a/Source/WebCore/dom/LoadableSpeculationRules.cpp
+++ b/Source/WebCore/dom/LoadableSpeculationRules.cpp
@@ -38,11 +38,13 @@
 #include "ResourceRequest.h"
 #include "ScriptController.h"
 #include "ScriptSourceCode.h"
-
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringConcatenate.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LoadableSpeculationRules);
 
 Ref<LoadableSpeculationRules> LoadableSpeculationRules::create(Document& document, const URL& url)
 {

--- a/Source/WebCore/dom/LoadableSpeculationRules.h
+++ b/Source/WebCore/dom/LoadableSpeculationRules.h
@@ -30,6 +30,7 @@
 #include <WebCore/FetchOptionsDestination.h>
 #include <WebCore/ResourceLoaderOptions.h>
 #include <WebCore/ResourceRequest.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/RefCounted.h>
 #include <wtf/URL.h>
@@ -43,10 +44,19 @@ class NetworkLoadMetrics;
 class WeakPtrImplWithEventTargetData;
 enum class LoadWillContinueInAnotherProcess : bool;
 
-class LoadableSpeculationRules final : public RefCounted<LoadableSpeculationRules>, public CachedResourceClient {
+class LoadableSpeculationRules final : public RefCounted<LoadableSpeculationRules>, public CachedResourceClient, public CanMakeCheckedPtr<LoadableSpeculationRules> {
+    WTF_MAKE_TZONE_ALLOCATED(LoadableSpeculationRules);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LoadableSpeculationRules);
 public:
     static Ref<LoadableSpeculationRules> create(Document&, const URL&);
     ~LoadableSpeculationRules();
+
+    // CachedResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     bool load(Document&, const URL&);
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) final;

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -40,6 +40,13 @@ public:
     static Ref<ProcessingInstruction> create(Document&, String&& target, String&& data);
     virtual ~ProcessingInstruction();
 
+    // CachedStyleSheetClient.
+    USING_CAN_MAKE_CHECKEDPTR(CharacterData);
+    uint32_t virtualCheckedPtrCount() const final { return CharacterData::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CharacterData::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CharacterData::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CharacterData::decrementCheckedPtrCount(); }
+
     const String& target() const { return m_target; }
 
     void setCreatedByParser(bool createdByParser) { m_createdByParser = createdByParser; }

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -177,7 +177,7 @@ public:
 private:
     Position m_start;
     Position m_end;
-    DocumentLoader* m_dataSource { nullptr };
+    SingleThreadWeakPtr<DocumentLoader> m_dataSource;
 
     HashMap<RefPtr<Element>, RetainPtr<NSDictionary>> m_attributesForElements;
     HashMap<RetainPtr<CFTypeRef>, RefPtr<Element>> m_textTableFooters;
@@ -1275,7 +1275,7 @@ BOOL HTMLConverter::_addAttachmentForElement(Element& element, NSURL *url, BOOL 
             fileWrapper = nil;
     }
     if (!fileWrapper && !notFound) {
-        fileWrapper = fileWrapperForURL(m_dataSource, url);
+        fileWrapper = fileWrapperForURL(RefPtr { m_dataSource.get() }.get(), url);
         if (usePlaceholder && fileWrapper && [[[[fileWrapper preferredFilename] pathExtension] lowercaseString] hasPrefix:@"htm"])
             notFound = YES;
         if (notFound)

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -54,6 +54,13 @@ public:
     static Ref<HTMLLinkElement> create(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLLinkElement();
 
+    // CachedStyleSheetClient.
+    USING_CAN_MAKE_CHECKEDPTR(HTMLElement);
+    uint32_t virtualCheckedPtrCount() const final { return HTMLElement::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return HTMLElement::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { HTMLElement::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { HTMLElement::decrementCheckedPtrCount(); }
+
     URL href() const;
     WEBCORE_EXPORT const AtomString& rel() const;
 

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
@@ -36,11 +36,18 @@
 #include "ExceptionOr.h"
 #include "FrameDestructionObserverInlines.h"
 #include "InspectorResourceUtilities.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorAuditResourcesObject::InspectorAuditCachedResourceClient);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorAuditResourcesObject::InspectorAuditCachedFontClient);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorAuditResourcesObject::InspectorAuditCachedRawResourceClient);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorAuditResourcesObject::InspectorAuditCachedSVGDocumentClient);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorAuditResourcesObject::InspectorAuditCachedStyleSheetClient);
 
 using namespace Inspector;
 
@@ -56,7 +63,7 @@ InspectorAuditResourcesObject::InspectorAuditResourcesObject(InspectorAuditAgent
 InspectorAuditResourcesObject::~InspectorAuditResourcesObject()
 {
     for (auto* cachedResource : m_resources.values())
-        cachedResource->removeClient(clientForResource(*cachedResource));
+        cachedResource->removeClient(checkedClientForResource(*cachedResource).get());
 }
 
 ExceptionOr<Vector<InspectorAuditResourcesObject::Resource>> InspectorAuditResourcesObject::getResources(Document& document)
@@ -83,7 +90,7 @@ ExceptionOr<Vector<InspectorAuditResourcesObject::Resource>> InspectorAuditResou
             }
         }
         if (!exists) {
-            cachedResource->addClient(clientForResource(*cachedResource));
+            cachedResource->addClient(checkedClientForResource(*cachedResource).get());
 
             resource.id = String::number(m_resources.size() + 1);
             m_resources.add(resource.id, cachedResource);

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.h
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.h
@@ -32,6 +32,7 @@
 #include "CachedSVGDocumentClient.h"
 #include "CachedStyleSheetClient.h"
 #include <JavaScriptCore/InspectorAuditAgent.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -70,28 +71,86 @@ private:
     explicit InspectorAuditResourcesObject(Inspector::InspectorAuditAgent&);
 
     CachedResourceClient& clientForResource(const CachedResource&);
+    CheckedRef<CachedResourceClient> checkedClientForResource(const CachedResource& resource) { return clientForResource(resource); }
 
     Inspector::InspectorAuditAgent& m_auditAgent;
 
-    class InspectorAuditCachedResourceClient : public CachedResourceClient { };
+    class InspectorAuditCachedResourceClient final : public CachedResourceClient, public CanMakeCheckedPtr<InspectorAuditCachedResourceClient> {
+        WTF_MAKE_TZONE_ALLOCATED(InspectorAuditCachedResourceClient);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorAuditCachedResourceClient);
+    public:
+        // CachedResourceClient.
+        USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+        uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+        uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+        void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+        void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    };
     InspectorAuditCachedResourceClient m_cachedResourceClient;
 
-    class InspectorAuditCachedFontClient : public CachedFontClient { };
+    class InspectorAuditCachedFontClient final : public CachedFontClient, public CanMakeCheckedPtr<InspectorAuditCachedResourceClient> {
+        WTF_MAKE_TZONE_ALLOCATED(InspectorAuditCachedFontClient);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorAuditCachedFontClient);
+    public:
+        // CachedFontClient.
+        USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+        uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+        uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+        void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+        void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    };
     InspectorAuditCachedFontClient m_cachedFontClient;
 
-    class InspectorAuditCachedImageClient final : public CachedImageClient {
+    class InspectorAuditCachedImageClient final : public CachedImageClient, public CanMakeCheckedPtr<InspectorAuditCachedImageClient> {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(InspectorAuditCachedImageClient);
         WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorAuditCachedImageClient);
+    public:
+        // CachedImageClient.
+        USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+        uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+        uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+        void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+        void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
     };
     InspectorAuditCachedImageClient m_cachedImageClient;
 
-    class InspectorAuditCachedRawResourceClient : public CachedRawResourceClient { };
+    class InspectorAuditCachedRawResourceClient final : public CachedRawResourceClient, public CanMakeCheckedPtr<InspectorAuditCachedRawResourceClient> {
+        WTF_MAKE_TZONE_ALLOCATED(InspectorAuditCachedRawResourceClient);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorAuditCachedRawResourceClient);
+    public:
+        // CachedRawResourceClient.
+        USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+        uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+        uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+        void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+        void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    };
     InspectorAuditCachedRawResourceClient m_cachedRawResourceClient;
 
-    class InspectorAuditCachedSVGDocumentClient : public CachedSVGDocumentClient { };
+    class InspectorAuditCachedSVGDocumentClient final : public CachedSVGDocumentClient, public CanMakeCheckedPtr<InspectorAuditCachedRawResourceClient> {
+        WTF_MAKE_TZONE_ALLOCATED(InspectorAuditCachedSVGDocumentClient);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorAuditCachedSVGDocumentClient);
+    public:
+        // CachedSVGDocumentClient.
+        USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+        uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+        uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+        void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+        void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    };
     InspectorAuditCachedSVGDocumentClient m_cachedSVGDocumentClient;
 
-    class InspectorAuditCachedStyleSheetClient : public CachedStyleSheetClient { };
+    class InspectorAuditCachedStyleSheetClient final : public CachedStyleSheetClient, public CanMakeCheckedPtr<InspectorAuditCachedRawResourceClient> {
+        WTF_MAKE_TZONE_ALLOCATED(InspectorAuditCachedStyleSheetClient);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorAuditCachedStyleSheetClient);
+    public:
+        // CachedStyleSheetClient.
+        USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+        uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+        uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+        void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+        void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    };
     InspectorAuditCachedStyleSheetClient m_cachedStyleSheetClient;
 
     MemoryCompactRobinHoodHashMap<String, CachedResource*> m_resources;

--- a/Source/WebCore/inspector/InspectorResourceUtilities.cpp
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.cpp
@@ -144,7 +144,7 @@ bool mainResourceContent(LocalFrame* frame, bool withBase64Encode, String* resul
 
 void resourceContent(Inspector::Protocol::ErrorString& errorString, LocalFrame* frame, const URL& url, String* result, bool* base64Encoded)
 {
-    DocumentLoader* loader = assertDocumentLoader(errorString, frame);
+    RefPtr loader = assertDocumentLoader(errorString, frame);
     if (!loader)
         return;
 
@@ -279,11 +279,11 @@ LocalFrame* findFrameWithSecurityOrigin(Page& page, const String& originRawStrin
 
 DocumentLoader* assertDocumentLoader(Inspector::Protocol::ErrorString& errorString, LocalFrame* frame)
 {
-    FrameLoader& frameLoader = frame->loader();
-    DocumentLoader* documentLoader = frameLoader.documentLoader();
-    if (!documentLoader)
-        errorString = "Missing document loader for given frame"_s;
-    return documentLoader;
+    if (auto* documentLoader = frame->loader().documentLoader())
+        return documentLoader;
+
+    errorString = "Missing document loader for given frame"_s;
+    return nullptr;
 }
 
 bool shouldTreatAsText(const String& mimeType)

--- a/Source/WebCore/loader/ApplicationManifestLoader.h
+++ b/Source/WebCore/loader/ApplicationManifestLoader.h
@@ -40,8 +40,10 @@ namespace WebCore {
 class CachedApplicationManifest;
 class DocumentLoader;
 
-class ApplicationManifestLoader final : private CachedRawResourceClient {
-WTF_MAKE_NONCOPYABLE(ApplicationManifestLoader); WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ApplicationManifestLoader, Loader);
+class ApplicationManifestLoader final : private CachedRawResourceClient, public CanMakeCheckedPtr<ApplicationManifestLoader> {
+    WTF_MAKE_NONCOPYABLE(ApplicationManifestLoader);
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ApplicationManifestLoader, Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ApplicationManifestLoader);
 public:
     typedef Function<void (CachedResourceHandle<CachedApplicationManifest>)> CompletionHandlerType;
 
@@ -52,6 +54,13 @@ public:
     void stopLoading();
 
     std::optional<ApplicationManifest>& processManifest();
+
+    // CachedRawResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess);

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -47,9 +47,12 @@
 #include "InspectorInstrumentation.h"
 #include "NetworkLoadMetrics.h"
 #include "SharedBuffer.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CrossOriginPreflightChecker);
 
 CrossOriginPreflightChecker::CrossOriginPreflightChecker(DocumentThreadableLoader& loader, ResourceRequest&& request)
     : m_loader(loader)

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.h
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.h
@@ -34,6 +34,7 @@
 #include "CachedResourceHandle.h"
 #include "ResourceLoaderIdentifier.h"
 #include "ResourceRequest.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -42,12 +43,21 @@ class Document;
 class DocumentThreadableLoader;
 class ResourceError;
 
-class CrossOriginPreflightChecker final : private CachedRawResourceClient {
+class CrossOriginPreflightChecker final : private CachedRawResourceClient, public CanMakeCheckedPtr<CrossOriginPreflightChecker> {
+    WTF_MAKE_TZONE_ALLOCATED(CrossOriginPreflightChecker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CrossOriginPreflightChecker);
 public:
     static void doPreflight(DocumentThreadableLoader&, ResourceRequest&&);
 
     CrossOriginPreflightChecker(DocumentThreadableLoader&, ResourceRequest&&);
     ~CrossOriginPreflightChecker();
+
+    // CachedRawResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void startPreflight();
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -440,40 +440,48 @@ bool DocumentLoader::isLoading() const
 void DocumentLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics& fetchMetrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
 {
     ASSERT(isMainThread());
+
+    // Run asynchronously since to avoid destroying `this` synchronously, in case
+    // there are CheckedPtrs on the stack.
+    callOnMainThread([this, protectedThis = Ref { *this }, resource = CachedResourceHandle { resource }, fetchMetrics, loadWillContinueInAnotherProcess]() mutable {
+        if (m_mainResource != resource.get())
+            return;
+
 #if ENABLE(CONTENT_FILTERING)
-    if (m_contentFilter && !m_contentFilter->continueAfterNotifyFinished(resource))
-        return;
+        if (m_contentFilter && !m_contentFilter->continueAfterNotifyFinished(*resource))
+            return;
 #endif
 
-    Box<NetworkLoadMetrics> metrics;
-    if (RefPtr frameLoader = this->frameLoader()) {
-        if (auto prefetchedMetrics = frameLoader->documentPrefetcher().takePrefetchedNetworkLoadMetrics(url()))
-            metrics = WTFMove(prefetchedMetrics);
-    }
-    if (!metrics)
-        metrics = Box<NetworkLoadMetrics>::create(fetchMetrics);
+        Box<NetworkLoadMetrics> metrics;
+        if (RefPtr frameLoader = this->frameLoader()) {
+            if (auto prefetchedMetrics = frameLoader->documentPrefetcher().takePrefetchedNetworkLoadMetrics(url()))
+                metrics = WTFMove(prefetchedMetrics);
+        }
+        if (!metrics)
+            metrics = Box<NetworkLoadMetrics>::create(fetchMetrics);
 
-    if (RefPtr document = this->document()) {
-        if (RefPtr window = document->window())
-            window->protectedPerformance()->documentLoadFinished(*metrics);
-    }
+        if (RefPtr document = this->document()) {
+            if (RefPtr window = document->window())
+                window->protectedPerformance()->documentLoadFinished(*metrics);
+        }
 
-    ASSERT_UNUSED(resource, m_mainResource == &resource);
-    ASSERT(m_mainResource);
-    if (!m_mainResource->errorOccurred() && !m_mainResource->wasCanceled()) {
-        finishedLoading();
-        return;
-    }
+        ASSERT_UNUSED(resource, m_mainResource == resource.get());
+        ASSERT(m_mainResource);
+        if (!m_mainResource->errorOccurred() && !m_mainResource->wasCanceled()) {
+            finishedLoading();
+            return;
+        }
 
-    if (m_request.cachePolicy() == ResourceRequestCachePolicy::ReturnCacheDataDontLoad && !m_mainResource->wasCanceled()) {
-        protectedFrameLoader()->retryAfterFailedCacheOnlyMainResourceLoad();
-        return;
-    }
+        if (m_request.cachePolicy() == ResourceRequestCachePolicy::ReturnCacheDataDontLoad && !m_mainResource->wasCanceled()) {
+            protectedFrameLoader()->retryAfterFailedCacheOnlyMainResourceLoad();
+            return;
+        }
 
-    if (!m_mainResource->resourceError().isNull())
-        DOCUMENTLOADER_RELEASE_LOG("notifyFinished: canceling load (type=%d, code=%d)", static_cast<int>(m_mainResource->resourceError().type()), m_mainResource->resourceError().errorCode());
+        if (!m_mainResource->resourceError().isNull())
+            DOCUMENTLOADER_RELEASE_LOG("notifyFinished: canceling load (type=%d, code=%d)", static_cast<int>(m_mainResource->resourceError().type()), m_mainResource->resourceError().errorCode());
 
-    mainReceivedError(m_mainResource->resourceError(), loadWillContinueInAnotherProcess);
+        mainReceivedError(m_mainResource->resourceError(), loadWillContinueInAnotherProcess);
+    });
 }
 
 void DocumentLoader::finishedLoading()

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -58,6 +58,7 @@
 #include <WebCore/StyleSheetContents.h>
 #include <WebCore/SubstituteData.h>
 #include <WebCore/Timer.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Platform.h>
@@ -183,8 +184,10 @@ class DocumentLoader
 #if ENABLE(CONTENT_FILTERING)
     , public ContentFilterClient
 #endif
+    , public CanMakeCheckedPtr<DocumentLoader>
     , public CachedRawResourceClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DocumentLoader, DocumentLoader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DocumentLoader);
     friend class ContentFilter;
 public:
 #if ENABLE(CONTENT_FILTERING)
@@ -198,6 +201,13 @@ public:
     }
 
     USING_CAN_MAKE_WEAKPTR(CachedRawResourceClient);
+
+    // CachedRawResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     WEBCORE_EXPORT static DocumentLoader* fromScriptExecutionContextIdentifier(ScriptExecutionContextIdentifier);
 

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -38,8 +38,11 @@
 #include "ResourceRequest.h"
 #include "SecurityOrigin.h"
 #include "SecurityPolicy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentPrefetcher);
 
 DocumentPrefetcher::DocumentPrefetcher(FrameLoader& frameLoader)
     : m_frameLoader(frameLoader)

--- a/Source/WebCore/loader/DocumentPrefetcher.h
+++ b/Source/WebCore/loader/DocumentPrefetcher.h
@@ -43,7 +43,9 @@ class ResourceRequest;
 
 enum class ReferrerPolicy : uint8_t;
 
-class DocumentPrefetcher : public RefCounted<DocumentPrefetcher>, public CachedRawResourceClient {
+class DocumentPrefetcher : public RefCounted<DocumentPrefetcher>, public CachedRawResourceClient, public CanMakeCheckedPtr<DocumentPrefetcher> {
+    WTF_MAKE_TZONE_ALLOCATED(DocumentPrefetcher);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DocumentPrefetcher);
 public:
     struct PrefetchedResourceData {
         // The resource needs to be here in order to be kept alive.
@@ -62,6 +64,12 @@ public:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) override;
     CachedResourceClientType resourceClientType() const override { return RawResourceType; }
 
+    // CachedRawResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     WeakRef<FrameLoader> m_frameLoader;

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -442,7 +442,13 @@ void DocumentThreadableLoader::didReceiveResponse(ResourceLoaderIdentifier ident
 void DocumentThreadableLoader::dataReceived(CachedResource& resource, const SharedBuffer& buffer)
 {
     ASSERT_UNUSED(resource, &resource == m_resource);
-    didReceiveData(buffer);
+
+    // Run asynchronously since to avoid destroying `this` synchronously, in case
+    // there are CheckedPtrs on the stack.
+    callOnMainThread([weakThis = WeakPtr { *this }, buffer = Ref { buffer }]() mutable {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->didReceiveData(buffer);
+    });
 }
 
 void DocumentThreadableLoader::didReceiveData(const SharedBuffer& buffer)
@@ -475,10 +481,17 @@ void DocumentThreadableLoader::notifyFinished(CachedResource& resource, const Ne
     ASSERT(m_client);
     ASSERT_UNUSED(resource, &resource == m_resource);
 
-    if (m_resource->errorOccurred())
-        didFail(m_resource->resourceLoaderIdentifier(), m_resource->resourceError());
-    else
-        didFinishLoading(m_resource->resourceLoaderIdentifier(), metrics);
+    // Run asynchronously since to avoid destroying `this` synchronously, in case
+    // there are CheckedPtrs on the stack.
+    callOnMainThread([weakThis = WeakPtr { *this }, metrics]() mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        if (protectedThis->m_resource->errorOccurred())
+            protectedThis->didFail(protectedThis->m_resource->resourceLoaderIdentifier(), protectedThis->m_resource->resourceError());
+        else
+            protectedThis->didFinishLoading(protectedThis->m_resource->resourceLoaderIdentifier(), metrics);
+    });
 }
 
 void DocumentThreadableLoader::didFinishLoading(std::optional<ResourceLoaderIdentifier> identifier, const NetworkLoadMetrics& metrics)

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -39,6 +39,7 @@
 #include "SecurityOrigin.h"
 #include "ThreadableLoader.h"
 #include "ThreadableLoaderClient.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -48,8 +49,9 @@ class CachedRawResource;
     class ThreadableLoaderClient;
     class WeakPtrImplWithEventTargetData;
 
-    class DocumentThreadableLoader : public RefCounted<DocumentThreadableLoader>, public ThreadableLoader, public CachedRawResourceClient {
+    class DocumentThreadableLoader final : public RefCounted<DocumentThreadableLoader>, public ThreadableLoader, public CachedRawResourceClient, public CanMakeCheckedPtr<DocumentThreadableLoader> {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DocumentThreadableLoader, Loader);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DocumentThreadableLoader);
     public:
         static void loadResourceSynchronously(Document&, ResourceRequest&&, ThreadableLoaderClient&, const ThreadableLoaderOptions&, RefPtr<SecurityOrigin>&&, std::unique_ptr<ContentSecurityPolicy>&&, std::optional<CrossOriginEmbedderPolicy>&&);
         static void loadResourceSynchronously(Document&, ResourceRequest&&, ThreadableLoaderClient&, const ThreadableLoaderOptions&);
@@ -59,6 +61,13 @@ class CachedRawResource;
         static RefPtr<DocumentThreadableLoader> create(Document&, ThreadableLoaderClient&, ResourceRequest&&, const ThreadableLoaderOptions&, String&& referrer = String());
 
         virtual ~DocumentThreadableLoader();
+
+        // CachedRawResourceClient.
+        USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+        uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+        uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+        void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+        void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
         void cancel() override;
         virtual void setDefersLoading(bool);

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -47,11 +47,18 @@ using ImageEventSender = EventSender<ImageLoader, SingleThreadWeakPtrImpl>;
 enum class RelevantMutation : bool { No, Yes };
 enum class LazyImageLoadState : uint8_t { None, Deferred, LoadImmediately, FullImage };
 
-class ImageLoader : public CachedImageClient {
+class ImageLoader : public CachedImageClient, public CanMakeCheckedPtr<ImageLoader> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ImageLoader, Loader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ImageLoader);
 public:
     virtual ~ImageLoader();
+
+    // CachedImageClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void ref() const;
     void deref() const;

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -67,9 +67,12 @@
 #include "StyleResolver.h"
 #include "UserContentProvider.h"
 #include <JavaScriptCore/ConsoleTypes.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LinkLoader);
 
 LinkLoader::LinkLoader(LinkLoaderClient& client)
     : m_client(client)

--- a/Source/WebCore/loader/LinkLoader.h
+++ b/Source/WebCore/loader/LinkLoader.h
@@ -37,15 +37,7 @@
 #include <WebCore/LinkLoaderClient.h>
 #include <WebCore/LinkRelAttribute.h>
 #include <WebCore/ReferrerPolicy.h>
-
-namespace WebCore {
-class LinkLoader;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::LinkLoader> : std::true_type { };
-}
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -66,10 +58,19 @@ struct LinkLoadParameters {
     RequestPriority fetchPriority { RequestPriority::Auto };
 };
 
-class LinkLoader : public CachedResourceClient {
+class LinkLoader final : public CachedResourceClient, public CanMakeCheckedPtr<LinkLoader> {
+    WTF_MAKE_TZONE_ALLOCATED(LinkLoader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LinkLoader);
 public:
     explicit LinkLoader(LinkLoaderClient&);
     virtual ~LinkLoader();
+
+    // CachedResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void loadLink(const LinkLoadParameters&, Document&);
     enum class ShouldLog : bool { No, Yes };

--- a/Source/WebCore/loader/LinkPreloadResourceClients.cpp
+++ b/Source/WebCore/loader/LinkPreloadResourceClients.cpp
@@ -39,8 +39,8 @@ LinkPreloadResourceClient::LinkPreloadResourceClient(LinkLoader& loader, CachedR
 
 void LinkPreloadResourceClient::triggerEvents(const CachedResource& resource)
 {
-    if (m_loader)
-        m_loader->triggerEvents(resource);
+    if (CheckedPtr loader = m_loader.get())
+        loader->triggerEvents(resource);
 }
 
 }

--- a/Source/WebCore/loader/LinkPreloadResourceClients.h
+++ b/Source/WebCore/loader/LinkPreloadResourceClients.h
@@ -37,6 +37,7 @@
 #include "CachedScript.h"
 #include <WebCore/CachedStyleSheetClient.h>
 #include "CachedTextTrack.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -75,8 +76,9 @@ private:
     CachedResourceHandle<CachedResource> m_resource;
 };
 
-class LinkPreloadDefaultResourceClient : public LinkPreloadResourceClient, CachedResourceClient {
+class LinkPreloadDefaultResourceClient final : public LinkPreloadResourceClient, CachedResourceClient, public CanMakeCheckedPtr<LinkPreloadDefaultResourceClient> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LinkPreloadDefaultResourceClient, Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LinkPreloadDefaultResourceClient);
 public:
     LinkPreloadDefaultResourceClient(LinkLoader& loader, CachedResource& resource)
         : LinkPreloadResourceClient(loader, resource)
@@ -84,20 +86,35 @@ public:
         addResource(*this);
     }
 
+    // CachedResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+
 private:
     void notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final { triggerEvents(resource); }
     void clear() final { clearResource(*this); }
     bool shouldMarkAsReferenced() const final { return false; }
 };
 
-class LinkPreloadStyleResourceClient : public LinkPreloadResourceClient, public CachedStyleSheetClient {
+class LinkPreloadStyleResourceClient final : public LinkPreloadResourceClient, public CachedStyleSheetClient, public CanMakeCheckedPtr<LinkPreloadStyleResourceClient> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LinkPreloadStyleResourceClient, Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LinkPreloadStyleResourceClient);
 public:
     LinkPreloadStyleResourceClient(LinkLoader& loader, CachedCSSStyleSheet& resource)
         : LinkPreloadResourceClient(loader, resource)
     {
         addResource(*this);
     }
+
+    // CachedStyleSheetClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     void setCSSStyleSheet(const String&, const URL&, ASCIILiteral, const CachedCSSStyleSheet* resource) final
@@ -111,7 +128,7 @@ private:
     bool shouldMarkAsReferenced() const final { return false; }
 };
 
-class LinkPreloadImageResourceClient : public LinkPreloadResourceClient, public CachedImageClient {
+class LinkPreloadImageResourceClient : public LinkPreloadResourceClient, public CachedImageClient, public CanMakeCheckedPtr<LinkPreloadImageResourceClient> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LinkPreloadImageResourceClient, Loader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LinkPreloadImageResourceClient);
 public:
@@ -121,20 +138,35 @@ public:
         addResource(*this);
     }
 
+    // CachedImageClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+
 private:
     void notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final { triggerEvents(resource); }
     void clear() final { clearResource(*this); }
     bool shouldMarkAsReferenced() const final { return false; }
 };
 
-class LinkPreloadFontResourceClient : public LinkPreloadResourceClient, public CachedFontClient {
+class LinkPreloadFontResourceClient final : public LinkPreloadResourceClient, public CachedFontClient, public CanMakeCheckedPtr<LinkPreloadFontResourceClient> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LinkPreloadFontResourceClient, Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LinkPreloadFontResourceClient);
 public:
     LinkPreloadFontResourceClient(LinkLoader& loader, CachedFont& resource)
         : LinkPreloadResourceClient(loader, resource)
     {
         addResource(*this);
     }
+
+    // CachedFontClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     void fontLoaded(CachedFont& resource) final
@@ -147,14 +179,22 @@ private:
     bool shouldMarkAsReferenced() const final { return false; }
 };
 
-class LinkPreloadRawResourceClient : public LinkPreloadResourceClient, public CachedRawResourceClient {
+class LinkPreloadRawResourceClient : public LinkPreloadResourceClient, public CachedRawResourceClient, public CanMakeCheckedPtr<LinkPreloadRawResourceClient> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LinkPreloadRawResourceClient, Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LinkPreloadRawResourceClient);
 public:
     LinkPreloadRawResourceClient(LinkLoader& loader, CachedRawResource& resource)
         : LinkPreloadResourceClient(loader, resource)
     {
         addResource(*this);
     }
+
+    // CachedRawResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     void notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final { triggerEvents(resource); }

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -361,14 +361,20 @@ void MediaResource::notifyFinished(CachedResource& resource, const NetworkLoadMe
 
     ASSERT_UNUSED(resource, &resource == m_resource);
 
-    Ref protectedThis { *this };
-    if (RefPtr client = this->client()) {
-        if (m_resource->loadFailedOrCanceled())
-            client->loadFailed(*this, m_resource->resourceError());
-        else
-            client->loadFinished(*this, metrics);
-    }
-    ensureShutdown();
+    // Run asynchronously since to avoid destroying `this` synchronously, in case
+    // there are CheckedPtrs on the stack.
+    callOnMainThread([weakThis = WeakPtr { *this }, metrics]() mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        if (RefPtr client = protectedThis->client()) {
+            if (protectedThis->m_resource->loadFailedOrCanceled())
+                client->loadFailed(*protectedThis, protectedThis->m_resource->resourceError());
+            else
+                client->loadFinished(*protectedThis, metrics);
+        }
+        protectedThis->ensureShutdown();
+    });
 }
 
 void MediaResource::ensureShutdown()

--- a/Source/WebCore/loader/MediaResourceLoader.h
+++ b/Source/WebCore/loader/MediaResourceLoader.h
@@ -35,6 +35,7 @@
 #include <WebCore/PlatformMediaResourceLoader.h>
 #include <WebCore/ResourceResponse.h>
 #include <wtf/Atomics.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
@@ -89,8 +90,9 @@ private:
     HashMap<URL, ValidationInformation> m_validationLoadInformations WTF_GUARDED_BY_CAPABILITY(mainThread);
 };
 
-class MediaResource : public PlatformMediaResource, public CachedRawResourceClient {
+class MediaResource final : public PlatformMediaResource, public CachedRawResourceClient, public CanMakeCheckedPtr<MediaResource> {
     WTF_MAKE_TZONE_ALLOCATED(MediaResource);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaResource);
 public:
     static Ref<MediaResource> create(MediaResourceLoader&, CachedResourceHandle<CachedRawResource>&&);
     virtual ~MediaResource();
@@ -106,6 +108,11 @@ public:
     void dataSent(CachedResource&, unsigned long long, unsigned long long) override;
     void dataReceived(CachedResource&, const SharedBuffer&) override;
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     CachedResourceHandle<CachedRawResource> protectedResource() const;

--- a/Source/WebCore/loader/ResourceLoadNotifier.cpp
+++ b/Source/WebCore/loader/ResourceLoadNotifier.cpp
@@ -72,7 +72,7 @@ void ResourceLoadNotifier::willSendRequest(ResourceLoader& loader, ResourceLoade
 
 void ResourceLoadNotifier::didReceiveResponse(ResourceLoader& loader, ResourceLoaderIdentifier identifier, const ResourceResponse& r)
 {
-    loader.documentLoader()->addResponse(r);
+    loader.protectedDocumentLoader()->addResponse(r);
 
     if (RefPtr page = m_frame->page())
         page->checkedProgress()->incrementProgress(identifier, r);

--- a/Source/WebCore/loader/TextTrackLoader.h
+++ b/Source/WebCore/loader/TextTrackLoader.h
@@ -78,6 +78,13 @@ public:
     Vector<Ref<VTTRegion>> getNewRegions();
     Vector<String> getNewStyleSheets();
 
+    // CachedResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+
 private:
     // CachedResourceClient
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
@@ -137,8 +137,8 @@ void CachedCSSStyleSheet::checkNotify(const NetworkLoadMetrics&, LoadWillContinu
         return;
 
     CachedResourceClientWalker<CachedStyleSheetClient> walker(*this);
-    while (CachedStyleSheetClient* c = walker.next())
-        c->setCSSStyleSheet(m_resourceRequest.url().string(), response().url(), protectedDecoder()->encoding().name(), this);
+    while (CheckedPtr client = walker.next())
+        client->setCSSStyleSheet(m_resourceRequest.url().string(), response().url(), protectedDecoder()->encoding().name(), this);
 }
 
 String CachedCSSStyleSheet::responseMIMEType() const

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -222,7 +222,7 @@ void CachedFont::checkNotify(const NetworkLoadMetrics&, LoadWillContinueInAnothe
         return;
 
     CachedResourceClientWalker<CachedFontClient> walker(*this);
-    while (CachedFontClient* client = walker.next())
+    while (CheckedPtr client = walker.next())
         client->fontLoaded(*this);
 }
 

--- a/Source/WebCore/loader/cache/CachedFontLoadRequest.h
+++ b/Source/WebCore/loader/cache/CachedFontLoadRequest.h
@@ -33,14 +33,16 @@
 #include <WebCore/FontLoadRequest.h>
 #include <WebCore/FontSelectionAlgorithm.h>
 #include <WebCore/ScriptExecutionContext.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 
 class FontCreationContext;
 
-class CachedFontLoadRequest final : public FontLoadRequest, public CachedFontClient {
+class CachedFontLoadRequest final : public FontLoadRequest, public CachedFontClient, public CanMakeCheckedPtr<CachedFontLoadRequest> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CachedFontLoadRequest, Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CachedFontLoadRequest);
 public:
     CachedFontLoadRequest(CachedFont& font, ScriptExecutionContext& context)
         : m_font(&font)
@@ -53,6 +55,13 @@ public:
         if (m_fontLoadRequestClient)
             protectedCachedFont()->removeClient(*this);
     }
+
+    // CachedFontClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     CachedFont& cachedFont() const { return *m_font; }
     CachedResourceHandle<CachedFont> protectedCachedFont() const { return m_font; }

--- a/Source/WebCore/loader/cache/CachedImageClient.h
+++ b/Source/WebCore/loader/cache/CachedImageClient.h
@@ -34,7 +34,7 @@ class IntRect;
 
 enum class VisibleInViewportState { Unknown, Yes, No };
 
-class WEBCORE_EXPORT CachedImageClient : public CachedResourceClient, public CanMakeCheckedPtr<CachedImageClient> {
+class WEBCORE_EXPORT CachedImageClient : public CachedResourceClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CachedImageClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CachedImageClient);
 public:

--- a/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -141,8 +141,8 @@ void CachedRawResource::notifyClientsDataWasReceived(const SharedBuffer& buffer)
 
     CachedResourceHandle protectedThis { this };
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
-    while (CachedRawResourceClient* c = walker.next())
-        c->dataReceived(*this, buffer);
+    while (CheckedPtr client = walker.next())
+        client->dataReceived(*this, buffer);
 }
 
 static void iterateRedirects(CachedResourceHandle<CachedRawResource>&& handle, CachedRawResourceClient& client, Vector<std::pair<ResourceRequest, ResourceResponse>>&& redirectsInReverseOrder, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
@@ -207,7 +207,7 @@ void CachedRawResource::allClientsRemoved()
 
 static void iterateClients(CachedResourceClientWalker<CachedRawResourceClient>&& walker, CachedResourceHandle<CachedRawResource>&& handle, ResourceRequest&& request, std::unique_ptr<ResourceResponse>&& response, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
 {
-    auto client = walker.next();
+    CheckedPtr client = walker.next();
     if (!client)
         return completionHandler(WTFMove(request));
     const ResourceResponse& responseReference = *response;
@@ -236,15 +236,15 @@ void CachedRawResource::responseReceived(ResourceResponse&& newResponse)
         m_resourceLoaderIdentifier = m_loader->identifier();
     CachedResource::responseReceived(WTFMove(newResponse));
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
-    while (CachedRawResourceClient* c = walker.next())
-        c->responseReceived(*this, response(), nullptr);
+    while (CheckedPtr client = walker.next())
+        client->responseReceived(*this, response(), nullptr);
 }
 
 bool CachedRawResource::shouldCacheResponse(const ResourceResponse& response)
 {
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
-    while (CachedRawResourceClient* c = walker.next()) {
-        if (!c->shouldCacheResponse(*this, response))
+    while (CheckedPtr client = walker.next()) {
+        if (!client->shouldCacheResponse(*this, response))
             return false;
     }
     return true;
@@ -253,15 +253,15 @@ bool CachedRawResource::shouldCacheResponse(const ResourceResponse& response)
 void CachedRawResource::didSendData(unsigned long long bytesSent, unsigned long long totalBytesToBeSent)
 {
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
-    while (CachedRawResourceClient* c = walker.next())
-        c->dataSent(*this, bytesSent, totalBytesToBeSent);
+    while (CheckedPtr client = walker.next())
+        client->dataSent(*this, bytesSent, totalBytesToBeSent);
 }
 
 void CachedRawResource::finishedTimingForWorkerLoad(ResourceTiming&& resourceTiming)
 {
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
-    while (CachedRawResourceClient* c = walker.next())
-        c->finishedTimingForWorkerLoad(*this, resourceTiming);
+    while (CheckedPtr client = walker.next())
+        client->finishedTimingForWorkerLoad(*this, resourceTiming);
 }
 
 void CachedRawResource::switchClientsToRevalidatedResource()
@@ -363,8 +363,8 @@ void CachedRawResource::previewResponseReceived(ResourceResponse&& newResponse)
     CachedResourceHandle protectedThis { this };
     CachedResource::previewResponseReceived(WTFMove(newResponse));
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
-    while (CachedRawResourceClient* c = walker.next())
-        c->previewResponseReceived(*this, response());
+    while (CheckedPtr client = walker.next())
+        client->previewResponseReceived(*this, response());
 }
 
 #endif

--- a/Source/WebCore/loader/cache/CachedRawResourceClient.h
+++ b/Source/WebCore/loader/cache/CachedRawResourceClient.h
@@ -26,15 +26,6 @@
 #include <wtf/CompletionHandler.h>
 
 namespace WebCore {
-class CachedRawResourceClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CachedRawResourceClient> : std::true_type { };
-}
-
-namespace WebCore {
 
 class CachedResource;
 class ResourceRequest;

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -234,7 +234,7 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
         m_fragmentIdentifierForRequest = String();
     }
 
-    if (m_options.keepAlive && type() != Type::Ping && !cachedResourceLoader.keepaliveRequestTracker().tryRegisterRequest(*this)) {
+    if (m_options.keepAlive && type() != Type::Ping && !cachedResourceLoader.checkedKeepaliveRequestTracker()->tryRegisterRequest(*this)) {
         setResourceError({ errorDomainWebKitInternal, 0, request.url(), "Reached maximum amount of queued data of 64Kb for keepalive requests"_s, ResourceError::Type::AccessControl });
         failBeforeStarting();
         return;
@@ -316,7 +316,7 @@ void CachedResource::checkNotify(const NetworkLoadMetrics& metrics, LoadWillCont
         return;
 
     CachedResourceClientWalker<CachedResourceClient> walker(*this);
-    while (CachedResourceClient* client = walker.next())
+    while (CheckedPtr client = walker.next())
         client->notifyFinished(*this, metrics, loadWillContinueInAnotherProcess);
 }
 
@@ -782,10 +782,10 @@ void CachedResource::switchClientsToRevalidatedResource()
 
     Vector<SingleThreadWeakPtr<CachedResourceClient>> clientsToMove;
     for (auto entry : m_clients) {
-        auto& client = entry.key;
+        CheckedRef client = entry.key;
         unsigned count = entry.value;
         while (count) {
-            clientsToMove.append(client);
+            clientsToMove.append(client.get());
             --count;
         }
     }

--- a/Source/WebCore/loader/cache/CachedResourceClient.h
+++ b/Source/WebCore/loader/cache/CachedResourceClient.h
@@ -30,15 +30,6 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class CachedResourceClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CachedResourceClient> : std::true_type { };
-}
-
-namespace WebCore {
 
 class CachedResource;
 class NetworkLoadMetrics;
@@ -54,6 +45,17 @@ public:
         SVGDocumentType,
         RawResourceType
     };
+
+    // CanMakeCheckedPtr.
+    uint32_t checkedPtrCount() const { return virtualCheckedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const { return virtualCheckedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const { virtualIncrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const { virtualDecrementCheckedPtrCount(); }
+
+    virtual uint32_t virtualCheckedPtrCount() const = 0;
+    virtual uint32_t virtualCheckedPtrCountWithoutThreadCheck() const = 0;
+    virtual void virtualIncrementCheckedPtrCount() const = 0;
+    virtual void virtualDecrementCheckedPtrCount() const = 0;
 
     virtual ~CachedResourceClient();
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -176,6 +176,7 @@ public:
     ResourceTimingInformation& resourceTimingInformation() { return m_resourceTimingInfo; }
 
     KeepaliveRequestTracker& keepaliveRequestTracker() { return m_keepaliveRequestTracker; }
+    CheckedRef<KeepaliveRequestTracker> checkedKeepaliveRequestTracker() { return m_keepaliveRequestTracker; }
 
     Vector<CachedResourceHandle<CachedResource>> visibleResourcesToPrioritize();
 

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
@@ -30,6 +30,7 @@
 #include <WebCore/CachedSVGDocumentClient.h>
 #include <WebCore/LoaderMalloc.h>
 #include <WebCore/StyleURL.h>
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -37,8 +38,9 @@ class CachedSVGDocument;
 class CachedResourceLoader;
 struct ResourceLoaderOptions;
 
-class CachedSVGDocumentReference final : public CachedSVGDocumentClient {
+class CachedSVGDocumentReference final : public CachedSVGDocumentClient, public CanMakeCheckedPtr<CachedSVGDocumentReference> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CachedSVGDocumentReference, Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CachedSVGDocumentReference);
 public:
     CachedSVGDocumentReference(const Style::URL&);
 
@@ -48,6 +50,13 @@ public:
     bool loadRequested() const { return m_loadRequested; }
 
     CachedSVGDocument* document() { return m_document.get(); }
+
+    // CachedSVGDocumentClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     Style::URL m_location;

--- a/Source/WebCore/loader/cache/CachedTextTrack.cpp
+++ b/Source/WebCore/loader/cache/CachedTextTrack.cpp
@@ -49,7 +49,7 @@ void CachedTextTrack::doUpdateBuffer(const FragmentedSharedBuffer* data)
     setEncodedSize(data ? data->size() : 0);
 
     CachedResourceClientWalker<CachedResourceClient> walker(*this);
-    while (CachedResourceClient* client = walker.next())
+    while (CheckedPtr client = walker.next())
         client->deprecatedDidReceiveCachedResource(*this);
 }
 

--- a/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
@@ -87,8 +87,8 @@ void CachedXSLStyleSheet::checkNotify(const NetworkLoadMetrics&, LoadWillContinu
         return;
     
     CachedResourceClientWalker<CachedStyleSheetClient> walker(*this);
-    while (CachedStyleSheetClient* c = walker.next())
-        c->setXSLStyleSheet(m_resourceRequest.url().string(), response().url(), m_sheet);
+    while (CheckedPtr client = walker.next())
+        client->setXSLStyleSheet(m_resourceRequest.url().string(), response().url(), m_sheet);
 }
 
 #endif

--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
@@ -26,7 +26,11 @@
 #include "config.h"
 #include "KeepaliveRequestTracker.h"
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(KeepaliveRequestTracker);
 
 const uint64_t maxInflightKeepaliveBytes { 65536 }; // 64 kibibytes as per Fetch specification.
 

--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.h
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.h
@@ -32,10 +32,19 @@
 
 namespace WebCore {
 
-class KeepaliveRequestTracker final : public CachedRawResourceClient {
+class KeepaliveRequestTracker final : public CachedRawResourceClient, public CanMakeCheckedPtr<KeepaliveRequestTracker> {
+    WTF_MAKE_TZONE_ALLOCATED(KeepaliveRequestTracker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(KeepaliveRequestTracker);
 public:
     ~KeepaliveRequestTracker();
     bool tryRegisterRequest(CachedResource&);
+
+    // CachedRawResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     // CachedRawResourceClient.

--- a/Source/WebCore/loader/icon/IconLoader.h
+++ b/Source/WebCore/loader/icon/IconLoader.h
@@ -28,6 +28,7 @@
 #include "CachedRawResourceClient.h"
 #include "CachedResourceHandle.h"
 #include "LoaderMalloc.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/URL.h>
@@ -39,14 +40,23 @@ class CachedRawResource;
 class DocumentLoader;
 class LocalFrame;
 
-class IconLoader final : private CachedRawResourceClient {
-    WTF_MAKE_NONCOPYABLE(IconLoader); WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(IconLoader, Loader);
+class IconLoader final : private CachedRawResourceClient, public CanMakeCheckedPtr<IconLoader> {
+    WTF_MAKE_NONCOPYABLE(IconLoader);
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(IconLoader, Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IconLoader);
 public:
     IconLoader(DocumentLoader&, const URL&);
     virtual ~IconLoader();
 
     void startLoading();
     void stopLoading();
+
+    // CachedRawResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;

--- a/Source/WebCore/page/PerformanceNavigation.cpp
+++ b/Source/WebCore/page/PerformanceNavigation.cpp
@@ -49,7 +49,7 @@ unsigned short PerformanceNavigation::type() const
     if (!frame)
         return TYPE_NAVIGATE;
 
-    DocumentLoader* documentLoader = frame->loader().documentLoader();
+    RefPtr documentLoader = frame->loader().documentLoader();
     if (!documentLoader)
         return TYPE_NAVIGATE;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -40,6 +40,7 @@
 #import <AVFoundation/AVAssetResourceLoader.h>
 #import <objc/runtime.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/CheckedRef.h>
 #import <wtf/Scope.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/TZoneMallocInlines.h>
@@ -55,11 +56,19 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCoreAVFResourceLoader);
 
-class CachedResourceMediaLoader final : CachedRawResourceClient {
+class CachedResourceMediaLoader final : CachedRawResourceClient, public CanMakeCheckedPtr<CachedResourceMediaLoader> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(CachedResourceMediaLoader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CachedResourceMediaLoader);
 public:
     static std::unique_ptr<CachedResourceMediaLoader> create(WebCoreAVFResourceLoader&, CachedResourceLoader&, ResourceRequest&&);
     ~CachedResourceMediaLoader() { stop(); }
+
+    // CachedRawResourceClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     CachedResourceMediaLoader(WebCoreAVFResourceLoader&, CachedResourceHandle<CachedRawResource>&&);

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -34,6 +34,7 @@
 #include "CachedSVGDocumentClient.h"
 #include "FilterRenderingMode.h"
 #include "RenderLayer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -44,11 +45,19 @@ class Element;
 class FilterOperations;
 class GraphicsContextSwitcher;
 
-class RenderLayerFilters final : private CachedSVGDocumentClient {
+class RenderLayerFilters final : private CachedSVGDocumentClient, public CanMakeCheckedPtr<RenderLayerFilters> {
     WTF_MAKE_TZONE_ALLOCATED(RenderLayerFilters);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderLayerFilters);
 public:
     explicit RenderLayerFilters(RenderLayer&);
     virtual ~RenderLayerFilters();
+
+    // CachedSVGDocumentClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     const LayoutRect& dirtySourceRect() const { return m_dirtySourceRect; }
     void expandDirtySourceRect(const LayoutRect& rect) { m_dirtySourceRect.unite(rect); }

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -48,7 +48,7 @@ public:
 
     HTMLSelectElement& selectElement() const;
 
-    // CheckedPtr interface.
+    // PopupMenuClient.
     uint32_t checkedPtrCount() const final { return RenderFlexibleBox::checkedPtrCount(); }
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return RenderFlexibleBox::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { RenderFlexibleBox::incrementCheckedPtrCount(); }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -121,9 +121,16 @@ RenderObject::SetLayoutNeededForbiddenScope::~SetLayoutNeededForbiddenScope()
 
 #endif
 
-struct SameSizeAsRenderObject final : public CachedImageClient {
+struct SameSizeAsRenderObject final : public CachedImageClient, public CanMakeCheckedPtr<SameSizeAsRenderObject> {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(SameSizeAsRenderObject);
     WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(SameSizeAsRenderObject);
+
+    // CachedImageClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     virtual ~SameSizeAsRenderObject() = default; // Allocate vtable pointer.
 #if ASSERT_ENABLED

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -111,7 +111,7 @@ enum class StyleColorOptions : uint8_t;
 typedef const void* WrappedImagePtr;
 
 // Base class for all rendering tree objects.
-class RenderObject : public CachedImageClient {
+class RenderObject : public CachedImageClient, public CanMakeCheckedPtr<RenderObject> {
     WTF_MAKE_PREFERABLY_COMPACT_TZONE_OR_ISO_ALLOCATED(RenderObject);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderObject);
     friend class RenderBlock;
@@ -342,6 +342,13 @@ public:
     // marked as anonymous in the constructor.
     RenderObject(Type, Node&, OptionSet<TypeFlag>, TypeSpecificFlags);
     virtual ~RenderObject();
+
+    // CachedImageClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     Type type() const { return m_type; }
     Layout::Box* layoutBox() { return m_layoutBox.get(); }

--- a/Source/WebCore/rendering/style/ReferenceFilterOperation.cpp
+++ b/Source/WebCore/rendering/style/ReferenceFilterOperation.cpp
@@ -71,7 +71,7 @@ void ReferenceFilterOperation::loadExternalDocumentIfNeeded(CachedResourceLoader
     if (!SVGURIReference::isExternalURIReference(m_url.resolved.string(), *cachedResourceLoader.protectedDocument()))
         return;
     m_cachedSVGDocumentReference = makeUnique<CachedSVGDocumentReference>(m_url);
-    m_cachedSVGDocumentReference->load(cachedResourceLoader, options);
+    CheckedRef { *m_cachedSVGDocumentReference }->load(cachedResourceLoader, options);
 }
 
 } // Style

--- a/Source/WebCore/rendering/style/StyleCrossfadeImage.h
+++ b/Source/WebCore/rendering/style/StyleCrossfadeImage.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 struct BlendingContext;
 
-class StyleCrossfadeImage final : public StyleGeneratedImage, private CachedImageClient {
+class StyleCrossfadeImage final : public StyleGeneratedImage, private CachedImageClient, public CanMakeCheckedPtr<StyleCrossfadeImage> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(StyleCrossfadeImage);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StyleCrossfadeImage);
 public:
@@ -51,6 +51,13 @@ public:
     bool equalInputImages(const StyleCrossfadeImage&) const;
 
     static constexpr bool isFixedSize = true;
+
+    // CachedImageClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     explicit StyleCrossfadeImage(RefPtr<StyleImage>&&, RefPtr<StyleImage>&&, double, bool);

--- a/Source/WebCore/rendering/style/StyleFilterImage.h
+++ b/Source/WebCore/rendering/style/StyleFilterImage.h
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-class StyleFilterImage final : public StyleGeneratedImage, private CachedImageClient {
+class StyleFilterImage final : public StyleGeneratedImage, private CachedImageClient, public CanMakeCheckedPtr<StyleFilterImage> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(StyleFilterImage);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StyleFilterImage);
 public:
@@ -42,6 +42,13 @@ public:
         return adoptRef(*new StyleFilterImage(WTFMove(image), WTFMove(filter)));
     }
     virtual ~StyleFilterImage();
+
+    // CachedImageClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     bool operator==(const StyleImage& other) const final;
     bool equals(const StyleFilterImage&) const;

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -37,11 +37,12 @@ public:
 
     virtual ~SVGFEImageElement();
 
-    // CheckedPtr interface
-    uint32_t checkedPtrCount() const { return SVGFilterPrimitiveStandardAttributes::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const { return SVGFilterPrimitiveStandardAttributes::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const { SVGFilterPrimitiveStandardAttributes::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const { SVGFilterPrimitiveStandardAttributes::decrementCheckedPtrCount(); }
+    // CachedImageClient.
+    USING_CAN_MAKE_CHECKEDPTR(SVGFilterPrimitiveStandardAttributes);
+    uint32_t virtualCheckedPtrCount() const final { return SVGFilterPrimitiveStandardAttributes::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return SVGFilterPrimitiveStandardAttributes::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { SVGFilterPrimitiveStandardAttributes::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { SVGFilterPrimitiveStandardAttributes::decrementCheckedPtrCount(); }
 
     bool renderingTaintsOrigin() const;
 

--- a/Source/WebCore/svg/SVGFontFaceUriElement.h
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.h
@@ -35,6 +35,13 @@ public:
 
     virtual ~SVGFontFaceUriElement();
 
+    // CachedFontClient.
+    USING_CAN_MAKE_CHECKEDPTR(SVGElement);
+    uint32_t virtualCheckedPtrCount() const final { return SVGElement::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return SVGElement::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { SVGElement::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { SVGElement::decrementCheckedPtrCount(); }
+
     Ref<CSSFontFaceSrcResourceValue> createSrcValue() const;
 
 private:

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -38,6 +38,13 @@ public:
     static Ref<SVGUseElement> create(const QualifiedName&, Document&);
     virtual ~SVGUseElement();
 
+    // CachedSVGDocumentClient.
+    USING_CAN_MAKE_CHECKEDPTR(SVGGraphicsElement);
+    uint32_t virtualCheckedPtrCount() const final { return SVGGraphicsElement::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return SVGGraphicsElement::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { SVGGraphicsElement::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { SVGGraphicsElement::decrementCheckedPtrCount(); }
+
     void invalidateShadowTree();
     void updateUserAgentShadowTree() final;
 

--- a/Source/WebCore/xml/XSLImportRule.h
+++ b/Source/WebCore/xml/XSLImportRule.h
@@ -27,18 +27,27 @@
 #include "CachedResourceHandle.h"
 #include "CachedStyleSheetClient.h"
 #include "XSLStyleSheet.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class CachedXSLStyleSheet;
 
-class XSLImportRule : private CachedStyleSheetClient {
+class XSLImportRule final : private CachedStyleSheetClient, public CanMakeCheckedPtr<XSLImportRule> {
     WTF_MAKE_TZONE_ALLOCATED(XSLImportRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(XSLImportRule);
 public:
     XSLImportRule(XSLStyleSheet& parentSheet, const String& href);
     virtual ~XSLImportRule();
-    
+
+    // CachedStyleSheetClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+
     const String& href() const { return m_strHref; }
     XSLStyleSheet* styleSheet() const { return m_styleSheet.get(); }
 

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
@@ -145,7 +145,7 @@ void WebResourceLoadScheduler::scheduleLoad(ResourceLoader* resourceLoader)
         return;
     }
 #else
-    if (resourceLoader->documentLoader()->archiveResourceForURL(resourceLoader->request().url())) {
+    if (resourceLoader->protectedDocumentLoader()->archiveResourceForURL(resourceLoader->request().url())) {
         resourceLoader->start();
         return;
     }

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -102,7 +102,7 @@ WebSocketChannel::ConnectStatus WebSocketChannel::connect(const URL& requestedUR
     String clientOrigin = m_document->securityOrigin().toString();
 
     bool isAppInitiated = true;
-    if (auto* documentLoader = m_document->loader())
+    if (RefPtr documentLoader = m_document->loader())
         isAppInitiated = documentLoader->lastNavigationWasAppInitiated();
 
     m_handshake = makeUnique<WebSocketHandshake>(validatedURL->url, protocol, userAgent, clientOrigin, m_allowCookies, isAppInitiated);

--- a/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
@@ -101,7 +101,7 @@ public:
         loader->detachDataSource();
     }
 
-    Ref<WebDocumentLoaderMac> loader;
+    const Ref<WebDocumentLoaderMac> loader;
     RetainPtr<id<WebDocumentRepresentation> > representation;
     BOOL representationFinishedLoading;
     BOOL includedInWebKitStatistics;

--- a/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h
+++ b/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h
@@ -38,7 +38,9 @@ namespace WebCore {
 class ResourceRequest;
 }
 
-class WebDocumentLoaderMac : public WebCore::DocumentLoader {
+class WebDocumentLoaderMac final : public WebCore::DocumentLoader {
+    WTF_MAKE_TZONE_ALLOCATED(WebDocumentLoaderMac);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebDocumentLoaderMac);
 public:
     static Ref<WebDocumentLoaderMac> create(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& data)
     {

--- a/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
@@ -31,8 +31,11 @@
 #import "WebKitVersionChecks.h"
 #import "WebView.h"
 #import <WebCore/FrameDestructionObserverInlines.h>
+#import <wtf/TZoneMallocInlines.h>
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDocumentLoaderMac);
 
 WebDocumentLoaderMac::WebDocumentLoaderMac(ResourceRequest&& request, SubstituteData&& substituteData)
     : DocumentLoader(WTFMove(request), WTFMove(substituteData))

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -829,10 +829,22 @@ const float _WebHTMLViewPrintingMaximumShrinkFactor = WebCore::PrintContext::max
 @implementation WebCoreScrollView
 @end
 
+class ConcreteCachedImageClient final : public WebCore::CachedImageClient, public CanMakeCheckedPtr<ConcreteCachedImageClient> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ConcreteCachedImageClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ConcreteCachedImageClient);
+public:
+    // CachedImageClient.
+    USING_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+    uint32_t virtualCheckedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t virtualCheckedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void virtualIncrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void virtualDecrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+};
+
 // We need this to be able to safely reference the CachedImage for the promised drag data
-static WebCore::CachedImageClient& promisedDataClient()
+static ConcreteCachedImageClient& promisedDataClient()
 {
-    static NeverDestroyed<WebCore::CachedImageClient> staticCachedResourceClient;
+    static NeverDestroyed<ConcreteCachedImageClient> staticCachedResourceClient;
     return staticCachedResourceClient.get();
 }
 


### PR DESCRIPTION
#### efbffbb7c247ab86ac62c0f0550c1b9a853e753b
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for CachedResourceClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=300775">https://bugs.webkit.org/show_bug.cgi?id=300775</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
(WebCore::NavigatorBeacon::from):
* Source/WebCore/Modules/beacon/NavigatorBeacon.h:
* Source/WebCore/Modules/mediasession/MediaMetadata.h:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::updateNowPlayingInfo):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp:
* Source/WebCore/bindings/js/CachedModuleScriptLoader.h:
* Source/WebCore/bindings/js/CachedScriptSourceProvider.h:
* Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h:
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcResourceValue::fontLoadRequest):
* Source/WebCore/css/StyleRuleImport.cpp:
* Source/WebCore/css/StyleRuleImport.h:
* Source/WebCore/dom/DataTransfer.cpp:
* Source/WebCore/dom/LoadableClassicScript.cpp:
* Source/WebCore/dom/LoadableClassicScript.h:
* Source/WebCore/dom/LoadableSpeculationRules.cpp:
* Source/WebCore/dom/LoadableSpeculationRules.h:
* Source/WebCore/dom/ProcessingInstruction.h:
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(HTMLConverter::_addAttachmentForElement):
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/inspector/InspectorAuditResourcesObject.cpp:
(WebCore::InspectorAuditResourcesObject::~InspectorAuditResourcesObject):
(WebCore::InspectorAuditResourcesObject::getResources):
* Source/WebCore/inspector/InspectorAuditResourcesObject.h:
(WebCore::InspectorAuditResourcesObject::checkedClientForResource):
* Source/WebCore/inspector/InspectorResourceUtilities.cpp:
(Inspector::ResourceUtilities::resourceContent):
(Inspector::ResourceUtilities::assertDocumentLoader):
* Source/WebCore/loader/ApplicationManifestLoader.h:
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
* Source/WebCore/loader/CrossOriginPreflightChecker.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::notifyFinished):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/DocumentPrefetcher.cpp:
* Source/WebCore/loader/DocumentPrefetcher.h:
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::dataReceived):
(WebCore::DocumentThreadableLoader::notifyFinished):
* Source/WebCore/loader/DocumentThreadableLoader.h:
(WebCore::DocumentThreadableLoader::clearClient): Deleted.
(WebCore::DocumentThreadableLoader::document): Deleted.
(WebCore::DocumentThreadableLoader::options const): Deleted.
(WebCore::DocumentThreadableLoader::referrer const): Deleted.
(WebCore::DocumentThreadableLoader::isLoading): Deleted.
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/LinkLoader.cpp:
* Source/WebCore/loader/LinkLoader.h:
* Source/WebCore/loader/LinkPreloadResourceClients.cpp:
(WebCore::LinkPreloadResourceClient::triggerEvents):
* Source/WebCore/loader/LinkPreloadResourceClients.h:
(WebCore::LinkPreloadDefaultResourceClient::LinkPreloadDefaultResourceClient): Deleted.
(WebCore::LinkPreloadStyleResourceClient::LinkPreloadStyleResourceClient): Deleted.
(WebCore::LinkPreloadFontResourceClient::LinkPreloadFontResourceClient): Deleted.
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResource::notifyFinished):
* Source/WebCore/loader/MediaResourceLoader.h:
* Source/WebCore/loader/ResourceLoadNotifier.cpp:
(WebCore::ResourceLoadNotifier::didReceiveResponse):
* Source/WebCore/loader/TextTrackLoader.h:
* Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp:
(WebCore::CachedCSSStyleSheet::checkNotify):
* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::checkNotify):
* Source/WebCore/loader/cache/CachedFontLoadRequest.h:
* Source/WebCore/loader/cache/CachedImageClient.h:
* Source/WebCore/loader/cache/CachedRawResource.cpp:
(WebCore::CachedRawResource::notifyClientsDataWasReceived):
(WebCore::iterateClients):
(WebCore::CachedRawResource::responseReceived):
(WebCore::CachedRawResource::shouldCacheResponse):
(WebCore::CachedRawResource::didSendData):
(WebCore::CachedRawResource::finishedTimingForWorkerLoad):
(WebCore::CachedRawResource::previewResponseReceived):
* Source/WebCore/loader/cache/CachedRawResourceClient.h:
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::load):
(WebCore::CachedResource::checkNotify):
(WebCore::CachedResource::switchClientsToRevalidatedResource):
* Source/WebCore/loader/cache/CachedResourceClient.h:
* Source/WebCore/loader/cache/CachedResourceLoader.h:
(WebCore::CachedResourceLoader::checkedKeepaliveRequestTracker):
* Source/WebCore/loader/cache/CachedSVGDocumentReference.h:
* Source/WebCore/loader/cache/CachedTextTrack.cpp:
(WebCore::CachedTextTrack::doUpdateBuffer):
* Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp:
(WebCore::CachedXSLStyleSheet::checkNotify):
* Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp:
* Source/WebCore/loader/cache/KeepaliveRequestTracker.h:
* Source/WebCore/loader/icon/IconLoader.h:
* Source/WebCore/page/PerformanceNavigation.cpp:
(WebCore::PerformanceNavigation::type const):
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
* Source/WebCore/rendering/RenderLayerFilters.h:
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/style/ReferenceFilterOperation.cpp:
(WebCore::Style::ReferenceFilterOperation::loadExternalDocumentIfNeeded):
* Source/WebCore/rendering/style/StyleCrossfadeImage.h:
* Source/WebCore/rendering/style/StyleFilterImage.h:
* Source/WebCore/svg/SVGFEImageElement.h:
* Source/WebCore/svg/SVGFontFaceUriElement.h:
* Source/WebCore/svg/SVGUseElement.h:
* Source/WebCore/xml/XSLImportRule.h:
(WebCore::XSLImportRule::href const): Deleted.
(WebCore::XSLImportRule::styleSheet const): Deleted.
(WebCore::XSLImportRule::parentStyleSheet const): Deleted.
(WebCore::XSLImportRule::setParentStyleSheet): Deleted.
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp:
(WebResourceLoadScheduler::scheduleLoad):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::connect):
* Source/WebKitLegacy/mac/WebView/WebDataSource.mm:
* Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h:
(WebDocumentLoaderMac::create): Deleted.
* Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm:
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(promisedDataClient):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efbffbb7c247ab86ac62c0f0550c1b9a853e753b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126798 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133746 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78416 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b469eff1-6c60-47f9-a50e-11a2492e68c3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54975 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96510 "Failure limit exceed. At least found 229 new test failures: fast/dom/HTMLLinkElement/link-preload-load-once.html fast/loader/main-document-url-for-non-http-loads.html fast/text/font-download-font-face-src-list.html fast/text/font-download-font-family-property.html fast/text/font-download-remote-fallback-all.html fast/text/font-style-download.html fast/text/font-weight-download-2.html fast/text/font-weight-download-3.html fast/text/font-weight-download.html fast/text/unicode-range-download.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64518 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/774544e9-8835-4657-b323-7fe3f7acf2bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129746 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37659 "Found unexpected failure with change (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/114503 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77008 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d5cb8f9a-f3d1-4c9c-990c-3dabcd325113) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36538 "Found unexpected failure with change (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31597 "Found 60 new test failures: css3/viewport-percentage-lengths/viewport-percentage-lengths-resize.html fast/dom/HTMLLinkElement/link-preload-load-once.html fast/eventsource/eventsource-constructor.html fast/forms/form-associated-element-crash3.html fast/forms/state-restore-per-form.html fast/frames/iframe-double-scale-contents.html fast/loader/file-protocol-fragment.html fast/loader/main-document-url-for-non-http-loads.html fast/text/font-download-font-face-src-list.html fast/text/font-download-font-family-property.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77140 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108363 "Build is being retried. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31901 "Found 60 new test failures: accessibility/mac/details-summary.html applicationmanifest/multiple-links.html fast/css/aspect-ratio-min-height-replaced.html fast/dom/HTMLLinkElement/link-preload-load-once.html fast/events/onunload-not-on-body.html fast/forms/state-restore-to-non-edited-controls.html fast/loader/main-document-url-for-non-http-loads.html fast/loader/redirect-to-invalid-url-using-meta-refresh-calls-policy-delegate.html fast/scrolling/mac/scrollbars/overflow-in-iframe-overlay-scrollbar-reveal.html fast/text/font-download-font-face-src-list.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136326 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53471 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41156 "Found 60 new test failures: accessibility/mac/details-summary.html applicationmanifest/multiple-links.html fast/dom/HTMLLinkElement/link-preload-load-once.html fast/forms/state-restore-to-non-edited-controls.html fast/loader/main-document-url-for-non-http-loads.html fast/loader/redirect-to-invalid-url-using-meta-refresh-calls-policy-delegate.html fast/mediastream/enumerateDevices-camera-denied-expose-with-capture.html fast/scrolling/mac/scrollbars/overflow-in-iframe-overlay-scrollbar-reveal.html fast/text/font-download-font-face-src-list.html fast/text/font-download-font-family-property.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105015 "Failure limit exceed. At least found 176 new test failures: fast/dom/HTMLLinkElement/link-preload-load-once.html fast/loader/main-document-url-for-non-http-loads.html fast/text/font-download-font-face-src-list.html fast/text/font-download-font-family-property.html fast/text/font-download-remote-fallback-all.html fast/text/font-style-download.html fast/text/font-weight-download-2.html fast/text/font-weight-download-3.html fast/text/font-weight-download.html fast/text/unicode-range-download.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104704 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50202 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28545 "Found unexpected failure with change (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50931 "Hash efbffbb7 for PR 52372 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53400 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59202 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52656 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55990 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54404 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->