### PR TITLE
PDF page number indicator background fades out without a transition

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
@@ -165,7 +165,12 @@ static constexpr Seconds indicatorMoveDuration { 0.3_s };
 
 - (void)hide:(NSTimer *)timer
 {
+    // FIXME: <rdar://162795344> Remove this workaround and directly setAlpha:0 after rdar://154649008.
+    static constexpr auto effectivelyTransparentAlpha = 0.0101;
     auto animations = [view = retainPtr(self)] {
+        [view setAlpha:effectivelyTransparentAlpha];
+    };
+    auto completion = [view = retainPtr(self)](BOOL) {
         [view setAlpha:0];
     };
 #if HAVE(UI_VIEW_ANIMATION_OPTION_FLUSH_UPDATES)
@@ -173,7 +178,7 @@ static constexpr Seconds indicatorMoveDuration { 0.3_s };
 #else
     static constexpr auto animationOptions = 0;
 #endif
-    [UIView animateWithDuration:indicatorFadeOutDuration.seconds() delay:0 options:animationOptions animations:animations completion:nil];
+    [UIView animateWithDuration:indicatorFadeOutDuration.seconds() delay:0 options:animationOptions animations:animations completion:completion];
 
     [std::exchange(_timer, nil) invalidate];
 }


### PR DESCRIPTION
#### 976745bfd6c771d5371b20a5897fe6f0d3143a38
<pre>
PDF page number indicator background fades out without a transition
<a href="https://bugs.webkit.org/show_bug.cgi?id=300913">https://bugs.webkit.org/show_bug.cgi?id=300913</a>
<a href="https://rdar.apple.com/161491666">rdar://161491666</a>

Reviewed by Tim Horton.

This patch is a workaround to <a href="https://rdar.apple.com/154722287&amp">rdar://154722287&amp</a>;154649008, where we
notice that performing setAlpha:0 on a UIView that contains a
UIGlassEffect visual effect view in its hierarchy (so, the page number
indicator) presents as an abrupt transition.

* Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm:
(-[WKPDFPageNumberIndicator hide:]):

Canonical link: <a href="https://commits.webkit.org/301685@main">https://commits.webkit.org/301685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20a0b2beef2a3aa89ce1db404add6c9a690af0ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133633 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78322 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/87dbbefa-4fb1-4e43-bec8-248d6c646eeb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96390 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76915 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36449 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77029 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107378 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.PostMessageWithMessagePorts (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136207 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104909 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53845 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109647 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104610 "Found 1 new API test failure: WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50097 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28431 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50790 "Hash 20a0b2be for PR 52495 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19828 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53278 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59085 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52549 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55885 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54289 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->