### PR TITLE
Add console message tests for Web Inspector with Web Worker.

### DIFF
--- a/LayoutTests/http/tests/inspector/console/message-from-iframe.html
+++ b/LayoutTests/http/tests/inspector/console/message-from-iframe.html
@@ -1,5 +1,13 @@
 <script src="/inspector/resources/inspector-test.js"></script>
 <script>
+    // Utilities for page code.
+    function addIFrame(url) {
+        const iframe = document.createElement("iframe");
+        iframe.src = url;
+        iframe.onload = () => console.log("iframe is loaded in " + location.href);
+        document.body.appendChild(iframe);
+    }
+
     function test() {
         // The purpose of these tests are to test that Web Inspector should receive console messages generated from various iframe tree correctly.
 
@@ -22,15 +30,6 @@
 
             InspectorTest.evaluateInPage(func);
         }
-        // Utilities for page code.
-        InspectorTest.evaluateInPage(`
-            function addIFrame(url) {
-                const iframe = document.createElement("iframe");
-                iframe.src = url;
-                iframe.onload = () => console.log("iframe is loaded in " + location.href);
-                document.body.appendChild(iframe);
-            }
-        `);
 
         suite.addTestCase({
             name: "MessageFromIFrame.SameOriginIFrame",

--- a/LayoutTests/http/tests/inspector/console/message-from-worker-expected.txt
+++ b/LayoutTests/http/tests/inspector/console/message-from-worker-expected.txt
@@ -1,0 +1,18 @@
+CONSOLE MESSAGE: iframe is loaded in http://127.0.0.1:8000/inspector/console/message-from-worker.html [same-origin]
+CONSOLE MESSAGE: iframe is loaded in http://127.0.0.1:8000/inspector/console/message-from-worker.html [cross-origin]
+
+== Running test suite: MessageFromWorker
+-- Running test case: MessageFromWorker.WorkerInSamePage
+Got message: Worker started
+Got message: Message received in the worker: Hello
+
+-- Running test case: MessageFromWorker.WorkerInSameOriginIFrame
+Got message: iframe is loaded in http://127.0.0.1:8000/inspector/console/message-from-worker.html [same-origin]
+Got message: Worker started
+Got message: Message received in the worker: Hello from http://127.0.0.1:8000/inspector/console/resources/worker-in-iframe.html
+
+-- Running test case: MessageFromWorker.WorkerInCrossOriginIFrame
+Got message: iframe is loaded in http://127.0.0.1:8000/inspector/console/message-from-worker.html [cross-origin]
+Got message: Worker started
+Got message: Message received in the worker: Hello from http://localhost:8000/inspector/console/resources/worker-in-iframe.html
+

--- a/LayoutTests/http/tests/inspector/console/message-from-worker.html
+++ b/LayoutTests/http/tests/inspector/console/message-from-worker.html
@@ -1,0 +1,60 @@
+<script src="/inspector/resources/inspector-test.js"></script>
+<script>
+    // Utilities for page code.
+    function addIFrame(url, testId) {
+        const iframe = document.createElement("iframe");
+        iframe.src = url;
+        iframe.onload = () => console.log("iframe is loaded in " + location.href + " [" + testId + "]");
+        document.body.appendChild(iframe);
+    }
+
+    function test() {
+        // The purpose of these tests:
+        // Web Inspector should receive console messages generated from workers correctly.
+
+        const suite = InspectorTest.createAsyncSuite("MessageFromWorker");
+
+        // Utilities for test code.
+        let callback = () => {};
+        WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, (event) => {
+            InspectorTest.log(`Got message: ${event.data.message._messageText}`);
+            callback();
+        });
+
+        function runMessageTest(resolve, expected, func) {
+            let seen = 0;
+
+            callback = () => {
+                if (++seen === expected)
+                    resolve();
+            };
+
+            InspectorTest.evaluateInPage(func);
+        }
+
+        suite.addTestCase({
+            name: "MessageFromWorker.WorkerInSamePage",
+            description: "console message comming from worker in the page",
+            test: (resolve) => runMessageTest(resolve, 2, `
+                const worker1 = new Worker('resources/worker.js');
+                worker1.postMessage('Hello');
+            `),
+        });
+
+        suite.addTestCase({
+            name: "MessageFromWorker.WorkerInSameOriginIFrame",
+            description: "console message comming from worker in same origin iframe",
+            test: (resolve) => runMessageTest(resolve, 3, `addIFrame('resources/worker-in-iframe.html', 'same-origin')`),
+        });
+
+        suite.addTestCase({
+            name: "MessageFromWorker.WorkerInCrossOriginIFrame",
+            description: "console message comming from worker in cross origin iframe",
+            test: (resolve) => runMessageTest(resolve, 3, `addIFrame('http://localhost:8000/inspector/console/resources/worker-in-iframe.html', 'cross-origin')`),
+        });
+
+        suite.runTestCasesAndFinish();
+    }
+</script>
+
+<body onload="runTest()"></body>

--- a/LayoutTests/http/tests/inspector/console/resources/worker-in-iframe.html
+++ b/LayoutTests/http/tests/inspector/console/resources/worker-in-iframe.html
@@ -1,0 +1,10 @@
+<h1>Iframe invoking Worker</h1>
+<script>
+    window.addEventListener('load', () => {
+        // Make sure worker is created after load event is handled in the parent.
+        setTimeout(() => {
+            const worker1 = new Worker('worker.js');
+            worker1.postMessage(`Hello from ${location.href}`);
+        }, 0);
+    });
+</script>

--- a/LayoutTests/http/tests/inspector/console/resources/worker.js
+++ b/LayoutTests/http/tests/inspector/console/resources/worker.js
@@ -1,0 +1,5 @@
+console.log(`Worker started`);
+
+self.addEventListener('message', (event) => {
+    console.log(`Message received in the worker: ${event.data}`);
+});


### PR DESCRIPTION
#### 0932a6f9958165005e0f402448f473d8ee92ee46
<pre>
Add console message tests for Web Inspector with Web Worker.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300708">https://bugs.webkit.org/show_bug.cgi?id=300708</a>
<a href="https://rdar.apple.com/162555035">rdar://162555035</a>

Reviewed by BJ Burg.

Test for console message that ensures messages are received by Web Inspector from:
- Worker created in same/cross origin iframe

* LayoutTests/http/tests/inspector/console/message-from-iframe.html:
* LayoutTests/http/tests/inspector/console/message-from-worker-expected.txt: Added.
* LayoutTests/http/tests/inspector/console/message-from-worker.html: Added.
* LayoutTests/http/tests/inspector/console/resources/worker-in-iframe.html: Added.
* LayoutTests/http/tests/inspector/console/resources/worker.js: Added.

Canonical link: <a href="https://commits.webkit.org/301903@main">https://commits.webkit.org/301903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b94f101efb8a46d11f72bb66f3cdefa54accbae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78116 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df403047-e65e-47a9-9218-5d25207c0ca1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96215 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64306 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b15cab8f-425f-4b7f-9bae-0884c49f442e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113050 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76688 "Found 3 new API test failures: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp, WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak, WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d26410a-5dcb-470f-9e09-1d9db72fb916) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31228 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76624 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107173 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135854 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104715 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104414 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26816 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49865 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28201 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50513 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53026 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52325 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55664 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->