### PR TITLE
Stream IPC synchronous sends should use wait_signal strategy

### DIFF
--- a/PerformanceTests/Canvas/WebGL-getError.html
+++ b/PerformanceTests/Canvas/WebGL-getError.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/runner.js"></script>
+<script>
+var canvas = document.createElement("canvas");
+var gl = canvas.getContext("webgl2");
+function testIteration()
+{
+    for (let i = 0; i < 5000; ++i) {
+        if (gl.getError() != gl.NO_ERROR)
+            throw "Unexpected result";
+    }    
+}
+testIteration();
+PerfTestRunner.measureRunsPerSecond({
+    description: 'Measures performance of WebGL getError() call (e.g. measures synchronous IPC).',
+    run: testIteration
+});
+</script>
+</body>
+</html>

--- a/Source/WebKit/Platform/IPC/IPCSemaphore.h
+++ b/Source/WebKit/Platform/IPC/IPCSemaphore.h
@@ -66,6 +66,7 @@ public:
     void signal();
     bool wait();
     bool waitFor(Timeout);
+    bool waitForAfterSignal(Semaphore& signal, Timeout waitTimeout);
 
 #if PLATFORM(COCOA)
     explicit Semaphore(MachSendRight&&);

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -139,7 +139,7 @@ void StreamClientConnection::invalidate()
 
 void StreamClientConnection::wakeUpServer(WakeUpServer wakeUpResult)
 {
-    if (wakeUpResult == WakeUpServer::No && !m_batchSize)
+    if (resolveWakeUpServer(wakeUpResult) == WakeUpServer::No)
         return;
     m_buffer.wakeUpServer();
     m_batchSize = 0;
@@ -147,10 +147,12 @@ void StreamClientConnection::wakeUpServer(WakeUpServer wakeUpResult)
 
 void StreamClientConnection::wakeUpServerBatched(WakeUpServer wakeUpResult)
 {
-    if (wakeUpResult == WakeUpServer::Yes || m_batchSize) {
-        m_batchSize++;
-        if (m_batchSize >= m_maxBatchSize)
-            wakeUpServer(WakeUpServer::Yes);
+    if (resolveWakeUpServer(wakeUpResult) == WakeUpServer::No)
+        return;
+    m_batchSize++;
+    if (m_batchSize >= m_maxBatchSize) {
+        m_buffer.wakeUpServer();
+        m_batchSize = 0;
     }
 }
 

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -129,6 +129,7 @@ private:
     using WakeUpServer = StreamClientConnectionBuffer::WakeUpServer;
     void wakeUpServerBatched(WakeUpServer);
     void wakeUpServer(WakeUpServer);
+    WakeUpServer resolveWakeUpServer(WakeUpServer);
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     static uintptr_t generateSignpostIdentifier();
@@ -327,9 +328,8 @@ std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection:
             return std::nullopt;
 
         auto wakeUpResult = m_buffer.release(messageEncoder.size());
-        wakeUpServer(wakeUpResult);
         if constexpr (T::isReplyStreamEncodable) {
-            auto replySpan = m_buffer.tryAcquireAll(timeout);
+            auto replySpan = m_buffer.tryAcquireAll(resolveWakeUpServer(wakeUpResult), timeout);
             if (!replySpan)
                 return makeUnexpected(Error::FailedToAcquireReplyBufferSpan);
 
@@ -338,8 +338,10 @@ std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection:
                 ASSERT(decoder->messageName() == MessageName::SyncMessageReply || decoder->messageName() == MessageName::CancelSyncMessageReply);
                 return decoder;
             }
-        } else
+        } else {
+            wakeUpServer(wakeUpResult);
             m_buffer.resetClientOffset();
+        }
 
         return m_connection->waitForSyncReply(syncRequestID, T::name(), timeout, { });
     }();
@@ -387,6 +389,11 @@ inline void StreamClientConnection::sendProcessOutOfStreamMessage(std::span<uint
     auto result = m_buffer.release(encoder.size());
     UNUSED_VARIABLE(result);
     m_batchSize = 0;
+}
+
+inline StreamClientConnection::WakeUpServer StreamClientConnection::resolveWakeUpServer(WakeUpServer wakeUpServer)
+{
+    return (wakeUpServer == WakeUpServer::No && !m_batchSize) ? WakeUpServer::No : WakeUpServer::Yes;
 }
 
 }

--- a/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
@@ -36,11 +36,11 @@ public:
     static std::optional<StreamClientConnectionBuffer> create(unsigned dataSizeLog2);
     StreamClientConnectionBuffer(StreamClientConnectionBuffer&&) = default;
     StreamClientConnectionBuffer& operator=(StreamClientConnectionBuffer&&) = default;
+    enum class WakeUpServer : bool { No, Yes };
 
     std::optional<std::span<uint8_t>> tryAcquire(Timeout);
-    std::optional<std::span<uint8_t>> tryAcquireAll(Timeout);
+    std::optional<std::span<uint8_t>> tryAcquireAll(WakeUpServer, Timeout);
 
-    enum class WakeUpServer : bool { No, Yes };
     WakeUpServer release(size_t writeSize);
     void resetClientOffset();
     std::span<uint8_t> alignedMutableSpan(size_t offset, size_t limit);
@@ -129,7 +129,7 @@ inline std::optional<std::span<uint8_t>> StreamClientConnectionBuffer::tryAcquir
     return std::nullopt;
 }
 
-inline std::optional<std::span<uint8_t>> StreamClientConnectionBuffer::tryAcquireAll(Timeout timeout)
+inline std::optional<std::span<uint8_t>> StreamClientConnectionBuffer::tryAcquireAll(WakeUpServer wakeUpServer, Timeout timeout)
 {
     // This would mean we try to send messages after a timeout. It is a programming error.
     // Since the value is trusted, we only assert.
@@ -147,7 +147,15 @@ inline std::optional<std::span<uint8_t>> StreamClientConnectionBuffer::tryAcquir
         if (!clientLimit && (clientOffset == ClientOffset::serverIsSleepingTag || !clientOffset))
             break;
 
-        if (!m_semaphores || !m_semaphores->clientWait.waitFor(timeout))
+        if (!m_semaphores)
+            return std::nullopt;
+        bool waitResult = false;
+        if (wakeUpServer == WakeUpServer::Yes) {
+            waitResult = m_semaphores->clientWait.waitForAfterSignal(m_semaphores->wakeUp, timeout);
+            wakeUpServer = WakeUpServer::No;
+        } else
+            waitResult = m_semaphores->clientWait.waitFor(timeout);
+        if (!waitResult)
             return std::nullopt;
         if (timeout.didTimeOut())
             return std::nullopt;

--- a/Source/WebKit/Platform/IPC/darwin/IPCSemaphoreDarwin.cpp
+++ b/Source/WebKit/Platform/IPC/darwin/IPCSemaphoreDarwin.cpp
@@ -87,6 +87,15 @@ bool Semaphore::waitFor(Timeout timeout)
     return ret == KERN_SUCCESS;
 }
 
+bool Semaphore::waitForAfterSignal(Semaphore& signal, Timeout timeout)
+{
+    Seconds waitTime = timeout.secondsUntilDeadline();
+    auto seconds = waitTime.secondsAs<unsigned>();
+    auto ret = semaphore_timedwait_signal(m_semaphore, signal.m_semaphore, { seconds, static_cast<clock_res_t>(waitTime.nanosecondsAs<uint64_t>() - seconds * NSEC_PER_SEC) });
+    ASSERT(ret == KERN_SUCCESS || ret == KERN_OPERATION_TIMED_OUT || ret == KERN_TERMINATED || ret == KERN_ABORTED);
+    return ret == KERN_SUCCESS;
+}
+
 MachSendRight Semaphore::createSendRight() const
 {
     return MachSendRight::create(m_semaphore);

--- a/Source/WebKit/Platform/IPC/unix/IPCSemaphoreUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/IPCSemaphoreUnix.cpp
@@ -123,6 +123,12 @@ bool Semaphore::waitFor(Timeout timeout)
 #endif
 }
 
+bool Semaphore::waitForAfterSignal(Semaphore& signaled, Timeout timeout)
+{
+    signaled.signal();
+    return waitFor(timeout);
+}
+
 UnixFileDescriptor Semaphore::duplicateDescriptor() const
 {
     return m_fd.duplicate();

--- a/Source/WebKit/Platform/IPC/win/IPCSemaphoreWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/IPCSemaphoreWin.cpp
@@ -76,9 +76,17 @@ bool Semaphore::waitFor(Timeout timeout)
     return WAIT_OBJECT_0 == WaitForSingleObject(m_semaphoreHandle.get(), milliseconds);
 }
 
+bool Semaphore::waitForAfterSignal(Semaphore& signaled, Timeout timeout)
+{
+    signaled.signal();
+    return waitFor(timeout);
+}
+
 void Semaphore::destroy()
 {
     m_semaphoreHandle = { };
 }
+
+
 
 } // namespace IPC

--- a/Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb
@@ -394,6 +394,7 @@
         MSC_pid_for_task
         MSC_semaphore_signal_trap
         MSC_semaphore_timedwait_trap
+        MSC_semaphore_timedwait_signal_trap
         MSC_semaphore_wait_trap
         MSC_semaphore_wait_signal_trap
         MSC_syscall_thread_switch

--- a/Source/WebKit/Shared/Sandbox/iOS/networking-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/networking-defines.sb
@@ -367,6 +367,7 @@
         MSC_mk_timer_destroy
         MSC_semaphore_signal_trap
         MSC_semaphore_timedwait_trap
+        MSC_semaphore_timedwait_signal_trap
         MSC_semaphore_wait_trap
         MSC_swtch_pri
         MSC_syscall_thread_switch

--- a/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
@@ -459,6 +459,7 @@
         MSC_mk_timer_destroy
         MSC_semaphore_signal_trap
         MSC_semaphore_timedwait_trap
+        MSC_semaphore_timedwait_signal_trap
         MSC_semaphore_wait_trap
         MSC_swtch_pri
         MSC_syscall_thread_switch

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1878,6 +1878,7 @@
     MSC_mk_timer_destroy
     MSC_semaphore_signal_trap
     MSC_semaphore_timedwait_trap
+    MSC_semaphore_timedwait_signal_trap
     MSC_semaphore_wait_trap
     MSC_syscall_thread_switch
     MSC_task_name_for_pid


### PR DESCRIPTION
#### e87e7d74daa4fde1b762ecd86f9f9520819ad592
<pre>
Stream IPC synchronous sends should use wait_signal strategy
<a href="https://bugs.webkit.org/show_bug.cgi?id=300796">https://bugs.webkit.org/show_bug.cgi?id=300796</a>
<a href="https://rdar.apple.com/162680463">rdar://162680463</a>

Reviewed by NOBODY (OOPS!).

Use semaphore_wait_signal call to signal and wait for synchronous
messages. This reduces the kernel overhead and lets the kernel know
that it can schedule the receiver next and the sender is not in a
hurry.

* PerformanceTests/Canvas/WebGL-getError.html: Added.
* Source/WebKit/Platform/IPC/IPCSemaphore.h:
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::wakeUpServer):
(IPC::StreamClientConnection::wakeUpServerBatched):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::trySendSyncStream):
(IPC::StreamClientConnection::resolveWakeUpServer):
* Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h:
(IPC::StreamClientConnectionBuffer::tryAcquireAll):
* Source/WebKit/Platform/IPC/darwin/IPCSemaphoreDarwin.cpp:
(IPC::Semaphore::waitForAfterSignal):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e87e7d74daa4fde1b762ecd86f9f9520819ad592

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78205 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/23c77860-e727-4c67-9284-bb09b02e0181) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96288 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64381 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/58c1fb52-497a-46ab-88d2-6dfa98c99da3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113160 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76761 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/445ebb69-e161-48a4-87a9-6d06e87792d5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36338 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76727 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135967 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40926 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104794 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53707 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109482 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104496 "Found 2 new API test failures: WebKitGTK/TestLoaderClient:/webkit/WebKitWebPage/get-uri, WebKitGTK/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49973 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28307 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50633 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53141 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58954 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52423 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55757 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54158 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->