### PR TITLE
Move SizedUnsignedTrait to StdLibExtras.h and remove dupes

### DIFF
--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -1208,7 +1208,7 @@ template <bool shouldBuildStrings> ALWAYS_INLINE typename Lexer<T>::StringParseR
 
     const T* stringStart = currentSourcePtr();
 
-    using UnsignedType = SIMD::SameSizeUnsignedInteger<T>;
+    using UnsignedType = SameSizeUnsignedInteger<T>;
     auto quoteMask = SIMD::splat<UnsignedType>(stringQuoteCharacter);
     constexpr auto escapeMask = SIMD::splat<UnsignedType>('\\');
     constexpr auto controlMask = SIMD::splat<UnsignedType>(0xE);
@@ -2968,7 +2968,7 @@ inSingleLineComment:
     {
         auto endPosition = currentPosition();
 
-        using UnsignedType = SIMD::SameSizeUnsignedInteger<T>;
+        using UnsignedType = SameSizeUnsignedInteger<T>;
         constexpr auto lineFeedMask = SIMD::splat<UnsignedType>('\n');
         constexpr auto carriageReturnMask = SIMD::splat<UnsignedType>('\r');
         constexpr auto u2028Mask = SIMD::splat<UnsignedType>(static_cast<UnsignedType>(0x2028));

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1081,7 +1081,7 @@ static ALWAYS_INLINE bool stringCopySameType(std::span<const CharType> span, Cha
 #if (CPU(ARM64) || CPU(X86_64)) && COMPILER(CLANG)
     constexpr size_t stride = SIMD::stride<CharType>;
     if (span.size() >= stride) {
-        using UnsignedType = SIMD::SameSizeUnsignedInteger<CharType>;
+        using UnsignedType = SameSizeUnsignedInteger<CharType>;
         using BulkType = decltype(SIMD::load(static_cast<const UnsignedType*>(nullptr)));
         constexpr auto quoteMask = SIMD::splat<UnsignedType>('"');
         constexpr auto escapeMask = SIMD::splat<UnsignedType>('\\');

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -935,7 +935,7 @@ ALWAYS_INLINE TokenType LiteralParser<CharType, reviverMode>::Lexer::lexString(L
             while (m_ptr < m_end && isSafeStringCharacterForIdentifier<SafeStringCharacterSet::Strict>(*m_ptr, terminator))
                 ++m_ptr;
         } else {
-            using UnsignedType = SIMD::SameSizeUnsignedInteger<CharType>;
+            using UnsignedType = SameSizeUnsignedInteger<CharType>;
             constexpr auto quoteMask = SIMD::splat<UnsignedType>('"');
             constexpr auto escapeMask = SIMD::splat<UnsignedType>('\\');
             constexpr auto controlMask = SIMD::splat<UnsignedType>(' ');
@@ -958,7 +958,7 @@ ALWAYS_INLINE TokenType LiteralParser<CharType, reviverMode>::Lexer::lexString(L
             while (m_ptr < m_end && isSafeStringCharacterForIdentifier<SafeStringCharacterSet::Sloppy>(*m_ptr, terminator))
                 ++m_ptr;
         } else {
-            using UnsignedType = SIMD::SameSizeUnsignedInteger<CharType>;
+            using UnsignedType = SameSizeUnsignedInteger<CharType>;
             auto quoteMask = SIMD::splat<UnsignedType>(terminator);
             constexpr auto escapeMask = SIMD::splat<UnsignedType>('\\');
             constexpr auto controlMask = SIMD::splat<UnsignedType>(' ');

--- a/Source/WTF/wtf/EnumSet.h
+++ b/Source/WTF/wtf/EnumSet.h
@@ -33,14 +33,9 @@
 #include <wtf/Assertions.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WTF {
-
-template<size_t> struct SizedUnsignedTrait;
-template<> struct SizedUnsignedTrait<1> { using Type = uint8_t; };
-template<> struct SizedUnsignedTrait<2> { using Type = uint16_t; };
-template<> struct SizedUnsignedTrait<4> { using Type = uint32_t; };
-template<> struct SizedUnsignedTrait<8> { using Type = uint64_t; };
 
 // EnumSet is a class that represents a set of enumerators in a space-efficient manner.
 // Unlike with OptionSet the enumerators don't need be powers of two but the highest value must be less than 64.

--- a/Source/WTF/wtf/HashFunctions.h
+++ b/Source/WTF/wtf/HashFunctions.h
@@ -24,15 +24,9 @@
 #include <tuple>
 #include <wtf/GetPtr.h>
 #include <wtf/RefPtr.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WTF {
-
-    template<size_t size> struct IntTypes;
-    template<> struct IntTypes<1> { typedef int8_t SignedType; typedef uint8_t UnsignedType; };
-    template<> struct IntTypes<2> { typedef int16_t SignedType; typedef uint16_t UnsignedType; };
-    template<> struct IntTypes<4> { typedef int32_t SignedType; typedef uint32_t UnsignedType; };
-    template<> struct IntTypes<8> { typedef int64_t SignedType; typedef uint64_t UnsignedType; };
-
     // integer hash function
 
     // Thomas Wang's 32 Bit Mix Function: http://www.cris.com/~Ttwang/tech/inthash.htm
@@ -100,13 +94,13 @@ namespace WTF {
     }
 
     template<typename T> struct IntHash {
-        static unsigned hash(T key) { return intHash(static_cast<typename IntTypes<sizeof(T)>::UnsignedType>(key)); }
+        static unsigned hash(T key) { return intHash(static_cast<typename SizedUnsignedTrait<sizeof(T)>::Type>(key)); }
         static bool equal(T a, T b) { return a == b; }
         static constexpr bool safeToCompareToEmptyOrDeleted = true;
     };
 
     template<typename T> struct FloatHash {
-        typedef typename IntTypes<sizeof(T)>::UnsignedType Bits;
+        typedef typename SizedUnsignedTrait<sizeof(T)>::Type Bits;
         static unsigned hash(T key)
         {
             return intHash(std::bit_cast<Bits>(key));

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -586,26 +586,6 @@ ALWAYS_INLINE simde_uint64x2_t greaterThanOrEqual(simde_uint64x2_t lhs, simde_ui
     return simde_vcgeq_u64(lhs, rhs);
 }
 
-template<size_t> struct SizedUnsignedTrait;
-template<>
-struct SizedUnsignedTrait<1> {
-    using Type = uint8_t;
-};
-template<>
-struct SizedUnsignedTrait<2> {
-    using Type = uint16_t;
-};
-template<>
-struct SizedUnsignedTrait<4> {
-    using Type = uint32_t;
-};
-template<>
-struct SizedUnsignedTrait<8> {
-    using Type = uint64_t;
-};
-template<typename T>
-using SameSizeUnsignedInteger = SizedUnsignedTrait<sizeof(T)>::Type;
-
 template<typename CharacterType, size_t threshold = SIMD::stride<CharacterType>>
 ALWAYS_INLINE const CharacterType* find(std::span<const CharacterType> span, const auto& vectorMatch, const auto& scalarMatch)
 {

--- a/Source/WTF/wtf/SortedArrayMap.h
+++ b/Source/WTF/wtf/SortedArrayMap.h
@@ -147,7 +147,7 @@ template<ASCIISubset subset> constexpr bool isInSubset(char character)
     }
 }
 
-template<ASCIISubset subset, typename CharacterType> constexpr SIMD::SameSizeUnsignedInteger<CharacterType> foldForComparison(CharacterType character)
+template<ASCIISubset subset, typename CharacterType> constexpr SameSizeUnsignedInteger<CharacterType> foldForComparison(CharacterType character)
 {
     switch (subset) {
     case ASCIISubset::All:

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1536,6 +1536,26 @@ ALWAYS_INLINE std::weak_ordering weakOrderingCast(std::partial_ordering ordering
     return is_lt(ordering) ? std::weak_ordering::less : std::weak_ordering::greater;
 }
 
+template<size_t> struct SizedUnsignedTrait;
+template<>
+struct SizedUnsignedTrait<1> {
+    using Type = uint8_t;
+};
+template<>
+struct SizedUnsignedTrait<2> {
+    using Type = uint16_t;
+};
+template<>
+struct SizedUnsignedTrait<4> {
+    using Type = uint32_t;
+};
+template<>
+struct SizedUnsignedTrait<8> {
+    using Type = uint64_t;
+};
+template<typename T>
+using SameSizeUnsignedInteger = SizedUnsignedTrait<sizeof(T)>::Type;
+
 } // namespace WTF
 
 #define WTFMove(value) std::move<WTF::CheckMoveParameter>(value)
@@ -1611,6 +1631,8 @@ using WTF::weakOrderingCast;
 using WTF::zeroBytes;
 using WTF::zeroSpan;
 using WTF::Invocable;
+using WTF::SameSizeUnsignedInteger;
+using WTF::SizedUnsignedTrait;
 using WTF::VariantWrapper;
 using WTF::VariantOrSingle;
 

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -1158,7 +1158,7 @@ ALWAYS_INLINE bool charactersContain(std::span<const CharacterType> span)
 
 #if CPU(ARM64) || CPU(X86_64)
     constexpr size_t stride = SIMD::stride<CharacterType>;
-    using UnsignedType = SIMD::SameSizeUnsignedInteger<CharacterType>;
+    using UnsignedType = SameSizeUnsignedInteger<CharacterType>;
     using BulkType = decltype(SIMD::load(static_cast<const UnsignedType*>(nullptr)));
     if (length >= stride) {
         size_t index = 0;
@@ -1183,7 +1183,7 @@ ALWAYS_INLINE bool charactersContain(std::span<const CharacterType> span)
 template<typename CharacterType>
 inline size_t countMatchedCharacters(std::span<const CharacterType> span, CharacterType character)
 {
-    using UnsignedType = SIMD::SameSizeUnsignedInteger<CharacterType>;
+    using UnsignedType = SameSizeUnsignedInteger<CharacterType>;
     auto mask = SIMD::splat<UnsignedType>(character);
     auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
         return SIMD::equal(input, mask);


### PR DESCRIPTION
#### aa083ee4071e4933cf921abc9be1c7c902cc0962
<pre>
Move SizedUnsignedTrait to StdLibExtras.h and remove dupes
<a href="https://bugs.webkit.org/show_bug.cgi?id=300822">https://bugs.webkit.org/show_bug.cgi?id=300822</a>
<a href="https://rdar.apple.com/162706445">rdar://162706445</a>

Reviewed by Keith Miller.

We have three copies of this. Move to a generic header.

* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;T&gt;::parseString):
(JSC::Lexer&lt;T&gt;::lexWithoutClearingLineTerminator):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::stringCopySameType):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::reviverMode&gt;::Lexer::lexString):
* Source/WTF/wtf/EnumSet.h:
* Source/WTF/wtf/HashFunctions.h:
(WTF::IntHash::hash):
* Source/WTF/wtf/SIMDHelpers.h:
* Source/WTF/wtf/SortedArrayMap.h:
(WTF::foldForComparison):
* Source/WTF/wtf/StdLibExtras.h:
* Source/WTF/wtf/text/StringCommon.h:
(WTF::charactersContain):
(WTF::countMatchedCharacters):

Canonical link: <a href="https://commits.webkit.org/301581@main">https://commits.webkit.org/301581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d234661e4e697e81b45140823fb12bccc6ae087

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36973 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/46729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54621 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/133345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1647e528-13ad-4d23-9120-f6271b488f59) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129377 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/46729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/113077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf75da22-9757-4412-91b4-b66185f97658) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/46729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118491 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/46729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135879 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124894 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40846 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109383 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26638 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49896 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50539 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53053 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58872 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157940 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52346 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39520 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54075 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->