### PR TITLE
[GTK][WPE] Fix MALLOC_HEAP_BREAKDOWN build with system headers defining boolean_t

### DIFF
--- a/Source/WTF/wtf/malloc_heap_breakdown/main.cpp
+++ b/Source/WTF/wtf/malloc_heap_breakdown/main.cpp
@@ -296,6 +296,6 @@ size_t malloc_zone_pressure_relief(malloc_zone_t*, size_t)
     return 0;
 }
 
-void malloc_zone_print(malloc_zone_t*, boolean_t)
+void malloc_zone_print(malloc_zone_t*, bool)
 {
 }

--- a/Source/WTF/wtf/malloc_heap_breakdown/malloc/malloc.h
+++ b/Source/WTF/wtf/malloc_heap_breakdown/malloc/malloc.h
@@ -25,6 +25,11 @@
 
 #pragma once
 
+#ifndef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
 #include <stddef.h>
 
 /* This file was inspired by malloc.h from MacOS. */
@@ -33,7 +38,6 @@ typedef struct _malloc_zone_t {
 } malloc_zone_t;
 
 typedef size_t vm_size_t;
-typedef bool boolean_t;
 
 /********* Creation and destruction ************/
 
@@ -79,5 +83,9 @@ size_t malloc_zone_pressure_relief(malloc_zone_t *zone, size_t goal);
 
 /********* Debug helpers ************/
 
-extern void malloc_zone_print(malloc_zone_t *zone, boolean_t verbose);
+extern void malloc_zone_print(malloc_zone_t *zone, bool verbose);
     /* Prints summary on zone; if !zone, prints all zones */
+
+#ifndef __cplusplus
+}
+#endif


### PR DESCRIPTION
#### 2907cb6685d88cdfe61aa137bc44ca416557b777
<pre>
[GTK][WPE] Fix MALLOC_HEAP_BREAKDOWN build with system headers defining boolean_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=300884">https://bugs.webkit.org/show_bug.cgi?id=300884</a>

Reviewed by Michael Catanzaro.

Remove useless boolean_t define and include stdbool.h instead.

This define can conflict with another define of boolean_t, from a
system header pulled by files using FastMalloc.

Also add missing extern &quot;C&quot; block.

* Source/WTF/wtf/malloc_heap_breakdown/main.cpp:
(malloc_zone_print):
* Source/WTF/wtf/malloc_heap_breakdown/malloc/malloc.h:

Canonical link: <a href="https://commits.webkit.org/301861@main">https://commits.webkit.org/301861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/606740b2c521b037b15e8b22c8c268fd38d2e5c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133834 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78437 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96521 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64532 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113449 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77035 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31626 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77229 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118871 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136361 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125292 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105027 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104724 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26786 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28572 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50970 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53430 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59264 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158331 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52684 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39609 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->