### PR TITLE
[WebCore] Debug assertion fails in needsTikTokOverflowingContentQuirk

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2002,7 +2002,7 @@ std::optional<Quirks::TikTokOverflowingContentQuirkType> Quirks::needsTikTokOver
     if (parentStyle.position() != PositionType::Fixed)
         return { };
 
-    if (!element.elementData())
+    if (!element.elementData() || !element.hasClass())
         return { };
 
     static LazyNeverDestroyed<AtomString> contentContainerSubstring;
@@ -2025,7 +2025,7 @@ std::optional<Quirks::TikTokOverflowingContentQuirkType> Quirks::needsTikTokOver
 
     auto parentElementClassNamesContainsBrowserModeContainerSubstring = [&] {
         RefPtr parentElement = element.parentElement();
-        if (!parentElement || !parentElement->elementData())
+        if (!parentElement || !parentElement->elementData() || !parentElement->hasClass())
             return false;
 
         for (auto& className : parentElement->classNames()) {


### PR DESCRIPTION
#### bd789d34b3e7cd8b7d9cdb6ed7224a670b278713
<pre>
[WebCore] Debug assertion fails in needsTikTokOverflowingContentQuirk
<a href="https://bugs.webkit.org/show_bug.cgi?id=300872">https://bugs.webkit.org/show_bug.cgi?id=300872</a>
<a href="https://rdar.apple.com/162756863">rdar://162756863</a>

Reviewed by Sammy Gill.

When navigating to <a href="https://threejs.org/examples/?q=webgpu#webgpu_loader_texture_ktx2">https://threejs.org/examples/?q=webgpu#webgpu_loader_texture_ktx2</a>
in a Debug build of MiniBrowser we get following assertion:

```
ASSERTION FAILED: hasClass()
/Volumes/Shared/wk1/OpenSource/Source/WebCore/dom/ElementInlines.h(150) : const SpaceSplitString &amp;WebCore::Element::classNames() const
1   0x3051b5268 WebCore::Element::classNames() const
2   0x306d44168 WebCore::Quirks::needsTikTokOverflowingContentQuirk(WebCore::Element const&amp;, WebCore::RenderStyle const&amp;) const::$_3::operator()() const
...
```

That seems to be caused by calling `Element::classNames` in `Quirks.cpp:2031` without
first checking whether `Element::hasClass`, so I added the check to pre-existing
early exit conditions.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsTikTokOverflowingContentQuirk const):

Canonical link: <a href="https://commits.webkit.org/301658@main">https://commits.webkit.org/301658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12c11d64bd414df99458474935c44f7c5506dc89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133610 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78301 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f694c8a5-e49a-4469-8db7-7101501866c4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54823 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96376 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0225c8af-fa4a-4dbb-a76e-e2e6972ee167) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76901 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ca62276b-7379-4305-bc3a-904b602da8a7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31452 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77006 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136180 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41028 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104888 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109624 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26672 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50076 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28413 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50760 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59063 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52527 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55863 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54264 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->