### PR TITLE
[JSC] Missing early return after performPromiseThen

### DIFF
--- a/JSTests/stress/perform-promise-then-does-not-cause-exception.js
+++ b/JSTests/stress/perform-promise-then-does-not-cause-exception.js
@@ -1,0 +1,11 @@
+try {
+function fn0() {}
+var v0 = new Promise(function () {});
+function fn3() {}
+try {
+  v0.constructor = fn3;
+} catch (e) {}
+fn0(Promise.resolve(v0) instanceof Promise);
+var v4 = __c_0.resolve().then();
+// Flags:
+} catch { }

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -61,8 +61,10 @@ static void promiseResolveThenableJobFastSlow(JSGlobalObject* globalObject, JSPr
     auto [resolve, reject] = promiseToResolve->createResolvingFunctions(vm, globalObject);
 
     auto capability = JSPromise::createNewPromiseCapability(globalObject, constructor);
-    if (!scope.exception()) [[likely]]
+    if (!scope.exception()) [[likely]] {
         promise->performPromiseThen(vm, globalObject, resolve, reject, capability, jsUndefined());
+        return;
+    }
 
     JSValue error = scope.exception()->value();
     if (!scope.clearExceptionExceptTermination()) [[unlikely]]
@@ -88,8 +90,10 @@ static void promiseResolveThenableJobWithoutPromiseFastSlow(JSGlobalObject* glob
     auto [resolve, reject] = JSPromise::createResolvingFunctionsWithoutPromise(vm, globalObject, onFulfilled, onRejected, context);
 
     auto capability = JSPromise::createNewPromiseCapability(globalObject, constructor);
-    if (!scope.exception()) [[likely]]
+    if (!scope.exception()) [[likely]] {
         promise->performPromiseThen(vm, globalObject, resolve, reject, capability, jsUndefined());
+        return;
+    }
 
     JSValue error = scope.exception()->value();
     if (!scope.clearExceptionExceptTermination()) [[unlikely]]


### PR DESCRIPTION
#### 6765125ae39a030ae60f040277d5102e77c77690
<pre>
[JSC] Missing early return after performPromiseThen
<a href="https://bugs.webkit.org/show_bug.cgi?id=300830">https://bugs.webkit.org/show_bug.cgi?id=300830</a>
<a href="https://rdar.apple.com/162622481">rdar://162622481</a>

Reviewed by Yijia Huang and Keith Miller.

301454@main accidentally removed early return after performPromiseThen.
This recovers that change.

Test: JSTests/stress/perform-promise-then-does-not-cause-exception.js

* JSTests/stress/perform-promise-then-does-not-cause-exception.js: Added.
(try.fn0):
(try.v0.new.Promise):
(try.fn3):
(try.catch):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::promiseResolveThenableJobFastSlow):
(JSC::promiseResolveThenableJobWithoutPromiseFastSlow):

Canonical link: <a href="https://commits.webkit.org/301585@main">https://commits.webkit.org/301585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d20704b54d5a53c07274589c95f3b2d0a991cd44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37001 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a711640d-f21b-41f8-a5e7-3678c9c10e37) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/46745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54640 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/133359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d4f0fec-8934-4745-bd43-ae3645964a59) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129399 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/46745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/113091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/063666be-d88d-4c95-86fc-57f27cce94a2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/46745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118508 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/46745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135895 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124916 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53153 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/40863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109403 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49910 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50557 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19770 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53071 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58888 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157962 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39527 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54092 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->