### PR TITLE
[threaded-animation-resolution] use a timeline to update remote animations

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -675,6 +675,7 @@ UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm @nonARC
 
 UIProcess/RemoteLayerTree/RemoteAnimation.cpp
 UIProcess/RemoteLayerTree/RemoteAnimationStack.mm @nonARC
+UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
 UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm @nonARC
 UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm @nonARC
 UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm @nonARC

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
+#include "RemoteAnimationTimeline.h"
 #include <WebCore/AcceleratedEffect.h>
 #include <WebCore/WebAnimationTime.h>
 #include <wtf/RefCounted.h>
@@ -37,17 +38,20 @@ namespace WebKit {
 class RemoteAnimation : public RefCounted<RemoteAnimation> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RemoteAnimation);
 public:
-    static Ref<RemoteAnimation> create(const WebCore::AcceleratedEffect&);
+    static Ref<RemoteAnimation> create(const WebCore::AcceleratedEffect&, const RemoteAnimationTimeline&);
+
+    const RemoteAnimationTimeline& timeline() const { return m_timeline.get(); }
 
     const OptionSet<WebCore::AcceleratedEffectProperty>& animatedProperties() const { return m_effect->animatedProperties(); }
     const Vector<WebCore::AcceleratedEffect::Keyframe>& keyframes() const { return m_effect->keyframes(); }
 
-    void apply(WebCore::WebAnimationTime, WebCore::AcceleratedEffectValues&);
+    void apply(WebCore::AcceleratedEffectValues&);
 
 private:
-    RemoteAnimation(const WebCore::AcceleratedEffect&);
+    RemoteAnimation(const WebCore::AcceleratedEffect&, const RemoteAnimationTimeline&);
 
     Ref<const WebCore::AcceleratedEffect> m_effect;
+    Ref<const RemoteAnimationTimeline> m_timeline;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
@@ -45,23 +45,23 @@ using RemoteAnimations = Vector<Ref<RemoteAnimation>>;
 class RemoteAnimationStack final : public RefCounted<RemoteAnimationStack> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RemoteAnimationStack);
 public:
-    static Ref<RemoteAnimationStack> create(RemoteAnimations&&, WebCore::AcceleratedEffectValues&&, WebCore::FloatRect, Seconds);
+    static Ref<RemoteAnimationStack> create(RemoteAnimations&&, WebCore::AcceleratedEffectValues&&, WebCore::FloatRect);
 
     bool isEmpty() const { return m_animations.isEmpty(); }
 
 #if PLATFORM(MAC)
-    void initEffectsFromMainThread(PlatformLayer*, MonotonicTime now);
-    void applyEffectsFromScrollingThread(MonotonicTime now) const;
+    void initEffectsFromMainThread(PlatformLayer*);
+    void applyEffectsFromScrollingThread() const;
 #endif
 
-    void applyEffectsFromMainThread(PlatformLayer*, MonotonicTime now, bool backdropRootIsOpaque) const;
+    void applyEffectsFromMainThread(PlatformLayer*, bool backdropRootIsOpaque) const;
 
     void clear(PlatformLayer*);
 
 private:
-    explicit RemoteAnimationStack(RemoteAnimations&&, WebCore::AcceleratedEffectValues&&, WebCore::FloatRect, Seconds);
+    explicit RemoteAnimationStack(RemoteAnimations&&, WebCore::AcceleratedEffectValues&&, WebCore::FloatRect);
 
-    WebCore::AcceleratedEffectValues computeValues(MonotonicTime now) const;
+    WebCore::AcceleratedEffectValues computeValues() const;
 
 #if PLATFORM(MAC)
     const WebCore::FilterOperations* longestFilterList() const;
@@ -78,7 +78,6 @@ private:
     RemoteAnimations m_animations;
     WebCore::AcceleratedEffectValues m_baseValues;
     WebCore::FloatRect m_bounds;
-    Seconds m_acceleratedTimelineTimeOrigin;
 
 #if PLATFORM(MAC)
     RetainPtr<CAPresentationModifierGroup> m_presentationModifierGroup;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
@@ -24,7 +24,7 @@
  */
 
 #import "config.h"
-#import "RemoteAnimation.h"
+#import "RemoteAnimationTimeline.h"
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
@@ -32,24 +32,30 @@
 
 namespace WebKit {
 
-WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RemoteAnimation);
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RemoteAnimationTimeline);
 
-Ref<RemoteAnimation> RemoteAnimation::create(const WebCore::AcceleratedEffect& effect, const RemoteAnimationTimeline& timeline)
+static WebCore::WebAnimationTime computeCurrentTime(Seconds originTime, MonotonicTime now)
 {
-    return adoptRef(*new RemoteAnimation(effect, timeline));
+    return now.secondsSinceEpoch() - originTime;
 }
 
-RemoteAnimation::RemoteAnimation(const WebCore::AcceleratedEffect& effect, const RemoteAnimationTimeline& timeline)
-    : m_effect(effect)
-    , m_timeline(timeline)
+Ref<RemoteAnimationTimeline> RemoteAnimationTimeline::create(Seconds originTime, MonotonicTime now)
+{
+    return adoptRef(*new RemoteAnimationTimeline(originTime, computeCurrentTime(originTime, now)));
+}
+
+RemoteAnimationTimeline::RemoteAnimationTimeline(Seconds originTime, WebCore::WebAnimationTime currentTime)
+    : m_originTime(originTime)
+    , m_currentTime(currentTime)
 {
 }
 
-void RemoteAnimation::apply(WebCore::AcceleratedEffectValues& values)
+void RemoteAnimationTimeline::updateCurrentTime(MonotonicTime now)
 {
-    Ref { m_effect }->apply(m_timeline->currentTime(), values);
+    m_currentTime = computeCurrentTime(m_originTime, now);
 }
 
 } // namespace WebKit
 
 #endif // ENABLE(THREADED_ANIMATION_RESOLUTION)
+

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
@@ -23,32 +23,30 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "RemoteAnimation.h"
+#pragma once
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
-#import <wtf/TZoneMallocInlines.h>
+#include <WebCore/WebAnimationTime.h>
+#include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
-WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RemoteAnimation);
+class RemoteAnimationTimeline final : public RefCounted<RemoteAnimationTimeline> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RemoteAnimationTimeline);
+public:
+    static Ref<RemoteAnimationTimeline> create(Seconds, MonotonicTime);
 
-Ref<RemoteAnimation> RemoteAnimation::create(const WebCore::AcceleratedEffect& effect, const RemoteAnimationTimeline& timeline)
-{
-    return adoptRef(*new RemoteAnimation(effect, timeline));
-}
+    void updateCurrentTime(MonotonicTime);
+    const WebCore::WebAnimationTime& currentTime() const { return m_currentTime; }
 
-RemoteAnimation::RemoteAnimation(const WebCore::AcceleratedEffect& effect, const RemoteAnimationTimeline& timeline)
-    : m_effect(effect)
-    , m_timeline(timeline)
-{
-}
+private:
+    RemoteAnimationTimeline(Seconds, WebCore::WebAnimationTime);
 
-void RemoteAnimation::apply(WebCore::AcceleratedEffectValues& values)
-{
-    Ref { m_effect }->apply(m_timeline->currentTime(), values);
-}
+    Seconds m_originTime;
+    WebCore::WebAnimationTime m_currentTime;
+};
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -44,6 +44,10 @@ class RemotePageDrawingAreaProxy;
 class RemoteScrollingCoordinatorProxy;
 class RemoteScrollingCoordinatorTransaction;
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+class RemoteAnimationTimeline;
+#endif
+
 class RemoteLayerTreeDrawingAreaProxy : public DrawingAreaProxy, public RefCounted<RemoteLayerTreeDrawingAreaProxy> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeDrawingAreaProxy);
     WTF_MAKE_NONCOPYABLE(RemoteLayerTreeDrawingAreaProxy);
@@ -78,8 +82,8 @@ public:
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
-    Seconds acceleratedTimelineTimeOrigin(WebCore::ProcessIdentifier) const;
-    MonotonicTime animationCurrentTime(WebCore::ProcessIdentifier) const;
+    void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds originTime, MonotonicTime now);
+    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const;
 #endif
 
     // For testing.
@@ -113,11 +117,6 @@ protected:
         std::optional<MonotonicTime> transactionStartTime;
         std::optional<TransactionID> lastLayerTreeTransactionID;
         std::optional<TransactionID> pendingLayerTreeTransactionID;
-
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-        Seconds acceleratedTimelineTimeOrigin;
-        MonotonicTime animationCurrentTime;
-#endif
     };
 
     ProcessState& processStateForConnection(IPC::Connection&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -50,6 +50,10 @@ namespace WebKit {
 class RemoteLayerTreeDrawingAreaProxy;
 class WebPageProxy;
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+class RemoteAnimationTimeline;
+#endif
+
 class RemoteLayerTreeHost {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeHost);
 public:
@@ -83,6 +87,7 @@ public:
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
+    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const;
 #endif
 
     void detachFromDrawingArea();
@@ -97,11 +102,6 @@ public:
     bool threadedAnimationResolutionEnabled() const;
 
     bool cssUnprefixedBackdropFilterEnabled() const;
-
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    Seconds acceleratedTimelineTimeOrigin(WebCore::ProcessIdentifier) const;
-    MonotonicTime animationCurrentTime(WebCore::ProcessIdentifier) const;
-#endif
 
     void remotePageProcessDidTerminate(WebCore::ProcessIdentifier);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -197,6 +197,10 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
             rootNode->addToHostingNode(*remoteRootNode);
     }
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    Ref { *m_drawingArea }->registerTimelineIfNecessary(processIdentifier, transaction.acceleratedTimelineTimeOrigin(), MonotonicTime::now());
+#endif
+
     for (auto& changedLayer : transaction.changedLayerProperties()) {
         auto layerID = changedLayer.key;
         const auto& properties = changedLayer.value.get();
@@ -513,14 +517,9 @@ void RemoteLayerTreeHost::animationsWereRemovedFromNode(RemoteLayerTreeNode& nod
     protectedDrawingArea()->animationsWereRemovedFromNode(node);
 }
 
-Seconds RemoteLayerTreeHost::acceleratedTimelineTimeOrigin(WebCore::ProcessIdentifier processIdentifier) const
+const RemoteAnimationTimeline* RemoteLayerTreeHost::timeline(WebCore::ProcessIdentifier processIdentifier) const
 {
-    return protectedDrawingArea()->acceleratedTimelineTimeOrigin(processIdentifier);
-}
-
-MonotonicTime RemoteLayerTreeHost::animationCurrentTime(WebCore::ProcessIdentifier processIdentifier) const
-{
-    return protectedDrawingArea()->animationCurrentTime(processIdentifier);
+    return protectedDrawingArea()->timeline(processIdentifier);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -57,6 +57,10 @@ class RemoteScrollingTree;
 class WebPageProxy;
 class WebWheelEvent;
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+class RemoteAnimationTimeline;
+#endif
+
 class RemoteScrollingCoordinatorProxy : public CanMakeWeakPtr<RemoteScrollingCoordinatorProxy>, public CanMakeCheckedPtr<RemoteScrollingCoordinatorProxy> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteScrollingCoordinatorProxy);
     WTF_MAKE_NONCOPYABLE(RemoteScrollingCoordinatorProxy);
@@ -141,6 +145,9 @@ public:
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     virtual void animationsWereAddedToNode(RemoteLayerTreeNode&) { }
     virtual void animationsWereRemovedFromNode(RemoteLayerTreeNode&) { }
+    virtual void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds, MonotonicTime) { }
+    virtual void updateTimelineCurrentTime(WebCore::ProcessIdentifier, MonotonicTime) { }
+    virtual const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const { return nullptr; }
 #endif
 
     String scrollingTreeAsText() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -30,6 +30,10 @@
 #include "RemoteScrollingCoordinatorProxy.h"
 #include <wtf/TZoneMalloc.h>
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+#import "RemoteAnimationTimeline.h"
+#endif
+
 OBJC_CLASS UIScrollView;
 OBJC_CLASS WKBaseScrollView;
 
@@ -71,6 +75,9 @@ public:
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
+    void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds, MonotonicTime) override;
+    void updateTimelineCurrentTime(WebCore::ProcessIdentifier, MonotonicTime) override;
+    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const override;
     void updateAnimations();
 #endif
 
@@ -100,6 +107,7 @@ private:
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     HashSet<WebCore::PlatformLayerIdentifier> m_animatedNodeLayerIDs;
+    HashMap<WebCore::ProcessIdentifier, Ref<RemoteAnimationTimeline>> m_timelines;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -44,6 +44,7 @@
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 #include "RemoteAnimationStack.h"
+#include "RemoteAnimationTimeline.h"
 #endif
 
 namespace WebCore {
@@ -66,6 +67,10 @@ class RemoteLayerTreeDrawingAreaProxyMac;
 class RemoteLayerTreeNode;
 class RemoteScrollingTree;
 class RemoteLayerTreeEventDispatcherDisplayLinkClient;
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+class RemoteAnimationTimeline;
+#endif
 
 // This class exists to act as a threadsafe DisplayLink::Client client, allowing RemoteScrollingCoordinatorProxyMac to
 // be main-thread only. It's the UI-process analogue of WebPage/EventDispatcher.
@@ -106,6 +111,9 @@ public:
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
     void updateAnimations();
+    void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds, MonotonicTime);
+    void updateTimelineCurrentTime(WebCore::ProcessIdentifier, MonotonicTime);
+    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const;
 #endif
 
 private:
@@ -196,6 +204,7 @@ private:
     friend class RemoteScrollingCoordinatorProxyMac;
     Lock m_animationStacksLock;
     HashMap<WebCore::PlatformLayerIdentifier, Ref<RemoteAnimationStack>> m_animationStacks WTF_GUARDED_BY_LOCK(m_animationStacksLock);
+    HashMap<WebCore::ProcessIdentifier, Ref<RemoteAnimationTimeline>> m_timelines WTF_GUARDED_BY_LOCK(m_animationStacksLock);
 #endif
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -77,6 +77,9 @@ private:
 
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
+    void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds, MonotonicTime) override;
+    void updateTimelineCurrentTime(WebCore::ProcessIdentifier, MonotonicTime) override;
+    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const override;
 #else
     void willCommitLayerAndScrollingTrees() override;
     void didCommitLayerAndScrollingTrees() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -318,6 +318,21 @@ void RemoteScrollingCoordinatorProxyMac::animationsWereRemovedFromNode(RemoteLay
 {
     m_eventDispatcher->animationsWereRemovedFromNode(node);
 }
+
+void RemoteScrollingCoordinatorProxyMac::registerTimelineIfNecessary(WebCore::ProcessIdentifier processIdentifier, Seconds originTime, MonotonicTime now)
+{
+    m_eventDispatcher->registerTimelineIfNecessary(processIdentifier, originTime, now);
+}
+
+void RemoteScrollingCoordinatorProxyMac::updateTimelineCurrentTime(WebCore::ProcessIdentifier processIdentifier, MonotonicTime now)
+{
+    m_eventDispatcher->updateTimelineCurrentTime(processIdentifier, now);
+}
+
+const RemoteAnimationTimeline* RemoteScrollingCoordinatorProxyMac::timeline(WebCore::ProcessIdentifier processIdentifier) const
+{
+    return m_eventDispatcher->timeline(processIdentifier);
+}
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1557,6 +1557,7 @@
 		7137BA8025F1542000914EE3 /* ModelElementController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7137BA7F25F1540C00914EE3 /* ModelElementController.h */; };
 		71A676A622C62325007D6295 /* WKTouchActionGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A676A422C62318007D6295 /* WKTouchActionGestureRecognizer.h */; };
 		71BAA73325FFD09800D7CD5D /* WKModelView.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BAA73125FFCCBA00D7CD5D /* WKModelView.h */; };
+		71C9EC9F2CF9FB6400B8AF06 /* RemoteAnimationTimeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C9EC9D2CF9F93600B8AF06 /* RemoteAnimationTimeline.h */; };
 		71E29A342B20610C0010F3C9 /* RemoteAnimationStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 71371D1E2B1F89C00092C32D /* RemoteAnimationStack.h */; };
 		71F62F752D076DEE00B591D2 /* RemoteAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F62F722D076DEE00B591D2 /* RemoteAnimation.h */; };
 		71FB810B2260627E00323677 /* WebsiteSimulatedMouseEventsDispatchPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 71FB810A2260627A00323677 /* WebsiteSimulatedMouseEventsDispatchPolicy.h */; };
@@ -6672,6 +6673,8 @@
 		71A676A522C62318007D6295 /* WKTouchActionGestureRecognizer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKTouchActionGestureRecognizer.mm; path = ios/WKTouchActionGestureRecognizer.mm; sourceTree = "<group>"; };
 		71BAA73125FFCCBA00D7CD5D /* WKModelView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKModelView.h; path = ios/WKModelView.h; sourceTree = "<group>"; };
 		71BAA73225FFCCBA00D7CD5D /* WKModelView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKModelView.mm; path = ios/WKModelView.mm; sourceTree = "<group>"; };
+		71C9EC9D2CF9F93600B8AF06 /* RemoteAnimationTimeline.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteAnimationTimeline.h; sourceTree = "<group>"; };
+		71C9EC9E2CF9F93600B8AF06 /* RemoteAnimationTimeline.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteAnimationTimeline.cpp; sourceTree = "<group>"; };
 		71E9650F2745682E00ADCF43 /* ModelIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModelIdentifier.h; sourceTree = "<group>"; };
 		71F62F722D076DEE00B591D2 /* RemoteAnimation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteAnimation.h; sourceTree = "<group>"; };
 		71F62F732D076DEE00B591D2 /* RemoteAnimation.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteAnimation.cpp; sourceTree = "<group>"; };
@@ -11366,6 +11369,8 @@
 				71F62F722D076DEE00B591D2 /* RemoteAnimation.h */,
 				71371D1E2B1F89C00092C32D /* RemoteAnimationStack.h */,
 				71371D1F2B1F89C10092C32D /* RemoteAnimationStack.mm */,
+				71C9EC9E2CF9F93600B8AF06 /* RemoteAnimationTimeline.cpp */,
+				71C9EC9D2CF9F93600B8AF06 /* RemoteAnimationTimeline.h */,
 				1AB16AE01648656D00290D62 /* RemoteLayerTreeDrawingAreaProxy.h */,
 				0FF24A2F1879E4FE003ABF0C /* RemoteLayerTreeDrawingAreaProxy.messages.in */,
 				1AB16ADF1648656D00290D62 /* RemoteLayerTreeDrawingAreaProxy.mm */,
@@ -17934,6 +17939,7 @@
 				57FD318222B3515E008D0E8B /* RedirectSOAuthorizationSession.h in Headers */,
 				71F62F752D076DEE00B591D2 /* RemoteAnimation.h in Headers */,
 				71E29A342B20610C0010F3C9 /* RemoteAnimationStack.h in Headers */,
+				71C9EC9F2CF9FB6400B8AF06 /* RemoteAnimationTimeline.h in Headers */,
 				9B1229D223FF2BCC008CA751 /* RemoteAudioDestinationIdentifier.h in Headers */,
 				9B1229CD23FF25F2008CA751 /* RemoteAudioDestinationManager.h in Headers */,
 				9B5BEC2A240101580070C6EF /* RemoteAudioDestinationProxy.h in Headers */,


### PR DESCRIPTION
#### 385433adbb4243049dda8504060ef3c72909af06
<pre>
[threaded-animation-resolution] use a timeline to update remote animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=300778">https://bugs.webkit.org/show_bug.cgi?id=300778</a>
<a href="https://rdar.apple.com/162666323">rdar://162666323</a>

Reviewed by Simon Fraser.

We used to save the origin time passed through the remote layer tree transaction onto each
remote animation stack to be able to compute the current time of each animation as time
progressed and we updated animations.

In preparation for the support of multiple timeline types (such as scroll timelines) we introduce
a remote monotonic timeline, stored on the `RemoteLayerTreeEventDispatcher` for macOS and
the `RemoteScrollingCoordinatorProxyIOS` for iOS keyed by process identifier. That timeline is
created in `RemoteLayerTreeHost::updateLayerTree()`.

Then, as we create the remote animations under `RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues()`,
we provide them with the timeline obtained through the `RemoteLayerTreeHost`. As time progresses,
the new monotonic time is passed onto the timeline to update its current time and animations
just query their timeline&apos;s current time to apply their effect.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp:
(WebKit::RemoteAnimation::create):
(WebKit::RemoteAnimation::RemoteAnimation):
(WebKit::RemoteAnimation::apply):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h:
(WebKit::RemoteAnimation::timeline const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm:
(WebKit::RemoteAnimationStack::create):
(WebKit::RemoteAnimationStack::RemoteAnimationStack):
(WebKit::RemoteAnimationStack::initEffectsFromMainThread):
(WebKit::RemoteAnimationStack::applyEffectsFromScrollingThread const):
(WebKit::RemoteAnimationStack::applyEffectsFromMainThread const):
(WebKit::RemoteAnimationStack::computeValues const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp: Copied from Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp.
(WebKit::computeCurrentTime):
(WebKit::RemoteAnimationTimeline::create):
(WebKit::RemoteAnimationTimeline::RemoteAnimationTimeline):
(WebKit::RemoteAnimationTimeline::updateCurrentTime):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h: Copied from Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
(WebKit::RemoteLayerTreeDrawingAreaProxy::registerTimelineIfNecessary):
(WebKit::RemoteLayerTreeDrawingAreaProxy::timeline const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::acceleratedTimelineTimeOrigin const): Deleted.
(WebKit::RemoteLayerTreeDrawingAreaProxy::animationCurrentTime const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
(WebKit::RemoteLayerTreeHost::timeline const):
(WebKit::RemoteLayerTreeHost::acceleratedTimelineTimeOrigin const): Deleted.
(WebKit::RemoteLayerTreeHost::animationCurrentTime const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::registerTimelineIfNecessary):
(WebKit::RemoteScrollingCoordinatorProxy::updateTimelineCurrentTime):
(WebKit::RemoteScrollingCoordinatorProxy::timeline const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::registerTimelineIfNecessary):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateTimelineCurrentTime):
(WebKit::RemoteScrollingCoordinatorProxyIOS::timeline const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateAnimations):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::registerTimelineIfNecessary):
(WebKit::RemoteLayerTreeEventDispatcher::updateTimelineCurrentTime):
(WebKit::RemoteLayerTreeEventDispatcher::timeline const):
(WebKit::RemoteLayerTreeEventDispatcher::updateAnimations):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::registerTimelineIfNecessary):
(WebKit::RemoteScrollingCoordinatorProxyMac::updateTimelineCurrentTime):
(WebKit::RemoteScrollingCoordinatorProxyMac::timeline const):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/301615@main">https://commits.webkit.org/301615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f960e1a81ab9c2cb9fb481285595f7a136fa94b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37110 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54725 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/133432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129490 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/37455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/113172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/31634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/53233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/40938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/135980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/53719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/109497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50649 "Failed to checkout and rebase branch from PR 52374") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19788 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53153 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58966 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/54170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->