### PR TITLE
[web-animations] add `WebAnimation::keyframeEffect()` to remove many calls to `dynamicDowncast<KeyframeEffect>`

### DIFF
--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -58,7 +58,7 @@ void AnimationTimeline::animationTimingDidChange(WebAnimation& animation)
         if (timeline && timeline.get() != this)
             timeline->removeAnimation(animation);
         else if (timeline.get() == this) {
-            if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(animation.effect())) {
+            if (RefPtr keyframeEffect = animation.keyframeEffect()) {
                 if (auto styleable = keyframeEffect->targetStyleable())
                     styleable->animationWasAdded(animation);
             }
@@ -77,7 +77,7 @@ void AnimationTimeline::removeAnimation(WebAnimation& animation)
 {
     ASSERT(!animation.timeline() || animation.timeline() == this);
     m_animations.remove(animation);
-    if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(animation.effect())) {
+    if (RefPtr keyframeEffect = animation.keyframeEffect()) {
         if (auto styleable = keyframeEffect->targetStyleable()) {
             styleable->animationWasRemoved(animation);
             if (auto* effectStack = styleable->keyframeEffectStack())

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -387,7 +387,7 @@ void CSSAnimation::keyframesRuleDidChange()
     if (m_overriddenProperties.contains(Property::Keyframes))
         return;
 
-    RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(effect());
+    RefPtr keyframeEffect = this->keyframeEffect();
     if (!keyframeEffect)
         return;
 
@@ -404,7 +404,7 @@ void CSSAnimation::updateKeyframesIfNeeded(const RenderStyle* oldStyle, const Re
     if (m_overriddenProperties.contains(Property::Keyframes))
         return;
 
-    RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(effect());
+    RefPtr keyframeEffect = this->keyframeEffect();
     if (!keyframeEffect)
         return;
 

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -231,7 +231,7 @@ bool DocumentTimeline::animationCanBeRemoved(WebAnimation& animation)
         return false;
 
     // - has an associated animation effect whose target element is a descendant of doc, and
-    RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(animation.effect());
+    RefPtr keyframeEffect = animation.keyframeEffect();
     if (!keyframeEffect)
         return false;
 
@@ -271,7 +271,7 @@ IGNORE_GCC_WARNINGS_END
             break;
 
         if (animationWithHigherCompositeOrder && animationWithHigherCompositeOrder->isReplaceable()) {
-            if (RefPtr keyframeEffectWithHigherCompositeOrder = dynamicDowncast<KeyframeEffect>(animationWithHigherCompositeOrder->effect())) {
+            if (RefPtr keyframeEffectWithHigherCompositeOrder = animationWithHigherCompositeOrder->keyframeEffect()) {
                 for (auto property : keyframeEffectWithHigherCompositeOrder->animatedProperties()) {
                     if (propertiesToMatch.remove(resolvedProperty(property)) && propertiesToMatch.isEmpty())
                         break;
@@ -331,7 +331,7 @@ void DocumentTimeline::removeReplacedAnimations()
 void DocumentTimeline::transitionDidComplete(Ref<CSSTransition>&& transition)
 {
     removeAnimation(transition.get());
-    if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(transition->effect())) {
+    if (RefPtr keyframeEffect = transition->keyframeEffect()) {
         if (auto styleable = keyframeEffect->targetStyleable()) {
             auto property = transition->property();
             if (styleable->hasRunningTransitionForProperty(property))
@@ -430,7 +430,7 @@ void DocumentTimeline::applyPendingAcceleratedAnimations()
 
     bool hasForcedLayout = false;
     for (auto& animation : acceleratedAnimationsPendingRunningStateChange) {
-        if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect())) {
+        if (RefPtr keyframeEffect = animation->keyframeEffect()) {
             if (!hasForcedLayout)
                 hasForcedLayout |= keyframeEffect->forceLayoutIfNeeded();
 

--- a/Source/WebCore/animation/ElementAnimationRareData.cpp
+++ b/Source/WebCore/animation/ElementAnimationRareData.cpp
@@ -55,7 +55,7 @@ void ElementAnimationRareData::setAnimationsCreatedByMarkup(CSSAnimationCollecti
 {
     if (m_keyframeEffectStack) {
         for (auto& animation : m_animationsCreatedByMarkup) {
-            if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect()))
+            if (RefPtr keyframeEffect = animation->keyframeEffect())
                 m_keyframeEffectStack->removeEffect(*keyframeEffect);
         }
     }

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -291,7 +291,7 @@ void ScrollTimeline::updateCurrentTimeIfStale()
 
     bool needsStyleUpdate = false;
     for (auto& animation : m_animations) {
-        if (RefPtr effect = dynamicDowncast<KeyframeEffect>(animation->effect())) {
+        if (RefPtr effect = animation->keyframeEffect()) {
             effect->invalidate();
             needsStyleUpdate = true;
         }

--- a/Source/WebCore/animation/StyleOriginatedAnimation.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.cpp
@@ -181,7 +181,7 @@ ExceptionOr<void> StyleOriginatedAnimation::bindingsPause()
 
 void StyleOriginatedAnimation::flushPendingStyleChanges() const
 {
-    if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(effect())) {
+    if (RefPtr keyframeEffect = this->keyframeEffect()) {
         if (RefPtr target = keyframeEffect->target())
             target->document().updateStyleIfNeeded();
     }

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -51,6 +51,7 @@ class AnimationEffect;
 class AnimationEventBase;
 class AnimationTimeline;
 class Document;
+class KeyframeEffect;
 class RenderStyle;
 
 template<typename IDLType> class DOMPromiseProxyWithResolveCallback;
@@ -84,6 +85,7 @@ public:
     virtual void setBindingsEffect(RefPtr<AnimationEffect>&&);
     AnimationEffect* effect() const { return m_effect.get(); }
     void setEffect(RefPtr<AnimationEffect>&&);
+    KeyframeEffect* keyframeEffect() const;
 
     virtual AnimationTimeline* bindingsTimeline() const { return timeline(); }
     virtual void setBindingsTimeline(RefPtr<AnimationTimeline>&&);

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -343,7 +343,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::Styleable>> Ins
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 
-    RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect());
+    RefPtr keyframeEffect = animation->keyframeEffect();
     if (!keyframeEffect)
         return makeUnexpected("Animation for given animationId does not have an effect"_s);
 

--- a/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
@@ -181,7 +181,7 @@ void CustomPropertyRegistry::notifyAnimationsOfCustomPropertyRegistration(const 
 {
     auto& document = m_scope.document();
     for (auto* animation : WebAnimation::instances()) {
-        if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect())) {
+        if (RefPtr keyframeEffect = animation->keyframeEffect()) {
             if (auto* target = keyframeEffect->target()) {
                 if (&target->document() == &document)
                     keyframeEffect->customPropertyRegistrationDidChange(customProperty);

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -194,9 +194,9 @@ bool Styleable::computeAnimationExtent(LayoutRect& bounds) const
     if (!animations)
         return false;
 
-    KeyframeEffect* matchingEffect = nullptr;
+    RefPtr<KeyframeEffect> matchingEffect = nullptr;
     for (const auto& animation : *animations) {
-        if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect())) {
+        if (RefPtr keyframeEffect = animation->keyframeEffect()) {
             if (keyframeEffect->blendingKeyframes().containsProperty(CSSPropertyTransform))
                 matchingEffect = keyframeEffect;
         }
@@ -255,7 +255,7 @@ bool Styleable::hasRunningAcceleratedAnimations() const
 
     if (auto* animations = this->animations()) {
         for (const auto& animation : *animations) {
-            if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect())) {
+            if (RefPtr keyframeEffect = animation->keyframeEffect()) {
                 if (keyframeEffect->isRunningAccelerated())
                     return true;
             }
@@ -978,7 +978,7 @@ void Styleable::queryContainerDidChange() const
     if (!animations)
         return;
     for (auto& animation : *animations) {
-        RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect());
+        RefPtr keyframeEffect = animation->keyframeEffect();
         if (keyframeEffect && keyframeEffect->blendingKeyframes().usesContainerUnits()) {
             if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation))
                 cssAnimation->keyframesRuleDidChange();


### PR DESCRIPTION
#### dfd1dee078d7f13ef50769996eedfc7234713dec
<pre>
[web-animations] add `WebAnimation::keyframeEffect()` to remove many calls to `dynamicDowncast&lt;KeyframeEffect&gt;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=300970">https://bugs.webkit.org/show_bug.cgi?id=300970</a>
<a href="https://rdar.apple.com/162843897">rdar://162843897</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::animationTimingDidChange):
(WebCore::AnimationTimeline::removeAnimation):
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::keyframesRuleDidChange):
(WebCore::CSSAnimation::updateKeyframesIfNeeded):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::animationCanBeRemoved):
(WebCore::DocumentTimeline::transitionDidComplete):
(WebCore::DocumentTimeline::applyPendingAcceleratedAnimations):
* Source/WebCore/animation/ElementAnimationRareData.cpp:
(WebCore::ElementAnimationRareData::setAnimationsCreatedByMarkup):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::updateCurrentTimeIfStale):
* Source/WebCore/animation/StyleOriginatedAnimation.cpp:
(WebCore::StyleOriginatedAnimation::flushPendingStyleChanges const):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::keyframeEffect const):
(WebCore::WebAnimation::setTimeline):
(WebCore::WebAnimation::willChangeRenderer):
(WebCore::WebAnimation::enqueueAnimationEvent):
(WebCore::WebAnimation::invalidateEffect):
(WebCore::WebAnimation::finishNotificationSteps):
(WebCore::WebAnimation::resolve):
(WebCore::WebAnimation::updateRelevance):
(WebCore::WebAnimation::isReplaceable const):
(WebCore::WebAnimation::commitStyles):
(WebCore::WebAnimation::setBindingsRangeStart):
(WebCore::WebAnimation::setBindingsRangeEnd):
(WebCore::WebAnimation::range):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::InspectorAnimationAgent::requestEffectTarget):
* Source/WebCore/style/StyleCustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::notifyAnimationsOfCustomPropertyRegistration):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::computeAnimationExtent const):
(WebCore::Styleable::hasRunningAcceleratedAnimations const):
(WebCore::Styleable::queryContainerDidChange const):

Canonical link: <a href="https://commits.webkit.org/301705@main">https://commits.webkit.org/301705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dcfb8702a87f411f297257b5e6cac33cb0d7d23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133763 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2e396472-ffbd-47d3-9c76-523491b579bf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54992 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/76891045-e490-4b6a-8d79-cccf7e5b02b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113435 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77019 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bad1d766-a6db-41d1-8b6a-627baed338f2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31612 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77157 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136343 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41172 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109794 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50216 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50951 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19838 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53417 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59219 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52673 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56007 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->