### PR TITLE
mute button wasn't being dropped during width reduction when isMediaControlsMacInlineSizeSpecsEnabled is enabled

### DIFF
--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-dropping-controls-expected.txt
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-dropping-controls-expected.txt
@@ -5,13 +5,13 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS ready() became true
 
-TracksButton was dropped at 482.
-PiPButton was dropped at 482.
-SkipForwardButton was dropped at 447.
-SkipBackButton was dropped at 418.
-MuteButton was dropped at 389.
-AirplayButton was dropped at 351.
-FullscreenButton was dropped at 319.
+TracksButton was dropped at 486.
+PiPButton was dropped at 486.
+SkipForwardButton was dropped at 451.
+SkipBackButton was dropped at 422.
+AirplayButton was dropped at 355.
+FullscreenButton was dropped at 323.
+MuteButton was dropped at 60.
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1773,9 +1773,6 @@ webkit.org/b/223975 inspector/protocol/condition.html [ Pass Timeout ]
 
 webkit.org/b/223976 [ Debug ] imported/w3c/web-platform-tests/cors/redirect-preflight.htm [ Pass Failure ]
 
-# webkit.org/b/224123 For failure, webkit.org/b/300944 for timeout
-media/modern-media-controls/macos-inline-media-controls/macos-inline-media-dropping-controls.html [ Failure Timeout ]
-
 webkit.org/b/224212 [ arm64 ] compositing/background-color/no-composited-background-color-when-perspective.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/215397 media/modern-media-controls/media-controller/media-controller-fullscreen-ltr.html [ Pass Failure ]

--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js
@@ -126,7 +126,13 @@ class MacOSInlineMediaControls extends InlineMediaControls
             this._volumeSliderContainer.y = this.bottomControlsBar.y - this._inlineBottomControlsBarHeight - this._inlineInsideMargin;
         } else {
             const hasMinimumHeight = this.height >= MinimumHeightToShowVolumeSlider;
-            const shouldShowVolumeContainer = hasMinimumHeight && !this.showsStartButton && this.visible && this.playPauseButton && this.playPauseButton.enabled;
+            const hasMinimumWidth = this.width >= 60;
+            const shouldShowVolumeContainer = hasMinimumHeight && hasMinimumWidth && !this.showsStartButton && this.visible && this.playPauseButton && this.playPauseButton.enabled;
+
+            // Force mute button visibility based on width even if container logic doesn't run
+            if (this.width < 60 && this.muteButton) {
+                this.muteButton.visible = false;
+            }
 
             const children = this.children ? [...this.children] : [];
             if (shouldShowVolumeContainer && !children.includes(this._volumeSliderContainer)) {


### PR DESCRIPTION
#### 9e7e1758167d18384d9e8e0490a97aedf10b900c
<pre>
mute button wasn&apos;t being dropped during width reduction when isMediaControlsMacInlineSizeSpecsEnabled is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=300969">https://bugs.webkit.org/show_bug.cgi?id=300969</a>
<a href="https://rdar.apple.com/162817951">rdar://162817951</a>

Reviewed by Jonathan Bedard.

Add width threshold logic to ensure the mute button can be properly dropped.

* LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-dropping-controls-expected.txt:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js:
(MacOSInlineMediaControls.prototype.layout):

Canonical link: <a href="https://commits.webkit.org/301725@main">https://commits.webkit.org/301725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99e21871385190c580d2f21453f2ee25870d23ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78406 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e13fca4a-ff35-4252-bda9-beca0df5b224) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96476 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a2a835cc-929d-40d4-9f92-cb61095bfab2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76996 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e7839456-1a17-4ebd-b6cc-dbd3c08a0135) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31585 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77127 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107468 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136313 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104985 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104689 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50189 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28533 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50913 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19843 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53387 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59186 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52644 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55978 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54392 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->