### PR TITLE
Resync `html/semantics/forms/the-form-element` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: constraint-validation
+  files:
+  - form-checkvalidity.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-check-validity-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-check-validity-crash.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<div id="container">
+  <form id="formId"></form>
+</div>
+<input id="inputId" required form="formId" oninvalid="container.remove()">
+<script>
+  formId.checkValidity();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-controls-id-removal-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-controls-id-removal-crash.html
@@ -1,0 +1,29 @@
+<script>
+document.addEventListener("DOMContentLoaded" , () => {
+  c.beginElement()
+  document.onselectstart = fuzz_01
+  document.execCommand("selectAll", false, null)
+})
+function fuzz_01() {
+  document.execCommand("underline", false, null)
+  c.onend = fuzz_01
+  document.designMode = "on"
+}
+function fuzz_02() {
+  d.insertAdjacentElement("beforebegin", b)
+  a.appendChild(c)
+  h.clientTop
+  b.insertAdjacentHTML("afterend", f.innerHTML)
+}
+</script>
+<svg>
+<path id="a">
+<polygon id="b">
+<set id="c" onbegin="fuzz_02()" max="2s">
+<strong>
+<style id="d">
+</style>
+</strong>
+<time id="f">
+<form id="g">
+<output id="h" form="g">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-controls-nested-id-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-controls-nested-id-crash.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1949893">
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  b.outerHTML = a.outerHTML
+  a.replaceWith()
+})
+</script>
+<fieldset form="a"></fieldset>
+<form id="a">
+<object>
+<param id="b">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-indexed-element-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-indexed-element-shadow-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS form.elements: indexed access reflects DOM order, not flat tree
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-indexed-element-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-indexed-element-shadow.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>form.elements: indexed access reflects DOM order, not flat tree</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Mozilla" href="https://mozilla.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<form id="target">
+  <div id="host">
+    <template shadowrootmode="open">
+      <slot name="first"></slot>
+      <slot name="second"></slot>
+    </template>
+    <input id="first" slot="second">
+    <input id="second" slot="first">
+  </div>
+</form>
+<script>
+test(function() {
+  let target = document.getElementById("target");
+  let host = document.getElementById("host");
+  assert_true(!!host.shadowRoot, "Should have a shadow tree");
+  assert_equals(target.elements[0], first, "form.elements reflects DOM order, not flat tree order");
+  assert_equals(target.elements[1], second);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-action-in-inactive-document-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-action-reflection-with-base-url.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-action-reflection.html
@@ -21,13 +22,17 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-action-submission.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-action.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-autocomplete.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-check-validity-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-checkvalidity.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-controls-id-removal-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-controls-nested-id-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-elements-filter.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-elements-interfaces-01.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-elements-matches.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-elements-nameditem-01.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-elements-nameditem-02.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-elements-sameobject.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-indexed-element-shadow.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-indexed-element.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-length.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-nameditem.html


### PR DESCRIPTION
#### eb6f597437cff61ef9755394f2b200addd72c015
<pre>
Resync `html/semantics/forms/the-form-element` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=300893">https://bugs.webkit.org/show_bug.cgi?id=300893</a>

Reviewed by Lily Spiniolas and Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/bda4a4698562f88fc6dcdd72964fda0a69e6eda2">https://github.com/web-platform-tests/wpt/commit/bda4a4698562f88fc6dcdd72964fda0a69e6eda2</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-check-validity-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-controls-id-removal-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-controls-nested-id-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-indexed-element-shadow-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-indexed-element-shadow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/301648@main">https://commits.webkit.org/301648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db8ab1d6b05a2ae6c03bac74e8339554185d8333

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133575 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78271 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/007a7b97-2274-45c1-9cd5-c47aa29ec8ed) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96346 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/625436c9-2077-4d95-a386-c2a489b005b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76871 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3acba2d4-933f-469d-958f-9891fdc6d566) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31417 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76972 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107320 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31711 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136143 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53292 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104856 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104553 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26670 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50036 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28380 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50724 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53212 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52493 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55827 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54228 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->