### PR TITLE
[threaded-animation-resolution] remove the `updateTimelineCurrentTime()` functions

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -146,7 +146,6 @@ public:
     virtual void animationsWereAddedToNode(RemoteLayerTreeNode&) { }
     virtual void animationsWereRemovedFromNode(RemoteLayerTreeNode&) { }
     virtual void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds, MonotonicTime) { }
-    virtual void updateTimelineCurrentTime(WebCore::ProcessIdentifier, MonotonicTime) { }
     virtual const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const { return nullptr; }
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -76,7 +76,6 @@ public:
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
     void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds, MonotonicTime) override;
-    void updateTimelineCurrentTime(WebCore::ProcessIdentifier, MonotonicTime) override;
     const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const override;
     void updateAnimations();
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -463,13 +463,6 @@ void RemoteScrollingCoordinatorProxyIOS::registerTimelineIfNecessary(WebCore::Pr
         m_timelines.set(processIdentifier, RemoteAnimationTimeline::create(originTime, now));
 }
 
-void RemoteScrollingCoordinatorProxyIOS::updateTimelineCurrentTime(WebCore::ProcessIdentifier processIdentifier, MonotonicTime now)
-{
-    auto it = m_timelines.find(processIdentifier);
-    if (it != m_timelines.end())
-        Ref { it->value }->updateCurrentTime(now);
-}
-
 const RemoteAnimationTimeline* RemoteScrollingCoordinatorProxyIOS::timeline(WebCore::ProcessIdentifier processIdentifier) const
 {
     auto it = m_timelines.find(processIdentifier);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -112,7 +112,6 @@ public:
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
     void updateAnimations();
     void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds, MonotonicTime);
-    void updateTimelineCurrentTime(WebCore::ProcessIdentifier, MonotonicTime);
     const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const;
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -650,14 +650,6 @@ void RemoteLayerTreeEventDispatcher::registerTimelineIfNecessary(WebCore::Proces
         m_timelines.set(processIdentifier, RemoteAnimationTimeline::create(originTime, now));
 }
 
-void RemoteLayerTreeEventDispatcher::updateTimelineCurrentTime(WebCore::ProcessIdentifier processIdentifier, MonotonicTime now)
-{
-    assertIsHeld(m_animationLock);
-    auto it = m_timelines.find(processIdentifier);
-    if (it != m_timelines.end())
-        Ref { it->value }->updateCurrentTime(now);
-}
-
 const RemoteAnimationTimeline* RemoteLayerTreeEventDispatcher::timeline(WebCore::ProcessIdentifier processIdentifier) const
 {
     assertIsHeld(m_animationLock);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -78,7 +78,6 @@ private:
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
     void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds, MonotonicTime) override;
-    void updateTimelineCurrentTime(WebCore::ProcessIdentifier, MonotonicTime) override;
     const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const override;
 #else
     void willCommitLayerAndScrollingTrees() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -324,11 +324,6 @@ void RemoteScrollingCoordinatorProxyMac::registerTimelineIfNecessary(WebCore::Pr
     m_eventDispatcher->registerTimelineIfNecessary(processIdentifier, originTime, now);
 }
 
-void RemoteScrollingCoordinatorProxyMac::updateTimelineCurrentTime(WebCore::ProcessIdentifier processIdentifier, MonotonicTime now)
-{
-    m_eventDispatcher->updateTimelineCurrentTime(processIdentifier, now);
-}
-
 const RemoteAnimationTimeline* RemoteScrollingCoordinatorProxyMac::timeline(WebCore::ProcessIdentifier processIdentifier) const
 {
     return m_eventDispatcher->timeline(processIdentifier);


### PR DESCRIPTION
#### 89e2ec151d8d4be7dc13e1cb4c82170a80480a2a
<pre>
[threaded-animation-resolution] remove the `updateTimelineCurrentTime()` functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=300889">https://bugs.webkit.org/show_bug.cgi?id=300889</a>
<a href="https://rdar.apple.com/162774083">rdar://162774083</a>

Reviewed by Anne van Kesteren.

Remove some unused code.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::registerTimelineIfNecessary):
(WebKit::RemoteScrollingCoordinatorProxy::updateTimelineCurrentTime): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateTimelineCurrentTime): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::registerTimelineIfNecessary):
(WebKit::RemoteLayerTreeEventDispatcher::updateTimelineCurrentTime): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::updateTimelineCurrentTime): Deleted.

Canonical link: <a href="https://commits.webkit.org/301634@main">https://commits.webkit.org/301634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1e52c51f6a5ed8a551e99cb5135e37fde6ab8f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133566 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78262 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c10d0d75-06ed-4c50-85c2-641380069982) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54775 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d058182a-ece8-4748-9c6a-1469e2f40fec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76865 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f0c70f45-c9cf-4332-8c2c-898d75ec0b77) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76963 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107314 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136131 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40985 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109572 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50027 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50712 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19798 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53203 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59016 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52484 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54219 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->