### PR TITLE
Remove use of `RefPtr::unsafeGet()` in `ScrollTimeline::nearestSource()`

### DIFF
--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -112,10 +112,10 @@ ScrollTimeline::ScrollTimeline(Scroller scroller, ScrollAxis axis)
 
 Element* ScrollTimeline::bindingsSource() const
 {
-    return source();
+    return source().get();
 }
 
-Element* ScrollTimeline::source() const
+RefPtr<Element> ScrollTimeline::source() const
 {
     auto source = m_source.styleable();
     if (!source)
@@ -129,7 +129,7 @@ Element* ScrollTimeline::source() const
                     Ref document = nearestSource->document();
                     RefPtr documentElement = document->documentElement();
                     if (nearestSource != documentElement)
-                        return nearestSource.unsafeGet();
+                        return nearestSource;
                     // RenderObject::enclosingScrollableContainer() will return the document element even in
                     // quirks mode, but the scrolling element in that case is the <body> element, so we must
                     // make sure to return Document::scrollingElement() in case the document element is

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -52,7 +52,7 @@ public:
 
     const WeakStyleable& sourceStyleable() const { return m_source; }
     virtual Element* bindingsSource() const;
-    virtual Element* source() const;
+    virtual RefPtr<Element> source() const;
     void setSource(Element*);
     void setSource(const Styleable&);
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -440,7 +440,7 @@ Element* ViewTimeline::bindingsSource() const
     return ScrollTimeline::bindingsSource();
 }
 
-Element* ViewTimeline::source() const
+RefPtr<Element> ViewTimeline::source() const
 {
     if (CheckedPtr sourceRender = sourceScrollerRenderer())
         return sourceRender->element();

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -90,7 +90,7 @@ public:
     const RenderBox* sourceScrollerRenderer() const;
     CheckedPtr<const RenderElement> stickyContainer() const;
     Element* bindingsSource() const override;
-    Element* source() const override;
+    RefPtr<Element> source() const override;
     Style::SingleAnimationRange defaultRange() const final;
 
     std::pair<WebAnimationTime, WebAnimationTime> intervalForAttachmentRange(const Style::SingleAnimationRange&) const final;


### PR DESCRIPTION
#### 50405cc608812967a7605f74223f409a7b6c034c
<pre>
Remove use of `RefPtr::unsafeGet()` in `ScrollTimeline::nearestSource()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=300811">https://bugs.webkit.org/show_bug.cgi?id=300811</a>
<a href="https://rdar.apple.com/162690987">rdar://162690987</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::bindingsSource const):
(WebCore::ScrollTimeline::source const):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::source const):
* Source/WebCore/animation/ViewTimeline.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50405cc608812967a7605f74223f409a7b6c034c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126823 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46464 "Hash 50405cc6 for PR 52557 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37440 "Hash 50405cc6 for PR 52557 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133825 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78434 "Hash 50405cc6 for PR 52557 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/975a60af-dd8b-45be-8d3e-5efb0b5d0688) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128694 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47090 "Hash 50405cc6 for PR 52557 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55000 "Hash 50405cc6 for PR 52557 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96514 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/78434 "Hash 50405cc6 for PR 52557 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2618355d-38a8-42ae-84ce-11dfed1bc1c6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129771 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/47090 "Hash 50405cc6 for PR 52557 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/37440 "Hash 50405cc6 for PR 52557 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77029 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7d9cd212-9484-4860-87b4-56a9082e2211) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/47090 "Hash 50405cc6 for PR 52557 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/37440 "Hash 50405cc6 for PR 52557 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77226 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/47090 "Hash 50405cc6 for PR 52557 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/37440 "Hash 50405cc6 for PR 52557 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136351 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53496 "Hash 50405cc6 for PR 52557 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/55000 "Hash 50405cc6 for PR 52557 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105023 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53992 "Hash 50405cc6 for PR 52557 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/37440 "Hash 50405cc6 for PR 52557 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104721 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/37440 "Hash 50405cc6 for PR 52557 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50963 "Hash 50405cc6 for PR 52557 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53425 "Hash 50405cc6 for PR 52557 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59237 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52681 "Hash 50405cc6 for PR 52557 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56015 "Hash 50405cc6 for PR 52557 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54429 "Hash 50405cc6 for PR 52557 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->