### PR TITLE
Reduce unsafeness in WebCore/editing

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -28,6 +28,38 @@ Modules/websockets/WebSocketChannelInspector.cpp
 Modules/websockets/WorkerThreadableWebSocketChannel.cpp
 StyleBuilderGenerated.cpp
 StyleExtractorGenerated.cpp
+[ Mac ] accessibility/isolatedtree/AXIsolatedTree.cpp
+[ Mac ] accessibility/mac/AXObjectCacheMac.mm
+[ Mac ] accessibility/mac/AccessibilityObjectMac.mm
+[ Mac ] dom/mac/ImageControlsMac.cpp
+[ Mac ] editing/mac/EditorMac.mm
+[ Mac ] page/ContextMenuController.cpp
+[ Mac ] page/mac/EventHandlerMac.mm
+[ Mac ] page/mac/ServicesOverlayController.mm
+[ Mac ] page/scrolling/ScrollLatchingController.cpp
+[ Mac ] platform/cocoa/DragImageCocoa.mm
+[ Mac ] testing/Internals.mm
+[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
+[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+[ iOS ] editing/ios/EditorIOS.mm
+[ iOS ] html/ColorInputType.cpp
+[ iOS ] html/HTMLAnchorElement.cpp
+[ iOS ] page/Chrome.cpp
+[ iOS ] page/DOMTimer.cpp
+[ iOS ] page/Page.cpp
+[ iOS ] page/Quirks.cpp
+[ iOS ] page/ios/ContentChangeObserver.cpp
+[ iOS ] page/ios/EventHandlerIOS.mm
+[ iOS ] page/ios/FrameIOS.mm
+[ iOS ] platform/ios/DeviceMotionClientIOS.mm
+[ iOS ] platform/ios/DeviceOrientationClientIOS.mm
+[ iOS ] platform/ios/PlatformScreenIOS.mm
+[ iOS ] platform/ios/TileControllerMemoryHandlerIOS.cpp
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.h
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
+[ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
+[ iOS ] rendering/RenderLineBreak.cpp
+[ iOS ] rendering/ios/RenderThemeIOS.mm
 accessibility/AXObjectCache.cpp
 accessibility/AXObjectCache.h
 accessibility/AccessibilityListBoxOption.cpp
@@ -44,9 +76,6 @@ accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilitySlider.cpp
 accessibility/AccessibilitySpinButton.cpp
 accessibility/cocoa/AccessibilityObjectCocoa.mm
-[ Mac ] accessibility/isolatedtree/AXIsolatedTree.cpp
-[ Mac ] accessibility/mac/AXObjectCacheMac.mm
-[ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 animation/AnimationTimelinesController.cpp
 animation/BlendingKeyframes.cpp
 animation/DocumentTimeline.cpp
@@ -156,7 +185,6 @@ dom/TreeScope.cpp
 dom/TreeScopeOrderedMap.cpp
 dom/TypedElementDescendantIteratorInlines.h
 dom/ViewTransition.cpp
-[ Mac ] dom/mac/ImageControlsMac.cpp
 editing/AlternativeTextController.cpp
 editing/ApplyBlockElementCommand.cpp
 editing/ApplyStyleCommand.cpp
@@ -179,13 +207,10 @@ editing/MarkupAccumulator.cpp
 editing/ModifySelectionListLevel.cpp
 editing/RemoveFormatCommand.cpp
 editing/RenderedPosition.cpp
-editing/ReplaceNodeWithSpanCommand.cpp
 editing/ReplaceSelectionCommand.cpp
 editing/ReplaceSelectionCommand.h
 editing/SimplifyMarkupCommand.cpp
 editing/SpellChecker.cpp
-editing/SplitTextNodeCommand.cpp
-editing/SplitTextNodeContainingElementCommand.cpp
 editing/TextCheckingHelper.cpp
 editing/TextInsertionBaseCommand.cpp
 editing/TextIterator.cpp
@@ -200,7 +225,6 @@ editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/EditorCocoa.mm
 editing/cocoa/NodeHTMLConverter.mm
 editing/cocoa/WebContentReaderCocoa.mm
-[ Mac ] editing/mac/EditorMac.mm
 editing/mac/FrameSelectionMac.mm
 editing/markup.cpp
 fileapi/BlobLoader.h
@@ -291,6 +315,7 @@ inspector/InspectorInstrumentation.h
 inspector/InspectorNodeFinder.cpp
 inspector/InspectorOverlay.cpp
 inspector/InspectorOverlayLabel.cpp
+inspector/InspectorResourceUtilities.cpp
 inspector/InspectorStyleSheet.cpp
 inspector/PageDebugger.cpp
 inspector/WorkerDebugger.cpp
@@ -308,7 +333,6 @@ inspector/agents/page/PageRuntimeAgent.cpp
 inspector/agents/worker/WorkerAuditAgent.cpp
 inspector/agents/worker/WorkerDebuggerAgent.cpp
 inspector/agents/worker/WorkerRuntimeAgent.cpp
-inspector/InspectorResourceUtilities.cpp
 layout/floats/FloatingContext.cpp
 layout/floats/PlacedFloats.cpp
 layout/formattingContexts/FormattingGeometry.cpp
@@ -399,7 +423,6 @@ mathml/MathMLOperatorElement.cpp
 mathml/MathMLPresentationElement.cpp
 mathml/MathMLSelectElement.cpp
 page/AutoscrollController.cpp
-[ Mac ] page/ContextMenuController.cpp
 page/DOMSelection.cpp
 page/DebugPageOverlays.cpp
 page/DragController.cpp
@@ -438,11 +461,8 @@ page/SpatialNavigation.cpp
 page/TextIndicator.cpp
 page/VisualViewport.cpp
 page/cocoa/PageCocoa.mm
-[ Mac ] page/mac/EventHandlerMac.mm
-[ Mac ] page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp
-[ Mac ] page/scrolling/ScrollLatchingController.cpp
 page/scrolling/ScrollSnapOffsetsInfo.cpp
 page/scrolling/ScrollingCoordinator.cpp
 page/scrolling/ScrollingStateNode.cpp
@@ -456,7 +476,6 @@ platform/ScrollingEffectsController.cpp
 platform/Widget.cpp
 platform/audio/PlatformMediaSession.cpp
 platform/audio/PlatformMediaSessionInterface.h
-[ Mac ] platform/cocoa/DragImageCocoa.mm
 platform/cocoa/LowPowerModeNotifier.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm
 platform/cocoa/WebAVPlayerLayer.mm
@@ -745,7 +764,6 @@ svg/graphics/SVGImage.cpp
 svg/properties/SVGAnimatedString.cpp
 svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
 testing/Internals.cpp
-[ Mac ] testing/Internals.mm
 workers/WorkerGlobalScope.cpp
 workers/WorkerMessagingProxy.cpp
 workers/WorkerNotificationClient.cpp
@@ -762,24 +780,3 @@ xml/XSLStyleSheetLibxslt.cpp
 xml/XSLTProcessorLibxslt.cpp
 xml/parser/XMLDocumentParser.cpp
 xml/parser/XMLDocumentParserLibxml2.cpp
-[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
-[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
-[ iOS ] editing/ios/EditorIOS.mm
-[ iOS ] html/ColorInputType.cpp
-[ iOS ] html/HTMLAnchorElement.cpp
-[ iOS ] page/Chrome.cpp
-[ iOS ] page/DOMTimer.cpp
-[ iOS ] page/Page.cpp
-[ iOS ] page/Quirks.cpp
-[ iOS ] page/ios/ContentChangeObserver.cpp
-[ iOS ] page/ios/EventHandlerIOS.mm
-[ iOS ] page/ios/FrameIOS.mm
-[ iOS ] platform/ios/DeviceMotionClientIOS.mm
-[ iOS ] platform/ios/DeviceOrientationClientIOS.mm
-[ iOS ] platform/ios/PlatformScreenIOS.mm
-[ iOS ] platform/ios/TileControllerMemoryHandlerIOS.cpp
-[ iOS ] platform/ios/VideoPresentationInterfaceIOS.h
-[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
-[ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
-[ iOS ] rendering/RenderLineBreak.cpp
-[ iOS ] rendering/ios/RenderThemeIOS.mm

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -8,6 +8,35 @@ Modules/storage/WorkerStorageConnection.cpp
 Modules/webaudio/AudioWorkletGlobalScope.cpp
 Modules/webdatabase/SQLStatement.cpp
 Modules/websockets/WebSocket.cpp
+[ Mac ]  testing/Internals.mm
+[ Mac ] accessibility/isolatedtree/AXIsolatedObject.cpp
+[ Mac ] accessibility/isolatedtree/AXIsolatedTree.cpp
+[ Mac ] accessibility/mac/AccessibilityObjectMac.mm
+[ Mac ] dom/mac/ImageControlsMac.cpp
+[ Mac ] editing/AlternativeTextController.cpp
+[ Mac ] editing/mac/EditorMac.mm
+[ Mac ] editing/mac/FrameSelectionMac.mm
+[ Mac ] page/ContextMenuController.cpp
+[ Mac ] page/mac/EventHandlerMac.mm
+[ Mac ] page/mac/ImageOverlayControllerMac.mm
+[ Mac ] page/mac/ServicesOverlayController.mm
+[ iOS ] accessibility/cocoa/AXTextMarkerCocoa.mm
+[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
+[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+[ iOS ] editing/cocoa/EditorCocoa.mm
+[ iOS ] editing/ios/DictationCommandIOS.cpp
+[ iOS ] html/HTMLAnchorElement.cpp
+[ iOS ] html/HTMLImageLoader.cpp
+[ iOS ] page/Chrome.cpp
+[ iOS ] page/DOMTimer.cpp
+[ iOS ] page/ios/ContentChangeObserver.cpp
+[ iOS ] page/ios/EventHandlerIOS.mm
+[ iOS ] page/ios/FrameIOS.mm
+[ iOS ] platform/ios/DragImageIOS.mm
+[ iOS ] platform/ios/PasteboardIOS.mm
+[ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
+[ iOS ] rendering/RenderLineBreak.cpp
+[ iOS ] rendering/ios/RenderThemeIOS.mm
 accessibility/AXObjectCache.cpp
 accessibility/AccessibilityListBoxOption.cpp
 accessibility/AccessibilityMathMLElement.cpp
@@ -17,9 +46,6 @@ accessibility/AccessibilityRenderObject.cpp
 accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilitySlider.cpp
 accessibility/cocoa/AccessibilityObjectCocoa.mm
-[ Mac ] accessibility/isolatedtree/AXIsolatedObject.cpp
-[ Mac ] accessibility/isolatedtree/AXIsolatedTree.cpp
-[ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 animation/AcceleratedEffectStackUpdater.cpp
 animation/BlendingKeyframes.cpp
 animation/DocumentTimeline.cpp
@@ -100,8 +126,6 @@ dom/StaticRange.cpp
 dom/TreeScope.cpp
 dom/TypedElementDescendantIteratorInlines.h
 dom/ViewTransition.cpp
-[ Mac ] dom/mac/ImageControlsMac.cpp
-[ Mac ] editing/AlternativeTextController.cpp
 editing/ApplyBlockElementCommand.cpp
 editing/ApplyStyleCommand.cpp
 editing/BreakBlockquoteCommand.cpp
@@ -117,11 +141,8 @@ editing/InsertParagraphSeparatorCommand.cpp
 editing/MarkupAccumulator.cpp
 editing/MergeIdenticalElementsCommand.cpp
 editing/ModifySelectionListLevel.cpp
-editing/RemoveNodePreservingChildrenCommand.cpp
 editing/RenderedPosition.cpp
-editing/ReplaceSelectionCommand.cpp
 editing/SimplifyMarkupCommand.cpp
-editing/SplitElementCommand.cpp
 editing/TextIterator.cpp
 editing/TextManipulationController.cpp
 editing/VisibleUnits.cpp
@@ -130,8 +151,6 @@ editing/cocoa/DictionaryLookup.mm
 editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/NodeHTMLConverter.mm
 editing/cocoa/WebContentReaderCocoa.mm
-[ Mac ] editing/mac/EditorMac.mm
-[ Mac ] editing/mac/FrameSelectionMac.mm
 editing/markup.cpp
 history/CachedFrame.cpp
 html/Autofill.cpp
@@ -258,7 +277,6 @@ loader/cache/CachedImage.cpp
 loader/cache/MemoryCache.cpp
 mathml/MathMLSelectElement.cpp
 page/AutoscrollController.cpp
-[ Mac ] page/ContextMenuController.cpp
 page/DeviceController.cpp
 page/DragController.cpp
 page/ElementTargetingController.cpp
@@ -290,9 +308,6 @@ page/ScrollBehavior.cpp
 page/SpatialNavigation.cpp
 page/TextIndicator.cpp
 page/WorkerNavigator.cpp
-[ Mac ] page/mac/EventHandlerMac.mm
-[ Mac ] page/mac/ImageOverlayControllerMac.mm
-[ Mac ] page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -546,26 +561,8 @@ svg/graphics/SVGImage.cpp
 svg/properties/SVGAnimatedString.cpp
 svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
 testing/Internals.cpp
-[ Mac ]  testing/Internals.mm
 testing/ServiceWorkerInternals.cpp
 testing/js/WebCoreTestSupport.cpp
 workers/WorkerGlobalScope.cpp
 workers/WorkerOrWorkletThread.cpp
 workers/WorkerRunLoop.cpp
-[ iOS ] accessibility/cocoa/AXTextMarkerCocoa.mm
-[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
-[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
-[ iOS ] editing/cocoa/EditorCocoa.mm
-[ iOS ] editing/ios/DictationCommandIOS.cpp
-[ iOS ] html/HTMLAnchorElement.cpp
-[ iOS ] html/HTMLImageLoader.cpp
-[ iOS ] page/Chrome.cpp
-[ iOS ] page/DOMTimer.cpp
-[ iOS ] page/ios/ContentChangeObserver.cpp
-[ iOS ] page/ios/EventHandlerIOS.mm
-[ iOS ] page/ios/FrameIOS.mm
-[ iOS ] platform/ios/DragImageIOS.mm
-[ iOS ] platform/ios/PasteboardIOS.mm
-[ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
-[ iOS ] rendering/RenderLineBreak.cpp
-[ iOS ] rendering/ios/RenderThemeIOS.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -9,8 +9,6 @@ Modules/identity/CredentialRequestCoordinator.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediasession/MediaMetadata.cpp
 Modules/mediasession/MediaSession.cpp
-[ Mac ] Modules/mediasession/MediaSessionCoordinator.cpp
-[ Mac ] Modules/mediasession/MediaSessionCoordinator.h
 Modules/mediasource/MediaSourceHandle.cpp
 Modules/mediastream/MediaStreamTrack.cpp
 Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -28,7 +26,6 @@ Modules/mediastream/RTCRtpTransform.cpp
 Modules/mediastream/UserMediaRequest.cpp
 Modules/mediastream/libwebrtc/LibWebRTCObservers.h
 Modules/model-element/HTMLModelElement.cpp
-[ Mac ] Modules/model-element/scenekit/SceneKitModelPlayer.mm
 Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
 Modules/push-api/PushManager.cpp
 Modules/push-api/PushSubscription.cpp
@@ -89,6 +86,66 @@ Modules/websockets/WebSocketChannelInspector.cpp
 Modules/websockets/WorkerThreadableWebSocketChannel.cpp
 Modules/webtransport/WebTransport.cpp
 StyleExtractorGenerated.cpp
+[ Mac ] Modules/mediasession/MediaSessionCoordinator.cpp
+[ Mac ] Modules/mediasession/MediaSessionCoordinator.h
+[ Mac ] Modules/model-element/scenekit/SceneKitModelPlayer.mm
+[ Mac ] accessibility/isolatedtree/AXIsolatedTree.cpp
+[ Mac ] accessibility/mac/AXObjectCacheMac.mm
+[ Mac ] accessibility/mac/AccessibilityObjectMac.mm
+[ Mac ] dom/mac/ImageControlsMac.cpp
+[ Mac ] editing/mac/EditorMac.mm
+[ Mac ] page/ContextMenuController.cpp
+[ Mac ] page/mac/EventHandlerMac.mm
+[ Mac ] page/mac/ImageOverlayControllerMac.mm
+[ Mac ] page/mac/ServicesOverlayController.mm
+[ Mac ] page/scrolling/AsyncScrollingCoordinator.h
+[ Mac ] page/scrolling/ScrollingTreeGestureState.cpp
+[ Mac ] page/scrolling/ThreadedScrollingCoordinator.cpp
+[ Mac ] page/scrolling/mac/ScrollingCoordinatorMac.mm
+[ Mac ] page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+[ Mac ] platform/cocoa/DragImageCocoa.mm
+[ Mac ] platform/graphics/cocoa/ImageAdapterCocoa.mm
+[ Mac ] platform/graphics/controls/ImageControlsButtonPart.h
+[ Mac ] platform/graphics/mac/PDFDocumentImageMac.mm
+[ Mac ] testing/Internals.mm
+[ Mac ] testing/MockMediaSessionCoordinator.cpp
+[ iOS ] Modules/system-preview/ARKitBadgeSystemImage.mm
+[ iOS ] Modules/webaudio/ChannelMergerNode.cpp
+[ iOS ] accessibility/ios/AXObjectCacheIOS.mm
+[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
+[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+[ iOS ] accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+[ iOS ] editing/EditCommand.cpp
+[ iOS ] editing/cocoa/DataDetection.mm
+[ iOS ] editing/ios/EditorIOS.mm
+[ iOS ] html/ColorInputType.cpp
+[ iOS ] html/HTMLAnchorElement.cpp
+[ iOS ] html/TextFieldInputType.cpp
+[ iOS ] loader/FrameLoader.cpp
+[ iOS ] loader/cache/CachedRawResource.cpp
+[ iOS ] loader/ios/LegacyPreviewLoader.mm
+[ iOS ] page/Quirks.cpp
+[ iOS ] page/ios/ContentChangeObserver.cpp
+[ iOS ] page/ios/EventHandlerIOS.mm
+[ iOS ] page/ios/FrameIOS.mm
+[ iOS ] platform/audio/ios/MediaSessionManagerIOS.mm
+[ iOS ] platform/graphics/avfoundation/SampleBufferDisplayLayer.h
+[ iOS ] platform/graphics/cg/PDFDocumentImage.cpp
+[ iOS ] platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+[ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
+[ iOS ] platform/ios/DeviceMotionClientIOS.mm
+[ iOS ] platform/ios/DeviceOrientationClientIOS.mm
+[ iOS ] platform/ios/LegacyTileGrid.mm
+[ iOS ] platform/ios/PlatformPasteboardIOS.mm
+[ iOS ] platform/ios/PlatformScreenIOS.mm
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.h
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
+[ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
+[ iOS ] platform/ios/wak/WAKWindow.mm
+[ iOS ] platform/mediastream/ios/ReplayKitCaptureSource.mm
+[ iOS ] rendering/RenderBlock.cpp
+[ iOS ] rendering/RenderLineBreak.cpp
+[ iOS ] rendering/ios/RenderThemeIOS.mm
 accessibility/AXLogger.cpp
 accessibility/AXObjectCache.cpp
 accessibility/AXObjectCache.h
@@ -105,9 +162,6 @@ accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilitySlider.cpp
 accessibility/AccessibilitySpinButton.cpp
 accessibility/AccessibilityTableHeaderContainer.cpp
-[ Mac ] accessibility/isolatedtree/AXIsolatedTree.cpp
-[ Mac ] accessibility/mac/AXObjectCacheMac.mm
-[ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 animation/AcceleratedEffectStackUpdater.cpp
 animation/AnimationEffectTiming.cpp
 animation/AnimationTimeline.cpp
@@ -363,14 +417,12 @@ dom/TreeScopeOrderedMap.cpp
 dom/TypedElementDescendantIteratorInlines.h
 dom/VisitedLinkState.cpp
 dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
-[ Mac ] dom/mac/ImageControlsMac.cpp
 editing/AlternativeTextController.cpp
 editing/ApplyBlockElementCommand.cpp
 editing/ApplyStyleCommand.cpp
 editing/BreakBlockquoteCommand.cpp
 editing/ChangeListTypeCommand.cpp
 editing/CompositeEditCommand.cpp
-editing/CustomUndoStep.cpp
 editing/DeleteSelectionCommand.cpp
 editing/Editing.cpp
 editing/Editor.cpp
@@ -385,13 +437,9 @@ editing/InsertParagraphSeparatorCommand.cpp
 editing/InsertTextCommand.cpp
 editing/ModifySelectionListLevel.cpp
 editing/RemoveFormatCommand.cpp
-editing/ReplaceNodeWithSpanCommand.cpp
 editing/ReplaceSelectionCommand.cpp
 editing/ReplaceSelectionCommand.h
-[ Mac ] editing/SelectionGeometryGatherer.cpp
 editing/SpellChecker.cpp
-editing/SplitTextNodeCommand.cpp
-editing/SplitTextNodeContainingElementCommand.cpp
 editing/TextIterator.cpp
 editing/TextManipulationController.cpp
 editing/TypingCommand.cpp
@@ -404,7 +452,6 @@ editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/EditorCocoa.mm
 editing/cocoa/NodeHTMLConverter.mm
 editing/cocoa/WebContentReaderCocoa.mm
-[ Mac ] editing/mac/EditorMac.mm
 editing/mac/FrameSelectionMac.mm
 editing/markup.cpp
 history/BackForwardCache.cpp
@@ -559,7 +606,6 @@ mathml/MathMLElement.cpp
 mathml/MathMLSelectElement.cpp
 page/AutoscrollController.cpp
 page/Chrome.cpp
-[ Mac ] page/ContextMenuController.cpp
 page/DOMSelection.cpp
 page/DOMTimer.cpp
 page/DOMWindowExtension.cpp
@@ -620,18 +666,10 @@ page/cocoa/ResourceUsageOverlayCocoa.mm
 page/cocoa/ResourceUsageThreadCocoa.mm
 page/cocoa/WebTextIndicatorLayer.mm
 page/mac/DragControllerMac.mm
-[ Mac ] page/mac/EventHandlerMac.mm
-[ Mac ] page/mac/ImageOverlayControllerMac.mm
-[ Mac ] page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
-[ Mac ] page/scrolling/AsyncScrollingCoordinator.h
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollSnapOffsetsInfo.cpp
 page/scrolling/ScrollingCoordinator.cpp
-[ Mac ] page/scrolling/ScrollingTreeGestureState.cpp
-[ Mac ] page/scrolling/ThreadedScrollingCoordinator.cpp
-[ Mac ] page/scrolling/mac/ScrollingCoordinatorMac.mm
-[ Mac ] page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
 page/text-extraction/TextExtraction.cpp
 page/writing-tools/WritingToolsController.mm
 platform/DragImage.cpp
@@ -642,7 +680,6 @@ platform/ScrollableArea.cpp
 platform/Widget.cpp
 platform/animation/AcceleratedEffectValues.cpp
 platform/audio/cocoa/AudioFileReaderCocoa.cpp
-[ Mac ] platform/cocoa/DragImageCocoa.mm
 platform/cocoa/PlaybackSessionModelMediaElement.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm
 platform/encryptedmedia/CDMProxy.cpp
@@ -677,10 +714,8 @@ platform/graphics/ca/TileGrid.cpp
 platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
-[ Mac ] platform/graphics/cocoa/ImageAdapterCocoa.mm
 platform/graphics/controls/ButtonPart.h
 platform/graphics/controls/ColorWellPart.h
-[ Mac ] platform/graphics/controls/ImageControlsButtonPart.h
 platform/graphics/controls/InnerSpinButtonPart.h
 platform/graphics/controls/MenuListButtonPart.h
 platform/graphics/controls/MenuListPart.h
@@ -702,7 +737,6 @@ platform/graphics/filters/software/FELightingSoftwareApplier.cpp
 platform/graphics/filters/software/FELightingSoftwareApplierInlines.h
 platform/graphics/filters/software/FELightingSoftwareParallelApplier.cpp
 platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
-[ Mac ] platform/graphics/mac/PDFDocumentImageMac.mm
 platform/graphics/opentype/OpenTypeMathData.cpp
 platform/graphics/transforms/TransformOperations.cpp
 platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.h
@@ -990,9 +1024,7 @@ svg/properties/SVGValuePropertyListAnimator.h
 svg/properties/SVGValuePropertyListAnimatorImpl.h
 testing/InternalSettings.cpp
 testing/Internals.cpp
-[ Mac ] testing/Internals.mm
 testing/LegacyMockCDM.cpp
-[ Mac ] testing/MockMediaSessionCoordinator.cpp
 testing/MockPageOverlay.cpp
 testing/MockPageOverlayClient.cpp
 testing/ServiceWorkerInternals.cpp
@@ -1014,40 +1046,3 @@ xml/XSLStyleSheetLibxslt.cpp
 xml/XSLTProcessorLibxslt.cpp
 xml/parser/XMLDocumentParser.cpp
 xml/parser/XMLDocumentParserLibxml2.cpp
-[ iOS ] Modules/system-preview/ARKitBadgeSystemImage.mm
-[ iOS ] Modules/webaudio/ChannelMergerNode.cpp
-[ iOS ] accessibility/ios/AXObjectCacheIOS.mm
-[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
-[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
-[ iOS ] accessibility/mac/WebAccessibilityObjectWrapperBase.mm
-[ iOS ] editing/EditCommand.cpp
-[ iOS ] editing/cocoa/DataDetection.mm
-[ iOS ] editing/ios/EditorIOS.mm
-[ iOS ] html/ColorInputType.cpp
-[ iOS ] html/HTMLAnchorElement.cpp
-[ iOS ] html/TextFieldInputType.cpp
-[ iOS ] loader/FrameLoader.cpp
-[ iOS ] loader/cache/CachedRawResource.cpp
-[ iOS ] loader/ios/LegacyPreviewLoader.mm
-[ iOS ] page/Quirks.cpp
-[ iOS ] page/ios/ContentChangeObserver.cpp
-[ iOS ] page/ios/EventHandlerIOS.mm
-[ iOS ] page/ios/FrameIOS.mm
-[ iOS ] platform/audio/ios/MediaSessionManagerIOS.mm
-[ iOS ] platform/graphics/avfoundation/SampleBufferDisplayLayer.h
-[ iOS ] platform/graphics/cg/PDFDocumentImage.cpp
-[ iOS ] platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
-[ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
-[ iOS ] platform/ios/DeviceMotionClientIOS.mm
-[ iOS ] platform/ios/DeviceOrientationClientIOS.mm
-[ iOS ] platform/ios/LegacyTileGrid.mm
-[ iOS ] platform/ios/PlatformPasteboardIOS.mm
-[ iOS ] platform/ios/PlatformScreenIOS.mm
-[ iOS ] platform/ios/VideoPresentationInterfaceIOS.h
-[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
-[ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
-[ iOS ] platform/ios/wak/WAKWindow.mm
-[ iOS ] platform/mediastream/ios/ReplayKitCaptureSource.mm
-[ iOS ] rendering/RenderBlock.cpp
-[ iOS ] rendering/RenderLineBreak.cpp
-[ iOS ] rendering/ios/RenderThemeIOS.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -2,7 +2,6 @@ Modules/applicationmanifest/ApplicationManifestParser.cpp
 Modules/mediacapabilities/MediaCapabilities.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediarecorder/MediaRecorder.cpp
-[ Mac ] Modules/mediasession/MediaSession.cpp
 Modules/mediasource/SourceBuffer.cpp
 Modules/mediastream/PeerConnectionBackend.cpp
 Modules/mediastream/RTCController.cpp
@@ -36,6 +35,35 @@ Modules/webauthn/AuthenticatorCoordinator.cpp
 Modules/webauthn/PublicKeyCredential.cpp
 Modules/webdatabase/Database.cpp
 Modules/webdatabase/DatabaseManager.cpp
+[ Mac ] Modules/mediasession/MediaSession.cpp
+[ Mac ] editing/mac/EditorMac.mm
+[ Mac ] editing/mac/FrameSelectionMac.mm
+[ Mac ] page/ContextMenuController.cpp
+[ Mac ] page/mac/EventHandlerMac.mm
+[ Mac ] page/mac/ImageOverlayControllerMac.mm
+[ Mac ] page/mac/ServicesOverlayController.mm
+[ Mac ] platform/graphics/mac/controls/MeterMac.mm
+[ Mac ] platform/graphics/mac/controls/ProgressBarMac.mm
+[ Mac ] platform/graphics/mac/controls/SliderTrackMac.mm
+[ Mac ] testing/Internals.mm
+[ iOS ] accessibility/AccessibilityNodeObject.cpp
+[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
+[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+[ iOS ] editing/ios/DictationCommandIOS.cpp
+[ iOS ] editing/ios/EditorIOS.mm
+[ iOS ] html/HTMLAnchorElement.cpp
+[ iOS ] html/HTMLImageLoader.cpp
+[ iOS ] page/Chrome.cpp
+[ iOS ] page/Quirks.cpp
+[ iOS ] page/ios/ContentChangeObserver.cpp
+[ iOS ] page/ios/EventHandlerIOS.mm
+[ iOS ] page/ios/FrameIOS.mm
+[ iOS ] platform/audio/ios/AudioSessionIOS.mm
+[ iOS ] platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+[ iOS ] platform/ios/DragImageIOS.mm
+[ iOS ] platform/ios/LegacyTileGrid.mm
+[ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
+[ iOS ] rendering/ios/RenderThemeIOS.mm
 accessibility/AXObjectCache.cpp
 animation/KeyframeEffect.cpp
 bindings/js/CommonVM.cpp
@@ -186,18 +214,10 @@ editing/IndentOutdentCommand.cpp
 editing/InsertParagraphSeparatorCommand.cpp
 editing/MarkupAccumulator.cpp
 editing/MergeIdenticalElementsCommand.cpp
-editing/RemoveNodePreservingChildrenCommand.cpp
-editing/ReplaceSelectionCommand.cpp
-editing/SplitElementCommand.cpp
-editing/TextManipulationController.cpp
-editing/VisibleSelection.cpp
-editing/VisibleUnits.cpp
 editing/cocoa/DataDetection.mm
 editing/cocoa/DictionaryLookup.mm
 editing/cocoa/EditorCocoa.mm
 editing/cocoa/NodeHTMLConverter.mm
-[ Mac ] editing/mac/EditorMac.mm
-[ Mac ] editing/mac/FrameSelectionMac.mm
 history/CachedFrame.cpp
 history/CachedPage.cpp
 html/Autofill.cpp
@@ -269,7 +289,6 @@ loader/EmptyClients.cpp
 mathml/MathMLSelectElement.cpp
 page/BarProp.cpp
 page/CaptionUserPreferences.cpp
-[ Mac ] page/ContextMenuController.cpp
 page/DebugPageOverlays.cpp
 page/DeviceController.cpp
 page/DragController.cpp
@@ -313,9 +332,6 @@ page/TextIndicator.cpp
 page/UserContentController.cpp
 page/UserContentProvider.cpp
 page/cocoa/ResourceUsageThreadCocoa.mm
-[ Mac ] page/mac/EventHandlerMac.mm
-[ Mac ] page/mac/ImageOverlayControllerMac.mm
-[ Mac ] page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollingCoordinator.cpp
@@ -363,9 +379,6 @@ platform/graphics/filters/software/FETileSoftwareApplier.cpp
 platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
 platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp
 platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
-[ Mac ] platform/graphics/mac/controls/MeterMac.mm
-[ Mac ] platform/graphics/mac/controls/ProgressBarMac.mm
-[ Mac ] platform/graphics/mac/controls/SliderTrackMac.mm
 platform/graphics/transforms/RotateTransformOperation.cpp
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mock/MockRealtimeVideoSource.cpp
@@ -485,26 +498,7 @@ svg/properties/SVGAnimatedString.cpp
 svg/properties/SVGPropertyOwnerRegistry.h
 testing/InternalSettings.cpp
 testing/Internals.cpp
-[ Mac ] testing/Internals.mm
 testing/LegacyMockCDM.cpp
 testing/MockCDMFactory.cpp
 testing/MockPageOverlayClient.cpp
 testing/ServiceWorkerInternals.cpp
-[ iOS ] accessibility/AccessibilityNodeObject.cpp
-[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
-[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
-[ iOS ] editing/ios/DictationCommandIOS.cpp
-[ iOS ] editing/ios/EditorIOS.mm
-[ iOS ] html/HTMLAnchorElement.cpp
-[ iOS ] html/HTMLImageLoader.cpp
-[ iOS ] page/Chrome.cpp
-[ iOS ] page/Quirks.cpp
-[ iOS ] page/ios/ContentChangeObserver.cpp
-[ iOS ] page/ios/EventHandlerIOS.mm
-[ iOS ] page/ios/FrameIOS.mm
-[ iOS ] platform/audio/ios/AudioSessionIOS.mm
-[ iOS ] platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
-[ iOS ] platform/ios/DragImageIOS.mm
-[ iOS ] platform/ios/LegacyTileGrid.mm
-[ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
-[ iOS ] rendering/ios/RenderThemeIOS.mm

--- a/Source/WebCore/editing/RemoveNodePreservingChildrenCommand.cpp
+++ b/Source/WebCore/editing/RemoveNodePreservingChildrenCommand.cpp
@@ -47,12 +47,12 @@ void RemoveNodePreservingChildrenCommand::doApply()
     if (!parent || (m_shouldAssumeContentIsAlwaysEditable == DoNotAssumeContentIsAlwaysEditable && !isEditableNode(*parent)))
         return;
 
-    for (Node* child = m_node->firstChild(); child; child = child->nextSibling())
+    for (RefPtr child = m_node->firstChild(); child; child = child->nextSibling())
         children.append(*child);
 
     size_t size = children.size();
     for (size_t i = 0; i < size; ++i) {
-        auto child = WTFMove(children[i]);
+        Ref child = WTFMove(children[i]);
         removeNode(child, m_shouldAssumeContentIsAlwaysEditable);
         insertNodeBefore(WTFMove(child), m_node, m_shouldAssumeContentIsAlwaysEditable);
     }

--- a/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
+++ b/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
@@ -65,7 +65,7 @@ void ReplaceNodeWithSpanCommand::doApply()
     if (!m_elementToReplace->isConnected())
         return;
     if (!m_spanElement)
-        m_spanElement = HTMLSpanElement::create(m_elementToReplace->document());
+        m_spanElement = HTMLSpanElement::create(m_elementToReplace->protectedDocument());
     swapInNodePreservingAttributesAndChildren(protectedSpanElement().releaseNonNull(), m_elementToReplace);
 }
 

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -417,7 +417,7 @@ inline void ReplaceSelectionCommand::InsertedNodes::willRemoveNodePreservingChil
             // If the last inserted node is at the end of the document and doesn't have any children, look backwards for the
             // previous node as the last inserted node, clamping to the first inserted node if needed to ensure that the
             // document position of the last inserted node is not behind the first inserted node.
-            auto* previousNode = NodeTraversal::previousSkippingChildren(*node);
+            RefPtr previousNode = NodeTraversal::previousSkippingChildren(*node);
             ASSERT(previousNode);
             m_lastNodeInserted = m_firstNodeInserted->compareDocumentPosition(*previousNode) & Node::DOCUMENT_POSITION_FOLLOWING ? previousNode : m_firstNodeInserted;
         }
@@ -662,11 +662,11 @@ void ReplaceSelectionCommand::inverseTransformColor(InsertedNodes& insertedNodes
         if (!element)
             continue;
 
-        auto* inlineStyle = element->inlineStyle();
+        RefPtr inlineStyle = element->inlineStyle();
         if (!inlineStyle)
             continue;
 
-        auto editingStyle = EditingStyle::create(inlineStyle);
+        Ref editingStyle = EditingStyle::create(inlineStyle.get());
         auto transformedStyle = editingStyle->inverseTransformColorIfNeeded(*element);
         if (editingStyle.ptr() == transformedStyle.ptr())
             continue;

--- a/Source/WebCore/editing/SelectionGeometryGatherer.cpp
+++ b/Source/WebCore/editing/SelectionGeometryGatherer.cpp
@@ -73,12 +73,13 @@ SelectionGeometryGatherer::Notifier::Notifier(SelectionGeometryGatherer& gathere
 
 SelectionGeometryGatherer::Notifier::~Notifier()
 {
-    RefPtr page = m_gatherer.m_renderView->view().frame().page();
+    Ref frame = m_gatherer.m_renderView->frame();
+    RefPtr page = frame->page();
     if (!page)
         return;
 
     page->protectedServicesOverlayController()->selectionRectsDidChange(m_gatherer.boundingRects(), m_gatherer.m_gapRects, m_gatherer.isTextOnly());
-    page->imageOverlayController().selectionQuadsDidChange(m_gatherer.m_renderView->frame(), m_gatherer.m_quads);
+    page->imageOverlayController().selectionQuadsDidChange(frame, m_gatherer.m_quads);
 }
 
 Vector<LayoutRect> SelectionGeometryGatherer::boundingRects() const

--- a/Source/WebCore/editing/SplitElementCommand.cpp
+++ b/Source/WebCore/editing/SplitElementCommand.cpp
@@ -81,7 +81,7 @@ void SplitElementCommand::doUnapply()
         return;
 
     Vector<Ref<Node>> children;
-    for (Node* node = element1->firstChild(); node; node = node->nextSibling())
+    for (RefPtr node = element1->firstChild(); node; node = node->nextSibling())
         children.append(*node);
 
     RefPtr<Node> refChild = element2->firstChild();

--- a/Source/WebCore/editing/SplitTextNodeCommand.cpp
+++ b/Source/WebCore/editing/SplitTextNodeCommand.cpp
@@ -103,7 +103,7 @@ void SplitTextNodeCommand::doReapply()
 void SplitTextNodeCommand::insertText1AndTrimText2()
 {
     Ref text2 = m_text2;
-    if (text2->parentNode()->insertBefore(*m_text1, text2.copyRef()).hasException())
+    if (text2->protectedParentNode()->insertBefore(*protectedText1(), text2.copyRef()).hasException())
         return;
     text2->deleteData(0, m_offset);
 }

--- a/Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp
+++ b/Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp
@@ -50,7 +50,11 @@ void SplitTextNodeContainingElementCommand::doApply()
     splitTextNode(m_text, m_offset);
 
     RefPtr parent = m_text->parentElement();
-    if (!parent || !parent->parentElement() || !parent->parentElement()->hasEditableStyle())
+    if (!parent)
+        return;
+
+    RefPtr parentParent = parent->parentElement();
+    if (!parentParent || !parentParent->hasEditableStyle())
         return;
 
     bool parentRendererIsNoneOrNotInline = false;

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -607,17 +607,17 @@ void TextManipulationController::scheduleObservationUpdate()
         controller->m_didScheduleObservationUpdate = false;
 
         NodeSet nodesToObserve;
-        for (auto& text : controller->m_manipulatedNodesWithNewContent) {
-            if (!controller->m_manipulatedNodes.contains(text))
+        for (Ref text : controller->m_manipulatedNodesWithNewContent) {
+            if (!controller->m_manipulatedNodes.contains(text.get()))
                 continue;
             if (shouldIgnoreNodeInTextField(text))
                 continue;
-            controller->m_manipulatedNodes.remove(text);
+            controller->m_manipulatedNodes.remove(text.get());
             nodesToObserve.add(text);
         }
         controller->m_manipulatedNodesWithNewContent.clear();
 
-        for (auto& node : controller->m_addedOrNewlyRenderedNodes) {
+        for (Ref node : controller->m_addedOrNewlyRenderedNodes) {
             if (shouldIgnoreNodeInTextField(node))
                 continue;
             nodesToObserve.add(node);
@@ -628,7 +628,7 @@ void TextManipulationController::scheduleObservationUpdate()
             return;
 
         RefPtr<Node> commonAncestor;
-        for (auto& node : nodesToObserve) {
+        for (Ref node : nodesToObserve) {
             if (!node->isConnected())
                 continue;
 
@@ -889,7 +889,7 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
         if (!firstContentNode)
             firstContentNode = content.node;
 
-        auto parentNode = content.node->parentNode();
+        RefPtr parentNode = content.node->parentNode();
         if (!commonAncestor)
             commonAncestor = parentNode;
         else if (!parentNode->isDescendantOf(commonAncestor.get())) {

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -480,17 +480,17 @@ void VisibleSelection::setWithoutValidation(const Position& anchor, const Positi
 
 Position VisibleSelection::adjustPositionForEnd(const Position& currentPosition, Node* startContainerNode)
 {
-    TreeScope& treeScope = startContainerNode->treeScope();
+    Ref treeScope = startContainerNode->treeScope();
 
-    ASSERT(&currentPosition.containerNode()->treeScope() != &treeScope);
+    ASSERT(&currentPosition.containerNode()->treeScope() != treeScope.ptr());
 
-    if (RefPtr ancestor = treeScope.ancestorNodeInThisScope(currentPosition.protectedContainerNode().get())) {
+    if (RefPtr ancestor = treeScope->ancestorNodeInThisScope(currentPosition.protectedContainerNode().get())) {
         if (ancestor->contains(startContainerNode))
             return positionAfterNode(ancestor.get());
         return positionBeforeNode(ancestor.get());
     }
 
-    if (RefPtr lastChild = treeScope.rootNode().lastChild())
+    if (RefPtr lastChild = treeScope->rootNode().lastChild())
         return positionAfterNode(lastChild.get());
 
     return Position();
@@ -498,17 +498,17 @@ Position VisibleSelection::adjustPositionForEnd(const Position& currentPosition,
 
 Position VisibleSelection::adjustPositionForStart(const Position& currentPosition, Node* endContainerNode)
 {
-    TreeScope& treeScope = endContainerNode->treeScope();
+    Ref treeScope = endContainerNode->treeScope();
 
-    ASSERT(&currentPosition.containerNode()->treeScope() != &treeScope);
+    ASSERT(&currentPosition.containerNode()->treeScope() != treeScope.ptr());
     
-    if (RefPtr ancestor = treeScope.ancestorNodeInThisScope(currentPosition.protectedContainerNode().get())) {
+    if (RefPtr ancestor = treeScope->ancestorNodeInThisScope(currentPosition.protectedContainerNode().get())) {
         if (ancestor->contains(endContainerNode))
             return positionBeforeNode(ancestor.get());
         return positionAfterNode(ancestor.get());
     }
 
-    if (RefPtr firstChild = treeScope.rootNode().firstChild())
+    if (RefPtr firstChild = treeScope->rootNode().firstChild())
         return positionBeforeNode(firstChild.get());
 
     return Position();

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -56,29 +56,29 @@
 
 namespace WebCore {
 
-static Node* previousLeafWithSameEditability(Node* node, EditableType editableType)
+static RefPtr<Node> previousLeafWithSameEditability(Node* node, EditableType editableType)
 {
     bool editable = hasEditableStyle(*node, editableType);
-    node = previousLeafNode(node);
-    while (node) {
-        if (editable == hasEditableStyle(*node, editableType))
-            return node;
-        node = previousLeafNode(node);
+    RefPtr previousNode = previousLeafNode(node);
+    while (previousNode) {
+        if (editable == hasEditableStyle(*previousNode, editableType))
+            return previousNode;
+        previousNode = previousLeafNode(previousNode.get());
     }
     return nullptr;
 }
 
-static Node* nextLeafWithSameEditability(Node* node, EditableType editableType)
+static RefPtr<Node> nextLeafWithSameEditability(Node* node, EditableType editableType)
 {
     if (!node)
         return nullptr;
     
     bool editable = hasEditableStyle(*node, editableType);
-    node = nextLeafNode(node);
-    while (node) {
-        if (editable == hasEditableStyle(*node, editableType))
-            return node;
-        node = nextLeafNode(node);
+    RefPtr nextNode = nextLeafNode(node);
+    while (nextNode) {
+        if (editable == hasEditableStyle(*nextNode, editableType))
+            return nextNode;
+        nextNode = nextLeafNode(nextNode.get());
     }
     return nullptr;
 }
@@ -573,11 +573,11 @@ static VisiblePosition previousBoundary(const VisiblePosition& position, Boundar
     if (!next)
         return it.atEnd() ? makeDeprecatedLegacyPosition(searchRange->start) : position;
 
-    auto& node = (it.atEnd() ? *searchRange : it.range()).start.container.unsafeGet();
-    auto* textNode = dynamicDowncast<Text>(node);
+    Ref node = (it.atEnd() ? *searchRange : it.range()).start.container;
+    RefPtr textNode = dynamicDowncast<Text>(node);
     if (textNode && !suffixLength && next <= textNode->length()) {
         // The next variable contains a usable index into a text node.
-        return makeDeprecatedLegacyPosition(&node, next);
+        return makeDeprecatedLegacyPosition(node.ptr(), next);
     }
 
     // Use the character iterator to translate the next value into a DOM position.

--- a/Source/WebCore/page/UndoItem.cpp
+++ b/Source/WebCore/page/UndoItem.cpp
@@ -53,11 +53,6 @@ void UndoItem::invalidate()
     m_document.clear();
 }
 
-bool UndoItem::isValid() const
-{
-    return !!m_undoManager;
-}
-
 Document* UndoItem::document() const
 {
     return m_document.get();

--- a/Source/WebCore/page/UndoItem.h
+++ b/Source/WebCore/page/UndoItem.h
@@ -51,7 +51,7 @@ public:
         return adoptRef(*new UndoItem(WTFMove(init)));
     }
 
-    bool isValid() const;
+    bool isValid() const { return !!m_undoManager; }
     void invalidate();
 
     Document* document() const;


### PR DESCRIPTION
#### acc6cbed1e5b65a7e9b4edc1effbac0d09d66f8f
<pre>
Reduce unsafeness in WebCore/editing
<a href="https://bugs.webkit.org/show_bug.cgi?id=300869">https://bugs.webkit.org/show_bug.cgi?id=300869</a>

Reviewed by Ryosuke Niwa.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a> to a
variety of files.

SelectionGeometryGatherer.cpp includes a subtle change. We go from

  m_gatherer.m_renderView-&gt;view().frame()

to

  m_gatherer.m_renderView-&gt;frame()

in order to be able to reuse a variable. As far as I can tell these are
equivalent so this should not be observable.

Canonical link: <a href="https://commits.webkit.org/301692@main">https://commits.webkit.org/301692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/655b59a18b0951bbb984865aa2fd8dc9d569b330

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78288 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/581315d9-62cd-4875-811f-029a8f9ca63a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96362 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d583f917-a100-4bde-a4de-5b6bf2cba1d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113253 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76887 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31437 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76992 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107339 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136164 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104873 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104571 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50056 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28398 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50743 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19831 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53233 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59046 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52512 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55848 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54248 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->