### PR TITLE
[Web Inspector] _consoleMessageViews is not required.

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
@@ -67,9 +67,6 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
         this._pendingMessagesForSessionOrGroup = new Map;
         this._scheduledRenderIdentifier = 0;
 
-        this._consoleMessageViews = [];
-        this._showTimestamps = WI.settings.showConsoleMessageTimestamps.value;
-
         this.startNewSession();
     }
 
@@ -288,7 +285,6 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
             this._pendingMessagesForSessionOrGroup.set(this._currentSessionOrGroup, pendingMessagesForSession);
         }
         pendingMessagesForSession.push(messageView);
-        this._consoleMessageViews.push(messageView);
 
         this._cleared = false;
         this._repeatCountWasInterrupted = repeatCountWasInterrupted || false;
@@ -343,7 +339,7 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
 
         this._currentSessionOrGroup = savedCurrentConsoleGroup;
 
-        this._currentSessionOrGroup.element.classList.toggle("timestamps-visible", this._showTimestamps);
+        this._handleShowConsoleMessageTimestampsSettingChanged();
 
         if (wasScrolledToBottom || lastMessageView instanceof WI.ConsoleCommandView || lastMessageView.message.type === WI.ConsoleMessage.MessageType.Result || lastMessageView.message.type === WI.ConsoleMessage.MessageType.Image)
             this.scrollToBottom();
@@ -406,14 +402,7 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
 
     _handleShowConsoleMessageTimestampsSettingChanged()
     {
-        this._showTimestamps = WI.settings.showConsoleMessageTimestamps.value;
-        this._currentSessionOrGroup.element.classList.toggle("timestamps-visible", this._showTimestamps);
-        if (this._showTimestamps) {
-            for (let consoleMessageView of this._consoleMessageViews) {
-                if (consoleMessageView instanceof WI.ConsoleMessageView)
-                    consoleMessageView.renderTimestamp();
-            }
-        }
+        this._currentSessionOrGroup.element.classList.toggle("timestamps-visible", WI.settings.showConsoleMessageTimestamps.value);
     }
 };
 


### PR DESCRIPTION
#### 748645e2c4d389faedc52fd1b7620673cae3c5b8
<pre>
[Web Inspector] _consoleMessageViews is not required.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300740">https://bugs.webkit.org/show_bug.cgi?id=300740</a>
<a href="https://rdar.apple.com/162638323">rdar://162638323</a>

Reviewed by Devin Rousso.

JavaScriptLogViewController does keep all messageView for each console messages in
_consoleMessageViews. This is there to re-render message views with timestam but
if is already rendered in super class. No need to keep it.

Also removing _showTimestamps and use settings valuse directly.

* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js:
(WI.JavaScriptLogViewController):
(WI.JavaScriptLogViewController.prototype._appendConsoleMessageView):
(WI.JavaScriptLogViewController.prototype.renderPendingMessages):
(WI.JavaScriptLogViewController.prototype._handleShowConsoleMessageTimestampsSettingChanged):

Canonical link: <a href="https://commits.webkit.org/301638@main">https://commits.webkit.org/301638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c72902aeed4bd56786c42018526252855fc533b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133579 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78274 "Failed to checkout and rebase branch from PR 52404") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4cb3104f-9c28-429b-8d64-cf1692fc0eef) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54788 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/78274 "Failed to checkout and rebase branch from PR 52404") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6fb0fc39-4917-4345-b0f8-38a6c71e438c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129553 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/37515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113234 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76874 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8df1b61c-7f1c-4f67-b2f2-5507217bf512) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31416 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76976 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136147 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40995 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109587 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26664 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50039 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28379 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50728 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53216 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59029 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52497 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55831 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54232 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->