### PR TITLE
[JSC] use __asm__ consistently

### DIFF
--- a/Source/JavaScriptCore/assembler/JITOperationList.cpp
+++ b/Source/JavaScriptCore/assembler/JITOperationList.cpp
@@ -47,8 +47,8 @@ namespace JSC {
 
 LazyNeverDestroyed<JITOperationList> jitOperationList;
 
-extern const JITOperationAnnotation startOfJITOperationsInJSC __asm("section$start$__DATA_CONST$__jsc_ops");
-extern const JITOperationAnnotation endOfJITOperationsInJSC __asm("section$end$__DATA_CONST$__jsc_ops");
+extern const JITOperationAnnotation startOfJITOperationsInJSC __asm__("section$start$__DATA_CONST$__jsc_ops");
+extern const JITOperationAnnotation endOfJITOperationsInJSC __asm__("section$end$__DATA_CONST$__jsc_ops");
 
 void JITOperationList::initialize()
 {

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
@@ -331,7 +331,7 @@ static_assert(JIT_PROBE_STACK_INITIALIZATION_FUNCTION_PTR_TAG == JITProbeStackIn
 
 // We use x29 and x30 instead of fp and lr because GCC's inline assembler does not recognize fp and lr.
 // See https://bugs.webkit.org/show_bug.cgi?id=175512 for details.
-asm (
+__asm__(
     ".text" "\n"
     ".balign 16" "\n"
     ".globl " SYMBOL_STRING(ctiMasmProbeTrampoline) "\n"
@@ -584,7 +584,7 @@ asm (
 );
 
 // And now, the slower version that saves the full width of FP registers:
-asm (
+__asm__(
     ".text" "\n"
     ".balign 16" "\n"
     ".globl " SYMBOL_STRING(ctiMasmProbeTrampolineSIMD) "\n"

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.cpp
@@ -218,7 +218,7 @@ static_assert(IN_R3_OFFSET == offsetof(IncomingRecord, r3), "IN_R3_OFFSET is inc
 static_assert(IN_ALIGNMENT_PADDING_OFFSET == offsetof(IncomingRecord, alignmentPadding), "IN_ALIGNMENT_PADDING_OFFSET is incorrect");
 static_assert(IN_SIZE == sizeof(IncomingRecord), "IN_SIZE is incorrect");
 
-asm (
+__asm__(
     ".text" "\n"
     ".align 2" "\n"
     ".globl " SYMBOL_STRING(ctiMasmProbeTrampoline) "\n"

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.cpp
@@ -264,7 +264,7 @@ static_assert(offsetof(RARestorationRecord, ra) == RA_RESTORATION_RA_OFFSET);
 static_assert(sizeof(RARestorationRecord) == RA_RESTORATION_SIZE);
 static_assert(!(RA_RESTORATION_SIZE & 0xf));
 
-asm(
+__asm__(
     ".text" "\n"
     ".globl " SYMBOL_STRING(ctiMasmProbeTrampoline) "\n"
     ".attribute arch, \"rv64gc\"" "\n"

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.cpp
@@ -181,7 +181,7 @@ static_assert(sizeof(Probe::State) == PROBE_SIZE, "Probe::State::size's matches 
 #undef PROBE_OFFSETOF
 
 #if CPU(X86_64)
-asm (
+__asm__(
     ".text" "\n"
     ".globl " SYMBOL_STRING(ctiMasmProbeTrampoline) "\n"
     HIDE_SYMBOL(ctiMasmProbeTrampoline) "\n"
@@ -381,7 +381,7 @@ asm (
 
 // And now, the slower version that saves the full width of vectors in xmm registers.
 
-asm (
+__asm__(
     ".text" "\n"
     ".globl " SYMBOL_STRING(ctiMasmProbeTrampolineSIMD) "\n"
     HIDE_SYMBOL(ctiMasmProbeTrampolineSIMD) "\n"

--- a/Source/JavaScriptCore/assembler/SecureARM64EHashPinsInlines.h
+++ b/Source/JavaScriptCore/assembler/SecureARM64EHashPinsInlines.h
@@ -34,7 +34,7 @@ namespace JSC {
 ALWAYS_INLINE uint64_t SecureARM64EHashPins::keyForCurrentThread()
 {
     uint64_t result;
-    asm (
+    __asm__(
         "mrs %x[result], TPIDRRO_EL0"
         : [result] "=r" (result)
         :

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -986,8 +986,8 @@ void run(const TestConfig* config)
 bool g_dumpB3AfterGeneration = false;
 
 #if ENABLE(JIT_OPERATION_VALIDATION) || ENABLE(JIT_OPERATION_DISASSEMBLY)
-extern const JSC::JITOperationAnnotation startOfJITOperationsInTestB3 __asm("section$start$__DATA_CONST$__jsc_ops");
-extern const JSC::JITOperationAnnotation endOfJITOperationsInTestB3 __asm("section$end$__DATA_CONST$__jsc_ops");
+extern const JSC::JITOperationAnnotation startOfJITOperationsInTestB3 __asm__("section$start$__DATA_CONST$__jsc_ops");
+extern const JSC::JITOperationAnnotation endOfJITOperationsInTestB3 __asm__("section$end$__DATA_CONST$__jsc_ops");
 #endif
 
 int main(int argc, char** argv)

--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -2505,7 +2505,7 @@ double correctSqrt(double value)
 {
 #if CPU(X86_64)
     double result;
-    asm ("sqrtsd %1, %0" : "=x"(result) : "x"(value));
+    __asm__("sqrtsd %1, %0" : "=x"(result) : "x"(value));
     return result;
 #else
     return sqrt(value);

--- a/Source/JavaScriptCore/interpreter/FrameTracers.h
+++ b/Source/JavaScriptCore/interpreter/FrameTracers.h
@@ -81,7 +81,7 @@ ALWAYS_INLINE static void assertStackPointerIsAligned()
 #if CPU(X86) && !OS(WINDOWS)
     uintptr_t stackPointer;
 
-    asm("movl %%esp,%0" : "=r"(stackPointer));
+    __asm__("movl %%esp,%0" : "=r"(stackPointer));
     ASSERT(!(stackPointer % stackAlignmentBytes()));
 #endif
 #endif

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -860,7 +860,7 @@ typedef MathThunkCallingConvention(*MathThunk)(MathThunkCallingConvention);
 #if CPU(X86_64) && COMPILER(GCC_COMPATIBLE) && (OS(DARWIN) || OS(LINUX))
 
 #define defineUnaryDoubleOpWrapper(function) \
-    asm( \
+    __asm__( \
         ".text\n" \
         ".globl " SYMBOL_STRING(function##Thunk) "\n" \
         HIDE_SYMBOL(function##Thunk) "\n" \
@@ -880,7 +880,7 @@ typedef MathThunkCallingConvention(*MathThunk)(MathThunkCallingConvention);
 #elif CPU(ARM_THUMB2) && COMPILER(GCC_COMPATIBLE) && OS(DARWIN)
 
 #define defineUnaryDoubleOpWrapper(function) \
-    asm( \
+    __asm__( \
         ".text\n" \
         ".align 2\n" \
         ".globl " SYMBOL_STRING(function##Thunk) "\n" \
@@ -905,7 +905,7 @@ typedef MathThunkCallingConvention(*MathThunk)(MathThunkCallingConvention);
 #elif CPU(ARM64)
 
 #define defineUnaryDoubleOpWrapper(function) \
-    asm( \
+    __asm__( \
         ".text\n" \
         ".align 2\n" \
         ".globl " SYMBOL_STRING(function##Thunk) "\n" \

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4500,8 +4500,8 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
 }
 
 #if ENABLE(JIT_OPERATION_VALIDATION) || ENABLE(JIT_OPERATION_DISASSEMBLY)
-extern const JITOperationAnnotation startOfJITOperationsInShell __asm("section$start$__DATA_CONST$__jsc_ops");
-extern const JITOperationAnnotation endOfJITOperationsInShell __asm("section$end$__DATA_CONST$__jsc_ops");
+extern const JITOperationAnnotation startOfJITOperationsInShell __asm__("section$start$__DATA_CONST$__jsc_ops");
+extern const JITOperationAnnotation endOfJITOperationsInShell __asm__("section$end$__DATA_CONST$__jsc_ops");
 #endif
 
 int jscmain(int argc, char** argv)

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -520,7 +520,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 // the jsc_llint_begin and jsc_llint_end labels help lldb_webkit.py find the
 // start and end of the llint instruction range quickly.
 
-#define OFFLINE_ASM_BEGIN   asm ( \
+#define OFFLINE_ASM_BEGIN   __asm__( \
     OFFLINE_ASM_GLOBAL_LABEL_IMPL(jsc_llint_begin, OFFLINE_ASM_NO_ALT_ENTRY_DIRECTIVE, OFFLINE_ASM_ALIGN4B, HIDE_SYMBOL) \
     OFFLINE_ASM_BEGIN_SPACER
 
@@ -651,7 +651,7 @@ DEBUGGER_ANNOTATION_MARKER(before_llint_asm)
 // See GdbJIT.cpp for a detailed explanation of how these DWARF directives work.
 #if !OS(DARWIN) && COMPILER(CLANG)
 #if CPU(ARM64)
-asm (
+__asm__(
     ".cfi_startproc\n"
     ".cfi_def_cfa fp, 16\n"
     ".cfi_offset lr, -8\n"
@@ -667,7 +667,7 @@ asm (
     OFFLINE_ASM_BEGIN_SPACER
 );
 #elif CPU(ARM_THUMB2)
-asm (
+__asm__(
     ".cfi_startproc\n"
     OFFLINE_ASM_BEGIN_SPACER
     ".cfi_def_cfa r7, 8\n"
@@ -689,7 +689,7 @@ asm (
 // See GdbJIT.cpp for a detailed explanation.
 #if !OS(DARWIN) && COMPILER(CLANG)
 #if CPU(ARM64) || CPU(ARM_THUMB2)
-asm (
+__asm__(
     ".cfi_endproc\n"
 );
 #endif

--- a/Source/JavaScriptCore/runtime/MathCommon.h
+++ b/Source/JavaScriptCore/runtime/MathCommon.h
@@ -319,7 +319,7 @@ ALWAYS_INLINE double jsMaxDouble(double lhs, double rhs)
     // Intentionally using fmax, not fmaxnm since fmax is aligned to JS Math.max semantics.
     // fmaxnm returns non-NaN number when either lhs or rhs is NaN. But Math.max returns NaN.
     double result;
-    asm (
+    __asm__(
         "fmax %d[result], %d[lhs], %d[rhs]"
         : [result] "=w"(result)
         : [lhs] "w"(lhs), [rhs] "w"(rhs)
@@ -337,7 +337,7 @@ ALWAYS_INLINE double jsMinDouble(double lhs, double rhs)
     // Intentionally using fmin, not fminnm since fmin is aligned to JS Math.min semantics.
     // fminnm returns non-NaN number when either lhs or rhs is NaN. But Math.min returns NaN.
     double result;
-    asm (
+    __asm__(
         "fmin %d[result], %d[lhs], %d[rhs]"
         : [result] "=w"(result)
         : [lhs] "w"(lhs), [rhs] "w"(rhs)

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -664,70 +664,70 @@ void WTFInitializeLogChannelStatesFromString(WTFLogChannel* channels[], size_t c
 
 void WTFCrashWithInfoImpl(int, const char*, const char*, int, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5, uint64_t misc6)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR asm(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR asm(CRASH_GPR3) = misc3;
-    register uint64_t misc4GPR asm(CRASH_GPR4) = misc4;
-    register uint64_t misc5GPR asm(CRASH_GPR5) = misc5;
-    register uint64_t misc6GPR asm(CRASH_GPR6) = misc6;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
+    register uint64_t misc4GPR __asm__(CRASH_GPR4) = misc4;
+    register uint64_t misc5GPR __asm__(CRASH_GPR5) = misc5;
+    register uint64_t misc6GPR __asm__(CRASH_GPR6) = misc6;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR), "r"(misc4GPR), "r"(misc5GPR), "r"(misc6GPR));
     __builtin_unreachable();
 }
 
 void WTFCrashWithInfoImpl(int, const char*, const char*, int, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR asm(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR asm(CRASH_GPR3) = misc3;
-    register uint64_t misc4GPR asm(CRASH_GPR4) = misc4;
-    register uint64_t misc5GPR asm(CRASH_GPR5) = misc5;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
+    register uint64_t misc4GPR __asm__(CRASH_GPR4) = misc4;
+    register uint64_t misc5GPR __asm__(CRASH_GPR5) = misc5;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR), "r"(misc4GPR), "r"(misc5GPR));
     __builtin_unreachable();
 }
 
 void WTFCrashWithInfoImpl(int, const char*, const char*, int, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR asm(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR asm(CRASH_GPR3) = misc3;
-    register uint64_t misc4GPR asm(CRASH_GPR4) = misc4;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
+    register uint64_t misc4GPR __asm__(CRASH_GPR4) = misc4;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR), "r"(misc4GPR));
     __builtin_unreachable();
 }
 
 void WTFCrashWithInfoImpl(int, const char*, const char*, int, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR asm(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR asm(CRASH_GPR3) = misc3;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR));
     __builtin_unreachable();
 }
 
 void WTFCrashWithInfoImpl(int, const char*, const char*, int, uint64_t reason, uint64_t misc1, uint64_t misc2)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR asm(CRASH_GPR2) = misc2;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR));
     __builtin_unreachable();
 }
 
 void WTFCrashWithInfoImpl(int, const char*, const char*, int, uint64_t reason, uint64_t misc1)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR));
     __builtin_unreachable();
 }
 
 void WTFCrashWithInfoImpl(int, const char*, const char*, int, uint64_t reason)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR));
     __builtin_unreachable();
 }

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -962,10 +962,10 @@ NO_RETURN_DUE_TO_CRASH ALWAYS_INLINE void WTFCrashWithInfo(int line, const char*
     uint64_t x1Value = reinterpret_cast<uintptr_t>(file);
     uint64_t x2Value = reinterpret_cast<uintptr_t>(function);
     uint64_t x3Value = static_cast<uint64_t>(static_cast<int64_t>(counter));
-    register uint64_t x0GPR asm(CRASH_ARG_GPR0) = x0Value;
-    register uint64_t x1GPR asm(CRASH_ARG_GPR1) = x1Value;
-    register uint64_t x2GPR asm(CRASH_ARG_GPR2) = x2Value;
-    register uint64_t x3GPR asm(CRASH_ARG_GPR3) = x3Value;
+    register uint64_t x0GPR __asm__(CRASH_ARG_GPR0) = x0Value;
+    register uint64_t x1GPR __asm__(CRASH_ARG_GPR1) = x1Value;
+    register uint64_t x2GPR __asm__(CRASH_ARG_GPR2) = x2Value;
+    register uint64_t x3GPR __asm__(CRASH_ARG_GPR3) = x3Value;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(x0GPR), "r"(x1GPR), "r"(x2GPR), "r"(x3GPR));
     __builtin_unreachable();
 }

--- a/Source/WTF/wtf/Atomics.h
+++ b/Source/WTF/wtf/Atomics.h
@@ -368,11 +368,11 @@ public:
         // ordering. This forces weak memory order CPUs to observe `location` and
         // dependent loads in their store order without the reader using a barrier
         // or an acquire load.
-        asm("eor %w[out], %w[in], %w[in]"
+        __asm__("eor %w[out], %w[in], %w[in]"
             : [out] "=r"(output)
             : [in] "r"(input));
 #elif CPU(ARM)
-        asm("eor %[out], %[in], %[in]"
+        __asm__("eor %[out], %[in], %[in]"
             : [out] "=r"(output)
             : [in] "r"(input));
 #else

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -678,7 +678,7 @@ inline uint32_t reverseBits32(uint32_t value)
 {
 #if CPU(ARM64)
     uint32_t result;
-    asm ("rbit %w0, %w1"
+    __asm__("rbit %w0, %w1"
         : "=r"(result)
         : "r"(value));
     return result;

--- a/Source/WTF/wtf/SaturatedArithmetic.h
+++ b/Source/WTF/wtf/SaturatedArithmetic.h
@@ -63,7 +63,7 @@ template<> inline int32_t saturatedSum<int32_t>(int32_t a, int32_t b)
 {
     int32_t result;
 #if CPU(ARM_THUMB2)
-    asm("qadd %[sum], %[addend], %[augend]"
+    __asm__("qadd %[sum], %[addend], %[augend]"
         : [sum]"=r"(result)
         : [augend]"r"(a), [addend]"r"(b)
         : /* Nothing is clobbered. */
@@ -96,7 +96,7 @@ template<> inline int32_t saturatedDifference<int32_t>(int32_t a, int32_t b)
 {
     int32_t result;
 #if CPU(ARM_THUMB2)
-    asm("qsub %[difference], %[minuend], %[subtrahend]"
+    __asm__("qsub %[difference], %[minuend], %[subtrahend]"
         : [difference]"=r"(result)
         : [minuend]"r"(a), [subtrahend]"r"(b)
         : /* Nothing is clobbered. */

--- a/Source/WTF/wtf/StackPointer.cpp
+++ b/Source/WTF/wtf/StackPointer.cpp
@@ -43,7 +43,7 @@ extern "C" __declspec(naked) void currentStackPointer()
 }
 
 #elif CPU(X86)
-asm (
+__asm__(
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"
@@ -55,10 +55,7 @@ asm (
 
 #elif CPU(X86_64) && OS(WINDOWS)
 
-// The Win64 port will use a hack where we define currentStackPointer in
-// LowLevelInterpreter.asm.
-
-asm (
+__asm__(
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"
@@ -72,7 +69,7 @@ asm (
 );
 
 #elif CPU(X86_64)
-asm (
+__asm__(
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"
@@ -84,7 +81,7 @@ asm (
 );
 
 #elif CPU(ARM64E)
-asm (
+__asm__(
     ".text" "\n"
     ".balign 16" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
@@ -97,7 +94,7 @@ asm (
 );
 
 #elif CPU(ARM64)
-asm (
+__asm__(
     ".text" "\n"
     ".balign 16" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
@@ -109,7 +106,7 @@ asm (
 );
 
 #elif CPU(ARM_THUMB2)
-asm (
+__asm__(
     ".text" "\n"
     ".align 2" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
@@ -123,7 +120,7 @@ asm (
 );
 
 #elif CPU(MIPS)
-asm (
+__asm__(
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"
@@ -139,7 +136,7 @@ asm (
 );
 
 #elif CPU(RISCV64)
-asm (
+__asm__(
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"
@@ -150,7 +147,7 @@ asm (
 );
 
 #elif CPU(LOONGARCH64)
-asm (
+__asm__(
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -946,7 +946,8 @@ inline void copyElements(std::span<uint8_t> destinationSpan, std::span<const uin
         const uintptr_t lengthLeft = end - destination;
         const uint8_t* const simdEnd = destination + (lengthLeft & ~memoryAccessMask);
         do {
-            asm("ld2   { v0.16B, v1.16B }, [%[SOURCE]], #32\n\t"
+            __asm__(
+                "ld2   { v0.16B, v1.16B }, [%[SOURCE]], #32\n\t"
                 "st1   { v0.16B }, [%[DESTINATION]], #16\n\t"
                 : [SOURCE]"+r" (source), [DESTINATION]"+r" (destination)
                 :
@@ -970,7 +971,8 @@ inline void copyElements(std::span<uint8_t> destinationSpan, std::span<const uin
         const uintptr_t lengthLeft = end - destination;
         const uint8_t* const simdEnd = end - (lengthLeft % memoryAccessSize);
         do {
-            asm("vld2.8   { d0-d1 }, [%[SOURCE]] !\n\t"
+            __asm__(
+                "vld2.8   { d0-d1 }, [%[SOURCE]] !\n\t"
                 "vst1.8   { d0 }, [%[DESTINATION],:64] !\n\t"
                 : [SOURCE]"+r" (source), [DESTINATION]"+r" (destination)
                 :
@@ -1003,7 +1005,8 @@ inline void copyElements(std::span<uint16_t> destinationSpan, std::span<const ui
         const auto* const simdEnd = destination + (lengthLeft & ~memoryAccessMask);
         // Use ld2 to load lower 16bit of 8 uint32_t.
         do {
-            asm("ld2   { v0.8H, v1.8H }, [%[SOURCE]], #32\n\t"
+            __asm__(
+                "ld2   { v0.8H, v1.8H }, [%[SOURCE]], #32\n\t"
                 "st1   { v0.8H }, [%[DESTINATION]], #16\n\t"
                 : [SOURCE]"+r" (source), [DESTINATION]"+r" (destination)
                 :
@@ -1032,7 +1035,8 @@ inline void copyElements(std::span<uint32_t> destinationSpan, std::span<const ui
         const auto* const simdEnd = destination + (lengthLeft & ~memoryAccessMask);
         // Use ld2 to load lower 32bit of 4 uint64_t.
         do {
-            asm("ld2   { v0.4S, v1.4S }, [%[SOURCE]], #32\n\t"
+            __asm__(
+                "ld2   { v0.4S, v1.4S }, [%[SOURCE]], #32\n\t"
                 "st1   { v0.4S }, [%[DESTINATION]], #16\n\t"
                 : [SOURCE]"+r" (source), [DESTINATION]"+r" (destination)
                 :
@@ -1061,7 +1065,8 @@ inline void copyElements(std::span<uint16_t> destinationSpan, std::span<const ui
         const auto* const simdEnd = destination + (lengthLeft & ~memoryAccessMask);
         // Use ld4 to load lower 16bit of 8 uint64_t.
         do {
-            asm("ld4   { v0.8H, v1.8H, v2.8H, v3.8H }, [%[SOURCE]], #64\n\t"
+            __asm__(
+                "ld4   { v0.8H, v1.8H, v2.8H, v3.8H }, [%[SOURCE]], #64\n\t"
                 "st1   { v0.8H }, [%[DESTINATION]], #16\n\t"
                 : [SOURCE]"+r" (source), [DESTINATION]"+r" (destination)
                 :
@@ -1091,7 +1096,8 @@ inline void copyElements(std::span<uint8_t> destinationSpan, std::span<const uin
         // Since ARM64 does not ld8, we use ld4 to load lower 16bit of 8 uint64_t.
         // And then narrow 8 16bit lanes into 8 8bit lanes and store it to the destination.
         do {
-            asm("ld4   { v0.8H, v1.8H, v2.8H, v3.8H }, [%[SOURCE]], #64\n\t"
+            __asm__(
+                "ld4   { v0.8H, v1.8H, v2.8H, v3.8H }, [%[SOURCE]], #64\n\t"
                 "xtn   v0.8B, v0.8H\n\t"
                 "st1   { v0.8B }, [%[DESTINATION]], #8\n\t"
                 : [SOURCE]"+r" (source), [DESTINATION]"+r" (destination)

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -795,7 +795,7 @@ template<typename CharacterType1, typename CharacterType2> inline std::strong_or
                 if constexpr (sizeof(CharacterType1) == 2) {
                     auto rev16 = [](uint64_t value) ALWAYS_INLINE_LAMBDA {
                         uint64_t result;
-                        asm ("rev16 %x0, %x1" : "=r"(result) : "r"(value));
+                        __asm__("rev16 %x0, %x1" : "=r"(result) : "r"(value));
                         return result;
                     };
                     return (rev16(flipBytes(lhs)) > rev16(flipBytes(rhs))) ? std::strong_ordering::greater : std::strong_ordering::less;

--- a/Source/WebCore/bindings/js/WebCoreJITOperations.cpp
+++ b/Source/WebCore/bindings/js/WebCoreJITOperations.cpp
@@ -32,8 +32,8 @@ namespace WebCore {
 
 #if ENABLE(JIT_OPERATION_VALIDATION) || ENABLE(JIT_OPERATION_DISASSEMBLY)
 
-extern const JSC::JITOperationAnnotation startOfJITOperationsInWebCore __asm("section$start$__DATA_CONST$__jsc_ops");
-extern const JSC::JITOperationAnnotation endOfJITOperationsInWebCore __asm("section$end$__DATA_CONST$__jsc_ops");
+extern const JSC::JITOperationAnnotation startOfJITOperationsInWebCore __asm__("section$start$__DATA_CONST$__jsc_ops");
+extern const JSC::JITOperationAnnotation endOfJITOperationsInWebCore __asm__("section$end$__DATA_CONST$__jsc_ops");
 
 #if ENABLE(JIT_OPERATION_VALIDATION)
 void populateJITOperations()

--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNeonParallelApplier.cpp
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNeonParallelApplier.cpp
@@ -213,7 +213,7 @@ extern "C" {
 void neonDrawLighting(FELightingNeonParallelApplier::ApplyParameters*);
 }
 
-asm ( // NOLINT
+__asm__( // NOLINT
 ".globl " TOSTRING(neonDrawLighting) NL
 TOSTRING(neonDrawLighting) ":" NL
     // Because of the clever register allocation, nothing is stored on the stack

--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -255,8 +255,8 @@ void setAdditionalSupportedImageTypesForTesting(const String& imageTypes)
 
 #if ENABLE(JIT_OPERATION_VALIDATION) || ENABLE(JIT_OPERATION_DISASSEMBLY)
 
-extern const JSC::JITOperationAnnotation startOfJITOperationsInWebCoreTestSupport __asm("section$start$__DATA_CONST$__jsc_ops");
-extern const JSC::JITOperationAnnotation endOfJITOperationsInWebCoreTestSupport __asm("section$end$__DATA_CONST$__jsc_ops");
+extern const JSC::JITOperationAnnotation startOfJITOperationsInWebCoreTestSupport __asm__("section$start$__DATA_CONST$__jsc_ops");
+extern const JSC::JITOperationAnnotation endOfJITOperationsInWebCoreTestSupport __asm__("section$end$__DATA_CONST$__jsc_ops");
 
 #if ENABLE(JIT_OPERATION_VALIDATION)
 

--- a/Source/WebKit/Platform/ExtraPublicSymbolsForTAPI.h
+++ b/Source/WebKit/Platform/ExtraPublicSymbolsForTAPI.h
@@ -31,7 +31,7 @@
 
 // FIXME: Remove these after <rdar://problem/30772200> is fixed.
 #define DECLARE_INSTALL_NAME(major, minor) \
-extern __attribute__((visibility("default"))) const char install_name_ ##major## _ ##minor __asm("$ld$install_name$os" #major "." #minor "$/System/Library/PrivateFrameworks/WebKit.framework/WebKit");
+extern __attribute__((visibility("default"))) const char install_name_ ##major## _ ##minor __asm__("$ld$install_name$os" #major "." #minor "$/System/Library/PrivateFrameworks/WebKit.framework/WebKit");
 
 DECLARE_INSTALL_NAME(4, 3);
 DECLARE_INSTALL_NAME(5, 0);

--- a/Source/WebKit/Shared/API/Cocoa/WebKit.m
+++ b/Source/WebKit/Shared/API/Cocoa/WebKit.m
@@ -39,7 +39,7 @@ char _swift_FORCE_LOAD_$_swiftWebKit = 0;
 #if PLATFORM(IOS) || PLATFORM(IOS_SIMULATOR)
 
 #define DEFINE_INSTALL_NAME(major, minor) \
-    extern __attribute__((visibility ("default"))) const char install_name_ ##major## _ ##minor __asm("$ld$install_name$os" #major "." #minor "$/System/Library/PrivateFrameworks/WebKit.framework/WebKit"); \
+    extern __attribute__((visibility ("default"))) const char install_name_ ##major## _ ##minor __asm__("$ld$install_name$os" #major "." #minor "$/System/Library/PrivateFrameworks/WebKit.framework/WebKit"); \
     const char install_name_ ##major## _ ##minor = 0;
 
 DEFINE_INSTALL_NAME(4, 3);

--- a/Source/WebKit/UIProcess/Cocoa/WebKitSwiftOverlayMacros.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebKitSwiftOverlayMacros.h
@@ -37,7 +37,7 @@
 #include "WKDeclarationSpecifiers.h"
 
 #define MIGRATE_SYMBOL(InstallName, Platform, Introduced, Migrated, Symbol) \
-    extern WK_EXPORT const char migrated_symbol_##Symbol __asm("$ld$previous$" InstallName "$$" #Platform "$" #Introduced "$" #Migrated "$" #Symbol "$") \
+    extern WK_EXPORT const char migrated_symbol_##Symbol __asm__("$ld$previous$" InstallName "$$" #Platform "$" #Introduced "$" #Migrated "$" #Symbol "$") \
 
 #if PLATFORM(MAC)
 #define DECLARE_MIGRATED_NAME(Symbol, macOSVersion, iOSVersion, visionOSVersion) \

--- a/Source/WebKit/UIProcess/ios/forms/WKFocusedFormControlView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFocusedFormControlView.mm
@@ -28,7 +28,7 @@
 
 #if HAVE(PEPPER_UI_CORE)
 
-asm(".linker_option \"-framework\", \"PepperUICore\"");
+__asm__(".linker_option \"-framework\", \"PepperUICore\"");
 
 #import "PepperUICoreSPI.h"
 #import <WebCore/LocalizedStrings.h>

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.c
@@ -83,63 +83,63 @@
 
 PAS_NEVER_INLINE PAS_NO_RETURN void pas_crash_with_info_impl1(uint64_t reason, uint64_t misc1)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
     __asm__ volatile (PAS_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR));
     __builtin_unreachable();
 }
 
 PAS_NEVER_INLINE PAS_NO_RETURN void pas_crash_with_info_impl2(uint64_t reason, uint64_t misc1, uint64_t misc2)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR asm(CRASH_GPR2) = misc2;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
     __asm__ volatile (PAS_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR));
     __builtin_unreachable();
 }
 
 PAS_NEVER_INLINE PAS_NO_RETURN void pas_crash_with_info_impl3(uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR asm(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR asm(CRASH_GPR3) = misc3;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
     __asm__ volatile (PAS_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR));
     __builtin_unreachable();
 }
 
 PAS_NEVER_INLINE PAS_NO_RETURN void pas_crash_with_info_impl4(uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR asm(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR asm(CRASH_GPR3) = misc3;
-    register uint64_t misc4GPR asm(CRASH_GPR4) = misc4;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
+    register uint64_t misc4GPR __asm__(CRASH_GPR4) = misc4;
     __asm__ volatile (PAS_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR), "r"(misc4GPR));
     __builtin_unreachable();
 }
 
 PAS_NEVER_INLINE PAS_NO_RETURN void pas_crash_with_info_impl5(uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR asm(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR asm(CRASH_GPR3) = misc3;
-    register uint64_t misc4GPR asm(CRASH_GPR4) = misc4;
-    register uint64_t misc5GPR asm(CRASH_GPR5) = misc5;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
+    register uint64_t misc4GPR __asm__(CRASH_GPR4) = misc4;
+    register uint64_t misc5GPR __asm__(CRASH_GPR5) = misc5;
     __asm__ volatile (PAS_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR), "r"(misc4GPR), "r"(misc5GPR));
     __builtin_unreachable();
 }
 
 PAS_NEVER_INLINE PAS_NO_RETURN void pas_crash_with_info_impl6(uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5, uint64_t misc6)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR asm(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR asm(CRASH_GPR3) = misc3;
-    register uint64_t misc4GPR asm(CRASH_GPR4) = misc4;
-    register uint64_t misc5GPR asm(CRASH_GPR5) = misc5;
-    register uint64_t misc6GPR asm(CRASH_GPR6) = misc6;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
+    register uint64_t misc4GPR __asm__(CRASH_GPR4) = misc4;
+    register uint64_t misc5GPR __asm__(CRASH_GPR5) = misc5;
+    register uint64_t misc6GPR __asm__(CRASH_GPR6) = misc6;
     __asm__ volatile (PAS_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR), "r"(misc4GPR), "r"(misc5GPR), "r"(misc6GPR));
     __builtin_unreachable();
 }
@@ -148,13 +148,13 @@ PAS_NEVER_INLINE PAS_NO_RETURN void pas_crash_with_info_impl6(uint64_t reason, u
 
 PAS_NEVER_INLINE PAS_NO_RETURN static void pas_crash_with_info_impl(uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5, uint64_t misc6)
 {
-    register uint64_t reasonGPR asm(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR asm(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR asm(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR asm(CRASH_GPR3) = misc3;
-    register uint64_t misc4GPR asm(CRASH_GPR4) = misc4;
-    register uint64_t misc5GPR asm(CRASH_GPR5) = misc5;
-    register uint64_t misc6GPR asm(CRASH_GPR6) = misc6;
+    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
+    register uint64_t misc4GPR __asm__(CRASH_GPR4) = misc4;
+    register uint64_t misc5GPR __asm__(CRASH_GPR5) = misc5;
+    register uint64_t misc6GPR __asm__(CRASH_GPR6) = misc6;
     __asm__ volatile (PAS_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR), "r"(misc4GPR), "r"(misc5GPR), "r"(misc6GPR));
     __builtin_trap();
 }


### PR DESCRIPTION
#### 3f5a9c62f905215e7b35df486d0cff14b55f4ed7
<pre>
[JSC] use __asm__ consistently
<a href="https://bugs.webkit.org/show_bug.cgi?id=300862">https://bugs.webkit.org/show_bug.cgi?id=300862</a>
<a href="https://rdar.apple.com/162746600">rdar://162746600</a>

Reviewed by Yijia Huang.

This patch replaces `asm(` to `__asm__(` consistently since we found
that `asm(` is not available on C compilers (not C++), and becoming a
problem in module verifier. As they get replaced with `__asm__`, let&apos;s
make all of them `__asm__` for consistent code.

Tests: Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_3.cpp
* Source/JavaScriptCore/assembler/JITOperationList.cpp:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp:
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.cpp:
* Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.cpp:
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.cpp:
* Source/JavaScriptCore/assembler/SecureARM64EHashPinsInlines.h:
(JSC::SecureARM64EHashPins::keyForCurrentThread):
* Source/JavaScriptCore/b3/testb3_1.cpp:
* Source/JavaScriptCore/b3/testb3_3.cpp:
(correctSqrt):
* Source/JavaScriptCore/interpreter/FrameTracers.h:
(JSC::assertStackPointerIsAligned):
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/llint/LowLevelInterpreter.cpp:
* Source/JavaScriptCore/runtime/MathCommon.h:
(JSC::Math::jsMaxDouble):
(JSC::Math::jsMinDouble):
* Source/WTF/wtf/Assertions.cpp:
(WTFCrashWithInfoImpl):
* Source/WTF/wtf/Assertions.h:
(WTFCrashWithInfo):
* Source/WTF/wtf/Atomics.h:
(WTF::Dependency::fence):
* Source/WTF/wtf/MathExtras.h:
(WTF::reverseBits32):
* Source/WTF/wtf/SaturatedArithmetic.h:
(WTF::saturatedSum&lt;int32_t&gt;):
(WTF::saturatedDifference&lt;int32_t&gt;):
* Source/WTF/wtf/StackPointer.cpp:
* Source/WTF/wtf/text/StringCommon.h:
(WTF::copyElements):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::codePointCompare):
* Source/WebCore/bindings/js/WebCoreJITOperations.cpp:
* Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNeonParallelApplier.cpp:
* Source/WebCore/testing/js/WebCoreTestSupport.cpp:
* Source/WebKit/Platform/ExtraPublicSymbolsForTAPI.h:
* Source/WebKit/Shared/API/Cocoa/WebKit.m:
* Source/WebKit/UIProcess/Cocoa/WebKitSwiftOverlayMacros.h:
* Source/WebKit/UIProcess/ios/forms/WKFocusedFormControlView.mm:
* Source/bmalloc/libpas/src/libpas/pas_utils.c:
(pas_crash_with_info_impl1):
(pas_crash_with_info_impl2):
(pas_crash_with_info_impl3):
(pas_crash_with_info_impl4):
(pas_crash_with_info_impl5):
(pas_crash_with_info_impl6):
(pas_crash_with_info_impl):

Canonical link: <a href="https://commits.webkit.org/301614@main">https://commits.webkit.org/301614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a540a4c03754deb63b013260951f77b0edc48d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126528 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78203 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0c380985-c85c-4db7-99a0-6bbdd5883cca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54711 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/184158cd-2575-4770-a3cb-d452dc9b6ece) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37444 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/113157 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c16d0405-1184-40e4-8ae7-b02429c7a7ca) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76725 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118578 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135965 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124993 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40924 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109479 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49974 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50631 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19787 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53139 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58952 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158038 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52421 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39542 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55755 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54156 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->