### PR TITLE
CMake Swift build should ignore pthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,12 @@ include(WebKitCommon)
 #------------------------------------------------------------------------------
 if (SWIFT_REQUIRED)
     enable_language(Swift)
+
+    # Override Swift compiler to a wrapper script to work around the
+    # fact pkg-config feeds CFLAGS even to swiftc
+    set(ORIGINAL_Swift_COMPILER "${CMAKE_Swift_COMPILER}" CACHE FILEPATH "Original Swift compiler" FORCE)
+    set(CMAKE_Swift_COMPILER "${CMAKE_SOURCE_DIR}/Tools/Scripts/swift/swiftc-wrapper.sh" CACHE FILEPATH "Swift compiler wrapper" FORCE)
+    add_compile_options($<$<COMPILE_LANGUAGE:Swift>:--original-swift-compiler=${ORIGINAL_Swift_COMPILER}>)
 endif ()
 
 # -----------------------------------------------------------------------------

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -519,7 +519,7 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         # Right now this macro is used only once; if it's used more often then
         # we should abstract this so it's executed only once.
         execute_process(
-            COMMAND ${CMAKE_Swift_COMPILER} -print-target-info
+            COMMAND ${ORIGINAL_Swift_COMPILER} -print-target-info
             OUTPUT_VARIABLE _swift_target_info
         )
         string(JSON _swift_target_paths GET ${_swift_target_info} "paths")
@@ -569,7 +569,7 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
             DEPENDS ${_swift_sources}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             COMMAND
-                ${CMAKE_Swift_COMPILER} -typecheck
+                ${ORIGINAL_Swift_COMPILER} -typecheck
                 ${_swift_options}
                 $<LIST:TRANSFORM,$<TARGET_PROPERTY:${_target},INCLUDE_DIRECTORIES>,PREPEND,-I>
                 ${_swift_sources}

--- a/Tools/Scripts/swift/swiftc-wrapper.sh
+++ b/Tools/Scripts/swift/swiftc-wrapper.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# cmake accumulates CFLAGS from pkg-config, and then passes them to swiftc.
+# One such argument is -pthread which swiftc cannot accommodate. Filter it out.
+
+set -e
+
+REAL_SWIFTC=
+args=()
+
+for arg in "$@"; do
+    if [ "$arg" != "-pthread" ]; then
+        if [[ "$arg" == --original-swift-compiler=* ]]; then
+            REAL_SWIFTC="${arg#--original-swift-compiler=}"
+        else
+            args+=("$arg")
+        fi
+    fi
+done
+
+exec "$REAL_SWIFTC" "${args[@]}"


### PR DESCRIPTION
#### 6a9a2e49a0006fb40a68ec14dd03bb009f1e7b17
<pre>
CMake Swift build should ignore pthread
<a href="https://bugs.webkit.org/show_bug.cgi?id=300978">https://bugs.webkit.org/show_bug.cgi?id=300978</a>
<a href="https://rdar.apple.com/162856104">rdar://162856104</a>

Reviewed by Jonathan Bedard.

This commit filters out any &apos;-pthread&apos; argument passed to swiftc compiler
invocations, by using a swiftc wrapper script. We&apos;re discussing a longer-term
fix with swift cmake experts, but this gets us building again for now.

Alternatives considered:
* Override cmake&apos;s macros which it uses to accumulate CFLAGS from
  pkg-config output. Despite working with a cmake expert, I was unable
  to successfully override the pkg_check_modules macro, which is where
  this would need to happen.
* Alter all of WebKit&apos;s logic where it finds individual packages. There
  are at least five packages which bring in a -pthread argument, and
  possibly dozens more if individual components of gstreamer are considered.
  Even if we chose to change each one of them, the discovery of these
  packages is spread between WebKit cmake rules (which we can change)
  and cmake&apos;s built-in rules (which we can&apos;t) so it&apos;s not clear that
  we would actually be able to do this.

These solutions require further investigation and discussion, but for now,
a compiler wrapper resolves this issue.

It is necessarily a partial and temporary solution because there are other
arguments accumulated from pkg-config which make their way into swiftc,
e.g. -Werror.

Canonical link: <a href="https://commits.webkit.org/301716@main">https://commits.webkit.org/301716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df2441d6923e90796e1192143d8575f9f3c29248

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133764 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78427 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/db97d2c7-c585-4801-8168-96efdb6f5684) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96498 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9045aff2-fd31-4d1a-a507-7d6d3d95c10b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77017 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/36d49374-fcb2-4c28-b989-5920ed2c303f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31609 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77158 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118859 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136344 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125280 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41173 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104712 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26707 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50218 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50952 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53418 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158319 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52674 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39606 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56008 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54422 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->