### PR TITLE
Address safer CPP warnings in _WKAttachment

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -4,7 +4,6 @@ UIProcess/API/Cocoa/WKUserScript.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
 UIProcess/API/Cocoa/WKWindowFeatures.mm
-UIProcess/API/Cocoa/_WKAttachment.mm
 UIProcess/API/Cocoa/_WKAutomationSession.mm
 UIProcess/API/Cocoa/_WKContentRuleListAction.mm
 UIProcess/API/Cocoa/_WKCustomHeaderFields.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
@@ -64,10 +64,15 @@ static const NSInteger InvalidAttachmentErrorCode = 2;
     return self;
 }
 
+- (Ref<const API::Attachment>)_protectedAttachment
+{
+    return *_attachment;
+}
+
 - (NSData *)data
 {
     NSData *result = nil;
-    _attachment->doWithFileWrapper([&](NSFileWrapper *fileWrapper) {
+    self._protectedAttachment->doWithFileWrapper([&](NSFileWrapper *fileWrapper) {
         // FIXME: Handle attachments backed by NSFileWrappers that represent directories.
         result = fileWrapper.isRegularFile ? fileWrapper.regularFileContents : nil;
     });
@@ -77,7 +82,7 @@ static const NSInteger InvalidAttachmentErrorCode = 2;
 - (NSString *)name
 {
     NSString *result = nil;
-    _attachment->doWithFileWrapper([&](NSFileWrapper *fileWrapper) {
+    self._protectedAttachment->doWithFileWrapper([&](NSFileWrapper *fileWrapper) {
         result = fileWrapper.filename.length ? fileWrapper.filename : fileWrapper.preferredFilename;
     });
     return result;
@@ -95,7 +100,7 @@ static const NSInteger InvalidAttachmentErrorCode = 2;
     // thumbnailing. This should be replaced with a method that instead takes a callback, and
     // invokes with callback with a file wrapper in a way that guarantees thread safety.
     NSFileWrapper *result = nil;
-    _attachment->doWithFileWrapper([&](NSFileWrapper *fileWrapper) {
+    self._protectedAttachment->doWithFileWrapper([&](NSFileWrapper *fileWrapper) {
         result = fileWrapper;
     });
     return result;
@@ -123,7 +128,7 @@ static const NSInteger InvalidAttachmentErrorCode = 2;
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKAttachment.class, self))
         return;
 
-    _attachment->~Attachment();
+    SUPPRESS_UNCOUNTED_ARG _attachment->~Attachment();
 
     [super dealloc];
 }
@@ -156,9 +161,10 @@ static const NSInteger InvalidAttachmentErrorCode = 2;
 
     // This file path member is only populated when the attachment is generated upon dropping files. When data is specified via NSFileWrapper
     // from the SPI client, the corresponding file path of the data is unknown, if it even exists at all.
-    _attachment->setFilePath({ });
-    _attachment->setFileWrapperAndUpdateContentType(fileWrapper, contentType);
-    _attachment->updateAttributes([capturedBlock = makeBlockPtr(completionHandler)] {
+    Ref attachment = *_attachment;
+    attachment->setFilePath({ });
+    attachment->setFileWrapperAndUpdateContentType(fileWrapper, contentType);
+    attachment->updateAttributes([capturedBlock = makeBlockPtr(completionHandler)] {
         if (capturedBlock)
             capturedBlock(nil);
     });


### PR DESCRIPTION
#### 53c5278c16b10ec57a97736a2b1bd3a0b9256c1b
<pre>
Address safer CPP warnings in _WKAttachment
<a href="https://bugs.webkit.org/show_bug.cgi?id=300985">https://bugs.webkit.org/show_bug.cgi?id=300985</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm:
(-[_WKAttachmentInfo _protectedAttachment]):
(-[_WKAttachmentInfo data]):
(-[_WKAttachmentInfo name]):
(-[_WKAttachmentInfo fileWrapper]):
(-[_WKAttachment dealloc]):
(-[_WKAttachment setFileWrapper:contentType:completion:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53c5278c16b10ec57a97736a2b1bd3a0b9256c1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78465 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55039 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96544 "15 failures") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64551 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77058 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36585 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136394 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41212 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105056 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104752 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50255 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51006 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53463 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59326 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52714 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56049 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54466 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->