### PR TITLE
[WPE][browserperfdash-benchmark] Update the browser flavors available

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py
@@ -56,7 +56,7 @@ class WPEMiniBrowserDriver(WPEMiniBrowserBaseDriver):
     browser_name = 'minibrowser-wpe'
 
     def _extra_wpe_minibrowser_args(self):
-        return ['--maximized']
+        return ['--fullscreen']
 
 
 class WPEMiniBrowserSkiaCPUDriver(WPEMiniBrowserDriver):
@@ -67,15 +67,17 @@ class WPEMiniBrowserSkiaCPUDriver(WPEMiniBrowserDriver):
         self._test_environ['WEBKIT_SKIA_ENABLE_CPU_RENDERING'] = '1'
 
 
-class WPEMiniBrowserOldAPIDriver(WPEMiniBrowserBaseDriver):
-    browser_name = 'minibrowser-wpe-oldapi'
+class WPEMiniBrowserNoHybridDriver(WPEMiniBrowserDriver):
+    browser_name = 'minibrowser-wpe-nohybrid'
+
+    def prepare_env(self, config):
+        super().prepare_env(config)
+        # Disabling CPU rendering threads disables hybrid mode.
+        self._test_environ['WEBKIT_SKIA_CPU_PAINTING_THREADS'] = '0'
+
+
+class WPEMiniBrowserLegacyAPIDriver(WPEMiniBrowserBaseDriver):
+    browser_name = 'minibrowser-wpe-legacy'
 
     def _extra_wpe_minibrowser_args(self):
         return ['--use-legacy-api']
-
-
-class WPEMiniBrowserSkiaCPUDriverFullScreen(WPEMiniBrowserSkiaCPUDriver):
-    browser_name = 'minibrowser-wpe-skiacpu-fullscreen'
-
-    def _extra_wpe_minibrowser_args(self):
-        return ['--fullscreen']

--- a/Tools/Scripts/webkitpy/browserperfdash/config-file-example.txt
+++ b/Tools/Scripts/webkitpy/browserperfdash/config-file-example.txt
@@ -48,11 +48,11 @@ browser = minibrowser-wpe
 [settings:skia-cpu]
 plan_list = motionmark
 timeout = 1200
-browser = minibrowser-wpe-skia-cpu
+browser = minibrowser-wpe-skiacpu
 
 # plan_list defaults to the value specified in the default [settings]
-[settings:old-api]
-browser = minibrowser-wpe-old-api
+[settings:legacy]
+browser = minibrowser-wpe-legacy
 
 # all the values but webdriver defaults to the values from the default [settings]
 [settings:webdriver]


### PR DESCRIPTION
#### 8aa3794195f9a0de0ac900368275c654ddc58e27
<pre>
[WPE][browserperfdash-benchmark] Update the browser flavors available
<a href="https://bugs.webkit.org/show_bug.cgi?id=300783">https://bugs.webkit.org/show_bug.cgi?id=300783</a>

Reviewed by Carlos Alberto Lopez Perez and Nikolas Zimmermann.

Use always fullscreen mode and add a flavor that disables hybrid rendering mode.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py:
(WPEMiniBrowserDriver._extra_wpe_minibrowser_args):
(WPEMiniBrowserNoHybridDriver):
(WPEMiniBrowserNoHybridDriver.prepare_env):
(WPEMiniBrowserLegacyAPIDriver):
(WPEMiniBrowserLegacyAPIDriver._extra_wpe_minibrowser_args):
(WPEMiniBrowserOldAPIDriver): Deleted.
(WPEMiniBrowserOldAPIDriver._extra_wpe_minibrowser_args): Deleted.
(WPEMiniBrowserSkiaCPUDriverFullScreen): Deleted.
(WPEMiniBrowserSkiaCPUDriverFullScreen._extra_wpe_minibrowser_args): Deleted.
* Tools/Scripts/webkitpy/browserperfdash/config-file-example.txt:

Canonical link: <a href="https://commits.webkit.org/302017@main">https://commits.webkit.org/302017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af5fb5b91d743bbdbc5fd4b00db716b555794453

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133741 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78411 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96481 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64513 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77001 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/126143 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31590 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77134 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107473 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136320 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104990 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109770 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104695 "Found 1 new API test failure: WebKitGTK/TestLoaderClient:/webkit/WebKitWebPage/get-uri (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50192 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28538 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50924 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19969 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53394 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->