### PR TITLE
Resync `css/css-cascade` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
@@ -26,4 +26,5 @@ PASS Modifying selectorText invalidates affected elements
 PASS Modifying selectorText invalidates affected elements (>)
 PASS Relative selectors set with selectorText are relative to :scope and &
 PASS Ancestor element affecting nested scope root (Through latter selector in list)
+PASS Parent element of subject affecting scope limit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation.html
@@ -900,3 +900,35 @@ test_scope_invalidation(document.currentScript, () => {
   assert_green(g);
 }, 'Ancestor element affecting nested scope root (Through latter selector in list)')
 </script>
+
+<template>
+  <style>
+    @scope (.a) to (.b .c) {
+      :scope .d .f{
+        background-color: green;
+      }
+    }
+    </style>
+
+  <div class=a>
+    <div class=b>
+      <div class=d>
+        <div class=c>
+          <div class=f>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+  test_scope_invalidation(document.currentScript, () => {
+  let b = main.querySelector('.b');
+  let f = main.querySelector('.f');
+  assert_not_green(f);
+  b.classList.remove('b');
+  assert_green(f);
+  b.classList.add('b');
+  assert_not_green(f);
+}, 'Parent element of subject affecting scope limit')
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
@@ -21,4 +21,6 @@ PASS Insert a nested style rule within @scope, &
 PASS Insert a nested style rule within @scope, :scope
 PASS Insert a CSSNestedDeclarations rule directly in top-level @scope
 PASS Mutating selectorText on outer style rule causes correct inner specificity
+PASS Modifying selectorText invalidates inner scoped rules
+PASS Modifying selectorText invalidates inner scoped rules (nested declarations)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting.html
@@ -693,3 +693,76 @@ test((t) => {
   assert_equals(getComputedStyle(child).getPropertyValue('--x'), '1'); // Changed.
 }, 'Mutating selectorText on outer style rule causes correct inner specificity');
 </script>
+
+<template id=test_set_selector_text>
+  <style id=style>
+    :where(.x) {
+      background-color: black;
+    }
+    .a {
+      @scope (&) {
+        :scope .x { background-color: green; }
+      }
+    }
+  </style>
+  <div class=a>
+    <div class=x>
+    </div>
+  </div>
+  <div class=b>
+    <div class=x>
+    </div>
+  </div>
+</template>
+<script>
+test((t) => {
+  t.add_cleanup(() => main.replaceChildren());
+  main.append(test_set_selector_text.content.cloneNode(true));
+  let ax = main.querySelector('.a > .x');
+  let bx = main.querySelector('.b > .x');
+  assert_equals(getComputedStyle(ax).backgroundColor, 'rgb(0, 128, 0)');
+  assert_equals(getComputedStyle(bx).backgroundColor, 'rgb(0, 0, 0)');
+  style.sheet.cssRules[1].selectorText = '.b'; // .a -> .
+  assert_equals(getComputedStyle(ax).backgroundColor, 'rgb(0, 0, 0)');
+  assert_equals(getComputedStyle(bx).backgroundColor, 'rgb(0, 128, 0)');
+}, 'Modifying selectorText invalidates inner scoped rules');
+</script>
+
+<template id=test_set_selector_text_nested_declarations>
+  <style id=style>
+    :where(.x) {
+      background-color: black;
+    }
+    .a {
+      @scope (&) {
+        :scope .x {
+          .unused {}
+          /* CSSNestedDeclarations { */
+          background-color: green;
+          /* } { */
+        }
+      }
+    }
+  </style>
+  <div class=a>
+    <div class=x>
+    </div>
+  </div>
+  <div class=b>
+    <div class=x>
+    </div>
+  </div>
+</template>
+<script>
+test((t) => {
+  t.add_cleanup(() => main.replaceChildren());
+  main.append(test_set_selector_text_nested_declarations.content.cloneNode(true));
+  let ax = main.querySelector('.a > .x');
+  let bx = main.querySelector('.b > .x');
+  assert_equals(getComputedStyle(ax).backgroundColor, 'rgb(0, 128, 0)');
+  assert_equals(getComputedStyle(bx).backgroundColor, 'rgb(0, 0, 0)');
+  style.sheet.cssRules[1].selectorText = '.b'; // .a -> .
+  assert_equals(getComputedStyle(ax).backgroundColor, 'rgb(0, 0, 0)');
+  assert_equals(getComputedStyle(bx).backgroundColor, 'rgb(0, 128, 0)');
+}, 'Modifying selectorText invalidates inner scoped rules (nested declarations)');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/w3c-import.log
@@ -9,12 +9,12 @@ Do NOT modify or remove this file.
 
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
-user-select
-text-size-adjust
-box-decoration-break
-mask-position-x
 mask-position-y
+user-select
+mask-position-x
+text-size-adjust
 initial-letter
+box-decoration-break
 Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------


### PR DESCRIPTION
#### d008e4f2fbc5dd386e5c6097f5b65d7ecbcfccc1
<pre>
Resync `css/css-cascade` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=300858">https://bugs.webkit.org/show_bug.cgi?id=300858</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/6456a0dc2036af09fe9f1a4545a48a43fe69fc9b">https://github.com/web-platform-tests/wpt/commit/6456a0dc2036af09fe9f1a4545a48a43fe69fc9b</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/301630@main">https://commits.webkit.org/301630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfb1e35867f42049f1182254362cfa34ae146599

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133410 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78196 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96279 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113149 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76753 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31328 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76718 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135958 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104788 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104490 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26661 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49964 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28296 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50625 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53132 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52414 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54149 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->