### PR TITLE
[MiniBrowser] Fix parameter passing to WebKitTestRunner.

### DIFF
--- a/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
+++ b/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
@@ -58,15 +58,13 @@ def main(argv):
     # URL. convert_arg_line_to_args() returns a list containing a single
     # string, so it needs to be split again.
     browser_args = [decode(s, "utf-8") for s in option_parser.convert_arg_line_to_args(' '.join(args))[0].split()]
+    if options.url:
+        browser_args.append(options.url)
     if options.platform == "mac" and options.site_isolation is not None:
         browser_args.append('--force-site-isolation')
         browser_args.append('YES' if options.site_isolation else 'NO')
     if options.web_inspector:
         browser_args.append('--web-inspector')
-    if options.url:
-        if options.platform == "mac":
-            browser_args.append('--url')
-        browser_args.append(options.url)
 
     try:
         port = factory.PortFactory(Host()).get(options.platform, options=options)


### PR DESCRIPTION
#### 235ac443b41f7d63d70ad42f83f58da00d75b063
<pre>
[MiniBrowser] Fix parameter passing to WebKitTestRunner.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300809">https://bugs.webkit.org/show_bug.cgi?id=300809</a>
<a href="https://rdar.apple.com/162689631">rdar://162689631</a>

Reviewed by Sihui Liu.

We can pass debugging flag like this before:

$ run-minibrowser -WebCoreLogging Layout

But it regressed at 299873@main. This is because we need to pass as is to WKTR.

At 299873@main, intension was to allow this kind of order:

$ run-minibrowser --site-isolation URL
$ run-minibrowser URL --site-isolation

To make this happen, we need to add `--url` before URL to WKTR. For known arguments,
this is perfect. But this doesn&apos;t work for the unknown arguments for python script.

So to support this kind of arguments, we cannot write like this:

$ run-minibrowser -WebCoreLogging Layout URL

URL must come before debug flags.

* Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py:
(main):

Canonical link: <a href="https://commits.webkit.org/301582@main">https://commits.webkit.org/301582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59c993dc044cfd5d190dc15c6cf043e4c0b20e5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133321 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78105 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e927aa9c-b9bb-42e4-983e-690f1689c74c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96207 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8e45fd2-8a73-4eed-a7a1-8ed2610aa7e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76683 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/acb582f2-8fa1-412d-a12d-0cd45ea0290e) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/125730 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31219 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76608 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135841 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40812 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104703 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109317 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104403 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26639 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49855 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28194 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50498 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53009 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52312 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55652 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->