### PR TITLE
[iOS] iCloud Drive: Backing out from “Take a photo/video” upload causes the upload button to stop working

### DIFF
--- a/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-camera-via-menu-expected.txt
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-camera-via-menu-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that presenting a menu and then the camera for file inputs correctly dispatches blur and focus events.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+BLUR
+FOCUS
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-camera-via-menu.html
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-camera-via-menu.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true shouldHandleRunOpenPanel=false ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="resources/window-blur-focus-utils.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("blur", (e) => {
+    debug("BLUR");
+});
+
+addEventListener("focus", (e) => {
+    debug("FOCUS");
+});
+
+addEventListener("load", async () => {
+    description("This test verifies that presenting a menu and then the camera for file inputs correctly dispatches blur and focus events.")
+
+    await UIHelper.activateElement(fileInput);
+    await UIHelper.waitForContextMenuToShow();
+    await waitForWindowBlur();
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.chooseMenuAction("Take Photo or Video");
+    await UIHelper.dismissFilePicker();
+    await waitForWindowFocus();
+    await UIHelper.ensurePresentationUpdate();
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<input id="fileInput" type="file">
+</body>
+</html>

--- a/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-document-picker-expected.txt
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-document-picker-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that presenting a document picker for file inputs correctly dispatches blur and focus events.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+BLUR
+FOCUS
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-document-picker-via-menu-expected.txt
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-document-picker-via-menu-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that presenting a menu and then a document picker for file inputs correctly dispatches blur and focus events.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+BLUR
+FOCUS
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-document-picker-via-menu.html
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-document-picker-via-menu.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true shouldHandleRunOpenPanel=false ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="resources/window-blur-focus-utils.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("blur", (e) => {
+    debug("BLUR");
+});
+
+addEventListener("focus", (e) => {
+    debug("FOCUS");
+});
+
+addEventListener("load", async () => {
+    description("This test verifies that presenting a menu and then a document picker for file inputs correctly dispatches blur and focus events.");
+
+    await UIHelper.activateElement(fileInput);
+    await UIHelper.waitForContextMenuToShow();
+    await UIHelper.chooseMenuAction("Choose File");
+    await waitForWindowBlur();
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.dismissFilePicker();
+    await waitForWindowFocus();
+    await UIHelper.ensurePresentationUpdate();
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<input id="fileInput" type="file">
+</body>
+</html>

--- a/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-document-picker.html
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-document-picker.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true shouldHandleRunOpenPanel=false ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="resources/window-blur-focus-utils.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("blur", (e) => {
+    debug("BLUR");
+});
+
+addEventListener("focus", (e) => {
+    debug("FOCUS");
+});
+
+addEventListener("load", async () => {
+    description("This test verifies that presenting a document picker for file inputs correctly dispatches blur and focus events.");
+
+    await UIHelper.activateElement(fileInputDocumentPickerOnly);
+    await UIHelper.waitForViewControllerToShow();
+    await waitForWindowBlur();
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.dismissFilePicker();
+    await waitForWindowFocus();
+    await UIHelper.ensurePresentationUpdate();
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<input id="fileInputDocumentPickerOnly" type="file" accept=".txt">
+</body>
+</html>

--- a/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-menu-expected.txt
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-menu-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that presenting and dismissing the menu for file inputs correctly dispatches blur and focus events.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+BLUR
+FOCUS
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-menu.html
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-menu.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true shouldHandleRunOpenPanel=false ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="resources/window-blur-focus-utils.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("blur", (e) => {
+    debug("BLUR");
+});
+
+addEventListener("focus", (e) => {
+    debug("FOCUS");
+});
+
+addEventListener("load", async () => {
+    description("This test verifies that presenting and dismissing the menu for file inputs correctly dispatches blur and focus events.");
+
+    await UIHelper.activateElement(fileInput);
+    await UIHelper.waitForContextMenuToShow();
+    await waitForWindowBlur();
+    await UIHelper.activateAt(0, 0);
+    await UIHelper.waitForContextMenuToHide();
+    await waitForWindowFocus();
+    await UIHelper.ensurePresentationUpdate();
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<input id="fileInput" type="file">
+</body>
+</html>

--- a/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-photo-picker-via-menu-expected.txt
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-photo-picker-via-menu-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that presenting a menu and then a photo picker for file inputs correctly dispatches blur and focus events.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+BLUR
+FOCUS
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-photo-picker-via-menu.html
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-photo-picker-via-menu.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true shouldHandleRunOpenPanel=false ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="resources/window-blur-focus-utils.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("blur", (e) => {
+    debug("BLUR");
+});
+
+addEventListener("focus", (e) => {
+    debug("FOCUS");
+});
+
+addEventListener("load", async () => {
+    description("This test verifies that presenting a menu and then a photo picker for file inputs correctly dispatches blur and focus events.");
+
+    await UIHelper.activateElement(fileInput);
+    await UIHelper.waitForContextMenuToShow();
+    await waitForWindowBlur();
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.chooseMenuAction("Photo Library");
+    await UIHelper.dismissFilePicker();
+    await waitForWindowFocus();
+    await UIHelper.ensurePresentationUpdate();
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<input id="fileInput" type="file">
+</body>
+</html>

--- a/LayoutTests/fast/forms/ios/resources/window-blur-focus-utils.js
+++ b/LayoutTests/fast/forms/ios/resources/window-blur-focus-utils.js
@@ -1,0 +1,27 @@
+async function waitForWindowBlur() {
+    return new Promise((resolve) => {
+        if (!document.hasFocus())
+            resolve();
+
+        const handleBlur = () => {
+            window.removeEventListener('blur', handleBlur);
+            resolve();
+        };
+
+        window.addEventListener('blur', handleBlur);
+    });
+}
+
+async function waitForWindowFocus() {
+    return new Promise((resolve) => {
+        if (document.hasFocus())
+            resolve();
+
+        const handleFocus = () => {
+            window.removeEventListener('focus', handleFocus);
+            resolve();
+        };
+
+        window.addEventListener('focus', handleFocus);
+    });
+}

--- a/LayoutTests/platform/ios-18/TestExpectations
+++ b/LayoutTests/platform/ios-18/TestExpectations
@@ -89,6 +89,10 @@ imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of
 
 imported/w3c/web-platform-tests/html/semantics/popovers/light-dismiss-event-ordering.html [ Pass ]
 
+# webkit.org/b/268568 [iOS] Assertion failure causing fast/forms/ios/file-upload-panel-capture.html to consistently crash. (268568) -[DOCWeakProxy forwardingTargetForSelector:]
+fast/forms/ios/file-upload-panel-blur-focus-document-picker.html [ Pass Crash ]
+fast/forms/ios/file-upload-panel-blur-focus-document-picker-via-menu.html [ Pass Crash ]
+
 # Tests which pass only with form-control-refresh enabled
 fast/forms/form-control-refresh [ Skip ]
 

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -859,6 +859,19 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static waitForViewControllerToShow()
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`
+                (function() {
+                    uiController.didPresentViewControllerCallback = () => uiController.uiScriptComplete();
+                })()`, resolve);
+        });
+    }
+
     static waitForContextMenuToShow()
     {
         if (!this.isWebKit2() || !this.isIOSFamily())

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -9667,7 +9667,10 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 - (void)fileUploadPanelDidDismiss:(WKFileUploadPanel *)fileUploadPanel
 {
     ASSERT(_fileUploadPanel.get() == fileUploadPanel);
-    
+
+    if ([self window] && ![[self window] firstResponder])
+        [self becomeFirstResponder];
+
     [_fileUploadPanel setDelegate:nil];
     _fileUploadPanel = nil;
 }

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -298,6 +298,8 @@ interface UIScriptController {
     attribute object willPresentPopoverCallback;
     attribute object didDismissPopoverCallback;
 
+    attribute object didPresentViewControllerCallback;
+
     attribute object willBeginZoomingCallback;
     attribute object didEndZoomingCallback;
 

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptContext.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptContext.h
@@ -68,6 +68,7 @@ typedef enum  {
     CallbackTypeDidShowContactPicker,
     CallbackTypeDidHideContactPicker,
     CallbackTypeWillStartInputSession,
+    CallbackTypeDidPresentViewController,
     CallbackTypeNonPersistent = firstNonPersistentCallbackID
 } CallbackType;
 

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -438,6 +438,9 @@ public:
     virtual void setWillPresentPopoverCallback(JSValueRef);
     JSValueRef willPresentPopoverCallback() const;
 
+    virtual void setDidPresentViewControllerCallback(JSValueRef);
+    JSValueRef didPresentViewControllerCallback() const;
+
     virtual void setDidEndScrollingCallback(JSValueRef);
     JSValueRef didEndScrollingCallback() const;
 

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -280,6 +280,16 @@ JSValueRef UIScriptController::didDismissPopoverCallback() const
     return m_context->callbackWithID(CallbackTypeDidDismissPopover);
 }
 
+void UIScriptController::setDidPresentViewControllerCallback(JSValueRef callback)
+{
+    m_context->registerCallback(callback, CallbackTypeDidPresentViewController);
+}
+
+JSValueRef UIScriptController::didPresentViewControllerCallback() const
+{
+    return m_context->callbackWithID(CallbackTypeDidPresentViewController);
+}
+
 void UIScriptController::setDidShowContactPickerCallback(JSValueRef callback)
 {
     m_context->registerCallback(callback, CallbackTypeDidShowContactPicker);

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
@@ -46,6 +46,7 @@
 @property (nonatomic, copy) void (^willStartInputSessionCallback)(void);
 @property (nonatomic, copy) void (^willPresentPopoverCallback)(void);
 @property (nonatomic, copy) void (^didDismissPopoverCallback)(void);
+@property (nonatomic, copy) void (^didPresentViewControllerCallback)(void);
 @property (nonatomic, copy) void (^didEndScrollingCallback)(void);
 @property (nonatomic, copy) void (^rotationDidEndCallback)(void);
 @property (nonatomic, copy) void (^windowTapRecognizedCallback)(void);

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -225,6 +225,7 @@ IGNORE_WARNINGS_END
     self.willStartInputSessionCallback = nil;
     self.willPresentPopoverCallback = nil;
     self.didDismissPopoverCallback = nil;
+    self.didPresentViewControllerCallback = nil;
     self.didEndScrollingCallback = nil;
     self.rotationDidEndCallback = nil;
     self.windowTapRecognizedCallback = nil;
@@ -559,6 +560,9 @@ static bool isQuickboardViewController(UIViewController *viewController)
 
 - (void)_didPresentViewController:(UIViewController *)viewController
 {
+    if (self.didPresentViewControllerCallback)
+        self.didPresentViewControllerCallback();
+
     if (isQuickboardViewController(viewController))
         [self _invokeShowKeyboardCallbackIfNecessary];
 }

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -175,6 +175,7 @@ private:
     void setWillStartInputSessionCallback(JSValueRef) override;
     void setWillPresentPopoverCallback(JSValueRef) override;
     void setDidDismissPopoverCallback(JSValueRef) override;
+    void setDidPresentViewControllerCallback(JSValueRef) override;
     void setDidEndScrollingCallback(JSValueRef) override;
     void clearAllCallbacks() override;
 

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1303,6 +1303,16 @@ void UIScriptControllerIOS::setDidDismissPopoverCallback(JSValueRef callback)
     }).get();
 }
 
+void UIScriptControllerIOS::setDidPresentViewControllerCallback(JSValueRef callback)
+{
+    UIScriptController::setDidPresentViewControllerCallback(callback);
+    webView().didPresentViewControllerCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
+        if (!m_context)
+            return;
+        m_context->fireCallback(CallbackTypeDidPresentViewController);
+    }).get();
+}
+
 JSObjectRef UIScriptControllerIOS::rectForMenuAction(JSStringRef jsAction) const
 {
     auto action = adoptCF(JSStringCopyCFString(kCFAllocatorDefault, jsAction));


### PR DESCRIPTION
#### 9b6f2b40feaedb2611696525b652acf8572a6831
<pre>
[iOS] iCloud Drive: Backing out from “Take a photo/video” upload causes the upload button to stop working
<a href="https://bugs.webkit.org/show_bug.cgi?id=300806">https://bugs.webkit.org/show_bug.cgi?id=300806</a>
<a href="https://rdar.apple.com/157789623">rdar://157789623</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

icloud.com disables their upload button when the file input is clicked, but only
re-enables the button when &quot;focus&quot; is dispatched on the window. The photo picker
and camera view do not take first responder from the content view, which means
that &quot;blur&quot; and &quot;focus&quot; events are not dispatched. In contrast, the document picker
does take first responder. Additionally, the same issue is encountered when
showing the context menu for the file input and dismissing it without selecting a
picker.

Fix by resigning and restoring first responder when the menu and/or picker are
presented/dismissed. This ensures &quot;focus&quot; and &quot;blur&quot; events are dispatched
correctly. The overall behavior now aligns with macOS and Android.

Add tests for various file picker scenarios:

1. Presenting and dismissing the menu without presenting any picker.
2. Presenting the menu and then using the document picker.
3. Presenting the menu and then using the photo picker.
4. Presenting the menu and then using the camera.
5. Presenting the document picker directly.

* LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-camera-via-menu-expected.txt: Added.
* LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-camera-via-menu.html: Added.
* LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-document-picker-expected.txt: Added.
* LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-document-picker-via-menu-expected.txt: Added.
* LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-document-picker-via-menu.html: Added.
* LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-document-picker.html: Added.
* LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-menu-expected.txt: Added.
* LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-menu.html: Added.
* LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-photo-picker-via-menu-expected.txt: Added.
* LayoutTests/fast/forms/ios/file-upload-panel-blur-focus-photo-picker-via-menu.html: Added.
* LayoutTests/fast/forms/ios/resources/window-blur-focus-utils.js: Added.
(async waitForWindowBlur):
(async waitForWindowFocus):
* LayoutTests/platform/ios-18/TestExpectations:
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.waitForViewControllerToShow):

Add a helper to wait for view controller presentation.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView fileUploadPanelDidDismiss:]):

Restore first responder when the file upload flow is complete. This dispatches
&quot;focus&quot; on the window.

* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[WKFileUploadPanel contextMenuInteraction:willDisplayMenuForConfiguration:animator:]):

Implement the delegate method for context menu presentation, so that the first
responder can be resigned when the menu is presented.

Call `_didShowContextMenu` to facilitate testing.

(-[WKFileUploadPanel contextMenuInteraction:willEndForConfiguration:animator:]):

Call `_didDismissContextMenu` to facilitate testing.

(-[WKFileUploadPanel _presentFullscreenViewController:animated:):

If the content view is still the first responder when an actual picker is
presented, resign.

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptContext.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::UIScriptController::setDidPresentViewControllerCallback):
(WTR::UIScriptController::didPresentViewControllerCallback const):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h:
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView resetInteractionCallbacks]):
(-[TestRunnerWKWebView _didPresentViewController:]):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::setDidPresentViewControllerCallback):

Canonical link: <a href="https://commits.webkit.org/301721@main">https://commits.webkit.org/301721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02be51d8599f5177576880d14dda6e89869d1cab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133657 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78342 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/54b581ac-53d9-4982-bde6-a23ae3cd052f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96412 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7bc29ca0-440e-4f21-8e1f-3ca76bab5871) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76937 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2259fdce-c49c-4515-999b-46fb9902e747) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31503 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77054 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136232 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104926 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104627 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28459 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50819 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19842 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53304 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59107 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52570 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55906 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54312 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->