### PR TITLE
[Site Isolation] Screen Orientation API

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/screen-orientation-rotate-device.html
+++ b/LayoutTests/http/tests/site-isolation/resources/screen-orientation-rotate-device.html
@@ -1,0 +1,25 @@
+<script src="/js-test-resources/ui-helper.js"></script>
+
+<script>
+    (async () => {
+        screen.orientation.onchange = function () {
+            var newScreenOrientationResults = screen.orientation;
+
+            var angleChanged = (originalScreenOrientationResultsAngle != parseInt(newScreenOrientationResults.angle));
+            var typeChanged = (originalScreenOrientationResultType != newScreenOrientationResults.type);
+            if (angleChanged && typeChanged)
+                window.parent.postMessage("Screen Orientation rotation succesful", "*");
+            else
+                window.parent.postMessage("Screen Orientation rotation failed", "*");
+        };
+
+        var originalScreenOrientationResultType = screen.orientation.type;
+        var originalScreenOrientationResultsAngle = parseInt(screen.orientation.angle);
+
+        if (UIHelper.isMac()) {
+            window.parent.postMessage("Screen Orientation: " + originalScreenOrientationResultType + "; Screen Angle: " + originalScreenOrientationResultsAngle, "*");
+        } else {
+            window.parent.postMessage("rotate device", "*");
+        }
+    })();
+</script>

--- a/LayoutTests/http/tests/site-isolation/screen-orientation-api-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/screen-orientation-api-expected.txt
@@ -1,0 +1,10 @@
+Tests screen orientation api readonly attributes and onchange event with site isolation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Screen Orientation rotation succesful
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/screen-orientation-api.html
+++ b/LayoutTests/http/tests/site-isolation/screen-orientation-api.html
@@ -1,0 +1,22 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+
+<script>
+    description("Tests screen orientation api readonly attributes and onchange event with site isolation.");
+    window.jsTestIsAsync = true;
+
+    addEventListener("message", (event) => {
+        if (event.data == "rotate device") {
+            (async () => {
+            await UIHelper.rotateDevice("landscape-right");
+            await UIHelper.ensurePresentationUpdate();
+            })();
+        }
+        else {
+            testPassed(event.data);
+            finishJSTest();
+        }
+    });
+</script>
+<iframe src="http://localhost:8000/site-isolation/resources/screen-orientation-rotate-device.html" id="orientationFrame"></iframe>

--- a/LayoutTests/platform/mac/http/tests/site-isolation/screen-orientation-api-expected.txt
+++ b/LayoutTests/platform/mac/http/tests/site-isolation/screen-orientation-api-expected.txt
@@ -1,0 +1,10 @@
+Tests screen orientation api readonly attributes and onchange event with site isolation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Screen Orientation: landscape-primary; Screen Angle: 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -429,6 +429,7 @@ UIProcess/RemotePageDrawingAreaProxy.cpp
 UIProcess/RemotePageFullscreenManagerProxy.cpp
 UIProcess/RemotePagePlaybackSessionManagerProxy.cpp
 UIProcess/RemotePageProxy.cpp
+UIProcess/RemotePageScreenOrientationManagerProxy.cpp
 UIProcess/RemotePageVideoPresentationManagerProxy.cpp
 UIProcess/ResponsivenessTimer.cpp
 UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -37,6 +37,7 @@
 #include "ProvisionalFrameProxy.h"
 #include "RemotePageDrawingAreaProxy.h"
 #include "RemotePageFullscreenManagerProxy.h"
+#include "RemotePageScreenOrientationManagerProxy.h"
 #include "RemotePageVisitedLinkStoreRegistration.h"
 #include "UserMediaProcessManager.h"
 #include "WebBackForwardList.h"
@@ -48,6 +49,7 @@
 #include "WebProcessActivityState.h"
 #include "WebProcessMessages.h"
 #include "WebProcessProxy.h"
+#include "WebScreenOrientationManagerProxy.h"
 #include <WebCore/MediaProducer.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/RemoteUserInputEventData.h>
@@ -108,6 +110,10 @@ void RemotePageProxy::injectPageIntoNewProcess()
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
     m_playbackSessionManager = RemotePagePlaybackSessionManagerProxy::create(pageID(), page->protectedPlaybackSessionManager().get(), m_process);
 #endif
+
+    if (RefPtr screenOrientationManager = page->screenOrientationManager())
+        m_screenOrientationManager = RemotePageScreenOrientationManagerProxy::create(m_webPageID, screenOrientationManager.get(), m_process);
+
     m_visitedLinkStoreRegistration = makeUnique<RemotePageVisitedLinkStoreRegistration>(*page, m_process);
 
     RefPtr websitePolicies = page->mainFrameWebsitePolicies();
@@ -232,6 +238,16 @@ void RemotePageProxy::setDrawingArea(DrawingAreaProxy* drawingArea)
             })
         ), 0
     );
+}
+
+void RemotePageProxy::setCurrentOrientation(WebCore::ScreenOrientationType orientation)
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    if (RefPtr manager = page->screenOrientationManager())
+        manager->setCurrentOrientation(orientation);
 }
 
 }

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -64,6 +64,7 @@ class NativeWebMouseEvent;
 class RemotePageDrawingAreaProxy;
 class RemotePageFullscreenManagerProxy;
 class RemotePagePlaybackSessionManagerProxy;
+class RemotePageScreenOrientationManagerProxy;
 class RemotePageVideoPresentationManagerProxy;
 class RemotePageVisitedLinkStoreRegistration;
 class UserData;
@@ -71,6 +72,7 @@ class WebFrameProxy;
 class WebPageProxy;
 class WebProcessActivityState;
 class WebProcessProxy;
+class WebScreenOrientationManagerProxy;
 
 struct FrameInfoData;
 struct FrameTreeCreationParameters;
@@ -106,6 +108,8 @@ public:
     WebCore::MediaProducerMediaStateFlags mediaState() const { return m_mediaState; }
     void setDrawingArea(DrawingAreaProxy*);
 
+    void setCurrentOrientation(WebCore::ScreenOrientationType);
+
 private:
     RemotePageProxy(WebPageProxy&, WebProcessProxy&, const WebCore::Site&, WebPageProxyMessageReceiverRegistration*, std::optional<WebCore::PageIdentifier>);
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -130,6 +134,7 @@ private:
     std::unique_ptr<RemotePageVisitedLinkStoreRegistration> m_visitedLinkStoreRegistration;
     WebPageProxyMessageReceiverRegistration m_messageReceiverRegistration;
     WebCore::MediaProducerMediaStateFlags m_mediaState;
+    RefPtr<RemotePageScreenOrientationManagerProxy> m_screenOrientationManager;
 };
 
 }

--- a/Source/WebKit/UIProcess/RemotePageScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageScreenOrientationManagerProxy.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemotePageScreenOrientationManagerProxy.h"
+
+#include "WebProcessProxy.h"
+#include "WebScreenOrientationManagerProxy.h"
+#include "WebScreenOrientationManagerProxyMessages.h"
+
+namespace WebKit {
+
+Ref<RemotePageScreenOrientationManagerProxy> RemotePageScreenOrientationManagerProxy::create(WebCore::PageIdentifier identifier, WebScreenOrientationManagerProxy* manager, WebProcessProxy& process)
+{
+    return adoptRef(*new RemotePageScreenOrientationManagerProxy(identifier, manager, process));
+}
+
+RemotePageScreenOrientationManagerProxy::RemotePageScreenOrientationManagerProxy(WebCore::PageIdentifier identifier, WebScreenOrientationManagerProxy* manager, WebProcessProxy& process)
+    : m_identifier(identifier)
+    , m_manager(manager)
+    , m_process(process)
+{
+    process.addMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_identifier, *this);
+}
+
+RemotePageScreenOrientationManagerProxy::~RemotePageScreenOrientationManagerProxy()
+{
+    m_process->removeMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_identifier);
+}
+
+void RemotePageScreenOrientationManagerProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+{
+    if (RefPtr manager = m_manager.get())
+        manager->didReceiveMessage(connection, decoder);
+}
+
+void RemotePageScreenOrientationManagerProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+{
+    if (RefPtr manager = m_manager.get())
+        manager->didReceiveSyncMessage(connection, decoder, replyEncoder);
+}
+
+}

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -826,6 +826,8 @@ public:
     void setMockVideoPresentationModeEnabled(bool);
 #endif
 
+    WebScreenOrientationManagerProxy* screenOrientationManager() { return m_screenOrientationManager.get(); }
+
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
     void ensureRemoteMediaSessionManagerProxy();
 #endif

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "MessageReceiver.h"
+#include <WebCore/PageIdentifier.h>
 #include <WebCore/ScreenOrientationLockType.h>
 #include <WebCore/ScreenOrientationType.h>
 #include <wtf/CompletionHandler.h>
@@ -38,6 +39,7 @@ class Exception;
 namespace WebKit {
 
 class WebPageProxy;
+class WebProcessProxy;
 struct SharedPreferencesForWebProcess;
 
 class WebScreenOrientationManagerProxy final : public IPC::MessageReceiver, public RefCounted<WebScreenOrientationManagerProxy> {
@@ -58,17 +60,18 @@ public:
     void unlockIfNecessary();
 
     void setCurrentOrientation(WebCore::ScreenOrientationType);
-
-private:
-    WebScreenOrientationManagerProxy(WebPageProxy&, WebCore::ScreenOrientationType);
-
-    std::optional<WebCore::Exception> platformShouldRejectLockRequest() const;
+    WebCore::ScreenOrientationType currentOrientationType() const { return m_currentOrientation; }
 
     // IPC message handlers.
     void currentOrientation(CompletionHandler<void(WebCore::ScreenOrientationType)>&&);
     void lock(WebCore::ScreenOrientationLockType, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
     void unlock();
     void setShouldSendChangeNotification(bool);
+
+private:
+    WebScreenOrientationManagerProxy(WebPageProxy&, WebCore::ScreenOrientationType);
+
+    std::optional<WebCore::Exception> platformShouldRejectLockRequest() const;
 
     Ref<WebPageProxy> protectedPage() const;
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -632,6 +632,7 @@
 		2984F589164BA095004BC0C6 /* LegacyCustomProtocolManagerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 2984F587164BA095004BC0C6 /* LegacyCustomProtocolManagerMessages.h */; };
 		29AD3093164B4C5D0072DEA9 /* LegacyCustomProtocolManagerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 29AD3092164B4C5D0072DEA9 /* LegacyCustomProtocolManagerProxy.h */; };
 		29CD55AA128E294F00133C85 /* WKAccessibilityWebPageObjectBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 29CD55A8128E294F00133C85 /* WKAccessibilityWebPageObjectBase.h */; };
+		2BBCCE242EB2B3F500FE7E5A /* RemotePageScreenOrientationManagerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BBCCE232EB2B3F500FE7E5A /* RemotePageScreenOrientationManagerProxy.h */; };
 		2D0C56FD229F1DEA00BD33E7 /* DeviceManagementSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D0C56FB229F1DEA00BD33E7 /* DeviceManagementSoftLink.h */; };
 		2D0C56FE229F1DEA00BD33E7 /* DeviceManagementSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D0C56FC229F1DEA00BD33E7 /* DeviceManagementSoftLink.mm */; };
 		2D1087611D2C573E00B85F82 /* LoadParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D10875F1D2C573E00B85F82 /* LoadParameters.h */; };
@@ -4695,6 +4696,8 @@
 		2B1B1C3A2E3A86F400D7D9ED /* UnretainedCallArgsCheckerExpectations */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnretainedCallArgsCheckerExpectations; sourceTree = "<group>"; };
 		2B1B1C3B2E3A86F400D7D9ED /* UnretainedLambdaCapturesCheckerExpectations */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnretainedLambdaCapturesCheckerExpectations; sourceTree = "<group>"; };
 		2B1B1C3C2E3A86F400D7D9ED /* UnretainedLocalVarsCheckerExpectations */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnretainedLocalVarsCheckerExpectations; sourceTree = "<group>"; };
+		2BBCCE222EB2B3DA00FE7E5A /* RemotePageScreenOrientationManagerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemotePageScreenOrientationManagerProxy.cpp; sourceTree = "<group>"; };
+		2BBCCE232EB2B3F500FE7E5A /* RemotePageScreenOrientationManagerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemotePageScreenOrientationManagerProxy.h; sourceTree = "<group>"; };
 		2D0035221BC7414800DA8716 /* PDFPlugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PDFPlugin.h; path = PDF/PDFPlugin.h; sourceTree = "<group>"; };
 		2D0035231BC7414800DA8716 /* PDFPlugin.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = PDFPlugin.mm; path = PDF/PDFPlugin.mm; sourceTree = "<group>"; };
 		2D0440922D58810D00E98A2E /* RemoteImageBufferSetConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteImageBufferSetConfiguration.h; sourceTree = "<group>"; };
@@ -15257,6 +15260,8 @@
 				FA4EFC4E2E024493005DADAF /* RemotePagePlaybackSessionManagerProxy.h */,
 				5C907E9A294D507100B3402D /* RemotePageProxy.cpp */,
 				5C907E99294D507100B3402D /* RemotePageProxy.h */,
+				2BBCCE222EB2B3DA00FE7E5A /* RemotePageScreenOrientationManagerProxy.cpp */,
+				2BBCCE232EB2B3F500FE7E5A /* RemotePageScreenOrientationManagerProxy.h */,
 				FA1A7DE52E012DB3005E394B /* RemotePageVideoPresentationManagerProxy.cpp */,
 				FA1A7DE42E012DB3005E394B /* RemotePageVideoPresentationManagerProxy.h */,
 				5CEB40A22A534EE100563C91 /* RemotePageVisitedLinkStoreRegistration.h */,
@@ -18061,6 +18066,7 @@
 				1AC1338618590C4600F3EC05 /* RemoteObjectRegistryMessages.h in Headers */,
 				71C9ECA12CF9FB7100B8AF06 /* RemoteProgressBasedTimeline.h in Headers */,
 				71722EB22EA919E9004218E6 /* RemoteProgressBasedTimelineRegistry.h in Headers */,
+				2BBCCE242EB2B3F500FE7E5A /* RemotePageScreenOrientationManagerProxy.h in Headers */,
 				46088A00261FA8BC00E2500D /* RemoteRenderingBackend.h in Headers */,
 				F4517D7C26FBCD39004C8475 /* RemoteRenderingBackendMessages.h in Headers */,
 				0F594790187B3B3A00437857 /* RemoteScrollingCoordinator.h in Headers */,


### PR DESCRIPTION
#### de041ea9a3c3d4078c606f83b0f52dae426e5e4e
<pre>
[Site Isolation] Screen Orientation API
<a href="https://bugs.webkit.org/show_bug.cgi?id=300948">https://bugs.webkit.org/show_bug.cgi?id=300948</a>
<a href="https://rdar.apple.com/156027815">rdar://156027815</a>

Reviewed by Sihui Liu.

Create test to verify screen orientation API in site isolation mode.

On iOS platform we test the readonly attributes along with on change events.

The on change event does not fire on the Mac as we seem to be always in landscape-primary mode.

The lock() and unlock() methods cannot be tested at this time due to underlying issues outside of site isolation.

* LayoutTests/http/tests/site-isolation/resources/screen-orientation-rotate-device.html: Added.
* LayoutTests/http/tests/site-isolation/screen-orientation-api-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/screen-orientation-api.html: Added.
* LayoutTests/platform/mac/http/tests/site-isolation/screen-orientation-api-expected.txt: Added.
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteMonotonicTimeline.cpp:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::injectPageIntoNewProcess):
(WebKit::RemotePageProxy::setCurrentOrientation):
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/RemotePageScreenOrientationManagerProxy.cpp: Added.
(WebKit::RemotePageScreenOrientationManagerProxy::create):
(WebKit::RemotePageScreenOrientationManagerProxy::RemotePageScreenOrientationManagerProxy):
(WebKit::RemotePageScreenOrientationManagerProxy::~RemotePageScreenOrientationManagerProxy):
(WebKit::RemotePageScreenOrientationManagerProxy::didReceiveMessage):
(WebKit::RemotePageScreenOrientationManagerProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/RemotePageScreenOrientationManagerProxy.h: Copied from Source/WebKit/UIProcess/RemoteLayerTree/RemoteMonotonicTimeline.cpp.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy):
(WebKit::WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy):
(WebKit::WebScreenOrientationManagerProxy::setCurrentOrientation):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::setDeviceOrientation):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/302333@main">https://commits.webkit.org/302333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f13511f69b63f0e2bea449006c47708c753019ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136154 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80147 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a9e7ec7b-6e3e-4c92-a63e-15c04f4c1535) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98031 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/20378e80-e764-433a-b892-0566785a065e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78639 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c3bdbdb5-1f9b-4ee1-9ae0-4a101515ab17) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33470 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79434 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138613 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/846 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/826 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106572 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106379 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27088 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/689 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30225 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53261 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/915 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64203 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/765 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/822 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/857 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->