### PR TITLE
Resync `html/semantics/forms/the-textarea-element` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -11712,7 +11712,6 @@
         "web-platform-tests/html/semantics/forms/the-textarea-element/multiline-placeholder-ref.html",
         "web-platform-tests/html/semantics/forms/the-textarea-element/placeholder-white-space-notref.html",
         "web-platform-tests/html/semantics/forms/the-textarea-element/textarea-newline-bidi-ref.html",
-        "web-platform-tests/html/semantics/forms/the-textarea-element/textarea-textLength.html",
         "web-platform-tests/html/semantics/forms/the-textarea-element/wrap-enumerated-ascii-case-insensitive-child.html",
         "web-platform-tests/html/semantics/forms/the-textarea-element/wrap-reflect-1-ref.html",
         "web-platform-tests/html/semantics/grouping-content/the-li-element/grouping-li-reftest-001-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/WEB_FEATURES.yml
@@ -1,0 +1,6 @@
+features:
+- name: constraint-validation
+  files:
+  - textarea-setcustomvalidity.html
+  - textarea-validity-clone.html
+  - textarea-validity-valueMissing-inside-datalist.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/change-to-empty-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/change-to-empty-value-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Change event when clearing a textarea
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/change-to-empty-value.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/change-to-empty-value.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Change event when clearing a textarea</title>
+<link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
+<link rel="author" href="https://mozilla.org" title="Mozilla">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1881457">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<textarea>abc</textarea>
+<script>
+promise_test(async function() {
+  let textarea = document.querySelector("textarea");
+  let changeFired = false;
+  textarea.addEventListener("change", () => {
+    changeFired = true;
+  }, { once: true });
+
+  textarea.focus();
+  assert_equals(document.activeElement, textarea, "Should focus textarea");
+  assert_false(changeFired, "Shouldn't have fired change event after focus");
+  textarea.select();
+  const kBackspaceKey = "\uE003";
+  await test_driver.send_keys(textarea, kBackspaceKey)
+  assert_false(changeFired, "Shouldn't have fired change event after select");
+  textarea.blur();
+  assert_true(changeFired, "Should've have fired change event after blur");
+  assert_equals(textarea.value, "", "Should've have cleared the value");
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/text-area-disconnected-firefox-bug-1933919-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/text-area-disconnected-firefox-bug-1933919-crash.html
@@ -1,0 +1,8 @@
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  b.prepend(a)
+  b.defaultValue = ""
+})
+</script>
+<blockquote id="a"></blockquote>
+<textarea id="b" hidden=""></textarea>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-splittext-with-range-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-splittext-with-range-crash.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script>
+addEventListener("load", () => {
+  const textarea = document.querySelector("textarea");
+  const ul = document.createElement('ul');
+
+  const textNodeInTextarea = document.createTextNode("");
+  textarea.appendChild(textNodeInTextarea);
+  document.documentElement.getBoundingClientRect();
+
+  textarea.appendChild(ul);
+  const range = document.createRange();
+  range.selectNode(ul);
+
+  textNodeInTextarea.data = "ab";
+  textNodeInTextarea.splitText(1);
+});
+</script>
+</head>
+<body><textarea></textarea></body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-splittext-with-range-simple-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-splittext-with-range-simple-crash.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  const textarea = document.querySelector("textarea");
+  getSelection().selectAllChildren(textarea);
+  textarea.firstChild.splitText(0);
+});
+</script>
+</head>
+<body><textarea>abcd</textarea></body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-update-default-value-in-shadow-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-update-default-value-in-shadow-crash.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script>
+"use strict";
+
+const p = document.createElement("p");
+document.documentElement.appendChild(p);
+const shadowRoot = p.attachShadow({mode: "open"});
+const textarea = document.createElement("textarea");
+shadowRoot.appendChild(textarea);
+textarea.defaultValue = "|";
+</script>
+</head>
+<body></body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/w3c-import.log
@@ -14,6 +14,8 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/change-to-empty-value.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/cloning-steps.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/multiline-placeholder-cr-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/multiline-placeholder-cr.html
@@ -25,6 +27,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/placeholder-white-space-notref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/placeholder-white-space.tentative-expected-mismatch.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/placeholder-white-space.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/text-area-disconnected-firefox-bug-1933919-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-maxlength.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-minlength.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-newline-bidi-expected.html
@@ -32,9 +35,13 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-newline-bidi.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-placeholder-lineheight.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-setcustomvalidity.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-splittext-with-range-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-splittext-with-range-simple-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-textLength.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-type.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-update-default-value-in-shadow-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-validity-clone.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-validity-valueMissing-inside-datalist.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/value-defaultValue-textContent-xhtml.xhtml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/value-defaultValue-textContent.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/wrap-enumerated-ascii-case-insensitive-child.html

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/change-to-empty-value-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/change-to-empty-value-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Change event when clearing a textarea assert_true: Should've have fired change event after blur expected true got false
+


### PR DESCRIPTION
#### 8a88cb9edf14869321f29b36541c7e6f278538c0
<pre>
Resync `html/semantics/forms/the-textarea-element` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=300960">https://bugs.webkit.org/show_bug.cgi?id=300960</a>
<a href="https://rdar.apple.com/162836357">rdar://162836357</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/19250d046daa69748ece904fb05c768713e045aa">https://github.com/web-platform-tests/wpt/commit/19250d046daa69748ece904fb05c768713e045aa</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/change-to-empty-value-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/change-to-empty-value.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/text-area-disconnected-firefox-bug-1933919-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-splittext-with-range-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-splittext-with-range-simple-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-update-default-value-in-shadow-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/w3c-import.log:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/change-to-empty-value-expected.txt: Add Platform Specific Expectation

Canonical link: <a href="https://commits.webkit.org/301711@main">https://commits.webkit.org/301711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44264244ed37987ed479154d4fe183fdae9bdc7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133713 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78388 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/16333426-eb82-4694-9662-f7a8ad11fc69) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96454 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a3ad8aff-f535-41ed-ba0b-3c4d10ccb663) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76978 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/26b1ad6b-1e21-4e30-bae3-1c8aad5c07e4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31561 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77106 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136290 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41121 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104968 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104671 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26700 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50170 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28511 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50888 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53363 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52622 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55959 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54371 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->