### PR TITLE
[threaded-animation-resolution] fix decoding of `AcceleratedEffectTiming`

### DIFF
--- a/Source/WebCore/animation/AnimationEffectTiming.h
+++ b/Source/WebCore/animation/AnimationEffectTiming.h
@@ -52,15 +52,15 @@ struct AnimationEffectTiming {
     PlaybackDirection direction { PlaybackDirection::Normal };
     double iterationStart { 0 };
     double iterations { 1 };
-    Seconds specifiedStartDelay { 0_s };
-    Seconds specifiedEndDelay { 0_s };
-    std::optional<Seconds> specifiedIterationDuration;
     WebAnimationTime startDelay { 0_s };
     WebAnimationTime endDelay { 0_s };
     WebAnimationTime iterationDuration { 0_s };
     WebAnimationTime intrinsicIterationDuration { 0_s };
     WebAnimationTime activeDuration { 0_s };
     WebAnimationTime endTime { 0_s };
+    Seconds specifiedStartDelay { 0_s };
+    Seconds specifiedEndDelay { 0_s };
+    std::optional<Seconds> specifiedIterationDuration;
 
     struct ResolutionData {
         std::optional<WebAnimationTime> timelineTime;

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -265,8 +265,6 @@ AcceleratedEffect::AcceleratedEffect(AnimationEffectTiming timing, Vector<Keyfra
     , m_startTime(startTime)
     , m_holdTime(holdTime)
 {
-    // FIXME: pass in the timeline duration for scroll timelines.
-    m_timing.updateComputedProperties(std::nullopt, m_playbackRate);
 }
 
 AcceleratedEffect::AcceleratedEffect(const AcceleratedEffect& source, OptionSet<AcceleratedEffectProperty>& propertyFilter)

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -84,7 +84,7 @@ public:
     WEBCORE_EXPORT void apply(WebAnimationTime, AcceleratedEffectValues&) const;
 
     // Encoding and decoding support
-    AnimationEffectTiming timing() const { return m_timing; }
+    const AnimationEffectTiming& timing() const { return m_timing; }
     const Vector<Keyframe>& keyframes() const { return m_keyframes; }
     WebAnimationType animationType() const { return m_animationType; }
     CompositeOperation compositeOperation() const final { return m_compositeOperation; }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6559,15 +6559,15 @@ struct WebCore::AnimationEffectTiming {
     WebCore::PlaybackDirection direction;
     double iterationStart;
     double iterations;
-    [NotSerialized] Seconds specifiedStartDelay;
-    [NotSerialized] Seconds specifiedEndDelay;
-    [NotSerialized] std::optional<Seconds> specifiedIterationDuration;
     WebCore::WebAnimationTime startDelay;
     WebCore::WebAnimationTime endDelay;
     WebCore::WebAnimationTime iterationDuration;
     WebCore::WebAnimationTime intrinsicIterationDuration;
     WebCore::WebAnimationTime activeDuration;
     WebCore::WebAnimationTime endTime;
+    [NotSerialized] Seconds specifiedStartDelay;
+    [NotSerialized] Seconds specifiedEndDelay;
+    [NotSerialized] std::optional<Seconds> specifiedIterationDuration;
 };
 
 header: <WebCore/AcceleratedEffect.h>


### PR DESCRIPTION
#### a992cac852a73024d23bf831adbff1cb2cc7fe2e
<pre>
[threaded-animation-resolution] fix decoding of `AcceleratedEffectTiming`
<a href="https://bugs.webkit.org/show_bug.cgi?id=300979">https://bugs.webkit.org/show_bug.cgi?id=300979</a>
<a href="https://rdar.apple.com/problem/162856767">rdar://problem/162856767</a>

Reviewed by Anne van Kesteren.

In 287181@main we differentiated between specified values for animation effect
timing properties `iterationDuration`, `startDelay` and `endDelay` and their
resolved values. While we updated the serialization for the affected class,
`AcceleratedEffectTiming`, we did not respect the order in which these properties
are encoded and decoded. This was not apparent because the various properties that
were switched around have types that can bridge between them (`WebAnimationTime`,
`double` and `Seconds`) but it led to some issues when decoding the values since
the wrong properties were being restored.

This was picked up while bringing up scroll-driven animations support in the remote
layer tree since time-based and percentage-based values were swapped, which was not
previously visible with only time-based animations.

Additionally, since the resolved values are now encoded, it&apos;s no longer necessary
to recompute them when decoding an `AcceleratedEffect`, so we remove the call to
`AnimationEffectTiming::updateComputedProperties()` from within the `AcceleratedEffect`
decoding constructor.

Finally, we also make a drive-by fix to the type returned by `AcceleratedEffect::timing()`
to return a reference rather than a copy.

* Source/WebCore/animation/AnimationEffectTiming.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::AcceleratedEffect):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
(WebCore::AcceleratedEffect::timing const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/301703@main">https://commits.webkit.org/301703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/501b31fc3a56c06d684314e8a758943f926d317a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133762 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a386fd13-eb2d-4249-956c-0684b7f1d9b2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54991 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/78716f86-1947-4a30-99e2-c463df502df2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77018 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fc50210e-6c40-4e0e-94af-f0598274a567) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31613 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77156 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107500 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136342 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41170 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109795 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104713 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50215 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50950 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19836 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53416 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59218 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52672 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56006 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54420 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->