### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException where it is no longer needed

### DIFF
--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -93,6 +93,9 @@ public:
         static_assert(
             HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
+        static_assert(
+            !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
+            "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
         ASSERT(canSafelyBeUsed());
         return m_impl ? static_cast<T*>(m_impl->template get<T>()) : nullptr;
@@ -117,6 +120,9 @@ public:
         static_assert(
             HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
+        static_assert(
+            !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
+            "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
         ASSERT(canSafelyBeUsed());
         auto* result = get();
@@ -129,6 +135,9 @@ public:
         static_assert(
             HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
+        static_assert(
+            !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
+            "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
         ASSERT(canSafelyBeUsed());
         auto* result = get();

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -30,15 +30,6 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
-class GStreamerPeerConnectionBackend;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::GStreamerPeerConnectionBackend> : std::true_type { };
-}
-
-namespace WebCore {
 
 class GStreamerMediaEndpoint;
 class GStreamerRtpReceiverBackend;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
@@ -30,17 +30,8 @@
 #include "RealtimeMediaSource.h"
 #include <wtf/TZoneMalloc.h>
 
-namespace WebCore {
-class LibWebRTCPeerConnectionBackend;
-}
-
 namespace webrtc {
 class IceCandidate;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::LibWebRTCPeerConnectionBackend> : std::true_type { };
 }
 
 namespace WebCore {

--- a/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
@@ -37,15 +37,6 @@
 #include <WebCore/AudioSampleDataSource.h>
 #endif
 
-namespace WebCore {
-class SpeechRecognitionCaptureSourceImpl;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SpeechRecognitionCaptureSourceImpl> : std::true_type { };
-}
-
 namespace WTF {
 class MediaTime;
 }

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -39,15 +39,6 @@
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {
-class MediaElementSession;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaElementSession> : std::true_type { };
-}
-
-namespace WebCore {
 
 enum class MediaSessionMainContentPurpose { MediaControls, Autoplay };
 enum class MediaPlaybackState { Playing, Paused };

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -65,15 +65,6 @@
 
 #include "GCGLSpan.h"
 
-namespace WebCore {
-class WebGLRenderingContextBase;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::WebGLRenderingContextBase> : std::true_type { };
-}
-
 namespace JSC {
 class AbstractSlotVisitor;
 }

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -36,16 +36,6 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class TrackListBase;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-// FIXME: TrackListBase inherits from RefCounted, what gives?
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::TrackListBase> : std::true_type { };
-}
-
-namespace WebCore {
 
 class TrackBase;
 using TrackID = uint64_t;

--- a/Source/WebCore/layout/LayoutState.h
+++ b/Source/WebCore/layout/LayoutState.h
@@ -32,17 +32,6 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-namespace Layout {
-class LayoutState;
-}
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::Layout::LayoutState> : std::true_type { };
-}
-
-namespace WebCore {
 
 class Document;
 

--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -45,15 +45,6 @@ OBJC_CLASS AVPlayerViewController;
 OBJC_CLASS UIViewController;
 #endif
 
-namespace WebCore {
-class VideoPresentationModelClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::VideoPresentationModelClient> : std::true_type { };
-}
-
 namespace WTF {
 class MachSendRight;
 }

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
@@ -48,15 +48,6 @@ OBJC_CLASS AVMediaSelectionOption;
 typedef const struct opaqueCMFormatDescription* CMFormatDescriptionRef;
 
 namespace WebCore {
-class AVTrackPrivateAVFObjCImpl;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AVTrackPrivateAVFObjCImpl> : std::true_type { };
-}
-
-namespace WebCore {
 
 class MediaSelectionOptionAVFObjC;
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -36,15 +36,6 @@
 
 OBJC_CLASS WebCoreAudioInputMuteChangeListener;
 
-namespace WebCore {
-class CoreAudioSharedUnit;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CoreAudioSharedUnit> : std::true_type { };
-}
-
 typedef UInt32 AudioUnitPropertyID;
 typedef UInt32 AudioUnitScope;
 typedef UInt32 AudioUnitElement;

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
@@ -42,13 +42,11 @@ OBJC_CLASS SCStreamDelegate;
 OBJC_CLASS WebDisplayMediaPromptHelper;
 
 namespace WebCore {
-class ScreenCaptureKitSharingSessionManager;
 class ScreenCaptureSessionSourceObserver;
 }
 
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ScreenCaptureKitSharingSessionManager> : std::true_type { };
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ScreenCaptureSessionSourceObserver> : std::true_type { };
 }
 

--- a/Source/WebCore/platform/mock/MediaPlaybackTargetPickerMock.h
+++ b/Source/WebCore/platform/mock/MediaPlaybackTargetPickerMock.h
@@ -35,15 +35,6 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-class MediaPlaybackTargetPickerMock;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaPlaybackTargetPickerMock> : std::true_type { };
-}
-
-namespace WebCore {
 
 class MediaPlaybackTargetPickerMock final : public MediaPlaybackTargetPicker, public CanMakeWeakPtr<MediaPlaybackTargetPickerMock> {
     WTF_MAKE_TZONE_ALLOCATED(MediaPlaybackTargetPickerMock);


### PR DESCRIPTION
#### a49f0d2b3c5d12e8abe5795f28588e02a135d89c
<pre>
Drop IsDeprecatedWeakRefSmartPointerException where it is no longer needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=300880">https://bugs.webkit.org/show_bug.cgi?id=300880</a>

Reviewed by Per Arne Vollan.

* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::get const):
(WTF::WeakPtr::operator-&gt; const):
(WTF::WeakPtr::operator* const):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h:
* Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h:
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/html/track/TrackListBase.h:
* Source/WebCore/layout/LayoutState.h:
* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h:
* Source/WebCore/platform/mock/MediaPlaybackTargetPickerMock.h:

Canonical link: <a href="https://commits.webkit.org/301684@main">https://commits.webkit.org/301684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a165b3e24c8239ad28c2d96ec3141bf9ac63e85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78339 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4dfc9eac-1b5f-4222-82c3-70dee323eb36) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54872 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/43a2fb73-6330-408f-bce9-4e2506aa2a97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76942 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d023312e-dd61-4f0d-a61b-ecf3fd0b60a2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31497 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77051 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118741 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107401 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136229 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125158 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104932 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109674 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104634 "Found 1 new API test failure: WebKitGTK/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26687 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50816 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53301 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59104 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158201 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52567 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39580 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55903 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54309 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->