### PR TITLE
[Cocoa] More CaptionUserPreferencesMediaAF API tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
@@ -27,9 +27,11 @@
 
 #import <CoreFoundation/CoreFoundation.h>
 #import <WebCore/CaptionUserPreferencesMediaAF.h>
-#import <WebCore/MediaAccessibilitySoftLink.h>
+#import <WebCore/Color.h>
 #import <WebCore/PageGroup.h>
 #import "SoftLinkShim.h"
+
+#import <WebCore/MediaAccessibilitySoftLink.h>
 
 namespace TestWebKitAPI {
 
@@ -47,6 +49,12 @@ static RetainPtr<resultType> functionName##Result; \
 
 #define DOMAIN_AND_BEHAVIOR MACaptionAppearanceDomain, MACaptionAppearanceBehavior*
 
+#define SOFT_LINK_SHIM_SET_RESULT(functionName, defaultValue) \
+MediaAccessibilityShim::functionName##Result = defaultValue; \
+
+#define SOFT_LINK_SHIM_DEFINE_RESULT(functionName, resultType) \
+resultType MediaAccessibilityShim::functionName##Result; \
+
 class MediaAccessibilityShim {
 public:
     SOFT_LINK_SHIM(MediaAccessibility, MACaptionAppearanceGetDisplayType, MACaptionAppearanceDisplayType, MACaptionAppearanceDomain);
@@ -62,27 +70,43 @@ public:
     SOFT_LINK_SHIM_CF_COPY(MediaAccessibility, MACaptionAppearanceCopySelectedLanguages, CFArrayRef, MACaptionAppearanceDomain);
     SOFT_LINK_SHIM_CF_COPY(MediaAccessibility, MACaptionAppearanceCopyPreferredCaptioningMediaCharacteristics, CFArrayRef, MACaptionAppearanceDomain);
     SOFT_LINK_SHIM_CF_COPY(MediaAccessibility, MACaptionAppearanceCopyFontDescriptorWithStrokeForStyle, CTFontDescriptorRef, DOMAIN_AND_BEHAVIOR, MACaptionAppearanceFontStyle, CFStringRef, CGFloat, CGFloat *);
+    SOFT_LINK_SHIM(MediaAccessibility, MACaptionAppearanceGetTextEdgeStyle, MACaptionAppearanceTextEdgeStyle, DOMAIN_AND_BEHAVIOR);
+
+    void resetToDefaultValues()
+    {
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetDisplayType, kMACaptionAppearanceDisplayTypeAutomatic);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyForegroundColor, CGColorGetConstantColor(kCGColorWhite));
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyBackgroundColor, CGColorGetConstantColor(kCGColorBlack));
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyWindowColor, CGColorGetConstantColor(kCGColorClear));
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyFontDescriptorForStyle, adoptCF(CTFontDescriptorCreateWithNameAndSize(CFSTR(".AppleSystemUIFont"), 10)));
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetForegroundOpacity, 1.);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetBackgroundOpacity, 1.);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetWindowOpacity, 1.);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetWindowRoundedCornerRadius, (CGFloat)0.f);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopySelectedLanguages, adoptCF((__bridge CFArrayRef)@[@"English"]));
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyPreferredCaptioningMediaCharacteristics, adoptCF((__bridge CFArrayRef)@[@"MAMediaCharacteristicDescribesMusicAndSoundForAccessibility"]));
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyFontDescriptorWithStrokeForStyle, adoptCF(CTFontDescriptorCreateWithNameAndSize(CFSTR(".AppleSystemUIFont"), 10)));
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetRelativeCharacterSize, (CGFloat)1.f);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetTextEdgeStyle, kMACaptionAppearanceTextEdgeStyleNone);
+    }
+    MediaAccessibilityShim() { resetToDefaultValues(); }
+    ~MediaAccessibilityShim() { resetToDefaultValues(); }
 };
 
-#define SOFT_LINK_SHIM_SET_RESULT(functionName, defaultValue) \
-MediaAccessibilityShim::functionName##Result = defaultValue; \
-
-#define SOFT_LINK_SHIM_DEFAULT_RESULT(functionName, defaultValue) \
-auto MediaAccessibilityShim::functionName##Result { defaultValue }; \
-
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceGetDisplayType, kMACaptionAppearanceDisplayTypeAutomatic);
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceCopyForegroundColor, adoptCF(CGColorGetConstantColor(kCGColorWhite)));
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceCopyBackgroundColor, adoptCF(CGColorGetConstantColor(kCGColorBlack)));
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceCopyWindowColor, adoptCF(CGColorGetConstantColor(kCGColorClear)));
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceCopyFontDescriptorForStyle, adoptCF(CTFontDescriptorCreateWithNameAndSize(CFSTR(".AppleSystemUIFont"), 10)));
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceGetForegroundOpacity, 1.);
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceGetBackgroundOpacity, 1.);
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceGetWindowOpacity, 0.);
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceGetWindowRoundedCornerRadius, (CGFloat)0.f);
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceCopySelectedLanguages, adoptCF((__bridge CFArrayRef)@[@"English"]));
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceCopyPreferredCaptioningMediaCharacteristics, adoptCF((__bridge CFArrayRef)@[@"MAMediaCharacteristicDescribesMusicAndSoundForAccessibility"]));
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceCopyFontDescriptorWithStrokeForStyle, adoptCF(CTFontDescriptorCreateWithNameAndSize(CFSTR(".AppleSystemUIFont"), 10)));
-SOFT_LINK_SHIM_DEFAULT_RESULT(MACaptionAppearanceGetRelativeCharacterSize, (CGFloat)1.f);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceGetDisplayType, MACaptionAppearanceDisplayType);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceCopyForegroundColor, RetainPtr<CGColorRef>);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceCopyBackgroundColor, RetainPtr<CGColorRef>);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceCopyWindowColor, RetainPtr<CGColorRef>);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceGetForegroundOpacity, CGFloat);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceGetBackgroundOpacity, CGFloat);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceGetWindowOpacity, CGFloat);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceGetWindowRoundedCornerRadius, CGFloat);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceGetRelativeCharacterSize, CGFloat);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceCopyFontDescriptorForStyle, RetainPtr<CTFontDescriptorRef>)
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceCopySelectedLanguages, RetainPtr<CFArrayRef>);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceCopyPreferredCaptioningMediaCharacteristics, RetainPtr<CFArrayRef>);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceCopyFontDescriptorWithStrokeForStyle, RetainPtr<CTFontDescriptorRef>);
+SOFT_LINK_SHIM_DEFINE_RESULT(MACaptionAppearanceGetTextEdgeStyle, MACaptionAppearanceTextEdgeStyle);
 
 TEST(CaptionPreferenceTests, ShimTest)
 {
@@ -105,13 +129,85 @@ TEST(CaptionPreferenceTests, FontFace)
     auto preferences = CaptionUserPreferencesMediaAF::create(group);
 
     SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyFontDescriptorForStyle, adoptCF(CTFontDescriptorCreateWithNameAndSize(CFSTR(".AppleSystemUIFontMonospaced-Romulan"), 10)));
-    EXPECT_EQ(preferences->captionsDefaultFontCSS(), "font-family: \"ui-monospace\";"_s);
+    EXPECT_STREQ(preferences->captionsDefaultFontCSS().utf8().data(), "font-family: \"ui-monospace\";");
 
     SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyFontDescriptorForStyle, adoptCF(CTFontDescriptorCreateWithNameAndSize(CFSTR(".AppleSystemUIFont-Klingon"), 10)));
-    EXPECT_EQ(preferences->captionsDefaultFontCSS(), "font-family: \"system-ui\";"_s);
+    EXPECT_STREQ(preferences->captionsDefaultFontCSS().utf8().data(), "font-family: \"system-ui\";");
 
     SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyFontDescriptorForStyle, adoptCF(CTFontDescriptorCreateWithNameAndSize(CFSTR("WingDings"), 10)));
-    EXPECT_EQ(preferences->captionsDefaultFontCSS(), "font-family: \"WingDings\";"_s);
+    EXPECT_STREQ(preferences->captionsDefaultFontCSS().utf8().data(), "font-family: \"WingDings\";");
+}
+
+TEST(CaptionPreferenceTests, FontSize)
+{
+    MediaAccessibilityShim shim;
+
+    PageGroup group { "CaptionPreferenceTests"_s };
+    auto preferences = CaptionUserPreferencesMediaAF::create(group);
+
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetRelativeCharacterSize, 2.f);
+    bool important = false;
+    float fontScale = preferences->captionFontSizeScaleAndImportance(important);
+    EXPECT_EQ(fontScale, 0.10f);
+
+    EXPECT_STREQ(preferences->captionsFontSizeCSS().utf8().data(), "font-size: 10cqmin;");
+}
+
+TEST(CaptionPreferenceTests, Colors)
+{
+    MediaAccessibilityShim shim;
+
+    PageGroup group { "CaptionPreferenceTests"_s };
+    auto preferences = CaptionUserPreferencesMediaAF::create(group);
+
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyForegroundColor, cachedCGColor(Color::red));
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyBackgroundColor, cachedCGColor(Color::blue));
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyWindowColor, cachedCGColor(Color::green));
+
+    EXPECT_STREQ(preferences->captionsTextColorCSS().utf8().data(), "color:#ff0000;");
+    EXPECT_STREQ(preferences->captionsBackgroundCSS().utf8().data(), "background-color:#0000ff;");
+    EXPECT_STREQ(preferences->captionsWindowCSS().utf8().data(), "background-color:#00ff00;");
+
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetForegroundOpacity, 0.75);
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetBackgroundOpacity, 0.5);
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetWindowOpacity, 0.25);
+
+    EXPECT_STREQ(preferences->captionsTextColorCSS().utf8().data(), "color:rgba(255, 0, 0, 0.75);");
+    EXPECT_STREQ(preferences->captionsBackgroundCSS().utf8().data(), "background-color:rgba(0, 0, 255, 0.5);");
+    EXPECT_STREQ(preferences->captionsWindowCSS().utf8().data(), "background-color:rgba(0, 255, 0, 0.25);");
+}
+
+TEST(CaptionPreferenceTests, BorderRadius)
+{
+    MediaAccessibilityShim shim;
+
+    PageGroup group { "CaptionPreferenceTests"_s };
+    auto preferences = CaptionUserPreferencesMediaAF::create(group);
+
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetWindowRoundedCornerRadius, 8.f);
+    EXPECT_STREQ(preferences->windowRoundedCornerRadiusCSS().utf8().data(), "border-radius:8px;padding:2px;");
+}
+
+TEST(CaptionPreferenceTests, TextEdge)
+{
+    MediaAccessibilityShim shim;
+
+    PageGroup group { "CaptionPreferenceTests"_s };
+    auto preferences = CaptionUserPreferencesMediaAF::create(group);
+
+    EXPECT_STREQ(preferences->captionsTextEdgeCSS().utf8().data(), "");
+
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetTextEdgeStyle, kMACaptionAppearanceTextEdgeStyleRaised);
+    EXPECT_STREQ(preferences->captionsTextEdgeCSS().utf8().data(), "text-shadow:-.1em -.1em .16em black;");
+
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetTextEdgeStyle, kMACaptionAppearanceTextEdgeStyleDepressed);
+    EXPECT_STREQ(preferences->captionsTextEdgeCSS().utf8().data(), "text-shadow:.1em .1em .16em black;");
+
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetTextEdgeStyle, kMACaptionAppearanceTextEdgeStyleDropShadow);
+    EXPECT_STREQ(preferences->captionsTextEdgeCSS().utf8().data(), "text-shadow:0 .1em .16em black;stroke-color:black;paint-order:stroke;stroke-linejoin:round;stroke-linecap:round;");
+
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetTextEdgeStyle, kMACaptionAppearanceTextEdgeStyleUniform);
+    EXPECT_STREQ(preferences->captionsTextEdgeCSS().utf8().data(), "stroke-color:black;paint-order:stroke;stroke-linejoin:round;stroke-linecap:round;");
 }
 
 }


### PR DESCRIPTION
#### 0a7522e8ec9d6f25a43c20e18d4bfb03e8e0687a
<pre>
[Cocoa] More CaptionUserPreferencesMediaAF API tests
<a href="https://rdar.apple.com/162834349">rdar://162834349</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300957">https://bugs.webkit.org/show_bug.cgi?id=300957</a>

Reviewed by Youenn Fablet.

Add tests for CaptionUserPreferencesMediaAF by shimming more Media Accessibility
soft linked methods.

* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm:
(TestWebKitAPI::MediaAccessibilityShim::resetToDefaultValues):
(TestWebKitAPI::MediaAccessibilityShim::MediaAccessibilityShim):
(TestWebKitAPI::MediaAccessibilityShim::~MediaAccessibilityShim):
(TestWebKitAPI::TEST(CaptionPreferenceTests, FontFace)):
(TestWebKitAPI::TEST(CaptionPreferenceTests, FontSize)):
(TestWebKitAPI::TEST(CaptionPreferenceTests, Colors)):
(TestWebKitAPI::TEST(CaptionPreferenceTests, BorderRadius)):
(TestWebKitAPI::TEST(CaptionPreferenceTests, TextEdge)):

Canonical link: <a href="https://commits.webkit.org/301724@main">https://commits.webkit.org/301724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e307188dc1dcaeea9714f97aa4e3c2da9710c26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133704 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78380 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96448 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113366 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76972 "Found 2 new API test failures: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak, WPE/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36500 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31551 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77097 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136281 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104966 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104669 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26713 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50159 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28501 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50878 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53353 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52612 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55950 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->