### PR TITLE
[GTK] Remove GTK dependency from WebCore when not building with cairo enabled

### DIFF
--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -74,7 +74,8 @@ list(APPEND WebCore_LIBRARIES
     ${HYPHEN_LIBRARIES}
     ${UPOWERGLIB_LIBRARIES}
     ${X11_X11_LIB}
-    GTK::GTK
+    Cairo::Cairo
+    GLib::GLib
 )
 
 list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
@@ -83,6 +84,13 @@ list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
     ${LIBTASN1_INCLUDE_DIRS}
     ${UPOWERGLIB_INCLUDE_DIRS}
 )
+
+if (USE_CAIRO)
+    # GTK is only used by WebCore when building with cairo enabled.
+    list(APPEND WebCore_LIBRARIES
+        GTK::GTK
+    )
+endif ()
 
 if (ENABLE_WAYLAND_TARGET)
     list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
@@ -130,7 +138,7 @@ include_directories(SYSTEM
     ${WebCore_SYSTEM_INCLUDE_DIRECTORIES}
 )
 
-list(APPEND WebCoreTestSupport_LIBRARIES PRIVATE GTK::GTK)
+list(APPEND WebCoreTestSupport_LIBRARIES PRIVATE GLib::GLib)
 
 if (ENABLE_SMOOTH_SCROLLING)
     list(APPEND WebCore_SOURCES

--- a/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
+++ b/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
@@ -28,9 +28,12 @@
 #include "WebProcessMain.h"
 
 #include "AuxiliaryProcessMain.h"
-#include "GtkVersioning.h"
 #include "WebProcess.h"
 #include <libintl.h>
+
+#if !USE(GTK4) && USE(CAIRO)
+#include <gtk/gtk.h>
+#endif
 
 #if USE(GSTREAMER)
 #include <WebCore/GStreamerCommon.h>
@@ -80,7 +83,9 @@ public:
             g_usleep(30 * G_USEC_PER_SEC);
 #endif
 
+#if !USE(GTK4) && USE(CAIRO)
         gtk_init(nullptr, nullptr);
+#endif
 
         bindtextdomain(GETTEXT_PACKAGE, LOCALEDIR);
         bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
@@ -98,18 +103,16 @@ public:
 
 int WebProcessMain(int argc, char** argv)
 {
+#if !USE(GTK4) && USE(CAIRO)
 #if USE(ATSPI)
-    // Disable ATK/GTK accessibility support in the WebProcess.
-#if USE(GTK4)
-    g_setenv("GTK_A11Y", "none", TRUE);
-#else
+    // Disable ATK accessibility support in the WebProcess.
     g_setenv("NO_AT_BRIDGE", "1", TRUE);
-#endif
 #endif
 
     // Ignore the GTK_THEME environment variable, the theme is always set by the UI process now.
     // This call needs to happen before any threads begin execution
     unsetenv("GTK_THEME");
+#endif
 
     return AuxiliaryProcessMain<WebProcessMainGtk>(argc, argv);
 }

--- a/Tools/TestWebKitAPI/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/PlatformGTK.cmake
@@ -47,7 +47,7 @@ list(APPEND TestWebCore_SOURCES
     Tests/WebCore/gstreamer/GstElementHarness.cpp
     Tests/WebCore/gstreamer/GstMappedBuffer.cpp
 
-    gtk/main.cpp
+    generic/main.cpp
 )
 
 list(APPEND TestWebCore_SYSTEM_INCLUDE_DIRECTORIES
@@ -58,7 +58,7 @@ list(APPEND TestWebCore_SYSTEM_INCLUDE_DIRECTORIES
 )
 
 list(APPEND TestWebCore_LIBRARIES
-    GTK::GTK
+    GLib::GLib
 )
 
 # TestWebKit

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/RunLoopObserver.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/RunLoopObserver.cpp
@@ -29,26 +29,13 @@ namespace TestWebKitAPI {
 using namespace WTF;
 using namespace WebCore;
 
-static void setUpTest()
-{
-    WTF::initializeMainThread();
-
-#if PLATFORM(GTK)
-    // GTK under X11 has pending sources from gtk_init() when we run the loop,
-    // we need to process them to ensure the tests start with no pending sources.
-    auto* context = RunLoop::currentSingleton().mainContext();
-    while (g_main_context_pending(context))
-        g_main_context_iteration(context, FALSE);
-#endif
-}
-
 // ============================================================================
 // 1. RunLoopObserver lifecycle tests
 // ============================================================================
 
 TEST(RunLoopObserver, Schedule)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     bool observerCalled = false;
     auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
@@ -76,7 +63,7 @@ TEST(RunLoopObserver, Schedule)
 
 TEST(RunLoopObserver, Invalidate)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
     auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
@@ -118,7 +105,7 @@ TEST(RunLoopObserver, Invalidate)
 
 TEST(RunLoopObserver, MultipleSchedule)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
     auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
@@ -163,7 +150,7 @@ TEST(RunLoopObserver, MultipleSchedule)
 
 TEST(RunLoopObserver, MultipleInvalidate)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
     auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
@@ -211,7 +198,7 @@ TEST(RunLoopObserver, MultipleInvalidate)
 
 TEST(RunLoopObserver, Destruction)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
     {
@@ -239,7 +226,7 @@ TEST(RunLoopObserver, Destruction)
 
 TEST(RunLoopObserver, Repeating)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
 
@@ -278,7 +265,7 @@ TEST(RunLoopObserver, Repeating)
 
 TEST(RunLoopObserver, OneShot)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
 
@@ -320,7 +307,7 @@ TEST(RunLoopObserver, OneShot)
 // ============================================================================
 TEST(RunLoopObserver, DefaultActivities)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
 
@@ -346,7 +333,7 @@ TEST(RunLoopObserver, DefaultActivities)
 
 TEST(RunLoopObserver, ActivityEntry)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
 
@@ -371,7 +358,7 @@ TEST(RunLoopObserver, ActivityEntry)
 
 TEST(RunLoopObserver, ActivityExit)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
 
@@ -396,7 +383,7 @@ TEST(RunLoopObserver, ActivityExit)
 
 TEST(RunLoopObserver, ActivityBeforeWaiting)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
 
@@ -420,7 +407,7 @@ TEST(RunLoopObserver, ActivityBeforeWaiting)
 
 TEST(RunLoopObserver, ActivityAfterWaiting)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
 
@@ -444,7 +431,7 @@ TEST(RunLoopObserver, ActivityAfterWaiting)
 
 TEST(RunLoopObserver, ActivityCombination)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
 
@@ -473,7 +460,7 @@ TEST(RunLoopObserver, ActivityCombination)
 
 TEST(RunLoopObserver, RemovesSelfDuringCallback)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
 
@@ -508,7 +495,7 @@ TEST(RunLoopObserver, RemovesSelfDuringCallback)
 
 TEST(RunLoopObserver, AddsNewObserverDuringCallback)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount1 = 0;
     unsigned observerCallCount2 = 0;
@@ -553,7 +540,7 @@ TEST(RunLoopObserver, AddsNewObserverDuringCallback)
 
 TEST(RunLoopObserver, AcrossMultipleIterations)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount = 0;
 
@@ -582,7 +569,7 @@ TEST(RunLoopObserver, AcrossMultipleIterations)
 
 TEST(RunLoopObserver, WellKnownOrderValues)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     Vector<unsigned> observerExecutionOrder;
 
@@ -620,7 +607,7 @@ TEST(RunLoopObserver, WellKnownOrderValues)
 
 TEST(RunLoopObserver, DifferentWellKnownOrderValues)
 {
-    setUpTest();
+    WTF::initializeMainThread();
 
     unsigned observerCallCount1 = 0;
     unsigned observerCallCount2 = 0;

--- a/Tools/WebKitTestRunner/PlatformGTK.cmake
+++ b/Tools/WebKitTestRunner/PlatformGTK.cmake
@@ -31,7 +31,7 @@ list(APPEND WebKitTestRunner_LIBRARIES
 
 list(APPEND TestRunnerInjectedBundle_LIBRARIES
     Fontconfig::Fontconfig
-    GTK::GTK
+    GLib::GLib
 )
 
 list(APPEND TestRunnerInjectedBundle_SOURCES


### PR DESCRIPTION
#### 739db3bc2d79db050603231e5876814cc78f54f5
<pre>
[GTK] Remove GTK dependency from WebCore when not building with cairo enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=300975">https://bugs.webkit.org/show_bug.cgi?id=300975</a>

Reviewed by Alejandro G. Castro.

GTK is now only used by WebCore when cairo is enabled, for theme
rendering when building GTK3 and for ImageBuffer utilities. That also
means that except for GTK3 builds with cairo enabled the web process no
longer needs to call gtk_init.

Canonical link: <a href="https://commits.webkit.org/301760@main">https://commits.webkit.org/301760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dadbbf39f693f8e9eff3d7a78284c8b7d71edcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96487 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64515 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77007 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31596 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77139 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136325 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104998 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104702 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50201 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28544 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50930 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19860 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53399 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59201 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52655 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->