### PR TITLE
[GTK][WPE] Fix build with -DENABLE_MALLOC_HEAP_BREAKDOWN=ON and without libpas

### DIFF
--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -706,6 +706,7 @@ set(bmalloc_LIBRARIES
 )
 
 if (ENABLE_MALLOC_HEAP_BREAKDOWN)
+    list(APPEND bmalloc_DEFINITIONS BENABLE_MALLOC_HEAP_BREAKDOWN=1)
     list(APPEND bmalloc_LIBRARIES ${MALLOC_HEAP_BREAKDOWN_LIBRARIES})
 endif ()
 
@@ -728,10 +729,6 @@ add_definitions(-DPAS_BMALLOC=1)
 if (MSVC)
     add_compile_options(/wd4206)
     add_compile_options(-mcx16)
-endif ()
-
-if (ENABLE_MALLOC_HEAP_BREAKDOWN)
-    add_definitions(-DBENABLE_MALLOC_HEAP_BREAKDOWN=1)
 endif ()
 
 WEBKIT_FRAMEWORK_DECLARE(bmalloc)


### PR DESCRIPTION
#### 2e79b6643310269f76168bc6a0c80b9a59c2bd84
<pre>
[GTK][WPE] Fix build with -DENABLE_MALLOC_HEAP_BREAKDOWN=ON and without libpas
<a href="https://bugs.webkit.org/show_bug.cgi?id=300883">https://bugs.webkit.org/show_bug.cgi?id=300883</a>

Reviewed by Yusuke Suzuki and Michael Catanzaro.

BENABLE_MALLOC_HEAP_BREAKDOWN needs to be propagated to bmalloc users, since it
is used in public bmalloc headers like IsoTLSInlines.h

Co-authored-by: Loïc Yhuel &lt;loic.yhuel@softathome.com&gt;

* Source/bmalloc/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/301712@main">https://commits.webkit.org/301712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7aed7850f101e358b72ac0bada42c6d786a73c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78246 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54758 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96322 "Failed to checkout and rebase branch from PR 52468") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64405 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36378 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31389 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/static-position/htb-ltr-ltr.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76897 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118625 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107297 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136082 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125040 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104830 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109547 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104530 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26701 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50015 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28353 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50692 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53186 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158085 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52467 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39553 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->