### PR TITLE
[visionOS] `ensurePositionInformationIsUpToDate` is called every time a scroll gesture occurs

### DIFF
--- a/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-expected.txt
+++ b/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-expected.txt
@@ -1,0 +1,16 @@
+ensurePositionInformationIsUpToDate should only be called when a scroll gesture occurs if a model element exists in the page.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was false, expected false
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was false, expected false
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was false, expected false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-frames-expected.txt
+++ b/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-frames-expected.txt
@@ -1,0 +1,18 @@
+
+ensurePositionInformationIsUpToDate should only be called when a scroll gesture occurs if a model element exists in the page, including iframes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was false, expected false
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was false, expected false
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was true, expected true
+PASS didCallEnsurePositionInformationIsUpToDateSinceLastCheck was false, expected false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-frames.html
+++ b/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-frames.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="../resources/js-test.js"></script>
+    <script src="../resources/basic-gestures.js"></script>
+    <script src="../resources/ui-helper.js"></script>
+    <style>
+        html, body {
+            padding: 0;
+            margin: 0;
+        }
+
+        #overflow_container {
+            height: 300px;
+            overflow: scroll;
+            border: 2px solid black;
+        }
+
+        #overflow {
+            background: linear-gradient(180deg, rgba(255, 199, 153, 1) 0%, rgba(255, 0, 102, 1) 100%);
+            height: 600px;
+        }
+    </style>
+</head>
+<script>
+    jsTestIsAsync = true;
+    testRunner.dumpAsText();
+
+    async function scroll() {
+        var fromX = overflow_container.offsetLeft + 50;
+        var fromY = overflow_container.offsetTop + overflow_container.offsetHeight - 5;
+        var toX = fromX;
+        var toY = fromY - 100;
+        await touchAndDragFromPointToPoint(fromX, fromY, toX, toY);
+        await liftUpAtPoint(toX, toY);
+        overflow_container.scrollTop = 0;
+    }
+
+    async function scrollAndCheckIfPositionInformationUpdated(correctValue) {
+        await scroll();
+        didWait = await UIHelper.didCallEnsurePositionInformationIsUpToDateSinceLastCheck();
+        const msg = "didCallEnsurePositionInformationIsUpToDateSinceLastCheck was " + didWait + ", expected " + correctValue;
+        if (didWait == correctValue)
+            testPassed(msg);
+        else
+            testFailed(msg);
+    }
+
+    function sendMessageToFrame(iframe, action, count = 0) {
+        return new Promise((resolve) => {
+            const messageHandler = (event) => {
+                if (event.data.action === action && event.data.completed) {
+                    window.removeEventListener('message', messageHandler);
+                    resolve(event.data);
+                }
+            };
+            window.addEventListener('message', messageHandler);
+            iframe.contentWindow.postMessage({ action, count }, '*');
+        });
+    }
+
+    async function addModelsToFrame(iframe, count) {
+        return await sendMessageToFrame(iframe, 'add', count);
+    }
+
+    async function removeModelsFromFrame(iframe, count) {
+        return await sendMessageToFrame(iframe, 'remove', count);
+    }
+
+    async function clearModelsInFrame(iframe) {
+        return await sendMessageToFrame(iframe, 'clear', 0);
+    }
+
+    async function navigateFrameToEmpty(iframe) {
+        return new Promise((resolve) => {
+            const messageHandler = (event) => {
+                if (event.data.action === 'frameLoaded' && event.data.completed) {
+                    window.removeEventListener('message', messageHandler);
+                    resolve();
+                }
+            };
+            window.addEventListener('message', messageHandler);
+            iframe.contentWindow.postMessage({ action: 'navigate' }, '*');
+        });
+    }
+
+    addEventListener("load", async () => {
+        var modelContainer = document.getElementById("model-container");
+
+        if (window.testRunner) {
+            description(`ensurePositionInformationIsUpToDate should only be called when a scroll gesture occurs if a model
+                element exists in the page, including iframes.`);
+
+            await UIHelper.clearEnsurePositionInformationIsUpToDateTracking();
+
+            modelContainer.innerHTML = "<iframe id='iframe' src='resources/models-frame.html'></iframe>"; // Page now has one model elements.
+            var newFrame = document.createElement("iframe");
+            newFrame.setAttribute("src", "resources/models-frame.html");
+            modelContainer.appendChild(newFrame); // Page now has two model elements.
+            await scrollAndCheckIfPositionInformationUpdated(true);
+            newFrame.remove(); // Page now has one model elements.
+            await scrollAndCheckIfPositionInformationUpdated(true);
+            document.getElementById("iframe").remove(); // Page now has zero model elements.
+            await scrollAndCheckIfPositionInformationUpdated(false);
+
+            newFrame = document.createElement("iframe");
+            newFrame.setAttribute("src", "resources/models-frame.html");
+            newFrame.setAttribute("id", "frame");
+
+            var secondFrame = newFrame.cloneNode(true);
+            var thirdFrame = newFrame.cloneNode(true);
+
+            modelContainer.appendChild(newFrame); // Page now has one model elements.
+            modelContainer.appendChild(secondFrame); // Page now has two model elements.
+            modelContainer.appendChild(thirdFrame); // Page now has three model elements.
+            await scrollAndCheckIfPositionInformationUpdated(true);
+
+            await clearModelsInFrame(newFrame); // Page now has two model elements.
+            await clearModelsInFrame(secondFrame); // Page now has one model elements.
+            await clearModelsInFrame(thirdFrame); // Page now has zero model elements.
+
+            await scrollAndCheckIfPositionInformationUpdated(false);
+
+            await addModelsToFrame(newFrame, 3); // Page now has three model elements.
+            await addModelsToFrame(secondFrame, 3); // Page now has six model elements.
+            await addModelsToFrame(thirdFrame, 3); // Page now has nine model elements.
+            await scrollAndCheckIfPositionInformationUpdated(true);
+            newModel = document.createElement("model");
+            modelContainer.appendChild(newModel); // Page now has ten model elements.
+
+            newFrame.remove() // Page now has seven model elements.
+            await clearModelsInFrame(secondFrame); // Page now has four model elements.
+            newModel.remove(); // Page now has three model elements.
+            await removeModelsFromFrame(thirdFrame, 2); // Page now has one model elements.
+            await scrollAndCheckIfPositionInformationUpdated(true);
+
+            await navigateFrameToEmpty(thirdFrame); // Page now has zero model elements.
+            await scrollAndCheckIfPositionInformationUpdated(false);
+
+            finishJSTest();
+        }
+    });
+</script>
+<body>
+    <div id="overflow_container">
+        <div id="overflow"></div>
+    </div>
+    <div id="model-container">
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-navigation-expected.txt
+++ b/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-navigation-expected.txt
@@ -1,0 +1,10 @@
+ensurePositionInformationIsUpToDate should only be called when a scroll gesture occurs if a model element exists in the page. After navigating from a page with a model element to a page without one and attempting to scroll, ensurePositionInformationIsUpToDate should not be called.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS After navigating from a page with model elements to a page without any and performing the scroll gesture, ensurePositionInformationIsUpToDate was not called.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-navigation.html
+++ b/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-navigation.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="../resources/js-test.js"></script>
+    <script src="../resources/basic-gestures.js"></script>
+    <script src="../resources/ui-helper.js"></script>
+    <style>
+        html, body {
+            padding: 0;
+            margin: 0;
+        }
+
+        #overflow_container {
+            height: 300px;
+            overflow: scroll;
+            border: 2px solid black;
+        }
+
+        #overflow {
+            background: linear-gradient(180deg, rgba(255, 199, 153, 1) 0%, rgba(255, 0, 102, 1) 100%);
+            height: 600px;
+        }
+    </style>
+</head>
+<script>
+    jsTestIsAsync = true;
+    testRunner.dumpAsText();
+
+    async function scroll() {
+        var fromX = overflow_container.offsetLeft + 50;
+        var fromY = overflow_container.offsetTop + overflow_container.offsetHeight - 5;
+        var toX = fromX;
+        var toY = fromY - 100;
+        await touchAndDragFromPointToPoint(fromX, fromY, toX, toY);
+        await liftUpAtPoint(toX, toY);
+        overflow_container.scrollTop = 0;
+    }
+
+    var testPassesSoFar = true;
+
+    async function scrollAndCheckIfPositionInformationUpdated(correctValue) {
+        await scroll();
+        didWait = await UIHelper.didCallEnsurePositionInformationIsUpToDateSinceLastCheck();
+        const msg = "didCallEnsurePositionInformationIsUpToDateSinceLastCheck was " + didWait + ", expected " + correctValue;
+        if (didWait == correctValue)
+            testPassed(msg);
+        else {
+            testFailed(msg);
+            testPassesSoFar = false;
+        }
+    }
+
+    addEventListener("load", async () => {
+        var modelContainer = document.getElementById("model-container");
+
+        var initialScrollPosition = overflow_container.scrollTop;
+
+        if (window.testRunner) {
+            description(`ensurePositionInformationIsUpToDate should only be called when a scroll gesture occurs if a model
+                element exists in the page. After navigating from a page with a model element to a page without one and
+                attempting to scroll, ensurePositionInformationIsUpToDate should not be called.`);
+
+            await UIHelper.clearEnsurePositionInformationIsUpToDateTracking();
+
+            // Page has one model element.
+            await scrollAndCheckIfPositionInformationUpdated(true);
+
+            model.remove(); // Page now has no model elements.
+
+            var newModel = document.createElement("model");
+            modelContainer.innerHTML = "<iframe id='iframe' src='resources/models-frame.html'></iframe>"; // Page now has one model elements.
+            var newFrame = document.createElement("iframe");
+            newFrame.setAttribute("src", "resources/models-frame.html");
+            modelContainer.appendChild(newFrame); // Page now has two model elements.
+            modelContainer.appendChild(newModel); // Page now has three model elements.
+            await scrollAndCheckIfPositionInformationUpdated(true);
+
+            if (testPassesSoFar)
+                window.location.href = 'resources/finish-models-navigation.html';
+            else
+                testRunner.notifyDone();
+        }
+    });
+</script>
+<body>
+    <div id="overflow_container">
+        <div id="overflow"></div>
+    </div>
+    <div id="model-container">
+        <model id="model"></model>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information.html
+++ b/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="../resources/js-test.js"></script>
+    <script src="../resources/basic-gestures.js"></script>
+    <script src="../resources/ui-helper.js"></script>
+    <style>
+        html, body {
+            padding: 0;
+            margin: 0;
+        }
+
+        #overflow_container {
+            height: 300px;
+            overflow: scroll;
+            border: 2px solid black;
+        }
+
+        #overflow {
+            background: linear-gradient(180deg, rgba(255, 199, 153, 1) 0%, rgba(255, 0, 102, 1) 100%);
+            height: 600px;
+        }
+    </style>
+</head>
+<script>
+    jsTestIsAsync = true;
+    testRunner.dumpAsText();
+
+    async function scroll() {
+        var fromX = overflow_container.offsetLeft + 50;
+        var fromY = overflow_container.offsetTop + overflow_container.offsetHeight - 5;
+        var toX = fromX;
+        var toY = fromY - 100;
+        await touchAndDragFromPointToPoint(fromX, fromY, toX, toY);
+        await liftUpAtPoint(toX, toY);
+        overflow_container.scrollTop = 0;
+    }
+
+    async function scrollAndCheckIfPositionInformationUpdated(correctValue) {
+        await scroll();
+        didWait = await UIHelper.didCallEnsurePositionInformationIsUpToDateSinceLastCheck();
+        const msg = "didCallEnsurePositionInformationIsUpToDateSinceLastCheck was " + didWait + ", expected " + correctValue;
+        if (didWait == correctValue)
+            testPassed(msg);
+        else
+            testFailed(msg);
+    }
+
+    addEventListener("load", async () => {
+        var didWait;
+        var modelContainer = document.getElementById("model-container");
+        var editableDivClicked = false;
+        var buttonClicked = false;
+
+        var initialScrollPosition = overflow_container.scrollTop;
+
+        if (window.testRunner) {
+            await UIHelper.clearEnsurePositionInformationIsUpToDateTracking();
+
+            description(`ensurePositionInformationIsUpToDate should only be called when a scroll gesture occurs if a model
+                element exists in the page.`);
+
+            // Page has one model element.
+            await scrollAndCheckIfPositionInformationUpdated(true);
+
+            model.remove(); // Page now has no model elements.
+            await scrollAndCheckIfPositionInformationUpdated(false);
+
+            var newModel = document.createElement("model");
+            modelContainer.appendChild(newModel); // Page now has one model element.
+
+            await scrollAndCheckIfPositionInformationUpdated(true);
+
+            var anotherModel = document.createElement("model");
+            modelContainer.appendChild(anotherModel); // Page now has two model elements.
+            newModel.remove(); // Page now has one model elements.
+            await scrollAndCheckIfPositionInformationUpdated(true);
+
+            anotherModel.remove(); // Page now has zero model elements.
+            await scrollAndCheckIfPositionInformationUpdated(false);
+
+            modelContainer.innerHTML = "<model id='model'></model>" // Page now has one model elements.
+            await scrollAndCheckIfPositionInformationUpdated(true);
+
+            modelContainer.innerHTML = ""; // Page now has zero model elements.
+            await scrollAndCheckIfPositionInformationUpdated(false);
+
+            finishJSTest();
+        }
+    });
+</script>
+<body>
+    <div id="overflow_container">
+        <div id="overflow"></div>
+    </div>
+    <div id="model-container">
+        <model id="model"></model>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/model-element/resources/finish-models-navigation.html
+++ b/LayoutTests/model-element/resources/finish-models-navigation.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/basic-gestures.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        html,
+        body {
+            padding: 0;
+            margin: 0;
+        }
+
+        #overflow_container {
+            height: 300px;
+            overflow: scroll;
+            border: 2px solid black;
+        }
+
+        #overflow {
+            background: linear-gradient(180deg, rgba(255, 199, 153, 1) 0%, rgba(255, 0, 102, 1) 100%);
+            height: 600px;
+        }
+    </style>
+</head>
+<script>
+    jsTestIsAsync = true;
+    testRunner.dumpAsText();
+
+    async function scroll() {
+        var fromX = overflow_container.offsetLeft + 50;
+        var fromY = overflow_container.offsetTop + overflow_container.offsetHeight - 5;
+        var toX = fromX;
+        var toY = fromY - 100;
+        await touchAndDragFromPointToPoint(fromX, fromY, toX, toY);
+        await liftUpAtPoint(toX, toY);
+        overflow_container.scrollTop = 0;
+    }
+
+    async function scrollAndCheckIfPositionInformationUpdated(correctValue) {
+        await scroll();
+        didWait = await UIHelper.didCallEnsurePositionInformationIsUpToDateSinceLastCheck();
+        if (didWait == correctValue)
+            testPassed("After navigating from a page with model elements to a page without any and performing the scroll gesture, ensurePositionInformationIsUpToDate was not called.");
+        else
+            testFailed("After navigating from a page with model elements to a page without any and performing the scroll gesture, ensurePositionInformationIsUpToDate was called but should not have been.");
+    }
+
+    addEventListener("load", async () => {
+        if (window.testRunner) {
+            description(`ensurePositionInformationIsUpToDate should only be called when a scroll gesture occurs if a model
+                element exists in the page. After navigating from a page with a model element to a page without one and
+                attempting to scroll, ensurePositionInformationIsUpToDate should not be called.`);
+
+            await scrollAndCheckIfPositionInformationUpdated(false);
+            finishJSTest();
+        }
+    });
+</script>
+<body>
+    <div id="overflow_container">
+        <div id="overflow"></div>
+    </div>
+    <div id="model-container">
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/model-element/resources/models-frame.html
+++ b/LayoutTests/model-element/resources/models-frame.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <model></model>
+    <script>
+        window.addEventListener('message', (event) => {
+            const { action, count } = event.data;
+            if (action === 'add') {
+                for (let i = 0; i < count; i++)
+                    document.body.appendChild(document.createElement('model'));
+                event.source.postMessage({ action: 'add', count, completed: true }, event.origin);
+            } else if (action === 'remove') {
+                const models = document.querySelectorAll('model');
+                const toRemove = Math.min(count, models.length);
+                for (let i = 0; i < toRemove; i++)
+                    models[i].remove();
+                event.source.postMessage({ action: 'remove', count: toRemove, completed: true }, event.origin);
+            } else if (action === 'clear') {
+                const models = document.querySelectorAll('model');
+                const cleared = models.length;
+                models.forEach(model => model.remove());
+                event.source.postMessage({ action: 'clear', count: cleared, completed: true }, event.origin);
+            } else if (action === 'navigate')
+                window.location.href = 'no-models.html';
+        });
+        window.addEventListener('load', () => {
+            window.parent.postMessage({ action: 'frameLoaded', completed: true }, '*');
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/model-element/resources/no-models.html
+++ b/LayoutTests/model-element/resources/no-models.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+    window.addEventListener('load', () => {
+        window.parent.postMessage({ action: 'frameLoaded', completed: true }, '*');
+    });
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -978,6 +978,33 @@ window.UIHelper = class UIHelper {
         return UIHelper.scrollbarState(scroller, false);
     }
 
+    static didCallEnsurePositionInformationIsUpToDateSinceLastCheck()
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve(false);
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`(function() {
+                uiController.uiScriptComplete(uiController.didCallEnsurePositionInformationIsUpToDateSinceLastCheck);
+            })()`, result => {
+                resolve(result === "true");
+            });
+        });
+    }
+
+    static clearEnsurePositionInformationIsUpToDateTracking()
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`(function() {
+                uiController.clearEnsurePositionInformationIsUpToDateTracking();
+                uiController.uiScriptComplete();
+            })()`, resolve);
+        });
+    }
+
     static getUICaretViewRect()
     {
         if (!this.isWebKit2() || !this.isIOSFamily())

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -1475,6 +1475,9 @@ Node::InsertedIntoAncestorResult HTMLModelElement::insertedIntoAncestor(Insertio
 
     if (insertionType.connectedToDocument) {
         document().registerForVisibilityStateChangedCallbacks(*this);
+#if ENABLE(MODEL_PROCESS)
+        document().incrementModelElementCount();
+#endif
         m_modelPlayerProvider = document().page()->modelPlayerProvider();
         LazyLoadModelObserver::observe(*this);
     }
@@ -1488,6 +1491,9 @@ void HTMLModelElement::removedFromAncestor(RemovalType removalType, ContainerNod
 
     if (removalType.disconnectedFromDocument) {
         document().unregisterForVisibilityStateChangedCallbacks(*this);
+#if ENABLE(MODEL_PROCESS)
+        document().decrementModelElementCount();
+#endif
         LazyLoadModelObserver::unobserve(*this, document());
 
         m_loadModelTimer = nullptr;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1937,6 +1937,12 @@ public:
     LazyLoadModelObserver& lazyLoadModelObserver();
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+    void incrementModelElementCount();
+    void decrementModelElementCount();
+    bool hasModelElement() const { return m_modelElementCount > 0; }
+#endif
+
     ContentVisibilityDocumentState& contentVisibilityDocumentState();
 
     void setHasVisuallyNonEmptyCustomContent() { m_hasVisuallyNonEmptyCustomContent = true; }
@@ -2307,6 +2313,10 @@ private:
     std::unique_ptr<LazyLoadImageObserver> m_lazyLoadImageObserver;
 #if ENABLE(MODEL_ELEMENT)
     std::unique_ptr<LazyLoadModelObserver> m_lazyLoadModelObserver;
+#endif
+
+#if ENABLE(MODEL_PROCESS)
+    unsigned m_modelElementCount { 0 };
 #endif
 
     std::unique_ptr<ContentVisibilityDocumentState> m_contentVisibilityDocumentState;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -293,6 +293,10 @@ public:
     virtual void didFinishLoadingImageForElement(HTMLImageElement&) = 0;
     virtual void didFinishLoadingImageForSVGImage(SVGImageElement&) { }
 
+#if ENABLE(MODEL_PROCESS)
+    virtual void setHasModelElement(bool) { }
+#endif
+
     virtual PlatformPageClient platformPageClient() const = 0;
 
     virtual void setCursor(const Cursor&) = 0;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3075,6 +3075,31 @@ void Page::schedulePlaybackControlsManagerUpdate()
 #endif
 }
 
+#if ENABLE(MODEL_PROCESS)
+
+void Page::incrementModelElementCount()
+{
+    m_modelElementCount++;
+    if (m_modelElementCount == 1)
+        chrome().client().setHasModelElement(true);
+}
+
+void Page::decrementModelElementCount(unsigned count)
+{
+    m_modelElementCount -= count;
+    if (!m_modelElementCount) {
+        chrome().client().setHasModelElement(false);
+        return;
+    }
+
+    if (m_modelElementCount < 0) [[unlikely]] {
+        m_modelElementCount = 0;
+        ASSERT_NOT_REACHED();
+    }
+}
+
+#endif
+
 #if ENABLE(VIDEO)
 
 RefPtr<HTMLMediaElement> Page::bestMediaElementForRemoteControls(MediaElementSession::PlaybackControlsPurpose purpose, Document* document)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1046,6 +1046,11 @@ public:
     WEBCORE_EXPORT void voiceActivityDetected();
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+    void incrementModelElementCount();
+    void decrementModelElementCount(unsigned);
+#endif
+
     std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const;
     WEBCORE_EXPORT bool mediaPlaybackExists();
     WEBCORE_EXPORT bool mediaPlaybackIsPaused();
@@ -1655,6 +1660,10 @@ private:
 
 #if ENABLE(VIDEO)
     Timer m_playbackControlsManagerUpdateTimer;
+#endif
+
+#if ENABLE(MODEL_PROCESS)
+    unsigned m_modelElementCount { 0 };
 #endif
 
     bool m_allowsMediaDocumentInlinePlayback { false };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -742,6 +742,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)didStartFormControlInteraction WK_API_AVAILABLE(ios(10.3));
 - (void)didEndFormControlInteraction WK_API_AVAILABLE(ios(10.3));
 
+- (void)didEnsurePositionInformationIsUpToDate WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 - (void)_beginInteractiveObscuredInsetsChange;
 - (void)_endInteractiveObscuredInsetsChange;
 - (void)_hideContentUntilNextUpdate;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4554,6 +4554,11 @@ static bool isLockdownModeWarningNeeded()
     // For subclasses to override.
 }
 
+- (void)didEnsurePositionInformationIsUpToDate
+{
+    // For subclasses to override.
+}
+
 - (void)_beginInteractiveObscuredInsetsChange
 {
     ASSERT(!_isChangingObscuredInsetsInteractively);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9327,6 +9327,13 @@ void WebPageProxy::setHasActiveAnimatedScrolls(bool isRunning)
 #endif
 }
 
+#if ENABLE(MODEL_PROCESS)
+void WebPageProxy::setHasModelElement(bool hasModelElement)
+{
+    m_hasModelElement = hasModelElement;
+}
+#endif
+
 void WebPageProxy::runOpenPanel(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, const FileChooserSettings& settings)
 {
     if (RefPtr openPanelResultListener = std::exchange(m_openPanelResultListener, nullptr))
@@ -11779,6 +11786,10 @@ void WebPageProxy::resetStateAfterProcessExited(ProcessTerminationReason termina
 
     // FIXME: <rdar://problem/38676604> In case of process swaps, the old process should gracefully suspend instead of terminating.
     protectedLegacyMainFrameProcess()->processTerminated();
+
+#if ENABLE(MODEL_PROCESS)
+    m_hasModelElement = false;
+#endif
 }
 
 WebPageProxyTesting* WebPageProxy::pageForTesting() const

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1033,6 +1033,11 @@ public:
 
     void setHasActiveAnimatedScrolls(bool isRunning);
 
+#if ENABLE(MODEL_PROCESS)
+    bool hasModelElement() const { return m_hasModelElement; }
+    void setHasModelElement(bool);
+#endif
+
     void setPrivateClickMeasurement(std::nullopt_t);
     void setPrivateClickMeasurement(WebCore::PrivateClickMeasurement&&);
     void setPrivateClickMeasurement(WebCore::PrivateClickMeasurement&&, String sourceDescription, String purchaser);
@@ -3694,6 +3699,10 @@ private:
 
     bool m_hasActiveAnimatedScroll { false };
     bool m_registeredForFullSpeedUpdates { false };
+
+#if ENABLE(MODEL_PROCESS)
+    bool m_hasModelElement { false };
+#endif
 
     bool m_shouldSuppressAppLinksInNextNavigationPolicyDecision { false };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -66,6 +66,9 @@ messages -> WebPageProxy {
     RunBeforeUnloadConfirmPanel(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, String message) -> (bool shouldClose) Synchronous
     PageDidScroll(WebCore::IntPoint scrollPosition)
     SetHasActiveAnimatedScrolls(bool hasActiveAnimatedScrolls)
+#if ENABLE(MODEL_PROCESS)
+    SetHasModelElement(bool hasModelElement)
+#endif
     RunOpenPanel(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, struct WebCore::FileChooserSettings parameters)
     [EnabledBy=WebShareEnabled] ShowShareSheet(struct WebCore::ShareDataWithParsedURL shareData) -> (bool granted)
     [EnabledBy=ContactPickerAPIEnabled] ShowContactPicker(struct WebCore::ContactsRequestData requestData) -> (std::optional<Vector<WebCore::ContactInfo>> info)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3279,6 +3279,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (BOOL)ensurePositionInformationIsUpToDate:(WebKit::InteractionInformationRequest)request
 {
+    [_webView didEnsurePositionInformationIsUpToDate];
     if ([self _currentPositionInformationIsValidForRequest:request])
         return YES;
 
@@ -3468,6 +3469,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(MODEL_PROCESS)
     if (gestureRecognizer == _modelInteractionPanGestureRecognizer) {
+        if (!_page->hasModelElement())
+            return NO;
+
         WebKit::InteractionInformationRequest request(WebCore::roundedIntPoint(point));
         if (![self ensurePositionInformationIsUpToDate:request])
             return NO;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -820,6 +820,14 @@ void WebChromeClient::didFinishLoadingImageForElement(HTMLImageElement& element)
         page->didFinishLoadingImageForElement(element);
 }
 
+#if ENABLE(MODEL_PROCESS)
+void WebChromeClient::setHasModelElement(bool hasModelElement)
+{
+    if (RefPtr page = m_page.get())
+        page->setHasModelElement(hasModelElement);
+}
+#endif
+
 PlatformPageClient WebChromeClient::platformPageClient() const
 {
     notImplemented();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -143,6 +143,10 @@ private:
 
     void didFinishLoadingImageForElement(WebCore::HTMLImageElement&) final;
 
+#if ENABLE(MODEL_PROCESS)
+    void setHasModelElement(bool) final;
+#endif
+
     PlatformPageClient platformPageClient() const final;
     void contentsSizeChanged(WebCore::LocalFrame&, const WebCore::IntSize&) const final;
     void intrinsicContentsSizeChanged(const WebCore::IntSize&) const final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9357,6 +9357,13 @@ void WebPage::didFinishLoadingImageForElement(WebCore::HTMLImageElement&)
 
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+void WebPage::setHasModelElement(bool hasModelElement)
+{
+    send(Messages::WebPageProxy::SetHasModelElement(hasModelElement));
+}
+#endif
+
 #if ENABLE(TEXT_AUTOSIZING)
 void WebPage::textAutoSizingAdjustmentTimerFired()
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1646,6 +1646,10 @@ public:
 
     void didFinishLoadingImageForElement(WebCore::HTMLImageElement&);
 
+#if ENABLE(MODEL_PROCESS)
+    void setHasModelElement(bool);
+#endif
+
     WebURLSchemeHandlerProxy* urlSchemeHandlerForScheme(StringView);
     void stopAllURLSchemeTasks();
 

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -451,4 +451,7 @@ interface UIScriptController {
     undefined resetVisibilityAdjustments(object callback);
 
     DOMString frontmostViewAtPoint(long x, long y);
+
+    readonly attribute boolean didCallEnsurePositionInformationIsUpToDateSinceLastCheck;
+    undefined clearEnsurePositionInformationIsUpToDateTracking();
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -461,6 +461,9 @@ public:
 
     virtual JSRetainPtr<JSStringRef> frontmostViewAtPoint(int, int) { notImplemented(); return { }; }
 
+    virtual bool didCallEnsurePositionInformationIsUpToDateSinceLastCheck() const { notImplemented(); return false; }
+    virtual void clearEnsurePositionInformationIsUpToDateTracking() { notImplemented(); }
+
 protected:
     explicit UIScriptController(UIScriptContext&);
     

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
@@ -74,6 +74,9 @@
 @property (nonatomic, readonly, getter=isInteractingWithFormControl) BOOL interactingWithFormControl;
 @property (nonatomic) _WKFocusStartsInputSessionPolicy focusStartsInputSessionPolicy;
 
+@property (nonatomic, readonly) BOOL didCallEnsurePositionInformationIsUpToDateSinceLastCheck;
+- (void)clearEnsurePositionInformationIsUpToDateTracking;
+
 @property (nonatomic, assign) UIInterfaceOrientationMask supportedInterfaceOrientations;
 @property (nonatomic) BOOL suppressInputAccessoryView;
 

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -78,6 +78,7 @@ struct CustomMenuActionInfo {
     RetainPtr<UITapGestureRecognizer> _windowTapGestureRecognizer;
     BlockPtr<void()> _windowTapRecognizedCallback;
     UIInterfaceOrientationMask _supportedInterfaceOrientations;
+    BOOL _didCallEnsurePositionInformationIsUpToDate;
 #endif
 }
 
@@ -258,6 +259,11 @@ IGNORE_WARNINGS_END
 
     if (self.didEndFormControlInteractionCallback)
         self.didEndFormControlInteractionCallback();
+}
+
+- (void)didEnsurePositionInformationIsUpToDate
+{
+    _didCallEnsurePositionInformationIsUpToDate = YES;
 }
 
 - (BOOL)isInteractingWithFormControl
@@ -670,5 +676,21 @@ static bool isQuickboardViewController(UIViewController *viewController)
 }
 
 #endif // HAVE(UI_EDIT_MENU_INTERACTION)
+
+#if PLATFORM(IOS_FAMILY)
+
+- (BOOL)didCallEnsurePositionInformationIsUpToDateSinceLastCheck
+{
+    const auto hasUpdated = _didCallEnsurePositionInformationIsUpToDate;
+    _didCallEnsurePositionInformationIsUpToDate = NO;
+    return hasUpdated;
+}
+
+- (void)clearEnsurePositionInformationIsUpToDateTracking
+{
+    _didCallEnsurePositionInformationIsUpToDate = NO;
+}
+
+#endif // PLATFORM(IOS_FAMILY)
 
 @end

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -212,6 +212,9 @@ private:
 
     JSRetainPtr<JSStringRef> scrollbarStateForScrollingNodeID(unsigned long long scrollingNodeID, unsigned long long processID, bool) const override;
 
+    bool didCallEnsurePositionInformationIsUpToDateSinceLastCheck() const final;
+    void clearEnsurePositionInformationIsUpToDateTracking() final;
+
 #if USE(BROWSERENGINEKIT)
     id<BETextInput> asyncTextInput() const;
 #endif

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1717,6 +1717,16 @@ JSRetainPtr<JSStringRef> UIScriptControllerIOS::frontmostViewAtPoint(int x, int 
     return nil;
 }
 
+bool UIScriptControllerIOS::didCallEnsurePositionInformationIsUpToDateSinceLastCheck() const
+{
+    return webView().didCallEnsurePositionInformationIsUpToDateSinceLastCheck;
+}
+
+void UIScriptControllerIOS::clearEnsurePositionInformationIsUpToDateTracking()
+{
+    [webView() clearEnsurePositionInformationIsUpToDateTracking];
+}
+
 }
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### f08f67b1112e2308cff608b60fe6d3de1207a441
<pre>
[visionOS] `ensurePositionInformationIsUpToDate` is called every time a scroll gesture occurs
<a href="https://bugs.webkit.org/show_bug.cgi?id=300964">https://bugs.webkit.org/show_bug.cgi?id=300964</a>
<a href="https://rdar.apple.com/157183410">rdar://157183410</a>

Reviewed by Wenson Hsieh.

In visionOS 26, support for the &lt;model&gt; element was added, which includes a new pan gesture recognizer
for the purpose of rotating model elements. This new recognizer means that pinch to scroll gestures are
first recognized as a potential pan gesture, and to determine whether we should actually pan, we check
if the gesture is occuring over a model element. However, in order to do this, we have to call
`ensurePositionInformationIsUpToDate` in WKContentViewInteraction.

`ensurePositionInformationIsUpToDate` must fetch the information from the web process if valid information
is not already present, and since this occurs synchronously, it can cause hangs. Since it is now called
for every scroll gesture, the number of hangs has increased.

To mitigate this, we now track whether or not a model element is present on the page. If one is present,
we continue as we did before, and if one is not present, we immediately stop processing the gesture as
a pan gesture, avoiding the unnecessary call to `ensurePositionInformationIsUpToDate`.

To track the presence of a model element, each Document and Page now keep a count of their total number
of model elements. When an HTMLModelElement is inserted or removed, it notifies the document that the
count should increase. The document then notifies the Page that the count should increase. When the count
changes to 0 or 1, the Page notifies the UI process that we either do or do not have a model element.

During document teardown, HTMLModelElement::removedFromAncestor is called after the page has already
been disconnected, which means the Page has an inaccurate model element count unless it is notified
in another manner. To achieve this, we decrement the count in Document::destroyRenderTree so that
the page can still be notified.

Added multiple layout tests to ensure that `ensurePositionInformationIsUpToDate` is only called during
scroll gestures if a model element is present on the page. Added UIHelper methods
`didCallEnsurePositionInformationIsUpToDateSinceLastCheck` and
`clearEnsurePositionInformationIsUpToDateTracking` to achieve this.

Tests: model-element/model-element-determines-if-scroll-gesture-updates-position-information-frames.html
       model-element/model-element-determines-if-scroll-gesture-updates-position-information-navigation.html
       model-element/model-element-determines-if-scroll-gesture-updates-position-information.html
* LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-expected.txt: Added.
* LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-frames-expected.txt: Added.
* LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-frames.html: Added.
* LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-navigation-expected.txt: Added.
* LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-navigation.html: Added.
* LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information.html: Added.
* LayoutTests/model-element/resources/finish-models-navigation.html: Added.
* LayoutTests/model-element/resources/models-frame.html: Added.
* LayoutTests/model-element/resources/no-models.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.didCallEnsurePositionInformationIsUpToDateSinceLastCheck.return.new.Promise):
(window.UIHelper.didCallEnsurePositionInformationIsUpToDateSinceLastCheck):
(window.UIHelper.clearEnsurePositionInformationIsUpToDateTracking.return.new.Promise):
(window.UIHelper.clearEnsurePositionInformationIsUpToDateTracking):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::insertedIntoAncestor):
(WebCore::HTMLModelElement::removedFromAncestor):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::destroyRenderTree):
(WebCore::Document::incrementModelElementCount):
(WebCore::Document::decrementModelElementCount):
* Source/WebCore/dom/Document.h:
(WebCore::Document::hasModelElement const):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::setHasModelElement):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::incrementModelElementCount):
(WebCore::Page::decrementModelElementCount):
* Source/WebCore/page/Page.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView didEnsurePositionInformationIsUpToDate]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setHasModelElement):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView ensurePositionInformationIsUpToDate:]):
(-[WKContentView gestureRecognizerShouldBegin:]):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::setHasModelElement):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setHasModelElement):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::didCallEnsurePositionInformationIsUpToDateSinceLastCheck const):
(WTR::UIScriptController::clearEnsurePositionInformationIsUpToDateTracking):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h:
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView didEnsurePositionInformationIsUpToDate]):
(-[TestRunnerWKWebView didCallEnsurePositionInformationIsUpToDateSinceLastCheck]):
(-[TestRunnerWKWebView clearEnsurePositionInformationIsUpToDateTracking]):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::didCallEnsurePositionInformationIsUpToDateSinceLastCheck const):
(WTR::UIScriptControllerIOS::clearEnsurePositionInformationIsUpToDateTracking):

Canonical link: <a href="https://commits.webkit.org/301766@main">https://commits.webkit.org/301766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdd6be78cbb351e304beec17fb5a1019be24fd8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133974 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78540 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9085998e-74e5-47af-b9d2-912d77781bf6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96619 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64615 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8bcdd4e9-1605-41e5-8814-e6f748a5d28b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77130 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e0a18214-5f30-4580-8caf-b28ed8933fc3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36652 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31733 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77367 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136499 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105133 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104824 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26733 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50342 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28686 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51110 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59430 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52798 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56131 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54557 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->