### PR TITLE
REGRESSION (295783@main): [iOS] Caret rect in fixed-position containers may appear in the wrong place when the page's scroll offset is very large

### DIFF
--- a/LayoutTests/editing/selection/ios/caret-rect-inside-scrollable-fixed-container-expected.txt
+++ b/LayoutTests/editing/selection/ios/caret-rect-inside-scrollable-fixed-container-expected.txt
@@ -1,0 +1,11 @@
+Verifies that when the scroll offset is extremely large, the caret rect for a focused text field inside a fixed container is positioned inside the text field
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS UIHelper.rectContainsOtherRect(textFieldRect, caretRect) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/editing/selection/ios/caret-rect-inside-scrollable-fixed-container.html
+++ b/LayoutTests/editing/selection/ios/caret-rect-inside-scrollable-fixed-container.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=false AsyncOverflowScrollingEnabled=true focusStartsInputSessionPolicy=allow ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <style>
+        body, html {
+            margin: 0;
+            width: 100%;
+            height: 100%;
+        }
+
+        .tall, .very-tall {
+            width: 1px;
+        }
+
+        .tall {
+            height: 500px;
+        }
+
+        .very-tall {
+            height: 21000px;
+        }
+
+        .fixed {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: lightgray;
+            z-index: 100;
+            overflow-y: scroll;
+        }
+
+        .centered {
+            text-align: center;
+        }
+
+        input {
+            width: 200px;
+            height: 44px;
+            font-size: 18px;
+            outline: none;
+            padding: 6px;
+            text-align: center;
+        }
+    </style>
+    <script>
+        jsTestIsAsync = true;
+
+        addEventListener("load", async () => {
+            description("Verifies that when the scroll offset is extremely large, the caret rect for a focused text field inside a fixed container is positioned inside the text field");
+            await UIHelper.setHardwareKeyboardAttached(false);
+            await UIHelper.renderingUpdate();
+            scrollTo(0, 20000);
+
+            textField = document.querySelector("input");
+            textField.focus();
+            await UIHelper.waitForKeyboardToShow();
+            await UIHelper.ensurePresentationUpdate();
+
+            caretRect = await UIHelper.getUICaretViewRect();
+            caretRect.top -= pageYOffset;
+            textFieldRect = textField.getBoundingClientRect();
+
+            shouldBeTrue("UIHelper.rectContainsOtherRect(textFieldRect, caretRect)");
+
+            textField.blur();
+            await UIHelper.waitForKeyboardToHide();
+
+            finishJSTest();
+        });
+    </script>
+</head>
+<body>
+    <div class="very-tall"></div>
+    <div class="fixed">
+        <div class="tall"></div>
+        <div class="centered"><input /></div>
+        <div class="tall"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -311,9 +311,9 @@ inline FloatPoint toFloatPoint(const FloatSize& a)
     return FloatPoint(a.width(), a.height());
 }
 
-inline bool areEssentiallyEqual(const FloatPoint& a, const FloatPoint& b, float epsilon = std::numeric_limits<float>::epsilon())
+inline bool areEssentiallyEqual(const FloatPoint& a, const FloatPoint& b)
 {
-    return WTF::areEssentiallyEqual(a.x(), b.x(), epsilon) && WTF::areEssentiallyEqual(a.y(), b.y(), epsilon);
+    return WTF::areEssentiallyEqual(a.x(), b.x()) && WTF::areEssentiallyEqual(a.y(), b.y());
 }
 
 inline void add(Hasher& hasher, const FloatPoint& point)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5124,8 +5124,18 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
     auto scrollPosition = shouldIgnoreScrollPositionUpdate(visibleContentRectUpdateInfo.lastLayerTreeTransactionID()) ? frameView.scrollPosition() : roundedIntPoint(unobscuredContentRect.location());
 
     // Computation of layoutViewportRect is done in LayoutUnits which loses some precision, so test with an epsilon.
-    constexpr auto epsilon = 2.0f / kFixedPointDenominator;
-    if (areEssentiallyEqual(unobscuredContentRect.location(), layoutViewportRect.location(), epsilon))
+    // FIXME: The loss of precision when converting floating point values to LayoutUnit does not, by itself, explain
+    // the differences between the `layoutViewportRect` and `unobscuredContentRect`'s locations. While scrolling on iOS,
+    // the absolute differences can sometimes exceed 3px, which is well over this fractional error threshold.
+    // For now, we maintain behavior shipped in iOS 26 by snapping to the unobscured content rect location as long as
+    // the difference is fairly small (~5 px).
+    static constexpr auto maxEpsilon = 5.0;
+    static constexpr auto epsilonRatio = 1.0 / (2 * kFixedPointDenominator);
+    auto unobscuredContentRectLocation = unobscuredContentRect.location();
+    auto epsilonX = std::min(maxEpsilon, epsilonRatio * std::abs(unobscuredContentRectLocation.x()));
+    auto epsilonY = std::min(maxEpsilon, epsilonRatio * std::abs(unobscuredContentRectLocation.y()));
+    auto layoutViewportRectLocation = layoutViewportRect.location();
+    if (std::abs(unobscuredContentRectLocation.x() - layoutViewportRectLocation.x()) <= epsilonX && std::abs(unobscuredContentRectLocation.y() - layoutViewportRectLocation.y()) <= epsilonY)
         layoutViewportRect.setLocation(scrollPosition);
 
     bool pageHasBeenScaledSinceLastLayerTreeCommitThatChangedPageScale = ([&] {


### PR DESCRIPTION
#### 46bfd8e48d3814386f441244ce11ea5651450343
<pre>
REGRESSION (295783@main): [iOS] Caret rect in fixed-position containers may appear in the wrong place when the page&apos;s scroll offset is very large
<a href="https://bugs.webkit.org/show_bug.cgi?id=300952">https://bugs.webkit.org/show_bug.cgi?id=300952</a>
<a href="https://rdar.apple.com/162158640">rdar://162158640</a>

Reviewed by Abrar Rahman Protyasha.

The changes in 295783@main were meant to clamp the `layoutViewportRect`&apos;s position to the
`unobscuredContentRect`&apos;s position, only in the case where the difference between the two positions
is due to rounding errors when converting floating point values to layout units — at most,
`2 / kFixedPointDenominator`.

However, the logic to try and achieve this result uses `WTF::areEssentiallyEqual` with an epsilon of
`2 / kFixedPointDenominator` (roughly 3%). This function interprets the `epsilon` argument as a
maximum _ratio_ of the difference to the first argument (the unobscured content rect&apos;s location)
rather than the maximum absolute difference between the two values.

Thus, during UI-driven scrolling as a result of bringing up the keyboard, differences of ~300 px
between the `unobscuredContentRect` and `layoutViewportRect` when the unobscured content rect&apos;s
scroll position is very large (~10000 px) cause us to incorrectly believe the two rects&apos; positions
are nearly equivalent because the 300 px difference is only 3% of 10000, leading to the layout
viewport being incorrectly shifted upwards.

This breaks hit-testing, caret/selection geometry calculations, and even the node highlight rect
when using Web Inspector to target individual elements.

To fix this, we instead check whether the maximum absolute difference in `x` or `y` is less than or
equal to an `epsilon` that&apos;s clamped at a (fairly small) maximum value of 5 px.

Test: editing/selection/ios/caret-rect-inside-scrollable-fixed-container.html

* LayoutTests/editing/selection/ios/caret-rect-inside-scrollable-fixed-container-expected.txt: Added.
* LayoutTests/editing/selection/ios/caret-rect-inside-scrollable-fixed-container.html: Added.
* Source/WebCore/platform/graphics/FloatPoint.h:
(WebCore::areEssentiallyEqual):

Also remove the optional `epsilon` argument, since `updateVisibleContentRects` was the only call
site that passed in a non-default `epsilon`.

* Source/WebCore/platform/graphics/FloatSize.h:
(WebCore::FloatSize::maxAbsoluteDimension const):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):

Canonical link: <a href="https://commits.webkit.org/301719@main">https://commits.webkit.org/301719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b53756feee67a019d168267468707f8c9a32705d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78375 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96442 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76966 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b99126c4-f31e-4bbd-a02b-22c8fd0cfe5d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31541 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77091 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136275 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104958 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53913 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104661 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26708 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50153 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28492 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50870 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53347 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59145 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52606 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55944 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54355 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->