### PR TITLE
[GLib] Fix GraphicsContextGL test build when WEBXR is disabled

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
@@ -92,8 +92,10 @@ protected:
     bool antialias() const { return std::get<0>(GetParam()); }
     bool preserveDrawingBuffer() const { return std::get<1>(GetParam()); }
     bool isWebGL2() const { return std::get<2>(GetParam()); }
+#if ENABLE(WEBXR)
     GraphicsContextGLAttributes attributes();
     RefPtr<TestedGraphicsContextGLTextureMapper> createTestContext(IntSize contextSize);
+#endif
 
     void SetUp() override // NOLINT
     {
@@ -108,6 +110,7 @@ private:
     std::optional<ScopedSetAuxiliaryProcessTypeForTesting> m_scopedProcessType;
 };
 
+#if ENABLE(WEBXR)
 GraphicsContextGLAttributes AnyContextAttributeTest::attributes()
 {
     GraphicsContextGLAttributes attributes;
@@ -128,6 +131,7 @@ RefPtr<TestedGraphicsContextGLTextureMapper> AnyContextAttributeTest::createTest
     context->reshape(contextSize.width(), contextSize.height());
     return context;
 }
+#endif
 
 } // namespace
 


### PR DESCRIPTION
#### eb9c4a48929cf3edb1918e75e9b35aca35bfe05b
<pre>
[GLib] Fix GraphicsContextGL test build when WEBXR is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=300879">https://bugs.webkit.org/show_bug.cgi?id=300879</a>

Reviewed by Fujii Hironori.

Build of GraphicsContextGL test fails with -Werror=unused-function
when WEBXR is disabled.

attributes() and createTestContext() methods are used only by WEBXR.

* Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp:

Canonical link: <a href="https://commits.webkit.org/301707@main">https://commits.webkit.org/301707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3e02d9a63bf28e226095e0cd90690b3f8586e2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133530 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78243 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54755 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96318 "Failed to checkout and rebase branch from PR 52466") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64410 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76842 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31384 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76894 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136079 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104826 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104528 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26699 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50008 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28348 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50687 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53183 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52464 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55798 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->