### PR TITLE
GraphicsContextGLANGLE::getAttachedShaders is unused

### DIFF
--- a/Source/WebCore/html/canvas/WebGLProgram.cpp
+++ b/Source/WebCore/html/canvas/WebGLProgram.cpp
@@ -123,50 +123,48 @@ void WebGLProgram::increaseLinkCount()
     m_infoValid = false;
 }
 
-WebGLShader* WebGLProgram::getAttachedShader(GCGLenum type)
+RefPtr<WebGLShader> WebGLProgram::fragmentShader() const
 {
-    switch (type) {
-    case GraphicsContextGL::VERTEX_SHADER:
-        return m_vertexShader.get();
-    case GraphicsContextGL::FRAGMENT_SHADER:
-        return m_fragmentShader.get();
-    default:
-        return 0;
-    }
+    return m_fragmentShader;
 }
 
-bool WebGLProgram::attachShader(const AbstractLocker&, WebGLShader* shader)
+RefPtr<WebGLShader> WebGLProgram::vertexShader() const
 {
-    if (!shader || !shader->object())
+    return m_vertexShader;
+}
+
+bool WebGLProgram::attachShader(const AbstractLocker&, WebGLShader& shader)
+{
+    if (!shader.object())
         return false;
-    switch (shader->getType()) {
+    switch (shader.getType()) {
     case GraphicsContextGL::VERTEX_SHADER:
         if (m_vertexShader)
             return false;
-        m_vertexShader = shader;
+        m_vertexShader = &shader;
         return true;
     case GraphicsContextGL::FRAGMENT_SHADER:
         if (m_fragmentShader)
             return false;
-        m_fragmentShader = shader;
+        m_fragmentShader = &shader;
         return true;
     default:
         return false;
     }
 }
 
-bool WebGLProgram::detachShader(const AbstractLocker&, WebGLShader* shader)
+bool WebGLProgram::detachShader(const AbstractLocker&, WebGLShader& shader)
 {
-    if (!shader || !shader->object())
+    if (!shader.object())
         return false;
-    switch (shader->getType()) {
+    switch (shader.getType()) {
     case GraphicsContextGL::VERTEX_SHADER:
-        if (m_vertexShader != shader)
+        if (m_vertexShader != &shader)
             return false;
         m_vertexShader = nullptr;
         return true;
     case GraphicsContextGL::FRAGMENT_SHADER:
-        if (m_fragmentShader != shader)
+        if (m_fragmentShader != &shader)
             return false;
         m_fragmentShader = nullptr;
         return true;

--- a/Source/WebCore/html/canvas/WebGLProgram.h
+++ b/Source/WebCore/html/canvas/WebGLProgram.h
@@ -68,9 +68,11 @@ public:
     // Also, we invalidate the cached program info.
     void increaseLinkCount();
 
-    WebGLShader* getAttachedShader(GCGLenum);
-    bool attachShader(const AbstractLocker&, WebGLShader*);
-    bool detachShader(const AbstractLocker&, WebGLShader*);
+    RefPtr<WebGLShader> fragmentShader() const;
+    RefPtr<WebGLShader> vertexShader() const;
+
+    bool attachShader(const AbstractLocker&, WebGLShader&);
+    bool detachShader(const AbstractLocker&, WebGLShader&);
     
     void setRequiredTransformFeedbackBufferCount(int count)
     {

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -943,7 +943,7 @@ void WebGLRenderingContextBase::attachShader(WebGLProgram& program, WebGLShader&
     Locker locker { objectGraphLock() };
     if (!validateWebGLObject("attachShader"_s, program) || !validateWebGLObject("attachShader"_s, shader))
         return;
-    if (!program.attachShader(locker, &shader)) {
+    if (!program.attachShader(locker, shader)) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "attachShader"_s, "shader attachment already has shader"_s);
         return;
     }
@@ -1529,7 +1529,7 @@ void WebGLRenderingContextBase::detachShader(WebGLProgram& program, WebGLShader&
     Locker locker { objectGraphLock() };
     if (!validateWebGLObject("detachShader"_s, program) || !validateWebGLObject("detachShader"_s, shader))
         return;
-    if (!program.detachShader(locker, &shader)) {
+    if (!program.detachShader(locker, shader)) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "detachShader"_s, "shader not attached"_s);
         return;
     }
@@ -1760,18 +1760,12 @@ std::optional<Vector<Ref<WebGLShader>>> WebGLRenderingContextBase::getAttachedSh
         return std::nullopt;
     if (!validateWebGLObject("getAttachedShaders"_s, program))
         return std::nullopt;
-
-    const GCGLenum shaderTypes[] = {
-        GraphicsContextGL::VERTEX_SHADER,
-        GraphicsContextGL::FRAGMENT_SHADER
-    };
-
-    Vector<Ref<WebGLShader>> shaderObjects;
-    for (auto shaderType : shaderTypes) {
-        if (RefPtr shader = program.getAttachedShader(shaderType))
-            shaderObjects.append(shader.releaseNonNull());
-    }
-    return shaderObjects;
+    Vector<Ref<WebGLShader>> result;
+    if (RefPtr vertexShader = program.vertexShader())
+        result.append(vertexShader.releaseNonNull());
+    if (RefPtr fragmentShader = program.fragmentShader())
+        result.append(fragmentShader.releaseNonNull());
+    return result;
 }
 
 GCGLint WebGLRenderingContextBase::getAttribLocation(WebGLProgram& program, const String& name)

--- a/Source/WebCore/inspector/InspectorShaderProgram.cpp
+++ b/Source/WebCore/inspector/InspectorShaderProgram.cpp
@@ -58,14 +58,14 @@ InspectorShaderProgram::InspectorShaderProgram(WebGLProgram& program, InspectorC
     ASSERT(is<WebGLRenderingContextBase>(m_canvas.canvasContext()));
 }
 
-static WebGLShader* shaderForType(WebGLProgram& program, Inspector::Protocol::Canvas::ShaderType shaderType)
+static RefPtr<WebGLShader> shaderForType(WebGLProgram& program, Inspector::Protocol::Canvas::ShaderType shaderType)
 {
     switch (shaderType) {
     case Inspector::Protocol::Canvas::ShaderType::Fragment:
-        return program.getAttachedShader(GraphicsContextGL::FRAGMENT_SHADER);
+        return program.fragmentShader();
 
     case Inspector::Protocol::Canvas::ShaderType::Vertex:
-        return program.getAttachedShader(GraphicsContextGL::VERTEX_SHADER);
+        return program.vertexShader();
 
     // Compute shaders are a WebGPU concept.
     case Inspector::Protocol::Canvas::ShaderType::Compute:
@@ -78,7 +78,7 @@ static WebGLShader* shaderForType(WebGLProgram& program, Inspector::Protocol::Ca
 
 String InspectorShaderProgram::requestShaderSource(Inspector::Protocol::Canvas::ShaderType shaderType)
 {
-    auto* shader = shaderForType(m_program, shaderType);
+    RefPtr shader = shaderForType(m_program, shaderType);
     if (!shader)
         return String();
     return shader->getSource();
@@ -86,7 +86,7 @@ String InspectorShaderProgram::requestShaderSource(Inspector::Protocol::Canvas::
 
 bool InspectorShaderProgram::updateShader(Inspector::Protocol::Canvas::ShaderType shaderType, const String& source)
 {
-    auto* shader = shaderForType(m_program, shaderType);
+    RefPtr shader = shaderForType(m_program, shaderType);
     if (!shader)
         return false;
     auto* context = dynamicDowncast<WebGLRenderingContextBase>(m_canvas.canvasContext());

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -1350,18 +1350,6 @@ std::optional<GraphicsContextGLActiveInfo> GraphicsContextGLANGLE::getActiveUnif
     return GraphicsContextGLActiveInfo { buffer.subspan(0, length), type, size };
 }
 
-void GraphicsContextGLANGLE::getAttachedShaders(PlatformGLObject program, GCGLsizei maxCount, GCGLsizei* count, PlatformGLObject* shaders)
-{
-    if (!program) {
-        addError(GCGLErrorCode::InvalidValue);
-        return;
-    }
-    if (!makeContextCurrent())
-        return;
-
-    GL_GetAttachedShaders(program, maxCount, count, shaders);
-}
-
 int GraphicsContextGLANGLE::getAttribLocation(PlatformGLObject program, const CString& name)
 {
     if (!program)

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -104,7 +104,6 @@ public:
     void generateMipmap(GCGLenum target) final;
     std::optional<GraphicsContextGLActiveInfo> getActiveAttrib(PlatformGLObject program, GCGLuint index) final;
     std::optional<GraphicsContextGLActiveInfo> getActiveUniform(PlatformGLObject program, GCGLuint index) final;
-    void getAttachedShaders(PlatformGLObject program, GCGLsizei maxCount, GCGLsizei* count, PlatformGLObject* shaders);
     GCGLint getAttribLocation(PlatformGLObject, const CString& name) final;
     void getBooleanv(GCGLenum pname, std::span<GCGLboolean> value) final;
     GCGLint getBufferParameteri(GCGLenum target, GCGLenum pname) final;


### PR DESCRIPTION
#### 9c6fbd6dbe714ab5c774d22d0813c1282cf26d93
<pre>
GraphicsContextGLANGLE::getAttachedShaders is unused
<a href="https://bugs.webkit.org/show_bug.cgi?id=300790">https://bugs.webkit.org/show_bug.cgi?id=300790</a>
<a href="https://rdar.apple.com/162676002">rdar://162676002</a>

Reviewed by Mike Wyrzykowski.

Remove the unused GraphicsContextGLANGLE::getAttachedShaders. The info
is already queried from WebGLProgram.

Simplify the trivial functions related to this in WebProgram.

* Source/WebCore/html/canvas/WebGLProgram.cpp:
(WebCore::WebGLProgram::fragmentShader const):
(WebCore::WebGLProgram::vertexShader const):
(WebCore::WebGLProgram::attachShader):
(WebCore::WebGLProgram::detachShader):
(WebCore::WebGLProgram::getAttachedShader): Deleted.
* Source/WebCore/html/canvas/WebGLProgram.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::attachShader):
(WebCore::WebGLRenderingContextBase::detachShader):
(WebCore::WebGLRenderingContextBase::getAttachedShaders):
* Source/WebCore/inspector/InspectorShaderProgram.cpp:
(WebCore::shaderForType):
(WebCore::InspectorShaderProgram::requestShaderSource):
(WebCore::InspectorShaderProgram::updateShader):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::getActiveUniform):
(WebCore::GraphicsContextGLANGLE::getAttachedShaders): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:

Canonical link: <a href="https://commits.webkit.org/301610@main">https://commits.webkit.org/301610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/854c326c71470bdbd7da4fc3878b1df957d30b21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78076 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c0daca6-408a-41e4-91b6-7d993190bdb3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96180 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64272 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113005 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76652 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/528a435c-e9b7-4dd9-b1e1-16998f44589e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31182 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76562 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107112 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135795 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40776 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104674 "Failed to checkout and rebase branch from PR 52381") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104368 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26652 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49829 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28160 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50456 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52967 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58792 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52277 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55618 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53998 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->