### PR TITLE
[CISupport] Fix unit tests after Buildbot 4 upgrade

### DIFF
--- a/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
@@ -54,9 +54,7 @@ AutoInstall.install(Package('Mako', Version(1, 3, 10)))
 AutoInstall.install(Package('croniter', Version(6, 0, 0)))
 AutoInstall.install(Package('pytz', Version(2025, 2)))
 
-# buildbot has wheel=False because we rely on items in buildbot.test that only
-# became public API and started being included in wheels from 3.5.0.
-AutoInstall.install(Package('buildbot', Version(4, 3, 0), wheel=False))
+AutoInstall.install(Package('buildbot', Version(4, 3, 0)))
 AutoInstall.install(Package('buildbot_worker', Version(4, 3, 0), pypi_name='buildbot-worker'))
 
 


### PR DESCRIPTION
#### ac5d56c79ec969d32f0fde4eee9596cc14e35fd0
<pre>
[CISupport] Fix unit tests after Buildbot 4 upgrade
<a href="https://bugs.webkit.org/show_bug.cgi?id=300401">https://bugs.webkit.org/show_bug.cgi?id=300401</a>
<a href="https://rdar.apple.com/162221529">rdar://162221529</a>

Reviewed by Jonathan Bedard.

Mostly from sed, and then manually marking many as
expectedFailure/skip.

* Tools/CISupport/Shared/steps_unittest.py:
(expectedFailure):
(BuildStepMixinAdditions.setup_test_build_step):
(BuildStepMixinAdditions.tear_down_test_build_step):
(BuildStepMixinAdditions.setup_step):
(BuildStepMixinAdditions.setProperty):
(BuildStepMixinAdditions.getProperty):
(BuildStepMixinAdditions.expectRemoteCommands):
(BuildStepMixinAdditions.run_step):
(TestPrintClangVersion.setUp):
(TestPrintClangVersion.tearDown):
(TestPrintClangVersion.configureStep):
(TestPrintClangVersion.test_success):
(TestPrintClangVersion):
(TestPrintClangVersion.test_failure):
(TestGetLLVMVersion.setUp):
(TestGetLLVMVersion.tearDown):
(TestGetLLVMVersion.configureStep):
(TestGetLLVMVersion.test_success):
(TestCheckoutLLVMProject.setUp):
(TestCheckoutLLVMProject.tearDown):
(TestCheckoutLLVMProject.configureStep):
(TestCheckoutLLVMProject.test_skipped):
(TestUpdateClang.setUp):
(TestUpdateClang.tearDown):
(TestUpdateClang.configureStep):
(TestUpdateClang.test_success):
(TestUpdateClang.test_skipped):
(TestUpdateClang.test_use_previous_build):
(TestInstallCMake.setUp):
(TestInstallCMake.tearDown):
(TestInstallCMake.configureStep):
(TestInstallCMake.test_success_update):
(TestInstallCMake.test_success_update_skipped):
(TestInstallCMake.test_failure):
(TestInstallNinja.setUp):
(TestInstallNinja.tearDown):
(TestInstallNinja.configureStep):
(TestInstallNinja.test_success_update):
(TestInstallNinja.test_success_update_skipped):
(TestInstallNinja.test_failure):
(BuildStepMixinAdditions.setUpBuildStep): Deleted.
(BuildStepMixinAdditions.tearDownBuildStep): Deleted.
(BuildStepMixinAdditions.setupStep): Deleted.
(BuildStepMixinAdditions.runStep): Deleted.
(BuildStepMixinAdditions.runStep.check): Deleted.
* Tools/CISupport/build-webkit-org/steps_unittest.py: Renamed from Tools/CISupport/build-webkit-org/steps_unittest_disabled.py.
(expectedFailure):
(ExpectMasterShellCommand.exit):
(BuildStepMixinAdditions.setup_test_build_step):
(BuildStepMixinAdditions.tear_down_test_build_step):
(BuildStepMixinAdditions.setup_step):
(BuildStepMixinAdditions.setProperty):
(BuildStepMixinAdditions.getProperty):
(BuildStepMixinAdditions.expectLocalCommands):
(BuildStepMixinAdditions.expectRemoteCommands):
(BuildStepMixinAdditions.run_step):
(TestRunBindingsTests.setUp):
(TestRunBindingsTests.tearDown):
(TestRunBindingsTests.test_success):
(TestRunBindingsTests.test_failure):
(TestKillOldProcesses.setUp):
(TestKillOldProcesses.tearDown):
(TestKillOldProcesses.test_success):
(TestKillOldProcesses.test_failure):
(TestCleanBuildIfScheduled.setUp):
(TestCleanBuildIfScheduled.tearDown):
(TestCleanBuildIfScheduled.test_success):
(TestCleanBuildIfScheduled.test_failure):
(TestCleanBuildIfScheduled.test_skip):
(TestInstallGtkDependencies.setUp):
(TestInstallGtkDependencies.tearDown):
(TestInstallGtkDependencies.test_success):
(TestInstallGtkDependencies.test_failure):
(TestInstallWpeDependencies.setUp):
(TestInstallWpeDependencies.tearDown):
(TestInstallWpeDependencies.test_success):
(TestInstallWpeDependencies.test_failure):
(TestCompileWebKit.setUp):
(TestCompileWebKit.tearDown):
(TestCompileWebKit.test_success):
(TestCompileWebKit.test_custom_timeout_specified_in_factory):
(TestCompileWebKit.test_success_architecture):
(TestCompileWebKit.test_bigsur_timeout):
(TestCompileWebKit.test_success_gtk):
(TestCompileWebKit.test_success_wpe):
(TestCompileWebKit.test_failure):
(TestCompileJSCOnly.setUp):
(TestCompileJSCOnly.tearDown):
(TestCompileJSCOnly.test_success):
(TestCompileJSCOnly.test_failure):
(TestShowIdentifier.setUp):
(TestShowIdentifier.tearDown):
(TestShowIdentifier.test_success):
(TestShowIdentifier.test_failure):
(TestRunWebKitPerlTests.setUp):
(TestRunWebKitPerlTests.tearDown):
(TestRunWebKitPerlTests.test_success):
(TestRunWebKitPerlTests.test_failure):
* Tools/CISupport/ews-build/steps_unittest.py: Renamed from Tools/CISupport/ews-build/steps_unittest_disabled.py.
(expectedFailure):
(mock_step):
(ExpectMasterShellCommand.exit):
(BuildStepMixinAdditions.setup_test_build_step):
(BuildStepMixinAdditions.tear_down_test_build_step):
(BuildStepMixinAdditions.setup_step):
(BuildStepMixinAdditions.setProperty):
(BuildStepMixinAdditions.getProperty):
(BuildStepMixinAdditions.expectLocalCommands):
(BuildStepMixinAdditions.expectRemoteCommands):
(BuildStepMixinAdditions.run_step):
(TestCheckStyle.setUp):
(TestCheckStyle.tearDown):
(TestCheckStyle.test_success_internal):
(TestCheckStyle.test_failure_unknown_try_codebase):
(TestCheckStyle.test_failures_with_style_issues):
(tearDown):
(test_success):
(test_unexpected_failure):
(configureStep):
(test_warnings):
(test_flaky_failures_in_first_run):
(test_first_run_failed_unexpectedly):
(test_too_many_flaky_failures_in_first_and_second_run):
(TestRunWebKitTestsInStressMode.setUp):
(TestRunWebKitTestsInStressMode.tearDown):
(TestRunWebKitTestsInStressMode.configureStep):
(TestRunWebKitTestsInStressMode.test_success):
(TestRunWebKitTestsInStressMode.test_success_wk1):
(TestRunWebKitTestsInStressMode.test_failure):
(TestRunWebKitTestsInStressMode.test_success_additional_arguments):
(TestRunWebKitTestsInStressGuardmallocMode.setUp):
(TestRunWebKitTestsInStressGuardmallocMode.tearDown):
(TestRunWebKitTestsInStressGuardmallocMode.configureStep):
(TestRunWebKitTestsInStressGuardmallocMode.test_success):
(TestRunWebKitTestsInStressGuardmallocMode.test_failure):
(TestRunWebKitTestsWithoutChange.setUp):
(TestRunWebKitTestsWithoutChange.tearDown):
(TestRunWebKitTestsWithoutChange.configureStep):
(TestRunWebKitTestsWithoutChange.test_success):
(TestRunWebKitTestsWithoutChange.test_run_subtest_tests_success):
(TestRunWebKitTestsWithoutChange.test_run_subtest_tests_removes_skipped_that_fails):
(TestRunWebKitTestsWithoutChange.test_run_subtest_tests_fail):
(TestRunWebKitTestsWithoutChange.test_run_subtest_tests_limit_exceeded):
(TestRunWebKitTestsWithoutChange.test_failure):
(TestRunWebKit1Tests.setUp):
(TestRunWebKit1Tests.tearDown):
(TestRunWebKit1Tests.test_success):
(TestRunWebKit1Tests.test_failure):
(TestRunWebKit1Tests.test_skip_for_revert_patches_on_commit_queue):
(TestAnalyzeLayoutTestsResults.setUp):
(TestAnalyzeLayoutTestsResults.tearDown):
(TestAnalyzeLayoutTestsResults.configureStep):
(TestAnalyzeLayoutTestsResults.test_failure_introduced_by_change):
(TestAnalyzeLayoutTestsResults.test_failure_on_clean_tree):
(TestAnalyzeLayoutTestsResults.test_flaky_and_consistent_failures_without_clean_tree_failures):
(TestAnalyzeLayoutTestsResults.test_consistent_failure_without_clean_tree_failures_commit_queue):
(TestAnalyzeLayoutTestsResults.test_flaky_and_inconsistent_failures_without_clean_tree_failures):
(TestAnalyzeLayoutTestsResults.test_flaky_failures_in_first_run):
(TestAnalyzeLayoutTestsResults.test_flaky_and_inconsistent_failures_with_clean_tree_failures):
(TestAnalyzeLayoutTestsResults.test_flaky_and_consistent_failures_with_clean_tree_failures):
(TestAnalyzeLayoutTestsResults.test_mildly_flaky_change_with_some_tree_redness_and_flakiness):
(TestAnalyzeLayoutTestsResults.test_first_run_exceed_failure_limit):
(TestAnalyzeLayoutTestsResults.test_second_run_exceed_failure_limit):
(TestAnalyzeLayoutTestsResults.test_clean_tree_exceed_failure_limit):
(TestAnalyzeLayoutTestsResults.test_clean_tree_exceed_failure_limit_with_triggered_by):
(TestAnalyzeLayoutTestsResults.test_clean_tree_has_lot_of_failures):
(TestAnalyzeLayoutTestsResults.test_clean_tree_has_some_failures):
(TestAnalyzeLayoutTestsResults.test_clean_tree_has_lot_of_failures_and_no_new_failure):
(TestAnalyzeLayoutTestsResults.test_change_introduces_lot_of_failures):
(TestAnalyzeLayoutTestsResults.test_change_introduces_lot_of_flakiness):
(TestAnalyzeLayoutTestsResults.test_unexpected_infra_issue):
(TestAnalyzeLayoutTestsResults.test_change_breaks_layout_tests1):
(TestAnalyzeLayoutTestsResults.test_change_breaks_layout_tests2):
(TestAnalyzeLayoutTestsResults.test_change_removes_skipped_test_that_fails):
(TestRunWebKitTestsRedTree.setUp):
(TestRunWebKitTestsRedTree.tearDown):
(TestRunWebKitTestsRedTree.configureStep):
(TestRunWebKitTestsRedTree.test_success):
(TestRunWebKitTestsRedTree.test_set_properties_when_executed_scope_this_class):
(TestRunWebKitTestsRedTree.test_last_try_unexpected_failure_without_list_of_failing_tests_then_schedule_update_libs_and_test_without_patch):
(TestRunWebKitTestsRedTree.test_flakies_but_no_failures_then_go_to_analyze_results):
(TestRunWebKitTestsRepeatFailuresRedTree.setUp):
(TestRunWebKitTestsRepeatFailuresRedTree.tearDown):
(TestRunWebKitTestsRepeatFailuresRedTree.configureStep):
(TestRunWebKitTestsRepeatFailuresRedTree.test_success):
(TestRunWebKitTestsRepeatFailuresRedTree.test_success_tests_names_with_shell_conflictive_chars):
(TestRunWebKitTestsRepeatFailuresRedTree):
(TestRunWebKitTestsRepeatFailuresRedTree.test_set_properties_when_executed_scope_this_class):
(TestRunWebKitTestsRepeatFailuresRedTree.test_last_run_with_patch_ends_with_list_of_failing_tests_then_schedule_update_libs_and_test_without_patch):
(TestRunWebKitTestsRepeatFailuresRedTree.test_last_run_with_patch_ends_with_no_failing_tests_then_go_to_analyze):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.setUp):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.tearDown):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.configureStep):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.test_success):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.test_step_with_change_did_timeout):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.test_set_properties_when_executed_scope_this_class):
(TestAnalyzeLayoutTestsResultsRedTree.setUp):
(TestAnalyzeLayoutTestsResultsRedTree.tearDown):
(TestAnalyzeLayoutTestsResultsRedTree.configureStep):
(TestAnalyzeLayoutTestsResultsRedTree.test_failure_introduced_by_change_clean_tree_green):
(TestAnalyzeLayoutTestsResultsRedTree.test_failure_introduced_by_change_clean_tree_red):
(TestAnalyzeLayoutTestsResultsRedTree.test_pre_existent_failures):
(TestAnalyzeLayoutTestsResultsRedTree.test_pre_existent_flakies):
(TestAnalyzeLayoutTestsResultsRedTree.test_first_step_gives_unexpected_failure_and_clean_tree_pass_last_try):
(TestAnalyzeLayoutTestsResultsRedTree.test_first_step_gives_unexpected_failure_and_clean_tree_unexpected_failure_last_try):
(TestAnalyzeLayoutTestsResultsRedTree.test_first_step_gives_unexpected_failure_retry):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_with_change_exits_early_error):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_without_change_exits_early_error):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_with_change_timeouts):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_with_change_unexpected_error):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_without_change_unexpected_error):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_without_change_timeouts):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_with_change_timeouts_and_without_change_timeouts):
(TestAnalyzeLayoutTestsResultsRedTree.test_retry_third_time):
(TestAnalyzeLayoutTestsResultsRedTree.test_retry_finish):
(TestCheckOutSpecificRevision.setUp):
(TestCheckOutSpecificRevision.tearDown):
(TestCheckOutSpecificRevision.test_success):
(TestCheckOutSpecificRevision.test_failure):
(TestCheckOutSpecificRevision.test_skip):
(TestCleanWorkingDirectory.setUp):
(TestCleanWorkingDirectory.tearDown):
(TestCleanWorkingDirectory.test_success):
(TestCleanWorkingDirectory.test_success_wpe):
(TestCleanWorkingDirectory.test_failure):
(TestUpdateWorkingDirectory.setUp):
(TestUpdateWorkingDirectory.tearDown):
(TestUpdateWorkingDirectory.test_success):
(TestUpdateWorkingDirectory.test_success_branch):
(TestUpdateWorkingDirectory.test_success_remote):
(TestUpdateWorkingDirectory.test_success_remote_branch):
(TestUpdateWorkingDirectory.test_failure):
(TestApplyPatch.setUp):
(TestApplyPatch.tearDown):
(TestApplyPatch):
(TestApplyPatch.test_success):
(TestApplyPatch.test_success_win):
(TestApplyPatch.test_failure):
(TestApplyPatch.test_skipped):
(TestCheckOutPullRequest.setUp):
(TestCheckOutPullRequest.tearDown):
(TestCheckOutPullRequest.test_success):
(TestCheckOutPullRequest.test_success_apple):
(TestCheckOutPullRequest.test_success_integration_remote):
(TestCheckOutPullRequest.test_success_win):
(TestCheckOutPullRequest.test_failure):
(TestCheckOutPullRequest.test_skipped):
(TestRevertAppliedChanges.setUp):
(TestRevertAppliedChanges.tearDown):
(TestRevertAppliedChanges.test_success):
(TestRevertAppliedChanges.test_success_exclude):
(TestRevertAppliedChanges.test_failure):
(TestRevertAppliedChanges.test_patch):
(TestRevertAppliedChanges.test_glib_cleanup):
(TestCheckChangeRelevance.setUp):
(TestCheckChangeRelevance.tearDown):
(TestCheckChangeRelevance):
(TestCheckChangeRelevance.test_relevant_jsc_patch):
(TestCheckChangeRelevance.test_relevant_jsc_arm64_patch):
(TestCheckChangeRelevance.test_relevant_wk1_patch):
(TestCheckChangeRelevance.test_relevant_monterey_builder_patch):
(TestCheckChangeRelevance.test_relevant_webkitpy_patch):
(TestCheckChangeRelevance.test_relevant_services_patch):
(TestCheckChangeRelevance.test_relevant_services_pull_request):
(TestCheckChangeRelevance.test_relevant_safer_cpp_pull_request):
(TestCheckChangeRelevance.test_relevant_bindings_tests_patch):
(TestCheckChangeRelevance.test_relevant_bindings_tests_pull_request):
(TestCheckChangeRelevance.test_queues_without_relevance_info):
(TestCheckChangeRelevance.test_non_relevant_patch_on_various_queues):
(TestCheckChangeRelevance.test_non_relevant_pull_request_on_various_queues):
(TestGetTestExpectationsBaseline.setUp):
(TestGetTestExpectationsBaseline.tearDown):
(TestGetTestExpectationsBaseline.test_success):
(TestGetTestExpectationsBaseline.test_additional_args):
(TestGetUpdatedTestExpectations.setUp):
(TestGetUpdatedTestExpectations.tearDown):
(TestGetUpdatedTestExpectations.test_success):
(TestGetUpdatedTestExpectations.test_additional_args):
(TestFindModifiedLayoutTests.setUp):
(TestFindModifiedLayoutTests.tearDown):
(TestFindModifiedLayoutTests.test_success):
(TestFindModifiedLayoutTests.test_success_svg):
(TestFindModifiedLayoutTests.test_success_xml):
(TestFindModifiedLayoutTests):
(TestFindModifiedLayoutTests.test_ignore_certain_directories):
(TestFindModifiedLayoutTests.test_ignore_certain_directories_svg):
(TestFindModifiedLayoutTests.test_ignore_certain_directories_xml):
(TestFindModifiedLayoutTests.test_ignore_certain_suffixes):
(TestFindModifiedLayoutTests.test_ignore_non_layout_test_in_html_directory):
(TestFindModifiedLayoutTests.test_non_relevant_patch):
(TestFindModifiedLayoutTests.test_non_accessible_patch):
(TestArchiveBuiltProduct.setUp):
(TestArchiveBuiltProduct.tearDown):
(TestArchiveBuiltProduct.test_success):
(TestArchiveBuiltProduct.test_failure):
(TestArchiveStaticAnalysis.setUp):
(TestArchiveStaticAnalysis.tearDown):
(TestArchiveStaticAnalysis.test_success):
(TestArchiveStaticAnalysis.test_failure):
(TestUploadBuiltProduct.setUp):
(TestUploadBuiltProduct.tearDown):
(TestUploadBuiltProduct):
(TestUploadBuiltProduct.test_success):
(TestUploadBuiltProduct.test_failure):
(TestDownloadBuiltProduct.setUp):
(TestDownloadBuiltProduct.tearDown):
(TestDownloadBuiltProduct):
(TestDownloadBuiltProduct.test_success):
(TestDownloadBuiltProduct.test_failure):
(TestDownloadBuiltProduct.test_deployment_skipped):
(TestDownloadBuiltProductFromMaster.setUp):
(TestDownloadBuiltProductFromMaster.tearDown):
(TestDownloadBuiltProductFromMaster):
(TestDownloadBuiltProductFromMaster.test_success):
(TestDownloadBuiltProductFromMaster.test_failure):
(TestExtractBuiltProduct.setUp):
(TestExtractBuiltProduct.tearDown):
(TestExtractBuiltProduct.test_success):
(TestExtractBuiltProduct.test_failure):
(TestGenerateS3URL.setUp):
(TestGenerateS3URL.tearDown):
(TestGenerateS3URL.configureStep):
(TestGenerateS3URL.disabled_test_success):
(TestGenerateS3URL):
(TestGenerateS3URL.test_failure):
(TestGenerateS3URL.test_failure_with_extension):
(TestGenerateS3URL.test_skipped):
(TestTransferToS3.setUp):
(TestTransferToS3.tearDown):
(TestTransferToS3):
(TestTransferToS3.test_success):
(TestTransferToS3.test_failure):
(TestTransferToS3.test_skipped):
(TestUploadFileToS3.setUp):
(TestUploadFileToS3.tearDown):
(TestUploadFileToS3.configureStep):
(TestUploadFileToS3.test_success):
(TestUploadFileToS3.test_success_content_type):
(TestUploadFileToS3.test_failure):
* Tools/Scripts/webkitpy/autoinstalled/buildbot.py:

Canonical link: <a href="https://commits.webkit.org/302931@main">https://commits.webkit.org/302931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74c0c92ad8d1f45ae0c39c2b26d6fd582577df46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41626 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/82300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/867cc8e3-d7e0-45e4-bb02-0eafe7961c3f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132542 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/2958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/2835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/138094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/82300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133618 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/2958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/117006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/138094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6459c85e-d5a6-4086-81ab-0f6161a8e22f) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/130021 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/2958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/35140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/81348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/2958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/35641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140572 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/2732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/2835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/108058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/130101 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/2776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/113349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/107991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/55725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20346 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/2802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/2622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/2823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/2728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->