### PR TITLE
[WPE] Fix build for ARM 32-bit after 301536@main

### DIFF
--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -36,7 +36,9 @@ namespace WebCore {
 
 struct GreaterThanOrSameSizeAsStyleRareInheritedData : public RefCounted<GreaterThanOrSameSizeAsStyleRareInheritedData> {
     float firstFloat;
-    void* styleImage;
+    float secondFloat;
+    Style::ImageOrNone styleImage;
+    Style::WebkitTextStrokeWidth textStrokeWidth;
     Style::Color firstColor;
     Style::Color colors[10];
     Style::ScrollbarColor scrollbarColor;
@@ -44,7 +46,7 @@ struct GreaterThanOrSameSizeAsStyleRareInheritedData : public RefCounted<Greater
     void* ownPtrs[1];
     AtomString atomStrings[5];
     void* refPtrs[3];
-    float secondFloat;
+    float thirdFloat;
     Style::TextEmphasisStyle textEmphasisStyle;
     Style::TextIndent textIndent;
     Style::TextUnderlineOffset offset;


### PR DESCRIPTION
#### 6da2789184a859d723ce27b11afa72f89c5e08db
<pre>
[WPE] Fix build for ARM 32-bit after 301536@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=299885">https://bugs.webkit.org/show_bug.cgi?id=299885</a>

Reviewed by Sam Weinig.

Fix build error in &apos;StyleRareInheritedData.cpp:74&apos;:

error: static assertion failed due to requirement
   74 | static_assert(sizeof(StyleRareInheritedData) &lt;= sizeof(GreaterThanOrSameSizeAsStyleRareInheritedData), &quot;StyleRareInheritedData should bit pack&quot;);

note: expression evaluates to &apos;416 &lt;= 408&apos;
   74 | static_assert(sizeof(StyleRareInheritedData) &lt;= sizeof(GreaterThanOrSameSizeAsStyleRareInheritedData), &quot;StyleRareInheritedData should bit pack&quot;);

The build error started happening after 301536@main.

This changeset adds a new data field, &apos;deviceScaleFactor&apos;,
to &apos;StyleRareInheritedData&apos; without updating &apos;GreaterThanOrSameSizeAsStyleRareInheritedData&apos;.

Still, adding this field alone doesn&apos;t fix the build error because
there was another data field, &apos;textStrokeWidth&apos;, pending to be added.

Also, change &apos;styleImage&apos; data type to &apos;Style::ImageOrNone&apos;.

* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:

Canonical link: <a href="https://commits.webkit.org/301686@main">https://commits.webkit.org/301686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/640e43440287d84c5ed5c98332db400a382b8bb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133534 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78247 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96324 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31391 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76898 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31683 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136083 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104829 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53753 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104531 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28355 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50696 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19829 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53187 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59000 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->