### PR TITLE
REGRESSION (298506@main): [PLT6] ~13% increase in time to first paint / DOMContentLoaded on Facebook

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-skips-negative-z-index-modal-containers-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-skips-negative-z-index-modal-containers-expected.txt
@@ -1,0 +1,10 @@
+PASS sampledColors.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+To manually test, open this page in Safari and verify that bottom fixed color extensions don’t appear
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-skips-negative-z-index-modal-containers.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-skips-negative-z-index-modal-containers.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body {
+    font-family: system-ui;
+    margin: 0;
+}
+
+.tall {
+    width: 100%;
+    height: 2000px;
+    background: white;
+}
+
+#description {
+    margin-top: 100px;
+}
+
+.modal {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: lightgray;
+    z-index: -1;
+    position: fixed;
+}
+
+.modal-child {
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+}
+</style>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("To manually test, open this page in Safari and verify that bottom fixed color extensions don’t appear");
+
+    await UIHelper.ensurePresentationUpdate();
+    sampledColors = await UIHelper.fixedContainerEdgeColors();
+    shouldBeNull("sampledColors.bottom");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <header></header>
+    <p id="description"></p>
+    <div class="tall"></div>
+    <div class="modal">
+        <div class="modal-child"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2309,6 +2309,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         IsHiddenOrTransparent,
         TooSmall,
         TooLarge,
+        NegativeZIndex,
         IsViewportSizedCandidate,
         IsDimmingLayer,
         IsCandidate,
@@ -2359,8 +2360,12 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         if (isProbablyDimmingContainer)
             return IsDimmingLayer;
 
-        if (lengthOnSide == ViewportComparison::Similar && lengthOnAdjacentSide == ViewportComparison::Similar)
+        if (lengthOnSide == ViewportComparison::Similar && lengthOnAdjacentSide == ViewportComparison::Similar) {
+            if (auto zIndex = renderer.style().usedZIndex().tryValue(); zIndex && zIndex->isNegative())
+                return NegativeZIndex;
+
             return IsViewportSizedCandidate;
+        }
 
         return IsCandidate;
     };
@@ -2412,6 +2417,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
             case NotFixedOrSticky:
             case TooSmall:
                 break;
+            case NegativeZIndex:
             case TooLarge:
             case IsHiddenOrTransparent: {
                 hitInvisiblePointerEventsNoneContainer = ancestor->usedPointerEvents() == PointerEvents::None;


### PR DESCRIPTION
#### ab284b2b78794e09d0d9250ed336cc01cd4e8b34
<pre>
REGRESSION (298506@main): [PLT6] ~13% increase in time to first paint / DOMContentLoaded on Facebook
<a href="https://bugs.webkit.org/show_bug.cgi?id=300831">https://bugs.webkit.org/show_bug.cgi?id=300831</a>
<a href="https://rdar.apple.com/162552413">rdar://162552413</a>

Reviewed by Abrar Rahman Protyasha.

After the changes in 298506@main, we now get a bottom fixed color extension on the old, PLT 6
version of Twitter (notably, not Facebook) due to the fact that we no longer ignore viewport-sized
modal containers for the purposes of color sampling. This means that when navigating from Twitter to
Facebook during warm PLT 6 (these two subtests run back-to-back), Safari removes the solid color
extension behind the navigation bar, which causes UIKit&apos;s scroll pocket code to resample and re-
render the scroll pocket.

This additional spike in CPU / GPU activity during navigation subsequently slows down the time to
first paint on Facebook by a few milliseconds — enough to cause a significant regression on certain
(older) device models.

To mitigate this, we make some changes to the color sampling heuristic, such that we avoid detecting
the fixed-position container (which is z-ordered below the rest of the feed) on Twitter for the
purposes of color sampling.

Test: fast/page-color-sampling/color-sampling-skips-negative-z-index-modal-containers.html

* LayoutTests/fast/page-color-sampling/color-sampling-skips-negative-z-index-modal-containers-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-skips-negative-z-index-modal-containers.html: Added.

Add a new layout test to exercise this adjustment.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Don&apos;t consider large (viewport-sized) containers with a negative `z-index` as candidates for color
sampling.

Canonical link: <a href="https://commits.webkit.org/301605@main">https://commits.webkit.org/301605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50c7f9ff1e21bf02536b03fd4c9193d516c576ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133390 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78176 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5718f538-5069-4f7a-be8d-df30b987df1d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54681 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96261 "Failed to checkout and rebase branch from PR 52432") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5bc74552-f956-4a7d-a478-983a514f4d52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113127 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b3a6bf2a-ed30-44fe-9ac4-e5bdae4fcb2c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36303 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76697 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135937 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40898 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104765 "Failed to checkout and rebase branch from PR 52432") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104467 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26648 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49940 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28276 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50592 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53110 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58925 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52394 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55728 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54128 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->