### PR TITLE
[Screen Time] Main Thread Checker: UI API called on a background thread: `-[WKWebView observeValueForKeyPath:ofObject:change:context:]`

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -477,6 +477,7 @@ UIProcess/Cocoa/WKContactPicker.mm @nonARC
 UIProcess/Cocoa/WKEditCommand.mm @nonARC
 UIProcess/Cocoa/WKFullKeyboardAccessWatcher.mm @nonARC
 UIProcess/Cocoa/WKReloadFrameErrorRecoveryAttempter.mm @nonARC
+UIProcess/Cocoa/WKScreenTimeConfigurationObserver.mm @nonARC
 UIProcess/Cocoa/WKTextPlaceholder.mm @nonARC
 UIProcess/Cocoa/WKTextSelectionRect.mm @nonARC
 UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm @nonARC

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -52,7 +52,6 @@
 #import <wtf/spi/cocoa/NSObjCRuntimeSPI.h>
 
 #if ENABLE(SCREEN_TIME)
-#import <ScreenTime/STScreenTimeConfiguration.h>
 #import <ScreenTime/STWebpageController.h>
 #endif
 
@@ -168,6 +167,10 @@ enum class HideScrollPocketReason : uint8_t {
 
 #if HAVE(DIGITAL_CREDENTIALS_UI)
 @class WKDigitalCredentialsPicker;
+#endif
+
+#if ENABLE(SCREEN_TIME)
+@class WKScreenTimeConfigurationObserver;
 #endif
 
 #if ENABLE(WRITING_TOOLS)
@@ -317,7 +320,7 @@ struct PerWebProcessState {
 
 #if ENABLE(SCREEN_TIME)
     RetainPtr<STWebpageController> _screenTimeWebpageController;
-    RetainPtr<STScreenTimeConfigurationObserver> _screenTimeConfigurationObserver;
+    RetainPtr<WKScreenTimeConfigurationObserver> _screenTimeConfigurationObserver;
 #if PLATFORM(MAC)
     RetainPtr<NSVisualEffectView> _screenTimeBlurredSnapshot;
 #else

--- a/Source/WebKit/UIProcess/Cocoa/WKScreenTimeConfigurationObserver.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKScreenTimeConfigurationObserver.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ENABLE(SCREEN_TIME)
+
+@class WKWebView;
+
+@interface WKScreenTimeConfigurationObserver : NSObject
+
+- (instancetype)initWithView:(WKWebView *)view;
+
+- (void)startObserving;
+- (void)stopObserving;
+
+- (BOOL)enforcesChildRestrictions;
+
+@end
+
+#endif

--- a/Source/WebKit/UIProcess/Cocoa/WKScreenTimeConfigurationObserver.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKScreenTimeConfigurationObserver.mm
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKScreenTimeConfigurationObserver.h"
+
+#if ENABLE(SCREEN_TIME)
+
+#import "WKWebViewInternal.h"
+#import <wtf/RetainPtr.h>
+#import <wtf/WeakObjCPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
+
+#import <pal/cocoa/ScreenTimeSoftLink.h>
+
+static void *screenTimeConfigurationObserverKVOContext = &screenTimeConfigurationObserverKVOContext;
+
+@implementation WKScreenTimeConfigurationObserver {
+    RetainPtr<STScreenTimeConfigurationObserver> _screenTimeConfigurationObserver;
+    WeakObjCPtr<WKWebView> _webView;
+}
+
+- (instancetype)initWithView:(WKWebView *)view
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _webView = view;
+
+    return self;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey, id> *)change context:(void *)context
+{
+    if (context == &screenTimeConfigurationObserverKVOContext) {
+        ensureOnMainRunLoop([webView = _webView] {
+            [webView _updateScreenTimeBasedOnWindowVisibility];
+        });
+        return;
+    }
+
+    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+}
+
+- (void)startObserving
+{
+    if (_screenTimeConfigurationObserver)
+        return;
+
+    _screenTimeConfigurationObserver = adoptNS([PAL::allocSTScreenTimeConfigurationObserverInstance() initWithUpdateQueue:globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)]);
+    [_screenTimeConfigurationObserver addObserver:self forKeyPath:@"configuration.enforcesChildRestrictions" options:0 context:&screenTimeConfigurationObserverKVOContext];
+    [_screenTimeConfigurationObserver startObserving];
+}
+
+- (void)stopObserving
+{
+    [_screenTimeConfigurationObserver stopObserving];
+    [_screenTimeConfigurationObserver removeObserver:self forKeyPath:@"configuration.enforcesChildRestrictions" context:&screenTimeConfigurationObserverKVOContext];
+    _screenTimeConfigurationObserver = nil;
+}
+
+- (BOOL)enforcesChildRestrictions
+{
+    return [_screenTimeConfigurationObserver configuration].enforcesChildRestrictions;
+}
+
+@end
+
+#endif

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -35,6 +35,7 @@
 #import "WKInspectorWKWebView.h"
 #import "WKOpenPanelParameters.h"
 #import "WKProcessPoolInternal.h"
+#import "WKWebViewInternal.h"
 #import "WKWebsiteDataStoreInternal.h"
 #import "WebInspectorUIProxy.h"
 #import "WebInspectorUtilities.h"
@@ -47,7 +48,6 @@
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKUIDelegatePrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
-#import <WebKit/WKWebViewPrivate.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 

--- a/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
@@ -28,6 +28,7 @@
 
 #if HAVE(UIKIT_WITH_MOUSE_SUPPORT)
 
+#import "Logging.h"
 #import "UIKitSPI.h"
 #import "WebIOSEventFactory.h"
 #import <pal/spi/ios/GraphicsServicesSPI.h>
@@ -35,6 +36,7 @@
 #import <wtf/Compiler.h>
 #import <wtf/MonotonicTime.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if ENABLE(POINTER_LOCK)

--- a/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
@@ -30,6 +30,7 @@
 
 #import "AppKitSPI.h"
 #import "WebPageProxy.h"
+#import <WebCore/LocalizedStrings.h>
 
 constexpr CGFloat kCalendarWidth = 139;
 constexpr CGFloat kCalendarHeight = 148;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2379,6 +2379,7 @@
 		E52CF55220A35C3A00DADA27 /* WebDataListSuggestionPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = E52CF55020A35C3A00DADA27 /* WebDataListSuggestionPicker.h */; };
 		E539DFEB2A44A6A600769F09 /* MRUIKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E539DFEA2A44A69100769F09 /* MRUIKitSPI.h */; };
 		E539DFED2A44A78600769F09 /* RealitySimulationServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E539DFEC2A44A78600769F09 /* RealitySimulationServicesSPI.h */; };
+		E555CC912EA0C171008957E0 /* WKScreenTimeConfigurationObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = E555CC8F2EA0C165008957E0 /* WKScreenTimeConfigurationObserver.h */; };
 		E55CD1F524CF747D0042DB9C /* WebDateTimeChooser.h in Headers */ = {isa = PBXBuildFile; fileRef = E55CD1F324CF747D0042DB9C /* WebDateTimeChooser.h */; };
 		E55CD20024D08D8F0042DB9C /* WebDateTimePicker.h in Headers */ = {isa = PBXBuildFile; fileRef = E55CD1FC24D0880B0042DB9C /* WebDateTimePicker.h */; };
 		E55CD20324D09F1F0042DB9C /* WebDateTimePickerMac.h in Headers */ = {isa = PBXBuildFile; fileRef = E55CD20124D09F1F0042DB9C /* WebDateTimePickerMac.h */; };
@@ -8435,6 +8436,8 @@
 		E539DFEA2A44A69100769F09 /* MRUIKitSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MRUIKitSPI.h; sourceTree = "<group>"; };
 		E539DFEC2A44A78600769F09 /* RealitySimulationServicesSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RealitySimulationServicesSPI.h; sourceTree = "<group>"; };
 		E54A14CE20FCFB7B007E13D8 /* WebDataListSuggestionsDropdown.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebDataListSuggestionsDropdown.cpp; sourceTree = "<group>"; };
+		E555CC8F2EA0C165008957E0 /* WKScreenTimeConfigurationObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKScreenTimeConfigurationObserver.h; sourceTree = "<group>"; };
+		E555CC902EA0C165008957E0 /* WKScreenTimeConfigurationObserver.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = WKScreenTimeConfigurationObserver.mm; sourceTree = "<group>"; };
 		E55CD1F324CF747D0042DB9C /* WebDateTimeChooser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebDateTimeChooser.h; sourceTree = "<group>"; };
 		E55CD1F424CF747D0042DB9C /* WebDateTimeChooser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebDateTimeChooser.cpp; sourceTree = "<group>"; };
 		E55CD1FC24D0880B0042DB9C /* WebDateTimePicker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebDateTimePicker.h; sourceTree = "<group>"; };
@@ -10418,6 +10421,8 @@
 				07CB79972CE943E400199C49 /* WKNavigationDelegateAdapter.swift */,
 				1AD01BCB1905D54900C9C45F /* WKReloadFrameErrorRecoveryAttempter.h */,
 				1AD01BCA1905D54900C9C45F /* WKReloadFrameErrorRecoveryAttempter.mm */,
+				E555CC8F2EA0C165008957E0 /* WKScreenTimeConfigurationObserver.h */,
+				E555CC902EA0C165008957E0 /* WKScreenTimeConfigurationObserver.mm */,
 				07AF79E02D693DD7004E8D3A /* WKScrollGeometryAdapter.swift */,
 				B6CDC0642CECFC85008A91FE /* WKSeparatedImageView.h */,
 				B62449472CF6728600CBB3CF /* WKSeparatedImageView.mm */,
@@ -18830,6 +18835,7 @@
 				BC8A501511765F5600757573 /* WKRetainPtr.h in Headers */,
 				F4974E76265ECBBC00B49B8C /* WKRevealItemPresenter.h in Headers */,
 				5274A4BB2C7082AC00B1A742 /* WKRKEntity.h in Headers */,
+				E555CC912EA0C171008957E0 /* WKScreenTimeConfigurationObserver.h in Headers */,
 				1A7E377918E4A4FE003D0FFF /* WKScriptMessage.h in Headers */,
 				1A7E377518E4A33A003D0FFF /* WKScriptMessageHandler.h in Headers */,
 				5109099723DACBF2003B1E4C /* WKScriptMessageHandlerWithReply.h in Headers */,


### PR DESCRIPTION
#### 79c5ad58ede504e1d7e792d00e931a2acb99522a
<pre>
[Screen Time] Main Thread Checker: UI API called on a background thread: `-[WKWebView observeValueForKeyPath:ofObject:change:context:]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=300904">https://bugs.webkit.org/show_bug.cgi?id=300904</a>
<a href="https://rdar.apple.com/162653113">rdar://162653113</a>

Reviewed by Abrar Rahman Protyasha.

300778@main added `WKWebView` as an observer of `STScreenTimeConfigurationObserver`,
which performs KVO on a background thread. This triggers the Main Thread Checker
as `WKWebView` is annotated for use on the main thread only. In reality, the
error is benign, since 300778@main ensured the actual logic is run on the main thread.

To avoid developer confusion due to this output, refactor the logic to occur
in a separate class, `WKScreenTimeConfigurationObserver`.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _installScreenTimeWebpageControllerIfNeeded]):
(-[WKWebView _uninstallScreenTimeWebpageController]):
(-[WKWebView observeValueForKeyPath:ofObject:change:context:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/WKScreenTimeConfigurationObserver.h: Added.
* Source/WebKit/UIProcess/Cocoa/WKScreenTimeConfigurationObserver.mm: Added.
(-[WKScreenTimeConfigurationObserver initWithView:]):
(-[WKScreenTimeConfigurationObserver observeValueForKeyPath:ofObject:change:context:]):
(-[WKScreenTimeConfigurationObserver startObserving]):
(-[WKScreenTimeConfigurationObserver stopObserving]):
(-[WKScreenTimeConfigurationObserver enforcesChildRestrictions]):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:

Unified sources build fix.

* Source/WebKit/UIProcess/ios/WKMouseInteraction.mm:

Unified sources build fix.

* Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm:

Unified sources build fix.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/301728@main">https://commits.webkit.org/301728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2fa477d75a9aca4ef53a35f6cc9a2982dcbd185

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78294 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/648c001b-bdb7-4588-8b2a-8e5941d6daf6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96370 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64439 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/18084973-eafd-4eb3-9564-efbe2308cdaf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129581 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76895 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9b1bf98d-a62d-452f-bc6f-212135f2141a) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76999 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136173 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41022 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104884 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104604 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50065 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50778 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19844 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53243 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59056 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52519 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55856 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->