### PR TITLE
Resync `domxpath` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/elements-are-parents-of-their-attributes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/elements-are-parents-of-their-attributes-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Elements are parents of their attributes
+PASS Attributes are not children of their parents
+

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/elements-are-parents-of-their-attributes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/elements-are-parents-of-their-attributes.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Relationship between elements and their attributes</title>
+        <link rel="author" title="Simon Wülker" href="mailto:simon.wuelker@arcor.de">
+        <link rel="help" href="https://www.w3.org/TR/1999/REC-xpath-19991116/#attribute-nodes">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <div id="context" foo="bar"></div>
+        <script>
+          const context = document.getElementById("context");
+
+          test(() => {
+              const result = document.evaluate(
+                "@foo/parent::*",
+                context,
+                null,
+                XPathResult.ORDERED_NODE_ITERATOR_TYPE,
+                null
+              );
+
+              assert_equals(result.iterateNext(), context);
+              assert_equals(result.iterateNext(), null);
+          }, "Elements are parents of their attributes");
+
+          test(() => {
+              const result = document.evaluate(
+                "node()",
+                context,
+                null,
+                XPathResult.ORDERED_NODE_ITERATOR_TYPE,
+                null
+              );
+
+              assert_equals(result.iterateNext(), null);
+          }, "Attributes are not children of their parents");
+      </script>
+    </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-id-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-id-expected.txt
@@ -1,0 +1,10 @@
+
+PASS id("test1"): <root><div id="test1">Match</div></root>
+PASS id("test1 test2"): <root><div id="test1">First</div><div id="test2">Second</div></root>
+PASS id("nonexistent"): <root><div id="test1">No match</div></root>
+PASS id("Test1"): <root><div id="test1">No match</div></root>
+FAIL id("duplicate"): <root><div id="duplicate">First</div><div id="duplicate">Second</div></root> assert_array_equals: Expected IDs duplicate,duplicate, got duplicate lengths differ, expected array ["duplicate", "duplicate"] length 2, got ["duplicate"] length 1
+PASS id("test-1"): <root><div id="test-1">Match</div></root>
+PASS id(""): <root><div id="">Empty ID</div></root>
+PASS id(" test1 "): <root><div id="test1">Match</div></root>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-id.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-id.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<link rel="help" href="https://www.w3.org/TR/1999/REC-xpath-19991116/#function-id">
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+// Test the id() function with various scenarios
+function testIdFunction(expression, xmlString, expectedIds) {
+  let doc = (new DOMParser()).parseFromString(xmlString, 'text/xml');
+  test(() => {
+    let result = doc.evaluate(expression, doc.documentElement, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+    assert_equals(result.resultType, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
+    let actualIds = [];
+    for (let i = 0; i < result.snapshotLength; i++) {
+      actualIds.push(result.snapshotItem(i).getAttribute('id'));
+    }
+    actualIds.sort();
+    expectedIds.sort();
+    assert_array_equals(actualIds, expectedIds, `Expected IDs ${expectedIds}, got ${actualIds}`);
+  }, `${expression}: ${doc.documentElement.outerHTML}`);
+}
+
+// Test single ID
+testIdFunction('id("test1")', '<root><div id="test1">Match</div></root>', ['test1']);
+
+// Test multiple IDs in space-separated string
+testIdFunction('id("test1 test2")', '<root><div id="test1">First</div><div id="test2">Second</div></root>', ['test1', 'test2']);
+
+// Test non-existent ID
+testIdFunction('id("nonexistent")', '<root><div id="test1">No match</div></root>', []);
+
+// Test mixed case IDs (should be case-sensitive)
+testIdFunction('id("Test1")', '<root><div id="test1">No match</div></root>', []);
+
+// Test multiple elements with same ID (should return all)
+testIdFunction('id("duplicate")', '<root><div id="duplicate">First</div><div id="duplicate">Second</div></root>', ['duplicate', 'duplicate']);
+
+// Test IDs with special characters
+testIdFunction('id("test-1")', '<root><div id="test-1">Match</div></root>', ['test-1']);
+
+// Test empty ID string
+testIdFunction('id("")', '<root><div id="">Empty ID</div></root>', []);
+
+// Test whitespace in ID string
+testIdFunction('id(" test1 ")', '<root><div id="test1">Match</div></root>', ['test1']);
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/result-iterateNext-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/result-iterateNext-expected.txt
@@ -1,0 +1,9 @@
+
+PASS Using an ordered iterator without modifying the dom should yield the expected elements in correct order without errors.
+PASS Using an unordered iterator without modifying the dom should yield the correct number of elements without errors.
+PASS invalidIteratorState should be false for non-iterable results.
+PASS Calling iterateNext on a non-iterable XPathResult should throw a TypeError.
+PASS Calling iterateNext on a non-iterable XPathResult after modifying the DOM should throw a TypeError.
+PASS Calling iterateNext after having modified the DOM should throw an exception.
+PASS Calling iterateNext after having modified the DOM should throw an exception even if the iterator is exhausted.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/result-iterateNext.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/result-iterateNext.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Invalidation of iterators over XPath results</title>
+  <link rel="author" title="Simon Wülker" href="mailto:simon.wuelker@arcor.de">
+  <link rel="help" href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-iterateNext">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <ul id="list">
+      <li id="first-child"></li>
+      <li id="second-child"></li>
+  </ul>
+  <script>
+    function make_xpath_query(result_type) {
+      return document.evaluate(
+        "//li",
+        document,
+        null,
+        result_type,
+        null
+      );
+    }
+
+    function invalidate_iterator(test) {
+      let new_element = document.createElement("li");
+      document.getElementById("list").appendChild(new_element);
+      test.add_cleanup(() => {
+        new_element.remove();
+      })
+    }
+
+    test((t) => {
+      let iterator = make_xpath_query(XPathResult.ORDERED_NODE_ITERATOR_TYPE);
+
+      assert_equals(iterator.iterateNext(), document.getElementById("first-child"));
+      assert_equals(iterator.iterateNext(), document.getElementById("second-child"));
+      assert_equals(iterator.iterateNext(), null);
+      assert_false(iterator.invalidIteratorState);
+    }, "Using an ordered iterator without modifying the dom should yield the expected elements in correct order without errors.");
+
+    test((t) => {
+      let iterator = make_xpath_query(XPathResult.UNORDERED_NODE_ITERATOR_TYPE);
+
+      assert_not_equals(iterator.iterateNext(), null);
+      assert_not_equals(iterator.iterateNext(), null);
+      assert_equals(iterator.iterateNext(), null);
+      assert_false(iterator.invalidIteratorState);
+    }, "Using an unordered iterator without modifying the dom should yield the correct number of elements without errors.");
+
+    test((t) => {
+      let non_iterator_query = make_xpath_query(XPathResult.BOOLEAN_TYPE);
+
+      assert_false(non_iterator_query.invalidIteratorState);
+      invalidate_iterator(t);
+      assert_false(non_iterator_query.invalidIteratorState);
+    }, "invalidIteratorState should be false for non-iterable results.");
+
+    test((t) => {
+      let non_iterator_query = make_xpath_query(XPathResult.BOOLEAN_TYPE);
+
+      assert_throws_js(TypeError, () => non_iterator_query.iterateNext());
+    }, "Calling iterateNext on a non-iterable XPathResult should throw a TypeError.");
+
+    test((t) => {
+      let non_iterator_query = make_xpath_query(XPathResult.BOOLEAN_TYPE);
+      invalidate_iterator(t);
+      assert_throws_js(TypeError, () => non_iterator_query.iterateNext());
+    }, "Calling iterateNext on a non-iterable XPathResult after modifying the DOM should throw a TypeError.");
+
+    test((t) => {
+        let iterator = make_xpath_query(XPathResult.ORDERED_NODE_ITERATOR_TYPE);
+
+        iterator.iterateNext();
+
+        invalidate_iterator(t);
+
+        assert_throws_dom(
+          "InvalidStateError",
+          () => iterator.iterateNext(),
+        );
+    }, "Calling iterateNext after having modified the DOM should throw an exception.");
+
+    test((t) => {
+        let iterator = make_xpath_query(XPathResult.ORDERED_NODE_ITERATOR_TYPE);
+
+        iterator.iterateNext();
+        iterator.iterateNext();
+
+        invalidate_iterator(t);
+
+        assert_throws_dom(
+          "InvalidStateError",
+          () => iterator.iterateNext(),
+        );
+    }, "Calling iterateNext after having modified the DOM should throw an exception even if the iterator is exhausted.");
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/variables-in-expression-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/variables-in-expression-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+
+<head>
+    <link rel="help" href="https://github.com/servo/servo/issues/36971">
+    <meta name="assert" content="Using variables in xpath expression should not crash.">
+</head>
+<body>
+    <script>
+      // The exact behaviour here is not defined. Firefox throws an error, Chrome doesn't.
+      document.evaluate("$foo", document.createElement("div"));
+    </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/w3c-import.log
@@ -18,6 +18,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/README.md
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/booleans.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/document.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/domxpath/elements-are-parents-of-their-attributes.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/evaluator-constructor.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/evaluator-cross-realm.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/evaluator-different-document.tentative.html
@@ -25,6 +26,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/expression-different-document.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-concat.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-contains.html
+/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-id.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-lang.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-normalize-space.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-starts-with.html
@@ -40,7 +42,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/resolver-callback-interface-cross-realm.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/resolver-callback-interface.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/resolver-non-string-result.html
+/LayoutTests/imported/w3c/web-platform-tests/domxpath/result-iterateNext.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/text-html-attributes.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/text-html-elements.html
+/LayoutTests/imported/w3c/web-platform-tests/domxpath/variables-in-expression-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/xpath-evaluate-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/domxpath/xpathevaluatorbase-creatensresolver.html


### PR DESCRIPTION
#### 7e281a93bf84d2591cc7a58b616b637bdb351040
<pre>
Resync `domxpath` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=300855">https://bugs.webkit.org/show_bug.cgi?id=300855</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/6456a0dc2036af09fe9f1a4545a48a43fe69fc9b">https://github.com/web-platform-tests/wpt/commit/6456a0dc2036af09fe9f1a4545a48a43fe69fc9b</a>

* LayoutTests/imported/w3c/web-platform-tests/domxpath/elements-are-parents-of-their-attributes-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/domxpath/elements-are-parents-of-their-attributes.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-id-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-id.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/domxpath/result-iterateNext-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/domxpath/result-iterateNext.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/domxpath/variables-in-expression-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/domxpath/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/301627@main">https://commits.webkit.org/301627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b228aec43873f9e2c5d9c29370af726c17cbb6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133405 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78191 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/44cb447e-8baa-4f35-bc99-ba274537b4b7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54699 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96276 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/96fdf395-7586-4f3e-8aad-48ef31c76c2d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76750 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/82d6085f-8864-43d4-a933-be3e85f6f757) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31322 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76713 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135953 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53207 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104780 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104482 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26660 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49957 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28291 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50615 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53127 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52409 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54144 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->