### PR TITLE
[webkitcorepy] subprocess_utils.py (run) should have the ability to stream and capture output.

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/subprocess_utils.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/subprocess_utils.py
@@ -21,6 +21,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
+import os
 import subprocess
 import sys
 import time
@@ -35,7 +36,10 @@ CompletedProcess = subprocess.CompletedProcess
 # Allows native integration with the Timeout context
 def run(*popenargs, **kwargs):
     timeout = kwargs.pop('timeout', None)
+    check = kwargs.pop('check', False)
+    input = kwargs.pop('input', None)
     capture_output = kwargs.pop('capture_output', False)
+    capture_and_stream_output = kwargs.pop('capture_and_stream_output', False)
 
     with Timeout.DisableAlarm():
         current_time = time.time()
@@ -44,12 +48,41 @@ def run(*popenargs, **kwargs):
 
         if difference:
             timeout = min(timeout or sys.maxsize, int(math.ceil(difference)))
-        if capture_output:
+        if input is not None:
+            if kwargs.get('stdin') is not None:
+                raise ValueError('stdin and input arguments may not both be used.')
+            kwargs['stdin'] = subprocess.PIPE
+        if capture_output or capture_and_stream_output:
             if ('stdout' in kwargs) or ('stderr' in kwargs):
-                raise ValueError('stdout and stderr arguments may not be used with capture_output.')
+                raise ValueError('stdout and stderr arguments may not be used with capture_output and capture_and_stream_output.')
             kwargs['stdout'] = subprocess.PIPE
-            kwargs['stderr'] = subprocess.PIPE
-        return subprocess.run(*popenargs, timeout=timeout, **kwargs)
+            kwargs['stderr'] = subprocess.STDOUT if capture_and_stream_output else subprocess.PIPE
+
+        # Mimic subprocess.run
+        with subprocess.Popen(*popenargs, **kwargs) as process:
+            output = []
+            stdout = stderr = None
+            try:
+                if capture_and_stream_output:
+                    for line in process.stdout:
+                        sys.stdout.write(line)
+                        output.append(line)
+                stdout, stderr = process.communicate(input, timeout=timeout)
+            except TimeoutExpired as exc:
+                process.kill()
+                if os.name == 'nt':
+                    exc.stdout, exc.stderr = process.communicate()
+                else:
+                    process.wait()
+                raise
+            except:
+                process.kill()
+                raise
+            retcode = process.poll()
+            output_to_use = ''.join(output) or stdout
+            if check and retcode:
+                raise subprocess.CalledProcessError(retcode, process.args, output=output_to_use, stderr=stderr)
+        return CompletedProcess(process.args, retcode, output_to_use, stderr)
 
 
 class Thread(threading.Thread):


### PR DESCRIPTION
#### f95b5b76f87b07c2dafcc7c7655e7c0fdb8e6505
<pre>
[webkitcorepy] subprocess_utils.py (run) should have the ability to stream and capture output.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300938">https://bugs.webkit.org/show_bug.cgi?id=300938</a>
<a href="https://rdar.apple.com/162813867">rdar://162813867</a>

Reviewed by NOBODY (OOPS!).

A deficiency of `subprocess.run` is that it can&apos;t stream output to stdout while
the process is running AND capture that output for use elsewhere. webkitcorepy
has an existing function in subprocess_utils.py (`run`) that wraps
`subprocess.run`. This change adds a new parameter to that function that
streams and captures stdout.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/subprocess_utils.py:
    (run): Add parameter `capture_and_stream_output`, change to using `Popen` instead of `run`.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f95b5b76f87b07c2dafcc7c7655e7c0fdb8e6505

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126724 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96425 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64487 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129672 "Passed tests") | [💥 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/683 "An unexpected error occured. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76950 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/126075 "Passed tests") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31523 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77078 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136258 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53403 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104943 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/126149 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104645 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50138 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28477 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50844 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53330 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52593 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->