### PR TITLE
[WebKit][Main+SU] [5188345e949abb3d] ASAN_TRAP | LayoutIntegration::LineLayout::hitTest; WebCore::RenderBlock::hitTestContents; WebCore::RenderBlock::hitTestChildren

### DIFF
--- a/LayoutTests/fast/html/details-hittest-crash-expected.txt
+++ b/LayoutTests/fast/html/details-hittest-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/html/details-hittest-crash.html
+++ b/LayoutTests/fast/html/details-hittest-crash.html
@@ -1,0 +1,29 @@
+<script>
+  testRunner?.dumpAsText();
+
+  let details1 = document.createElement('details');
+  document.documentElement.append(details1);
+
+  details1.append(document.createElement('div'));
+
+  let details2 = document.createElement('details');
+  details1.append(details2);
+
+  let div = document.createElement('div');
+  details1.appendChild(div);
+
+(async () => {
+internals.withUserGesture(() => {});
+
+details2.requestFullscreen();
+
+await (()=>{
+  div.offsetHeight;
+  setTimeout(function() {
+    window.document.caretRangeFromPoint(0);
+  }, 10);
+})()
+
+})();
+</script>
+PASS if no crash.

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2080,8 +2080,11 @@ bool RenderBlock::nodeAtPoint(const HitTestRequest& request, HitTestResult& resu
 
 bool RenderBlock::hitTestContents(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction hitTestAction)
 {
-    if (childrenInline() && !isRenderTable())
+    if (childrenInline() && !isRenderTable()) {
+        if (style().isSkippedRootOrSkippedContent())
+            return false;
         return hitTestInlineChildren(request, result, locationInContainer, accumulatedOffset, hitTestAction);
+    }
 
     // Hit test our children.
     HitTestAction childHitTest = hitTestAction;


### PR DESCRIPTION
#### 8d66f7338e51d5daf2924177daa9888a5395a46e
<pre>
[WebKit][Main+SU] [5188345e949abb3d] ASAN_TRAP | LayoutIntegration::LineLayout::hitTest; WebCore::RenderBlock::hitTestContents; WebCore::RenderBlock::hitTestChildren
<a href="https://bugs.webkit.org/show_bug.cgi?id=300838">https://bugs.webkit.org/show_bug.cgi?id=300838</a>
<a href="https://rdar.apple.com/160119099">rdar://160119099</a>

Reviewed by Alan Baradlay.

Do not hit test when the content is stale, instead indicate the
hit test fails for the RenderBlock.

Test: fast/html/details-hittest-crash.html
* LayoutTests/fast/html/details-hittest-crash-expected.txt: Added.
* LayoutTests/fast/html/details-hittest-crash.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::hitTestContents):

Canonical link: <a href="https://commits.webkit.org/301710@main">https://commits.webkit.org/301710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7081e554e32122056036360c3c93bc73caaa19ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133729 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78403 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96472 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76992 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31578 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77122 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136308 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104983 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104686 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26704 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28526 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50908 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59181 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52640 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55975 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54388 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->