### PR TITLE
[GTK][WPE] Fix tracking and leaking reallocated memory with MALLOC_HEAP_BREAKDOWN

### DIFF
--- a/Source/WTF/wtf/malloc_heap_breakdown/main.cpp
+++ b/Source/WTF/wtf/malloc_heap_breakdown/main.cpp
@@ -109,8 +109,13 @@ public:
             zoneFree(zone, memory);
             return nullptr;
         }
-        m_zoneAllocations[zone][memory] = size;
-        return realloc(memory, size);
+        void* ptr = realloc(memory, size);
+        if (ptr) {
+            if (ptr != memory)
+                m_zoneAllocations[zone].erase(memory);
+            m_zoneAllocations[zone][ptr] = size;
+        }
+        return ptr;
     }
     void* zoneMemalign(malloc_zone_t* zone, size_t alignment, size_t size)
     {


### PR DESCRIPTION
#### ea2e6d0dea2ce2d9031cb3fbf3e28b6f40890483
<pre>
[GTK][WPE] Fix tracking and leaking reallocated memory with MALLOC_HEAP_BREAKDOWN
<a href="https://bugs.webkit.org/show_bug.cgi?id=300882">https://bugs.webkit.org/show_bug.cgi?id=300882</a>

Reviewed by Michael Catanzaro.

Memory reallocated with zoneRealloc() was not tracked properly.

If realloc() returns a different pointer, the old pointer is left
accounted for in the zone allocations with the new size, and the new
pointer is not tracked at all.

So when the new pointer is freed by zoneFree():
- the new memory was leaked because the function checks if the
  allocation is tracked before calling free()
- the old pointer allocation was left in the allocation statistics

This has been noticed with a backport of this feature on WPE 2.42,
which showed incorrect leaks of AssemblerData and MetadataTable objects.

* Source/WTF/wtf/malloc_heap_breakdown/main.cpp:
(MallocZoneHeapManager::zoneRealloc):

Canonical link: <a href="https://commits.webkit.org/301709@main">https://commits.webkit.org/301709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1549719af1eb863444e31f2358d710ae0de13685

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78261 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96338 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64417 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76864 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31404 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76962 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118641 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136130 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125056 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104847 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109571 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104545 "Found 2 new API test failures: WebKitGTK/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request, WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/clear (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26702 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50025 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28367 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50711 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53202 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59015 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158101 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52483 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39560 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55817 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->