### PR TITLE
[LCP] Use ElementRareData to store LCP-related data

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -99,6 +99,7 @@
 #include "KeyboardEvent.h"
 #include "KeyframeAnimationOptions.h"
 #include "KeyframeEffect.h"
+#include "LargestContentfulPaintData.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
@@ -5201,7 +5202,7 @@ IntersectionObserverData& Element::ensureIntersectionObserverData()
     return *rareData.intersectionObserverData();
 }
 
-IntersectionObserverData* Element::intersectionObserverDataIfExists()
+IntersectionObserverData* Element::intersectionObserverDataIfExists() const
 {
     return hasRareData() ? elementRareData()->intersectionObserverData() : nullptr;
 }
@@ -5384,9 +5385,22 @@ ResizeObserverData& Element::ensureResizeObserverData()
     return *rareData.resizeObserverData();
 }
 
-ResizeObserverData* Element::resizeObserverDataIfExists()
+ResizeObserverData* Element::resizeObserverDataIfExists() const
 {
     return hasRareData() ? elementRareData()->resizeObserverData() : nullptr;
+}
+
+ElementLargestContentfulPaintData& Element::ensureLargestContentfulPaintData()
+{
+    auto& rareData = ensureElementRareData();
+    if (!rareData.largestContentfulPaintData())
+        rareData.setLargestContentfulPaintData(makeUnique<ElementLargestContentfulPaintData>());
+    return *rareData.largestContentfulPaintData();
+}
+
+ElementLargestContentfulPaintData* Element::largestContentfulPaintDataIfExists() const
+{
+    return hasRareData() ? elementRareData()->largestContentfulPaintData() : nullptr;
 }
 
 std::optional<LayoutUnit> Element::lastRememberedLogicalWidth() const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -137,6 +137,7 @@ struct GetAnimationsOptions;
 struct GetHTMLOptions;
 struct IntersectionObserverData;
 struct KeyframeAnimationOptions;
+struct ElementLargestContentfulPaintData;
 struct PointerLockOptions;
 struct ResizeObserverData;
 struct ScrollIntoViewOptions;
@@ -859,10 +860,13 @@ public:
     void setAttributeEventListener(const AtomString& eventType, const QualifiedName& attributeName, const AtomString& value);
 
     virtual IntersectionObserverData& ensureIntersectionObserverData();
-    virtual IntersectionObserverData* intersectionObserverDataIfExists();
+    virtual IntersectionObserverData* intersectionObserverDataIfExists() const;
 
     ResizeObserverData& ensureResizeObserverData();
-    ResizeObserverData* resizeObserverDataIfExists();
+    ResizeObserverData* resizeObserverDataIfExists() const;
+
+    ElementLargestContentfulPaintData& ensureLargestContentfulPaintData();
+    ElementLargestContentfulPaintData* largestContentfulPaintDataIfExists() const;
 
     std::optional<LayoutUnit> lastRememberedLogicalWidth() const;
     std::optional<LayoutUnit> lastRememberedLogicalHeight() const;

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -42,8 +42,9 @@ struct SameSizeAsElementRareData : NodeRareData {
     HashMap<std::optional<Style::PseudoElementIdentifier>, AtomString> viewTransitionCapture;
     void* pointers[18];
     void* intersectionObserverData;
-    void* typedOMData[2];
     void* resizeObserverData;
+    void* largestContentfulPaintData;
+    void* typedOMData[2];
     Markable<LayoutUnit> lastRemembedSize[2];
     ExplicitlySetAttrElementsMap explicitlySetAttrElementsMap;
     uint8_t visibilityAdjustment;

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -33,6 +33,7 @@
 #include "FormAssociatedCustomElement.h"
 #include "IntersectionObserver.h"
 #include "KeyframeEffectStack.h"
+#include "LargestContentfulPaintData.h"
 #include "NamedNodeMap.h"
 #include "NodeRareData.h"
 #include "PopoverData.h"
@@ -125,6 +126,9 @@ public:
 
     ResizeObserverData* resizeObserverData() { return m_resizeObserverData.get(); }
     void setResizeObserverData(std::unique_ptr<ResizeObserverData>&& data) { m_resizeObserverData = WTFMove(data); }
+
+    ElementLargestContentfulPaintData* largestContentfulPaintData() { return m_largestContentfulPaintData.get(); }
+    void setLargestContentfulPaintData(std::unique_ptr<ElementLargestContentfulPaintData>&& data) { m_largestContentfulPaintData = WTFMove(data); }
 
     std::optional<LayoutUnit> lastRememberedLogicalWidth() const { return m_lastRememberedLogicalWidth; }
     std::optional<LayoutUnit> lastRememberedLogicalHeight() const { return m_lastRememberedLogicalHeight; }
@@ -246,8 +250,8 @@ private:
     const std::unique_ptr<NamedNodeMap> m_attributeMap;
 
     std::unique_ptr<IntersectionObserverData> m_intersectionObserverData;
-
     std::unique_ptr<ResizeObserverData> m_resizeObserverData;
+    std::unique_ptr<ElementLargestContentfulPaintData> m_largestContentfulPaintData;
 
     Markable<LayoutUnit> m_lastRememberedLogicalWidth;
     Markable<LayoutUnit> m_lastRememberedLogicalHeight;

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -1067,7 +1067,7 @@ IntersectionObserverData& HTMLImageElement::ensureIntersectionObserverData()
     return *m_intersectionObserverData;
 }
 
-IntersectionObserverData* HTMLImageElement::intersectionObserverDataIfExists()
+IntersectionObserverData* HTMLImageElement::intersectionObserverDataIfExists() const
 {
     return m_intersectionObserverData.get();
 }

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -245,7 +245,7 @@ private:
     void setSourceElement(HTMLSourceElement*);
 
     IntersectionObserverData& ensureIntersectionObserverData() final;
-    IntersectionObserverData* intersectionObserverDataIfExists() final;
+    IntersectionObserverData* intersectionObserverDataIfExists() const final;
 
     const std::unique_ptr<HTMLImageLoader> m_imageLoader;
     std::unique_ptr<IntersectionObserverData> m_intersectionObserverData;

--- a/Source/WebCore/page/LargestContentfulPaintData.h
+++ b/Source/WebCore/page/LargestContentfulPaintData.h
@@ -45,6 +45,19 @@ class WeakPtrImplWithEventTargetData;
 
 using DOMHighResTimeStamp = double;
 
+struct PerElementImageData {
+    WeakPtr<CachedImage> image;
+    FloatRect rect;
+    Markable<MonotonicTime> loadTime;
+    bool inContentSet { false };
+};
+
+struct ElementLargestContentfulPaintData {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(ElementLargestContentfulPaintData);
+    FloatRect accumulatedTextRect;
+    Vector<PerElementImageData> imageData;
+};
+
 class LargestContentfulPaintData {
     WTF_MAKE_TZONE_ALLOCATED(LargestContentfulPaintData);
 public:
@@ -71,19 +84,15 @@ private:
 
     void potentiallyAddLargestContentfulPaintEntry(Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intersectionRect, MonotonicTime loadTime, DOMHighResTimeStamp paintTimestamp, std::optional<FloatSize>& viewportSize);
 
+    void scheduleRenderingUpdateIfNecessary(Element&);
+
     float m_largestPaintArea { 0 };
 
-    struct PendingImageData {
-        FloatRect rect;
-        Markable<MonotonicTime> loadTime;
-    };
-
-    WeakHashMap<Element, WeakHashSet<CachedImage>, WeakPtrImplWithEventTargetData> m_imageContentSet;
-    WeakHashMap<Element, WeakHashMap<CachedImage, PendingImageData>, WeakPtrImplWithEventTargetData> m_pendingImageRecords;
-
-    WeakHashMap<Element, FloatRect, WeakPtrImplWithEventTargetData> m_paintedTextRecords;
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_paintedTextRecords;
+    WeakHashMap<Element, Vector<WeakPtr<CachedImage>>, WeakPtrImplWithEventTargetData> m_pendingImageRecords;
 
     RefPtr<LargestContentfulPaint> m_pendingEntry;
+    bool m_haveNewCandidate { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6cbd9be5b0cdb8c19994ec061b24460e70da260e
<pre>
[LCP] Use ElementRareData to store LCP-related data
<a href="https://bugs.webkit.org/show_bug.cgi?id=300945">https://bugs.webkit.org/show_bug.cgi?id=300945</a>
<a href="https://rdar.apple.com/162818522">rdar://162818522</a>

Reviewed by Ryosuke Niwa.

We can save a few weak hash map/set lookups and traversals by storing LCP-related
data in ElementRareData, so make `ElementLargestContentfulPaintData` accessible from
Element just like `ResizeObserverData` and `IntersectionObserverData` (while fixing
their accessors to be const).

LCP for images requires storing data per CachedImage on each element, so use a Vector
to hold per-image data (since there will be few, a HashMap is overkill). Usually,
`didLoadImage` will append data for an image to this vector with `loadTime`, and `didPaintImage`
will annotate it with a rectangle.

A minor optimization is to call `scheduleRenderingUpdate` just once for both new image
and text paints, via the `m_haveNewCandidate` flag.

Tested by WPTs.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::intersectionObserverDataIfExists const):
(WebCore::Element::resizeObserverDataIfExists const):
(WebCore::Element::ensureLargestContentfulPaintData):
(WebCore::Element::largestContentfulPaintDataIfExists const):
(WebCore::Element::intersectionObserverDataIfExists): Deleted.
(WebCore::Element::resizeObserverDataIfExists): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::largestContentfulPaintData):
(WebCore::ElementRareData::setLargestContentfulPaintData):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::intersectionObserverDataIfExists const):
(WebCore::HTMLImageElement::intersectionObserverDataIfExists): Deleted.
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/page/LargestContentfulPaintData.cpp:
(WebCore::LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry):
(WebCore::LargestContentfulPaintData::generateLargestContentfulPaintEntry):
(WebCore::LargestContentfulPaintData::didLoadImage):
(WebCore::LargestContentfulPaintData::didPaintImage):
(WebCore::LargestContentfulPaintData::didPaintText):
(WebCore::LargestContentfulPaintData::scheduleRenderingUpdateIfNecessary):
* Source/WebCore/page/LargestContentfulPaintData.h:

Canonical link: <a href="https://commits.webkit.org/301688@main">https://commits.webkit.org/301688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b067ea1ac44f84362b46d41c9b17cef76cc6c715

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133675 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78359 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/609100b4-a502-4aef-a99c-df0bd3ddd19c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54894 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96427 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e9c541c9-eb74-4da8-9227-fed674a83f39) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76952 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0f1c13c2-5a77-4f98-80af-a8b5ef183938) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31520 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77072 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107412 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136251 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41082 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104644 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26688 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50134 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28475 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50837 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53323 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59124 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52587 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55923 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54331 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->