### PR TITLE
IndexedDB should properly handle names containing unpaired UTF-16 surrogates

### DIFF
--- a/LayoutTests/storage/indexeddb/database-name-with-surrogates-expected.txt
+++ b/LayoutTests/storage/indexeddb/database-name-with-surrogates-expected.txt
@@ -1,0 +1,53 @@
+Test that IndexedDB correctly handles database names containing unpaired UTF-16 surrogates
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+Test 1: Normal
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db1"
+database.close()
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db1"
+
+Test 2: Unpaired high surrogate
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db2_\ud9b2test"
+database.close()
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db2_\ud9b2test"
+
+Test 3: Unpaired low surrogate
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db3_\udc00test"
+database.close()
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db3_\udc00test"
+
+Test 4: Valid surrogate pair (ðŸ˜€)
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db4_NaNtest"
+database.close()
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db4_NaNtest"
+
+Test all database names
+indexedDB.databases()
+PASS actualDatabases.length is 4
+PASS actualDatabases[0].name is "db1"
+PASS actualDatabases[1].name is "db2_\ud9b2test"
+PASS actualDatabases[2].name is "db3_\udc00test"
+PASS actualDatabases[3].name is "db4_NaNtest"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/database-name-with-surrogates-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/database-name-with-surrogates-private-expected.txt
@@ -1,0 +1,53 @@
+Test that IndexedDB correctly handles database names containing unpaired UTF-16 surrogates
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+Test 1: Normal
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db1"
+database.close()
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db1"
+
+Test 2: Unpaired high surrogate
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db2_\ud9b2test"
+database.close()
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db2_\ud9b2test"
+
+Test 3: Unpaired low surrogate
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db3_\udc00test"
+database.close()
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db3_\udc00test"
+
+Test 4: Valid surrogate pair (ðŸ˜€)
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db4_NaNtest"
+database.close()
+indexedDB.open(databaseName)
+actualName = database.name
+PASS actualName is "db4_NaNtest"
+
+Test all database names
+indexedDB.databases()
+PASS actualDatabases.length is 4
+PASS actualDatabases[0].name is "db1"
+PASS actualDatabases[1].name is "db2_\ud9b2test"
+PASS actualDatabases[2].name is "db3_\udc00test"
+PASS actualDatabases[3].name is "db4_NaNtest"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/database-name-with-surrogates-private.html
+++ b/LayoutTests/storage/indexeddb/database-name-with-surrogates-private.html
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/database-name-with-surrogates.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/database-name-with-surrogates.html
+++ b/LayoutTests/storage/indexeddb/database-name-with-surrogates.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/database-name-with-surrogates.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/resources/database-name-with-surrogates.js
+++ b/LayoutTests/storage/indexeddb/resources/database-name-with-surrogates.js
@@ -1,0 +1,65 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+    importScripts('shared.js');
+}
+
+description("Test that IndexedDB correctly handles database names containing unpaired UTF-16 surrogates");
+
+// Per Web Standards: DOMString = sequence of UTF-16 code units (can include unpaired surrogates).
+// IndexedDB database names are DOMString, so they can contain unpaired surrogates.
+
+const testCases = [
+    { name:"Normal", databaseName:"db1" },
+    { name:"Unpaired high surrogate", databaseName:"db2_" + String.fromCharCode(0xD9B2) + "test" },
+    { name:"Unpaired low surrogate", databaseName:"db3_" + String.fromCharCode(0xDC00) + "test" },
+    { name:"Valid surrogate pair (😀)", databaseName:"db4_" + + String.fromCharCode(0xD83D, 0xDE00) + "test" }
+];
+var index = 0;
+var databaseName, database;
+
+function test() {
+    if (index >= testCases.length) {
+        testIDBFactoryDatabases();
+        return;
+    }
+
+    testCase = testCases[index++];
+    debug("");
+    debug("Test " + index + ": " + testCase.name);
+    databaseName = testCase.databaseName;
+    indexedDB.deleteDatabase(databaseName);
+    request = evalAndLog("indexedDB.open(databaseName)");
+    request.onerror = unexpectedErrorCallback;
+    request.onsuccess = function(event) {
+        database = event.target.result;
+        evalAndLog("actualName = database.name");
+        shouldBeEqualToString("actualName", databaseName);
+        evalAndLog("database.close()");
+        request2 = evalAndLog("indexedDB.open(databaseName)");
+        request2.onerror = unexpectedErrorCallback;
+        request2.onsuccess = function(event) {
+            database = event.target.result;
+            evalAndLog("actualName = database.name");
+            shouldBeEqualToString("actualName", databaseName);
+            database.close();
+            test();
+        };
+    };
+}
+
+function testIDBFactoryDatabases() {
+    debug("");
+    debug("Test all database names");
+
+    promise = evalAndLog("indexedDB.databases()");
+    promise.then((databases) => {
+        actualDatabases = databases;
+        shouldBe("actualDatabases.length", "4");
+        actualDatabases.sort((a, b) => a.name > b.name);
+        for (index = 0; index <actualDatabases.length; ++index)
+            shouldBeEqualToString("actualDatabases["+ index +"].name", testCases[index].databaseName);
+        finishJSTest();
+    })
+}
+
+test();

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -65,8 +65,11 @@ constexpr auto v2ObjectStoreInfoSchema = "CREATE TABLE ObjectStoreInfo (id INTEG
 constexpr auto v1IndexRecordsRecordIndexSchema = "CREATE INDEX IndexRecordsRecordIndex ON IndexRecords (objectStoreID, objectStoreRecordID)"_s;
 constexpr auto IndexRecordsIndexSchema = "CREATE INDEX IndexRecordsIndex ON IndexRecords (indexID, key, value)"_s;
 
-// Current version of the metadata schema being used in the metadata database.
-static const int currentMetadataVersion = 1;
+/* Current version of the metadata schema and format being used in the metadata database.
+ * Version 1 - Initial version.
+ * Version 2 - Store database name as blob.
+ */
+static constexpr int currentMetadataVersion = 2;
 
 // The IndexedDatabase spec defines the max key generator value as 2^53.
 static const uint64_t maxGeneratorValue = 0x20000000000000;
@@ -463,7 +466,7 @@ std::unique_ptr<IDBDatabaseInfo> SQLiteIDBBackingStore::createAndPopulateInitial
     {
         auto sql = sqliteDB->prepareStatement("INSERT INTO IDBDatabaseInfo VALUES ('DatabaseName', ?);"_s);
         if (!sql
-            || CheckedRef { *sql }->bindText(1, m_identifier.databaseName()) != SQLITE_OK
+            || CheckedRef { *sql }->bindBlob(1, m_identifier.databaseName()) != SQLITE_OK
             || CheckedRef { *sql }->step() != SQLITE_DONE) {
             LOG_ERROR("Could not insert database name into IDBDatabaseInfo table (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
             closeSQLiteDB();
@@ -669,6 +672,77 @@ bool SQLiteIDBBackingStore::migrateIndexRecordsTableForIDUpdate(const HashMap<st
     return true;
 }
 
+static String getDatabaseNameFromDatabase(SQLiteDatabase& database, uint64_t metadataVersion)
+{
+    auto sql = database.prepareStatement("SELECT value FROM IDBDatabaseInfo WHERE key = 'DatabaseName';"_s);
+    if (!sql)
+        return { };
+
+    CheckedRef statement = *sql;
+    if (metadataVersion == 1)
+        return statement->columnText(0);
+
+    return statement->columnBlobAsString(0);
+}
+
+static IDBError migrateIDBDatabaseInfoTableIfNecessary(SQLiteDatabase& database, const String& databaseName)
+{
+    String tableStatement = database.tableSQL("IDBDatabaseInfo"_s);
+    if (tableStatement.isEmpty())
+        return IDBError { ExceptionCode::UnknownError, makeString("IDBDatabaseInfo table does not exist ("_s, database.lastError(), ") - "_s, unsafeSpan(database.lastErrorMsg())) };
+
+    uint64_t metadataVersion = 0;
+    {
+        auto sql = database.prepareStatement("SELECT value FROM IDBDatabaseInfo WHERE key = 'MetadataVersion';"_s);
+        if (!sql)
+            return IDBError { ExceptionCode::UnknownError, makeString("Failed to prepare statement for getting metadata version ("_s, database.lastError(), ") - "_s, unsafeSpan(database.lastErrorMsg())) };
+        CheckedRef statement = *sql;
+        String stringVersion = statement->columnText(0);
+        auto parsedVersion = parseInteger<uint64_t>(stringVersion);
+        if (!parsedVersion)
+            return IDBError { ExceptionCode::UnknownError, makeString("Database metadata version on disk ("_s, stringVersion, ") cannot be converted to unsigned 64-bit integer"_s) };
+        metadataVersion = *parsedVersion;
+    }
+
+    String existingDatabaseName = getDatabaseNameFromDatabase(database, metadataVersion);
+    // UTF-8 encoded names should always match regardless of metadata version.
+    if (existingDatabaseName.utf8() != databaseName.utf8())
+        return IDBError { ExceptionCode::UnknownError, "Stored database name does not match requested name"_s };
+
+    if (metadataVersion == currentMetadataVersion) {
+        if (existingDatabaseName == databaseName)
+            return IDBError { };
+
+        return IDBError { ExceptionCode::UnknownError, "Metadata versions match, but stored database name does not match requested name"_s };
+    }
+
+    RELEASE_ASSERT(metadataVersion < currentMetadataVersion);
+
+    SQLiteTransaction transaction(database);
+    transaction.begin();
+
+    if (existingDatabaseName != databaseName) {
+        auto sql = database.prepareStatement("REPLACE INTO IDBDatabaseInfo VALUES ('DatabaseName', ?);"_s);
+        if (!sql
+            || CheckedRef { *sql }->bindBlob(1, databaseName) != SQLITE_OK
+            || CheckedRef { *sql }->step() != SQLITE_DONE) {
+            return IDBError { ExceptionCode::UnknownError, makeString("Cannot update database name ("_s, database.lastError(), ") - "_s, unsafeSpan(database.lastErrorMsg())) };
+        }
+    }
+
+    {
+        auto sql = database.prepareStatement("REPLACE INTO IDBDatabaseInfo VALUES ('MetadataVersion', ?);"_s);
+        if (!sql
+            || CheckedRef { *sql }->bindInt(1, currentMetadataVersion) != SQLITE_OK
+            || CheckedRef { *sql }->step() != SQLITE_DONE) {
+            return IDBError { ExceptionCode::UnknownError, makeString("Cannot update database metadata version ("_s, database.lastError(), ") - "_s, unsafeSpan(database.lastErrorMsg())) };
+        }
+    }
+
+    transaction.commit();
+    return IDBError { };
+}
+
 std::unique_ptr<IDBDatabaseInfo> SQLiteIDBBackingStore::extractExistingDatabaseInfo()
 {
     CheckedPtr sqliteDB = m_sqliteDB.get();
@@ -677,16 +751,12 @@ std::unique_ptr<IDBDatabaseInfo> SQLiteIDBBackingStore::extractExistingDatabaseI
     if (!sqliteDB->tableExists("IDBDatabaseInfo"_s))
         return nullptr;
 
-    String databaseName;
-    {
-        auto sql = sqliteDB->prepareStatement("SELECT value FROM IDBDatabaseInfo WHERE key = 'DatabaseName';"_s);
-        CheckedRef statement = *sql;
-        databaseName = statement->columnText(0);
-        if (databaseName != m_identifier.databaseName()) {
-            LOG_ERROR("Database name in the info database ('%s') does not match the expected name ('%s')", databaseName.utf8().data(), m_identifier.databaseName().utf8().data());
-            return nullptr;
-        }
+    IDBError error = migrateIDBDatabaseInfoTableIfNecessary(*sqliteDB, m_identifier.databaseName());
+    if (!error.isNull()) {
+        RELEASE_LOG_ERROR(IndexedDB, "%p - SQLiteIDBBackingStore::extractExistingDatabaseInfo(): Failed to migrate IDBDatabaseInfo table (%s)", this, error.messageForSerialization().utf8().data());
+        return nullptr;
     }
+
     uint64_t databaseVersion;
     {
         auto sql = sqliteDB->prepareStatement("SELECT value FROM IDBDatabaseInfo WHERE key = 'DatabaseVersion';"_s);
@@ -700,8 +770,7 @@ std::unique_ptr<IDBDatabaseInfo> SQLiteIDBBackingStore::extractExistingDatabaseI
         databaseVersion = *parsedVersion;
     }
 
-    auto databaseInfo = makeUnique<IDBDatabaseInfo>(databaseName, databaseVersion, 0);
-
+    auto databaseInfo = makeUnique<IDBDatabaseInfo>(m_identifier.databaseName(), databaseVersion, 0);
     auto result = ensureValidObjectStoreInfoTable();
     if (!result)
         return nullptr;
@@ -855,7 +924,7 @@ std::optional<IDBDatabaseNameAndVersion> SQLiteIDBBackingStore::databaseNameAndV
         LOG_ERROR("Could not prepare statement to get database name(%i) - %s", database.lastError(), database.lastErrorMsg());
         return std::nullopt;
     }
-    auto databaseName = CheckedRef { *namesql }->columnText(0);
+    auto databaseName = CheckedRef { *namesql }->columnBlobAsString(0);
 
     auto versql = database.prepareStatement("SELECT value FROM IDBDatabaseInfo WHERE key = 'DatabaseVersion';"_s);
     String stringVersion = versql ? CheckedRef { *versql }->columnText(0) : String();

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
@@ -27,6 +27,7 @@
 #include "IDBStorageManager.h"
 
 #include "IDBStorageRegistry.h"
+#include "Logging.h"
 #include <WebCore/IDBRequestData.h>
 #include <WebCore/IDBServer.h>
 #include <WebCore/MemoryIDBBackingStore.h>
@@ -353,6 +354,18 @@ void IDBStorageManager::handleLowMemoryWarning()
 {
     for (auto& database : m_databases.values())
         database->handleLowMemoryWarning();
+}
+
+void IDBStorageManager::tryCloseDatabase(const WebCore::IDBDatabaseIdentifier& identifier)
+{
+    bool closed = false;
+    if (CheckedPtr database = m_databases.get(identifier))
+        closed = database->tryClose();
+
+    if (closed) {
+        RELEASE_LOG(IndexedDB, "%p - IDBStorageManager::tryCloseDatabase: Closed database", this);
+        m_databases.remove(identifier);
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
@@ -68,6 +68,7 @@ public:
     void openDBRequestCancelled(const WebCore::IDBOpenRequestData&);
     void deleteDatabase(WebCore::IDBServer::IDBConnectionToClient&, const WebCore::IDBOpenRequestData&);
     Vector<WebCore::IDBDatabaseNameAndVersion> getAllDatabaseNamesAndVersions();
+    void tryCloseDatabase(const WebCore::IDBDatabaseIdentifier&);
 
 private:
     WebCore::IDBServer::UniqueIDBDatabase& getOrCreateUniqueIDBDatabase(const WebCore::IDBDatabaseIdentifier&);


### PR DESCRIPTION
#### 4905ec5f9240c6826dca52cfea2ae496fbb7b8b3
<pre>
IndexedDB should properly handle names containing unpaired UTF-16 surrogates
<a href="https://bugs.webkit.org/show_bug.cgi?id=300902">https://bugs.webkit.org/show_bug.cgi?id=300902</a>
<a href="https://rdar.apple.com/161082712">rdar://161082712</a>

Reviewed by Chris Dumez.

SQLiteIDBBackingStore currently uses UTF-8 encoding for database name. UTF-8 is designed to encode valid Unicode code
points, and invalid code points like lone UTF-16 surrogate (e.g. U+D9B2) will be replaced with special bytes. According
to spec, database name is DOMString, which can contain unpaired UTF-16 surrogates. This means the database name stored
in database (with UTF-8 encoding) can be different from database name created from JavaScript.

To preserve the exact UTF-16 data, now we make SQLiteIDBBackingStore store database name as blob instead of text. As
SQLite has dynamic typing, we don&apos;t need to change schema for this. For existing databases, we upgrade its metadata
version and database name on open, if the stored UTF-8 encoded name matches UTF-8 encoded requested name.

The patch also includes a change to close IndexedDB SQLite database connection when it becomes idle (no more client and
no in-memory data). This would help avoid resource leakage (fd, memory, etc), and it allows us to test re-open behavior
(with IDBDatabase.close) in the new tests.

Tests: storage/indexeddb/database-name-with-surrogates-private.html
       storage/indexeddb/database-name-with-surrogates.html

* LayoutTests/storage/indexeddb/database-name-with-surrogates-expected.txt: Added.
* LayoutTests/storage/indexeddb/database-name-with-surrogates-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/database-name-with-surrogates-private.html: Added.
* LayoutTests/storage/indexeddb/database-name-with-surrogates.html: Added.
* LayoutTests/storage/indexeddb/resources/database-name-with-surrogates.js: Added.
(test.request2.onsuccess):
(test.request.onsuccess):
(test):
(testIDBFactoryDatabases):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::createAndPopulateInitialDatabaseInfo):
(WebCore::IDBServer::getDatabaseNameFromDatabase):
(WebCore::IDBServer::migrateIDBDatabaseInfoTableIfNecessary):
(WebCore::IDBServer::SQLiteIDBBackingStore::extractExistingDatabaseInfo):
(WebCore::IDBServer::SQLiteIDBBackingStore::databaseNameAndVersionFromFile):
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp:
(WebKit::IDBStorageManager::tryCloseDatabase):
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::databaseConnectionClosed):

Canonical link: <a href="https://commits.webkit.org/301753@main">https://commits.webkit.org/301753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19b6cdda575d184e361c10782bc5fe120b3fd77f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78500 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b32e33f3-8940-4626-ae28-62ebe78b11ef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96578 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64582 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/24f44344-6a0b-4a52-8876-55e791e60f69) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113524 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77092 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/debc9524-14e8-4c0f-b655-2a441b603781) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36615 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31692 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77313 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136444 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41250 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105096 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104788 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26724 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28639 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51056 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59376 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52753 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56087 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54509 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->