### PR TITLE
[iOS] [SaferC++] Adopt memory safe guidelines in UIProcess and GPUProcess iOS code

### DIFF
--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
@@ -79,6 +79,7 @@ public:
 class WEBCORE_EXPORT MediaSessionHelper : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaSessionHelper> {
 public:
     static MediaSessionHelper& sharedHelper();
+    static Ref<MediaSessionHelper> protectedSharedHelper();
     static void setSharedHelper(Ref<MediaSessionHelper>&&);
     static void resetSharedHelper();
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -129,6 +129,11 @@ MediaSessionHelper& MediaSessionHelper::sharedHelper()
     return *helper;
 }
 
+Ref<MediaSessionHelper> MediaSessionHelper::protectedSharedHelper()
+{
+    return sharedHelper();
+}
+
 void MediaSessionHelper::resetSharedHelper()
 {
     sharedHelperInstance() = adoptRef(*new MediaSessionHelperIOS());

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
@@ -42,13 +42,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionHelperProxy);
 RemoteMediaSessionHelperProxy::RemoteMediaSessionHelperProxy(GPUConnectionToWebProcess& gpuConnection)
     : m_gpuConnection(gpuConnection)
 {
-    MediaSessionHelper::sharedHelper().addClient(*this);
+    MediaSessionHelper::protectedSharedHelper()->addClient(*this);
 }
 
 RemoteMediaSessionHelperProxy::~RemoteMediaSessionHelperProxy()
 {
     stopMonitoringWirelessRoutes();
-    MediaSessionHelper::sharedHelper().removeClient(*this);
+    MediaSessionHelper::protectedSharedHelper()->removeClient(*this);
 }
 
 void RemoteMediaSessionHelperProxy::ref() const
@@ -67,7 +67,7 @@ void RemoteMediaSessionHelperProxy::startMonitoringWirelessRoutes()
         return;
 
     m_isMonitoringWirelessRoutes = true;
-    MediaSessionHelper::sharedHelper().startMonitoringWirelessRoutes();
+    MediaSessionHelper::protectedSharedHelper()->startMonitoringWirelessRoutes();
 }
 
 void RemoteMediaSessionHelperProxy::stopMonitoringWirelessRoutes()
@@ -76,7 +76,7 @@ void RemoteMediaSessionHelperProxy::stopMonitoringWirelessRoutes()
         return;
 
     m_isMonitoringWirelessRoutes = false;
-    MediaSessionHelper::sharedHelper().stopMonitoringWirelessRoutes();
+    MediaSessionHelper::protectedSharedHelper()->stopMonitoringWirelessRoutes();
 }
 
 void RemoteMediaSessionHelperProxy::uiApplicationWillEnterForeground(SuspendedUnderLock suspendedUnderLock)

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -76,14 +76,11 @@ WebProcess/cocoa/WebProcessCocoa.mm
 [ iOS ] GPUProcess/GPUConnectionToWebProcess.cpp
 [ iOS ] GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
 [ iOS ] GPUProcess/media/RemoteAudioSessionProxyManager.cpp
-[ iOS ] GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
 [ iOS ] NetworkProcess/NetworkConnectionToWebProcess.cpp
 [ iOS ] NetworkProcess/NetworkProcess.cpp
 [ iOS ] NetworkProcess/cocoa/NetworkProcessCocoa.mm
 [ iOS ] NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
 [ iOS ] Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
-[ iOS ] UIProcess/API/APIHTTPCookieStore.cpp
-[ iOS ] UIProcess/API/C/WKWebsiteDataStoreRef.cpp
 [ iOS ] UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
 [ iOS ] UIProcess/API/Cocoa/WKWebExtensionCommand.mm
 [ iOS ] UIProcess/API/Cocoa/WKWebView.mm

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
@@ -62,7 +62,7 @@ void HTTPCookieStore::filterAppBoundCookies(Vector<WebCore::Cookie>&& cookies, C
 #if ENABLE(APP_BOUND_DOMAINS)
     if (!m_owningDataStore)
         return completionHandler({ });
-    m_owningDataStore->getAppBoundDomains([cookies = WTFMove(cookies), completionHandler = WTFMove(completionHandler)] (auto& domains) mutable {
+    RefPtr { m_owningDataStore.get() }->getAppBoundDomains([cookies = WTFMove(cookies), completionHandler = WTFMove(completionHandler)] (auto& domains) mutable {
         Vector<WebCore::Cookie> appBoundCookies;
         if (!domains.isEmpty() && !isFullWebBrowserOrRunningTest()) {
             for (auto& cookie : WTFMove(cookies)) {

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -443,7 +443,7 @@ void WKWebsiteDataStoreStatisticsHasIsolatedSession(WKWebsiteDataStoreRef dataSt
 void WKWebsiteDataStoreHasAppBoundSession(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreHasAppBoundSessionFunction callback)
 {
 #if ENABLE(APP_BOUND_DOMAINS)
-    WebKit::toImpl(dataStoreRef)->hasAppBoundSession([context, callback](bool hasAppBoundSession) {
+    WebKit::toProtectedImpl(dataStoreRef)->hasAppBoundSession([context, callback](bool hasAppBoundSession) {
         callback(hasAppBoundSession, context);
     });
 #else
@@ -520,11 +520,8 @@ void WKWebsiteDataStoreSetAppBoundDomainsForTesting(WKArrayRef originURLsRef, vo
     HashSet<WebCore::RegistrableDomain> domains;
     domains.reserveInitialCapacity(newSize);
     for (size_t i = 0; i < newSize; ++i) {
-        auto* originURL = originURLsArray->at<API::URL>(i);
-        if (!originURL)
-            continue;
-        
-        domains.add(WebCore::RegistrableDomain { URL { originURL->string() } });
+        if (RefPtr originURL = originURLsArray->at<API::URL>(i))
+            domains.add(WebCore::RegistrableDomain { URL { originURL->string() } });
     }
 
     WebKit::WebsiteDataStore::setAppBoundDomainsForTesting(WTFMove(domains), [context, completionHandler] {
@@ -740,7 +737,7 @@ void WKWebsiteDataStoreSetOriginQuotaRatioEnabled(WKWebsiteDataStoreRef dataStor
 void WKWebsiteDataStoreClearAppBoundSession(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreClearAppBoundSessionFunction completionHandler)
 {
 #if ENABLE(APP_BOUND_DOMAINS)
-    WebKit::toImpl(dataStoreRef)->clearAppBoundSession([context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->clearAppBoundSession([context, completionHandler] {
         completionHandler(context);
     });
 #else
@@ -752,7 +749,7 @@ void WKWebsiteDataStoreClearAppBoundSession(WKWebsiteDataStoreRef dataStoreRef, 
 void WKWebsiteDataStoreReinitializeAppBoundDomains(WKWebsiteDataStoreRef dataStoreRef)
 {
 #if ENABLE(APP_BOUND_DOMAINS)
-    WebKit::toImpl(dataStoreRef)->reinitializeAppBoundDomains();
+    WebKit::toProtectedImpl(dataStoreRef)->reinitializeAppBoundDomains();
 #else
     UNUSED_PARAM(dataStoreRef);
 #endif


### PR DESCRIPTION
#### 83c496cc4c50cd2049de1237de63dce199542a94
<pre>
[iOS] [SaferC++] Adopt memory safe guidelines in UIProcess and GPUProcess iOS code
<a href="https://bugs.webkit.org/show_bug.cgi?id=300834">https://bugs.webkit.org/show_bug.cgi?id=300834</a>
<a href="https://rdar.apple.com/162722138">rdar://162722138</a>

Reviewed by Ryosuke Niwa.

Address iOS only saferC++ issues found by the static analyzer.

* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelper::protectedSharedHelper):
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp:
(WebKit::RemoteMediaSessionHelperProxy::RemoteMediaSessionHelperProxy):
(WebKit::RemoteMediaSessionHelperProxy::~RemoteMediaSessionHelperProxy):
(WebKit::RemoteMediaSessionHelperProxy::startMonitoringWirelessRoutes):
(WebKit::RemoteMediaSessionHelperProxy::stopMonitoringWirelessRoutes):
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp:
(API::HTTPCookieStore::filterAppBoundCookies):
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp:
(WKWebsiteDataStoreHasAppBoundSession):
(WKWebsiteDataStoreSetAppBoundDomainsForTesting):
(WKWebsiteDataStoreClearAppBoundSession):
(WKWebsiteDataStoreReinitializeAppBoundDomains):

Canonical link: <a href="https://commits.webkit.org/301640@main">https://commits.webkit.org/301640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90af24c8df543fef2b121e2406c6858abad888bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78188 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f2d2759a-49ac-4a32-94dc-36f45140c640) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96269 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c543e1f1-f894-4b50-8d1b-6deed3ecb1b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76743 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b155e31a-5e35-4e1d-9e1c-0ecf1d5c8c7c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31317 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76709 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107235 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135949 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104778 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109461 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104480 "Found 1 new API test failure: WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26666 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49956 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28287 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50609 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53123 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58937 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52406 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55740 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54141 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->