### PR TITLE
Reduce unsafeness in WebCore/editing, part 2

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -14,7 +14,6 @@ dom/CollectionIndexCache.h
 dom/Node.cpp
 dom/Node.h
 editing/TextCheckingHelper.h
-editing/VisiblePosition.h
 html/parser/HTMLTreeBuilder.h
 inspector/InstrumentingAgents.h
 inspector/agents/WebHeapAgent.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -7,6 +7,13 @@ Modules/push-api/ServiceWorkerRegistrationPushAPI.h
 Modules/storage/StorageManager.cpp
 Modules/webdatabase/DatabaseTask.h
 Modules/webdatabase/SQLTransactionBackend.h
+[ Mac ] inspector/InspectorFrontendHost.cpp
+[ Mac ] inspector/InspectorFrontendHost.h
+[ Mac ] page/scrolling/ScrollLatchingController.h
+[ iOS ] page/ios/ContentChangeObserver.h
+[ iOS ] platform/audio/ios/AudioSessionIOS.mm
+[ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
+[ iOS ] platform/ios/wak/WAKWindow.h
 accessibility/AXSearchManager.h
 bindings/js/JSEventTargetCustom.h
 bindings/js/JSLazyEventListener.cpp
@@ -28,12 +35,9 @@ dom/CollectionIndexCache.h
 dom/Node.cpp
 dom/Node.h
 dom/TreeScope.h
-editing/cocoa/NodeHTMLConverter.mm
 html/FormListedElement.cpp
 html/parser/HTMLTreeBuilder.h
 html/track/TrackBase.h
-[ Mac ] inspector/InspectorFrontendHost.cpp
-[ Mac ] inspector/InspectorFrontendHost.h
 inspector/InspectorShaderProgram.h
 inspector/InspectorStyleSheet.h
 inspector/InspectorWebAgentBase.h
@@ -44,7 +48,6 @@ page/PointerLockController.h
 page/RenderingUpdateScheduler.h
 page/UndoManager.h
 page/WheelEventTestMonitor.h
-[ Mac ] page/scrolling/ScrollLatchingController.h
 page/scrolling/ScrollingCoordinator.h
 page/scrolling/ScrollingTreeGestureState.h
 platform/PODInterval.h
@@ -81,7 +84,3 @@ svg/properties/SVGPropertyOwnerRegistry.h
 workers/WorkerMessagingProxy.h
 xml/XPathGrammar.cpp
 xml/XPathGrammar.h
-[ iOS ] page/ios/ContentChangeObserver.h
-[ iOS ] platform/audio/ios/AudioSessionIOS.mm
-[ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
-[ iOS ] platform/ios/wak/WAKWindow.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -189,7 +189,6 @@ editing/AlternativeTextController.cpp
 editing/ApplyBlockElementCommand.cpp
 editing/ApplyStyleCommand.cpp
 editing/BreakBlockquoteCommand.cpp
-editing/ChangeListTypeCommand.cpp
 editing/CompositeEditCommand.cpp
 editing/DeleteSelectionCommand.cpp
 editing/Editing.cpp
@@ -220,8 +219,6 @@ editing/VisiblePosition.cpp
 editing/VisiblePosition.h
 editing/VisibleSelection.cpp
 editing/VisibleUnits.cpp
-editing/cocoa/AutofillElements.cpp
-editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/EditorCocoa.mm
 editing/cocoa/NodeHTMLConverter.mm
 editing/cocoa/WebContentReaderCocoa.mm

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -134,13 +134,7 @@ editing/DictationCommand.cpp
 editing/Editing.cpp
 editing/Editor.cpp
 editing/EditorCommand.cpp
-editing/FormatBlockCommand.cpp
 editing/FrameSelection.cpp
-editing/IndentOutdentCommand.cpp
-editing/InsertParagraphSeparatorCommand.cpp
-editing/MarkupAccumulator.cpp
-editing/MergeIdenticalElementsCommand.cpp
-editing/ModifySelectionListLevel.cpp
 editing/RenderedPosition.cpp
 editing/SimplifyMarkupCommand.cpp
 editing/TextIterator.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -421,7 +421,6 @@ editing/AlternativeTextController.cpp
 editing/ApplyBlockElementCommand.cpp
 editing/ApplyStyleCommand.cpp
 editing/BreakBlockquoteCommand.cpp
-editing/ChangeListTypeCommand.cpp
 editing/CompositeEditCommand.cpp
 editing/DeleteSelectionCommand.cpp
 editing/Editing.cpp
@@ -447,7 +446,6 @@ editing/VisiblePosition.cpp
 editing/VisiblePosition.h
 editing/VisibleSelection.cpp
 editing/VisibleUnits.cpp
-editing/cocoa/AutofillElements.cpp
 editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/EditorCocoa.mm
 editing/cocoa/NodeHTMLConverter.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -208,12 +208,8 @@ editing/ChangeListTypeCommand.cpp
 editing/Editing.cpp
 editing/Editor.cpp
 editing/EditorCommand.cpp
-editing/FormatBlockCommand.cpp
 editing/FrameSelection.cpp
-editing/IndentOutdentCommand.cpp
-editing/InsertParagraphSeparatorCommand.cpp
 editing/MarkupAccumulator.cpp
-editing/MergeIdenticalElementsCommand.cpp
 editing/cocoa/DataDetection.mm
 editing/cocoa/DictionaryLookup.mm
 editing/cocoa/EditorCocoa.mm

--- a/Source/WebCore/editing/ChangeListTypeCommand.cpp
+++ b/Source/WebCore/editing/ChangeListTypeCommand.cpp
@@ -87,10 +87,10 @@ void ChangeListTypeCommand::doApply()
     if (!typeAndElement || typeAndElement->first != m_type)
         return;
 
-    auto listToReplace = WTFMove(typeAndElement->second);
-    auto newList = createNewList(listToReplace);
+    Ref listToReplace = WTFMove(typeAndElement->second);
+    Ref newList = createNewList(listToReplace);
     insertNodeBefore(newList.copyRef(), listToReplace);
-    moveRemainingSiblingsToNewParent(listToReplace->firstChild(), nullptr, newList);
+    moveRemainingSiblingsToNewParent(listToReplace->protectedFirstChild().get(), nullptr, newList);
     removeNode(listToReplace);
     setEndingSelection({ Position { newList.ptr(), Position::PositionIsAfterChildren }});
 }

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -1177,7 +1177,7 @@ LayoutRect localCaretRectInRendererForCaretPainting(const VisiblePosition& caret
         return LayoutRect();
     ASSERT(caretPosition.deepEquivalent().deprecatedNode()->renderer());
     auto [localRect, renderer] = caretPosition.localCaretRect();
-    return localCaretRectInRendererForRect(localRect, caretPosition.deepEquivalent().deprecatedNode(), renderer, caretPainter);
+    return localCaretRectInRendererForRect(localRect, caretPosition.deepEquivalent().deprecatedNode(), renderer.get(), caretPainter);
 }
 
 LayoutRect localCaretRectInRendererForRect(LayoutRect& localRect, Node* node, RenderObject* renderer, RenderBlock*& caretPainter)

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -167,12 +167,12 @@ void IndentOutdentCommand::outdentParagraph()
         // outdentRegion() assumes it is operating on the first paragraph of an enclosing blockquote, but if there are multiply nested blockquotes and we've
         // just removed one, then this assumption isn't true. By splitting the next containing blockquote after this node, we keep this assumption true
         if (splitPoint) {
-            if (ContainerNode* splitPointParent = splitPoint->parentNode()) {
+            if (RefPtr splitPointParent = dynamicDowncast<Element>(splitPoint->parentNode())) {
                 if (splitPointParent->hasTagName(blockquoteTag)
                     && !splitPoint->hasTagName(blockquoteTag)
                     && splitPointParent->parentNode()
                     && splitPointParent->parentNode()->hasEditableStyle()) // We can't outdent if there is no place to go!
-                    splitElement(downcast<Element>(*splitPointParent), *splitPoint);
+                    splitElement(*splitPointParent, *splitPoint);
             }
         }
 

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -129,8 +129,8 @@ void InsertParagraphSeparatorCommand::getAncestorsInsideBlock(const Node* insert
     
     // Build up list of ancestors elements between the insertion node and the outer block.
     if (insertionNode != outerBlock) {
-        for (Element* n = insertionNode->parentElement(); n && n != outerBlock; n = n->parentElement())
-            ancestors.append(n);
+        for (RefPtr element = insertionNode->parentElement(); element && element != outerBlock; element = element->parentElement())
+            ancestors.append(element);
     }
 }
 
@@ -400,7 +400,7 @@ void InsertParagraphSeparatorCommand::doApply()
         insertionPosition = positionInParentAfterNode(br.ptr());
         // If the insertion point is a break element, there is nothing else
         // we need to do.
-        if (auto* renderer = visiblePos.deepEquivalent().anchorNode()->renderer(); renderer && renderer->isBR()) {
+        if (CheckedPtr renderer = visiblePos.deepEquivalent().anchorNode()->renderer(); renderer && renderer->isBR()) {
             setEndingSelection(VisibleSelection(VisiblePosition(insertionPosition, Affinity::Downstream), endingSelection().directionality()));
             return;
         }

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -307,7 +307,7 @@ void MarkupAccumulator::serializeNodesWithNamespaces(Node& targetNode, Serialize
                 }
             }
 
-            if (auto* child = firstChild(*current)) {
+            if (RefPtr child = firstChild(*current)) {
                 current = child;
                 namespaceStack.append(namespaceStack.last());
                 continue;
@@ -328,7 +328,7 @@ void MarkupAccumulator::serializeNodesWithNamespaces(Node& targetNode, Serialize
             if (shouldIncludeShadowRoots() && current->isShadowRoot()) {
                 current = current->shadowHost();
                 if (m_serializeShadowRoots != SerializeShadowRoots::AllForInterchange) {
-                    if (auto* child = firstChild(*current)) {
+                    if (RefPtr child = firstChild(*current)) {
                         current = child;
                         namespaceStack.append(namespaceStack.last());
                         break;
@@ -403,7 +403,7 @@ void MarkupAccumulator::startAppendingNode(const Node& node, Namespaces* namespa
         if (m_serializationContext && is<HTMLHeadElement>(element))
             m_markup.append("<meta charset=\"UTF-8\"><!-- Encoding specified by WebKit -->"_s);
 
-    } else if (auto* shadowRoot = suitableShadowRoot(node)) {
+    } else if (RefPtr shadowRoot = suitableShadowRoot(node)) {
         m_markup.append("<template shadowrootmode=\""_s);
         switch (shadowRoot->mode()) {
         case ShadowRootMode::Open:

--- a/Source/WebCore/editing/MergeIdenticalElementsCommand.cpp
+++ b/Source/WebCore/editing/MergeIdenticalElementsCommand.cpp
@@ -47,10 +47,10 @@ void MergeIdenticalElementsCommand::doApply()
     m_atChild = m_element2->firstChild();
 
     Vector<Ref<Node>> children;
-    for (Node* child = m_element1->firstChild(); child; child = child->nextSibling())
+    for (RefPtr child = m_element1->firstChild(); child; child = child->nextSibling())
         children.append(*child);
 
-    for (auto& child : children)
+    for (Ref child : children)
         m_element2->insertBefore(child, m_atChild.copyRef());
 
     m_element1->remove();
@@ -68,10 +68,10 @@ void MergeIdenticalElementsCommand::doUnapply()
         return;
 
     Vector<Ref<Node>> children;
-    for (Node* child = m_element2->firstChild(); child && child != atChild; child = child->nextSibling())
+    for (RefPtr child = m_element2->firstChild(); child && child != atChild; child = child->nextSibling())
         children.append(*child);
 
-    for (auto& child : children)
+    for (Ref child : children)
         m_element1->appendChild(child);
 }
 

--- a/Source/WebCore/editing/ModifySelectionListLevel.cpp
+++ b/Source/WebCore/editing/ModifySelectionListLevel.cpp
@@ -81,9 +81,9 @@ static bool getStartEndListChildren(const VisibleSelection& selection, RefPtr<No
     
     // if the selection ends on a list item with a sublist, include the entire sublist
     if (endListChild->renderer()->isRenderListItem()) {
-        RenderObject* r = endListChild->renderer()->nextSibling();
-        if (r && isListHTMLElement(r->node()) && r->node()->parentNode() == startListChild->parentNode())
-            endListChild = r->node();
+        CheckedPtr renderer = endListChild->renderer()->nextSibling();
+        if (renderer && isListHTMLElement(renderer->node()) && renderer->node()->parentNode() == startListChild->parentNode())
+            endListChild = renderer->node();
     }
 
     start = WTFMove(startListChild);

--- a/Source/WebCore/editing/VisiblePosition.h
+++ b/Source/WebCore/editing/VisiblePosition.h
@@ -74,7 +74,7 @@ public:
 
     struct LocalCaretRect {
         LayoutRect rect;
-        RenderObject* renderer { nullptr };
+        CheckedPtr<RenderObject> renderer;
     };
     WEBCORE_EXPORT LocalCaretRect localCaretRect() const;
 

--- a/Source/WebCore/editing/cocoa/AutofillElements.h
+++ b/Source/WebCore/editing/cocoa/AutofillElements.h
@@ -39,9 +39,9 @@ public:
     const HTMLInputElement* username() const { return m_username.get(); }
 private:
     AutofillElements(RefPtr<HTMLInputElement>&&, RefPtr<HTMLInputElement>&&, RefPtr<HTMLInputElement>&&);
-    RefPtr<HTMLInputElement> m_username;
-    RefPtr<HTMLInputElement> m_password;
-    RefPtr<HTMLInputElement> m_secondPassword;
+    const RefPtr<HTMLInputElement> m_username;
+    const RefPtr<HTMLInputElement> m_password;
+    const RefPtr<HTMLInputElement> m_secondPassword;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -177,7 +177,7 @@ public:
 private:
     Position m_start;
     Position m_end;
-    DocumentLoader* m_dataSource { nullptr };
+    SingleThreadWeakPtr<DocumentLoader> m_dataSource;
 
     HashMap<RefPtr<Element>, RetainPtr<NSDictionary>> m_attributesForElements;
     HashMap<RetainPtr<CFTypeRef>, RefPtr<Element>> m_textTableFooters;
@@ -1275,7 +1275,7 @@ BOOL HTMLConverter::_addAttachmentForElement(Element& element, NSURL *url, BOOL 
             fileWrapper = nil;
     }
     if (!fileWrapper && !notFound) {
-        fileWrapper = fileWrapperForURL(m_dataSource, url);
+        fileWrapper = fileWrapperForURL(m_dataSource.get(), url);
         if (usePlaceholder && fileWrapper && [[[[fileWrapper preferredFilename] pathExtension] lowercaseString] hasPrefix:@"htm"])
             notFound = YES;
         if (notFound)


### PR DESCRIPTION
#### 9018757c64f271d2e19408850182e6b841159b53
<pre>
Reduce unsafeness in WebCore/editing, part 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=300981">https://bugs.webkit.org/show_bug.cgi?id=300981</a>

Reviewed by Ryosuke Niwa.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/301765@main">https://commits.webkit.org/301765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c79d223bcfd9f2c119937daeb740e0fe30d656c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78547 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8175e6c2-e550-4358-92b9-1cbdf8be01ef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55145 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c3325467-bc2c-4f77-8d5f-8152909872be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37800 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/113582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77135 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cfe62770-adcd-4ff8-89b8-5ee5f45382dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36663 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31738 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77378 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107640 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136511 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41299 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105140 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54141 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104832 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50352 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28696 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51128 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19863 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53569 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59442 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52808 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56142 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54567 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->