### PR TITLE
[WebVTT] Custom Caption Text Size Settings do not adjust cue font size

### DIFF
--- a/LayoutTests/media/track/track-user-stylesheet-cue-font-size-expected.txt
+++ b/LayoutTests/media/track/track-user-stylesheet-cue-font-size-expected.txt
@@ -1,0 +1,11 @@
+
+
+RUN(internals.setCaptionDisplayMode('AlwaysOn'))
+RUN(internals.setCaptionsStyleSheetOverride('video::cue { font-size: 20px; }'))
+RUN(video.textTracks[0].mode = "showing")
+EXPECTED (video.textTracks[0].cues.length > '0') OK
+RUN(video.currentTime = 0.5)
+EXPECTED (firstCueElement() != 'null') OK
+EXPECTED (window.getComputedStyle(firstCueElement()).fontSize == '20px') OK
+END OF TEST
+

--- a/LayoutTests/media/track/track-user-stylesheet-cue-font-size.html
+++ b/LayoutTests/media/track/track-user-stylesheet-cue-font-size.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+    <script src=../media-file.js></script>
+    <script src=../video-test.js></script>
+
+    <style>
+    	video { height: 200px; }
+    </style>
+
+    <script>
+    window.addEventListener('load', event => {
+    	runTest().then(endTest).catch(failTest);
+    });
+
+    function firstCueElement() {
+        return internals.shadowRoot(video).querySelector('[useragentpart="-internal-cue-background"]');
+    }
+
+    async function runTest() {
+        consoleWrite("");
+        run("internals.setCaptionDisplayMode('AlwaysOn')");
+        run("internals.setCaptionsStyleSheetOverride('video::cue { font-size: 20px; }')");
+
+        findMediaElement();
+        video.src = findMediaFile('video', '../content/test');
+        await waitFor(video, 'canplaythrough', true);
+
+        run('video.textTracks[0].mode = "showing"');
+        await testExpectedEventually('video.textTracks[0].cues.length', '0', '>');
+
+        run('video.currentTime = 0.5');
+        await waitFor(video, 'seeked', true);
+
+        await testExpectedEventually('firstCueElement()', null, '!=');
+        await testExpected(`window.getComputedStyle(firstCueElement()).fontSize`, '20px');
+    }
+    </script>
+</head>
+<body>
+    <video>
+        <track src="captions-webvtt/styling.vtt" kind="captions">
+    </video>
+</body>
+</html>

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -186,7 +186,6 @@ void MediaControlTextTrackContainerElement::updateDisplay()
             if (cue->protectedTrack()->isSpoken())
                 continue;
 
-            cue->setFontSize(m_fontSize, m_fontSizeIsImportant);
             if (RefPtr vttCue = dynamicDowncast<VTTCue>(cue))
                 processActiveVTTCue(*vttCue);
             else {
@@ -262,12 +261,6 @@ void MediaControlTextTrackContainerElement::updateActiveCuesFontSize()
     // scale by display size. Since |vh| is a decimal percentage, multiply
     // the scale factor by 100 to achive the final font size.
     m_fontSize = lroundf(100 * fontScale);
-
-    for (auto& activeCue : mediaElement->currentlyActiveCues()) {
-        RefPtr cue = activeCue.data();
-        if (cue->isRenderable())
-            cue->setFontSize(m_fontSize, m_fontSizeIsImportant);
-    }
 }
 
 void MediaControlTextTrackContainerElement::updateTextStrokeStyle()

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -249,11 +249,6 @@ void VTTCueBox::applyCSSProperties()
     // unless if it is the child of a region, then it is to be relatively positioned.
     setInlineStyleProperty(CSSPropertyPosition, CSSValueAbsolute);
 
-    // The font shorthand property on the (root) list of WebVTT Node Objects
-    // must be set to 5vh sans-serif. [CSS-VALUES]
-    // NOTE: We use 'cqh' rather than 'vh' as the video element is not a proper viewport.
-    setInlineStyleProperty(CSSPropertyFontSize, cue->fontSize(), CSSUnitType::CSS_CQMIN, cue->fontSizeIsImportant() ? IsImportant::Yes : IsImportant::No);
-
     if (!cue->snapToLines()) {
         setInlineStyleProperty(CSSPropertyWhiteSpaceCollapse, CSSValuePreserve);
         setInlineStyleProperty(CSSPropertyTextWrapMode, CSSValueNowrap);

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -502,6 +502,19 @@ String CaptionUserPreferencesMediaAF::captionsDefaultFontCSS() const
     return builder.toString();
 }
 
+String CaptionUserPreferencesMediaAF::captionsFontSizeCSS() const
+{
+    bool important = false;
+    float fontScale = captionFontSizeScaleAndImportance(important);
+
+    // Caption fonts are defined as |size vh| units, so there's no need to
+    // scale by display size. Since |vh| is a decimal percentage, multiply
+    // the scale factor by 100 to achive the final font size.
+    long fontSize = lroundf(100 * fontScale);
+
+    return makeString("font-size: "_s, fontSize, "cqmin"_s, important ? "!important;"_s : ";"_s);
+}
+
 float CaptionUserPreferencesMediaAF::captionFontSizeScaleAndImportance(bool& important) const
 {
     if (testingMode() || !MediaAccessibilityLibrary())
@@ -623,10 +636,11 @@ String CaptionUserPreferencesMediaAF::captionsStyleSheetOverride() const
     String captionsColor = captionsTextColorCSS();
     String edgeStyle = captionsTextEdgeCSS();
     String fontName = captionsDefaultFontCSS();
+    String fontSize = captionsFontSizeCSS();
     String background = captionsBackgroundCSS();
-    if (!background.isEmpty() || !captionsColor.isEmpty() || !edgeStyle.isEmpty() || !fontName.isEmpty()) {
-        captionsOverrideStyleSheet.append(" ::"_s, UserAgentParts::cue(), '{', background, captionsColor, edgeStyle, fontName, '}');
-        captionsOverrideStyleSheet.append(" ::"_s, UserAgentParts::cue(), "(rt) {"_s, background, captionsColor, edgeStyle, fontName, '}');
+    if (!background.isEmpty() || !captionsColor.isEmpty() || !edgeStyle.isEmpty() || !fontName.isEmpty() || !fontSize.isEmpty()) {
+        captionsOverrideStyleSheet.append(" ::"_s, UserAgentParts::cue(), '{', background, captionsColor, edgeStyle, fontName, fontSize, '}');
+        captionsOverrideStyleSheet.append(" ::"_s, UserAgentParts::cue(), "(rt) {"_s, background, captionsColor, edgeStyle, fontName, fontSize, '}');
     }
     String windowColor = captionsWindowCSS();
     String windowCornerRadius = windowRoundedCornerRadiusCSS();


### PR DESCRIPTION
#### 9bac85c317ff5f333ad931d0de43ffacdf636882
<pre>
[WebVTT] Custom Caption Text Size Settings do not adjust cue font size
<a href="https://rdar.apple.com/162547969">rdar://162547969</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300861">https://bugs.webkit.org/show_bug.cgi?id=300861</a>

Reviewed by Eric Carlson.

In 265596@main, VTTCue was updated to set a font-size property in the cue&apos;s
own style attribute. However, this style attribute did not propogate the font
size down to child elements that contained the cue text.

Rather than set the font-size as a per-element style attribute, move the font
size property into the &lt;style&gt; tag attached to the text track rendering area
along with all the other system-settings derived styles.

Test: media/track/track-user-stylesheet-cue-font-size.html

* LayoutTests/media/track/track-user-stylesheet-cue-font-size-expected.txt: Added.
* LayoutTests/media/track/track-user-stylesheet-cue-font-size.html: Added.
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateDisplay):
(WebCore::MediaControlTextTrackContainerElement::updateActiveCuesFontSize):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCueBox::applyCSSProperties):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::captionsFontSizeCSS const):
(WebCore::CaptionUserPreferencesMediaAF::captionsStyleSheetOverride const):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.h:

Canonical link: <a href="https://commits.webkit.org/301681@main">https://commits.webkit.org/301681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0cecf56b559eb8cd5488ecb7eb5cd2defcadd6b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133678 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b9950f2c-cfe5-4b88-bfc6-51997727d2e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54897 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/898e0694-6b14-4ee3-8350-b9b2f3cb2478) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129668 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/37592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113330 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/68bf6582-499a-47e9-92c6-4c8d395f3aeb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31515 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/77075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136254 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53400 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/41083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109691 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26685 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50131 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50840 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53326 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/59127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54334 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->