### PR TITLE
AX: AccessibilityNodeObject::clearChildren() can dereference a nullptr

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -738,17 +738,13 @@ void AccessibilityNodeObject::updateChildrenIfNecessary()
 void AccessibilityNodeObject::clearChildren()
 {
     AccessibilityObject::clearChildren();
+
     m_childrenDirty = false;
+    m_containsOnlyStaticText = false;
+    m_containsOnlyStaticTextDirty = false;
 
-    if (isNativeLabel()) {
-        m_containsOnlyStaticText = false;
-        m_containsOnlyStaticTextDirty = false;
-    }
-
-    CheckedPtr rareData = isTable() ? this->rareData() : nullptr;
-    if (!rareData)
-        return;
-    rareData->resetChildrenDependentTableFields();
+    if (CheckedPtr rareData = this->rareData())
+        rareData->resetChildrenDependentTableFields();
 }
 
 void AccessibilityNodeObject::updateOwnedChildrenIfNecessary()


### PR DESCRIPTION
#### b952846cd5b13e621a9f87977649d201fd1b3726
<pre>
AX: AccessibilityNodeObject::clearChildren() can dereference a nullptr
<a href="https://bugs.webkit.org/show_bug.cgi?id=300851">https://bugs.webkit.org/show_bug.cgi?id=300851</a>
<a href="https://rdar.apple.com/161093750">rdar://161093750</a>

Reviewed by Chris Fleizach.

Given this sequence:

  1. Element::~Element()
  2. AXObjectCache::remove(WebCore::Node&amp;)
  3. AXObjectCache::remove(AXID)
  4. AccessibilityNodeObject::detachRemoteParts()
  5. AccessibilityNodeObject::clearChildren()
  6. AccessibilityNodeObject::isNativeLabel()

We dereference a nullptr when trying to check dynamicDowncast&lt;HTMLLabelElement&gt;(node()), because while the node is non-null
and not yet destroyed, it&apos;s m_tagName field has been cleared (and is this null), so the is&lt;HTMLLabelElement&gt; check dereferences
the null tagname.

Avoid this by removing the isNativeLabel() branch entirely. This virtual function call is not necessary, we can just
unconditionally reset the m_containsOnlyStaticText and m_containsOnlyStaticTextDirty bools. Also remove unnecessary
virtual function call to isTable() to avoid similar issues.

* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::clearChildren):

Canonical link: <a href="https://commits.webkit.org/301612@main">https://commits.webkit.org/301612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3c9bb0d856e55e477156716169a5eb632ad2129

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78181 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/90dacd94-2323-4920-b9d7-bead162ddd60) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96263 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/77176fd0-4717-4fae-9f8b-2ee7c4c81217) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76736 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/54946f68-3cc6-4911-8376-87ea1d844323) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31309 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76702 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135942 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104771 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26654 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49949 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28280 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50597 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53115 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58930 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52399 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55733 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54133 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->