### PR TITLE
[build.webkit.org] Build requests are not collapsed since the switch to multi-master mode

### DIFF
--- a/Tools/CISupport/build-webkit-org-webserver/master.cfg
+++ b/Tools/CISupport/build-webkit-org-webserver/master.cfg
@@ -42,7 +42,12 @@ use_multi_master = not is_test_mode_enabled
 c = BuildmasterConfig = {}
 c['title'] = f'WebKit CI{custom_suffix.upper()}'
 c['titleURL'] = f'https://webkit{custom_suffix}.org'
-c['collapseRequests'] = True
+# If the workers and builders are not defined also for this master then the
+# feature to collapse build-requests doesn't work. See: webkit.org/b/300920
+# And it is needed to define a PB port, otherwise buildbot fails with:
+#  ""workers are configured, but c['protocols'] no""
+# But this PB port is not used and the workers should not connect to it.
+c['protocols'] = {'pb': {'port': 17777}}
 
 if use_multi_master:
     c['multiMaster'] = True
@@ -110,4 +115,3 @@ loadConfig.loadBuilderConfig(
     setup_main_schedulers=True,
     setup_force_schedulers=True,
 )
-c['workers'] = c['builders'] = []

--- a/Tools/CISupport/build-webkit-org/master.cfg
+++ b/Tools/CISupport/build-webkit-org/master.cfg
@@ -42,7 +42,6 @@ c = BuildmasterConfig = {}
 c['title'] = f'WebKit CI{custom_suffix.upper()}'
 c['titleURL'] = f'https://webkit{custom_suffix}.org'
 c['protocols'] = {'pb': {'port': 17000}}
-c['collapseRequests'] = True
 
 if use_multi_master:
     c['multiMaster'] = True


### PR DESCRIPTION
#### c9fec4eec9b7fffa23849078d2125a3535ca5cd8
<pre>
[build.webkit.org] Build requests are not collapsed since the switch to multi-master mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=300920">https://bugs.webkit.org/show_bug.cgi?id=300920</a>

Reviewed by Aakash Jain.

At 301496@main I thought that the issue with the build requests not being collapsed anymore
since the migration to version 4.3 was because a change of default value for the parameter
collapseRequests from 2.10 to 4.3, but this was not the case in the end.

The problem is not caused by the new version, but by the new multi-master deployment.
The &quot;-webserver&quot; master is configured without the list of builders and workers, and that
causes that the feature to collapse the requests (which runs on this master) to be unable
to find the object representing the builder (given its name), and then it is skipping to
run the function to collapse the builds which is part of this builder object.

Fix that by defining also the list of workers for the &quot;-webserver&quot; master, that way
it can find the builder object and the feature to collapse build requests works again.

This also reverts 301496@main since the value to collapseRequests actually defauls to True.

* Tools/CISupport/build-webkit-org-webserver/master.cfg:
* Tools/CISupport/build-webkit-org/master.cfg:

Canonical link: <a href="https://commits.webkit.org/301655@main">https://commits.webkit.org/301655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f885b4e41c0b3135391ba8bbb142c5cb0885cb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37273 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54848 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/133631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129614 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/37558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/113292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/77027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/31773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136204 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53352 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/41048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/126092 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53842 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/109650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50094 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50787 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19812 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53275 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54287 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->