### PR TITLE
Resync `html/semantics/forms/the-button-element` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/WEB_FEATURES.yml
@@ -1,0 +1,10 @@
+features:
+- name: constraint-validation
+  files:
+  - button-checkvalidity.html
+  - button-setcustomvalidity.html
+  - button-validation.html
+  - button-validationmessage.html
+  - button-validity.html
+  - button-willvalidate-readonly-attribute.html
+  - button-willvalidate.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-resets-with-commandfor.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-resets-with-commandfor.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS clicking a reset button should trigger a reset (with command attribute)
+PASS clicking a button should trigger a reset (with commandfor attribute)
+PASS clicking a button should trigger a reset (with command and commandfor attribute)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-resets-with-commandfor.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-resets-with-commandfor.tentative.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>Clicking a button should submit the form</title>
+<meta name="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<link
+  rel="help"
+  href="https://html.spec.whatwg.org/multipage/#attr-button-type-submit-state"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<form id="form">
+  <button id="button" type="reset"></button>
+</form>
+
+<script>
+  const form = document.getElementById("form");
+  const button = document.getElementById("button");
+
+  function resetState() {
+    button.removeAttribute("commandfor");
+    button.removeAttribute("command");
+    button.removeAttribute("disabled");
+    button.removeAttribute("form");
+    button.setAttribute("type", "reset");
+  }
+
+  test((t) => {
+    t.add_cleanup(resetState);
+    button.setAttribute("command", "--foo");
+
+    let called = false;
+    form.addEventListener("reset", (e) => {
+      called = true;
+    });
+    button.click();
+    assert_true(called, "reset should have been dispatched");
+  }, "clicking a reset button should trigger a reset (with command attribute)");
+
+  test((t) => {
+    t.add_cleanup(resetState);
+    button.setAttribute("commandfor", "whatever");
+
+    let called = false;
+    form.addEventListener("reset", (e) => {
+      called = true;
+    });
+    button.click();
+    assert_true(called, "reset should have been dispatched");
+  }, "clicking a button should trigger a reset (with commandfor attribute)");
+
+  test((t) => {
+    t.add_cleanup(resetState);
+    button.setAttribute("command", "--foo");
+    button.setAttribute("commandfor", "whatever");
+
+    let called = false;
+    form.addEventListener("reset", (e) => {
+      called = true;
+    });
+    button.click();
+    assert_true(called, "reset should have been dispatched");
+  }, "clicking a button should trigger a reset (with command and commandfor attribute)");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits-expected.txt
@@ -7,6 +7,7 @@ hello
 
 
 
+
 PASS clicking a button with .click() should trigger a submit (form connected)
 PASS clicking a button with .click() should not trigger a submit (form disconnected)
 PASS clicking a button by dispatching an event should trigger a submit (form connected)
@@ -18,4 +19,5 @@ PASS clicking a button inside a disabled fieldset's legend *should* trigger subm
 PASS clicking the child of a button with .click() should trigger a submit
 PASS clicking the child of a button by dispatching a bubbling event should trigger a submit
 FAIL clicking the child of a button by dispatching a non-bubbling event should not trigger submit assert_unreached: Form should not be submitted Reached unreachable code
+PASS clicking the child of a disabled button with .click() should not trigger submit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits-with-commandfor.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits-with-commandfor.tentative-expected.txt
@@ -1,0 +1,9 @@
+
+
+PASS clicking a button (implicit type) should NOT trigger a submit (with command attribute)
+PASS clicking a button (implicit type) should NOT trigger a submit (with commandfor attribute)
+PASS clicking a button (implicit type) should NOT trigger a submit (with command and commandfor attribute)
+PASS clicking a button (explicit type=submit) SHOULD trigger a submit (with command attribute)
+PASS clicking a button (explicit type=submit) SHOULD trigger a submit (with commandfor attribute)
+PASS clicking a button (explicit type=submit) SHOULD trigger a submit (with command and commandfor attribute)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits-with-commandfor.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits-with-commandfor.tentative.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>Clicking a button should submit the form</title>
+<meta name="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<link
+  rel="help"
+  href="https://html.spec.whatwg.org/multipage/#attr-button-type-submit-state"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<form id="form">
+  <button id="button"></button>
+</form>
+
+<script>
+  const form = document.getElementById("form");
+  const button = document.getElementById("button");
+
+  function resetState() {
+    button.removeAttribute("commandfor");
+    button.removeAttribute("command");
+    button.removeAttribute("disabled");
+    button.removeAttribute("form");
+    button.removeAttribute("type");
+  }
+
+  test((t) => {
+    t.add_cleanup(resetState);
+    button.setAttribute("command", "--foo");
+
+    let called = false;
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      called = true;
+    }, { once: true });
+    button.click();
+    assert_false(called, "submit should not have been dispatched");
+  }, "clicking a button (implicit type) should NOT trigger a submit (with command attribute)");
+
+  test((t) => {
+    t.add_cleanup(resetState);
+    button.setAttribute("commandfor", "whatever");
+
+    let called = false;
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      called = true;
+    }, { once: true });
+    button.click();
+    assert_false(called, "submit should not have been dispatched");
+  }, "clicking a button (implicit type) should NOT trigger a submit (with commandfor attribute)");
+
+  test((t) => {
+    t.add_cleanup(resetState);
+    button.setAttribute("command", "--foo");
+    button.setAttribute("commandfor", "whatever");
+
+    let called = false;
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      called = true;
+    }, { once: true });
+    button.click();
+    assert_false(called, "submit should not have been dispatched");
+  }, "clicking a button (implicit type) should NOT trigger a submit (with command and commandfor attribute)");
+
+  test((t) => {
+    t.add_cleanup(resetState);
+    button.setAttribute("command", "--foo");
+    button.setAttribute("type", "submit");
+
+    let called = false;
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      called = true;
+    }, { once: true });
+    button.click();
+    assert_true(called, "submit should have been dispatched");
+  }, "clicking a button (explicit type=submit) SHOULD trigger a submit (with command attribute)");
+
+  test((t) => {
+    t.add_cleanup(resetState);
+    button.setAttribute("commandfor", "whatever");
+    button.setAttribute("type", "submit");
+
+    let called = false;
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      called = true;
+    }, { once: true });
+    button.click();
+    assert_true(called, "submit should have been dispatched");
+  }, "clicking a button (explicit type=submit) SHOULD trigger a submit (with commandfor attribute)");
+
+  test((t) => {
+    t.add_cleanup(resetState);
+    button.setAttribute("command", "--foo");
+    button.setAttribute("commandfor", "whatever");
+    button.setAttribute("type", "submit");
+
+    let called = false;
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      called = true;
+    }, { once: true });
+    button.click();
+    assert_true(called, "submit should have been dispatched");
+  }, "clicking a button (explicit type=submit) SHOULD trigger a submit (with command and commandfor attribute)");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits.html
@@ -198,7 +198,6 @@ async_test(t => {
   }));
 
   span.addEventListener("click", t.step_func(ev => {
-    ev.preventDefault();
     t.step_timeout(() => t.done(), 500);
   }));
 
@@ -207,4 +206,27 @@ async_test(t => {
 
 }, "clicking the child of a button by dispatching a non-bubbling event should not trigger submit");
 
+async_test(t => {
+
+  const form = document.createElement("form");
+  const button = document.createElement("button");
+  button.disabled = true;
+  const span = document.createElement("span");
+  button.appendChild(span);
+  form.appendChild(button);
+  document.body.appendChild(form);
+
+  form.addEventListener("submit", t.step_func_done(ev => {
+    ev.preventDefault();
+    assert_unreached("Form should not be submitted");
+  }));
+
+  span.addEventListener("click", t.step_func(ev => {
+    assert_true(true, "span was clicked");
+    t.step_timeout(() => t.done(), 500);
+  }));
+
+  span.click();
+
+}, "clicking the child of a disabled button with .click() should not trigger submit");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-submit-children-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-submit-children-expected.txt
@@ -3,4 +3,5 @@
 button child div text
 
 PASS This test will pass if a form navigation successfully occurs when clicking a child element of a <button type=submit> element with a onclick event handler which prevents the default form submission and manually calls form.submit() instead.
+PASS clicking a submit button, which calls form.submit and has a parent calling e.prevenDefault() should still submit the form
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-submit-children.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-submit-children.html
@@ -7,11 +7,13 @@
 
 <iframe name=frame1 id=frame1></iframe>
 <form id=form1 target=frame1 action="does_not_exist.html">
-  <button id=submitbutton type=submit>
-    <div id=buttonchilddiv>
-      button child div text
-    </div>
-  </button>
+  <div id=parentdiv>
+    <button id=submitbutton type=submit>
+      <div id=buttonchilddiv>
+        button child div text
+      </div>
+    </button>
+  </div>
 </form>
 
 <script>
@@ -31,4 +33,26 @@ async_test(t => {
     buttonChildDiv.click();
   });
 }, 'This test will pass if a form navigation successfully occurs when clicking a child element of a <button type=submit> element with a onclick event handler which prevents the default form submission and manually calls form.submit() instead.');
+
+async_test(t => {
+  window.addEventListener('load', () => {
+    const frame1 = document.getElementById('frame1');
+    frame1.addEventListener('load', t.step_func_done(() => {}));
+
+    const submitButton = document.getElementById('submitbutton');
+    submitButton.addEventListener('click', event => {
+      const form = document.getElementById('form1');
+      form.submit();
+    });
+
+    const parentDiv = document.getElementById("parentdiv");
+    parentDiv.addEventListener("click", event => {
+      // event was already handled for the button
+      // but it's activation behavior won't have run yet and we prevent that now
+      event.preventDefault();
+    })
+
+    submitButton.click();
+  });
+}, "clicking a submit button, which calls form.submit and has a parent calling e.prevenDefault() should still submit the form");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-untrusted-key-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-untrusted-key-event-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Dispatching untrusted keypress events to submit button should not cause click event
+PASS Dispatching untrusted keyup/keydown events to submit button should not cause click event
+PASS Dispatching untrusted keypress events to reset button should not cause click event
+PASS Dispatching untrusted keyup/keydown events to reset button should not cause click event
+PASS Dispatching untrusted keypress events to button button should not cause click event
+PASS Dispatching untrusted keyup/keydown events to button button should not cause click event
+Submit  Reset  Button

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-untrusted-key-event.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-untrusted-key-event.html
@@ -1,0 +1,112 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Forms</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<form id="input_form">
+  <button name="submitButton" type="submit">Submit</button>
+  <button name="resetButton" type="reset">Reset</button>
+  <button name="buttonButton" type="button">Button</button>
+</form>
+<script type="module">
+const form = document.querySelector("form");
+form.addEventListener("submit", (e) => {
+  e.preventDefault();
+  assert_true(false, 'form should not be submitted');
+});
+
+for (const button of document.querySelectorAll("button")) {
+  button.addEventListener("click", function(e) {
+    assert_true(false, `${button.type} button should not be clicked`);
+  });
+}
+
+// Create and append button elements
+for (const button of document.querySelectorAll("button")) {
+  test(() => {
+    // keyCode: Enter
+    button.dispatchEvent(
+      new KeyboardEvent("keypress", {
+        keyCode: 13,
+      })
+    );
+
+    // key: Enter
+    button.dispatchEvent(
+      new KeyboardEvent("keypress", {
+        key: "Enter",
+      })
+    );
+
+    // keyCode: Space
+    button.dispatchEvent(
+      new KeyboardEvent("keypress", {
+        keyCode: 32,
+      })
+    );
+
+    // key: Space
+    button.dispatchEvent(
+      new KeyboardEvent("keypress", {
+        key: " ",
+      })
+    );
+  }, `Dispatching untrusted keypress events to ${button.type} button should not cause click event`);
+
+  test(() => {
+    // keyCode: Enter
+    button.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        keyCode: 13,
+      })
+    );
+    button.dispatchEvent(
+      new KeyboardEvent("keyup", {
+        keyCode: 13,
+      })
+    );
+
+    // key: Enter
+    button.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+      })
+    );
+    button.dispatchEvent(
+      new KeyboardEvent("keyup", {
+        key: "Enter",
+      })
+    );
+
+    // keyCode: Space
+    button.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        keyCode: 32,
+      })
+    );
+    button.dispatchEvent(
+      new KeyboardEvent("keyup", {
+        keyCode: 32,
+      })
+    );
+
+    // key: Space
+    button.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: " ",
+      })
+    );
+    button.dispatchEvent(
+      new KeyboardEvent("keyup", {
+        key: " ",
+      })
+    );
+  }, `Dispatching untrusted keyup/keydown events to ${button.type} button should not cause click event`);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/w3c-import.log
@@ -14,11 +14,14 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/active-onblur.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-activate-frame.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-activate-keyup-prevented.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-activate.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-checkvalidity.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-resets-with-commandfor.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits-with-commandfor.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-events.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-labels.html
@@ -30,7 +33,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-submit-remove-jssubmit.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-type-enumerated-ascii-case-insensitive.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-type.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-untrusted-key-event.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-validation.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-validationmessage.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-validity.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-willvalidate-readonly-attribute.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-willvalidate.html


### PR DESCRIPTION
#### b8ea75ad036f8142935373e1b094a82f3753fa81
<pre>
Resync `html/semantics/forms/the-button-element` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=300859">https://bugs.webkit.org/show_bug.cgi?id=300859</a>

Reviewed by Aditya Keerthi.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/bda4a4698562f88fc6dcdd72964fda0a69e6eda2">https://github.com/web-platform-tests/wpt/commit/bda4a4698562f88fc6dcdd72964fda0a69e6eda2</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-resets-with-commandfor.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-resets-with-commandfor.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits-with-commandfor.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits-with-commandfor.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-click-submits.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-submit-children-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-submit-children.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-untrusted-key-event-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-untrusted-key-event.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/301631@main">https://commits.webkit.org/301631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaa1c5e5a121638f7ff35e9b5703d7d5a67d084c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78199 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96282 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c8bdac8-ef23-4f66-a309-acaa855fc664) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76756 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/119188e7-6080-4d2f-a878-62c4f33b3175) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31331 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76721 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107248 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135961 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104787 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104489 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26658 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49969 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28299 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50627 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53135 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52417 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55751 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54152 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->