### PR TITLE
Make method to set LayoutRect/FloatRect via edge coordinates public

### DIFF
--- a/Source/WebCore/platform/graphics/FloatRect.cpp
+++ b/Source/WebCore/platform/graphics/FloatRect.cpp
@@ -96,7 +96,7 @@ void FloatRect::intersect(const FloatRect& other)
         b = 0;
     }
 
-    setLocationAndSizeFromEdges(l, t, r, b);
+    shiftEdgesTo(l, t, r, b);
 }
 
 bool FloatRect::edgeInclusiveIntersect(const FloatRect& other)
@@ -138,7 +138,7 @@ void FloatRect::uniteEvenIfEmpty(const FloatRect& other)
     float maxX = std::max(this->maxX(), other.maxX());
     float maxY = std::max(this->maxY(), other.maxY());
 
-    setLocationAndSizeFromEdges(minX, minY, maxX, maxY);
+    shiftEdgesTo(minX, minY, maxX, maxY);
 }
 
 void FloatRect::uniteIfNonZero(const FloatRect& other)
@@ -161,7 +161,7 @@ void FloatRect::extend(FloatPoint p)
     float maxX = std::max(this->maxX(), p.x());
     float maxY = std::max(this->maxY(), p.y());
 
-    setLocationAndSizeFromEdges(minX, minY, maxX, maxY);
+    shiftEdgesTo(minX, minY, maxX, maxY);
 }
 
 void FloatRect::extend(FloatPoint minPoint, FloatPoint maxPoint)
@@ -173,7 +173,7 @@ void FloatRect::extend(FloatPoint minPoint, FloatPoint maxPoint)
     float maxX = std::max(this->maxX(), maxPoint.x());
     float maxY = std::max(this->maxY(), maxPoint.y());
 
-    setLocationAndSizeFromEdges(minX, minY, maxX, maxY);
+    shiftEdgesTo(minX, minY, maxX, maxY);
 }
 
 void FloatRect::scale(float sx, float sy)

--- a/Source/WebCore/platform/graphics/FloatRect.h
+++ b/Source/WebCore/platform/graphics/FloatRect.h
@@ -122,6 +122,13 @@ public:
     }
     void contract(float dw, float dh) { m_size.expand(-dw, -dh); }
 
+    void shiftEdgesTo(float left, float top, float right, float bottom)
+    {
+        m_location.set(left, top);
+        m_size.setWidth(right - left);
+        m_size.setHeight(bottom - top);
+    }
+
     void shiftXEdgeTo(float edge)
     {
         float delta = edge - x();
@@ -250,13 +257,6 @@ public:
 private:
     FloatPoint m_location;
     FloatSize m_size;
-
-    void setLocationAndSizeFromEdges(float left, float top, float right, float bottom)
-    {
-        m_location.set(left, top);
-        m_size.setWidth(right - left);
-        m_size.setHeight(bottom - top);
-    }
 };
 
 inline FloatRect intersection(const FloatRect& a, const FloatRect& b)

--- a/Source/WebCore/platform/graphics/LayoutRect.cpp
+++ b/Source/WebCore/platform/graphics/LayoutRect.cpp
@@ -110,7 +110,7 @@ void LayoutRect::uniteEvenIfEmpty(const LayoutRect& other)
     auto maxX = std::max(this->maxX(), other.maxX());
     auto maxY = std::max(this->maxY(), other.maxY());
 
-    setLocationAndSizeFromEdges(minX, minY, maxX, maxY);
+    shiftEdgesTo(minX, minY, maxX, maxY);
 }
 
 bool LayoutRect::checkedUnite(const LayoutRect& other)

--- a/Source/WebCore/platform/graphics/LayoutRect.h
+++ b/Source/WebCore/platform/graphics/LayoutRect.h
@@ -104,6 +104,8 @@ public:
     }
     template<typename T, typename U> void contract(T dw, U dh) { m_size.expand(-dw, -dh); }
 
+    void shiftEdgesTo(LayoutUnit left, LayoutUnit top, LayoutUnit right, LayoutUnit bottom);
+
     void shiftXEdgeTo(LayoutUnit edge)
     {
         LayoutUnit delta = edge - x();
@@ -130,10 +132,20 @@ public:
         setHeight(std::max<LayoutUnit>(0, height() + delta));
     }
 
+    template<typename T> void shiftXEdgeTo(T edge) { shiftXEdgeTo(LayoutUnit(edge)); }
+    template<typename T> void shiftMaxXEdgeTo(T edge) { shiftMaxXEdgeTo(LayoutUnit(edge)); }
+    template<typename T> void shiftYEdgeTo(T edge) { shiftYEdgeTo(LayoutUnit(edge)); }
+    template<typename T> void shiftMaxYEdgeTo(T edge) { shiftMaxYEdgeTo(LayoutUnit(edge)); }
+
     void shiftXEdgeBy(LayoutUnit delta)
     {
         move(delta, 0);
         setWidth(std::max<LayoutUnit>(0, width() - delta));
+    }
+
+    void shiftMaxXEdgeBy(LayoutUnit delta)
+    {
+        setWidth(std::max<LayoutUnit>(0, width() + delta));
     }
 
     void shiftYEdgeBy(LayoutUnit delta)
@@ -142,10 +154,10 @@ public:
         setHeight(std::max<LayoutUnit>(0, height() - delta));
     }
 
-    template<typename T> void shiftXEdgeTo(T edge) { shiftXEdgeTo(LayoutUnit(edge)); }
-    template<typename T> void shiftMaxXEdgeTo(T edge) { shiftMaxXEdgeTo(LayoutUnit(edge)); }
-    template<typename T> void shiftYEdgeTo(T edge) { shiftYEdgeTo(LayoutUnit(edge)); }
-    template<typename T> void shiftMaxYEdgeTo(T edge) { shiftMaxYEdgeTo(LayoutUnit(edge)); }
+    void shiftMaxYEdgeBy(LayoutUnit delta)
+    {
+        setHeight(std::max<LayoutUnit>(0, height() + delta));
+    }
 
     LayoutPoint minXMinYCorner() const { return m_location; } // typically topLeft
     LayoutPoint maxXMinYCorner() const { return LayoutPoint(m_location.x() + m_size.width(), m_location.y()); } // typically topRight
@@ -208,7 +220,6 @@ public:
 
 private:
     friend struct IPC::ArgumentCoder<WebCore::LayoutRect, void>;
-    void setLocationAndSizeFromEdges(LayoutUnit left, LayoutUnit top, LayoutUnit right, LayoutUnit bottom);
 
     LayoutPoint m_location;
     LayoutSize m_size;
@@ -235,7 +246,7 @@ inline bool LayoutRect::isInfinite() const
     return *this == LayoutRect::infiniteRect();
 }
 
-inline void LayoutRect::setLocationAndSizeFromEdges(LayoutUnit left, LayoutUnit top, LayoutUnit right, LayoutUnit bottom)
+inline void LayoutRect::shiftEdgesTo(LayoutUnit left, LayoutUnit top, LayoutUnit right, LayoutUnit bottom)
 {
     m_location = { left, top };
     m_size.setWidth(right - left);


### PR DESCRIPTION
#### 680f94ca8549cec45f6584167019f74fd29499bf
<pre>
Make method to set LayoutRect/FloatRect via edge coordinates public
<a href="https://bugs.webkit.org/show_bug.cgi?id=300826">https://bugs.webkit.org/show_bug.cgi?id=300826</a>
<a href="https://rdar.apple.com/162710333">rdar://162710333</a>

Reviewed by Simon Fraser.

Shifts the setLocationAndSizeFromEdges() method from private to public and
renames it to shiftEdgesTo() to align with the various shift*EdgeTo() methods.

Also adds the two missing shift*EdgeBy() methods to LayoutRect.

* Source/WebCore/platform/graphics/FloatRect.cpp:
(WebCore::FloatRect::intersect):
(WebCore::FloatRect::uniteEvenIfEmpty):
(WebCore::FloatRect::extend):
* Source/WebCore/platform/graphics/FloatRect.h:
(WebCore::FloatRect::shiftEdgesTo):
(WebCore::FloatRect::setLocationAndSizeFromEdges): Deleted.
* Source/WebCore/platform/graphics/LayoutRect.cpp:
(WebCore::LayoutRect::uniteEvenIfEmpty):
* Source/WebCore/platform/graphics/LayoutRect.h:
(WebCore::LayoutRect::shiftEdgesTo):
(WebCore::LayoutRect::setLocationAndSizeFromEdges): Deleted.

Canonical link: <a href="https://commits.webkit.org/301603@main">https://commits.webkit.org/301603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27ae8d7b45d94ca06b6010aee8942d890ed60344

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133352 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78139 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0f61159-7e16-42ef-8baf-d0c31cb5d344) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96233 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f54ca182-98f9-44b6-ae04-7f33ba2e6846) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76706 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31259 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76656 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107192 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135886 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40855 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104736 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104439 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26647 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49901 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28232 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50547 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53061 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58879 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52353 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55688 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54083 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->