### PR TITLE
Rename PseudoId to PseudoElementType

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1879,11 +1879,11 @@ bool AccessibilityObject::shouldCacheStringValue() const
     if (CheckedPtr containingBlock = renderer->containingBlock()) {
         // Check for ::first-letter, which would require some special handling to serve off the main-thread
         // that we don't have right now.
-        if (containingBlock->style().hasPseudoStyle(PseudoId::FirstLetter))
+        if (containingBlock->style().hasPseudoStyle(PseudoElementType::FirstLetter))
             return true;
         if (containingBlock->isAnonymous()) {
             containingBlock = containingBlock->containingBlock();
-            return containingBlock && containingBlock->style().hasPseudoStyle(PseudoId::FirstLetter);
+            return containingBlock && containingBlock->style().hasPseudoStyle(PseudoElementType::FirstLetter);
         }
     }
     // Getting to the end means we can avoid caching string value.

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1569,7 +1569,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
     if (!renderText)
         return { };
 
-    // FIXME: Need to handle PseudoId::FirstLetter. Right now, it will be chopped off from the other
+    // FIXME: Need to handle PseudoElementType::FirstLetter. Right now, it will be chopped off from the other
     // other text in the line, and AccessibilityRenderObject::computeIsIgnored ignores the
     // first-letter RenderText, meaning we can't recover it later by combining text across AX objects.
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1662,7 +1662,7 @@ bool KeyframeEffect::isCurrentlyAffectingProperty(CSSPropertyID property, Accele
     if (!m_blendingKeyframes.properties().contains(property))
         return false;
 
-    if (m_pseudoElementIdentifier && m_pseudoElementIdentifier->pseudoId == PseudoId::Marker && !Style::isValidMarkerStyleProperty(property))
+    if (m_pseudoElementIdentifier && m_pseudoElementIdentifier->type == PseudoElementType::Marker && !Style::isValidMarkerStyleProperty(property))
         return false;
 
     return m_phaseAtLastApplication == AnimationEffectPhase::Active;
@@ -2906,7 +2906,7 @@ void KeyframeEffect::computeHasSizeDependentTransform()
     // the position at the same time as the size animates, even slight desynchronizations look
     // stuttery.
     if (auto target = targetStyleable()) {
-        if (target->pseudoElementIdentifier && target->pseudoElementIdentifier->pseudoId == PseudoId::ViewTransitionGroup)
+        if (target->pseudoElementIdentifier && target->pseudoElementIdentifier->type == PseudoElementType::ViewTransitionGroup)
             m_animatesSizeAndSizeDependentTransform |= ((m_blendingKeyframes.containsProperty(CSSPropertyWidth) || m_blendingKeyframes.containsProperty(CSSPropertyHeight)) && m_blendingKeyframes.containsProperty(CSSPropertyTransform));
     }
 }

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -68,38 +68,38 @@ static bool compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeO
         if (!pseudoElementIdentifier)
             return NotPseudo;
 
-        switch (pseudoElementIdentifier->pseudoId) {
-        case PseudoId::Marker:
+        switch (pseudoElementIdentifier->type) {
+        case PseudoElementType::Marker:
             return Marker;
-        case PseudoId::Before:
+        case PseudoElementType::Before:
             return Before;
-        case PseudoId::FirstLetter:
+        case PseudoElementType::FirstLetter:
             return FirstLetter;
-        case PseudoId::FirstLine:
+        case PseudoElementType::FirstLine:
             return FirstLine;
-        case PseudoId::GrammarError:
+        case PseudoElementType::GrammarError:
             return GrammarError;
-        case PseudoId::Highlight:
+        case PseudoElementType::Highlight:
             return Highlight;
-        case PseudoId::WebKitScrollbar:
+        case PseudoElementType::WebKitScrollbar:
             return WebKitScrollbar;
-        case PseudoId::Selection:
+        case PseudoElementType::Selection:
             return Selection;
-        case PseudoId::SpellingError:
+        case PseudoElementType::SpellingError:
             return SpellingError;
-        case PseudoId::TargetText:
+        case PseudoElementType::TargetText:
             return TargetText;
-        case PseudoId::After:
+        case PseudoElementType::After:
             return After;
-        case PseudoId::ViewTransition:
+        case PseudoElementType::ViewTransition:
             return ViewTransition;
-        case PseudoId::ViewTransitionGroup:
+        case PseudoElementType::ViewTransitionGroup:
             return ViewTransitionGroup;
-        case PseudoId::ViewTransitionImagePair:
+        case PseudoElementType::ViewTransitionImagePair:
             return ViewTransitionImagePair;
-        case PseudoId::ViewTransitionOld:
+        case PseudoElementType::ViewTransitionOld:
             return ViewTransitionOld;
-        case PseudoId::ViewTransitionNew:
+        case PseudoElementType::ViewTransitionNew:
             return ViewTransitionNew;
         default:
             ASSERT_NOT_REACHED();
@@ -328,38 +328,38 @@ String pseudoElementIdentifierAsString(const std::optional<Style::PseudoElementI
     static NeverDestroyed<const String> targetText(MAKE_STATIC_STRING_IMPL("::target-text"));
     static NeverDestroyed<const String> viewTransition(MAKE_STATIC_STRING_IMPL("::view-transition"));
     static NeverDestroyed<const String> webkitScrollbar(MAKE_STATIC_STRING_IMPL("::-webkit-scrollbar"));
-    switch (pseudoElementIdentifier->pseudoId) {
-    case PseudoId::After:
+    switch (pseudoElementIdentifier->type) {
+    case PseudoElementType::After:
         return after;
-    case PseudoId::Before:
+    case PseudoElementType::Before:
         return before;
-    case PseudoId::FirstLetter:
+    case PseudoElementType::FirstLetter:
         return firstLetter;
-    case PseudoId::FirstLine:
+    case PseudoElementType::FirstLine:
         return firstLine;
-    case PseudoId::GrammarError:
+    case PseudoElementType::GrammarError:
         return grammarError;
-    case PseudoId::Highlight:
+    case PseudoElementType::Highlight:
         return makeString("::highlight"_s, '(', pseudoElementIdentifier->nameArgument, ')');
-    case PseudoId::Marker:
+    case PseudoElementType::Marker:
         return marker;
-    case PseudoId::Selection:
+    case PseudoElementType::Selection:
         return selection;
-    case PseudoId::SpellingError:
+    case PseudoElementType::SpellingError:
         return spellingError;
-    case PseudoId::TargetText:
+    case PseudoElementType::TargetText:
         return targetText;
-    case PseudoId::ViewTransition:
+    case PseudoElementType::ViewTransition:
         return viewTransition;
-    case PseudoId::ViewTransitionGroup:
+    case PseudoElementType::ViewTransitionGroup:
         return makeString("::view-transition-group"_s, '(', pseudoElementIdentifier->nameArgument, ')');
-    case PseudoId::ViewTransitionImagePair:
+    case PseudoElementType::ViewTransitionImagePair:
         return makeString("::view-transition-image-pair"_s, '(', pseudoElementIdentifier->nameArgument, ')');
-    case PseudoId::ViewTransitionOld:
+    case PseudoElementType::ViewTransitionOld:
         return makeString("::view-transition-old"_s, '(', pseudoElementIdentifier->nameArgument, ')');
-    case PseudoId::ViewTransitionNew:
+    case PseudoElementType::ViewTransitionNew:
         return makeString("::view-transition-new"_s, '(', pseudoElementIdentifier->nameArgument, ')');
-    case PseudoId::WebKitScrollbar:
+    case PseudoElementType::WebKitScrollbar:
         return webkitScrollbar;
     default:
         return emptyString();

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -275,57 +275,57 @@ unsigned CSSSelector::specificityForPage() const
     return s;
 }
 
-std::optional<PseudoId> CSSSelector::pseudoId(PseudoElement type)
+std::optional<PseudoElementType> CSSSelector::stylePseudoElementTypeFor(PseudoElement type)
 {
     switch (type) {
     case PseudoElement::FirstLine:
-        return PseudoId::FirstLine;
+        return PseudoElementType::FirstLine;
     case PseudoElement::FirstLetter:
-        return PseudoId::FirstLetter;
+        return PseudoElementType::FirstLetter;
     case PseudoElement::GrammarError:
-        return PseudoId::GrammarError;
+        return PseudoElementType::GrammarError;
     case PseudoElement::SpellingError:
-        return PseudoId::SpellingError;
+        return PseudoElementType::SpellingError;
     case PseudoElement::Selection:
-        return PseudoId::Selection;
+        return PseudoElementType::Selection;
     case PseudoElement::TargetText:
-        return PseudoId::TargetText;
+        return PseudoElementType::TargetText;
     case PseudoElement::Highlight:
-        return PseudoId::Highlight;
+        return PseudoElementType::Highlight;
     case PseudoElement::Marker:
-        return PseudoId::Marker;
+        return PseudoElementType::Marker;
     case PseudoElement::Backdrop:
-        return PseudoId::Backdrop;
+        return PseudoElementType::Backdrop;
     case PseudoElement::Before:
-        return PseudoId::Before;
+        return PseudoElementType::Before;
     case PseudoElement::After:
-        return PseudoId::After;
+        return PseudoElementType::After;
     case PseudoElement::WebKitScrollbar:
-        return PseudoId::WebKitScrollbar;
+        return PseudoElementType::WebKitScrollbar;
     case PseudoElement::WebKitScrollbarButton:
-        return PseudoId::WebKitScrollbarButton;
+        return PseudoElementType::WebKitScrollbarButton;
     case PseudoElement::WebKitScrollbarCorner:
-        return PseudoId::WebKitScrollbarCorner;
+        return PseudoElementType::WebKitScrollbarCorner;
     case PseudoElement::WebKitScrollbarThumb:
-        return PseudoId::WebKitScrollbarThumb;
+        return PseudoElementType::WebKitScrollbarThumb;
     case PseudoElement::WebKitScrollbarTrack:
-        return PseudoId::WebKitScrollbarTrack;
+        return PseudoElementType::WebKitScrollbarTrack;
     case PseudoElement::WebKitScrollbarTrackPiece:
-        return PseudoId::WebKitScrollbarTrackPiece;
+        return PseudoElementType::WebKitScrollbarTrackPiece;
     case PseudoElement::WebKitResizer:
-        return PseudoId::WebKitResizer;
+        return PseudoElementType::WebKitResizer;
     case PseudoElement::ViewTransition:
-        return PseudoId::ViewTransition;
+        return PseudoElementType::ViewTransition;
     case PseudoElement::ViewTransitionGroup:
-        return PseudoId::ViewTransitionGroup;
+        return PseudoElementType::ViewTransitionGroup;
     case PseudoElement::ViewTransitionImagePair:
-        return PseudoId::ViewTransitionImagePair;
+        return PseudoElementType::ViewTransitionImagePair;
     case PseudoElement::ViewTransitionOld:
-        return PseudoId::ViewTransitionOld;
+        return PseudoElementType::ViewTransitionOld;
     case PseudoElement::ViewTransitionNew:
-        return PseudoId::ViewTransitionNew;
+        return PseudoElementType::ViewTransitionNew;
     case PseudoElement::InternalWritingSuggestions:
-        return PseudoId::InternalWritingSuggestions;
+        return PseudoElementType::InternalWritingSuggestions;
 #if ENABLE(VIDEO)
     case PseudoElement::Cue:
 #endif

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -121,7 +121,8 @@ public:
 
     enum AttributeMatchType { CaseSensitive, CaseInsensitive };
 
-    static std::optional<PseudoId> pseudoId(PseudoElement);
+    // Maps from the selector pseudo-element type to the style type. Only pseudo-elements that are not element-backed have a type in style.
+    static std::optional<PseudoElementType> stylePseudoElementTypeFor(PseudoElement);
     static bool isPseudoClassEnabled(PseudoClass, const CSSSelectorParserContext&);
     static bool isPseudoElementEnabled(PseudoElement, StringView, const CSSSelectorParserContext&);
     static std::optional<PseudoElement> parsePseudoElementName(StringView, const CSSSelectorParserContext&);

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -101,7 +101,7 @@ public:
 
         // These are simple fields so they are easier for SelectorCompiler to generate code against.
         bool hasRequestedPseudoElement { false };
-        PseudoId pseudoId { };
+        PseudoElementType pseudoElementType { };
         AtomString pseudoElementNameArgument;
 
     public:
@@ -116,7 +116,7 @@ public:
 
         // FIXME: It would be nicer to have a separate object for return values. This requires some more work in the selector compiler.
         Style::Relations styleRelations;
-        EnumSet<PseudoId> pseudoIDSet;
+        EnumSet<PseudoElementType> publicPseudoElements;
         bool matchedInsideScope { false };
         bool disallowHasPseudoClass { false };
         bool scopingRootMatchesVisited { false };
@@ -135,7 +135,7 @@ public:
     struct LocalContext;
     
 private:
-    MatchResult matchRecursively(CheckingContext&, LocalContext&, EnumSet<PseudoId>&) const;
+    MatchResult matchRecursively(CheckingContext&, LocalContext&, EnumSet<PseudoElementType>&) const;
     bool checkOne(CheckingContext&, LocalContext&, MatchType&) const;
     bool matchSelectorList(CheckingContext&, const LocalContext&, const Element&, const CSSSelectorList&) const;
     bool matchHasPseudoClass(CheckingContext&, const Element&, const CSSSelector&) const;

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1407,12 +1407,12 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
     return CSSSelectorList { WTFMove(result) };
 }
 
-static std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifierFor(CSSSelectorPseudoElement type)
+static std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifierFor(CSSSelectorPseudoElement selectorPseudoElement)
 {
-    auto pseudoId = CSSSelector::pseudoId(type);
-    if (!pseudoId)
+    auto type = CSSSelector::stylePseudoElementTypeFor(selectorPseudoElement);
+    if (!type)
         return { };
-    return Style::PseudoElementIdentifier { *pseudoId };
+    return Style::PseudoElementIdentifier { *type };
 }
 
 // FIXME: It's probably worth investigating if more logic can be shared with
@@ -1458,7 +1458,7 @@ std::pair<bool, std::optional<Style::PseudoElementIdentifier>> CSSSelectorParser
         auto& ident = block.consumeIncludingWhitespace();
         if (ident.type() != IdentToken || !block.atEnd())
             return { };
-        return { true, Style::PseudoElementIdentifier { PseudoId::Highlight, ident.value().toAtomString() } };
+        return { true, Style::PseudoElementIdentifier { PseudoElementType::Highlight, ident.value().toAtomString() } };
     }
     case CSSSelector::PseudoElement::ViewTransitionGroup:
     case CSSSelector::PseudoElement::ViewTransitionImagePair:
@@ -1467,7 +1467,7 @@ std::pair<bool, std::optional<Style::PseudoElementIdentifier>> CSSSelectorParser
         auto& ident = block.consumeIncludingWhitespace();
         if (ident.type() != IdentToken || !isValidCustomIdentifier(ident.id()) || !block.atEnd())
             return { };
-        return { true, Style::PseudoElementIdentifier { *CSSSelector::pseudoId(*pseudoElement), ident.value().toAtomString() } };
+        return { true, Style::PseudoElementIdentifier { *CSSSelector::stylePseudoElementTypeFor(*pseudoElement), ident.value().toAtomString() } };
     }
     default:
         return { };

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -2285,7 +2285,7 @@ void SelectorCodeGenerator::generateSelectorChecker()
     StackAllocator earlyFailureStack = m_stackAllocator;
 
     Assembler::JumpList failureOnFunctionEntry;
-    // Test selector's pseudo element equals to requested PseudoId.
+    // Test selector's pseudo element equals to requested PseudoElementType.
     if (m_selectorContext != SelectorContext::QuerySelector && m_functionType == FunctionType::SelectorCheckerWithCheckingContext) {
         ASSERT_WITH_MESSAGE(fragmentMatchesTheRightmostElement(m_selectorFragments.first()), "Matching pseudo elements only make sense for the rightmost fragment.");
         generateRequestedPseudoElementEqualsToSelectorPseudoElement(failureOnFunctionEntry, m_selectorFragments.first(), checkingContextRegister);
@@ -4359,16 +4359,16 @@ void SelectorCodeGenerator::generateElementHasPseudoElement(Assembler::JumpList&
 void SelectorCodeGenerator::generateRequestedPseudoElementEqualsToSelectorPseudoElement(Assembler::JumpList& failureCases, const SelectorFragment& fragment, Assembler::RegisterID checkingContext)
 {
     ASSERT(m_selectorContext != SelectorContext::QuerySelector);
-    // Make sure that the requested pseudoId equals to the pseudo element of the rightmost fragment.
+    // Make sure that the requested pseudoElementType equals to the pseudo element of the rightmost fragment.
     // If the rightmost fragment doesn't have a pseudo element, the request must not have one either to succeed the matching.
-    // Otherwise, the requested pseudoId need to equal to the pseudo element of the rightmost fragment.
+    // Otherwise, the requested pseudoElementType need to equal to the pseudo element of the rightmost fragment.
     if (fragmentMatchesTheRightmostElement(fragment)) {
-        static_assert(sizeof(SelectorChecker::CheckingContext::pseudoId) == 1);
+        static_assert(sizeof(SelectorChecker::CheckingContext::pseudoElementType) == 1);
         if (!fragment.pseudoElementSelector)
             failureCases.append(m_assembler.branchTest8(Assembler::NonZero, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, hasRequestedPseudoElement))));
         else {
             Assembler::Jump skip = m_assembler.branchTest8(Assembler::Zero, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, hasRequestedPseudoElement)));
-            failureCases.append(m_assembler.branch8(Assembler::NotEqual, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(*CSSSelector::pseudoId(fragment.pseudoElementSelector->pseudoElement())))));
+            failureCases.append(m_assembler.branch8(Assembler::NotEqual, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoElementType)), Assembler::TrustedImm32(static_cast<unsigned>(*CSSSelector::stylePseudoElementTypeFor(fragment.pseudoElementSelector->pseudoElement())))));
             skip.link(&m_assembler);
         }
     }
@@ -4451,24 +4451,24 @@ void SelectorCodeGenerator::generateMarkPseudoStyleForPseudoElement(Assembler::J
 
     Assembler::JumpList successCases;
 
-    // When there is a requested pseudoId, there's no need to mark the pseudo element style.
+    // When there is a requestedpseudoElementType, there's no need to mark the pseudo element style.
     static_assert(sizeof(SelectorChecker::CheckingContext::hasRequestedPseudoElement) == 1);
-    static_assert(sizeof(SelectorChecker::CheckingContext::pseudoId) == 1);
+    static_assert(sizeof(SelectorChecker::CheckingContext::pseudoElementType) == 1);
     successCases.append(m_assembler.branchTest8(Assembler::NonZero, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, hasRequestedPseudoElement))));
 
     // When style invalidation, there's no need to mark the pseudo element style.
     successCases.append(branchOnResolvingModeWithCheckingContext(Assembler::Equal, SelectorChecker::Mode::StyleInvalidation, checkingContext));
 
     // When resolving mode is ResolvingStyle, mark the pseudo style for pseudo element.
-    auto dynamicPseudo = *CSSSelector::pseudoId(fragment.pseudoElementSelector->pseudoElement());
-    if (allPublicPseudoIds.contains(dynamicPseudo)) {
+    auto pseudoElementType = *CSSSelector::stylePseudoElementTypeFor(fragment.pseudoElementSelector->pseudoElement());
+    if (allPublicPseudoElementTypes.contains(pseudoElementType)) {
         failureCases.append(branchOnResolvingModeWithCheckingContext(Assembler::NotEqual, SelectorChecker::Mode::ResolvingStyle, checkingContext));
 
-        static_assert(sizeof(EnumSet<PseudoId>::StorageType) == 4);
-        Assembler::Address pseudoIDSetAddress(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoIDSet));
-        auto pseudoIDSetDataAddress = pseudoIDSetAddress.withOffset(EnumSet<PseudoId>::storageMemoryOffset());
-        EnumSet<PseudoId> value { dynamicPseudo };
-        m_assembler.store32(Assembler::TrustedImm32(value.toRaw()), pseudoIDSetDataAddress);
+        static_assert(sizeof(decltype(SelectorChecker::CheckingContext::publicPseudoElements)::StorageType) == 4);
+        Assembler::Address pseudoElementSetAddress(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, publicPseudoElements));
+        auto pseudoElementSetDataAddress = pseudoElementSetAddress.withOffset(EnumSet<PseudoElementType>::storageMemoryOffset());
+        EnumSet<PseudoElementType> value { pseudoElementType };
+        m_assembler.store32(Assembler::TrustedImm32(value.toRaw()), pseudoElementSetDataAddress);
     }
 
     // We have a pseudoElementSelector, we are not in CollectingRulesIgnoringVirtualPseudoElements so

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3187,8 +3187,8 @@ std::unique_ptr<RenderStyle> Document::styleForElementIgnoringPendingStylesheets
 
     auto elementStyle = resolver->styleForElement(element, { parentStyle });
     if (pseudoElementIdentifier) {
-        auto pseudoId = pseudoElementIdentifier->pseudoId;
-        if ((pseudoId == PseudoId::FirstLetter || pseudoId == PseudoId::FirstLine) && elementStyle.style && !Style::supportsFirstLineAndLetterPseudoElement(*elementStyle.style))
+        auto type = pseudoElementIdentifier->type;
+        if ((type == PseudoElementType::FirstLetter || type == PseudoElementType::FirstLine) && elementStyle.style && !Style::supportsFirstLineAndLetterPseudoElement(*elementStyle.style))
             return { };
 
         auto style = resolver->styleForPseudoElement(element, { *pseudoElementIdentifier }, { parentStyle });

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4610,12 +4610,12 @@ void Element::removeFromTopLayer()
     });
 }
 
-static PseudoElement* beforeOrAfterPseudoElement(const Element& host, PseudoId pseudoElementSpecifier)
+static PseudoElement* beforeOrAfterPseudoElement(const Element& host, PseudoElementType pseudoElementSpecifier)
 {
     switch (pseudoElementSpecifier) {
-    case PseudoId::Before:
+    case PseudoElementType::Before:
         return host.beforePseudoElement();
-    case PseudoId::After:
+    case PseudoElementType::After:
         return host.afterPseudoElement();
     default:
         return nullptr;
@@ -4777,7 +4777,7 @@ const RenderStyle* Element::computedStyle(const std::optional<Style::PseudoEleme
         return nullptr;
 
     if (pseudoElementIdentifier) {
-        if (RefPtr pseudoElement = beforeOrAfterPseudoElement(*this, pseudoElementIdentifier->pseudoId))
+        if (RefPtr pseudoElement = beforeOrAfterPseudoElement(*this, pseudoElementIdentifier->type))
             return pseudoElement->computedStyle();
     }
 
@@ -4886,17 +4886,17 @@ void Element::normalizeAttributes()
         attrNode->normalize();
 }
 
-PseudoElement& Element::ensurePseudoElement(PseudoId pseudoId)
+PseudoElement& Element::ensurePseudoElement(PseudoElementType type)
 {
-    if (pseudoId == PseudoId::Before) {
+    if (type == PseudoElementType::Before) {
         if (!beforePseudoElement())
-            ensureElementRareData().setBeforePseudoElement(PseudoElement::create(*this, pseudoId));
+            ensureElementRareData().setBeforePseudoElement(PseudoElement::create(*this, type));
         return *beforePseudoElement();
     }
 
-    ASSERT(pseudoId == PseudoId::After);
+    ASSERT(type == PseudoElementType::After);
     if (!afterPseudoElement())
-        ensureElementRareData().setAfterPseudoElement(PseudoElement::create(*this, pseudoId));
+        ensureElementRareData().setAfterPseudoElement(PseudoElement::create(*this, type));
     return *afterPseudoElement();
 }
 
@@ -4912,9 +4912,9 @@ PseudoElement* Element::afterPseudoElement() const
 
 RefPtr<PseudoElement> Element::pseudoElementIfExists(Style::PseudoElementIdentifier pseudoElementIdentifier)
 {
-    if (pseudoElementIdentifier.pseudoId == PseudoId::Before)
+    if (pseudoElementIdentifier.type == PseudoElementType::Before)
         return beforePseudoElement();
-    if (pseudoElementIdentifier.pseudoId == PseudoId::After)
+    if (pseudoElementIdentifier.type == PseudoElementType::After)
         return afterPseudoElement();
     return nullptr;
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -630,7 +630,7 @@ public:
     void beginParsingChildren() { clearIsParsingChildrenFinished(); }
     virtual void finishParsingChildren();
 
-    PseudoElement& ensurePseudoElement(PseudoId);
+    PseudoElement& ensurePseudoElement(PseudoElementType);
     WEBCORE_EXPORT PseudoElement* beforePseudoElement() const;
     WEBCORE_EXPORT PseudoElement* afterPseudoElement() const;
     RefPtr<PseudoElement> pseudoElementIfExists(Style::PseudoElementIdentifier);

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -236,7 +236,7 @@ inline const AtomString& Element::getAttribute(const QualifiedName& name, const 
 
 inline bool isInTopLayerOrBackdrop(const RenderStyle& style, const Element* element)
 {
-    return (element && element->isInTopLayer()) || style.pseudoElementType() == PseudoId::Backdrop;
+    return (element && element->isInTopLayer()) || style.pseudoElementType() == PseudoElementType::Backdrop;
 }
 
 inline void Element::hideNonce()

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -255,7 +255,7 @@ public:
     bool isPseudoElement() const { return isElementNode() && hasTypeFlag(TypeFlag::IsPseudoElementOrSpecialInternalNode); }
     inline bool isBeforePseudoElement() const;
     inline bool isAfterPseudoElement() const;
-    inline std::optional<PseudoId> pseudoId() const;
+    inline std::optional<PseudoElementType> pseudoElementType() const;
     inline std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -122,26 +122,26 @@ inline RefPtr<Element> Node::protectedParentElement() const
 bool Node::isBeforePseudoElement() const
 {
     auto* pseudoElement = dynamicDowncast<PseudoElement>(*this);
-    return pseudoElement && pseudoElement->pseudoId() == PseudoId::Before;
+    return pseudoElement && pseudoElement->pseudoElementType() == PseudoElementType::Before;
 }
 
 bool Node::isAfterPseudoElement() const
 {
     auto* pseudoElement = dynamicDowncast<PseudoElement>(*this);
-    return pseudoElement && pseudoElement->pseudoId() == PseudoId::After;
+    return pseudoElement && pseudoElement->pseudoElementType() == PseudoElementType::After;
 }
 
-std::optional<PseudoId> Node::pseudoId() const
+std::optional<PseudoElementType> Node::pseudoElementType() const
 {
     if (auto* pseudoElement = dynamicDowncast<PseudoElement>(*this))
-        return pseudoElement->pseudoId();
+        return pseudoElement->pseudoElementType();
     return { };
 }
 
 std::optional<Style::PseudoElementIdentifier> Node::pseudoElementIdentifier() const
 {
-    if (auto pseudoId = this->pseudoId())
-        return Style::PseudoElementIdentifier { *pseudoId };
+    if (auto type = pseudoElementType())
+        return Style::PseudoElementIdentifier { *type };
     return { };
 }
 

--- a/Source/WebCore/dom/PseudoElement.cpp
+++ b/Source/WebCore/dom/PseudoElement.cpp
@@ -48,13 +48,13 @@ const QualifiedName& pseudoElementTagName()
     return name;
 }
 
-PseudoElement::PseudoElement(Element& host, PseudoId pseudoId)
+PseudoElement::PseudoElement(Element& host, PseudoElementType pseudoElementType)
     : Element(pseudoElementTagName(), host.document(), { TypeFlag::IsPseudoElementOrSpecialInternalNode })
     , m_hostElement(host)
-    , m_pseudoId(pseudoId)
+    , m_pseudoElementType(pseudoElementType)
 {
     setEventTargetFlag(EventTargetFlag::IsConnected);
-    ASSERT(pseudoId == PseudoId::Before || pseudoId == PseudoId::After);
+    ASSERT(pseudoElementType == PseudoElementType::Before || pseudoElementType == PseudoElementType::After);
 }
 
 PseudoElement::~PseudoElement()
@@ -62,9 +62,9 @@ PseudoElement::~PseudoElement()
     ASSERT(!m_hostElement);
 }
 
-Ref<PseudoElement> PseudoElement::create(Element& host, PseudoId pseudoId)
+Ref<PseudoElement> PseudoElement::create(Element& host, PseudoElementType pseudoElementType)
 {
-    Ref pseudoElement = adoptRef(*new PseudoElement(host, pseudoId));
+    Ref pseudoElement = adoptRef(*new PseudoElement(host, pseudoElementType));
 
     InspectorInstrumentation::pseudoElementCreated(host.document().protectedPage().get(), pseudoElement.get());
 
@@ -86,7 +86,7 @@ bool PseudoElement::rendererIsNeeded(const RenderStyle& style)
         return true;
 
     if (RefPtr element = m_hostElement.get()) {
-        if (auto* stack = element->keyframeEffectStack(Style::PseudoElementIdentifier { pseudoId() }))
+        if (auto* stack = element->keyframeEffectStack(Style::PseudoElementIdentifier { pseudoElementType() }))
             return stack->requiresPseudoElement();
     }
     return false;

--- a/Source/WebCore/dom/PseudoElement.h
+++ b/Source/WebCore/dom/PseudoElement.h
@@ -35,13 +35,13 @@ class PseudoElement final : public Element {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PseudoElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PseudoElement);
 public:
-    static Ref<PseudoElement> create(Element& host, PseudoId);
+    static Ref<PseudoElement> create(Element& host, PseudoElementType);
     virtual ~PseudoElement();
 
     Element* hostElement() const { return m_hostElement.get(); }
     void clearHostElement();
 
-    PseudoId pseudoId() const { return m_pseudoId; }
+    PseudoElementType pseudoElementType() const { return m_pseudoElementType; }
 
     bool rendererIsNeeded(const RenderStyle&) override;
 
@@ -49,10 +49,10 @@ public:
     bool canContainRangeEndPoint() const override { return false; }
 
 private:
-    PseudoElement(Element&, PseudoId);
+    PseudoElement(Element&, PseudoElementType);
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_hostElement;
-    PseudoId m_pseudoId;
+    PseudoElementType m_pseudoElementType;
 };
 
 const QualifiedName& pseudoElementTagName();

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -820,15 +820,15 @@ void ViewTransition::handleTransitionFrame()
         return false;
     };
 
-    bool hasActiveAnimations = checkForActiveAnimations({ PseudoId::ViewTransition });
+    bool hasActiveAnimations = checkForActiveAnimations({ PseudoElementType::ViewTransition });
 
     for (auto& name : namedElements().keys()) {
         if (hasActiveAnimations)
             break;
-        hasActiveAnimations = checkForActiveAnimations({ PseudoId::ViewTransitionGroup, name })
-            || checkForActiveAnimations({ PseudoId::ViewTransitionImagePair, name })
-            || checkForActiveAnimations({ PseudoId::ViewTransitionNew, name })
-            || checkForActiveAnimations({ PseudoId::ViewTransitionOld, name });
+        hasActiveAnimations = checkForActiveAnimations({ PseudoElementType::ViewTransitionGroup, name })
+            || checkForActiveAnimations({ PseudoElementType::ViewTransitionImagePair, name })
+            || checkForActiveAnimations({ PseudoElementType::ViewTransitionNew, name })
+            || checkForActiveAnimations({ PseudoElementType::ViewTransitionOld, name });
     }
 
     if (!hasActiveAnimations) {
@@ -1036,7 +1036,7 @@ ExceptionOr<void> ViewTransition::updatePseudoElementRenderers()
             if (!renderer || renderer->isSkippedContent())
                 return Exception { ExceptionCode::InvalidStateError, "One of the transitioned elements has become hidden."_s };
 
-            Styleable styleable(*documentElement, Style::PseudoElementIdentifier { PseudoId::ViewTransitionNew, name });
+            Styleable styleable(*documentElement, Style::PseudoElementIdentifier { PseudoElementType::ViewTransitionNew, name });
             if (CheckedPtr viewTransitionCapture = dynamicDowncast<RenderViewTransitionCapture>(styleable.renderer())) {
                 if (viewTransitionCapture->setCapturedSize(capturedElement->newState.size, capturedElement->newState.overflowRect, capturedElement->newState.layerToLayoutOffset))
                     viewTransitionCapture->setNeedsLayout();
@@ -1069,7 +1069,7 @@ RenderViewTransitionCapture* ViewTransition::viewTransitionNewPseudoForCapturedE
     if (capturedName.isNull())
         return nullptr;
 
-    Styleable pseudoStyleable(*renderer.document().documentElement(), Style::PseudoElementIdentifier { PseudoId::ViewTransitionNew, capturedName });
+    Styleable pseudoStyleable(*renderer.document().documentElement(), Style::PseudoElementIdentifier { PseudoElementType::ViewTransitionNew, capturedName });
     return dynamicDowncast<RenderViewTransitionCapture>(pseudoStyleable.renderer());
 }
 

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -414,56 +414,56 @@ bool InspectorCSSAgent::forcePseudoState(const Element& element, CSSSelector::Ps
     return m_nodeIdToForcedPseudoState.get(nodeId).contains(pseudoClass);
 }
 
-std::optional<Inspector::Protocol::CSS::PseudoId> InspectorCSSAgent::protocolValueForPseudoId(PseudoId pseudoId)
+std::optional<Inspector::Protocol::CSS::PseudoId> InspectorCSSAgent::protocolValueForPseudoElementType(PseudoElementType pseudoElementType)
 {
-    switch (pseudoId) {
-    case PseudoId::FirstLine:
+    switch (pseudoElementType) {
+    case PseudoElementType::FirstLine:
         return Inspector::Protocol::CSS::PseudoId::FirstLine;
-    case PseudoId::FirstLetter:
+    case PseudoElementType::FirstLetter:
         return Inspector::Protocol::CSS::PseudoId::FirstLetter;
-    case PseudoId::GrammarError:
+    case PseudoElementType::GrammarError:
         return Inspector::Protocol::CSS::PseudoId::GrammarError;
-    case PseudoId::Marker:
+    case PseudoElementType::Marker:
         return Inspector::Protocol::CSS::PseudoId::Marker;
-    case PseudoId::Backdrop:
+    case PseudoElementType::Backdrop:
         return Inspector::Protocol::CSS::PseudoId::Backdrop;
-    case PseudoId::Before:
+    case PseudoElementType::Before:
         return Inspector::Protocol::CSS::PseudoId::Before;
-    case PseudoId::After:
+    case PseudoElementType::After:
         return Inspector::Protocol::CSS::PseudoId::After;
-    case PseudoId::Selection:
+    case PseudoElementType::Selection:
         return Inspector::Protocol::CSS::PseudoId::Selection;
-    case PseudoId::Highlight:
+    case PseudoElementType::Highlight:
         return Inspector::Protocol::CSS::PseudoId::Highlight;
-    case PseudoId::SpellingError:
+    case PseudoElementType::SpellingError:
         return Inspector::Protocol::CSS::PseudoId::SpellingError;
-    case PseudoId::TargetText:
+    case PseudoElementType::TargetText:
         return Inspector::Protocol::CSS::PseudoId::TargetText;
-    case PseudoId::ViewTransition:
+    case PseudoElementType::ViewTransition:
         return Inspector::Protocol::CSS::PseudoId::ViewTransition;
-    case PseudoId::ViewTransitionGroup:
+    case PseudoElementType::ViewTransitionGroup:
         return Inspector::Protocol::CSS::PseudoId::ViewTransitionGroup;
-    case PseudoId::ViewTransitionImagePair:
+    case PseudoElementType::ViewTransitionImagePair:
         return Inspector::Protocol::CSS::PseudoId::ViewTransitionImagePair;
-    case PseudoId::ViewTransitionOld:
+    case PseudoElementType::ViewTransitionOld:
         return Inspector::Protocol::CSS::PseudoId::ViewTransitionOld;
-    case PseudoId::ViewTransitionNew:
+    case PseudoElementType::ViewTransitionNew:
         return Inspector::Protocol::CSS::PseudoId::ViewTransitionNew;
-    case PseudoId::WebKitResizer:
+    case PseudoElementType::WebKitResizer:
         return Inspector::Protocol::CSS::PseudoId::WebKitResizer;
-    case PseudoId::WebKitScrollbar:
+    case PseudoElementType::WebKitScrollbar:
         return Inspector::Protocol::CSS::PseudoId::WebKitScrollbar;
-    case PseudoId::WebKitScrollbarThumb:
+    case PseudoElementType::WebKitScrollbarThumb:
         return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarThumb;
-    case PseudoId::WebKitScrollbarButton:
+    case PseudoElementType::WebKitScrollbarButton:
         return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarButton;
-    case PseudoId::WebKitScrollbarTrack:
+    case PseudoElementType::WebKitScrollbarTrack:
         return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarTrack;
-    case PseudoId::WebKitScrollbarTrackPiece:
+    case PseudoElementType::WebKitScrollbarTrackPiece:
         return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarTrackPiece;
-    case PseudoId::WebKitScrollbarCorner:
+    case PseudoElementType::WebKitScrollbarCorner:
         return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarCorner;
-    case PseudoId::InternalWritingSuggestions:
+    case PseudoElementType::InternalWritingSuggestions:
         return { };
 
     default:
@@ -501,25 +501,25 @@ Inspector::Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Inspector::Pr
     if (!originalElement->isPseudoElement()) {
         if (!includePseudo || *includePseudo) {
             pseudoElements = JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>::create();
-            for (PseudoId pseudoId : allPseudoIds) {
+            for (auto pseudoElementType : allPseudoElementTypes) {
                 // `*::marker` selectors are only applicable to elements with `display: list-item`.
-                if (pseudoId == PseudoId::Marker && element->computedStyle()->display() != DisplayType::ListItem)
+                if (pseudoElementType == PseudoElementType::Marker && element->computedStyle()->display() != DisplayType::ListItem)
                     continue;
 
-                if (pseudoId == PseudoId::Backdrop && !element->isInTopLayer())
+                if (pseudoElementType == PseudoElementType::Backdrop && !element->isInTopLayer())
                     continue;
 
-                if (pseudoId == PseudoId::ViewTransition && (!element->document().activeViewTransition() || element != element->document().documentElement()))
+                if (pseudoElementType == PseudoElementType::ViewTransition && (!element->document().activeViewTransition() || element != element->document().documentElement()))
                     continue;
 
-                auto pseudoElementIdentifier = Style::PseudoElementIdentifier { pseudoId };
+                auto pseudoElementIdentifier = Style::PseudoElementIdentifier { pseudoElementType };
 
                 // FIXME: Add named view transition pseudo-element support to Web Inspector. (webkit.org/b/283951)
                 if (isNamedViewTransitionPseudoElement(pseudoElementIdentifier))
                     continue;
 
-                if (auto protocolPseudoId = protocolValueForPseudoId(pseudoId)) {
-                    auto matchedRules = styleResolver.pseudoStyleRulesForElement(element, pseudoId, Style::Resolver::AllCSSRules);
+                if (auto protocolPseudoId = protocolValueForPseudoElementType(pseudoElementType)) {
+                    auto matchedRules = styleResolver.pseudoStyleRulesForElement(element, pseudoElementType, Style::Resolver::AllCSSRules);
                     if (!matchedRules.isEmpty()) {
                         auto matches = Inspector::Protocol::CSS::PseudoIdMatches::create()
                             .setPseudoId(protocolPseudoId.value())

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -91,7 +91,7 @@ public:
         const CheckedPtr<ContentSecurityPolicy> m_contentSecurityPolicy;
     };
 
-    static std::optional<Inspector::Protocol::CSS::PseudoId> protocolValueForPseudoId(PseudoId);
+    static std::optional<Inspector::Protocol::CSS::PseudoId> protocolValueForPseudoElementType(PseudoElementType);
 
     // InspectorAgentBase
     void didCreateFrontendAndBackend();

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
@@ -207,9 +207,9 @@ Ref<Inspector::Protocol::LayerTree::Layer> InspectorLayerTreeAgent::buildObjectF
     if (isAnonymous && !renderer->isRenderView()) {
         layerObject->setIsAnonymous(true);
         auto& style = renderer->style();
-        if (style.pseudoElementType() == PseudoId::FirstLetter)
+        if (style.pseudoElementType() == PseudoElementType::FirstLetter)
             layerObject->setPseudoElement("first-letter"_s);
-        else if (style.pseudoElementType() == PseudoId::FirstLine)
+        else if (style.pseudoElementType() == PseudoElementType::FirstLine)
             layerObject->setPseudoElement("first-line"_s);
     }
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -1155,7 +1155,7 @@ LineBuilder::RectAndFloatConstraints LineBuilder::adjustedLineRectWithCandidateI
 std::optional<LineBuilder::InitialLetterOffsets> LineBuilder::adjustLineRectForInitialLetterIfApplicable(const Box& floatBox)
 {
     auto drop = floatBox.style().initialLetter().drop();
-    auto isInitialLetter = floatBox.isFloatingPositioned() && floatBox.style().pseudoElementType() == PseudoId::FirstLetter && drop;
+    auto isInitialLetter = floatBox.isFloatingPositioned() && floatBox.style().pseudoElementType() == PseudoElementType::FirstLetter && drop;
     if (!isInitialLetter)
         return { };
 

--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
@@ -64,8 +64,8 @@ bool InlineInvalidation::rootStyleWillChange(const ElementBox& formattingContext
         if (!oldStyle.fontCascadeEqual(newStyle))
             return true;
 
-        auto* newFirstLineStyle = newStyle.getCachedPseudoStyle({ PseudoId::FirstLine });
-        auto* oldFirstLineStyle = oldStyle.getCachedPseudoStyle({ PseudoId::FirstLine });
+        auto* newFirstLineStyle = newStyle.getCachedPseudoStyle({ PseudoElementType::FirstLine });
+        auto* oldFirstLineStyle = oldStyle.getCachedPseudoStyle({ PseudoElementType::FirstLine });
         if (newFirstLineStyle && oldFirstLineStyle && !oldFirstLineStyle->fontCascadeEqual(*newFirstLineStyle))
             return true;
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -125,10 +125,10 @@ static bool shouldInvalidateLineLayoutAfterChangeFor(const RenderBlockFlow& root
     }
     auto hasFirstLetter = [&] {
         // FIXME: RenderTreeUpdater::updateTextRenderer produces odd values for offset/length when first-letter is present webkit.org/b/263343
-        if (rootBlockContainer.style().hasPseudoStyle(PseudoId::FirstLetter))
+        if (rootBlockContainer.style().hasPseudoStyle(PseudoElementType::FirstLetter))
             return true;
         if (rootBlockContainer.isAnonymous())
-            return rootBlockContainer.containingBlock() && rootBlockContainer.containingBlock()->style().hasPseudoStyle(PseudoId::FirstLetter);
+            return rootBlockContainer.containingBlock() && rootBlockContainer.containingBlock()->style().hasPseudoStyle(PseudoElementType::FirstLetter);
         return false;
     };
     if (hasFirstLetter())
@@ -619,7 +619,7 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
 
         if (layoutBox.isFloatingPositioned()) {
             // FIXME: Find out what to do with discarded (see line-clamp) floats in render tree.
-            auto isInitialLetter = layoutBox.style().pseudoElementType() == PseudoId::FirstLetter;
+            auto isInitialLetter = layoutBox.style().pseudoElementType() == PseudoElementType::FirstLetter;
             auto& floatingObject = flow().insertFloatingBox(renderer);
             auto [marginBoxVisualRect, borderBoxVisualRect] = toMarginAndBorderBoxVisualRect(logicalGeometry, m_inlineContentConstraints->containerRenderSize(), placedFloatsWritingMode);
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1676,7 +1676,7 @@ bool LocalFrameView::styleHidesScrollbarWithOrientation(ScrollbarOrientation ori
     StyleScrollbarState scrollbarState;
     scrollbarState.scrollbarPart = ScrollbarBGPart;
     scrollbarState.orientation = orientation;
-    auto scrollbarStyle = renderer->getUncachedPseudoStyle({ PseudoId::WebKitScrollbar, scrollbarState }, &renderer->style());
+    auto scrollbarStyle = renderer->getUncachedPseudoStyle({ PseudoElementType::WebKitScrollbar, scrollbarState }, &renderer->style());
     return scrollbarStyle && scrollbarStyle->display() == DisplayType::None;
 }
 
@@ -5188,7 +5188,7 @@ void LocalFrameView::updateScrollCorner()
         RefPtr body = doc ? doc->bodyOrFrameset() : nullptr;
         if (body && body->renderer()) {
             renderer = body->renderer();
-            cornerStyle = renderer->getUncachedPseudoStyle({ PseudoId::WebKitScrollbarCorner }, &renderer->style());
+            cornerStyle = renderer->getUncachedPseudoStyle({ PseudoElementType::WebKitScrollbarCorner }, &renderer->style());
         }
         
         if (!cornerStyle) {
@@ -5196,7 +5196,7 @@ void LocalFrameView::updateScrollCorner()
             RefPtr docElement = doc ? doc->documentElement() : nullptr;
             if (docElement && docElement->renderer()) {
                 renderer = docElement->renderer();
-                cornerStyle = renderer->getUncachedPseudoStyle({ PseudoId::WebKitScrollbarCorner }, &renderer->style());
+                cornerStyle = renderer->getUncachedPseudoStyle({ PseudoElementType::WebKitScrollbarCorner }, &renderer->style());
             }
         }
         
@@ -5204,7 +5204,7 @@ void LocalFrameView::updateScrollCorner()
             // If we have an owning iframe/frame element, then it can set the custom scrollbar also.
             // FIXME: Seems wrong to do this for cross-origin frames.
             if (RefPtr renderer = m_frame->ownerRenderer())
-                cornerStyle = renderer->getUncachedPseudoStyle({ PseudoId::WebKitScrollbarCorner }, &renderer->style());
+                cornerStyle = renderer->getUncachedPseudoStyle({ PseudoElementType::WebKitScrollbarCorner }, &renderer->style());
         }
     }
 

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -114,7 +114,7 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
     auto& parentStyle = parentRenderer.style();
     if (auto highlightRegistry = renderer.document().highlightRegistryIfExists()) {
         for (auto& highlightName : highlightRegistry->highlightNames()) {
-            auto renderStyle = parentRenderer.getUncachedPseudoStyle({ PseudoId::Highlight, highlightName }, &parentStyle);
+            auto renderStyle = parentRenderer.getUncachedPseudoStyle({ PseudoElementType::Highlight, highlightName }, &parentStyle);
             if (!renderStyle)
                 continue;
             if (renderStyle->textDecorationLineInEffect().isNone() && phase == PaintPhase::Decoration)

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1958,9 +1958,9 @@ bool RenderBlock::isPointInOverflowControl(HitTestResult& result, const LayoutPo
 
 Node* RenderBlock::nodeForHitTest() const
 {
-    if (auto pseudoId = style().pseudoElementType()) {
-        switch (*pseudoId) {
-        case PseudoId::Backdrop:
+    if (auto type = style().pseudoElementType()) {
+        switch (*type) {
+        case PseudoElementType::Backdrop:
             // If we're a ::backdrop pseudo-element, we should hit-test to the element that generated it.
             // This matches the behavior that other browsers have.
             for (auto& element : document().topLayerElements()) {
@@ -1973,9 +1973,9 @@ Node* RenderBlock::nodeForHitTest() const
             ASSERT_NOT_REACHED();
             break;
 
-        case PseudoId::ViewTransition:
-        case PseudoId::ViewTransitionGroup:
-        case PseudoId::ViewTransitionImagePair:
+        case PseudoElementType::ViewTransition:
+        case PseudoElementType::ViewTransitionGroup:
+        case PseudoElementType::ViewTransitionImagePair:
             // The view transition pseudo-elements should hit-test to their originating element (the document element).
             return document().documentElement();
 
@@ -2466,7 +2466,7 @@ static inline RenderBlock* findFirstLetterBlock(RenderBlock* start)
 {
     RenderBlock* firstLetterBlock = start;
     while (true) {
-        bool canHaveFirstLetterRenderer = firstLetterBlock->style().hasPseudoStyle(PseudoId::FirstLetter)
+        bool canHaveFirstLetterRenderer = firstLetterBlock->style().hasPseudoStyle(PseudoElementType::FirstLetter)
             && firstLetterBlock->canHaveGeneratedChildren()
             && isRenderBlockFlowOrRenderButton(*firstLetterBlock);
         if (canHaveFirstLetterRenderer)
@@ -2485,7 +2485,7 @@ static inline RenderBlock* findFirstLetterBlock(RenderBlock* start)
 std::pair<RenderObject*, RenderElement*> RenderBlock::firstLetterAndContainer(RenderObject* skipThisAsFirstLetter)
 {
     // Don't recur
-    if (style().pseudoElementType() == PseudoId::FirstLetter)
+    if (style().pseudoElementType() == PseudoElementType::FirstLetter)
         return { };
     
     // FIXME: We need to destroy the first-letter object if it is no longer the first child. Need to find
@@ -2509,7 +2509,7 @@ std::pair<RenderObject*, RenderElement*> RenderBlock::firstLetterAndContainer(Re
         if (is<RenderListMarker>(current))
             firstLetter = current.nextSibling();
         else if (current.isFloatingOrOutOfFlowPositioned()) {
-            if (current.style().pseudoElementType() == PseudoId::FirstLetter) {
+            if (current.style().pseudoElementType() == PseudoElementType::FirstLetter) {
                 firstLetter = current.firstChild();
                 break;
             }
@@ -2518,7 +2518,7 @@ std::pair<RenderObject*, RenderElement*> RenderBlock::firstLetterAndContainer(Re
             break;
         else if (current.isFlexibleBoxIncludingDeprecated() || current.isRenderGrid())
             return { };
-        else if (current.style().hasPseudoStyle(PseudoId::FirstLetter) && current.canHaveGeneratedChildren())  {
+        else if (current.style().hasPseudoStyle(PseudoElementType::FirstLetter) && current.canHaveGeneratedChildren())  {
             // We found a lower-level node with first-letter, which supersedes the higher-level style
             firstLetterContainer = &current;
             firstLetter = current.firstChild();
@@ -2985,8 +2985,8 @@ String RenderBlock::debugDescription() const
         builder.append(renderName(), " 0x"_s, hex(reinterpret_cast<uintptr_t>(this), Lowercase));
 
         builder.append(" ::view-transition"_s);
-        if (style().pseudoElementType() != PseudoId::ViewTransition) {
-            builder.append("-"_s, style().pseudoElementType() == PseudoId::ViewTransitionGroup ? "group("_s : "image-pair("_s);
+        if (style().pseudoElementType() != PseudoElementType::ViewTransition) {
+            builder.append("-"_s, style().pseudoElementType() == PseudoElementType::ViewTransitionGroup ? "group("_s : "image-pair("_s);
             builder.append(style().pseudoElementNameArgument(), ')');
         }
         return builder.toString();

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2204,7 +2204,7 @@ LayoutUnit RenderBlockFlow::adjustForUnsplittableChild(RenderBox& child, LayoutU
         if (!hasUniformPageLogicalHeight && !pushToNextPageWithMinimumLogicalHeight(remainingLogicalHeight, logicalOffset, childLogicalHeight))
             return logicalOffset;
         auto result = logicalOffset + remainingLogicalHeight;
-        bool isInitialLetter = child.isFloating() && child.style().pseudoElementType() == PseudoId::FirstLetter && child.style().initialLetter().drop() > 0;
+        bool isInitialLetter = child.isFloating() && child.style().pseudoElementType() == PseudoElementType::FirstLetter && child.style().initialLetter().drop() > 0;
         if (isInitialLetter) {
             // Increase our logical height to ensure that lines all get pushed along with the letter.
             setLogicalHeight(logicalOffset + remainingLogicalHeight);
@@ -2664,7 +2664,7 @@ void RenderBlockFlow::computeLogicalLocationForFloat(FloatingObject& floatingObj
     LayoutUnit floatLogicalLeft;
 
     bool insideFragmentedFlow = enclosingFragmentedFlow();
-    bool isInitialLetter = childBox.style().pseudoElementType() == PseudoId::FirstLetter && childBox.style().initialLetter().drop() > 0;
+    bool isInitialLetter = childBox.style().pseudoElementType() == PseudoElementType::FirstLetter && childBox.style().initialLetter().drop() > 0;
 
     if (isInitialLetter) {
         if (auto lowestInitialLetterLogicalBottom = this->lowestInitialLetterLogicalBottom()) {
@@ -2932,7 +2932,7 @@ std::optional<LayoutUnit> RenderBlockFlow::lowestInitialLetterLogicalBottom() co
         return { };
     auto lowestFloatBottom = std::optional<LayoutUnit> { };
     for (auto& floatingObject : m_floatingObjects->set()) {
-        if (floatingObject->isPlaced() && floatingObject->renderer().style().pseudoElementType() == PseudoId::FirstLetter && floatingObject->renderer().style().initialLetter().drop() > 0)
+        if (floatingObject->isPlaced() && floatingObject->renderer().style().pseudoElementType() == PseudoElementType::FirstLetter && floatingObject->renderer().style().initialLetter().drop() > 0)
             lowestFloatBottom = std::max(lowestFloatBottom.value_or(0_lu), logicalBottomForFloat(*floatingObject));
     }
     return lowestFloatBottom;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2089,7 +2089,7 @@ void RenderBox::imageChanged(WrappedImagePtr image, const IntRect*)
 
     repaintForBackgroundAndMask(style());
 
-    if (auto* firstLineStyle = style().getCachedPseudoStyle({ PseudoId::FirstLine }))
+    if (auto* firstLineStyle = style().getCachedPseudoStyle({ PseudoElementType::FirstLine }))
         repaintForBackgroundAndMask(*firstLineStyle);
 
     bool isNonEmpty;
@@ -4774,7 +4774,7 @@ bool RenderBox::isUnsplittableForPagination() const
         || (is<HTMLFormControlElement>(element()) && !is<HTMLFieldSetElement>(element()))
         || hasUnsplittableScrollingOverflow()
         || (parent() && isWritingModeRoot())
-        || (isFloating() && style().pseudoElementType() == PseudoId::FirstLetter && style().initialLetter().drop() > 0)
+        || (isFloating() && style().pseudoElementType() == PseudoElementType::FirstLetter && style().initialLetter().drop() > 0)
         || shouldApplySizeContainment();
 }
 

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -234,7 +234,7 @@ public:
 
     void paintMaskForTextFillBox(GraphicsContext&, const FloatRect&, const InlineIterator::InlineBoxIterator&, const LayoutRect&);
 
-    // For RenderBlocks and RenderInlines with m_style->pseudoElementType() == PseudoId::FirstLetter, this tracks their remaining text fragments
+    // For RenderBlocks and RenderInlines with m_style->pseudoElementType() == PseudoElementType::FirstLetter, this tracks their remaining text fragments
     RenderTextFragment* firstLetterRemainingText() const;
     void setFirstLetterRemainingText(RenderTextFragment&);
     void clearFirstLetterRemainingText();

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -208,8 +208,8 @@ static std::optional<CounterPlan> planCounter(RenderElement& renderer, const Ato
 
     if (style.pseudoElementType()) {
         switch (*style.pseudoElementType()) {
-        case PseudoId::Before:
-        case PseudoId::After:
+        case PseudoElementType::Before:
+        case PseudoElementType::After:
             break;
         default:
             return std::nullopt; // Counters are forbidden from all other pseudo elements.
@@ -494,7 +494,7 @@ void RenderCounter::updateCounter()
             if (!beforeAfterContainer->isAnonymous() && !beforeAfterContainer->isPseudoElement())
                 return;
             auto containerStyle = beforeAfterContainer->style().pseudoElementType();
-            if (containerStyle == PseudoId::Before || containerStyle == PseudoId::After)
+            if (containerStyle == PseudoElementType::Before || containerStyle == PseudoElementType::After)
                 break;
             beforeAfterContainer = beforeAfterContainer->parent();
         }

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -332,7 +332,7 @@ public:
     bool isFixedPositioned() const { return isOutOfFlowPositioned() && style().position() == PositionType::Fixed; }
     bool isAbsolutelyPositioned() const { return isOutOfFlowPositioned() && style().position() == PositionType::Absolute; }
 
-    bool isViewTransitionContainer() const { return style().pseudoElementType() == PseudoId::ViewTransition || style().pseudoElementType() == PseudoId::ViewTransitionGroup || style().pseudoElementType() == PseudoId::ViewTransitionImagePair; }
+    bool isViewTransitionContainer() const { return style().pseudoElementType() == PseudoElementType::ViewTransition || style().pseudoElementType() == PseudoElementType::ViewTransitionGroup || style().pseudoElementType() == PseudoElementType::ViewTransitionImagePair; }
     bool isViewTransitionPseudo() const { return isRenderViewTransitionCapture() || isViewTransitionContainer(); }
 
     inline bool hasPotentiallyScrollableOverflow() const;
@@ -440,7 +440,7 @@ private:
     void updateReferencedSVGResources();
     void clearReferencedSVGResources();
 
-    const RenderStyle* textSegmentPseudoStyle(PseudoId) const;
+    const RenderStyle* textSegmentPseudoStyle(PseudoElementType) const;
 
     SingleThreadPackedWeakPtr<RenderObject> m_firstChild;
     unsigned m_hasInitializedStyle : 1;

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -94,7 +94,7 @@ inline bool RenderElement::isBeforeContent() const
     // Text nodes don't have their own styles, so ignore the style on a text node.
     // if (isRenderText())
     //     return false;
-    if (style().pseudoElementType() != PseudoId::Before)
+    if (style().pseudoElementType() != PseudoElementType::Before)
         return false;
     return true;
 }
@@ -104,7 +104,7 @@ inline bool RenderElement::isAfterContent() const
     // Text nodes don't have their own styles, so ignore the style on a text node.
     // if (isRenderText())
     //     return false;
-    if (style().pseudoElementType() != PseudoId::After)
+    if (style().pseudoElementType() != PseudoElementType::After)
         return false;
     return true;
 }

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -581,7 +581,7 @@ LayoutRect RenderInline::clippedOverflowRect(const RenderLayerModelObject* repai
         }
         return false;
     };
-    ASSERT_UNUSED(insideSelfPaintingInlineBox, !view().frameView().layoutContext().isPaintOffsetCacheEnabled() || style().pseudoElementType() == PseudoId::FirstLetter || insideSelfPaintingInlineBox());
+    ASSERT_UNUSED(insideSelfPaintingInlineBox, !view().frameView().layoutContext().isPaintOffsetCacheEnabled() || style().pseudoElementType() == PseudoElementType::FirstLetter || insideSelfPaintingInlineBox());
 #endif
 
     auto knownEmpty = [&] {

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -299,7 +299,7 @@ RenderLayerBacking::RenderLayerBacking(RenderLayer& layer)
 #if ENABLE(FULLSCREEN_API)
     auto isFullsizeBackdrop = [](const RenderElement& renderer) -> bool {
         auto& style = renderer.style();
-        if (style.pseudoElementType() != PseudoId::Backdrop || style.position() != PositionType::Fixed)
+        if (style.pseudoElementType() != PseudoElementType::Backdrop || style.position() != PositionType::Fixed)
             return false;
 
         if (style.hasTransform() || style.hasClip() || style.hasMask())
@@ -1000,7 +1000,7 @@ bool RenderLayerBacking::shouldClipCompositedBounds() const
 
     if (renderer().effectiveCapturedInViewTransition())
         return false;
-    if (renderer().style().pseudoElementType() == PseudoId::ViewTransitionNew)
+    if (renderer().style().pseudoElementType() == PseudoElementType::ViewTransitionNew)
         return false;
 
     if (m_isFrameLayerWithTiledBacking)

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1676,7 +1676,7 @@ void RenderLayerCompositor::traverseUnchangedSubtree(RenderLayer* ancestorLayer,
 
 void RenderLayerCompositor::collectViewTransitionNewContentLayers(RenderLayer& layer, Vector<Ref<GraphicsLayer>>& childList)
 {
-    if (layer.renderer().style().pseudoElementType() != PseudoId::ViewTransitionNew || !layer.hasVisibleContent())
+    if (layer.renderer().style().pseudoElementType() != PseudoElementType::ViewTransitionNew || !layer.hasVisibleContent())
         return;
 
     if (!downcast<RenderViewTransitionCapture>(layer.renderer()).canUseExistingLayers())
@@ -3791,7 +3791,7 @@ bool RenderLayerCompositor::clipsCompositingDescendants(const RenderLayer& layer
 {
     // View transition new always has composited descendants in the graphics layer
     // tree due to hosting (but not in the RenderLayer tree).
-    if (layer.renderer().style().pseudoElementType() == PseudoId::ViewTransitionNew && layer.renderer().hasClipOrNonVisibleOverflow())
+    if (layer.renderer().style().pseudoElementType() == PseudoElementType::ViewTransitionNew && layer.renderer().hasClipOrNonVisibleOverflow())
         return true;
 
     if (!(layer.hasCompositingDescendant() && layer.renderer().hasClipOrNonVisibleOverflow()))

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1798,7 +1798,7 @@ void RenderLayerScrollableArea::updateScrollCornerStyle()
 {
     auto& renderer = m_layer.renderer();
     RenderElement* actualRenderer = rendererForScrollbar(renderer);
-    auto corner = (renderer.hasNonVisibleOverflow() && !renderer.style().usesStandardScrollbarStyle()) ? actualRenderer->getUncachedPseudoStyle({ PseudoId::WebKitScrollbarCorner }, &actualRenderer->style()) : nullptr;
+    auto corner = (renderer.hasNonVisibleOverflow() && !renderer.style().usesStandardScrollbarStyle()) ? actualRenderer->getUncachedPseudoStyle({ PseudoElementType::WebKitScrollbarCorner }, &actualRenderer->style()) : nullptr;
 
     if (!corner) {
         clearScrollCorner();
@@ -1829,7 +1829,7 @@ void RenderLayerScrollableArea::updateResizerStyle()
 
     auto& renderer = m_layer.renderer();
     RenderElement* actualRenderer = rendererForScrollbar(renderer);
-    auto resizer = renderer.hasNonVisibleOverflow() ? actualRenderer->getUncachedPseudoStyle({ PseudoId::WebKitResizer }, &actualRenderer->style()) : nullptr;
+    auto resizer = renderer.hasNonVisibleOverflow() ? actualRenderer->getUncachedPseudoStyle({ PseudoElementType::WebKitResizer }, &actualRenderer->style()) : nullptr;
 
     if (!resizer) {
         clearResizer();

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -67,7 +67,7 @@ RenderListItem::~RenderListItem()
 RenderStyle RenderListItem::computeMarkerStyle() const
 {
     if (!is<PseudoElement>(element())) {
-        if (auto markerStyle = getCachedPseudoStyle({ PseudoId::Marker }, &style()))
+        if (auto markerStyle = getCachedPseudoStyle({ PseudoElementType::Marker }, &style()))
             return RenderStyle::clone(*markerStyle);
     }
 

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -225,7 +225,7 @@ Color RenderReplaced::calculateHighlightColor() const
                 if (!isHighlighted(state, renderHighlight))
                     continue;
 
-                if (auto highlightStyle = getCachedPseudoStyle({ PseudoId::Highlight, highlight.key }, &style()))
+                if (auto highlightStyle = getCachedPseudoStyle({ PseudoElementType::Highlight, highlight.key }, &style()))
                     return highlightStyle->colorResolvingCurrentColor(highlightStyle->backgroundColor());
             }
         }

--- a/Source/WebCore/rendering/RenderScrollbar.cpp
+++ b/Source/WebCore/rendering/RenderScrollbar.cpp
@@ -141,7 +141,7 @@ void RenderScrollbar::setPressedPart(ScrollbarPart part)
     updateScrollbarPart(TrackBGPart);
 }
 
-std::unique_ptr<RenderStyle> RenderScrollbar::getScrollbarPseudoStyle(ScrollbarPart partType, PseudoId pseudoId) const
+std::unique_ptr<RenderStyle> RenderScrollbar::getScrollbarPseudoStyle(ScrollbarPart partType, PseudoElementType pseudoElementType) const
 {
     if (!owningRenderer())
         return nullptr;
@@ -155,7 +155,7 @@ std::unique_ptr<RenderStyle> RenderScrollbar::getScrollbarPseudoStyle(ScrollbarP
     scrollbarState.enabled = enabled();
     scrollbarState.scrollCornerIsVisible = scrollableArea().isScrollCornerVisible();
     
-    std::unique_ptr<RenderStyle> result = owningRenderer()->getUncachedPseudoStyle({ pseudoId, scrollbarState }, &owningRenderer()->style());
+    std::unique_ptr<RenderStyle> result = owningRenderer()->getUncachedPseudoStyle({ pseudoElementType, scrollbarState }, &owningRenderer()->style());
     // Scrollbars for root frames should always have background color 
     // unless explicitly specified as transparent. So we force it.
     // This is because WebKit assumes scrollbar to be always painted and missing background
@@ -195,29 +195,29 @@ void RenderScrollbar::updateScrollbarParts()
     }
 }
 
-static PseudoId pseudoForScrollbarPart(ScrollbarPart part)
+static PseudoElementType pseudoForScrollbarPart(ScrollbarPart part)
 {
     switch (part) {
         case BackButtonStartPart:
         case ForwardButtonStartPart:
         case BackButtonEndPart:
         case ForwardButtonEndPart:
-            return PseudoId::WebKitScrollbarButton;
+            return PseudoElementType::WebKitScrollbarButton;
         case BackTrackPart:
         case ForwardTrackPart:
-            return PseudoId::WebKitScrollbarTrackPiece;
+            return PseudoElementType::WebKitScrollbarTrackPiece;
         case ThumbPart:
-            return PseudoId::WebKitScrollbarThumb;
+            return PseudoElementType::WebKitScrollbarThumb;
         case TrackBGPart:
-            return PseudoId::WebKitScrollbarTrack;
+            return PseudoElementType::WebKitScrollbarTrack;
         case ScrollbarBGPart:
-            return PseudoId::WebKitScrollbar;
+            return PseudoElementType::WebKitScrollbar;
         case NoPart:
         case AllParts:
             break;
     }
     ASSERT_NOT_REACHED();
-    return PseudoId::WebKitScrollbar;
+    return PseudoElementType::WebKitScrollbar;
 }
 
 void RenderScrollbar::updateScrollbarPart(ScrollbarPart partType)

--- a/Source/WebCore/rendering/RenderScrollbar.h
+++ b/Source/WebCore/rendering/RenderScrollbar.h
@@ -58,7 +58,7 @@ public:
     
     bool isHiddenByStyle() const override;
 
-    std::unique_ptr<RenderStyle> getScrollbarPseudoStyle(ScrollbarPart, PseudoId) const;
+    std::unique_ptr<RenderStyle> getScrollbarPseudoStyle(ScrollbarPart, PseudoElementType) const;
 
 private:
     RenderScrollbar(ScrollableArea&, ScrollbarOrientation, Element*, LocalFrame*);

--- a/Source/WebCore/rendering/RenderTextFragment.cpp
+++ b/Source/WebCore/rendering/RenderTextFragment.cpp
@@ -107,7 +107,7 @@ RenderBlock* RenderTextFragment::blockForAccompanyingFirstLetter()
     for (auto& block : ancestorsOfType<RenderBlock>(*m_firstLetter)) {
         if (is<RenderMultiColumnFlow>(block))
             break;
-        if (block.style().hasPseudoStyle(PseudoId::FirstLetter) && block.canHaveChildren())
+        if (block.style().hasPseudoStyle(PseudoElementType::FirstLetter) && block.canHaveChildren())
             return &block;
     }
     return nullptr;

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -112,7 +112,7 @@ void RenderViewTransitionCapture::updateFromStyle()
     // The ::view-transition-new(root) capture should hold exactly the snapshot containing
     // block without overflow, but can host layers that extend outside this area. Force overflow
     // clipping.
-    if (effectiveOverflowX() != Overflow::Visible || effectiveOverflowY() != Overflow::Visible || (m_isRootElementCapture && style().pseudoElementType() == PseudoId::ViewTransitionNew))
+    if (effectiveOverflowX() != Overflow::Visible || effectiveOverflowY() != Overflow::Visible || (m_isRootElementCapture && style().pseudoElementType() == PseudoElementType::ViewTransitionNew))
         setHasNonVisibleOverflow();
 }
 
@@ -139,7 +139,7 @@ Node* RenderViewTransitionCapture::nodeForHitTest() const
 
 bool RenderViewTransitionCapture::paintsContent() const
 {
-    if (style().pseudoElementType() == PseudoId::ViewTransitionOld)
+    if (style().pseudoElementType() == PseudoElementType::ViewTransitionOld)
         return true;
     return !canUseExistingLayers();
 }
@@ -150,7 +150,7 @@ String RenderViewTransitionCapture::debugDescription() const
 
     builder.append(renderName(), " 0x"_s, hex(reinterpret_cast<uintptr_t>(this), Lowercase));
 
-    builder.append(" ::view-transition-"_s, style().pseudoElementType() == PseudoId::ViewTransitionNew ? "new("_s : "old("_s);
+    builder.append(" ::view-transition-"_s, style().pseudoElementType() == PseudoElementType::ViewTransitionNew ? "new("_s : "old("_s);
     builder.append(style().pseudoElementNameArgument(), ')');
     return builder.toString();
 }

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -84,7 +84,7 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
         break;
     }
     case MarkedText::Type::Highlight: {
-        auto renderStyle = renderer.parent()->getUncachedPseudoStyle({ PseudoId::Highlight, markedText.highlightName }, &renderer.style());
+        auto renderStyle = renderer.parent()->getUncachedPseudoStyle({ PseudoElementType::Highlight, markedText.highlightName }, &renderer.style());
         computeStyleForPseudoElementStyle(style, renderStyle.get(), paintInfo);
         break;
     }

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -54,7 +54,7 @@ static RenderStyle cloneRenderStyleWithState(const RenderStyle& currentStyle)
     auto newStyle = RenderStyle::clone(currentStyle);
 
     // FIXME: This should probably handle at least ::first-line too.
-    if (auto* firstLetterStyle = currentStyle.getCachedPseudoStyle({ PseudoId::FirstLetter }))
+    if (auto* firstLetterStyle = currentStyle.getCachedPseudoStyle({ PseudoElementType::FirstLetter }))
         newStyle.addCachedPseudoStyle(makeUnique<RenderStyle>(RenderStyle::clone(*firstLetterStyle)));
 
     if (currentStyle.lastChildState())
@@ -191,7 +191,7 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
         auto [firstLetter, firstLetterContainer] = block->firstLetterAndContainer();
         if (firstLetter && firstLetter->parent() && firstLetter->parent()->parent()) {
             auto& parentStyle = firstLetter->parent()->parent()->style();
-            auto* firstLetterStyle = parentStyle.getCachedPseudoStyle({ PseudoId::FirstLetter });
+            auto* firstLetterStyle = parentStyle.getCachedPseudoStyle({ PseudoElementType::FirstLetter });
             if (!firstLetterStyle)
                 continue;
             auto fontDescription = firstLetterStyle->fontDescription();

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -316,7 +316,7 @@ void TextDecorationPainter::paintLineThrough(const ForegroundDecorationGeometry&
         m_context.drawLineForText(rect, m_isPrinting, style == TextDecorationStyle::Double, strokeStyle);
 }
 
-static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, Style::TextDecorationLine remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, std::optional<PseudoId> pseudoId)
+static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, Style::TextDecorationLine remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, std::optional<PseudoElementType> pseudoElementType)
 {
     auto extractDecorations = [&] (const RenderStyle& style, Style::TextDecorationLine decorations) {
         if (!decorations.containsAny({ Style::TextDecorationLine::Flag::Underline, Style::TextDecorationLine::Flag::Overline, Style::TextDecorationLine::Flag::LineThrough }))
@@ -343,10 +343,10 @@ static void collectStylesForRenderer(TextDecorationPainter::Styles& result, cons
     };
 
     auto styleForRenderer = [&] (const RenderObject& renderer) -> const RenderStyle& {
-        if (pseudoId && renderer.style().hasPseudoStyle(*pseudoId)) {
+        if (pseudoElementType && renderer.style().hasPseudoStyle(*pseudoElementType)) {
             if (auto textRenderer = dynamicDowncast<RenderText>(renderer))
-                return *textRenderer->getCachedPseudoStyle({ *pseudoId });
-            return *downcast<RenderElement>(renderer).getCachedPseudoStyle({ *pseudoId });
+                return *textRenderer->getCachedPseudoStyle({ *pseudoElementType });
+            return *downcast<RenderElement>(renderer).getCachedPseudoStyle({ *pseudoElementType });
         }
         return firstLineStyle ? renderer.firstLineStyle() : renderer.style();
     };
@@ -386,15 +386,15 @@ Color TextDecorationPainter::decorationColor(const RenderStyle& style, OptionSet
     return style.visitedDependentColorWithColorFilter(CSSPropertyTextDecorationColor, paintBehavior);
 }
 
-auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, Style::TextDecorationLine requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, std::optional<PseudoId> pseudoId) -> Styles
+auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, Style::TextDecorationLine requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, std::optional<PseudoElementType> pseudoElementType) -> Styles
 {
     if (requestedDecorations.isNone())
         return { };
 
     Styles result;
-    collectStylesForRenderer(result, renderer, requestedDecorations, false, paintBehavior, pseudoId);
+    collectStylesForRenderer(result, renderer, requestedDecorations, false, paintBehavior, pseudoElementType);
     if (firstLineStyle)
-        collectStylesForRenderer(result, renderer, requestedDecorations, true, paintBehavior, pseudoId);
+        collectStylesForRenderer(result, renderer, requestedDecorations, true, paintBehavior, pseudoElementType);
     return result;
 }
 

--- a/Source/WebCore/rendering/TextDecorationPainter.h
+++ b/Source/WebCore/rendering/TextDecorationPainter.h
@@ -74,7 +74,7 @@ public:
     void paintForegroundDecorations(const ForegroundDecorationGeometry&, const Styles&);
 
     static Color decorationColor(const RenderStyle&, OptionSet<PaintBehavior> paintBehavior = { });
-    static Styles stylesForRenderer(const RenderObject&, Style::TextDecorationLine requestedDecorations, bool firstLineStyle = false, OptionSet<PaintBehavior> paintBehavior = { }, std::optional<PseudoId> = { });
+    static Styles stylesForRenderer(const RenderObject&, Style::TextDecorationLine requestedDecorations, bool firstLineStyle = false, OptionSet<PaintBehavior> paintBehavior = { }, std::optional<PseudoElementType> = { });
     static Style::TextDecorationLine textDecorationsInEffectForStyle(const TextDecorationPainter::Styles&);
 
 private:

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -107,12 +107,12 @@ struct SameSizeAsRenderStyle : CanMakeCheckedPtr<SameSizeAsRenderStyle> {
 
 static_assert(sizeof(RenderStyle) == sizeof(SameSizeAsRenderStyle), "RenderStyle should stay small");
 
-static_assert(PublicPseudoIDBits == allPublicPseudoIds.size());
+static_assert(PublicPseudoIDBits == allPublicPseudoElementTypes.size());
 
 static_assert(!(static_cast<unsigned>(maxTextTransformValue) >> TextTransformBits));
 
 // Value zero is used to indicate no pseudo-element.
-static_assert(!((enumToUnderlyingType(PseudoId::HighestEnumValue) + 1) >> PseudoElementTypeBits));
+static_assert(!((enumToUnderlyingType(PseudoElementType::HighestEnumValue) + 1) >> PseudoElementTypeBits));
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PseudoStyleCache);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(RenderStyle);
@@ -166,7 +166,7 @@ RenderStyle RenderStyle::createAnonymousStyleWithDisplay(const RenderStyle& pare
 
 RenderStyle RenderStyle::createStyleInheritingFromPseudoStyle(const RenderStyle& pseudoStyle)
 {
-    ASSERT(pseudoStyle.pseudoElementType() == PseudoId::Before || pseudoStyle.pseudoElementType() == PseudoId::After);
+    ASSERT(pseudoStyle.pseudoElementType() == PseudoElementType::Before || pseudoStyle.pseudoElementType() == PseudoElementType::After);
 
     auto style = create();
     style.inheritFrom(pseudoStyle);
@@ -1139,15 +1139,15 @@ bool RenderStyle::changeRequiresLayout(const RenderStyle& other, OptionSet<Style
     if ((usedVisibility() == Visibility::Collapse) != (other.usedVisibility() == Visibility::Collapse))
         return true;
 
-    bool hasFirstLineStyle = hasPseudoStyle(PseudoId::FirstLine);
-    if (hasFirstLineStyle != other.hasPseudoStyle(PseudoId::FirstLine))
+    bool hasFirstLineStyle = hasPseudoStyle(PseudoElementType::FirstLine);
+    if (hasFirstLineStyle != other.hasPseudoStyle(PseudoElementType::FirstLine))
         return true;
 
     if (hasFirstLineStyle) {
-        auto* firstLineStyle = getCachedPseudoStyle({ PseudoId::FirstLine });
+        auto* firstLineStyle = getCachedPseudoStyle({ PseudoElementType::FirstLine });
         if (!firstLineStyle)
             return true;
-        auto* otherFirstLineStyle = other.getCachedPseudoStyle({ PseudoId::FirstLine });
+        auto* otherFirstLineStyle = other.getCachedPseudoStyle({ PseudoElementType::FirstLine });
         if (!otherFirstLineStyle)
             return true;
         // FIXME: Not all first line style changes actually need layout.

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -499,7 +499,7 @@ public:
     StyleSelfAlignmentData resolvedJustifySelf(const RenderStyle* parentStyle, ItemPosition normalValueBehavior) const;
     StyleContentAlignmentData resolvedJustifyContent(const StyleContentAlignmentData& normalValueBehavior) const;
 
-    std::optional<PseudoId> pseudoElementType() const;
+    std::optional<PseudoElementType> pseudoElementType() const;
     const AtomString& pseudoElementNameArgument() const;
 
     std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
@@ -566,8 +566,8 @@ public:
     bool isStyleAvailable() const;
 
     inline bool hasAnyPublicPseudoStyles() const;
-    inline bool hasPseudoStyle(PseudoId) const;
-    inline void setHasPseudoStyles(EnumSet<PseudoId>);
+    inline bool hasPseudoStyle(PseudoElementType) const;
+    inline void setHasPseudoStyles(EnumSet<PseudoElementType>);
 
     inline bool hasDisplayAffectedByAnimations() const;
     inline void setHasDisplayAffectedByAnimations();
@@ -2512,8 +2512,8 @@ private:
         inline void copyNonInheritedFrom(const NonInheritedFlags&);
 
         inline bool hasAnyPublicPseudoStyles() const;
-        bool hasPseudoStyle(PseudoId) const;
-        void setHasPseudoStyles(EnumSet<PseudoId>);
+        bool hasPseudoStyle(PseudoElementType) const;
+        void setHasPseudoStyles(EnumSet<PseudoElementType>);
 
 #if !LOG_DISABLED
         void dumpDifferences(TextStream&, const NonInheritedFlags&) const;
@@ -2539,7 +2539,7 @@ private:
         PREFERRED_TYPE(bool) unsigned firstChildState : 1;
         PREFERRED_TYPE(bool) unsigned lastChildState : 1;
         PREFERRED_TYPE(bool) unsigned isLink : 1;
-        PREFERRED_TYPE(PseudoId) unsigned pseudoElementType : PseudoElementTypeBits;
+        PREFERRED_TYPE(PseudoElementType) unsigned pseudoElementType : PseudoElementTypeBits;
         unsigned pseudoBits : PublicPseudoIDBits;
         PREFERRED_TYPE(Style::TextDecorationLine) unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element.
 

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -977,33 +977,33 @@ TextStream& operator<<(TextStream& ts, PrintColorAdjust colorAdjust)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, PseudoId pseudoId)
+TextStream& operator<<(TextStream& ts, PseudoElementType pseudoElementType)
 {
-    switch (pseudoId) {
-    case PseudoId::FirstLine: ts << "first-line"_s; break;
-    case PseudoId::FirstLetter: ts << "first-letter"_s; break;
-    case PseudoId::GrammarError: ts << "grammar-error"_s; break;
-    case PseudoId::Highlight: ts << "highlight"_s; break;
-    case PseudoId::InternalWritingSuggestions: ts << "-internal-writing-suggestions"_s; break;
-    case PseudoId::Marker: ts << "marker"_s; break;
-    case PseudoId::Backdrop: ts << "backdrop"_s; break;
-    case PseudoId::Before: ts << "before"_s; break;
-    case PseudoId::After: ts << "after"_s; break;
-    case PseudoId::Selection: ts << "selection"_s; break;
-    case PseudoId::SpellingError: ts << "spelling-error"_s; break;
-    case PseudoId::TargetText: ts << "target-text"_s; break;
-    case PseudoId::ViewTransition: ts << "view-transition"_s; break;
-    case PseudoId::ViewTransitionGroup: ts << "view-transition-group"_s; break;
-    case PseudoId::ViewTransitionImagePair: ts << "view-transition-image-pair"_s; break;
-    case PseudoId::ViewTransitionOld: ts << "view-transition-old"_s; break;
-    case PseudoId::ViewTransitionNew: ts << "view-transition-new"_s; break;
-    case PseudoId::WebKitResizer: ts << "-webkit-resizer"_s; break;
-    case PseudoId::WebKitScrollbar: ts << "-webkit-scrollbar"_s; break;
-    case PseudoId::WebKitScrollbarThumb: ts << "-webkit-scrollbar-thumb"_s; break;
-    case PseudoId::WebKitScrollbarButton: ts << "-webkit-scrollbar-button"_s; break;
-    case PseudoId::WebKitScrollbarTrack: ts << "-webkit-scrollbar-track"_s; break;
-    case PseudoId::WebKitScrollbarTrackPiece: ts << "-webkit-scrollbar-trackpiece"_s; break;
-    case PseudoId::WebKitScrollbarCorner: ts << "-webkit-scrollbar-corner"_s; break;
+    switch (pseudoElementType) {
+    case PseudoElementType::FirstLine: ts << "first-line"_s; break;
+    case PseudoElementType::FirstLetter: ts << "first-letter"_s; break;
+    case PseudoElementType::GrammarError: ts << "grammar-error"_s; break;
+    case PseudoElementType::Highlight: ts << "highlight"_s; break;
+    case PseudoElementType::InternalWritingSuggestions: ts << "-internal-writing-suggestions"_s; break;
+    case PseudoElementType::Marker: ts << "marker"_s; break;
+    case PseudoElementType::Backdrop: ts << "backdrop"_s; break;
+    case PseudoElementType::Before: ts << "before"_s; break;
+    case PseudoElementType::After: ts << "after"_s; break;
+    case PseudoElementType::Selection: ts << "selection"_s; break;
+    case PseudoElementType::SpellingError: ts << "spelling-error"_s; break;
+    case PseudoElementType::TargetText: ts << "target-text"_s; break;
+    case PseudoElementType::ViewTransition: ts << "view-transition"_s; break;
+    case PseudoElementType::ViewTransitionGroup: ts << "view-transition-group"_s; break;
+    case PseudoElementType::ViewTransitionImagePair: ts << "view-transition-image-pair"_s; break;
+    case PseudoElementType::ViewTransitionOld: ts << "view-transition-old"_s; break;
+    case PseudoElementType::ViewTransitionNew: ts << "view-transition-new"_s; break;
+    case PseudoElementType::WebKitResizer: ts << "-webkit-resizer"_s; break;
+    case PseudoElementType::WebKitScrollbar: ts << "-webkit-scrollbar"_s; break;
+    case PseudoElementType::WebKitScrollbarThumb: ts << "-webkit-scrollbar-thumb"_s; break;
+    case PseudoElementType::WebKitScrollbarButton: ts << "-webkit-scrollbar-button"_s; break;
+    case PseudoElementType::WebKitScrollbarTrack: ts << "-webkit-scrollbar-track"_s; break;
+    case PseudoElementType::WebKitScrollbarTrackPiece: ts << "-webkit-scrollbar-trackpiece"_s; break;
+    case PseudoElementType::WebKitScrollbarCorner: ts << "-webkit-scrollbar-corner"_s; break;
     default:
         ts << "other"_s;
         break;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -84,7 +84,7 @@ enum class StyleDifferenceContextSensitiveProperty : uint8_t {
     WillChange  = 1 << 5,
 };
 
-enum class PseudoId : uint8_t {
+enum class PseudoElementType : uint8_t {
     // Public:
     FirstLine,
     FirstLetter,
@@ -116,46 +116,46 @@ enum class PseudoId : uint8_t {
     HighestEnumValue = InternalWritingSuggestions
 };
 
-constexpr auto allPublicPseudoIds = EnumSet {
-    PseudoId::FirstLine,
-    PseudoId::FirstLetter,
-    PseudoId::GrammarError,
-    PseudoId::Highlight,
-    PseudoId::Marker,
-    PseudoId::Before,
-    PseudoId::After,
-    PseudoId::Selection,
-    PseudoId::Backdrop,
-    PseudoId::WebKitScrollbar,
-    PseudoId::SpellingError,
-    PseudoId::TargetText,
-    PseudoId::ViewTransition,
-    PseudoId::ViewTransitionGroup,
-    PseudoId::ViewTransitionImagePair,
-    PseudoId::ViewTransitionOld,
-    PseudoId::ViewTransitionNew
+constexpr auto allPublicPseudoElementTypes = EnumSet {
+    PseudoElementType::FirstLine,
+    PseudoElementType::FirstLetter,
+    PseudoElementType::GrammarError,
+    PseudoElementType::Highlight,
+    PseudoElementType::Marker,
+    PseudoElementType::Before,
+    PseudoElementType::After,
+    PseudoElementType::Selection,
+    PseudoElementType::Backdrop,
+    PseudoElementType::WebKitScrollbar,
+    PseudoElementType::SpellingError,
+    PseudoElementType::TargetText,
+    PseudoElementType::ViewTransition,
+    PseudoElementType::ViewTransitionGroup,
+    PseudoElementType::ViewTransitionImagePair,
+    PseudoElementType::ViewTransitionOld,
+    PseudoElementType::ViewTransitionNew
 };
 
-constexpr auto allInternalPseudoIds = EnumSet {
-    PseudoId::WebKitScrollbarThumb,
-    PseudoId::WebKitScrollbarButton,
-    PseudoId::WebKitScrollbarTrack,
-    PseudoId::WebKitScrollbarTrackPiece,
-    PseudoId::WebKitScrollbarCorner,
-    PseudoId::WebKitResizer,
-    PseudoId::InternalWritingSuggestions,
+constexpr auto allInternalPseudoElementTypes = EnumSet {
+    PseudoElementType::WebKitScrollbarThumb,
+    PseudoElementType::WebKitScrollbarButton,
+    PseudoElementType::WebKitScrollbarTrack,
+    PseudoElementType::WebKitScrollbarTrackPiece,
+    PseudoElementType::WebKitScrollbarCorner,
+    PseudoElementType::WebKitResizer,
+    PseudoElementType::InternalWritingSuggestions,
 };
 
-constexpr auto allPseudoIds = allPublicPseudoIds | allInternalPseudoIds;
+constexpr auto allPseudoElementTypes = allPublicPseudoElementTypes | allInternalPseudoElementTypes;
 
-inline std::optional<PseudoId> parentPseudoElement(PseudoId pseudoId)
+inline std::optional<PseudoElementType> parentPseudoElement(PseudoElementType pseudoElementType)
 {
-    switch (pseudoId) {
-    case PseudoId::FirstLetter: return PseudoId::FirstLine;
-    case PseudoId::ViewTransitionGroup: return PseudoId::ViewTransition;
-    case PseudoId::ViewTransitionImagePair: return PseudoId::ViewTransitionGroup;
-    case PseudoId::ViewTransitionNew: return PseudoId::ViewTransitionImagePair;
-    case PseudoId::ViewTransitionOld: return PseudoId::ViewTransitionImagePair;
+    switch (pseudoElementType) {
+    case PseudoElementType::FirstLetter: return PseudoElementType::FirstLine;
+    case PseudoElementType::ViewTransitionGroup: return PseudoElementType::ViewTransition;
+    case PseudoElementType::ViewTransitionImagePair: return PseudoElementType::ViewTransitionGroup;
+    case PseudoElementType::ViewTransitionNew: return PseudoElementType::ViewTransitionImagePair;
+    case PseudoElementType::ViewTransitionOld: return PseudoElementType::ViewTransitionImagePair;
     default: return std::nullopt;
     }
 }
@@ -1371,7 +1371,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, PointerEvents);
 WTF::TextStream& operator<<(WTF::TextStream&, PositionType);
 WTF::TextStream& operator<<(WTF::TextStream&, PositionVisibility);
 WTF::TextStream& operator<<(WTF::TextStream&, PrintColorAdjust);
-WTF::TextStream& operator<<(WTF::TextStream&, PseudoId);
+WTF::TextStream& operator<<(WTF::TextStream&, PseudoElementType);
 WTF::TextStream& operator<<(WTF::TextStream&, QuoteType);
 WTF::TextStream& operator<<(WTF::TextStream&, ReflectionDirection);
 WTF::TextStream& operator<<(WTF::TextStream&, Resize);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -297,7 +297,7 @@ inline bool RenderStyle::hasContent() const { return content().isData(); }
 inline bool RenderStyle::hasDisplayAffectedByAnimations() const { return m_nonInheritedData->miscData->hasDisplayAffectedByAnimations; }
 // FIXME: Rename this function.
 inline bool RenderStyle::hasUsedAppearance() const { return usedAppearance() != StyleAppearance::None && usedAppearance() != StyleAppearance::Base; }
-inline bool RenderStyle::hasUsedContentNone() const { return content().isNone() || (content().isNormal() && (pseudoElementType() == PseudoId::Before || pseudoElementType() == PseudoId::After)); }
+inline bool RenderStyle::hasUsedContentNone() const { return content().isNone() || (content().isNormal() && (pseudoElementType() == PseudoElementType::Before || pseudoElementType() == PseudoElementType::After)); }
 inline bool RenderStyle::hasExplicitlySetBorderBottomLeftRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderBottomLeftRadius; }
 inline bool RenderStyle::hasExplicitlySetBorderBottomRightRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderBottomRightRadius; }
 inline bool RenderStyle::hasExplicitlySetBorderRadius() const { return hasExplicitlySetBorderBottomLeftRadius() || hasExplicitlySetBorderBottomRightRadius() || hasExplicitlySetBorderTopLeftRadius() || hasExplicitlySetBorderTopRightRadius(); }
@@ -320,7 +320,7 @@ inline bool RenderStyle::hasOutline() const { return outlineStyle() != OutlineSt
 inline bool RenderStyle::hasOutlineInVisualOverflow() const { return hasOutline() && outlineSize() > 0; }
 inline bool RenderStyle::hasPerspective() const { return !perspective().isNone(); }
 inline bool RenderStyle::hasPositionedMask() const { return maskLayers().hasImage(); }
-inline bool RenderStyle::hasPseudoStyle(PseudoId pseudo) const { return m_nonInheritedFlags.hasPseudoStyle(pseudo); }
+inline bool RenderStyle::hasPseudoStyle(PseudoElementType pseudo) const { return m_nonInheritedFlags.hasPseudoStyle(pseudo); }
 inline bool RenderStyle::hasRotate() const { return !rotate().isNone(); }
 inline bool RenderStyle::hasScale() const { return !scale().isNone(); }
 inline bool RenderStyle::hasStaticBlockPosition(bool horizontal) const { return horizontal ? hasAutoTopAndBottom() : hasAutoLeftAndRight(); }
@@ -798,11 +798,11 @@ inline bool RenderStyle::specifiesColumns() const { return !columnCount().isAuto
 constexpr OptionSet<Containment> RenderStyle::strictContainment() { return { Containment::Size, Containment::Layout, Containment::Paint, Containment::Style }; }
 inline const Style::Color& RenderStyle::strokeColor() const { return m_rareInheritedData->strokeColor; }
 inline Style::StrokeMiterlimit RenderStyle::strokeMiterLimit() const { return m_rareInheritedData->miterLimit; }
-inline std::optional<PseudoId> RenderStyle::pseudoElementType() const
+inline std::optional<PseudoElementType> RenderStyle::pseudoElementType() const
 {
     if (!m_nonInheritedFlags.pseudoElementType)
         return { };
-    return static_cast<PseudoId>(m_nonInheritedFlags.pseudoElementType - 1);
+    return static_cast<PseudoElementType>(m_nonInheritedFlags.pseudoElementType - 1);
 }
 inline const AtomString& RenderStyle::pseudoElementNameArgument() const { return m_nonInheritedData->rareData->pseudoElementNameArgument; }
 inline const Style::TabSize& RenderStyle::tabSize() const { return m_rareInheritedData->tabSize; }
@@ -886,7 +886,7 @@ inline const Style::CornerShapeValue& RenderStyle::cornerTopRightShape() const {
 
 // ignore non-standard ::-webkit-scrollbar when standard properties are in use
 inline bool RenderStyle::usesStandardScrollbarStyle() const { return scrollbarWidth() != ScrollbarWidth::Auto || !scrollbarColor().isAuto(); }
-inline bool RenderStyle::usesLegacyScrollbarStyle() const { return hasPseudoStyle(PseudoId::WebKitScrollbar) && !usesStandardScrollbarStyle(); }
+inline bool RenderStyle::usesLegacyScrollbarStyle() const { return hasPseudoStyle(PseudoElementType::WebKitScrollbar) && !usesStandardScrollbarStyle(); }
 
 #if ENABLE(APPLE_PAY)
 inline ApplePayButtonStyle RenderStyle::applePayButtonStyle() const { return static_cast<ApplePayButtonStyle>(m_nonInheritedData->rareData->applePayButtonStyle); }
@@ -1049,10 +1049,10 @@ inline Style::SVGMarkerResource RenderStyle::initialMarkerEnd() { return CSS::Ke
 constexpr MaskType RenderStyle::initialMaskType() { return MaskType::Luminance; }
 inline Style::SVGBaselineShift RenderStyle::initialBaselineShift() { return CSS::Keyword::Baseline { }; }
 
-inline bool RenderStyle::NonInheritedFlags::hasPseudoStyle(PseudoId pseudo) const
+inline bool RenderStyle::NonInheritedFlags::hasPseudoStyle(PseudoElementType pseudo) const
 {
-    ASSERT(allPublicPseudoIds.contains(pseudo));
-    return EnumSet<PseudoId>::fromRaw(pseudoBits).contains(pseudo);
+    ASSERT(allPublicPseudoElementTypes.contains(pseudo));
+    return EnumSet<PseudoElementType>::fromRaw(pseudoBits).contains(pseudo);
 }
 
 inline bool RenderStyle::NonInheritedFlags::hasAnyPublicPseudoStyles() const

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -177,7 +177,7 @@ inline void RenderStyle::setHasExplicitlySetPaddingRight(bool value) { SET_NESTE
 inline void RenderStyle::setHasExplicitlySetPaddingTop(bool value) { SET_NESTED(m_nonInheritedData, surroundData, hasExplicitlySetPaddingTop, value); }
 inline void RenderStyle::setHasExplicitlySetStrokeColor(bool value) { SET(m_rareInheritedData, hasSetStrokeColor, static_cast<unsigned>(value)); }
 inline void RenderStyle::setHasExplicitlySetStrokeWidth(bool value) { SET(m_rareInheritedData, hasSetStrokeWidth, static_cast<unsigned>(value)); }
-inline void RenderStyle::setHasPseudoStyles(EnumSet<PseudoId> set) { m_nonInheritedFlags.setHasPseudoStyles(set); }
+inline void RenderStyle::setHasPseudoStyles(EnumSet<PseudoElementType> set) { m_nonInheritedFlags.setHasPseudoStyles(set); }
 inline void RenderStyle::setHasVisitedLinkAutoCaretColor() { SET_PAIR(m_rareInheritedData, hasVisitedLinkAutoCaretColor, true, visitedLinkCaretColor, Style::Color::currentColor()); }
 inline void RenderStyle::setHeight(Style::PreferredSize&& length) { SET_NESTED(m_nonInheritedData, boxData, m_height, WTFMove(length)); }
 inline void RenderStyle::setHyphenateLimitAfter(Style::HyphenateLimitEdge limit) { SET(m_rareInheritedData, hyphenateLimitAfter, limit); }
@@ -442,11 +442,11 @@ inline void RenderStyle::setMarkerStart(Style::SVGMarkerResource&& marker) { SET
 inline void RenderStyle::setMarkerMid(Style::SVGMarkerResource&& marker) { SET_NESTED(m_svgStyle, inheritedResourceData, markerMid, WTFMove(marker)); }
 inline void RenderStyle::setMarkerEnd(Style::SVGMarkerResource&& marker) { SET_NESTED(m_svgStyle, inheritedResourceData, markerEnd, WTFMove(marker)); }
 
-inline void RenderStyle::NonInheritedFlags::setHasPseudoStyles(EnumSet<PseudoId> pseudoIdSet)
+inline void RenderStyle::NonInheritedFlags::setHasPseudoStyles(EnumSet<PseudoElementType> pseudoElementSet)
 {
-    ASSERT(pseudoIdSet);
-    ASSERT(pseudoIdSet.containsOnly(allPublicPseudoIds));
-    pseudoBits = pseudoIdSet.toRaw();
+    ASSERT(pseudoElementSet);
+    ASSERT(pseudoElementSet.containsOnly(allPublicPseudoElementTypes));
+    pseudoBits = pseudoElementSet.toRaw();
 }
 
 inline void RenderStyle::resetBorder()
@@ -511,7 +511,7 @@ inline bool RenderStyle::setUsedZoom(float zoomLevel)
 inline void RenderStyle::setPseudoElementIdentifier(std::optional<Style::PseudoElementIdentifier>&& identifier)
 {
     if (identifier) {
-        m_nonInheritedFlags.pseudoElementType = enumToUnderlyingType(identifier->pseudoId) + 1;
+        m_nonInheritedFlags.pseudoElementType = enumToUnderlyingType(identifier->type) + 1;
         SET_NESTED(m_nonInheritedData, rareData, pseudoElementNameArgument, WTFMove(identifier->nameArgument));
     } else {
         m_nonInheritedFlags.pseudoElementType = 0;

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
@@ -195,7 +195,7 @@ void SVGTextBoxPainter<TextBoxPath>::paint()
 
     const RenderStyle* selectionStyle = &style;
     if (hasSelection && shouldPaintSelectionHighlight) {
-        selectionStyle = parentRenderer.getCachedPseudoStyle({ PseudoId::Selection });
+        selectionStyle = parentRenderer.getCachedPseudoStyle({ PseudoElementType::Selection });
         if (selectionStyle) {
             if (!hasFill)
                 hasFill = selectionStyle->hasFill();

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -46,7 +46,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderTreeBuilder::FirstLetter);
 static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& firstLetterContainer)
 {
     auto& styleContainer = firstLetterContainer.isAnonymous() ? *firstLetterContainer.firstNonAnonymousAncestor() : firstLetterContainer;
-    auto style = styleContainer.style().getCachedPseudoStyle({ PseudoId::FirstLetter });
+    auto style = styleContainer.style().getCachedPseudoStyle({ PseudoElementType::FirstLetter });
     if (!style)
         return { };
 
@@ -87,7 +87,7 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
         }
     }
 
-    firstLetterStyle.setPseudoElementIdentifier({ { PseudoId::FirstLetter } });
+    firstLetterStyle.setPseudoElementIdentifier({ { PseudoElementType::FirstLetter } });
     // Force inline display (except for floating first-letters).
     firstLetterStyle.setDisplay(firstLetterStyle.isFloating() ? DisplayType::Block : DisplayType::Inline);
     // CSS2 says first-letter can't be positioned.
@@ -127,7 +127,7 @@ RenderTreeBuilder::FirstLetter::FirstLetter(RenderTreeBuilder& builder)
 
 void RenderTreeBuilder::FirstLetter::updateAfterDescendants(RenderBlock& block)
 {
-    if (!block.style().hasPseudoStyle(PseudoId::FirstLetter))
+    if (!block.style().hasPseudoStyle(PseudoElementType::FirstLetter))
         return;
 
     if (!supportsFirstLetter(block))
@@ -144,7 +144,7 @@ void RenderTreeBuilder::FirstLetter::updateAfterDescendants(RenderBlock& block)
 
     // If the child already has style, then it has already been created, so we just want
     // to update it.
-    if (firstLetter->parent()->style().pseudoElementType() == PseudoId::FirstLetter) {
+    if (firstLetter->parent()->style().pseudoElementType() == PseudoElementType::FirstLetter) {
         updateStyle(block, *firstLetter);
         return;
     }

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -349,7 +349,7 @@ void RenderTreeUpdater::popParentsToDepth(unsigned depth)
 void RenderTreeUpdater::updateBeforeDescendants(Element& element, const Style::ElementUpdate* update)
 {
     if (update)
-        generatedContent().updateBeforeOrAfterPseudoElement(element, *update, PseudoId::Before);
+        generatedContent().updateBeforeOrAfterPseudoElement(element, *update, PseudoElementType::Before);
 
     if (auto* before = element.beforePseudoElement())
         storePreviousRenderer(*before);
@@ -358,7 +358,7 @@ void RenderTreeUpdater::updateBeforeDescendants(Element& element, const Style::E
 void RenderTreeUpdater::updateAfterDescendants(Element& element, const Style::ElementUpdate* update)
 {
     if (update)
-        generatedContent().updateBeforeOrAfterPseudoElement(element, *update, PseudoId::After);
+        generatedContent().updateBeforeOrAfterPseudoElement(element, *update, PseudoElementType::After);
 
     auto* renderer = element.renderer();
     if (!renderer) {
@@ -863,7 +863,7 @@ void RenderTreeUpdater::tearDownRenderers(Element& root, TeardownType teardownTy
                 // we cannot create a Styleable with a PseudoElement.
                 if (auto* renderListItem = dynamicDowncast<RenderListItem>(element.renderer())) {
                     if (renderListItem->markerRenderer())
-                        Styleable(element, Style::PseudoElementIdentifier { PseudoId::Marker }).cancelStyleOriginatedAnimations();
+                        Styleable(element, Style::PseudoElementIdentifier { PseudoElementType::Marker }).cancelStyleOriginatedAnimations();
                 }
             }
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
@@ -40,7 +40,7 @@ public:
     GeneratedContent(RenderTreeUpdater&);
 
     void updateBackdropRenderer(RenderElement&, StyleDifference minimalStyleDifference);
-    void updateBeforeOrAfterPseudoElement(Element&, const Style::ElementUpdate&, PseudoId);
+    void updateBeforeOrAfterPseudoElement(Element&, const Style::ElementUpdate&, PseudoElementType);
     void updateRemainingQuotes();
     void updateCounters();
     void updateWritingSuggestionsRenderer(RenderElement&, StyleDifference minimalStyleDifference);

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -728,7 +728,7 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::findAnchorForAnchorFun
 
         // FIXME: Support remaining box generating pseudo-elements (like ::marker).
         auto pseudoElement = style.pseudoElementType();
-        if (pseudoElement && pseudoElement != PseudoId::Before && pseudoElement != PseudoId::After)
+        if (pseudoElement && pseudoElement != PseudoElementType::Before && pseudoElement != PseudoElementType::After)
             return false;
 
         return true;
@@ -1534,7 +1534,7 @@ RefPtr<const Element> AnchorPositionEvaluator::anchorPositionedElementOrPseudoEl
 AnchorPositionedKey AnchorPositionEvaluator::keyForElementOrPseudoElement(const Element& element)
 {
     if (auto* pseudoElement = dynamicDowncast<PseudoElement>(element))
-        return { pseudoElement->hostElement(), PseudoElementIdentifier { pseudoElement->pseudoId() } };
+        return { pseudoElement->hostElement(), PseudoElementIdentifier { pseudoElement->pseudoElementType() } };
     return { &element, { } };
 }
 
@@ -1555,8 +1555,8 @@ bool AnchorPositionEvaluator::isImplicitAnchor(const RenderStyle& style)
 
     // "The implicit anchor element of a pseudo-element is its originating element, unless otherwise specified."
     // https://drafts.csswg.org/css-anchor-position-1/#implicit
-    auto isImplicitAnchorForPseudoElement = [&](PseudoId pseudoId) {
-        const RenderStyle* pseudoElementStyle = style.getCachedPseudoStyle({ pseudoId });
+    auto isImplicitAnchorForPseudoElement = [&](PseudoElementType pseudoElementType) {
+        const RenderStyle* pseudoElementStyle = style.getCachedPseudoStyle({ pseudoElementType });
         if (!pseudoElementStyle)
             return false;
         // If we have an explicit anchor name then there is no need for an implicit anchor.
@@ -1565,7 +1565,7 @@ bool AnchorPositionEvaluator::isImplicitAnchor(const RenderStyle& style)
 
         return pseudoElementStyle->usesAnchorFunctions() || isLayoutTimeAnchorPositioned(*pseudoElementStyle);
     };
-    return isImplicitAnchorForPseudoElement(PseudoId::Before) || isImplicitAnchorForPseudoElement(PseudoId::After);
+    return isImplicitAnchorForPseudoElement(PseudoElementType::Before) || isImplicitAnchorForPseudoElement(PseudoElementType::After);
 }
 
 ScopedName AnchorPositionEvaluator::defaultAnchorName(const RenderStyle& style)

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -570,7 +570,7 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
             specificity = selector->computeSpecificity();
     }
 
-    m_matchedPseudoElementIds.add(context.pseudoIDSet);
+    m_matchedPseudoElements.add(context.publicPseudoElements);
     m_styleRelations.appendVector(context.styleRelations);
 
     return selectorMatches;
@@ -935,7 +935,7 @@ void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedPrope
 void ElementRuleCollector::addAuthorKeyframeRules(const StyleRuleKeyframe& keyframe)
 {
     ASSERT(m_result->authorDeclarations.isEmpty());
-    auto propertyAllowlist = m_pseudoElementRequest ? propertyAllowlistForPseudoId(m_pseudoElementRequest->pseudoId()) : PropertyAllowlist::None;
+    auto propertyAllowlist = m_pseudoElementRequest ? propertyAllowlistForPseudoElement(m_pseudoElementRequest->type()) : PropertyAllowlist::None;
     m_result->authorDeclarations.append({ keyframe.properties(), SelectorChecker::MatchAll, propertyAllowlist });
 }
 

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -72,7 +72,7 @@ public:
 
     void clearMatchedRules();
 
-    EnumSet<PseudoId> matchedPseudoElementIds() const { return m_matchedPseudoElementIds; }
+    EnumSet<PseudoElementType> matchedPseudoElements() const { return m_matchedPseudoElements; }
     const Relations& styleRelations() const { return m_styleRelations; }
 
     void addAuthorKeyframeRules(const StyleRuleKeyframe&);
@@ -135,7 +135,7 @@ private:
     Vector<RefPtr<const StyleRule>> m_matchedRuleList;
     Ref<MatchResult> m_result;
     Relations m_styleRelations;
-    EnumSet<PseudoId> m_matchedPseudoElementIds;
+    EnumSet<PseudoElementType> m_matchedPseudoElements;
 };
 
 }

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -71,7 +71,7 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderS
     if (&element == element.document().documentElement())
         return false;
     // FIXME: Without the following early return we hit the final assert in
-    // Element::resolvePseudoElementStyle(). Making matchedPseudoElementIds
+    // Element::resolvePseudoElementStyle(). Making matchedPseudoElements
     // PseudoElementIdentifier-aware might be a possible solution.
     if (!style.pseudoElementNameArgument().isNull())
         return false;

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -29,9 +29,9 @@
 namespace WebCore {
 namespace Style {
 
-PropertyAllowlist propertyAllowlistForPseudoId(PseudoId pseudoId)
+PropertyAllowlist propertyAllowlistForPseudoElement(PseudoElementType type)
 {
-    if (pseudoId == PseudoId::Marker)
+    if (type == PseudoElementType::Marker)
         return PropertyAllowlist::Marker;
     return PropertyAllowlist::None;
 }

--- a/Source/WebCore/style/PropertyAllowlist.h
+++ b/Source/WebCore/style/PropertyAllowlist.h
@@ -42,7 +42,7 @@ enum class PropertyAllowlist : uint8_t {
 #endif
 };
 
-PropertyAllowlist propertyAllowlistForPseudoId(PseudoId);
+PropertyAllowlist propertyAllowlistForPseudoElement(PseudoElementType);
 
 bool isValidMarkerStyleProperty(CSSPropertyID);
 #if ENABLE(VIDEO)

--- a/Source/WebCore/style/PseudoElementIdentifier.h
+++ b/Source/WebCore/style/PseudoElementIdentifier.h
@@ -33,7 +33,7 @@
 namespace WebCore::Style {
 
 struct PseudoElementIdentifier {
-    PseudoId pseudoId;
+    PseudoElementType type;
 
     // highlight name for ::highlight or view transition name for view transition pseudo elements.
     AtomString nameArgument { nullAtom() };
@@ -43,12 +43,12 @@ struct PseudoElementIdentifier {
 
 inline void add(Hasher& hasher, const PseudoElementIdentifier& pseudoElementIdentifier)
 {
-    add(hasher, pseudoElementIdentifier.pseudoId, pseudoElementIdentifier.nameArgument);
+    add(hasher, pseudoElementIdentifier.type, pseudoElementIdentifier.nameArgument);
 }
 
 inline WTF::TextStream& operator<<(WTF::TextStream& ts, const PseudoElementIdentifier& pseudoElementIdentifier)
 {
-    ts << "::"_s << pseudoElementIdentifier.pseudoId;
+    ts << "::"_s << pseudoElementIdentifier.type;
     if (!pseudoElementIdentifier.nameArgument.isNull())
         ts << '(' << pseudoElementIdentifier.nameArgument << ')';
     return ts;
@@ -59,11 +59,11 @@ inline bool isNamedViewTransitionPseudoElement(const std::optional<Style::Pseudo
     if (!pseudoElementIdentifier)
         return false;
 
-    switch (pseudoElementIdentifier->pseudoId) {
-    case PseudoId::ViewTransitionGroup:
-    case PseudoId::ViewTransitionImagePair:
-    case PseudoId::ViewTransitionOld:
-    case PseudoId::ViewTransitionNew:
+    switch (pseudoElementIdentifier->type) {
+    case PseudoElementType::ViewTransitionGroup:
+    case PseudoElementType::ViewTransitionImagePair:
+    case PseudoElementType::ViewTransitionOld:
+    case PseudoElementType::ViewTransitionNew:
         return true;
     default:
         return false;

--- a/Source/WebCore/style/PseudoElementRequest.h
+++ b/Source/WebCore/style/PseudoElementRequest.h
@@ -34,16 +34,16 @@ namespace WebCore::Style {
 
 class PseudoElementRequest {
 public:
-    PseudoElementRequest(PseudoId pseudoId, std::optional<StyleScrollbarState> scrollbarState = std::nullopt)
-        : m_identifier({ pseudoId })
+    PseudoElementRequest(PseudoElementType type, std::optional<StyleScrollbarState> scrollbarState = std::nullopt)
+        : m_identifier({ type })
         , m_scrollbarState(scrollbarState)
     {
     }
 
-    PseudoElementRequest(PseudoId pseudoId, const AtomString& nameArgument)
-        : m_identifier({ pseudoId, nameArgument })
+    PseudoElementRequest(PseudoElementType type, const AtomString& nameArgument)
+        : m_identifier({ type, nameArgument })
     {
-        ASSERT(pseudoId == PseudoId::Highlight || pseudoId == PseudoId::ViewTransitionGroup || pseudoId == PseudoId::ViewTransitionImagePair || pseudoId == PseudoId::ViewTransitionOld || pseudoId == PseudoId::ViewTransitionNew);
+        ASSERT(type == PseudoElementType::Highlight || type == PseudoElementType::ViewTransitionGroup || type == PseudoElementType::ViewTransitionImagePair || type == PseudoElementType::ViewTransitionOld || type == PseudoElementType::ViewTransitionNew);
     }
 
     PseudoElementRequest(const PseudoElementIdentifier& pseudoElementIdentifier)
@@ -52,7 +52,7 @@ public:
     }
 
     const PseudoElementIdentifier& identifier() const { return m_identifier; }
-    PseudoId pseudoId() const { return m_identifier.pseudoId; }
+    PseudoElementType type() const { return m_identifier.type; }
     const AtomString& nameArgument() const { return m_identifier.nameArgument; }
     const std::optional<StyleScrollbarState>& scrollbarState() const { return m_scrollbarState; }
 

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -100,7 +100,7 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* se
             return PropertyAllowlist::CueBackground;
 #endif
         if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::Marker)
-            return propertyAllowlistForPseudoId(PseudoId::Marker);
+            return propertyAllowlistForPseudoElement(PseudoElementType::Marker);
 
         if (const auto* selectorList = selector->selectorList()) {
             for (auto& subSelector : *selectorList) {

--- a/Source/WebCore/style/StylableInlines.h
+++ b/Source/WebCore/style/StylableInlines.h
@@ -34,7 +34,7 @@ inline const Styleable Styleable::fromElement(Element& element)
 {
     if (auto* pseudoElement = dynamicDowncast<PseudoElement>(element))
         return Styleable(*pseudoElement->hostElement(), *element.pseudoElementIdentifier());
-    ASSERT(!element.pseudoId());
+    ASSERT(!element.pseudoElementType());
     return Styleable(element, std::nullopt);
 }
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -479,7 +479,7 @@ void Adjuster::adjustFromBuilder(RenderStyle& style)
 
 void Adjuster::adjustFirstLetterStyle(RenderStyle& style)
 {
-    if (style.pseudoElementType() != PseudoId::FirstLetter)
+    if (style.pseudoElementType() != PseudoElementType::FirstLetter)
         return;
 
     // Force inline display (except for floating first-letters).
@@ -885,7 +885,7 @@ void Adjuster::adjustDisplayContentsStyle(RenderStyle& style) const
         return;
     }
 
-    if (!m_element && style.pseudoElementType() != PseudoId::Before && style.pseudoElementType() != PseudoId::After) {
+    if (!m_element && style.pseudoElementType() != PseudoElementType::Before && style.pseudoElementType() != PseudoElementType::After) {
         style.setEffectiveDisplay(DisplayType::None);
         return;
     }
@@ -1255,8 +1255,8 @@ bool Adjuster::adjustForTextAutosizing(RenderStyle& style, const Element& elemen
 
 void Adjuster::adjustVisibilityForPseudoElement(RenderStyle& style, const Element& host)
 {
-    if ((style.pseudoElementType() == PseudoId::After && host.visibilityAdjustment().contains(VisibilityAdjustment::AfterPseudo))
-        || (style.pseudoElementType() == PseudoId::Before && host.visibilityAdjustment().contains(VisibilityAdjustment::BeforePseudo)))
+    if ((style.pseudoElementType() == PseudoElementType::After && host.visibilityAdjustment().contains(VisibilityAdjustment::AfterPseudo))
+        || (style.pseudoElementType() == PseudoElementType::Before && host.visibilityAdjustment().contains(VisibilityAdjustment::BeforePseudo)))
         style.setIsForceHidden();
 }
 

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -130,7 +130,7 @@ RefPtr<StyleImage> BuilderState::createStyleImage(const CSSValue& value) const
 
 void BuilderState::registerContentAttribute(const AtomString& attributeLocalName)
 {
-    if (style().pseudoElementType() == PseudoId::Before || style().pseudoElementType() == PseudoId::After)
+    if (style().pseudoElementType() == PseudoElementType::Before || style().pseudoElementType() == PseudoElementType::After)
         m_registeredContentAttributes.append(attributeLocalName);
 }
 

--- a/Source/WebCore/style/StyleChange.cpp
+++ b/Source/WebCore/style/StyleChange.cpp
@@ -61,7 +61,7 @@ OptionSet<Change> determineChanges(const RenderStyle& s1, const RenderStyle& s2)
     auto needsRendererUpdate = [&] {
         if (s1.display() != s2.display())
             return true;
-        if (s1.hasPseudoStyle(PseudoId::FirstLetter) != s2.hasPseudoStyle(PseudoId::FirstLetter))
+        if (s1.hasPseudoStyle(PseudoElementType::FirstLetter) != s2.hasPseudoStyle(PseudoElementType::FirstLetter))
             return true;
         if (columnSpanNeedsNewRenderer())
             return true;

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -106,7 +106,7 @@ void loadPendingResources(RenderStyle& style, Document& document, const Element*
         loadPendingImage(document, shapeValueImage.get(), element, LoadPolicy::Anonymous);
 
     // Are there other pseudo-elements that need resource loading? 
-    if (auto* firstLineStyle = style.getCachedPseudoStyle({ PseudoId::FirstLine }))
+    if (auto* firstLineStyle = style.getCachedPseudoStyle({ PseudoElementType::FirstLine }))
         loadPendingResources(*firstLineStyle, document, element);
 }
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -333,8 +333,8 @@ UnadjustedStyle Resolver::unadjustedStyleForElement(Element& element, const Reso
     else
         collector.matchAllRules(m_matchAuthorAndUserStyles, matchingBehavior != RuleMatchingBehavior::MatchAllRulesExcludingSMIL);
 
-    if (collector.matchedPseudoElementIds())
-        style.setHasPseudoStyles(collector.matchedPseudoElementIds());
+    if (collector.matchedPseudoElements())
+        style.setHasPseudoStyles(collector.matchedPseudoElements());
 
     auto elementStyleRelations = commitRelationsToRenderStyle(style, element, collector.styleRelations());
 
@@ -593,7 +593,7 @@ std::optional<ResolvedStyle> Resolver::styleForPseudoElement(Element& element, c
         collector.matchAuthorRules();
     }
 
-    ASSERT(!collector.matchedPseudoElementIds());
+    ASSERT(!collector.matchedPseudoElements());
 
     if (collector.matchResult().isEmpty())
         return { };

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -365,7 +365,7 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
 
         auto pseudoElementChanges = [&]() -> OptionSet<Change> {
             if (pseudoElementUpdate) {
-                if (pseudoElementIdentifier.pseudoId == PseudoId::WebKitScrollbar)
+                if (pseudoElementIdentifier.type == PseudoElementType::WebKitScrollbar)
                     return pseudoElementUpdate->changes;
                 if (!pseudoElementUpdate->changes)
                     return { };
@@ -374,7 +374,7 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
             if (!existingStyle || !existingStyle->getCachedPseudoStyle(pseudoElementIdentifier))
                 return { };
             // If ::first-letter goes aways rebuild the renderers.
-            if (pseudoElementIdentifier.pseudoId == PseudoId::FirstLetter)
+            if (pseudoElementIdentifier.type == PseudoElementType::FirstLetter)
                 return { Change::Renderer };
             return { Change::NonInherited };
         }();
@@ -387,28 +387,28 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
         return pseudoElementUpdate->changes;
     };
     
-    if (resolveAndAddPseudoElementStyle({ PseudoId::FirstLine }))
+    if (resolveAndAddPseudoElementStyle({ PseudoElementType::FirstLine }))
         descendantsToResolve = DescendantsToResolve::All;
-    if (resolveAndAddPseudoElementStyle({ PseudoId::FirstLetter }))
+    if (resolveAndAddPseudoElementStyle({ PseudoElementType::FirstLetter }))
         descendantsToResolve = DescendantsToResolve::All;
-    if (resolveAndAddPseudoElementStyle({ PseudoId::WebKitScrollbar }))
+    if (resolveAndAddPseudoElementStyle({ PseudoElementType::WebKitScrollbar }))
         descendantsToResolve = DescendantsToResolve::All;
 
-    resolveAndAddPseudoElementStyle({ PseudoId::Marker });
-    resolveAndAddPseudoElementStyle({ PseudoId::Before });
-    resolveAndAddPseudoElementStyle({ PseudoId::After });
-    resolveAndAddPseudoElementStyle({ PseudoId::Backdrop });
+    resolveAndAddPseudoElementStyle({ PseudoElementType::Marker });
+    resolveAndAddPseudoElementStyle({ PseudoElementType::Before });
+    resolveAndAddPseudoElementStyle({ PseudoElementType::After });
+    resolveAndAddPseudoElementStyle({ PseudoElementType::Backdrop });
 
     if (isDocumentElement && m_document->hasViewTransitionPseudoElementTree()) {
-        resolveAndAddPseudoElementStyle({ PseudoId::ViewTransition });
+        resolveAndAddPseudoElementStyle({ PseudoElementType::ViewTransition });
 
         RefPtr activeViewTransition = m_document->activeViewTransition();
         ASSERT(activeViewTransition);
         for (auto& name : activeViewTransition->namedElements().keys()) {
-            resolveAndAddPseudoElementStyle({ PseudoId::ViewTransitionGroup, name });
-            resolveAndAddPseudoElementStyle({ PseudoId::ViewTransitionImagePair, name });
-            resolveAndAddPseudoElementStyle({ PseudoId::ViewTransitionNew, name });
-            resolveAndAddPseudoElementStyle({ PseudoId::ViewTransitionOld, name });
+            resolveAndAddPseudoElementStyle({ PseudoElementType::ViewTransitionGroup, name });
+            resolveAndAddPseudoElementStyle({ PseudoElementType::ViewTransitionImagePair, name });
+            resolveAndAddPseudoElementStyle({ PseudoElementType::ViewTransitionNew, name });
+            resolveAndAddPseudoElementStyle({ PseudoElementType::ViewTransitionOld, name });
         }
     }
 
@@ -430,9 +430,9 @@ std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element
     if (elementUpdate.style->display() == DisplayType::None)
         return { };
 
-    if (pseudoElementIdentifier.pseudoId == PseudoId::Backdrop && !element.isInTopLayer())
+    if (pseudoElementIdentifier.type == PseudoElementType::Backdrop && !element.isInTopLayer())
         return { };
-    if (pseudoElementIdentifier.pseudoId == PseudoId::Marker && elementUpdate.style->display() != DisplayType::ListItem)
+    if (pseudoElementIdentifier.type == PseudoElementType::Marker && elementUpdate.style->display() != DisplayType::ListItem)
         return { };
 
     auto userAgentShadowTreeEnclosingResolver = [&] -> Resolver* {
@@ -441,7 +441,7 @@ std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element
         return nullptr;
     };
 
-    if (pseudoElementIdentifier.pseudoId == PseudoId::FirstLine && !scope().resolver->usesFirstLineRules()) {
+    if (pseudoElementIdentifier.type == PseudoElementType::FirstLine && !scope().resolver->usesFirstLineRules()) {
         // For user-agent shadow tree elements, also check the enclosing (document) scope
         // because user-agent pseudo-elements like details::details-content::first-line
         // are defined in the document scope but target elements in the shadow tree
@@ -450,31 +450,31 @@ std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element
             return { };
     }
 
-    if (pseudoElementIdentifier.pseudoId == PseudoId::FirstLetter && !scope().resolver->usesFirstLetterRules()) {
+    if (pseudoElementIdentifier.type == PseudoElementType::FirstLetter && !scope().resolver->usesFirstLetterRules()) {
         RefPtr resolver = userAgentShadowTreeEnclosingResolver();
         if (!resolver || !resolver->usesFirstLetterRules())
             return { };
     }
 
-    if (pseudoElementIdentifier.pseudoId == PseudoId::WebKitScrollbar && elementUpdate.style->overflowX() != Overflow::Scroll && elementUpdate.style->overflowY() != Overflow::Scroll)
+    if (pseudoElementIdentifier.type == PseudoElementType::WebKitScrollbar && elementUpdate.style->overflowX() != Overflow::Scroll && elementUpdate.style->overflowY() != Overflow::Scroll)
         return { };
 
-    ASSERT_IMPLIES(pseudoElementIdentifier.pseudoId == PseudoId::ViewTransition
-        || pseudoElementIdentifier.pseudoId == PseudoId::ViewTransitionGroup
-        || pseudoElementIdentifier.pseudoId == PseudoId::ViewTransitionImagePair
-        || pseudoElementIdentifier.pseudoId == PseudoId::ViewTransitionNew
-        || pseudoElementIdentifier.pseudoId == PseudoId::ViewTransitionOld,
+    ASSERT_IMPLIES(pseudoElementIdentifier.type == PseudoElementType::ViewTransition
+        || pseudoElementIdentifier.type == PseudoElementType::ViewTransitionGroup
+        || pseudoElementIdentifier.type == PseudoElementType::ViewTransitionImagePair
+        || pseudoElementIdentifier.type == PseudoElementType::ViewTransitionNew
+        || pseudoElementIdentifier.type == PseudoElementType::ViewTransitionOld,
         m_document->hasViewTransitionPseudoElementTree() && &element == m_document->documentElement());
 
-    if (!elementUpdate.style->hasPseudoStyle(pseudoElementIdentifier.pseudoId))
+    if (!elementUpdate.style->hasPseudoStyle(pseudoElementIdentifier.type))
         return resolveAncestorPseudoElement(element, pseudoElementIdentifier, elementUpdate);
 
-    if ((pseudoElementIdentifier.pseudoId == PseudoId::FirstLine || pseudoElementIdentifier.pseudoId == PseudoId::FirstLetter) && !supportsFirstLineAndLetterPseudoElement(*elementUpdate.style))
+    if ((pseudoElementIdentifier.type == PseudoElementType::FirstLine || pseudoElementIdentifier.type == PseudoElementType::FirstLetter) && !supportsFirstLineAndLetterPseudoElement(*elementUpdate.style))
         return { };
 
     auto resolutionContext = makeResolutionContextForPseudoElement(elementUpdate, pseudoElementIdentifier);
 
-    bool pseudoSupportsPositionTry = pseudoElementIdentifier.pseudoId == PseudoId::Before || pseudoElementIdentifier.pseudoId == PseudoId::After || pseudoElementIdentifier.pseudoId == PseudoId::Backdrop;
+    bool pseudoSupportsPositionTry = pseudoElementIdentifier.type == PseudoElementType::Before || pseudoElementIdentifier.type == PseudoElementType::After || pseudoElementIdentifier.type == PseudoElementType::Backdrop;
 
     Styleable styleable { element, pseudoElementIdentifier };
 
@@ -503,17 +503,17 @@ std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element
 
     auto animatedUpdate = createAnimatedElementUpdate(WTFMove(*resolvedStyle), styleable, elementUpdate.changes, resolutionContext, isInDisplayNoneTree);
 
-    if (pseudoElementIdentifier.pseudoId == PseudoId::Before || pseudoElementIdentifier.pseudoId == PseudoId::After) {
+    if (pseudoElementIdentifier.type == PseudoElementType::Before || pseudoElementIdentifier.type == PseudoElementType::After) {
         if (scope().resolver->usesFirstLineRules()) {
             // ::first-line can inherit to ::before/::after
             if (auto firstLineContext = makeResolutionContextForInheritedFirstLine(elementUpdate, *elementUpdate.style)) {
                 auto firstLineStyle = scope().resolver->styleForPseudoElement(element, pseudoElementIdentifier, *firstLineContext);
-                firstLineStyle->style->setPseudoElementIdentifier({ { PseudoId::FirstLine } });
+                firstLineStyle->style->setPseudoElementIdentifier({ { PseudoElementType::FirstLine } });
                 animatedUpdate.style->addCachedPseudoStyle(WTFMove(firstLineStyle->style));
             }
         }
         if (scope().resolver->usesFirstLetterRules()) {
-            auto beforeAfterContext = makeResolutionContextForPseudoElement(animatedUpdate, { PseudoId::FirstLetter });
+            auto beforeAfterContext = makeResolutionContextForPseudoElement(animatedUpdate, { PseudoElementType::FirstLetter });
             if (auto firstLetterStyle = resolveAncestorFirstLetterPseudoElement(element, elementUpdate, beforeAfterContext))
                 animatedUpdate.style->addCachedPseudoStyle(WTFMove(firstLetterStyle->style));
         }
@@ -524,14 +524,14 @@ std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element
 
 std::optional<ElementUpdate> TreeResolver::resolveAncestorPseudoElement(Element& element, const PseudoElementIdentifier& pseudoElementIdentifier, const ElementUpdate& elementUpdate)
 {
-    ASSERT(!elementUpdate.style->hasPseudoStyle(pseudoElementIdentifier.pseudoId));
+    ASSERT(!elementUpdate.style->hasPseudoStyle(pseudoElementIdentifier.type));
 
     auto pseudoElementStyle = [&]() -> std::optional<ResolvedStyle> {
         // ::first-line and ::first-letter defined on an ancestor element may need to be resolved for the current element.
-        if (pseudoElementIdentifier.pseudoId == PseudoId::FirstLine)
+        if (pseudoElementIdentifier.type == PseudoElementType::FirstLine)
             return resolveAncestorFirstLinePseudoElement(element, elementUpdate);
-        if (pseudoElementIdentifier.pseudoId == PseudoId::FirstLetter) {
-            auto resolutionContext = makeResolutionContextForPseudoElement(elementUpdate, { PseudoId::FirstLetter });
+        if (pseudoElementIdentifier.type == PseudoElementType::FirstLetter) {
+            auto resolutionContext = makeResolutionContextForPseudoElement(elementUpdate, { PseudoElementType::FirstLetter });
             return resolveAncestorFirstLetterPseudoElement(element, elementUpdate, resolutionContext);
         }
         return { };
@@ -573,7 +573,7 @@ std::optional<ResolvedStyle> TreeResolver::resolveAncestorFirstLinePseudoElement
             return { };
 
         auto elementStyle = scope().resolver->styleForElement(element, *resolutionContext);
-        elementStyle.style->setPseudoElementIdentifier({ { PseudoId::FirstLine } });
+        elementStyle.style->setPseudoElementIdentifier({ { PseudoElementType::FirstLine } });
 
         return elementStyle;
     }
@@ -591,7 +591,7 @@ std::optional<ResolvedStyle> TreeResolver::resolveAncestorFirstLinePseudoElement
                 continue;
             if (!supportsFirstLineAndLetterPseudoElement(parent.style))
                 return nullptr;
-            if (parent.style.hasPseudoStyle(PseudoId::FirstLine))
+            if (parent.style.hasPseudoStyle(PseudoElementType::FirstLine))
                 return parent.element;
             if (!isChildInBlockFormattingContext(parent.style))
                 return nullptr;
@@ -603,17 +603,17 @@ std::optional<ResolvedStyle> TreeResolver::resolveAncestorFirstLinePseudoElement
     if (!firstLineElement)
         return { };
 
-    auto resolutionContext = makeResolutionContextForPseudoElement(elementUpdate, { PseudoId::FirstLine });
+    auto resolutionContext = makeResolutionContextForPseudoElement(elementUpdate, { PseudoElementType::FirstLine });
     // Can't use the cached state since the element being resolved is not the current one.
     resolutionContext.selectorMatchingState = nullptr;
 
-    return scope().resolver->styleForPseudoElement(*firstLineElement, { PseudoId::FirstLine }, resolutionContext);
+    return scope().resolver->styleForPseudoElement(*firstLineElement, { PseudoElementType::FirstLine }, resolutionContext);
 }
 
 std::optional<ResolvedStyle> TreeResolver::resolveAncestorFirstLetterPseudoElement(Element& element, const ElementUpdate& elementUpdate, ResolutionContext& resolutionContext)
 {
     auto findFirstLetterElement = [&]() -> Element* {
-        if (elementUpdate.style->hasPseudoStyle(PseudoId::FirstLetter) && supportsFirstLineAndLetterPseudoElement(*elementUpdate.style))
+        if (elementUpdate.style->hasPseudoStyle(PseudoElementType::FirstLetter) && supportsFirstLineAndLetterPseudoElement(*elementUpdate.style))
             return &element;
 
         // ::first-letter is only propagated to the first box.
@@ -633,7 +633,7 @@ std::optional<ResolvedStyle> TreeResolver::resolveAncestorFirstLetterPseudoEleme
 
             if (!supportsFirstLineAndLetterPseudoElement(parent.style))
                 return nullptr;
-            if (parent.style.hasPseudoStyle(PseudoId::FirstLetter))
+            if (parent.style.hasPseudoStyle(PseudoElementType::FirstLetter))
                 return parent.element;
             if (!isChildInBlockFormattingContext(parent.style))
                 return nullptr;
@@ -648,7 +648,7 @@ std::optional<ResolvedStyle> TreeResolver::resolveAncestorFirstLetterPseudoEleme
     // Can't use the cached state since the element being resolved is not the current one.
     resolutionContext.selectorMatchingState = nullptr;
 
-    return scope().resolver->styleForPseudoElement(*firstLetterElement, { PseudoId::FirstLetter }, resolutionContext);
+    return scope().resolver->styleForPseudoElement(*firstLetterElement, { PseudoElementType::FirstLetter }, resolutionContext);
 }
 
 ResolutionContext TreeResolver::makeResolutionContext()
@@ -665,8 +665,8 @@ ResolutionContext TreeResolver::makeResolutionContext()
 ResolutionContext TreeResolver::makeResolutionContextForPseudoElement(const ElementUpdate& elementUpdate, const PseudoElementIdentifier& pseudoElementIdentifier)
 {
     auto parentStyle = [&]() -> const RenderStyle* {
-        if (auto parentPseudoId = parentPseudoElement(pseudoElementIdentifier.pseudoId)) {
-            if (auto* parentPseudoStyle = elementUpdate.style->getCachedPseudoStyle({ *parentPseudoId, (*parentPseudoId == PseudoId::ViewTransitionGroup || *parentPseudoId == PseudoId::ViewTransitionImagePair) ? pseudoElementIdentifier.nameArgument : nullAtom() }))
+        if (auto parentPseudoId = parentPseudoElement(pseudoElementIdentifier.type)) {
+            if (auto* parentPseudoStyle = elementUpdate.style->getCachedPseudoStyle({ *parentPseudoId, (*parentPseudoId == PseudoElementType::ViewTransitionGroup || *parentPseudoId == PseudoElementType::ViewTransitionImagePair) ? pseudoElementIdentifier.nameArgument : nullAtom() }))
                 return parentPseudoStyle;
         }
         return elementUpdate.style.get();
@@ -683,7 +683,7 @@ ResolutionContext TreeResolver::makeResolutionContextForPseudoElement(const Elem
 
 std::optional<ResolutionContext> TreeResolver::makeResolutionContextForInheritedFirstLine(const ElementUpdate& elementUpdate, const RenderStyle& inheritStyle)
 {
-    auto parentFirstLineStyle = inheritStyle.getCachedPseudoStyle({ PseudoId::FirstLine });
+    auto parentFirstLineStyle = inheritStyle.getCachedPseudoStyle({ PseudoElementType::FirstLine });
     if (!parentFirstLineStyle)
         return { };
 
@@ -1496,8 +1496,8 @@ auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderSt
     };
 
     update(style);
-    update(style->getCachedPseudoStyle({ PseudoId::Before }));
-    update(style->getCachedPseudoStyle({ PseudoId::After }));
+    update(style->getCachedPseudoStyle({ PseudoElementType::Before }));
+    update(style->getCachedPseudoStyle({ PseudoElementType::After }));
 
     auto needsInterleavedLayout = hasUnresolvedAnchorPosition({ element, { } });
     if (needsInterleavedLayout)

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -74,35 +74,35 @@ const std::optional<const Styleable> Styleable::fromRenderer(const RenderElement
     }
 
     switch (*renderer.style().pseudoElementType()) {
-    case PseudoId::Backdrop:
+    case PseudoElementType::Backdrop:
         for (auto& topLayerElement : renderer.document().topLayerElements()) {
             if (topLayerElement->renderer() && topLayerElement->renderer()->backdropRenderer() == &renderer)
-                return Styleable(topLayerElement.get(), Style::PseudoElementIdentifier { PseudoId::Backdrop });
+                return Styleable(topLayerElement.get(), Style::PseudoElementIdentifier { PseudoElementType::Backdrop });
         }
         break;
-    case PseudoId::Marker: {
+    case PseudoElementType::Marker: {
         auto* ancestor = renderer.parent();
         while (ancestor) {
             auto* renderListItem = dynamicDowncast<RenderListItem>(ancestor);
             if (renderListItem && ancestor->element() && renderListItem->markerRenderer() == &renderer)
-                return Styleable(*ancestor->element(), Style::PseudoElementIdentifier { PseudoId::Marker });
+                return Styleable(*ancestor->element(), Style::PseudoElementIdentifier { PseudoElementType::Marker });
             ancestor = ancestor->parent();
         }
         break;
     }
-    case PseudoId::ViewTransitionGroup:
-    case PseudoId::ViewTransitionImagePair:
-    case PseudoId::ViewTransitionNew:
-    case PseudoId::ViewTransitionOld:
+    case PseudoElementType::ViewTransitionGroup:
+    case PseudoElementType::ViewTransitionImagePair:
+    case PseudoElementType::ViewTransitionNew:
+    case PseudoElementType::ViewTransitionOld:
         if (auto* documentElement = renderer.document().documentElement())
             return Styleable(*documentElement, renderer.style().pseudoElementIdentifier());
         break;
-    case PseudoId::ViewTransition:
+    case PseudoElementType::ViewTransition:
         if (auto* documentElement = renderer.document().documentElement())
-            return Styleable(*documentElement, Style::PseudoElementIdentifier { PseudoId::ViewTransition });
+            return Styleable(*documentElement, Style::PseudoElementIdentifier { PseudoElementType::ViewTransition });
         break;
-    case PseudoId::After:
-    case PseudoId::Before:
+    case PseudoElementType::After:
+    case PseudoElementType::Before:
         if (auto* element = renderer.element())
             return fromElement(*element);
         break;
@@ -118,36 +118,36 @@ RenderElement* Styleable::renderer() const
     if (!pseudoElementIdentifier)
         return element.renderer();
 
-    switch (pseudoElementIdentifier->pseudoId) {
-    case PseudoId::After:
+    switch (pseudoElementIdentifier->type) {
+    case PseudoElementType::After:
         if (auto* afterPseudoElement = element.afterPseudoElement())
             return afterPseudoElement->renderer();
         break;
-    case PseudoId::Backdrop:
+    case PseudoElementType::Backdrop:
         if (auto* hostRenderer = element.renderer())
             return hostRenderer->backdropRenderer().get();
         break;
-    case PseudoId::Before:
+    case PseudoElementType::Before:
         if (auto* beforePseudoElement = element.beforePseudoElement())
             return beforePseudoElement->renderer();
         break;
-    case PseudoId::Marker:
+    case PseudoElementType::Marker:
         if (auto* renderListItem = dynamicDowncast<RenderListItem>(element.renderer())) {
             auto* markerRenderer = renderListItem->markerRenderer();
             if (markerRenderer && !markerRenderer->style().hasUsedContentNone())
                 return markerRenderer;
         }
         break;
-    case PseudoId::ViewTransition:
+    case PseudoElementType::ViewTransition:
         if (element.renderer() && element.renderer()->isDocumentElementRenderer()) {
             if (WeakPtr containingBlock = element.renderer()->view().viewTransitionContainingBlock())
                 return containingBlock->firstChildBox();
         }
         break;
-    case PseudoId::ViewTransitionGroup:
-    case PseudoId::ViewTransitionImagePair:
-    case PseudoId::ViewTransitionNew:
-    case PseudoId::ViewTransitionOld: {
+    case PseudoElementType::ViewTransitionGroup:
+    case PseudoElementType::ViewTransitionImagePair:
+    case PseudoElementType::ViewTransitionNew:
+    case PseudoElementType::ViewTransitionOld: {
         if (!element.renderer() || !element.renderer()->isDocumentElementRenderer())
             return nullptr;
 
@@ -157,12 +157,12 @@ RenderElement* Styleable::renderer() const
             return nullptr;
 
         // Return early if we're looking for ::view-transition-group().
-        if (pseudoElementIdentifier->pseudoId == PseudoId::ViewTransitionGroup)
+        if (pseudoElementIdentifier->type == PseudoElementType::ViewTransitionGroup)
             return correctGroup.unsafeGet();
 
         // Go through all descendants until we find the relevant pseudo element otherwise.
         for (auto& descendant : descendantsOfType<RenderBox>(*correctGroup)) {
-            if (descendant.style().pseudoElementType() == pseudoElementIdentifier->pseudoId)
+            if (descendant.style().pseudoElementType() == pseudoElementIdentifier->type)
                 return &descendant;
         }
         break;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7132,7 +7132,7 @@ String Internals::highlightPseudoElementColor(const AtomString& highlightName, E
     if (!parentStyle)
         return { };
 
-    auto resolvedStyle = styleResolver.styleForPseudoElement(element, { PseudoId::Highlight, highlightName }, { parentStyle });
+    auto resolvedStyle = styleResolver.styleForPseudoElement(element, { PseudoElementType::Highlight, highlightName }, { parentStyle });
     if (!resolvedStyle)
         return { };
 


### PR DESCRIPTION
#### a25210285dc718a3409e20cb0623752c17f1ba21
<pre>
Rename PseudoId to PseudoElementType
<a href="https://bugs.webkit.org/show_bug.cgi?id=300982">https://bugs.webkit.org/show_bug.cgi?id=300982</a>
<a href="https://rdar.apple.com/problem/162862210">rdar://problem/162862210</a>

Reviewed by Tim Nguyen.

Use a less vague name for this enum.
Also some related renamings and cleanups.

This patch does not touch Inspector or the inspector protocol where the old name is still used.

* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::shouldCacheStringValue const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::isCurrentlyAffectingProperty const):
(WebCore::KeyframeEffect::computeHasSizeDependentTransform):
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeOrder):
(WebCore::pseudoElementIdentifierAsString):
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::stylePseudoElementTypeFor):
(WebCore::CSSSelector::pseudoId): Deleted.
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::CheckingContext::setRequestedPseudoElement):
(WebCore::SelectorChecker::CheckingContext::requestedPseudoElement const):
(WebCore::SelectorChecker::match const):
(WebCore::SelectorChecker::matchHostPseudoClass const):
(WebCore::hasViewTransitionPseudoElement):
(WebCore::hasScrollbarPseudoElement):
(WebCore::SelectorChecker::matchRecursively const):
(WebCore::SelectorChecker::checkOne const):
(WebCore::SelectorChecker::matchSelectorList const):
(WebCore::SelectorChecker::matchHasPseudoClass const):
(WebCore::SelectorChecker::checkViewTransitionPseudoClass const):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::pseudoElementIdentifierFor):
(WebCore::CSSSelectorParser::parsePseudoElement):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateSelectorChecker):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateRequestedPseudoElementEqualsToSelectorPseudoElement):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateMarkPseudoStyleForPseudoElement):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::styleForElementIgnoringPendingStylesheets):
* Source/WebCore/dom/Element.cpp:
(WebCore::beforeOrAfterPseudoElement):
(WebCore::Element::computedStyle):
(WebCore::Element::ensurePseudoElement):
(WebCore::Element::pseudoElementIfExists):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementInlines.h:
(WebCore::isInTopLayerOrBackdrop):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::isBeforePseudoElement const):
(WebCore::Node::isAfterPseudoElement const):
(WebCore::Node::pseudoElementType const):
(WebCore::Node::pseudoElementIdentifier const):
(WebCore::Node::pseudoId const): Deleted.
* Source/WebCore/dom/PseudoElement.cpp:
(WebCore::PseudoElement::PseudoElement):
(WebCore::m_pseudoElementType):
(WebCore::PseudoElement::create):
(WebCore::PseudoElement::rendererIsNeeded):
(WebCore::m_pseudoId): Deleted.
* Source/WebCore/dom/PseudoElement.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::handleTransitionFrame):
(WebCore::ViewTransition::updatePseudoElementRenderers):
(WebCore::ViewTransition::viewTransitionNewPseudoForCapturedElement):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::protocolValueForPseudoId):
(WebCore::InspectorCSSAgent::getMatchedStylesForNode):
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::elementToPushForStyleable):
(WebCore::InspectorDOMAgent::pushStyleablePathToFrontend):
(WebCore::InspectorDOMAgent::highlightSelector):
(WebCore::pseudoElementType):
(WebCore::InspectorDOMAgent::buildObjectForNode):
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp:
(WebCore::InspectorLayerTreeAgent::buildObjectForLayer):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::adjustLineRectForInitialLetterIfApplicable):
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp:
(WebCore::Layout::InlineInvalidation::rootStyleWillChange):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::shouldInvalidateLineLayoutAfterChangeFor):
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::styleHidesScrollbarWithOrientation const):
(WebCore::LocalFrameView::updateScrollCorner):
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForHighlights):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::nodeForHitTest const):
(WebCore::findFirstLetterBlock):
(WebCore::RenderBlock::debugDescription const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::adjustForUnsplittableChild):
(WebCore::RenderBlockFlow::computeLogicalLocationForFloat):
(WebCore::RenderBlockFlow::lowestInitialLetterLogicalBottom const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::imageChanged):
(WebCore::RenderBox::isUnsplittableForPagination const):
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::planCounter):
(WebCore::RenderCounter::updateCounter):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::firstLineStyle const):
(WebCore::RenderElement::styleDidChange):
(WebCore::RenderElement::willBeDestroyed):
(WebCore::RenderElement::getCachedPseudoStyle const):
(WebCore::RenderElement::getUncachedPseudoStyle const):
(WebCore::RenderElement::textSegmentPseudoStyle const):
(WebCore::RenderElement::selectionPseudoStyle const):
(WebCore::RenderElement::spellingErrorPseudoStyle const):
(WebCore::RenderElement::grammarErrorPseudoStyle const):
(WebCore::RenderElement::targetTextPseudoStyle const):
(WebCore::RenderElement::isViewTransitionRoot const):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::isViewTransitionContainer const):
* Source/WebCore/rendering/RenderElementInlines.h:
(WebCore::RenderElement::isBeforeContent const):
(WebCore::RenderElement::isAfterContent const):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::clippedOverflowRect const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::RenderLayerBacking):
(WebCore::RenderLayerBacking::shouldClipCompositedBounds const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::collectViewTransitionNewContentLayers):
(WebCore::RenderLayerCompositor::clipsCompositingDescendants):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollCornerStyle):
(WebCore::RenderLayerScrollableArea::updateResizerStyle):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::computeMarkerStyle const):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::calculateHighlightColor const):
* Source/WebCore/rendering/RenderScrollbar.cpp:
(WebCore::RenderScrollbar::getScrollbarPseudoStyle const):
(WebCore::pseudoForScrollbarPart):
* Source/WebCore/rendering/RenderScrollbar.h:
* Source/WebCore/rendering/RenderTextFragment.cpp:
(WebCore::RenderTextFragment::blockForAccompanyingFirstLetter):
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp:
(WebCore::RenderViewTransitionCapture::updateFromStyle):
(WebCore::RenderViewTransitionCapture::paintsContent const):
(WebCore::RenderViewTransitionCapture::debugDescription const):
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):
* Source/WebCore/rendering/TextAutoSizing.cpp:
(WebCore::cloneRenderStyleWithState):
(WebCore::TextAutoSizingValue::adjustTextNodeSizes):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::collectStylesForRenderer):
(WebCore::TextDecorationPainter::stylesForRenderer):
* Source/WebCore/rendering/TextDecorationPainter.h:
(WebCore::TextDecorationPainter::stylesForRenderer):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::createStyleInheritingFromPseudoStyle):
(WebCore::RenderStyle::changeRequiresLayout const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
(WebCore::parentPseudoElement):
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::hasUsedContentNone const):
(WebCore::RenderStyle::hasPseudoStyle const):
(WebCore::RenderStyle::pseudoElementType const):
(WebCore::RenderStyle::usesLegacyScrollbarStyle const):
(WebCore::RenderStyle::NonInheritedFlags::hasPseudoStyle const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setHasPseudoStyles):
(WebCore::RenderStyle::NonInheritedFlags::setHasPseudoStyles):
(WebCore::RenderStyle::setPseudoElementIdentifier):
* Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp:
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::paint):
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
(WebCore::styleForFirstLetter):
(WebCore::RenderTreeBuilder::FirstLetter::updateAfterDescendants):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateBeforeDescendants):
(WebCore::RenderTreeUpdater::updateAfterDescendants):
(WebCore::RenderTreeUpdater::tearDownRenderers):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::keyframeEffectStackForPseudoElement):
(WebCore::needsPseudoElementForAnimation):
(WebCore::createContentRenderers):
(WebCore::RenderTreeUpdater::GeneratedContent::updateBeforeOrAfterPseudoElement):
(WebCore::RenderTreeUpdater::GeneratedContent::updateBackdropRenderer):
(WebCore::RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer):
(WebCore::keyframeEffectStackForElementAndPseudoId): Deleted.
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementTree):
(WebCore::createRendererIfNeeded):
(WebCore::RenderTreeUpdater::ViewTransition::buildPseudoElementGroup):
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementGroup):
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):
(WebCore::Style::AnchorPositionEvaluator::keyForElementOrPseudoElement):
(WebCore::Style::AnchorPositionEvaluator::isImplicitAnchor):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ruleMatches):
(WebCore::Style::ElementRuleCollector::addAuthorKeyframeRules):
* Source/WebCore/style/ElementRuleCollector.h:
(WebCore::Style::ElementRuleCollector::matchedPseudoElements const):
(WebCore::Style::ElementRuleCollector::matchedPseudoElementIds const): Deleted.
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::isCacheable):
* Source/WebCore/style/PropertyAllowlist.cpp:
(WebCore::Style::propertyAllowlistForPseudoElement):
(WebCore::Style::propertyAllowlistForPseudoId): Deleted.
* Source/WebCore/style/PropertyAllowlist.h:
* Source/WebCore/style/PseudoElementIdentifier.h:
(WebCore::Style::add):
(WebCore::Style::operator&lt;&lt;):
(WebCore::Style::isNamedViewTransitionPseudoElement):
* Source/WebCore/style/PseudoElementRequest.h:
(WebCore::Style::PseudoElementRequest::PseudoElementRequest):
(WebCore::Style::PseudoElementRequest::type const):
(WebCore::Style::PseudoElementRequest::pseudoId const): Deleted.
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::determinePropertyAllowlist):
* Source/WebCore/style/StylableInlines.h:
(WebCore::Styleable::fromElement):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustFirstLetterStyle):
(WebCore::Style::Adjuster::adjustDisplayContentsStyle const):
(WebCore::Style::Adjuster::adjustVisibilityForPseudoElement):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::registerContentAttribute):
* Source/WebCore/style/StyleChange.cpp:
(WebCore::Style::determineChanges):
* Source/WebCore/style/StylePendingResources.cpp:
(WebCore::Style::loadPendingResources):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::unadjustedStyleForElement):
(WebCore::Style::Resolver::styleForPseudoElement):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::resolvePseudoElement):
(WebCore::Style::TreeResolver::resolveAncestorPseudoElement):
(WebCore::Style::TreeResolver::resolveAncestorFirstLinePseudoElement):
(WebCore::Style::TreeResolver::resolveAncestorFirstLetterPseudoElement):
(WebCore::Style::TreeResolver::makeResolutionContextForPseudoElement):
(WebCore::Style::TreeResolver::makeResolutionContextForInheritedFirstLine):
(WebCore::Style::TreeResolver::updateAnchorPositioningState):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::fromRenderer):
(WebCore::Styleable::renderer const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::highlightPseudoElementColor):

Canonical link: <a href="https://commits.webkit.org/301770@main">https://commits.webkit.org/301770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc1920e9f555c7cb37a7143e7929a3294eccbb4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134000 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78561 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dc68bff2-0c0d-4c06-bdb4-e85fdecd4abf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55159 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96636 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113608 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/77147 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/80ffe84e-e1cd-47b6-9512-d50f29613dfe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36675 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77392 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136526 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53651 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/41310 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105151 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104843 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26735 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50364 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51154 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53583 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59456 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52822 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56156 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54581 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->