### PR TITLE
[CoreIPC] [Fuzz Blocker] Disallow async reply messages with destinationID 0

### DIFF
--- a/LayoutTests/ipc/async-with-reply-destination-id-zero-expected.txt
+++ b/LayoutTests/ipc/async-with-reply-destination-id-zero-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/async-with-reply-destination-id-zero.html
+++ b/LayoutTests/ipc/async-with-reply-destination-id-zero.html
@@ -1,0 +1,26 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+// This test attempts to send an async reply to a receiver with destination 0.
+// 0 is not a valid identifier so this reply is invalid and should be dropped. 
+// When IPCTestingAPIEnabled is false, the WebContent process that initially  
+// sent the message is terminated.
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+setTimeout(async () => {
+    if (!window.IPC) // Only run test for compiles with ENABLE(IPC_TESTING_API)
+        return testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+    CoreIPC.UI.WebExtensionContextProxy.DispatchRuntimeMessageEventReply(
+        0, { replyJSON : 'A' });
+    testRunner?.notifyDone();
+}, 10);
+
+</script>
+
+<body>
+    <p>This test passes if WebKit does not crash.</p>
+</body>


### PR DESCRIPTION
#### 4a5d0682ce8fc2a4ad6a86fcb4809c0ad23fe673
<pre>
[CoreIPC] [Fuzz Blocker] Disallow async reply messages with destinationID 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=300836">https://bugs.webkit.org/show_bug.cgi?id=300836</a>
<a href="https://rdar.apple.com/161637876">rdar://161637876</a>

Reviewed by Alex Christensen.

This patch disallows CoreIPC async replies with invalid destination IDs.
Invalid destination IDs include 0 and std::numerical_limits&lt;uint64_t&gt;.

This patch adds a check while processing incoming event replies and marks
async event replies as invalid. By marking the message as invalid, the
WebContent process sent this message will be terminated. In IPC testing mode,
it drops the invalid message without termination.

The accompanying test case tries to send an async reply with a destination
ID of 0 and is expected to crash (as indicated in the TestExpectations).

Test: ipc/async-with-reply-destination-id-zero.html
* LayoutTests/ipc/async-with-reply-destination-id-zero-expected.txt: Added.
* LayoutTests/ipc/async-with-reply-destination-id-zero.html: Added.
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::processIncomingMessage):

Canonical link: <a href="https://commits.webkit.org/301811@main">https://commits.webkit.org/301811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d01b637f299299facad9811868eb4eb01ba8600e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133653 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78338 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ad41414d-5b4c-4eff-a44e-619b7ff28bdc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96406 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64469 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/72b7ae38-6077-4eda-9356-7b26b7b7c909) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76931 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/30db6722-c86d-4bbd-a311-b1784b24c0d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36466 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31493 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77050 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136228 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41068 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104922 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104623 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28450 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50815 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19886 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53300 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59103 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52566 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55902 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54308 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->