### PR TITLE
Remove unnecessary retaining of NS globals after 301588@main

### DIFF
--- a/Source/WebCore/platform/mac/WebCoreFullScreenWarningView.mm
+++ b/Source/WebCore/platform/mac/WebCoreFullScreenWarningView.mm
@@ -66,8 +66,8 @@ static const CGFloat WarningViewShadowRadius = 5;
     NSFont* textFont = [NSFont boldSystemFontOfSize:WarningViewTextSize];
     NSColor* textColor = [NSColor colorWithCalibratedWhite:WarningViewTextWhite alpha:WarningViewTextAlpha];
     RetainPtr<NSDictionary> attributes = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:
-                                                  textFont, RetainPtr { NSFontAttributeName }.get(),
-                                                  textColor, RetainPtr { NSForegroundColorAttributeName }.get(),
+                                                  textFont, NSFontAttributeName,
+                                                  textColor, NSForegroundColorAttributeName,
                                                   nil]);
     RetainPtr<NSAttributedString> text = adoptNS([[NSAttributedString alloc] initWithString:title attributes:attributes.get()]);
     [_textField setAttributedStringValue:text.get()];

--- a/Source/WebCore/platform/mac/WebCoreNSFontManagerExtras.mm
+++ b/Source/WebCore/platform/mac/WebCoreNSFontManagerExtras.mm
@@ -125,25 +125,25 @@ FontAttributeChanges computedFontAttributeChanges(NSFontManager *fontManager, id
     NSDictionary *convertedAttributesA = [attributeConverter convertAttributes:originalAttributesA];
     NSDictionary *convertedAttributesB = [attributeConverter convertAttributes:originalAttributesB];
 
-    RetainPtr convertedBackgroundColorA = [convertedAttributesA objectForKey:RetainPtr { NSBackgroundColorAttributeName }.get()];
-    if (convertedBackgroundColorA == [convertedAttributesB objectForKey:RetainPtr { NSBackgroundColorAttributeName }.get()])
+    RetainPtr convertedBackgroundColorA = [convertedAttributesA objectForKey:NSBackgroundColorAttributeName];
+    if (convertedBackgroundColorA == [convertedAttributesB objectForKey:NSBackgroundColorAttributeName])
         changes.setBackgroundColor(colorFromCocoaColor(convertedBackgroundColorA ? convertedBackgroundColorA.get() : RetainPtr { NSColor.clearColor }.get()));
 
-    changes.setFontChanges(computedFontChanges(fontManager, originalFontA.get(), [convertedAttributesA objectForKey:RetainPtr { NSFontAttributeName }.get()], [convertedAttributesB objectForKey: RetainPtr { NSFontAttributeName }.get()]));
+    changes.setFontChanges(computedFontChanges(fontManager, originalFontA.get(), [convertedAttributesA objectForKey:NSFontAttributeName], [convertedAttributesB objectForKey: NSFontAttributeName]));
 
-    RetainPtr convertedForegroundColorA = [convertedAttributesA objectForKey:RetainPtr { NSForegroundColorAttributeName }.get()];
-    if (convertedForegroundColorA == [convertedAttributesB objectForKey:RetainPtr { NSForegroundColorAttributeName }.get()])
+    RetainPtr convertedForegroundColorA = [convertedAttributesA objectForKey:NSForegroundColorAttributeName];
+    if (convertedForegroundColorA == [convertedAttributesB objectForKey:NSForegroundColorAttributeName])
         changes.setForegroundColor(colorFromCocoaColor(convertedForegroundColorA ? convertedForegroundColorA.get() : RetainPtr { NSColor.blackColor }.get()));
 
-    RetainPtr<NSShadow> convertedShadow = [convertedAttributesA objectForKey:RetainPtr { NSShadowAttributeName }.get()];
+    RetainPtr<NSShadow> convertedShadow = [convertedAttributesA objectForKey:NSShadowAttributeName];
     if (convertedShadow) {
         FloatSize offset { LayoutUnit::fromFloatRound(static_cast<float>([convertedShadow shadowOffset].width)).toFloat(), LayoutUnit::fromFloatRound(static_cast<float>([convertedShadow shadowOffset].height)).toFloat() };
         changes.setShadow({ colorFromCocoaColor(RetainPtr { [convertedShadow shadowColor] ?: NSColor.blackColor }.get()), offset, [convertedShadow shadowBlurRadius] });
-    } else if (![convertedAttributesB objectForKey:RetainPtr { NSShadowAttributeName }.get()])
+    } else if (![convertedAttributesB objectForKey:NSShadowAttributeName])
         changes.setShadow({ });
 
-    int convertedSuperscriptA = [[convertedAttributesA objectForKey:RetainPtr { NSSuperscriptAttributeName }.get()] intValue];
-    if (convertedSuperscriptA == [[convertedAttributesB objectForKey:RetainPtr { NSSuperscriptAttributeName }.get()] intValue]) {
+    int convertedSuperscriptA = [[convertedAttributesA objectForKey:NSSuperscriptAttributeName] intValue];
+    if (convertedSuperscriptA == [[convertedAttributesB objectForKey:NSSuperscriptAttributeName] intValue]) {
         if (convertedSuperscriptA > 0)
             changes.setVerticalAlign(VerticalAlignChange::Superscript);
         else if (convertedSuperscriptA < 0)
@@ -152,12 +152,12 @@ FontAttributeChanges computedFontAttributeChanges(NSFontManager *fontManager, id
             changes.setVerticalAlign(VerticalAlignChange::Baseline);
     }
 
-    int convertedStrikeThroughA = [[convertedAttributesA objectForKey:RetainPtr { NSStrikethroughStyleAttributeName }.get()] intValue];
-    if (convertedStrikeThroughA == [[convertedAttributesB objectForKey:RetainPtr { NSStrikethroughStyleAttributeName }.get()] intValue])
+    int convertedStrikeThroughA = [[convertedAttributesA objectForKey:NSStrikethroughStyleAttributeName] intValue];
+    if (convertedStrikeThroughA == [[convertedAttributesB objectForKey:NSStrikethroughStyleAttributeName] intValue])
         changes.setStrikeThrough(convertedStrikeThroughA != NSUnderlineStyleNone);
 
-    int convertedUnderlineA = [[convertedAttributesA objectForKey:RetainPtr { NSUnderlineStyleAttributeName }.get()] intValue];
-    if (convertedUnderlineA == [[convertedAttributesB objectForKey:RetainPtr { NSUnderlineStyleAttributeName }.get()] intValue])
+    int convertedUnderlineA = [[convertedAttributesA objectForKey:NSUnderlineStyleAttributeName] intValue];
+    if (convertedUnderlineA == [[convertedAttributesB objectForKey:NSUnderlineStyleAttributeName] intValue])
         changes.setUnderline(convertedUnderlineA != NSUnderlineStyleNone);
 
     return changes;

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -439,7 +439,7 @@ static Color activeButtonTextColor()
 static SRGBA<uint8_t> menuBackgroundColor()
 {
     RetainPtr offscreenRep = adoptNS([[NSBitmapImageRep alloc] initWithBitmapDataPlanes:nil pixelsWide:1 pixelsHigh:1
-        bitsPerSample:8 samplesPerPixel:4 hasAlpha:YES isPlanar:NO colorSpaceName:RetainPtr { NSDeviceRGBColorSpace }.get() bytesPerRow:4 bitsPerPixel:32]);
+        bitsPerSample:8 samplesPerPixel:4 hasAlpha:YES isPlanar:NO colorSpaceName:NSDeviceRGBColorSpace bytesPerRow:4 bitsPerPixel:32]);
 
     {
         LocalCurrentCGContext localContext { [NSGraphicsContext graphicsContextWithBitmapImageRep:offscreenRep.get()].CGContext };

--- a/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
+++ b/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
@@ -113,7 +113,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
 #if HAVE(LIQUID_GLASS)
             [paymentCoordinatorProxy->m_sheetWindow setStyleMask:NSWindowStyleMaskAlertWindow | NSWindowStyleMaskTitled];
 #endif
-            paymentCoordinatorProxy->m_sheetWindowWillCloseObserver = [[NSNotificationCenter defaultCenter] addObserverForName:RetainPtr { NSWindowWillCloseNotification }.get() object:paymentCoordinatorProxy->m_sheetWindow.get() queue:nil usingBlock:[paymentCoordinatorProxy](NSNotification *) {
+            paymentCoordinatorProxy->m_sheetWindowWillCloseObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowWillCloseNotification object:paymentCoordinatorProxy->m_sheetWindow.get() queue:nil usingBlock:[paymentCoordinatorProxy](NSNotification *) {
                 paymentCoordinatorProxy->didReachFinalState();
             }];
 

--- a/Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm
@@ -39,7 +39,7 @@ namespace WebKit {
 
 static RetainPtr<NSPasteboard> findPasteboard()
 {
-    return [NSPasteboard pasteboardWithName:RetainPtr { NSPasteboardNameFind }.get()];
+    return [NSPasteboard pasteboardWithName:NSPasteboardNameFind];
 }
 
 #else

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -390,7 +390,7 @@ void SOAuthorizationSession::presentViewController(SOAuthorizationViewController
 
     m_sheetWindow = [NSWindow windowWithContentViewController:m_viewController.get()];
 
-    m_sheetWindowWillCloseObserver = [[NSNotificationCenter defaultCenter] addObserverForName:RetainPtr { NSWindowWillCloseNotification }.get() object:m_sheetWindow.get() queue:nil usingBlock:[weakThis = ThreadSafeWeakPtr { *this }] (NSNotification *) {
+    m_sheetWindowWillCloseObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowWillCloseNotification object:m_sheetWindow.get() queue:nil usingBlock:[weakThis = ThreadSafeWeakPtr { *this }] (NSNotification *) {
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -474,7 +474,7 @@ void SOAuthorizationSession::dismissViewController()
                     AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: [Miniaturized] Already has a deminiaturized observer (%p). Hidden observer is %p", m_presentingWindowDidDeminiaturizeObserver.get(), m_applicationDidUnhideObserver.get());
                     return;
                 }
-                m_presentingWindowDidDeminiaturizeObserver = [[NSNotificationCenter defaultCenter] addObserverForName:RetainPtr { NSWindowDidDeminiaturizeNotification }.get() object:presentingWindow.get() queue:nil usingBlock:[protectedThis = Ref { *this }, this] (NSNotification *) {
+                m_presentingWindowDidDeminiaturizeObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowDidDeminiaturizeNotification object:presentingWindow.get() queue:nil usingBlock:[protectedThis = Ref { *this }, this] (NSNotification *) {
                     AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: Window has deminiaturized. Completing the dismissal.");
                     dismissViewController();
                     [[NSNotificationCenter defaultCenter] removeObserver:m_presentingWindowDidDeminiaturizeObserver.get()];
@@ -493,7 +493,7 @@ void SOAuthorizationSession::dismissViewController()
             return;
         }
         // FIXME: We should not need to protect NSApp here (rdar://problem/161068288).
-        m_applicationDidUnhideObserver = [[NSNotificationCenter defaultCenter] addObserverForName:RetainPtr { NSApplicationDidUnhideNotification }.get() object:RetainPtr { NSApp }.get() queue:nil usingBlock:[protectedThis = Ref { *this }, this] (NSNotification *) {
+        m_applicationDidUnhideObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidUnhideNotification object:NSApp queue:nil usingBlock:[protectedThis = Ref { *this }, this] (NSNotification *) {
             AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: Application is no longer hidden. Completing the dismissal.");
             dismissViewController();
             [[NSNotificationCenter defaultCenter] removeObserver:m_applicationDidUnhideObserver.get()];

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -873,25 +873,25 @@ void WebProcessPool::registerNotificationObservers()
         sendToAllProcesses(Messages::WebProcess::ScrollerStylePreferenceChanged(scrollbarStyle));
     }];
 
-    m_activationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:RetainPtr { NSApplicationDidBecomeActiveNotification }.get() object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
+    m_activationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidBecomeActiveNotification object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
 #if ENABLE(CFPREFS_DIRECT_MODE)
         startObservingPreferenceChanges();
 #endif
         setApplicationIsActive(true);
     }];
 
-    m_deactivationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:RetainPtr { NSApplicationDidResignActiveNotification }.get() object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
+    m_deactivationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidResignActiveNotification object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
         setApplicationIsActive(false);
     }];
 
-    m_didChangeScreenParametersNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:RetainPtr { NSApplicationDidChangeScreenParametersNotification }.get() object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
+    m_didChangeScreenParametersNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidChangeScreenParametersNotification object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
         screenPropertiesChanged();
     }];
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    m_didBeginSuppressingHighDynamicRange = [[NSNotificationCenter defaultCenter] addObserverForName:RetainPtr { NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification }.get() object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
+    m_didBeginSuppressingHighDynamicRange = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
         suppressEDR(true);
     }];
-    m_didEndSuppressingHighDynamicRange = [[NSNotificationCenter defaultCenter] addObserverForName:RetainPtr { NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification }.get() object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
+    m_didEndSuppressingHighDynamicRange = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
         suppressEDR(false);
     }];
 #endif

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -341,8 +341,8 @@ void WebInspectorUIProxy::didBecomeActive()
 
 void WebInspectorUIProxy::attachmentViewDidChange(NSView *oldView, NSView *newView)
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:m_objCAdapter.get() name:RetainPtr { NSViewFrameDidChangeNotification }.get() object:oldView];
-    [[NSNotificationCenter defaultCenter] addObserver:m_objCAdapter.get() selector:@selector(inspectedViewFrameDidChange:) name:RetainPtr { NSViewFrameDidChangeNotification }.get() object:newView];
+    [[NSNotificationCenter defaultCenter] removeObserver:m_objCAdapter.get() name:NSViewFrameDidChangeNotification object:oldView];
+    [[NSNotificationCenter defaultCenter] addObserver:m_objCAdapter.get() selector:@selector(inspectedViewFrameDidChange:) name:NSViewFrameDidChangeNotification object:newView];
 
     if (m_isAttached)
         attach(m_attachmentSide);
@@ -476,7 +476,7 @@ RefPtr<WebPageProxy> WebInspectorUIProxy::platformCreateFrontendPage()
 
     m_objCAdapter = adoptNS([[WKWebInspectorUIProxyObjCAdapter alloc] initWithWebInspectorUIProxy:this]);
     RetainPtr inspectedView = inspectedPage->inspectorAttachmentView();
-    [[NSNotificationCenter defaultCenter] addObserver:m_objCAdapter.get() selector:@selector(inspectedViewFrameDidChange:) name:RetainPtr { NSViewFrameDidChangeNotification }.get() object:inspectedView.get()];
+    [[NSNotificationCenter defaultCenter] addObserver:m_objCAdapter.get() selector:@selector(inspectedViewFrameDidChange:) name:NSViewFrameDidChangeNotification object:inspectedView.get()];
 
     Ref configuration = inspectedPage->uiClient().configurationForLocalInspector(*inspectedPage, *this);
     m_inspectorViewController = adoptNS([[WKInspectorViewController alloc] initWithConfiguration:protectedWrapper(configuration.get()).get() inspectedPage:inspectedPage.get()]);

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -80,14 +80,14 @@ void WebPopupMenuProxyMac::populate(const Vector<WebPopupItem>& items, NSFont *f
             [paragraphStyle setBaseWritingDirection:writingDirection];
             [paragraphStyle setAlignment:menuTextDirection == TextDirection::LTR ? NSTextAlignmentLeft : NSTextAlignmentRight];
             RetainPtr<NSMutableDictionary> attributes = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:
-                paragraphStyle.get(), RetainPtr { NSParagraphStyleAttributeName }.get(),
-                font, RetainPtr { NSFontAttributeName }.get(),
+                paragraphStyle.get(), NSParagraphStyleAttributeName,
+                font, NSFontAttributeName,
             nil]);
             if (items[i].m_hasTextDirectionOverride) {
                 auto writingDirectionValue = static_cast<NSInteger>(writingDirection) + static_cast<NSInteger>(NSWritingDirectionOverride);
                 RetainPtr<NSNumber> writingDirectionNumber = adoptNS([[NSNumber alloc] initWithInteger:writingDirectionValue]);
                 RetainPtr<NSArray> writingDirectionArray = adoptNS([[NSArray alloc] initWithObjects:writingDirectionNumber.get(), nil]);
-                [attributes setObject:writingDirectionArray.get() forKey:RetainPtr { NSWritingDirectionAttributeName }.get()];
+                [attributes setObject:writingDirectionArray.get() forKey:NSWritingDirectionAttributeName];
             }
             if (!items[i].m_language.isEmpty())
                 [attributes setObject:items[i].m_language.createNSString().get() forKey:NSLanguageIdentifierAttributeName];

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -266,7 +266,7 @@ WTF_DECLARE_CF_TYPE_TRAIT(CGImage);
     _impl = &impl;
 
     RetainPtr workspaceNotificationCenter = [[NSWorkspace sharedWorkspace] notificationCenter];
-    [workspaceNotificationCenter addObserver:self selector:@selector(_settingsDidChange:) name:RetainPtr { NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification }.get() object:nil];
+    [workspaceNotificationCenter addObserver:self selector:@selector(_settingsDidChange:) name:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification object:nil];
 
     return self;
 }
@@ -274,7 +274,7 @@ WTF_DECLARE_CF_TYPE_TRAIT(CGImage);
 - (void)dealloc
 {
     RetainPtr workspaceNotificationCenter = [[NSWorkspace sharedWorkspace] notificationCenter];
-    [workspaceNotificationCenter removeObserver:self name:RetainPtr { NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification }.get() object:nil];
+    [workspaceNotificationCenter removeObserver:self name:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification object:nil];
 
     [super dealloc];
 }
@@ -315,7 +315,7 @@ WTF_DECLARE_CF_TYPE_TRAIT(CGImage);
     _impl = impl;
 
     RetainPtr workspaceNotificationCenter = [[NSWorkspace sharedWorkspace] notificationCenter];
-    [workspaceNotificationCenter addObserver:self selector:@selector(_activeSpaceDidChange:) name:RetainPtr { NSWorkspaceActiveSpaceDidChangeNotification }.get() object:nil];
+    [workspaceNotificationCenter addObserver:self selector:@selector(_activeSpaceDidChange:) name:NSWorkspaceActiveSpaceDidChangeNotification object:nil];
 
     return self;
 }
@@ -350,29 +350,29 @@ static void* keyValueObservingContext = &keyValueObservingContext;
     RetainPtr defaultNotificationCenter = [NSNotificationCenter defaultCenter];
 
     // An NSView derived object such as WKView cannot observe these notifications, because NSView itself observes them.
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidOrderOffScreen:) name:RetainPtr { NSWindowDidOrderOffScreenNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidOrderOnScreen:) name:RetainPtr { NSWindowDidOrderOnScreenNotification }.get() object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidOrderOffScreen:) name:NSWindowDidOrderOffScreenNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidOrderOnScreen:) name:NSWindowDidOrderOnScreenNotification object:window];
 
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidBecomeKey:) name:RetainPtr { NSWindowDidBecomeKeyNotification }.get() object:nil];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidResignKey:) name:RetainPtr { NSWindowDidResignKeyNotification }.get() object:nil];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidMiniaturize:) name:RetainPtr { NSWindowDidMiniaturizeNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidDeminiaturize:) name:RetainPtr { NSWindowDidDeminiaturizeNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidMove:) name:RetainPtr { NSWindowDidMoveNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidResize:) name:RetainPtr { NSWindowDidResizeNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowWillBeginSheet:) name:RetainPtr { NSWindowWillBeginSheetNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidChangeBackingProperties:) name:RetainPtr { NSWindowDidChangeBackingPropertiesNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidChangeScreen:) name:RetainPtr { NSWindowDidChangeScreenNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidChangeOcclusionState:) name:RetainPtr { NSWindowDidChangeOcclusionStateNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowWillClose:) name:RetainPtr { NSWindowWillCloseNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowWillEnterOrExitFullScreen:) name:RetainPtr { NSWindowWillEnterFullScreenNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidEnterOrExitFullScreen:) name:RetainPtr { NSWindowDidEnterFullScreenNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowWillEnterOrExitFullScreen:) name:RetainPtr { NSWindowWillExitFullScreenNotification }.get() object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidEnterOrExitFullScreen:) name:RetainPtr { NSWindowDidExitFullScreenNotification }.get() object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidBecomeKey:) name:NSWindowDidBecomeKeyNotification object:nil];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidResignKey:) name:NSWindowDidResignKeyNotification object:nil];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidMiniaturize:) name:NSWindowDidMiniaturizeNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidDeminiaturize:) name:NSWindowDidDeminiaturizeNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidMove:) name:NSWindowDidMoveNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidResize:) name:NSWindowDidResizeNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowWillBeginSheet:) name:NSWindowWillBeginSheetNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidChangeBackingProperties:) name:NSWindowDidChangeBackingPropertiesNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidChangeScreen:) name:NSWindowDidChangeScreenNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidChangeOcclusionState:) name:NSWindowDidChangeOcclusionStateNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowWillClose:) name:NSWindowWillCloseNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowWillEnterOrExitFullScreen:) name:NSWindowWillEnterFullScreenNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidEnterOrExitFullScreen:) name:NSWindowDidEnterFullScreenNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowWillEnterOrExitFullScreen:) name:NSWindowWillExitFullScreenNotification object:window];
+    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidEnterOrExitFullScreen:) name:NSWindowDidExitFullScreenNotification object:window];
 
-    [defaultNotificationCenter addObserver:self selector:@selector(_screenDidChangeColorSpace:) name:RetainPtr { NSScreenColorSpaceDidChangeNotification }.get() object:nil];
+    [defaultNotificationCenter addObserver:self selector:@selector(_screenDidChangeColorSpace:) name:NSScreenColorSpaceDidChangeNotification object:nil];
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    [defaultNotificationCenter addObserver:self selector:@selector(_applicationShouldBeginSuppressingHDR:) name:RetainPtr { NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification }.get() object:NSApp];
-    [defaultNotificationCenter addObserver:self selector:@selector(_applicationShouldEndSuppressingHDR:) name:RetainPtr { NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification }.get() object:NSApp];
+    [defaultNotificationCenter addObserver:self selector:@selector(_applicationShouldBeginSuppressingHDR:) name:NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification object:NSApp];
+    [defaultNotificationCenter addObserver:self selector:@selector(_applicationShouldEndSuppressingHDR:) name:NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification object:NSApp];
 #endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
 
     if (_shouldObserveFontPanel) {
@@ -404,27 +404,27 @@ static void* keyValueObservingContext = &keyValueObservingContext;
 
     RetainPtr defaultNotificationCenter = [NSNotificationCenter defaultCenter];
 
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidOrderOffScreenNotification }.get() object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidOrderOnScreenNotification }.get() object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidOrderOffScreenNotification object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidOrderOnScreenNotification object:window.get()];
 
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidBecomeKeyNotification }.get() object:nil];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidResignKeyNotification }.get() object:nil];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidMiniaturizeNotification }.get() object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidDeminiaturizeNotification }.get() object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidMoveNotification }.get() object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidResizeNotification }.get() object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowWillBeginSheetNotification }.get() object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidChangeBackingPropertiesNotification }.get() object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidChangeScreenNotification }.get() object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidBecomeKeyNotification object:nil];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidResignKeyNotification object:nil];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidMiniaturizeNotification object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidDeminiaturizeNotification object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidMoveNotification object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidResizeNotification object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowWillBeginSheetNotification object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidChangeBackingPropertiesNotification object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidChangeScreenNotification object:window.get()];
     [defaultNotificationCenter removeObserver:self name:_NSWindowDidChangeContentsHostedInLayerSurfaceNotification object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidChangeOcclusionStateNotification }.get() object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowWillCloseNotification }.get() object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowWillEnterFullScreenNotification }.get() object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidEnterFullScreenNotification }.get() object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowWillExitFullScreenNotification }.get() object:window.get()];
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSWindowDidExitFullScreenNotification }.get() object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidChangeOcclusionStateNotification object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowWillCloseNotification object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowWillEnterFullScreenNotification object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidEnterFullScreenNotification object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowWillExitFullScreenNotification object:window.get()];
+    [defaultNotificationCenter removeObserver:self name:NSWindowDidExitFullScreenNotification object:window.get()];
 
-    [defaultNotificationCenter removeObserver:self name:RetainPtr { NSScreenColorSpaceDidChangeNotification }.get() object:nil];
+    [defaultNotificationCenter removeObserver:self name:NSScreenColorSpaceDidChangeNotification object:nil];
 
     if (!objc_getAssociatedObject(window.get(), _impl.get()))
         return;
@@ -4514,7 +4514,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
 
             auto clientDragLocation = IntPoint(dragLocationInMainFrameCoordinates.value());
 
-            RetainPtr pasteboard = [NSPasteboard pasteboardWithName:RetainPtr { NSPasteboardNameDrag }.get()];
+            RetainPtr pasteboard = [NSPasteboard pasteboardWithName:NSPasteboardNameDrag];
 
             if (promisedAttachmentInfo) {
                 RefPtr attachment = page->attachmentForIdentifier(promisedAttachmentInfo.attachmentIdentifier);
@@ -4735,7 +4735,7 @@ static RetainPtr<NSPasteboard> pasteboardForAccessCategory(WebCore::DOMPasteAcce
         return NSPasteboard.generalPasteboard;
 
     case WebCore::DOMPasteAccessCategory::Fonts:
-        return [NSPasteboard pasteboardWithName:RetainPtr { NSPasteboardNameFont }.get()];
+        return [NSPasteboard pasteboardWithName:NSPasteboardNameFont];
     }
 }
 
@@ -5525,11 +5525,11 @@ static BOOL shouldUseHighlightsForMarkedText(NSAttributedString *string)
     __block BOOL result = NO;
 
     [string enumerateAttributesInRange:NSMakeRange(0, string.length) options:0 usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attributes, NSRange, BOOL *stop) {
-        BOOL hasUnderlineStyle = !![attributes objectForKey:RetainPtr { NSUnderlineStyleAttributeName }.get()];
-        BOOL hasUnderlineColor = !![attributes objectForKey:RetainPtr { NSUnderlineColorAttributeName }.get()];
+        BOOL hasUnderlineStyle = !![attributes objectForKey:NSUnderlineStyleAttributeName];
+        BOOL hasUnderlineColor = !![attributes objectForKey:NSUnderlineColorAttributeName];
 
-        BOOL hasBackgroundColor = !![attributes objectForKey:RetainPtr { NSBackgroundColorAttributeName }.get()];
-        BOOL hasForegroundColor = !![attributes objectForKey:RetainPtr { NSForegroundColorAttributeName }.get()];
+        BOOL hasBackgroundColor = !![attributes objectForKey:NSBackgroundColorAttributeName];
+        BOOL hasForegroundColor = !![attributes objectForKey:NSForegroundColorAttributeName];
 
         // Marked text may be represented either as an underline or a highlight; this mode is dictated
         // by the attributes it has, and therefore having both types of attributes is not allowed.
@@ -5555,11 +5555,11 @@ static Vector<WebCore::CompositionHighlight> compositionHighlights(NSAttributedS
     Vector<WebCore::CompositionHighlight> highlights;
     [string enumerateAttributesInRange:NSMakeRange(0, string.length) options:0 usingBlock:[&highlights](NSDictionary<NSAttributedStringKey, id> *attributes, NSRange range, BOOL *) {
         std::optional<WebCore::Color> backgroundHighlightColor;
-        if (RetainPtr<WebCore::CocoaColor> backgroundColor = attributes[RetainPtr { NSBackgroundColorAttributeName }.get()])
+        if (RetainPtr<WebCore::CocoaColor> backgroundColor = attributes[NSBackgroundColorAttributeName])
             backgroundHighlightColor = WebCore::colorFromCocoaColor(backgroundColor.get());
 
         std::optional<WebCore::Color> foregroundHighlightColor;
-        if (RetainPtr<WebCore::CocoaColor> foregroundColor = attributes[RetainPtr { NSForegroundColorAttributeName }.get()])
+        if (RetainPtr<WebCore::CocoaColor> foregroundColor = attributes[NSForegroundColorAttributeName])
             foregroundHighlightColor = WebCore::colorFromCocoaColor(foregroundColor.get());
 
         highlights.append({ static_cast<unsigned>(range.location), static_cast<unsigned>(NSMaxRange(range)), backgroundHighlightColor, foregroundHighlightColor });
@@ -5598,11 +5598,11 @@ static Vector<WebCore::CompositionUnderline> compositionUnderlines(NSAttributedS
     Vector<WebCore::CompositionUnderline> underlines;
 
     [string enumerateAttributesInRange:NSMakeRange(0, string.length) options:0 usingBlock:[&underlines](NSDictionary<NSAttributedStringKey, id> *attributes, NSRange range, BOOL *) {
-        RetainPtr<NSNumber> style = [attributes objectForKey:RetainPtr { NSUnderlineStyleAttributeName }.get()];
+        RetainPtr<NSNumber> style = [attributes objectForKey:NSUnderlineStyleAttributeName];
         if (!style)
             return;
 
-        RetainPtr<NSColor> underlineColor = attributes[RetainPtr { NSUnderlineColorAttributeName }.get()];
+        RetainPtr<NSColor> underlineColor = attributes[NSUnderlineColorAttributeName];
         bool isClear = [underlineColor isEqual:NSColor.clearColor];
 
         if (!isClear)
@@ -5635,10 +5635,10 @@ static Vector<WebCore::CompositionUnderline> compositionUnderlines(NSAttributedS
         NSRange range;
         RetainPtr<NSDictionary> attrs = [string attributesAtIndex:i longestEffectiveRange:&range inRange:NSMakeRange(i, length - i)];
 
-        if (RetainPtr<NSNumber> style = [attrs objectForKey:RetainPtr { NSUnderlineStyleAttributeName }.get()]) {
+        if (RetainPtr<NSNumber> style = [attrs objectForKey:NSUnderlineStyleAttributeName]) {
             WebCore::Color color = WebCore::Color::black;
             WebCore::CompositionUnderlineColor compositionUnderlineColor = WebCore::CompositionUnderlineColor::TextColor;
-            if (RetainPtr<NSColor> colorAttribute = [attrs objectForKey:RetainPtr { NSUnderlineColorAttributeName }.get()]) {
+            if (RetainPtr<NSColor> colorAttribute = [attrs objectForKey:NSUnderlineColorAttributeName]) {
                 color = WebCore::colorFromCocoaColor(colorAttribute.get());
                 compositionUnderlineColor = WebCore::CompositionUnderlineColor::GivenColor;
             }
@@ -5663,7 +5663,7 @@ void WebViewImpl::setMarkedText(id string, NSRange selectedRange, NSRange replac
         BOOL hasTextCompletion = [&] {
             __block BOOL result = NO;
 
-            [attributedString enumerateAttribute:RetainPtr { NSTextCompletionAttributeName }.get() inRange:NSMakeRange(0, [attributedString length]) options:0 usingBlock:^(id value, NSRange range, BOOL *stop) {
+            [attributedString enumerateAttribute:NSTextCompletionAttributeName inRange:NSMakeRange(0, [attributedString length]) options:0 usingBlock:^(id value, NSRange range, BOOL *stop) {
                 if ([value respondsToSelector:@selector(boolValue)] && [value boolValue]) {
                     result = YES;
                     *stop = YES;
@@ -6531,9 +6531,9 @@ void WebViewImpl::updateTextTouchBar()
         m_textTouchBarItemController = adoptNS([[WKTextTouchBarItemController alloc] initWithWebViewImpl:this]);
 
     if (!m_startedListeningToCustomizationEvents) {
-        [[NSNotificationCenter defaultCenter] addObserver:m_textTouchBarItemController.get() selector:@selector(touchBarDidExitCustomization:) name:RetainPtr { NSTouchBarDidExitCustomization }.get() object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:m_textTouchBarItemController.get() selector:@selector(touchBarWillEnterCustomization:) name:RetainPtr { NSTouchBarWillEnterCustomization }.get() object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:m_textTouchBarItemController.get() selector:@selector(didChangeAutomaticTextCompletion:) name:RetainPtr { NSSpellCheckerDidChangeAutomaticTextCompletionNotification }.get() object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:m_textTouchBarItemController.get() selector:@selector(touchBarDidExitCustomization:) name:NSTouchBarDidExitCustomization object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:m_textTouchBarItemController.get() selector:@selector(touchBarWillEnterCustomization:) name:NSTouchBarWillEnterCustomization object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:m_textTouchBarItemController.get() selector:@selector(didChangeAutomaticTextCompletion:) name:NSSpellCheckerDidChangeAutomaticTextCompletionNotification object:nil];
 
         m_startedListeningToCustomizationEvents = true;
     }


### PR DESCRIPTION
#### ae2a2c316ec30e51b2d90f89698321fcb05e4f68
<pre>
Remove unnecessary retaining of NS globals after 301588@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=300892">https://bugs.webkit.org/show_bug.cgi?id=300892</a>

Reviewed by Ryosuke Niwa.

These are considered safe by the checker so there is no need
to retain them.

* Source/WebCore/platform/mac/WebCoreFullScreenWarningView.mm:
* Source/WebCore/platform/mac/WebCoreNSFontManagerExtras.mm:
(WebCore::computedFontAttributeChanges):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::menuBackgroundColor):
* Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm:
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm:
(WebKit::findPasteboard):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::presentViewController):
(WebKit::SOAuthorizationSession::dismissViewController):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::attachmentViewDidChange):
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::populate):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKAccessibilitySettingsObserver initWithImpl:]):
(-[WKAccessibilitySettingsObserver dealloc]):
(-[WKWindowVisibilityObserver initWithView:impl:]):
(-[WKWindowVisibilityObserver startObserving:]):
(-[WKWindowVisibilityObserver stopObserving]):
(WebKit::WebViewImpl::startDrag):
(WebKit::pasteboardForAccessCategory):
(WebKit::shouldUseHighlightsForMarkedText):
(WebKit::compositionHighlights):
(WebKit::compositionUnderlines):
(WebKit::WebViewImpl::setMarkedText):
(WebKit::WebViewImpl::updateTextTouchBar):

Canonical link: <a href="https://commits.webkit.org/301635@main">https://commits.webkit.org/301635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8a5aa3a8f602279b49424da040fde1b564f89e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126598 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133572 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54781 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113228 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/76868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31409 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76969 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136140 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40990 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104550 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26663 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50032 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28373 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50721 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53209 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59022 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52490 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55824 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/54225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->