### PR TITLE
Expose HTMLTextAreaElement.lastChangeWasUserEdit to JS when _WKContentWorldConfiguration.allowAutofill is YES

### DIFF
--- a/Source/WebCore/html/HTMLTextAreaElement.idl
+++ b/Source/WebCore/html/HTMLTextAreaElement.idl
@@ -62,4 +62,7 @@
     [ImplementedAs=setSelectionRangeForBindings] undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString autocomplete;
+
+    // WebKit extension for autofill.
+    [EnabledForWorld=allowAutofill] readonly attribute boolean lastChangeWasUserEdit;
 };


### PR DESCRIPTION
#### 35b9bbb8b468357da275f9f53cd35aaeb297b7fa
<pre>
Expose HTMLTextAreaElement.lastChangeWasUserEdit to JS when _WKContentWorldConfiguration.allowAutofill is YES
<a href="https://bugs.webkit.org/show_bug.cgi?id=300911">https://bugs.webkit.org/show_bug.cgi?id=300911</a>
<a href="https://rdar.apple.com/145296109">rdar://145296109</a>

Reviewed by Alex Christensen.

lastChangeWasUserEdit is a property of HTMLTextFormControlElement. It is
exposed to the injected bundle for HTMLInputElement and HTMLTextArea.
But is exposed to JS in allowAutoFill worlds only for HTMLInputElement.
We need to expose it to HTMLTextArea for parity with injected bundle.

* Source/WebCore/html/HTMLTextAreaElement.idl:

Canonical link: <a href="https://commits.webkit.org/301691@main">https://commits.webkit.org/301691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2be4f6f2035cf6eecd309b18294146bc2adc480

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133670 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78354 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8116e260-cb85-4bf0-92cd-b297ca204341) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96423 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a47cb782-bc46-43db-b3d4-0938aef4f50b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76946 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1e12e119-8688-40a5-989c-a4561d2a6496) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31512 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77067 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107407 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136245 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104935 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104637 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26690 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28467 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50832 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53317 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59119 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52582 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55918 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54325 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->