### PR TITLE
Make separate "Copy for commit log" button on WebKit Bugzilla

### DIFF
--- a/Websites/bugs.webkit.org/skins/custom/global.css
+++ b/Websites/bugs.webkit.org/skins/custom/global.css
@@ -1642,33 +1642,19 @@ label.required, .required_explanation {
     font-weight: 400;
 }
 
-#copy-commitlog + #copy-commitlog-label:after {
-    display: inline-block;
-    overflow: visible;
-    background-image: var(--copy-commitlog-glyph);
-    background-color: transparent;
-    background-repeat: no-repeat;
-    background-size: 1.6rem;
-    background-position: 0.7rem 0.1rem;
-
-    content: "Copy bug for commit log";
-    
-    text-wrap: nowrap;
-
-    font-weight: 400;
-    color: var(--text-color-coolgray);
-    opacity: 0;
-    width: 0;
-    padding-left: 3rem;
-    transition: width 0ms, opacity 500ms ease-in-out;
+#copy-commitlog {
+   padding: 0.2rem 1rem;
+   font-size: var(--font-size-xsmall);
+   margin-inline-start: 1rem;
+   opacity: 0;
+   transition: opacity 500ms ease-in-out;
 }
 
-#copy-commitlog:hover + #copy-commitlog-label:after {
-    width: auto;
+.bz_short_desc_container:hover #copy-commitlog {
     opacity: 1;
 }
 
-#copy-commitlog.clicked + #copy-commitlog-label:after {
+#copy-commitlog.clicked {
     color: green;
     content: "Copied!";
 }

--- a/Websites/bugs.webkit.org/template/en/custom/bug/edit.html.tmpl
+++ b/Websites/bugs.webkit.org/template/en/custom/bug/edit.html.tmpl
@@ -140,8 +140,8 @@
           [% IF bug.dup_id %]
             of [% "${terms.bug} ${bug.dup_id}" FILTER bug_link(bug.dup_id) FILTER none %]
           [% END %]
-        [% END %]
-      </span><a href="show_bug.cgi?id=[% bug.bug_id %]" class="bug_id" [% IF user.id %]  id="copy-commitlog"[% END %]>[% bug.bug_id FILTER html %]</a> [% IF user.id %]<span id="copy-commitlog-label"></span>[% END %]
+        [% END %]</span><a href="show_bug.cgi?id=[% bug.bug_id %]" class="bug_id">[% bug.bug_id FILTER html %]</a>
+        [% IF user.id %]<button id="copy-commitlog">Copy for commit log</button>[% END %]
      </div>
      <style>
      a.bug_id::before {


### PR DESCRIPTION
#### 7714edf7a361bd046c4f827d1811197fca97a6fb
<pre>
Make separate &quot;Copy for commit log&quot; button on WebKit Bugzilla
<a href="https://bugs.webkit.org/show_bug.cgi?id=300818">https://bugs.webkit.org/show_bug.cgi?id=300818</a>

Reviewed by Simon Fraser.

Canonical link: <a href="https://commits.webkit.org/301572@main">https://commits.webkit.org/301572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f36cf6393e3791aade54455b42559d9710fc82f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36969 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ee397e8-1de3-4579-9794-f9f295d9da7a) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/46725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/54617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/133341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9e8c21b-2339-4a27-86a8-0ad099809a80) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129373 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/46725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/113068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06c0db50-504f-402d-a9f6-048e88b9af5d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/46725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/46725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/31513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/53133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/54617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/135875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/53612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/109370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19764 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/53049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/54071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->