### PR TITLE
menus.create should use iconVariants key not icon_variants

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -59,6 +59,7 @@ static constexpr auto iconsManifestKey = "icons"_s;
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
 static constexpr auto iconVariantsManifestKey = "icon_variants"_s;
 static constexpr auto colorSchemesManifestKey = "color_schemes"_s;
+static constexpr auto colorSchemesAPIKey = "colorSchemes"_s;
 static constexpr auto lightManifestKey = "light"_s;
 static constexpr auto darkManifestKey = "dark"_s;
 static constexpr auto anyManifestKey = "any"_s;
@@ -2095,7 +2096,7 @@ RefPtr<JSON::Object> WebExtension::bestIconVariantJSONObject(RefPtr<JSON::Array>
             continue;
 
         RefPtr variantObject = variant->asObject();
-        auto colorSchemes = toColorSchemes(variantObject ? variantObject->getValue(colorSchemesManifestKey) : nullptr);
+        auto colorSchemes = toColorSchemes(variantObject ? variantObject->getValue(colorSchemesManifestKey) ?: variantObject->getValue(colorSchemesAPIKey) : nullptr);
         auto currentBestSize = bestIconSize(*variantObject, idealPixelSize);
 
         if (colorSchemes.contains(idealColorScheme)) {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -60,7 +60,9 @@ static NSString * const titleKey = @"title";
 
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
 static NSString * const variantsKey = @"variants";
-static NSString * const colorSchemesKey = @"color_schemes";
+// FIXME: <https://webkit.org/b/300927> Deprecate `color_schemes` key.
+static NSString * const deprecatedColorSchemesKey = @"color_schemes";
+static NSString * const colorSchemesKey = @"colorSchemes";
 static NSString * const lightKey = @"light";
 static NSString * const darkKey = @"dark";
 static NSString * const anyKey = @"any";
@@ -422,7 +424,7 @@ NSMutableDictionary *WebExtensionAPIAction::parseIconPathsDictionary(NSDictionar
 
     for (NSString *key in input) {
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
-        if (forVariants && [key isEqualToString:colorSchemesKey])
+        if (forVariants && ([key isEqualToString:colorSchemesKey] || [key isEqualToString:deprecatedColorSchemesKey]))
             continue;
 #endif
 
@@ -448,7 +450,7 @@ NSMutableDictionary *WebExtensionAPIAction::parseIconImageDataDictionary(NSDicti
 
     for (NSString *key in input) {
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
-        if (forVariants && [key isEqualToString:colorSchemesKey])
+        if (forVariants && ([key isEqualToString:colorSchemesKey] || [key isEqualToString:deprecatedColorSchemesKey]))
             continue;
 #endif
 
@@ -495,8 +497,9 @@ NSArray *WebExtensionAPIAction::parseIconVariants(NSArray *input, const URL& bas
             continue;
         }
 
-        if (NSArray *colorSchemes = dictionary[colorSchemesKey]) {
-            auto *colorSchemesCompositeKey = [NSString stringWithFormat:@"%@['%@']", compositeKey, colorSchemesKey];
+        auto *usedColorSchemesKey = dictionary[colorSchemesKey] ? colorSchemesKey : deprecatedColorSchemesKey;
+        if (NSArray *colorSchemes = dictionary[usedColorSchemesKey]) {
+            auto *colorSchemesCompositeKey = [NSString stringWithFormat:@"%@['%@']", compositeKey, usedColorSchemesKey];
             if (!validateObject(colorSchemes, colorSchemesCompositeKey, @[ NSString.class ], !firstExceptionString ? &firstExceptionString : nullptr))
                 continue;
 
@@ -506,7 +509,7 @@ NSArray *WebExtensionAPIAction::parseIconVariants(NSArray *input, const URL& bas
                 continue;
             }
 
-            parsedDictionary[colorSchemesKey] = colorSchemes;
+            parsedDictionary[usedColorSchemesKey] = colorSchemes;
         }
 
         ASSERT(parsedDictionary);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -1080,8 +1080,8 @@ TEST(WKWebExtensionAPIAction, SetIconWithVariants)
     auto *backgroundScript = Util::constructScript(@[
         @"await browser.test.assertSafeResolve(() => browser.action.setIcon({",
         @"    variants: [",
-        @"        { 32: 'action-dark-32.png', 64: 'action-dark-64.png', 'color_schemes': [ 'dark' ] },",
-        @"        { 32: 'action-light-32.png', 64: 'action-light-64.png', 'color_schemes': [ 'light' ] }",
+        @"        { 32: 'action-dark-32.png', 64: 'action-dark-64.png', 'colorSchemes': [ 'dark' ] },",
+        @"        { 32: 'action-light-32.png', 64: 'action-light-64.png', 'colorSchemes': [ 'light' ] }",
         @"    ]",
         @"}))",
     ]);
@@ -1145,8 +1145,8 @@ TEST(WKWebExtensionAPIAction, SetIconWithImageDataAndVariants)
 
         @"await browser.test.assertSafeResolve(() => browser.action.setIcon({",
         @"    variants: [",
-        @"        { 32: imageDataDark32, 64: imageDataDark64, 'color_schemes': [ 'dark' ] },",
-        @"        { 32: imageDataLight32, 64: imageDataLight64, 'color_schemes': [ 'light' ] }",
+        @"        { 32: imageDataDark32, 64: imageDataDark64, 'colorSchemes': [ 'dark' ] },",
+        @"        { 32: imageDataLight32, 64: imageDataLight64, 'colorSchemes': [ 'light' ] }",
         @"    ]",
         @"}))",
     ]);
@@ -1198,12 +1198,12 @@ TEST(WKWebExtensionAPIAction, SetIconThrowsWithNoValidVariants)
         @"const invalidImageData = createImageData(32, 'white')",
 
         @"await browser.test.assertThrows(() => browser.action.setIcon({",
-        @"    variants: [ { 'thirtytwo': invalidImageData, 'color_schemes': [ 'light' ] } ]",
+        @"    variants: [ { 'thirtytwo': invalidImageData, 'colorSchemes': [ 'light' ] } ]",
         @"}), /'variants\\[0\\]' value is invalid, because 'thirtytwo' is not a valid dimension/s)",
 
         @"await browser.test.assertThrows(() => browser.action.setIcon({",
-        @"    variants: [ { 32: invalidImageData, 'color_schemes': [ 'bad' ] } ]",
-        @"}), /'variants\\[0\\]\\['color_schemes'\\]' value is invalid, because it must specify either 'light' or 'dark'/s)",
+        @"    variants: [ { 32: invalidImageData, 'colorSchemes': [ 'bad' ] } ]",
+        @"}), /'variants\\[0\\]\\['colorSchemes'\\]' value is invalid, because it must specify either 'light' or 'dark'/s)",
 
         @"browser.test.notifyPass()"
     ]);
@@ -1232,8 +1232,8 @@ TEST(WKWebExtensionAPIAction, SetIconWithMixedValidAndInvalidVariants)
 
         @"await browser.test.assertSafeResolve(() => browser.action.setIcon({",
         @"    variants: [",
-        @"        { '32': imageDataLight32, 'color_schemes': ['light'] },",
-        @"        { '32.5': invalidImageData, 'color_schemes': ['dark'] }",
+        @"        { '32': imageDataLight32, 'colorSchemes': ['light'] },",
+        @"        { '32.5': invalidImageData, 'colorSchemes': ['dark'] }",
         @"    ]",
         @"}))",
     ]);
@@ -1280,8 +1280,8 @@ TEST(WKWebExtensionAPIAction, SetIconWithAnySizeVariantAndSVGDataURL)
 
         @"await browser.test.assertSafeResolve(() => browser.action.setIcon({",
         @"    variants: [",
-        @"        { any: whiteSVGData, 'color_schemes': [ 'dark' ] },",
-        @"        { any: blackSVGData, 'color_schemes': [ 'light' ] }",
+        @"        { any: whiteSVGData, 'colorSchemes': [ 'dark' ] },",
+        @"        { any: blackSVGData, 'colorSchemes': [ 'light' ] }",
         @"    ]",
         @"}))",
     ]);


### PR DESCRIPTION
#### 92c4111ec3f8005d00327d0c0d0a2465aa02f95b
<pre>
menus.create should use iconVariants key not icon_variants
<a href="https://bugs.webkit.org/show_bug.cgi?id=300404">https://bugs.webkit.org/show_bug.cgi?id=300404</a>
<a href="https://rdar.apple.com/problem/162225272">rdar://problem/162225272</a>

Reviewed by Timothy Hatcher.

To align with other JS APIs, we should use camelCase and not snake_case for these keys.
Keep support for the old API keys to avoid breaking existing extensions. Filed <a href="https://webkit.org/b/300927">https://webkit.org/b/300927</a>
to follow up with a full deprecation of these keys.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:

(WebKit::WebExtension::bestIconVariantJSONObject):
Check for both the manifest and API version of this key since this method is used for both cases.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::parseIconPathsDictionary):
(WebKit::WebExtensionAPIAction::parseIconImageDataDictionary):
(WebKit::WebExtensionAPIAction::parseIconVariants):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::parseCreateAndUpdateProperties):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithImageDataAndVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconThrowsWithNoValidVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithMixedValidAndInvalidVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithAnySizeVariantAndSVGDataURL)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, CreateMenuWithDeprecatedKeys)):
Verify that the new API keys take precedent over the deprecated keys.

(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithIconVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithImageDataVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithWithNoValidVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithMixedValidAndInvalidIconVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithAnySizeVariantAndSVGDataURL)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, UpdateMenuItemWithIconVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithNull)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithEmpty)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithSymbolImageIconVariants)):

Canonical link: <a href="https://commits.webkit.org/301718@main">https://commits.webkit.org/301718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a3b363731f351a98946196d1f9b15bead4c2ccd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126837 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/46478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/37455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128708 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/47103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/55013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/133843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129785 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/47103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/37455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/133843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/47103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/37455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/77237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/47103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/37455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/136369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/53509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/55013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/136369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/54005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/37455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/136369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/37455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19841 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/53438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/59286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/54441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->