### PR TITLE
[WebAuthn] Do not request user presence before U2F fallback

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt
@@ -10,4 +10,8 @@ PASS PublicKeyCredential's [[get]] with multiple accounts in a mock hid authenti
 PASS PublicKeyCredential's [[get]] with PIN supported in the authenticator but userVerification = 'discouraged' in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with many allowCredentials necessitating batching in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with many allowCredentials necessitating batching in a mock hid authenticator. 2
+PASS PublicKeyCredential's [[get]] uses maxCredentialCountInList for batching without requiring maxCredentialIdLength.
+PASS PublicKeyCredential's [[get]] with CTAP2â†’U2F downgrade skips wasteful CTAP2 tap (multi-credential).
+PASS PublicKeyCredential's [[get]] with CTAP2â†’U2F downgrade skips wasteful CTAP2 tap (single credential).
+PASS PublicKeyCredential's [[get]] with empty allowCredentials does NOT skip CTAP2 (resident key safety).
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
@@ -207,4 +207,147 @@
             checkCtapGetAssertionResult(credential);
         });
     }, "PublicKeyCredential's [[get]] with many allowCredentials necessitating batching in a mock hid authenticator. 2");
+
+    // Test for efficient batching: verify batching works without requiring maxCredentialIdLength
+    promise_test(t => {
+        let config = {
+            hid: {
+                maxCredentialCountInList: 10,
+                stage: "request",
+                subStage: "msg",
+                error: "success",
+                payloadBase64: [testAssertionMessageBase64]
+            }
+        };
+        const options = {
+            publicKey: {
+                challenge: Base64URL.parse("MTIzNDU2"),
+                timeout: 1000,
+                allowCredentials: [],
+            }
+        };
+
+        const numCredentials = 25;
+        const expectedBatches = Math.ceil(numCredentials / config.hid.maxCredentialCountInList);  // 3 batches
+
+        for (let i = 0; i < numCredentials; i++)
+            options.publicKey.allowCredentials.push({ type: "public-key", id: generateID(i) });
+        for (let i = 0; i < expectedBatches; i++)
+            config.hid.payloadBase64.unshift("Lg==");
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.get(options).then(credential => {
+            return checkCtapGetAssertionResult(credential);
+        });
+    }, "PublicKeyCredential's [[get]] uses maxCredentialCountInList for batching without requiring maxCredentialIdLength.");
+
+    // Test for CTAP2→U2F downgrade optimization: skip wasteful CTAP2 tap (multi-credential case)
+    promise_test(t => {
+        let config = {
+            hid: {
+                canDowngrade: true,
+                validateExpectedCommands: true,
+                stage: "request",
+                subStage: "msg",
+                error: "success",
+                expectedCommandsBase64: [
+                    "AqQBaWxvY2FsaG9zdAJYIOr/zl5rE7v6WBJXzBhlxVkTUjZEZKyT9c+v9Ce6UFFqA4GiYmlkWEA+vYm/d+xQl1XunCY176qseyucXO8XNsNxfaSFNMjGtlTX/5RfULXMTngFW905a2T3jaLF+WIAzNQVzQj+QgA4ZHR5cGVqcHVibGljLWtleQWhYnVw9A==",  // Batch 0 silent (CTAP2)
+                    "AqQBaWxvY2FsaG9zdAJYIOr/zl5rE7v6WBJXzBhlxVkTUjZEZKyT9c+v9Ce6UFFqA4GiYmlkWCABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGR0eXBlanB1YmxpYy1rZXkFoWJ1cPQ=",  // Batch 1 silent (CTAP2)
+                    // NO CTAP2 with up=true - that's what we're testing!
+                    "AAIDAAAAger/zl5rE7v6WBJXzBhlxVkTUjZEZKyT9c+v9Ce6UFFqSZYN5YgOjGh0NBcPZHZgW4/krrmihjLHmVzzuoMdl2NAPr2Jv3fsUJdV7pwmNe+qrHsrnFzvFzbDcX2khTTIxrZU1/+UX1C1zE54BVvdOWtk942ixfliAMzUFc0I/kIAOAAA"  // U2F sign testU2fCredentialId
+                ],
+                payloadBase64: [
+                    "Lg==",  // CTAP2 silent batch 0 → NO_CREDENTIALS
+                    "Lg==",  // CTAP2 silent batch 1 → NO_CREDENTIALS
+                    testU2fSignResponse  // U2F cred 0 success
+                ]
+            }
+        };
+        const options = {
+            publicKey: {
+                challenge: Base64URL.parse("MTIzNDU2"),
+                timeout: 100,
+                allowCredentials: [
+                    { type: "public-key", id: Base64URL.parse(testU2fCredentialIdBase64) },
+                    { type: "public-key", id: generateID(1) }
+                ],
+            }
+        };
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.get(options).then(credential => {
+            return checkU2fGetAssertionResult(credential);
+        });
+    }, "PublicKeyCredential's [[get]] with CTAP2→U2F downgrade skips wasteful CTAP2 tap (multi-credential).");
+
+    // Test for CTAP2→U2F downgrade optimization: single credential case
+    promise_test(t => {
+        let config = {
+            hid: {
+                canDowngrade: true,
+                validateExpectedCommands: true,
+                stage: "request",
+                subStage: "msg",
+                error: "success",
+                expectedCommandsBase64: [
+                    "AqQBaWxvY2FsaG9zdAJYIOr/zl5rE7v6WBJXzBhlxVkTUjZEZKyT9c+v9Ce6UFFqA4GiYmlkWEA+vYm/d+xQl1XunCY176qseyucXO8XNsNxfaSFNMjGtlTX/5RfULXMTngFW905a2T3jaLF+WIAzNQVzQj+QgA4ZHR5cGVqcHVibGljLWtleQWhYnVw9A==",  // Silent check (CTAP2)
+                    // NO CTAP2 with up=true - verifying the optimization!
+                    "AAIDAAAAger/zl5rE7v6WBJXzBhlxVkTUjZEZKyT9c+v9Ce6UFFqSZYN5YgOjGh0NBcPZHZgW4/krrmihjLHmVzzuoMdl2NAPr2Jv3fsUJdV7pwmNe+qrHsrnFzvFzbDcX2khTTIxrZU1/+UX1C1zE54BVvdOWtk942ixfliAMzUFc0I/kIAOAAA"  // U2F sign
+                ],
+                payloadBase64: [
+                    "Lg==",  // CTAP2 silent check → NO_CREDENTIALS
+                    testU2fSignResponse  // U2F sign → success
+                ]
+            }
+        };
+        const options = {
+            publicKey: {
+                challenge: Base64URL.parse("MTIzNDU2"),
+                timeout: 100,
+                allowCredentials: [
+                    { type: "public-key", id: Base64URL.parse(testU2fCredentialIdBase64) }
+                ],
+            }
+        };
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.get(options).then(credential => {
+            return checkU2fGetAssertionResult(credential);
+        });
+    }, "PublicKeyCredential's [[get]] with CTAP2→U2F downgrade skips wasteful CTAP2 tap (single credential).");
+
+    // Test that empty allowCredentials (resident key) does NOT skip CTAP2
+    promise_test(t => {
+        let config = {
+            hid: {
+                canDowngrade: true,
+                validateExpectedCommands: true,
+                stage: "request",
+                subStage: "msg",
+                error: "success",
+                expectedCommandsBase64: [
+                    "AqMBaWxvY2FsaG9zdAJYIOr/zl5rE7v6WBJXzBhlxVkTUjZEZKyT9c+v9Ce6UFFqBaFidXD1"   // CTAP2 with up=true (no silent check!)
+                ],
+                payloadBase64: [
+                    testAssertionMessageBase64  // CTAP2 with UP → success
+                ]
+            }
+        };
+        const options = {
+            publicKey: {
+                challenge: Base64URL.parse("MTIzNDU2"),
+                timeout: 100,
+                allowCredentials: []  // Empty - resident key flow
+            }
+        };
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.get(options).then(credential => {
+            return checkCtapGetAssertionResult(credential);
+        });
+    }, "PublicKeyCredential's [[get]] with empty allowCredentials does NOT skip CTAP2 (resident key safety).");
 </script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https.html
@@ -150,7 +150,7 @@
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", canDowngrade: true, payloadBase64: [testCtapErrInvalidCredentialResponseBase64, testU2fSignResponse] } });
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", canDowngrade: true, payloadBase64: ["Lg==", testU2fSignResponse] } });
         return navigator.credentials.get(options).then(credential => {
             return checkU2fGetAssertionResult(credential);
         });
@@ -167,7 +167,7 @@
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", canDowngrade: true, payloadBase64: [testCtapErrInvalidCredentialResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fSignResponse] } });
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", canDowngrade: true, payloadBase64: ["Lg==", testU2fApduWrongDataOnlyResponseBase64, testU2fSignResponse] } });
         return navigator.credentials.get(options).then(credential => {
             return checkU2fGetAssertionResult(credential, true, "7eabc5cc3251bdc59115ef87b5f7ee74cb03747e39ba8341748565cc129c0719");
         });

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -68,6 +68,7 @@ private:
     void continueRequestAfterGetPinToken(Vector<uint8_t>&&, const fido::pin::TokenRequest&);
     bool tryRestartPin(const fido::CtapDeviceResponseCode&);
 
+    bool canDowngradeToU2f() const;
     bool tryDowngrade();
 
     Vector<WebCore::AuthenticatorTransport> transports() const;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/web-authentication-get-assertion-nfc.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/web-authentication-get-assertion-nfc.html
@@ -11,7 +11,7 @@
         "4/F0VB7DlUVM09IHPmxe1MzHUwRoCRZbCAIgGKov6xoAx2MEf6/6qNs8OutzhP2C" +
         "QoJ1L7Fe64G9uBeQAA==";
     if (window.internals) {
-        internals.setMockWebAuthenticationConfiguration({ silentFailure: true, nfc: { payloadBase64: [testNfcCtapVersionBase64, testGetInfoResponseApduBase64, testAssertionMessageApduBase64] } });
+        internals.setMockWebAuthenticationConfiguration({ silentFailure: true, nfc: { payloadBase64: [testNfcCtapVersionBase64, testGetInfoResponseApduBase64, "Lg==", testAssertionMessageApduBase64] } });
         internals.withUserGesture(() => { input.focus(); });
     }
 


### PR DESCRIPTION
#### ddef090f6b4d8984da6b8081120d40bf6e1a277e
<pre>
[WebAuthn] Do not request user presence before U2F fallback
<a href="https://rdar.apple.com/159976632">rdar://159976632</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300839">https://bugs.webkit.org/show_bug.cgi?id=300839</a>

Reviewed by Brent Fulgham.

When authenticating with a security key supporting both CTAP2 and U2F, WebKit would
unnecessarily require two user taps and perform inefficient credential checking.

After CTAP2 silent credential checks failed, WebKit sent a CTAP2 request with user
presence (first tap), received an error, then downgraded to U2F (second tap). This
patch skips the wasteful CTAP2 request and downgrades immediately when silent checks
indicate no credentials exist, reducing taps from 2 to 1.

The batching logic incorrectly required both maxCredentialIDLength and
maxCredentialCountInList from getInfo to enable batching. The fix checks
for maxCredentialCountInList alone, enabling proper batching if maxCredentialIDLength
is missing.

Added layout tests to exercise this behavior.

* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https.html:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::getAssertion):
(WebKit::CtapAuthenticator::canDowngradeToU2f const):
(WebKit::CtapAuthenticator::tryDowngrade):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:

Canonical link: <a href="https://commits.webkit.org/301723@main">https://commits.webkit.org/301723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ced7855c3ccac005fb0a1fe17213ba50d562e9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133750 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78418 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96489 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77009 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31598 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77144 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136330 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104999 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104703 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26712 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50208 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28546 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50935 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59206 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52660 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55994 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54408 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->