### PR TITLE
[GTK] Move GRefPtrGtk and GUniquePtrGtk from WebCore to WebKit

### DIFF
--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -64,8 +64,6 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/graphics/x11/XErrorTrapper.h
 
-    platform/gtk/GRefPtrGtk.h
-    platform/gtk/GUniquePtrGtk.h
     platform/gtk/ScrollbarThemeGtk.h
 
     platform/text/enchant/TextCheckerEnchant.h

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -91,7 +91,6 @@ platform/graphics/opentype/OpenTypeVerticalData.cpp
 
 platform/graphics/x11/XErrorTrapper.cpp @no-unify
 
-platform/gtk/GRefPtrGtk.cpp
 platform/gtk/LocalizedStringsGtk.cpp
 platform/gtk/PasteboardGtk.cpp
 platform/gtk/PlatformKeyboardEventGtk.cpp

--- a/Source/WebCore/platform/gtk/RenderThemeGadget.cpp
+++ b/Source/WebCore/platform/gtk/RenderThemeGadget.cpp
@@ -30,8 +30,12 @@
 #if !USE(GTK4) && USE(CAIRO)
 
 #include "FloatRect.h"
-#include "GRefPtrGtk.h"
+#include <wtf/glib/GRefPtr.h>
 #include <wtf/TZoneMallocInlines.h>
+
+namespace WTF {
+WTF_DEFINE_GREF_TRAITS_INLINE(GtkWidgetPath, gtk_widget_path_ref, gtk_widget_path_unref)
+}
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -47,11 +47,15 @@
 #include <wtf/glib/GUniquePtr.h>
 
 #if USE(LIBSECRET)
-#include "GRefPtrGtk.h"
 #include <glib/gi18n-lib.h>
 #define SECRET_WITH_UNSTABLE 1
 #define SECRET_API_SUBJECT_TO_CHANGE 1
 #include <libsecret/secret.h>
+#include <wtf/glib/GRefPtr.h>
+
+namespace WTF {
+WTF_DEFINE_GREF_TRAITS_INLINE(SecretValue, secret_value_ref, secret_value_unref)
+}
 #endif
 
 namespace WebCore {

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
@@ -29,8 +29,8 @@
 #include <wtf/glib/WTFGType.h>
 
 #if PLATFORM(GTK)
-#include <WebCore/GRefPtrGtk.h>
-#include <WebCore/GUniquePtrGtk.h>
+#include "GRefPtrGtk.h"
+#include "GUniquePtrGtk.h"
 #endif
 
 #if ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h
@@ -24,8 +24,8 @@
 #include "WebKitContextMenu.h"
 
 #if PLATFORM(GTK)
-#include <WebCore/GRefPtrGtk.h>
-#include <WebCore/GUniquePtrGtk.h>
+#include "GRefPtrGtk.h"
+#include "GUniquePtrGtk.h"
 #endif
 
 WebKitContextMenu* webkitContextMenuCreate(const Vector<WebKit::WebContextMenuItemData>&);

--- a/Source/WebKit/Shared/NativeWebKeyboardEvent.h
+++ b/Source/WebKit/Shared/NativeWebKeyboardEvent.h
@@ -36,8 +36,8 @@ OBJC_CLASS NSView;
 #endif
 
 #if PLATFORM(GTK)
-#include <WebCore/GRefPtrGtk.h>
-#include <WebCore/GUniquePtrGtk.h>
+#include "GRefPtrGtk.h"
+#include "GUniquePtrGtk.h"
 #if USE(GTK4)
 typedef struct _GdkEvent GdkEvent;
 #else

--- a/Source/WebKit/Shared/NativeWebMouseEvent.h
+++ b/Source/WebKit/Shared/NativeWebMouseEvent.h
@@ -35,8 +35,8 @@ OBJC_CLASS NSEvent;
 #endif
 
 #if PLATFORM(GTK)
-#include <WebCore/GRefPtrGtk.h>
-#include <WebCore/GUniquePtrGtk.h>
+#include "GRefPtrGtk.h"
+#include "GUniquePtrGtk.h"
 #if USE(GTK4)
 typedef struct _GdkEvent GdkEvent;
 #else

--- a/Source/WebKit/Shared/NativeWebTouchEvent.h
+++ b/Source/WebKit/Shared/NativeWebTouchEvent.h
@@ -36,8 +36,8 @@
 #if PLATFORM(IOS_FAMILY)
 #include "WKTouchEventsGestureRecognizerTypes.h"
 #elif PLATFORM(GTK)
-#include <WebCore/GRefPtrGtk.h>
-#include <WebCore/GUniquePtrGtk.h>
+#include "GRefPtrGtk.h"
+#include "GUniquePtrGtk.h"
 #elif USE(LIBWPE)
 #include <wpe/wpe.h>
 #endif

--- a/Source/WebKit/Shared/NativeWebWheelEvent.h
+++ b/Source/WebKit/Shared/NativeWebWheelEvent.h
@@ -34,8 +34,8 @@ OBJC_CLASS NSEvent;
 #endif
 
 #if PLATFORM(GTK)
-#include <WebCore/GRefPtrGtk.h>
-#include <WebCore/GUniquePtrGtk.h>
+#include "GRefPtrGtk.h"
+#include "GUniquePtrGtk.h"
 #if USE(GTK4)
 typedef struct _GdkEvent GdkEvent;
 #else

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -280,6 +280,7 @@ UIProcess/gtk/ClipboardGtk4.cpp @no-unify
 UIProcess/gtk/Display.cpp @no-unify
 UIProcess/gtk/DisplayX11.cpp @no-unify
 UIProcess/gtk/DisplayWayland.cpp @no-unify
+UIProcess/gtk/GRefPtrGtk.cpp @no-unify
 UIProcess/gtk/GtkUtilities.cpp @no-unify
 UIProcess/gtk/WebDateTimePickerGtk.cpp
 UIProcess/gtk/HardwareAccelerationManager.cpp

--- a/Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.cpp
@@ -25,8 +25,8 @@
 #include <wtf/glib/WTFGType.h>
 
 #if PLATFORM(GTK)
-#include <WebCore/GRefPtrGtk.h>
-#include <WebCore/GUniquePtrGtk.h>
+#include "GRefPtrGtk.h"
+#include "GUniquePtrGtk.h"
 #endif
 
 using namespace WebKit;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -95,6 +95,7 @@
 #include <wtf/text/StringBuilder.h>
 
 #if PLATFORM(GTK)
+#include "GUniquePtrGtk.h"
 #include "GtkUtilities.h"
 #include "WebKitFaviconDatabasePrivate.h"
 #include "WebKitInputMethodContextImplGtk.h"
@@ -102,7 +103,6 @@
 #include "WebKitPrintOperationPrivate.h"
 #include "WebKitWebInspectorPrivate.h"
 #include "WebKitWebViewBasePrivate.h"
-#include <WebCore/GUniquePtrGtk.h>
 #include <WebCore/GdkCairoUtilities.h>
 #include <WebCore/RefPtrCairo.h>
 #endif

--- a/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
@@ -28,9 +28,9 @@
 
 #if ENABLE(DRAG_SUPPORT) && !USE(GTK4)
 
+#include "GRefPtrGtk.h"
 #include "GtkUtilities.h"
 #include "WebKitWebViewBasePrivate.h"
-#include <WebCore/GRefPtrGtk.h>
 #include <WebCore/PasteboardCustomData.h>
 #include <gtk/gtk.h>
 

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp
@@ -28,11 +28,11 @@
 
 #if ENABLE(DRAG_SUPPORT) && !USE(GTK4)
 
+#include "GRefPtrGtk.h"
 #include "GtkUtilities.h"
 #include "SandboxExtension.h"
 #include "WebKitWebViewBasePrivate.h"
 #include <WebCore/DragData.h>
-#include <WebCore/GRefPtrGtk.h>
 #include <WebCore/PasteboardCustomData.h>
 #include <gtk/gtk.h>
 #include <wtf/glib/GUniquePtr.h>

--- a/Source/WebKit/UIProcess/API/gtk/InputMethodFilterGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/InputMethodFilterGtk.cpp
@@ -20,10 +20,10 @@
 #include "config.h"
 #include "InputMethodFilter.h"
 
+#include "GUniquePtrGtk.h"
 #include "WebKitInputMethodContextImplGtk.h"
 #include "WebKitInputMethodContextPrivate.h"
 #include "WebKitWebViewBaseInternal.h"
-#include <WebCore/GUniquePtrGtk.h>
 #include <WebCore/IntRect.h>
 #include <gdk/gdk.h>
 #include <wtf/SetForScope.h>

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -36,6 +36,8 @@
 #include "DrawingAreaProxyCoordinatedGraphics.h"
 #include "DropTarget.h"
 #include "EditorState.h"
+#include "GRefPtrGtk.h"
+#include "GUniquePtrGtk.h"
 #include "GtkUtilities.h"
 #include "GtkVersioning.h"
 #include "InputMethodFilter.h"
@@ -66,8 +68,6 @@
 #include "WebProcessPool.h"
 #include "WebUserContentControllerProxy.h"
 #include <WebCore/ActivityState.h>
-#include <WebCore/GRefPtrGtk.h>
-#include <WebCore/GUniquePtrGtk.h>
 #include <WebCore/GdkCairoUtilities.h>
 #include <WebCore/Image.h>
 #include <WebCore/NativeImage.h>

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -28,6 +28,8 @@
 #pragma once
 
 #include "APIPageConfiguration.h"
+#include "GRefPtrGtk.h"
+#include "GUniquePtrGtk.h"
 #include "InputMethodState.h"
 #include "RendererBufferDescription.h"
 #include "SameDocumentNavigationType.h"
@@ -42,8 +44,6 @@
 #include "WebPageProxy.h"
 #include <WebCore/Cursor.h>
 #include <WebCore/DragActions.h>
-#include <WebCore/GRefPtrGtk.h>
-#include <WebCore/GUniquePtrGtk.h>
 #include <WebCore/SelectionData.h>
 #include <WebCore/ShareableBitmap.h>
 

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -49,7 +49,7 @@
 #include <wtf/glib/GRefPtr.h>
 
 #if USE(GTK4)
-#include <WebCore/GRefPtrGtk.h>
+#include "GRefPtrGtk.h"
 #endif
 #endif
 

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
@@ -28,9 +28,9 @@
 
 #if !USE(GTK4)
 
+#include "GRefPtrGtk.h"
 #include "GtkUtilities.h"
 #include "WebPasteboardProxy.h"
-#include <WebCore/GRefPtrGtk.h>
 #include <WebCore/PasteboardCustomData.h>
 #include <WebCore/SelectionData.h>
 #include <WebCore/SharedBuffer.h>

--- a/Source/WebKit/UIProcess/gtk/GRefPtrGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/GRefPtrGtk.cpp
@@ -22,12 +22,6 @@
 
 #include <gtk/gtk.h>
 
-#if USE(LIBSECRET)
-#define SECRET_WITH_UNSTABLE 1
-#define SECRET_API_SUBJECT_TO_CHANGE 1
-#include <libsecret/secret.h>
-#endif
-
 namespace WTF {
 
 #if USE(GTK4)
@@ -36,10 +30,6 @@ WTF_DEFINE_GREF_TRAITS(GdkEvent, gdk_event_ref, gdk_event_unref)
 #else
 WTF_DEFINE_GREF_TRAITS(GtkTargetList, gtk_target_list_ref, gtk_target_list_unref)
 WTF_DEFINE_GREF_TRAITS(GtkWidgetPath, gtk_widget_path_ref, gtk_widget_path_unref)
-#endif
-
-#if USE(LIBSECRET)
-WTF_DEFINE_GREF_TRAITS(SecretValue, secret_value_ref, secret_value_unref)
 #endif
 
 } // namespace WTF

--- a/Source/WebKit/UIProcess/gtk/GRefPtrGtk.h
+++ b/Source/WebKit/UIProcess/gtk/GRefPtrGtk.h
@@ -1,5 +1,6 @@
 /*
- *  Copyright (C) 2014 Igalia S.L.
+ *  Copyright (C) 2008 Collabora Ltd.
+ *  Copyright (C) 2009 Martin Robinson
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -17,20 +18,22 @@
  *  Boston, MA 02110-1301, USA.
  */
 
-#ifndef GUniquePtrGtk_h
-#define GUniquePtrGtk_h
+#pragma once
 
-#include <gtk/gtk.h>
-#include <wtf/glib/GUniquePtr.h>
+#include <wtf/glib/GRefPtr.h>
+
+typedef struct _GtkWidgetPath GtkWidgetPath;
+typedef struct _GskRenderNode GskRenderNode;
 
 namespace WTF {
 
-#if !USE(GTK4)
-WTF_DEFINE_GPTR_DELETER(GdkEvent, gdk_event_free)
+#if USE(GTK4)
+WTF_DECLARE_GREF_TRAITS(GskRenderNode)
+WTF_DECLARE_GREF_TRAITS(GdkEvent)
+#else
+WTF_DECLARE_GREF_TRAITS(GtkTargetList)
+WTF_DECLARE_GREF_TRAITS(GtkWidgetPath)
 #endif
-
-WTF_DEFINE_GPTR_DELETER(GtkTreePath, gtk_tree_path_free)
 
 } // namespace WTF
 
-#endif

--- a/Source/WebKit/UIProcess/gtk/GUniquePtrGtk.h
+++ b/Source/WebKit/UIProcess/gtk/GUniquePtrGtk.h
@@ -1,6 +1,5 @@
 /*
- *  Copyright (C) 2008 Collabora Ltd.
- *  Copyright (C) 2009 Martin Robinson
+ *  Copyright (C) 2014 Igalia S.L.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -20,25 +19,15 @@
 
 #pragma once
 
-#include <wtf/glib/GRefPtr.h>
-
-typedef struct _GtkWidgetPath GtkWidgetPath;
-typedef struct _SecretValue SecretValue;
-typedef struct _GskRenderNode GskRenderNode;
+#include <gtk/gtk.h>
+#include <wtf/glib/GUniquePtr.h>
 
 namespace WTF {
 
-#if USE(GTK4)
-WTF_DECLARE_GREF_TRAITS(GskRenderNode)
-WTF_DECLARE_GREF_TRAITS(GdkEvent)
-#else
-WTF_DECLARE_GREF_TRAITS(GtkTargetList)
-WTF_DECLARE_GREF_TRAITS(GtkWidgetPath)
+#if !USE(GTK4)
+WTF_DEFINE_GPTR_DELETER(GdkEvent, gdk_event_free)
 #endif
 
-#if USE(LIBSECRET)
-WTF_DECLARE_GREF_TRAITS(SecretValue)
-#endif
+WTF_DEFINE_GPTR_DELETER(GtkTreePath, gtk_tree_path_free)
 
 } // namespace WTF
-

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -28,9 +28,9 @@
 
 #include "APINavigation.h"
 #include "DrawingAreaProxy.h"
+#include "GRefPtrGtk.h"
 #include "WebBackForwardList.h"
 #include "WebPageProxy.h"
-#include <WebCore/GRefPtrGtk.h>
 #include <WebCore/Scrollbar.h>
 #include <WebCore/UserInterfaceLayoutDirection.h>
 

--- a/Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(CONTEXT_MENUS)
 
 #include "APIContextMenuClient.h"
+#include "GUniquePtrGtk.h"
 #include "GtkUtilities.h"
 #include "NativeWebMouseEvent.h"
 #include "WebContextMenuItem.h"
@@ -37,7 +38,6 @@
 #include "WebPageProxy.h"
 #include "WebPopupMenuProxy.h"
 #include "WebProcessProxy.h"
-#include <WebCore/GUniquePtrGtk.h>
 #include <gio/gio.h>
 #include <gtk/gtk.h>
 #include <wtf/text/CString.h>

--- a/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
@@ -26,11 +26,11 @@
 #include "config.h"
 #include "WebDataListSuggestionsDropdownGtk.h"
 
+#include "GUniquePtrGtk.h"
 #include "GtkUtilities.h"
 #include "GtkVersioning.h"
 #include "WebPageProxy.h"
 #include <WebCore/DataListSuggestionInformation.h>
-#include <WebCore/GUniquePtrGtk.h>
 #include <WebCore/IntPoint.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>

--- a/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebPopupMenuProxyGtk.h"
 
+#include "GUniquePtrGtk.h"
 #include "GtkUtilities.h"
 #include "GtkVersioning.h"
 #include "NativeWebMouseEvent.h"

--- a/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.h
+++ b/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.h
@@ -19,8 +19,8 @@
 
 #pragma once
 
+#include "GUniquePtrGtk.h"
 #include "WebPopupMenuProxy.h"
-#include <WebCore/GUniquePtrGtk.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/text/WTFString.h>

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/gtk/WebViewTestGtk.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/gtk/WebViewTestGtk.cpp
@@ -21,7 +21,6 @@
 #include "config.h"
 #include "WebViewTest.h"
 
-#include <WebCore/GUniquePtrGtk.h>
 #include <WebKit/GtkVersioning.h>
 #include <gtk/gtk.h>
 #include <webkit/WebKitWebViewBaseInternal.h>

--- a/Tools/TestWebKitAPI/gtk/PlatformWebViewGtk.cpp
+++ b/Tools/TestWebKitAPI/gtk/PlatformWebViewGtk.cpp
@@ -26,13 +26,11 @@
 #include "config.h"
 #include "PlatformWebView.h"
 
-#include <WebCore/GUniquePtrGtk.h>
 #include <WebKit/GtkVersioning.h>
 #include <WebKit/WKRetainPtr.h>
 #include <WebKit/WKView.h>
 #include <gtk/gtk.h>
 #include <webkit/WebKitWebViewBaseInternal.h>
-#include <wtf/glib/GUniquePtr.h>
 
 namespace TestWebKitAPI {
 


### PR DESCRIPTION
#### 382ae43b09bd64096604ca01f639153e471ee207
<pre>
[GTK] Move GRefPtrGtk and GUniquePtrGtk from WebCore to WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=300788">https://bugs.webkit.org/show_bug.cgi?id=300788</a>

Reviewed by Patrick Griffis.

Canonical link: <a href="https://commits.webkit.org/301548@main">https://commits.webkit.org/301548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38832b098c7658b671fca3d2d8db0047c2554456

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133276 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54528 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37315 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/113003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76649 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76561 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135794 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53064 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/40774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109260 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/49823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19751 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52966 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/58791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->