### PR TITLE
Wrong console message's repeat count is updated when messages are mixed from page and Web Workers.

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -244,11 +244,11 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         console.assert(false, "not reached");
     }
 
-    messageRepeatCountUpdated(count, timestamp)
+    messageRepeatCountUpdated(target, count, timestamp)
     {
         this._incrementMessageLevelCount(this._lastMessageLevel, 1);
 
-        this.dispatchEventToListeners(WI.ConsoleManager.Event.PreviousMessageRepeatCountUpdated, {count, timestamp});
+        this.dispatchEventToListeners(WI.ConsoleManager.Event.PreviousMessageRepeatCountUpdated, {target, count, timestamp});
     }
 
     requestClearMessages()

--- a/Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
@@ -40,7 +40,7 @@ WI.ConsoleObserver = class ConsoleObserver extends InspectorBackend.Dispatcher
 
     messageRepeatCountUpdated(count, timestamp)
     {
-        WI.consoleManager.messageRepeatCountUpdated(count, timestamp);
+        WI.consoleManager.messageRepeatCountUpdated(this._target, count, timestamp);
     }
 
     messagesCleared(reason)

--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
@@ -520,7 +520,8 @@ WI.LogContentView = class LogContentView extends WI.ContentView
 
     _previousMessageRepeatCountUpdated(event)
     {
-        if (!this._logViewController.updatePreviousMessageRepeatCount(event.data.count, event.data.timestamp))
+        let {target, count, timestamp} = event.data;
+        if (!this._logViewController.updatePreviousMessageRepeatCount(target, count, timestamp))
             return;
 
         if (this._lastMessageView) {


### PR DESCRIPTION
#### 1a9813d49b1b047214403cd0b6a26ce46eabb270
<pre>
Wrong console message&apos;s repeat count is updated when messages are mixed from page and Web Workers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300728">https://bugs.webkit.org/show_bug.cgi?id=300728</a>
<a href="https://rdar.apple.com/162612099">rdar://162612099</a>

Reviewed by Devin Rousso.

Console messages are compared in each target in Web Content process. If the message is
same with previous message, it sends `messageRepeatCountUpdated` message to the frontend.
In frontend, it updates simply previously displayed messageView&apos;s repeat count.

If a Worker sends a message, the things get messy. Because comparison happens in each
target, they don&apos;t know each other. Only checks if the message is same with the one from
the target. But that message can be not the one in the frontend.

1. main frame send a message A.
2. Worker send a message B.
3. Now console UI have line A and B.
4. In main frame, send identical message A.
5. Before sending the message, ConsoleAgent compares the one with previously sent message at step 1.
6. Because they are identical, it send `messageRepeatCountUpdated` with count 2.
7. Frontend get `messageRepeatCountUpdated` and it tries to update previous message view, but that is view for B.
8. B has updated with [2] count label.

To fix this, keep storing the messageView for each target. When `updatePreviousMessageRepeatCount`
is called, it checks _previousMessageView has same target and if not, it creates the new
messageView with previous message to avoid updating the wrong message count.

* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager.prototype.messageRepeatCountUpdated):
* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js:
(WI.JavaScriptLogViewController):
(WI.JavaScriptLogViewController.prototype.startNewSession):
(WI.JavaScriptLogViewController.prototype.appendConsoleMessage):
(WI.JavaScriptLogViewController.prototype.updatePreviousMessageRepeatCount):
(WI.JavaScriptLogViewController.prototype._appendConsoleMessageView):
(WI.JavaScriptLogViewController.prototype._didRenderConsoleMessageView):
* Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js:
(WI.ConsoleObserver.prototype.messageRepeatCountUpdated):
* Source/WebInspectorUI/UserInterface/Views/LogContentView.js:
(WI.LogContentView.prototype._previousMessageRepeatCountUpdated):

Canonical link: <a href="https://commits.webkit.org/301917@main">https://commits.webkit.org/301917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5448d9a5fc84e956ef3aa9e4a8c6fa24bc5ad017

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134436 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78927 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e1ec7c16-88da-441b-b556-70f10237bd91) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96937 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6ddc881d-29a3-4d7b-9462-bae7dec7561b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77431 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3288686d-d513-49d2-9cbe-52a6a7573cc3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36965 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32197 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77818 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136919 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105457 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54542 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105134 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26824 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50658 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29108 "Found 1 new test failure: http/tests/misc/ftp-eplf-directory.py (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51610 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53968 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60055 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53202 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56659 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54961 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->