### PR TITLE
Replace PseudoId::None with std::optional

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -275,7 +275,7 @@ unsigned CSSSelector::specificityForPage() const
     return s;
 }
 
-PseudoId CSSSelector::pseudoId(PseudoElement type)
+std::optional<PseudoId> CSSSelector::pseudoId(PseudoElement type)
 {
     switch (type) {
     case PseudoElement::FirstLine:
@@ -334,11 +334,11 @@ PseudoId CSSSelector::pseudoId(PseudoElement type)
     case PseudoElement::UserAgentPart:
     case PseudoElement::UserAgentPartLegacyAlias:
     case PseudoElement::WebKitUnknown:
-        return PseudoId::None;
+        return { };
     }
 
     ASSERT_NOT_REACHED();
-    return PseudoId::None;
+    return { };
 }
 
 std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElementName(StringView name, const CSSSelectorParserContext& context)

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -121,7 +121,7 @@ public:
 
     enum AttributeMatchType { CaseSensitive, CaseInsensitive };
 
-    static PseudoId pseudoId(PseudoElement);
+    static std::optional<PseudoId> pseudoId(PseudoElement);
     static bool isPseudoClassEnabled(PseudoClass, const CSSSelectorParserContext&);
     static bool isPseudoElementEnabled(PseudoElement, StringView, const CSSSelectorParserContext&);
     static std::optional<PseudoElement> parsePseudoElementName(StringView, const CSSSelectorParserContext&);

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "PseudoElementIdentifier.h"
 #include "SelectorMatchingState.h"
 #include "StyleRelations.h"
 #include "StyleScrollbarState.h"
@@ -41,6 +42,10 @@ class Element;
 class RenderScrollbar;
 class RenderStyle;
 class StyleRuleScope;
+
+namespace SelectorCompiler {
+class SelectorCodeGenerator;
+}
 
 class SelectorChecker {
     WTF_MAKE_NONCOPYABLE(SelectorChecker);
@@ -87,9 +92,19 @@ public:
         { }
 
         const SelectorChecker::Mode resolvingMode;
-        // FIXME: Switch to PseudoElementIdentifier.
-        PseudoId pseudoId { PseudoId::None };
+
+        void setRequestedPseudoElement(Style::PseudoElementIdentifier);
+        std::optional<Style::PseudoElementIdentifier> requestedPseudoElement() const;
+
+    private:
+        friend class SelectorCompiler::SelectorCodeGenerator;
+
+        // These are simple fields so they are easier for SelectorCompiler to generate code against.
+        bool hasRequestedPseudoElement { false };
+        PseudoId pseudoId { };
         AtomString pseudoElementNameArgument;
+
+    public:
         std::optional<StyleScrollbarState> scrollbarState;
         Vector<AtomString> classList;
         RefPtr<const ContainerNode> scope;

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1410,9 +1410,9 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
 static std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifierFor(CSSSelectorPseudoElement type)
 {
     auto pseudoId = CSSSelector::pseudoId(type);
-    if (pseudoId == PseudoId::None)
+    if (!pseudoId)
         return { };
-    return Style::PseudoElementIdentifier { pseudoId };
+    return Style::PseudoElementIdentifier { *pseudoId };
 }
 
 // FIXME: It's probably worth investigating if more logic can be shared with
@@ -1467,7 +1467,7 @@ std::pair<bool, std::optional<Style::PseudoElementIdentifier>> CSSSelectorParser
         auto& ident = block.consumeIncludingWhitespace();
         if (ident.type() != IdentToken || !isValidCustomIdentifier(ident.id()) || !block.atEnd())
             return { };
-        return { true, Style::PseudoElementIdentifier { CSSSelector::pseudoId(*pseudoElement), ident.value().toAtomString() } };
+        return { true, Style::PseudoElementIdentifier { *CSSSelector::pseudoId(*pseudoElement), ident.value().toAtomString() } };
     }
     default:
         return { };

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4757,9 +4757,7 @@ const RenderStyle& Element::resolvePseudoElementStyle(const Style::PseudoElement
     if (!style) {
         style = RenderStyle::createPtr();
         style->inheritFrom(*parentStyle);
-        // FIXME: RenderStyle should switch to use PseudoElementIdentifier.
-        style->setPseudoElementType(pseudoElementIdentifier.pseudoId);
-        style->setPseudoElementNameArgument(pseudoElementIdentifier.nameArgument);
+        style->setPseudoElementIdentifier(pseudoElementIdentifier);
     }
 
     auto* computedStyle = style.get();

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -255,7 +255,8 @@ public:
     bool isPseudoElement() const { return isElementNode() && hasTypeFlag(TypeFlag::IsPseudoElementOrSpecialInternalNode); }
     inline bool isBeforePseudoElement() const;
     inline bool isAfterPseudoElement() const;
-    inline PseudoId pseudoId() const;
+    inline std::optional<PseudoId> pseudoId() const;
+    inline std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
 
 #if ENABLE(VIDEO)
     virtual bool isWebVTTElement() const { return false; }

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -121,19 +121,28 @@ inline RefPtr<Element> Node::protectedParentElement() const
 
 bool Node::isBeforePseudoElement() const
 {
-    return pseudoId() == PseudoId::Before;
+    auto* pseudoElement = dynamicDowncast<PseudoElement>(*this);
+    return pseudoElement && pseudoElement->pseudoId() == PseudoId::Before;
 }
 
 bool Node::isAfterPseudoElement() const
 {
-    return pseudoId() == PseudoId::After;
+    auto* pseudoElement = dynamicDowncast<PseudoElement>(*this);
+    return pseudoElement && pseudoElement->pseudoId() == PseudoId::After;
 }
 
-PseudoId Node::pseudoId() const
+std::optional<PseudoId> Node::pseudoId() const
 {
     if (auto* pseudoElement = dynamicDowncast<PseudoElement>(*this))
         return pseudoElement->pseudoId();
-    return PseudoId::None;
+    return { };
+}
+
+std::optional<Style::PseudoElementIdentifier> Node::pseudoElementIdentifier() const
+{
+    if (auto pseudoId = this->pseudoId())
+        return Style::PseudoElementIdentifier { *pseudoId };
+    return { };
 }
 
 inline void Node::setTabIndexState(TabIndexState state)

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -133,7 +133,7 @@ static Ref<JSON::ArrayOf<Inspector::Protocol::Animation::Keyframe>> buildObjectF
 
         // Synthesize CSS style declarations for each keyframe so the frontend can display them.
 
-        auto pseudoElementIdentifier = target->pseudoId() == PseudoId::None ? std::nullopt : std::optional(Style::PseudoElementIdentifier { target->pseudoId() });
+        auto pseudoElementIdentifier = target->pseudoElementIdentifier();
         Style::Extractor computedStyleExtractor(target, false, pseudoElementIdentifier);
 
         for (size_t i = 0; i < blendingKeyframes.size(); ++i) {

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -179,7 +179,7 @@ private:
 
     RefPtr<Inspector::Protocol::CSS::CSSRule> buildObjectForRule(const StyleRule*, Style::Resolver&, Element&);
     RefPtr<Inspector::Protocol::CSS::CSSRule> buildObjectForRule(CSSStyleRule*);
-    Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> buildArrayForMatchedRuleList(const Vector<RefPtr<const StyleRule>>&, Style::Resolver&, Element&, PseudoId);
+    Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> buildArrayForMatchedRuleList(const Vector<RefPtr<const StyleRule>>&, Style::Resolver&, Element&, std::optional<Style::PseudoElementIdentifier>);
     RefPtr<Inspector::Protocol::CSS::CSSStyle> buildObjectForAttributesStyle(StyledElement&);
 
     void nodeHasLayoutFlagsChange(Node&);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1677,7 +1677,6 @@ Ref<CSSStyleDeclaration> LocalDOMWindow::getComputedStyle(Element& element, cons
     auto [pseudoElementIsParsable, pseudoElementIdentifier] = CSSSelectorParser::parsePseudoElement(pseudoElt, CSSSelectorParserContext { element.protectedDocument() });
     if (!pseudoElementIsParsable)
         return CSSComputedStyleDeclaration::createEmpty(element);
-    // FIXME: CSSSelectorParser::parsePseudoElement should never return PseudoId::None.
     return CSSComputedStyleDeclaration::create(element, pseudoElementIdentifier);
 }
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -407,7 +407,7 @@ bool RenderBlockFlow::willCreateColumns(std::optional<unsigned> desiredColumnCou
     if (!firstChild())
         return false;
 
-    if (style().pseudoElementType() != PseudoId::None)
+    if (style().pseudoElementType())
         return false;
 
     // If overflow-y is set to paged-x or paged-y on the body or html element, we'll handle the paginating in the RenderView instead.

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -206,18 +206,19 @@ static std::optional<CounterPlan> planCounter(RenderElement& renderer, const Ato
 
     auto& style = renderer.style();
 
-    switch (style.pseudoElementType()) {
-    case PseudoId::None:
+    if (style.pseudoElementType()) {
+        switch (*style.pseudoElementType()) {
+        case PseudoId::Before:
+        case PseudoId::After:
+            break;
+        default:
+            return std::nullopt; // Counters are forbidden from all other pseudo elements.
+        }
+    } else {
         // Sometimes elements have more then one renderer. Only the first one gets the counter
         // LayoutTests/http/tests/css/counter-crash.html
         if (generatingElement->renderer() != &renderer)
             return std::nullopt;
-        break;
-    case PseudoId::Before:
-    case PseudoId::After:
-        break;
-    default:
-        return std::nullopt; // Counters are forbidden from all other pseudo elements.
     }
 
     auto directives = style.counterDirectives().map.get(identifier);

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -860,7 +860,7 @@ void RenderElement::propagateStyleToAnonymousChildren(StylePropagationType propa
 {
     // FIXME: We could save this call when the change only affected non-inherited properties.
     for (CheckedRef elementChild : childrenOfType<RenderElement>(*this)) {
-        if (!elementChild->isAnonymous() || elementChild->style().pseudoElementType() != PseudoId::None || elementChild->isViewTransitionContainingBlock())
+        if (!elementChild->isAnonymous() || elementChild->style().pseudoElementType() || elementChild->isViewTransitionContainingBlock())
             continue;
 
         bool isBlockOrRuby = is<RenderBlock>(elementChild.get()) || elementChild->style().display() == DisplayType::Ruby;

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -53,7 +53,7 @@ inline bool RenderElement::isAnonymousBlock() const
 {
     return isAnonymous()
         && (style().display() == DisplayType::Block || style().display() == DisplayType::Box)
-        && style().pseudoElementType() == PseudoId::None
+        && !style().pseudoElementType()
         && isRenderBlock()
 #if ENABLE(MATHML)
         && !isRenderMathMLBlock()

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3084,7 +3084,7 @@ RenderLayer::OverflowControlRects RenderLayer::overflowControlsRects() const
     auto overflowControlsPositioningRect = snappedIntRect(renderBox.paddingBoxRectIncludingScrollbar());
 
     bool placeVerticalScrollbarOnTheLeft = renderBox.shouldPlaceVerticalScrollbarOnLeft();
-    bool haveResizer = renderer().style().resize() != Resize::None && renderer().style().pseudoElementType() == PseudoId::None;
+    bool haveResizer = renderer().style().resize() != Resize::None && !renderer().style().pseudoElementType();
 
     OverflowControlRects result;
     auto cornerRect = [&](IntSize cornerSize) {
@@ -4666,9 +4666,11 @@ bool RenderLayer::ancestorLayerIsDOMParent(const RenderLayer* ancestor) const
     auto parent = flattenedParent(renderer().element());
     if (parent && ancestor->renderer().element() == parent)
         return true;
-
-    std::optional<PseudoId> parentPseudoId = parentPseudoElement(renderer().style().pseudoElementType());
-    return parentPseudoId && *parentPseudoId == ancestor->renderer().style().pseudoElementType();
+    if (renderer().style().pseudoElementType()) {
+        auto parentPseudoId = parentPseudoElement(*renderer().style().pseudoElementType());
+        return parentPseudoId && *parentPseudoId == ancestor->renderer().style().pseudoElementType();
+    }
+    return false;
 }
 
 bool RenderLayer::participatesInPreserve3D() const

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -720,7 +720,7 @@ RenderLayer::OverflowControlRects RenderLayerScrollableArea::overflowControlsRec
     bool haveNonOverlayHorizontalScrollbar = isNonOverlayScrollbar(hBar.get());
     bool haveNonOverlayVerticalScrollbar = isNonOverlayScrollbar(vBar.get());
     bool placeVerticalScrollbarOnTheLeft = shouldPlaceVerticalScrollbarOnLeft();
-    bool haveResizer = renderBox.style().resize() != Resize::None && renderBox.style().pseudoElementType() == PseudoId::None;
+    bool haveResizer = renderBox.style().resize() != Resize::None && !renderBox.style().pseudoElementType();
     bool scrollbarsAvoidCorner = ((haveNonOverlayHorizontalScrollbar && haveNonOverlayVerticalScrollbar) || (haveResizer && (haveNonOverlayHorizontalScrollbar || haveNonOverlayVerticalScrollbar))) && renderBox.style().scrollbarWidth() != ScrollbarWidth::None;
 
     IntSize cornerSize;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1377,8 +1377,8 @@ void RenderObject::outputRenderObject(TextStream& stream, bool mark, int depth) 
     else
         stream << nameView;
 
-    if (style().pseudoElementType() != PseudoId::None)
-        stream << " (::" << style().pseudoElementType() << ")";
+    if (style().pseudoElementType())
+        stream << " (::" << *style().pseudoElementType() << ")";
 
     if (auto* renderBox = dynamicDowncast<RenderBox>(*this)) {
         FloatRect boxRect = renderBox->frameRect();

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -316,7 +316,7 @@ void TextDecorationPainter::paintLineThrough(const ForegroundDecorationGeometry&
         m_context.drawLineForText(rect, m_isPrinting, style == TextDecorationStyle::Double, strokeStyle);
 }
 
-static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, Style::TextDecorationLine remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId)
+static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, Style::TextDecorationLine remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, std::optional<PseudoId> pseudoId)
 {
     auto extractDecorations = [&] (const RenderStyle& style, Style::TextDecorationLine decorations) {
         if (!decorations.containsAny({ Style::TextDecorationLine::Flag::Underline, Style::TextDecorationLine::Flag::Overline, Style::TextDecorationLine::Flag::LineThrough }))
@@ -343,10 +343,10 @@ static void collectStylesForRenderer(TextDecorationPainter::Styles& result, cons
     };
 
     auto styleForRenderer = [&] (const RenderObject& renderer) -> const RenderStyle& {
-        if (pseudoId != PseudoId::None && renderer.style().hasPseudoStyle(pseudoId)) {
+        if (pseudoId && renderer.style().hasPseudoStyle(*pseudoId)) {
             if (auto textRenderer = dynamicDowncast<RenderText>(renderer))
-                return *textRenderer->getCachedPseudoStyle({ pseudoId });
-            return *downcast<RenderElement>(renderer).getCachedPseudoStyle({ pseudoId });
+                return *textRenderer->getCachedPseudoStyle({ *pseudoId });
+            return *downcast<RenderElement>(renderer).getCachedPseudoStyle({ *pseudoId });
         }
         return firstLineStyle ? renderer.firstLineStyle() : renderer.style();
     };
@@ -386,7 +386,7 @@ Color TextDecorationPainter::decorationColor(const RenderStyle& style, OptionSet
     return style.visitedDependentColorWithColorFilter(CSSPropertyTextDecorationColor, paintBehavior);
 }
 
-auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, Style::TextDecorationLine requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId) -> Styles
+auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, Style::TextDecorationLine requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, std::optional<PseudoId> pseudoId) -> Styles
 {
     if (requestedDecorations.isNone())
         return { };

--- a/Source/WebCore/rendering/TextDecorationPainter.h
+++ b/Source/WebCore/rendering/TextDecorationPainter.h
@@ -74,7 +74,7 @@ public:
     void paintForegroundDecorations(const ForegroundDecorationGeometry&, const Styles&);
 
     static Color decorationColor(const RenderStyle&, OptionSet<PaintBehavior> paintBehavior = { });
-    static Styles stylesForRenderer(const RenderObject&, Style::TextDecorationLine requestedDecorations, bool firstLineStyle = false, OptionSet<PaintBehavior> paintBehavior = { }, PseudoId = PseudoId::None);
+    static Styles stylesForRenderer(const RenderObject&, Style::TextDecorationLine requestedDecorations, bool firstLineStyle = false, OptionSet<PaintBehavior> paintBehavior = { }, std::optional<PseudoId> = { });
     static Style::TextDecorationLine textDecorationsInEffectForStyle(const TextDecorationPainter::Styles&);
 
 private:

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -111,7 +111,8 @@ static_assert(PublicPseudoIDBits == allPublicPseudoIds.size());
 
 static_assert(!(static_cast<unsigned>(maxTextTransformValue) >> TextTransformBits));
 
-static_assert(!(enumToUnderlyingType(PseudoId::HighestEnumValue) >> PseudoElementTypeBits));
+// Value zero is used to indicate no pseudo-element.
+static_assert(!((enumToUnderlyingType(PseudoId::HighestEnumValue) + 1) >> PseudoElementTypeBits));
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PseudoStyleCache);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(RenderStyle);
@@ -224,7 +225,7 @@ RenderStyle::RenderStyle(CreateDefaultStyleTag)
     m_nonInheritedFlags.firstChildState = false;
     m_nonInheritedFlags.lastChildState = false;
     m_nonInheritedFlags.isLink = false;
-    m_nonInheritedFlags.pseudoElementType = static_cast<unsigned>(PseudoId::None);
+    m_nonInheritedFlags.pseudoElementType = 0;
     m_nonInheritedFlags.pseudoBits = 0;
 
     static_assert((sizeof(InheritedFlags) <= 8), "InheritedFlags does not grow");
@@ -477,7 +478,7 @@ RenderStyle* RenderStyle::addCachedPseudoStyle(std::unique_ptr<RenderStyle> pseu
     if (!pseudo)
         return nullptr;
 
-    ASSERT(pseudo->pseudoElementType() > PseudoId::None);
+    ASSERT(pseudo->pseudoElementType());
 
     RenderStyle* result = pseudo.get();
 
@@ -3690,9 +3691,9 @@ void RenderStyle::setUsedPositionOptionIndex(std::optional<size_t> index)
 
 std::optional<Style::PseudoElementIdentifier> RenderStyle::pseudoElementIdentifier() const
 {
-    if (pseudoElementType() == PseudoId::None)
+    if (!pseudoElementType())
         return { };
-    return Style::PseudoElementIdentifier { pseudoElementType(), pseudoElementNameArgument() };
+    return Style::PseudoElementIdentifier { *pseudoElementType(), pseudoElementNameArgument() };
 }
 
 void RenderStyle::adjustScrollTimelines()

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -499,12 +499,11 @@ public:
     StyleSelfAlignmentData resolvedJustifySelf(const RenderStyle* parentStyle, ItemPosition normalValueBehavior) const;
     StyleContentAlignmentData resolvedJustifyContent(const StyleContentAlignmentData& normalValueBehavior) const;
 
-    PseudoId pseudoElementType() const;
-    void setPseudoElementType(PseudoId);
+    std::optional<PseudoId> pseudoElementType() const;
     const AtomString& pseudoElementNameArgument() const;
-    void setPseudoElementNameArgument(const AtomString&);
 
     std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
+    void setPseudoElementIdentifier(std::optional<Style::PseudoElementIdentifier>&&);
 
     RenderStyle* getCachedPseudoStyle(const Style::PseudoElementIdentifier&) const;
     RenderStyle* addCachedPseudoStyle(std::unique_ptr<RenderStyle>);

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -980,7 +980,6 @@ TextStream& operator<<(TextStream& ts, PrintColorAdjust colorAdjust)
 TextStream& operator<<(TextStream& ts, PseudoId pseudoId)
 {
     switch (pseudoId) {
-    case PseudoId::None: ts << "none"_s; break;
     case PseudoId::FirstLine: ts << "first-line"_s; break;
     case PseudoId::FirstLetter: ts << "first-letter"_s; break;
     case PseudoId::GrammarError: ts << "grammar-error"_s; break;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -85,9 +85,6 @@ enum class StyleDifferenceContextSensitiveProperty : uint8_t {
 };
 
 enum class PseudoId : uint8_t {
-    // FIXME: Get rid of the None value, use std::optional<PseudoId> instead.
-    None,
-
     // Public:
     FirstLine,
     FirstLetter,

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -798,7 +798,12 @@ inline bool RenderStyle::specifiesColumns() const { return !columnCount().isAuto
 constexpr OptionSet<Containment> RenderStyle::strictContainment() { return { Containment::Size, Containment::Layout, Containment::Paint, Containment::Style }; }
 inline const Style::Color& RenderStyle::strokeColor() const { return m_rareInheritedData->strokeColor; }
 inline Style::StrokeMiterlimit RenderStyle::strokeMiterLimit() const { return m_rareInheritedData->miterLimit; }
-inline PseudoId RenderStyle::pseudoElementType() const { return static_cast<PseudoId>(m_nonInheritedFlags.pseudoElementType); }
+inline std::optional<PseudoId> RenderStyle::pseudoElementType() const
+{
+    if (!m_nonInheritedFlags.pseudoElementType)
+        return { };
+    return static_cast<PseudoId>(m_nonInheritedFlags.pseudoElementType - 1);
+}
 inline const AtomString& RenderStyle::pseudoElementNameArgument() const { return m_nonInheritedData->rareData->pseudoElementNameArgument; }
 inline const Style::TabSize& RenderStyle::tabSize() const { return m_rareInheritedData->tabSize; }
 inline TableLayoutType RenderStyle::tableLayout() const { return static_cast<TableLayoutType>(m_nonInheritedData->miscData->tableLayout); }
@@ -1047,8 +1052,7 @@ inline Style::SVGBaselineShift RenderStyle::initialBaselineShift() { return CSS:
 inline bool RenderStyle::NonInheritedFlags::hasPseudoStyle(PseudoId pseudo) const
 {
     ASSERT(allPublicPseudoIds.contains(pseudo));
-    // Shift because PseudoId::None is not stored.
-    return EnumSet<PseudoId>::fromRaw(pseudoBits << 1).contains(pseudo);
+    return EnumSet<PseudoId>::fromRaw(pseudoBits).contains(pseudo);
 }
 
 inline bool RenderStyle::NonInheritedFlags::hasAnyPublicPseudoStyles() const

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -446,7 +446,7 @@ inline void RenderStyle::NonInheritedFlags::setHasPseudoStyles(EnumSet<PseudoId>
 {
     ASSERT(pseudoIdSet);
     ASSERT(pseudoIdSet.containsOnly(allPublicPseudoIds));
-    pseudoBits = pseudoIdSet.toRaw() >> 1; // Shift down as we do not store a bit for PseudoId::None.
+    pseudoBits = pseudoIdSet.toRaw();
 }
 
 inline void RenderStyle::resetBorder()
@@ -508,20 +508,15 @@ inline bool RenderStyle::setUsedZoom(float zoomLevel)
     return true;
 }
 
-inline void RenderStyle::setPseudoElementNameArgument(const AtomString& identifier)
+inline void RenderStyle::setPseudoElementIdentifier(std::optional<Style::PseudoElementIdentifier>&& identifier)
 {
-    ASSERT(pseudoElementType() == PseudoId::ViewTransitionGroup
-        || pseudoElementType() == PseudoId::ViewTransitionImagePair
-        || pseudoElementType() == PseudoId::ViewTransitionNew
-        || pseudoElementType() == PseudoId::ViewTransitionOld
-        || pseudoElementType() == PseudoId::Highlight
-        || identifier.isNull());
-    SET_NESTED(m_nonInheritedData, rareData, pseudoElementNameArgument, identifier);
-}
-
-inline void RenderStyle::setPseudoElementType(PseudoId pseudoElementType)
-{
-    m_nonInheritedFlags.pseudoElementType = enumToUnderlyingType(pseudoElementType);
+    if (identifier) {
+        m_nonInheritedFlags.pseudoElementType = enumToUnderlyingType(identifier->pseudoId) + 1;
+        SET_NESTED(m_nonInheritedData, rareData, pseudoElementNameArgument, WTFMove(identifier->nameArgument));
+    } else {
+        m_nonInheritedFlags.pseudoElementType = 0;
+        SET_NESTED(m_nonInheritedData, rareData, pseudoElementNameArgument, nullAtom());
+    }
 }
 
 inline void RenderStyle::setGridTemplateColumns(Style::GridTemplateList&& list)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -87,7 +87,7 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
         }
     }
 
-    firstLetterStyle.setPseudoElementType(PseudoId::FirstLetter);
+    firstLetterStyle.setPseudoElementIdentifier({ { PseudoId::FirstLetter } });
     // Force inline display (except for floating first-letters).
     firstLetterStyle.setDisplay(firstLetterStyle.isFloating() ? DisplayType::Block : DisplayType::Inline);
     // CSS2 says first-letter can't be positioned.

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -97,7 +97,7 @@ static KeyframeEffectStack* keyframeEffectStackForElementAndPseudoId(const Eleme
     if (!element.mayHaveKeyframeEffects())
         return nullptr;
 
-    return element.keyframeEffectStack(pseudoId == PseudoId::None ? std::nullopt : std::optional(Style::PseudoElementIdentifier { pseudoId }));
+    return element.keyframeEffectStack(std::optional(Style::PseudoElementIdentifier { pseudoId }));
 }
 
 static bool needsPseudoElementForAnimation(const Element& element, PseudoId pseudoId)
@@ -221,7 +221,7 @@ void RenderTreeUpdater::GeneratedContent::updateBeforeOrAfterPseudoElement(Eleme
         // For display:contents we create an inline wrapper that inherits its
         // style from the display:contents style.
         auto contentsStyle = RenderStyle::createPtr();
-        contentsStyle->setPseudoElementType(pseudoId);
+        contentsStyle->setPseudoElementIdentifier({ { pseudoId } });
         contentsStyle->inheritFrom(*updateStyle);
         contentsStyle->copyContentFrom(*updateStyle);
         contentsStyle->copyPseudoElementsFrom(*updateStyle);

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
@@ -204,7 +204,7 @@ void RenderTreeUpdater::ViewTransition::updatePseudoElementGroup(const RenderSty
 
     enum class ShouldDeleteRenderer : bool { No, Yes };
     auto updateRenderer = [&](auto& renderer) -> ShouldDeleteRenderer {
-        auto style = documentElementRenderer.getCachedPseudoStyle({ renderer.style().pseudoElementType(), name }, &documentElementStyle);
+        auto style = documentElementRenderer.getCachedPseudoStyle({ *renderer.style().pseudoElementType(), name }, &documentElementStyle);
         if (!style || style->display() == DisplayType::None)
             return ShouldDeleteRenderer::Yes;
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -728,7 +728,7 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::findAnchorForAnchorFun
 
         // FIXME: Support remaining box generating pseudo-elements (like ::marker).
         auto pseudoElement = style.pseudoElementType();
-        if (pseudoElement != PseudoId::None && pseudoElement != PseudoId::Before && pseudoElement != PseudoId::After)
+        if (pseudoElement && pseudoElement != PseudoId::Before && pseudoElement != PseudoId::After)
             return false;
 
         return true;

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -541,11 +541,11 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
 
     SelectorChecker::CheckingContext context(m_mode);
     if (m_pseudoElementRequest) {
-        context.pseudoId = m_pseudoElementRequest->pseudoId();
-        context.pseudoElementNameArgument = m_pseudoElementRequest->nameArgument();
+        auto pseudoElementIdentifier = m_pseudoElementRequest->identifier();
+        context.setRequestedPseudoElement(pseudoElementIdentifier);
         context.scrollbarState = m_pseudoElementRequest->scrollbarState();
-        if (isNamedViewTransitionPseudoElement(m_pseudoElementRequest->identifier()))
-            context.classList = classListForNamedViewTransitionPseudoElement(element().document(), context.pseudoElementNameArgument);
+        if (isNamedViewTransitionPseudoElement(pseudoElementIdentifier))
+            context.classList = classListForNamedViewTransitionPseudoElement(element().document(), pseudoElementIdentifier.nameArgument);
     }
     context.styleScopeOrdinal = styleScopeOrdinal;
     context.selectorMatchingState = m_selectorMatchingState;
@@ -935,7 +935,8 @@ void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedPrope
 void ElementRuleCollector::addAuthorKeyframeRules(const StyleRuleKeyframe& keyframe)
 {
     ASSERT(m_result->authorDeclarations.isEmpty());
-    m_result->authorDeclarations.append({ keyframe.properties(), SelectorChecker::MatchAll, propertyAllowlistForPseudoId(m_pseudoElementRequest ? m_pseudoElementRequest->pseudoId() : PseudoId::None) });
+    auto propertyAllowlist = m_pseudoElementRequest ? propertyAllowlistForPseudoId(m_pseudoElementRequest->pseudoId()) : PropertyAllowlist::None;
+    m_result->authorDeclarations.append({ keyframe.properties(), SelectorChecker::MatchAll, propertyAllowlist });
 }
 
 }

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -76,7 +76,7 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderS
     if (!style.pseudoElementNameArgument().isNull())
         return false;
     // content:attr() value depends on the element it is being applied to.
-    if (style.hasAttrContent() || (style.pseudoElementType() != PseudoId::None && parentStyle.hasAttrContent()))
+    if (style.hasAttrContent() || (style.pseudoElementType() && parentStyle.hasAttrContent()))
         return false;
     if (style.zoom() != RenderStyle::initialZoom())
         return false;

--- a/Source/WebCore/style/PseudoElementIdentifier.h
+++ b/Source/WebCore/style/PseudoElementIdentifier.h
@@ -79,7 +79,7 @@ struct HashTraits<WebCore::Style::PseudoElementIdentifier> : GenericHashTraits<W
     typedef WebCore::Style::PseudoElementIdentifier EmptyValueType;
 
     static constexpr bool emptyValueIsZero = false;
-    static EmptyValueType emptyValue() { return WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::None, nullAtom() }; }
+    static EmptyValueType emptyValue() { return WebCore::Style::PseudoElementIdentifier { { }, emptyAtom() }; }
 
     static void constructDeletedValue(WebCore::Style::PseudoElementIdentifier& identifer) { new (NotNull, &identifer.nameArgument) AtomString { HashTableDeletedValue }; }
     static bool isDeletedValue(const WebCore::Style::PseudoElementIdentifier& identifer) { return identifer.nameArgument.isHashTableDeletedValue(); }
@@ -97,7 +97,7 @@ struct HashTraits<std::optional<WebCore::Style::PseudoElementIdentifier>> : Gene
     typedef std::optional<WebCore::Style::PseudoElementIdentifier> EmptyValueType;
 
     static constexpr bool emptyValueIsZero = false;
-    static EmptyValueType emptyValue() { return WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::None, nullAtom() }; }
+    static EmptyValueType emptyValue() { return HashTraits<WebCore::Style::PseudoElementIdentifier>::emptyValue(); }
 
     static void constructDeletedValue(std::optional<WebCore::Style::PseudoElementIdentifier>& identifer)
     {

--- a/Source/WebCore/style/PseudoElementRequest.h
+++ b/Source/WebCore/style/PseudoElementRequest.h
@@ -38,7 +38,6 @@ public:
         : m_identifier({ pseudoId })
         , m_scrollbarState(scrollbarState)
     {
-        ASSERT(pseudoId != PseudoId::None);
     }
 
     PseudoElementRequest(PseudoId pseudoId, const AtomString& nameArgument)
@@ -50,7 +49,6 @@ public:
     PseudoElementRequest(const PseudoElementIdentifier& pseudoElementIdentifier)
         : m_identifier(pseudoElementIdentifier)
     {
-        ASSERT(pseudoElementIdentifier.pseudoId != PseudoId::None);
     }
 
     const PseudoElementIdentifier& identifier() const { return m_identifier; }

--- a/Source/WebCore/style/StylableInlines.h
+++ b/Source/WebCore/style/StylableInlines.h
@@ -33,8 +33,8 @@ namespace WebCore {
 inline const Styleable Styleable::fromElement(Element& element)
 {
     if (auto* pseudoElement = dynamicDowncast<PseudoElement>(element))
-        return Styleable(*pseudoElement->hostElement(), Style::PseudoElementIdentifier { element.pseudoId() });
-    ASSERT(element.pseudoId() == PseudoId::None);
+        return Styleable(*pseudoElement->hostElement(), *element.pseudoElementIdentifier());
+    ASSERT(!element.pseudoId());
     return Styleable(element, std::nullopt);
 }
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -530,7 +530,7 @@ void Adjuster::adjust(RenderStyle& style) const
 
         // FIXME: Don't support this mutation for pseudo styles like first-letter or first-line, since it's not completely
         // clear how that should work.
-        if (style.display() == DisplayType::Inline && style.pseudoElementType() == PseudoId::None && style.writingMode().computedWritingMode() != m_parentStyle.writingMode().computedWritingMode())
+        if (style.display() == DisplayType::Inline && !style.pseudoElementType() && style.writingMode().computedWritingMode() != m_parentStyle.writingMode().computedWritingMode())
             style.setEffectiveDisplay(DisplayType::InlineBlock);
 
         // After performing the display mutation, check table rows. We do not honor position:relative or position:sticky on

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -508,7 +508,7 @@ std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element
             // ::first-line can inherit to ::before/::after
             if (auto firstLineContext = makeResolutionContextForInheritedFirstLine(elementUpdate, *elementUpdate.style)) {
                 auto firstLineStyle = scope().resolver->styleForPseudoElement(element, pseudoElementIdentifier, *firstLineContext);
-                firstLineStyle->style->setPseudoElementType(PseudoId::FirstLine);
+                firstLineStyle->style->setPseudoElementIdentifier({ { PseudoId::FirstLine } });
                 animatedUpdate.style->addCachedPseudoStyle(WTFMove(firstLineStyle->style));
             }
         }
@@ -573,7 +573,7 @@ std::optional<ResolvedStyle> TreeResolver::resolveAncestorFirstLinePseudoElement
             return { };
 
         auto elementStyle = scope().resolver->styleForElement(element, *resolutionContext);
-        elementStyle.style->setPseudoElementType(PseudoId::FirstLine);
+        elementStyle.style->setPseudoElementIdentifier({ { PseudoId::FirstLine } });
 
         return elementStyle;
     }
@@ -937,8 +937,7 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAgainInDifferentContext(const 
     auto newStyle = RenderStyle::createPtr();
     newStyle->inheritFrom(parentStyle);
 
-    newStyle->setPseudoElementType(resolvedStyle.style->pseudoElementType());
-    newStyle->setPseudoElementNameArgument(resolvedStyle.style->pseudoElementNameArgument());
+    newStyle->setPseudoElementIdentifier(resolvedStyle.style->pseudoElementIdentifier());
     newStyle->copyPseudoElementBitsFrom(*resolvedStyle.style);
 
     auto builderContext = BuilderContext {

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -67,7 +67,13 @@ namespace WebCore {
 
 const std::optional<const Styleable> Styleable::fromRenderer(const RenderElement& renderer)
 {
-    switch (renderer.style().pseudoElementType()) {
+    if (!renderer.style().pseudoElementType()) {
+        if (auto* element = renderer.element())
+            return fromElement(*element);
+        return { };
+    }
+
+    switch (*renderer.style().pseudoElementType()) {
     case PseudoId::Backdrop:
         for (auto& topLayerElement : renderer.document().topLayerElements()) {
             if (topLayerElement->renderer() && topLayerElement->renderer()->backdropRenderer() == &renderer)
@@ -97,7 +103,6 @@ const std::optional<const Styleable> Styleable::fromRenderer(const RenderElement
         break;
     case PseudoId::After:
     case PseudoId::Before:
-    case PseudoId::None:
         if (auto* element = renderer.element())
             return fromElement(*element);
         break;

--- a/Source/WebCore/style/values/content/StyleContent.cpp
+++ b/Source/WebCore/style/values/content/StyleContent.cpp
@@ -62,7 +62,7 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
 
     // FIXME: Replace with support for CSS Values 5 attr() substitution function.
     auto processAttrContent = [&](const CSSAttrValue& value) -> AtomString {
-        if (state.style().pseudoElementType() == PseudoId::None)
+        if (!state.style().pseudoElementType())
             state.style().setHasAttrContent();
         else
             const_cast<RenderStyle&>(state.parentStyle()).setHasAttrContent();

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -203,7 +203,7 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
         if (!element)
             return { };
 
-        auto mode = conversionData.style()->pseudoElementType() == PseudoId::None
+        auto mode = !conversionData.style()->pseudoElementType()
             ? Style::ContainerQueryEvaluator::SelectionMode::Element
             : Style::ContainerQueryEvaluator::SelectionMode::PseudoElement;
 


### PR DESCRIPTION
#### f535da1fd52fb616bbf439d6c9eed36653b989d8
<pre>
Replace PseudoId::None with std::optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=300906">https://bugs.webkit.org/show_bug.cgi?id=300906</a>
<a href="https://rdar.apple.com/162790552">rdar://162790552</a>

Reviewed by Tim Nguyen.

Modernize code by removing the awkward PseudoId::None value.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::pseudoId):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::CheckingContext::setRequestedPseudoElement):
(WebCore::SelectorChecker::CheckingContext::requestedPseudoElement const):

Add setters, but keep the simple field structure instead of using std::optional etc as they are easier for the SelectorCompiler.

(WebCore::SelectorChecker::match const):
(WebCore::SelectorChecker::matchRecursively const):
(WebCore::SelectorChecker::checkOne const):
(WebCore::SelectorChecker::checkViewTransitionPseudoClass const):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::pseudoElementIdentifierFor):
(WebCore::CSSSelectorParser::parsePseudoElement):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateRequestedPseudoElementEqualsToSelectorPseudoElement):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateMarkPseudoStyleForPseudoElement):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resolvePseudoElementStyle):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::isBeforePseudoElement const):
(WebCore::Node::isAfterPseudoElement const):
(WebCore::Node::pseudoId const):
(WebCore::Node::pseudoElementIdentifier const):
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForKeyframes):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getMatchedStylesForNode):
(WebCore::InspectorCSSAgent::buildArrayForMatchedRuleList):
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::highlightSelector):
(WebCore::InspectorDOMAgent::buildObjectForNode):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::getComputedStyle const):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::nodeForHitTest const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::willCreateColumns const):
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::planCounter):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::propagateStyleToAnonymousChildren):
* Source/WebCore/rendering/RenderElementInlines.h:
(WebCore::RenderElement::isAnonymousBlock const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::overflowControlsRects const):
(WebCore::RenderLayer::ancestorLayerIsDOMParent const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::overflowControlsRects const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::outputRenderObject const):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::collectStylesForRenderer):
(WebCore::TextDecorationPainter::stylesForRenderer):
* Source/WebCore/rendering/TextDecorationPainter.h:
(WebCore::TextDecorationPainter::stylesForRenderer):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::RenderStyle):
(WebCore::RenderStyle::addCachedPseudoStyle):
(WebCore::RenderStyle::pseudoElementIdentifier const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::pseudoElementType const):
(WebCore::RenderStyle::NonInheritedFlags::hasPseudoStyle const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::NonInheritedFlags::setHasPseudoStyles):
(WebCore::RenderStyle::setPseudoElementIdentifier):
(WebCore::RenderStyle::setPseudoElementNameArgument): Deleted.
(WebCore::RenderStyle::setPseudoElementType): Deleted.

Remove these in favour of a single setPseudoElementIdentifier setter.

* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
(WebCore::styleForFirstLetter):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::keyframeEffectStackForElementAndPseudoId):
(WebCore::RenderTreeUpdater::GeneratedContent::updateBeforeOrAfterPseudoElement):
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementGroup):
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ruleMatches):
(WebCore::Style::ElementRuleCollector::addAuthorKeyframeRules):
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::isCacheable):
* Source/WebCore/style/PseudoElementIdentifier.h:
(WTF::HashTraits&lt;WebCore::Style::PseudoElementIdentifier&gt;::emptyValue):
(WTF::HashTraits&lt;std::optional&lt;WebCore::Style::PseudoElementIdentifier&gt;&gt;::emptyValue):
* Source/WebCore/style/PseudoElementRequest.h:
(WebCore::Style::PseudoElementRequest::m_scrollbarState):
(WebCore::Style::PseudoElementRequest::PseudoElementRequest):
* Source/WebCore/style/StylableInlines.h:
(WebCore::Styleable::fromElement):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe const):
(WebCore::Style::Resolver::styleForPseudoElement):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolvePseudoElement):
(WebCore::Style::TreeResolver::resolveAncestorFirstLinePseudoElement):
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::fromRenderer):
* Source/WebCore/style/values/content/StyleContent.cpp:
(WebCore::Style::CSSValueConversion&lt;Content&gt;::operator):
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
(WebCore::Style::computeNonCalcLengthDouble):

Canonical link: <a href="https://commits.webkit.org/301699@main">https://commits.webkit.org/301699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9520a904f17226e0f0a0ef5813e5bec1dd81007

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133739 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54967 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129738 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/37652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113412 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/77006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77132 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136318 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41147 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109772 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26695 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50198 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50922 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53392 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59194 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52649 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54397 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->