### PR TITLE
Improve organization of containingBlockLogical*ForPositioned

### DIFF
--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -65,13 +65,10 @@ PositionedLayoutConstraints::PositionedLayoutConstraints(const RenderBox& render
     ASSERT(m_container);
 
     // Compute basic containing block info.
-    auto containingInlineSize = renderer.containingBlockLogicalWidthForPositioned(*m_container, false);
-    if (LogicalBoxAxis::Inline == m_containingAxis)
-        m_containingRange.set(m_container->borderLogicalLeft(), containingInlineSize);
-    else
-        m_containingRange.set(m_container->borderBefore(), renderer.containingBlockLogicalHeightForPositioned(*m_container, false));
-    m_containingInlineSize = containingInlineSize;
-    m_originalContainingRange = m_containingRange;
+    m_originalContainingRange = renderer.containingBlockRangeForPositioned(*m_container, m_physicalAxis);
+    m_containingRange = m_originalContainingRange;
+    m_containingInlineSize = (LogicalBoxAxis::Inline == m_containingAxis) ? m_containingRange.size()
+        : renderer.containingBlockRangeForPositioned(*m_container, oppositeAxis(m_physicalAxis)).size();
 
     // Adjust for scrollable area.
     captureScrollableArea();

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <WebCore/FontBaseline.h>
+#include <WebCore/LayoutRange.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/RenderBoxModelObject.h>
 #include <WebCore/RenderOverflow.h>
@@ -360,8 +361,7 @@ public:
 
     LayoutUnit containingBlockLogicalWidthForContent() const override;
     LayoutUnit containingBlockLogicalHeightForContent(AvailableLogicalHeightType) const;
-    LayoutUnit containingBlockLogicalWidthForPositioned(const RenderBoxModelObject& containingBlock, bool checkForPerpendicularWritingMode = true) const;
-    LayoutUnit containingBlockLogicalHeightForPositioned(const RenderBoxModelObject& containingBlock, bool checkForPerpendicularWritingMode = true) const;
+    LayoutRange containingBlockRangeForPositioned(const RenderBoxModelObject& containingBlock, BoxAxis physicalAxis) const;
     LayoutUnit containingBlockAvailableLineWidth() const;
     LayoutUnit perpendicularContainingBlockLogicalHeight() const;
 

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -443,14 +443,16 @@ template<CSSPropertyID propertyID, typename InsetEdgeApplier, typename NumberAsP
             else
                 containingBlockSize = enclosingClippingBox.contentBoxLogicalWidth();
         } else {
-            if (isVerticalProperty == containingBlock->isHorizontalWritingMode()) {
-                containingBlockSize = box->isOutOfFlowPositioned()
-                    ? box->containingBlockLogicalHeightForPositioned(*containingBlock, false)
-                    : box->containingBlockLogicalHeightForContent(AvailableLogicalHeightType::ExcludeMarginBorderPadding);
+            if (box->isOutOfFlowPositioned()) {
+                if (isVerticalProperty)
+                    containingBlockSize = box->containingBlockRangeForPositioned(*containingBlock, BoxAxis::Vertical).size();
+                else
+                    containingBlockSize = box->containingBlockRangeForPositioned(*containingBlock, BoxAxis::Horizontal).size();
             } else {
-                containingBlockSize = box->isOutOfFlowPositioned()
-                    ? box->containingBlockLogicalWidthForPositioned(*containingBlock, false)
-                    : box->containingBlockLogicalWidthForContent();
+                if (isVerticalProperty == containingBlock->isHorizontalWritingMode())
+                    containingBlockSize = box->containingBlockLogicalHeightForContent(AvailableLogicalHeightType::ExcludeMarginBorderPadding);
+                else
+                    containingBlockSize = box->containingBlockLogicalWidthForContent();
             }
         }
         return numberAsPixelsApplier(Style::evaluate<LayoutUnit>(inset, containingBlockSize, Style::ZoomNeeded { }));


### PR DESCRIPTION
#### 2db1d7c644330c2d354ec8a9b567f95238671103
<pre>
Improve organization of containingBlockLogical*ForPositioned
<a href="https://bugs.webkit.org/show_bug.cgi?id=300956">https://bugs.webkit.org/show_bug.cgi?id=300956</a>
<a href="https://rdar.apple.com/162833177">rdar://162833177</a>

Reviewed by Alan Baradlay.

Merges RenderBox::containingBlockLogicalWidthForPositioned() and
RenderBox::containingBlockLogicalHeightForPositioned() so that any differences
in logic between the two can be obvious. Takes the opportunity to organize their
internals better, too.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::containingBlockRangeForPositioned const):
(WebCore::RenderBox::containingBlockLogicalWidthForPositioned const): Deleted.
(WebCore::RenderBox::containingBlockLogicalHeightForPositioned const): Deleted.
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::extractZoomAdjustedInset):

Canonical link: <a href="https://commits.webkit.org/301900@main">https://commits.webkit.org/301900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/598d6f3ada1fa86688f53be3775005dddbc5d8d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78758 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b37aa767-5d79-4d16-9879-b7f023a5553d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96809 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64857 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a2b8aa04-224f-422a-ac28-884112492049) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77313 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/367442fe-792b-4f1e-8e32-a26de3ab75de) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32089 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77647 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107861 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136750 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105330 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105016 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/26814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50543 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29005 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51425 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53799 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59886 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53031 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56444 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54792 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->