### PR TITLE
[macOS + iOS Model] Compute bounding box when geometry is updated

### DIFF
--- a/Source/WebCore/Modules/Model/InternalAPI/DDMesh.h
+++ b/Source/WebCore/Modules/Model/InternalAPI/DDMesh.h
@@ -31,6 +31,11 @@
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
+#if PLATFORM(COCOA)
+#include <simd/simd.h>
+#include <wtf/MachSendRight.h>
+#endif
+
 namespace WebCore::DDModel {
 
 struct DDMaterialDescriptor;
@@ -63,6 +68,7 @@ public:
     virtual void render() = 0;
 #if PLATFORM(COCOA)
     virtual Vector<MachSendRight> ioSurfaceHandles() { return { }; }
+    virtual std::pair<simd_float4, simd_float4> getCenterAndExtents() const { return std::make_pair(simd_make_float4(0.f), simd_make_float4(0.f)); }
 #endif
 
 protected:

--- a/Source/WebCore/Modules/model-element/DDModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/DDModelPlayer.h
@@ -43,6 +43,7 @@ class DDMesh;
 
 namespace WebCore {
 
+class GraphicsLayerContentsDisplayDelegate;
 class ModelDisplayBufferDisplayDelegate;
 class ModelPlayerClient;
 class Page;
@@ -95,6 +96,7 @@ private:
     WeakRef<Page> m_page;
     mutable RefPtr<ModelDisplayBufferDisplayDelegate> m_contentsDisplayDelegate;
     uint32_t m_currentTexture { 0 };
+    bool m_didFinishLoading { false };
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.cpp
@@ -30,7 +30,9 @@
 
 #include "ModelConvertToBackingContext.h"
 #include "RemoteDDMeshMessages.h"
+#include <WebCore/DDFloat4x4.h>
 #include <WebCore/DDMeshDescriptor.h>
+#include <WebCore/DDMeshPart.h>
 #include <WebCore/DDTextureDescriptor.h>
 #include <WebCore/DDUpdateMeshDescriptor.h>
 #include <WebCore/DDUpdateTextureDescriptor.h>
@@ -39,6 +41,43 @@
 namespace WebKit::DDModel {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteDDMeshProxy);
+
+#if ENABLE(GPU_PROCESS_MODEL)
+static std::pair<simd_float4, simd_float4> computeCenterAndExtents(const Vector<KeyValuePair<int32_t, WebCore::DDModel::DDMeshPart>>& parts, const Vector<WebCore::DDModel::DDFloat4x4>& instanceTransforms)
+{
+    simd_float3 minCorner = simd_make_float3(FLT_MAX, FLT_MAX, FLT_MAX);
+    simd_float3 maxCorner = simd_make_float3(-FLT_MAX, -FLT_MAX, -FLT_MAX);
+    for (const KeyValuePair<int32_t, WebCore::DDModel::DDMeshPart>& part : parts) {
+        minCorner = simd_min(part.value.boundsMin, minCorner);
+        maxCorner = simd_max(part.value.boundsMax, maxCorner);
+    }
+
+    simd_float3 simdCenter = 0.5f * (minCorner + maxCorner);
+    simd_float3 simdExtent = maxCorner - simdCenter;
+
+    if (!instanceTransforms.size())
+        return std::make_pair(simd_make_float4(simdCenter), simd_make_float4(2.f * simdExtent));
+
+    simd_float4 simdCenter4 = simd::make_float4(simdCenter.x, simdCenter.y, simdCenter.z, 1.f);
+    simd_float4 simdExtent4 = simd::make_float4(simdExtent.x, simdExtent.y, simdExtent.z, 0.f);
+
+    simd_float4 minCorner4 = simd::make_float4(FLT_MAX, FLT_MAX, FLT_MAX, 1.f);
+    simd_float4 maxCorner4 = simd::make_float4(-FLT_MAX, -FLT_MAX, -FLT_MAX, 1.f);
+
+    for (auto& transform : instanceTransforms) {
+        simd_float4 transformedCenter = simd_mul(transform, simdCenter4);
+        simd_float4 transformedExtent = simd_mul(transform, simdExtent4);
+
+        minCorner4 = simd_min(transformedCenter - transformedExtent, minCorner4);
+        maxCorner4 = simd_max(transformedCenter + transformedExtent, maxCorner4);
+    }
+
+    simdCenter4 = 0.5f * (minCorner4 + maxCorner4);
+    simdExtent4 = maxCorner4 - simdCenter4;
+
+    return std::make_pair(simdCenter4, 2.f * simdExtent4.x);
+}
+#endif
 
 RemoteDDMeshProxy::RemoteDDMeshProxy(Ref<RemoteGPUProxy>&& root, ConvertToBackingContext& convertToBackingContext, DDModelIdentifier identifier)
     : m_backing(identifier)
@@ -68,6 +107,9 @@ void RemoteDDMeshProxy::addMesh(const WebCore::DDModel::DDMeshDescriptor& descri
 void RemoteDDMeshProxy::update(const WebCore::DDModel::DDUpdateMeshDescriptor& descriptor)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
+    auto [center, extents] = computeCenterAndExtents(descriptor.parts, descriptor.instanceTransforms4x4);
+    m_center = center;
+    m_extents = extents;
     auto sendResult = send(Messages::RemoteDDMesh::Update(descriptor));
     UNUSED_PARAM(sendResult);
 #else
@@ -132,6 +174,13 @@ void RemoteDDMeshProxy::updateMaterial(const WebCore::DDModel::DDUpdateMaterialD
     UNUSED_PARAM(descriptor);
 #endif
 }
+
+#if PLATFORM(COCOA)
+std::pair<simd_float4, simd_float4> RemoteDDMeshProxy::getCenterAndExtents() const
+{
+    return std::make_pair(m_center, m_extents);
+}
+#endif
 
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h
@@ -33,6 +33,10 @@
 #include <WebCore/DDMeshDescriptor.h>
 #include <wtf/TZoneMalloc.h>
 
+#if PLATFORM(COCOA)
+#include <simd/simd.h>
+#endif
+
 namespace WebKit::DDModel {
 
 class ConvertToBackingContext;
@@ -75,6 +79,9 @@ private:
     void updateTexture(const WebCore::DDModel::DDUpdateTextureDescriptor&) final;
     void addMaterial(const WebCore::DDModel::DDMaterialDescriptor&) final;
     void updateMaterial(const WebCore::DDModel::DDUpdateMaterialDescriptor&) final;
+#if PLATFORM(COCOA)
+    std::pair<simd_float4, simd_float4> getCenterAndExtents() const final;
+#endif
 
     void render() final;
     void setLabelInternal(const String&) final;
@@ -82,6 +89,10 @@ private:
     const DDModelIdentifier m_backing;
     const Ref<ConvertToBackingContext> m_convertToBackingContext;
     const Ref<RemoteGPUProxy> m_root;
+#if PLATFORM(COCOA)
+    simd_float4 m_center;
+    simd_float4 m_extents;
+#endif
 };
 
 }


### PR DESCRIPTION
#### 6cc828448d7b5f7c8b03f2752d79c2f5e41e3c3b
<pre>
[macOS + iOS Model] Compute bounding box when geometry is updated
<a href="https://bugs.webkit.org/show_bug.cgi?id=300410">https://bugs.webkit.org/show_bug.cgi?id=300410</a>
<a href="https://rdar.apple.com/162233357">rdar://162233357</a>

Reviewed by Etienne Segonzac.

Compute bounding box when the mesh geometry is updated.

Test: model-element/model-element-bounding-box.html passes locally after this change

* Source/WebCore/Modules/model-element/DDModelPlayer.mm:
(WebCore::computeCenterAndExtents):
(WebCore::DDModelPlayer::load):

Canonical link: <a href="https://commits.webkit.org/302194@main">https://commits.webkit.org/302194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b16f6c5f6ffe322f22db17e9753c4198b79f1727

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135481 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79610 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97530 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65423 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/01464882-a8cb-4bbd-b62d-e1ba5ab6bdd8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78100 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7b9762d8-1837-454f-a5d1-fe85ae051b7f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32875 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78791 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137971 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/240 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106058 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105797 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27015 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/190 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29665 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52435 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61815 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/207 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/280 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->