### PR TITLE
REGRESSION(301011@main): YouTube vidoes start black, or are black after an ad

### DIFF
--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -70,7 +70,7 @@ public:
     virtual void setIsVisible(bool) = 0;
     virtual void setPresentationSize(const IntSize&) = 0;
     virtual void setShouldMaintainAspectRatio(bool) { }
-    virtual void acceleratedRenderingStateChanged(bool) { }
+    virtual void renderingCanBeAcceleratedChanged(bool) { }
     virtual void contentBoxRectChanged(const LayoutRect&) { }
     virtual void notifyFirstFrameAvailable(Function<void()>&&) { }
     virtual void notifyWhenHasAvailableVideoFrame(Function<void(const MediaTime&, double)>&&) { }

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -121,7 +121,7 @@ public:
     void setIsVisible(bool);
     void setPresentationSize(const IntSize&) final;
     void setShouldMaintainAspectRatio(bool) final;
-    void acceleratedRenderingStateChanged(bool) final;
+    void renderingCanBeAcceleratedChanged(bool) final;
     void contentBoxRectChanged(const LayoutRect&) final;
     void notifyFirstFrameAvailable(Function<void()>&&) final;
     void notifyWhenHasAvailableVideoFrame(Function<void(const MediaTime&, double)>&&) final;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -698,7 +698,7 @@ void AudioVideoRendererAVFObjC::setShouldMaintainAspectRatio(bool shouldMaintain
     [CATransaction commit];
 }
 
-void AudioVideoRendererAVFObjC::acceleratedRenderingStateChanged(bool isAccelerated)
+void AudioVideoRendererAVFObjC::renderingCanBeAcceleratedChanged(bool isAccelerated)
 {
     m_renderingCanBeAccelerated = isAccelerated;
     if (isAccelerated)
@@ -1083,7 +1083,7 @@ bool AudioVideoRendererAVFObjC::shouldEnsureLayerOrVideoRenderer() const
     if (!canUseDecompressionSession())
         return true;
 
-    return ((m_sampleBufferDisplayLayer && !CGRectIsEmpty([m_sampleBufferDisplayLayer bounds])) || (!m_presentationSize.isEmpty() && m_renderingCanBeAccelerated));
+    return m_renderingCanBeAccelerated;
 }
 
 WebSampleBufferVideoRendering *AudioVideoRendererAVFObjC::layerOrVideoRenderer() const

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -287,7 +287,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::load(const URL&, const LoadOptions& o
     m_loadOptions = options;
     m_renderer->setPreferences(options.videoRendererPreferences);
     if (RefPtr player = m_player.get())
-        m_renderer->acceleratedRenderingStateChanged(player->renderingCanBeAccelerated());
+        m_renderer->renderingCanBeAcceleratedChanged(player->renderingCanBeAccelerated());
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::setResourceOwner(const ProcessIdentity& resourceOwner)
@@ -798,7 +798,7 @@ Ref<AudioVideoRenderer> MediaPlayerPrivateMediaSourceAVFObjC::audioVideoRenderer
 void MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged()
 {
     RefPtr player = m_player.get();
-    m_renderer->acceleratedRenderingStateChanged(player ? player->renderingCanBeAccelerated() : false);
+    m_renderer->renderingCanBeAcceleratedChanged(player ? player->renderingCanBeAccelerated() : false);
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::notifyActiveSourceBuffersChanged()

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -171,7 +171,7 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
         }
     });
 
-    m_renderer->acceleratedRenderingStateChanged(player->renderingCanBeAccelerated());
+    m_renderer->renderingCanBeAcceleratedChanged(player->renderingCanBeAccelerated());
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     m_defaultSpatialTrackingLabel = player->defaultSpatialTrackingLabel();
@@ -840,7 +840,7 @@ void MediaPlayerPrivateWebM::setPresentationSize(const IntSize& newSize)
 void MediaPlayerPrivateWebM::acceleratedRenderingStateChanged()
 {
     RefPtr player = m_player.get();
-    m_renderer->acceleratedRenderingStateChanged(player ? player->renderingCanBeAccelerated() : false);
+    m_renderer->renderingCanBeAcceleratedChanged(player ? player->renderingCanBeAccelerated() : false);
 }
 
 RetainPtr<PlatformLayer> MediaPlayerPrivateWebM::createVideoFullscreenLayer()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -410,10 +410,10 @@ void RemoteAudioVideoRendererProxyManager::setShouldMaintainAspectRatio(RemoteAu
         renderer->setShouldMaintainAspectRatio(maintain);
 }
 
-void RemoteAudioVideoRendererProxyManager::acceleratedRenderingStateChanged(RemoteAudioVideoRendererIdentifier identifier, bool renderingIsAccelerated)
+void RemoteAudioVideoRendererProxyManager::renderingCanBeAcceleratedChanged(RemoteAudioVideoRendererIdentifier identifier, bool renderingIsAccelerated)
 {
     if (RefPtr renderer = rendererFor(identifier))
-        renderer->acceleratedRenderingStateChanged(renderingIsAccelerated);
+        renderer->renderingCanBeAcceleratedChanged(renderingIsAccelerated);
 }
 
 void RemoteAudioVideoRendererProxyManager::contentBoxRectChanged(RemoteAudioVideoRendererIdentifier identifier, const WebCore::LayoutRect& rect)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -128,7 +128,7 @@ private:
     void setIsVisible(RemoteAudioVideoRendererIdentifier, bool);
     void setPresentationSize(RemoteAudioVideoRendererIdentifier, const WebCore::IntSize&);
     void setShouldMaintainAspectRatio(RemoteAudioVideoRendererIdentifier, bool);
-    void acceleratedRenderingStateChanged(RemoteAudioVideoRendererIdentifier, bool);
+    void renderingCanBeAcceleratedChanged(RemoteAudioVideoRendererIdentifier, bool);
     void contentBoxRectChanged(RemoteAudioVideoRendererIdentifier, const WebCore::LayoutRect&);
     void notifyWhenHasAvailableVideoFrame(RemoteAudioVideoRendererIdentifier, bool);
     void expectMinimumUpcomingPresentationTime(RemoteAudioVideoRendererIdentifier, const MediaTime&);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -71,7 +71,7 @@ messages -> RemoteAudioVideoRendererProxyManager {
     SetIsVisible(WebKit::RemoteAudioVideoRendererIdentifier identifier, bool isVisible)
     SetPresentationSize(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::IntSize size)
     SetShouldMaintainAspectRatio(WebKit::RemoteAudioVideoRendererIdentifier identifier, bool maintain)
-    AcceleratedRenderingStateChanged(WebKit::RemoteAudioVideoRendererIdentifier identifier, bool accelerated)
+    RenderingCanBeAcceleratedChanged(WebKit::RemoteAudioVideoRendererIdentifier identifier, bool accelerated)
     ContentBoxRectChanged(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::LayoutRect boxRect)
     NotifyWhenHasAvailableVideoFrame(WebKit::RemoteAudioVideoRendererIdentifier identifier, bool notify)
     ExpectMinimumUpcomingPresentationTime(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime expected)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -185,13 +185,13 @@ void AudioVideoRendererRemote::setShouldMaintainAspectRatio(bool maintain)
     gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::SetShouldMaintainAspectRatio(m_identifier, maintain), 0);
 }
 
-void AudioVideoRendererRemote::acceleratedRenderingStateChanged(bool acceleratedRendering)
+void AudioVideoRendererRemote::renderingCanBeAcceleratedChanged(bool acceleratedRendering)
 {
     RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
     if (!isGPURunning() || !gpuProcessConnection)
         return;
 
-    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::AcceleratedRenderingStateChanged(m_identifier, acceleratedRendering), 0);
+    gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::RenderingCanBeAcceleratedChanged(m_identifier, acceleratedRendering), 0);
 }
 
 void AudioVideoRendererRemote::contentBoxRectChanged(const LayoutRect& rect)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -113,7 +113,7 @@ private:
     void setIsVisible(bool) final;
     void setPresentationSize(const WebCore::IntSize&) final;
     void setShouldMaintainAspectRatio(bool) final;
-    void acceleratedRenderingStateChanged(bool) final;
+    void renderingCanBeAcceleratedChanged(bool) final;
     void contentBoxRectChanged(const WebCore::LayoutRect&) final;
     void notifyFirstFrameAvailable(Function<void()>&&) final;
     void notifyWhenHasAvailableVideoFrame(Function<void(const MediaTime&, double)>&&) final;


### PR DESCRIPTION
#### 9cc81c236089a08e268a9b6e6778766744cb3606
<pre>
REGRESSION(301011@main): YouTube vidoes start black, or are black after an ad
<a href="https://bugs.webkit.org/show_bug.cgi?id=300949">https://bugs.webkit.org/show_bug.cgi?id=300949</a>
<a href="https://rdar.apple.com/162654138">rdar://162654138</a>

Reviewed by Youenn Fablet.

The AudioVideoRendererAVFObjC was using the original MediaPlayerPrivateWebM
logic to determine when a video layer had to be created: which occured when
both presentationSize was not empty and renderingCanBeAccelerated set to true.
The original MediaPlayerPrivateMediaSourceAVFObjC however only relied on
renderingCanBeAccelerated becoming true.
YouTube when displaying an ad re-use the existing HTMLMediaElement as change
the source attribute, only once the video resume to set the same HTMLMediaElement&apos;s
src to a new MediaSource. When this happened MediaPlayer::setPresentationSize
isn&apos;t always called (it&apos;s racy and depends in the order in which the layer
code has rendered elements).
If setPresentationSize wasn&apos;t called on the new MediaPlayer, we would not
create the AVSBDL.
Resizing the page or going into fullscreen would force setPresentationSize
to be called and the AVSBDL would then be created. This explained the behaviour
described.
That same issue would have existed with the MediaPlayerPrivateWebM for years
but luckily it was never used that way.

We revert to the original MediaPlayerPrivateMediaSourceAVFObjC logic on
creating the AVSBDL as soon as the renderingCanBeAccelerated returns true.

We rename AudioVideoRenderer::acceleratedRenderingStateChanged method to
renderingCanBeAcceleratedChanged as it&apos;s more indicative on when that method
is called.

Manually tested. Couldn&apos;t reproduce the issue through a simple test page.
Test will be added in webkit.org/b/300973

* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
(WebCore::VideoInterface::renderingCanBeAcceleratedChanged):
(WebCore::VideoInterface::acceleratedRenderingStateChanged): Deleted.
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::renderingCanBeAcceleratedChanged):
(WebCore::AudioVideoRendererAVFObjC::shouldEnsureLayerOrVideoRenderer const):
(WebCore::AudioVideoRendererAVFObjC::acceleratedRenderingStateChanged): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::acceleratedRenderingStateChanged):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::renderingCanBeAcceleratedChanged):
(WebKit::RemoteAudioVideoRendererProxyManager::acceleratedRenderingStateChanged): Deleted.
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::renderingCanBeAcceleratedChanged):
(WebKit::AudioVideoRendererRemote::acceleratedRenderingStateChanged): Deleted.
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:

Canonical link: <a href="https://commits.webkit.org/301743@main">https://commits.webkit.org/301743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16f964334d5c0e67220c31b32bc17570417f1a31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78413 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/03dd6929-00a5-4856-a937-232b68c12e9f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96483 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64516 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7373b80b-395c-44e5-80cc-f54ee111faaa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77003 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5d1d7c76-3014-429d-80c3-b82a9bcdffeb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36533 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31593 "Found 1 new test failure: media/media-source/media-source-seek-back-after-ended.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77137 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107476 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136323 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104994 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104699 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26721 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50199 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28541 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Skipped layout-tests; 11 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50927 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59199 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52653 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55987 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->