### PR TITLE
Disable auto margins in combination with position-area [css-anchor-position-1]

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/auto-margins-position-area-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/auto-margins-position-area-expected.html
@@ -1,10 +1,5 @@
 <!DOCTYPE html>
 <title>CSS Anchor Positioning: position-area vs margins</title>
-<link rel="help" href="https://drafts.csswg.org/css-anchor-position/#position-area">
-<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#anchor-center">
-
-<link rel="match" href="position-area-margin-auto-ref.html">
-
 <style>
   .container {
     position: absolute;
@@ -25,16 +20,14 @@
   .anchored {
     position: absolute;
     position-anchor: --anchor;
-    inset: 0;
     width: 20px;
     height: 20px;
     border: solid 1px;
     opacity: 30%;
-    margin: auto 0 0 auto;
   }
 </style>
 <div class="container">
-  <div class="anchored" style="background: silver"></div>
+  <div class="anchored" style="background: silver; inset: auto 0 0 auto"></div>
   <div class="anchored" style="position-area: span-all; background: maroon"></div>
   <div class="anchored" style="position-area: top center; background: orange"></div>
   <div class="anchored" style="position-area: left center; background: yellow"></div>
@@ -43,7 +36,7 @@
   <div class="anchored" style="position-area: span-bottom; background: teal"></div>
   <div class="anchored" style="position-area: right; background: blue"></div>
   <div class="anchored" style="position-area: bottom; background: purple"></div>
-  <div class="anchored" style="align-self: anchor-center; background: fuchsia"></div>
-  <div class="anchored" style="justify-self: anchor-center; background: aqua"></div>
+  <div class="anchored" style="align-self: anchor-center; background: fuchsia; right: 0"></div>
+  <div class="anchored" style="justify-self: anchor-center; background: aqua; bottom: 0"></div>
   <div class="anchor"></div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/auto-margins-position-area-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/auto-margins-position-area-expected.txt
@@ -1,3 +1,0 @@
-
-PASS .abspos 1
-

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/auto-margins-position-area-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/auto-margins-position-area-ref.html
@@ -1,10 +1,5 @@
 <!DOCTYPE html>
 <title>CSS Anchor Positioning: position-area vs margins</title>
-<link rel="help" href="https://drafts.csswg.org/css-anchor-position/#position-area">
-<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#anchor-center">
-
-<link rel="match" href="position-area-margin-auto-ref.html">
-
 <style>
   .container {
     position: absolute;
@@ -25,16 +20,15 @@
   .anchored {
     position: absolute;
     position-anchor: --anchor;
-    inset: 0;
     width: 20px;
     height: 20px;
     border: solid 1px;
     opacity: 30%;
-    margin: auto 0 0 auto;
+    margin: 0;
   }
 </style>
 <div class="container">
-  <div class="anchored" style="background: silver"></div>
+  <div class="anchored" style="background: silver; inset: auto 0 0 auto"></div>
   <div class="anchored" style="position-area: span-all; background: maroon"></div>
   <div class="anchored" style="position-area: top center; background: orange"></div>
   <div class="anchored" style="position-area: left center; background: yellow"></div>
@@ -43,7 +37,7 @@
   <div class="anchored" style="position-area: span-bottom; background: teal"></div>
   <div class="anchored" style="position-area: right; background: blue"></div>
   <div class="anchored" style="position-area: bottom; background: purple"></div>
-  <div class="anchored" style="align-self: anchor-center; background: fuchsia"></div>
-  <div class="anchored" style="justify-self: anchor-center; background: aqua"></div>
+  <div class="anchored" style="align-self: anchor-center; background: fuchsia; right: 0"></div>
+  <div class="anchored" style="justify-self: anchor-center; background: aqua; bottom: 0"></div>
   <div class="anchor"></div>
 </div>

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -356,8 +356,8 @@ void PositionedLayoutConstraints::resolvePosition(RenderBox::LogicalExtentComput
 
     bool hasAutoBeforeInset = m_insetBefore.isAuto();
     bool hasAutoAfterInset = m_insetAfter.isAuto();
-    bool hasAutoBeforeMargin = m_marginBefore.isAuto();
-    bool hasAutoAfterMargin = m_marginAfter.isAuto();
+    bool hasAutoBeforeMargin = m_marginBefore.isAuto() && !m_defaultAnchorBox;
+    bool hasAutoAfterMargin = m_marginAfter.isAuto() && !m_defaultAnchorBox;
 
     auto distributeSpaceToAutoMargins = [&] {
         ASSERT(!hasAutoBeforeInset && !hasAutoAfterInset && (hasAutoBeforeMargin || hasAutoAfterMargin));


### PR DESCRIPTION
#### 560b0ef798f38493e99ad6f5913daf4264e89d58
<pre>
Disable auto margins in combination with position-area [css-anchor-position-1]
<a href="https://bugs.webkit.org/show_bug.cgi?id=300823">https://bugs.webkit.org/show_bug.cgi?id=300823</a>

Reviewed by Alan Baradlay.

Converts auto margins to zero when position-area or anchor-center is in effect.
See <a href="https://github.com/w3c/csswg-drafts/issues/10258">https://github.com/w3c/csswg-drafts/issues/10258</a>

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/auto-margins-position-area.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/auto-margins-position-area.html: Rewritten.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/auto-margins-position-area-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/auto-margins-position-area-ref.html: Added.

<a href="https://github.com/web-platform-tests/wpt/pull/55460">https://github.com/web-platform-tests/wpt/pull/55460</a>

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::captureInsets):

Canonical link: <a href="https://commits.webkit.org/301662@main">https://commits.webkit.org/301662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ded263505a460261efc7f2dc4443a4940f1a8575

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78198 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a0ef8b2c-f055-4837-8468-36b52d9793c3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96281 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76755 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aa42b29c-22a5-46ed-a669-d92c831197f3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31330 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76720 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107244 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135960 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104786 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53700 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104488 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26674 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49967 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28298 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50626 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53134 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58947 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52416 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55750 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54151 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->