### PR TITLE
[threaded-animation-resolution] upload timelines through the remote layer tree transaction

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2447,7 +2447,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/animation/AcceleratedEffect.h
     platform/animation/AcceleratedEffectStack.h
     platform/animation/AcceleratedEffectValues.h
+    platform/animation/AcceleratedTimeline.h
     platform/animation/AnimationUtilities.h
+    platform/animation/TimelineIdentifier.h
     platform/animation/TimingFunction.h
     platform/animation/values/AcceleratedEffectOffsetAnchor.h
     platform/animation/values/AcceleratedEffectOffsetDistance.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -162,7 +162,6 @@ accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilitySlider.cpp
 accessibility/AccessibilitySpinButton.cpp
 accessibility/AccessibilityTableHeaderContainer.cpp
-animation/AcceleratedEffectStackUpdater.cpp
 animation/AnimationEffectTiming.cpp
 animation/AnimationTimeline.cpp
 animation/AnimationTimelinesController.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2389,6 +2389,7 @@ platform/Widget.cpp
 platform/animation/AcceleratedEffect.cpp
 platform/animation/AcceleratedEffectStack.cpp @no-unify
 platform/animation/AcceleratedEffectValues.cpp
+platform/animation/AcceleratedTimeline.cpp
 platform/animation/TimingFunction.cpp
 platform/animation/values/AcceleratedEffectOffsetAnchor.cpp
 platform/animation/values/AcceleratedEffectOffsetDistance.cpp

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
@@ -30,7 +30,6 @@
 #include <WebCore/AcceleratedEffect.h>
 #include <WebCore/AnimationMalloc.h>
 #include <wtf/HashSet.h>
-#include <wtf/Seconds.h>
 
 namespace WebCore {
 
@@ -41,19 +40,17 @@ struct Styleable;
 class AcceleratedEffectStackUpdater {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AcceleratedEffectStackUpdater, Animation);
 public:
-    AcceleratedEffectStackUpdater(Document&);
+    AcceleratedEffectStackUpdater() = default;
 
     void updateEffectStacks();
     void updateEffectStackForTarget(const Styleable&);
 
-    Seconds timeOrigin() const { return m_timeOrigin; }
-
-protected:
+    const HashSet<Ref<AcceleratedTimeline>>& timelines() const { return m_timelines; }
 
 private:
     using HashedStyleable = std::pair<Element*, std::optional<Style::PseudoElementIdentifier>>;
     HashSet<HashedStyleable> m_targetsPendingUpdate;
-    Seconds m_timeOrigin;
+    HashSet<Ref<AcceleratedTimeline>> m_timelines;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -38,8 +38,11 @@
 namespace WebCore {
 
 AnimationTimeline::AnimationTimeline(std::optional<WebAnimationTime> duration)
-    : m_duration(duration)
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    : m_acceleratedTimelineIdentifier(TimelineIdentifier::generate())
+#endif
 {
+    m_duration = duration;
 }
 
 AnimationTimeline::~AnimationTimeline() = default;
@@ -120,5 +123,23 @@ Style::SingleAnimationRange AnimationTimeline::defaultRange() const
         .end = { CSS::Keyword::Normal { } },
     };
 }
+
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+AcceleratedTimeline& AnimationTimeline::acceleratedRepresentation()
+{
+    if (!m_acceleratedRepresentation)
+        m_acceleratedRepresentation = createAcceleratedRepresentation();
+    return *m_acceleratedRepresentation;
+}
+
+Ref<AcceleratedTimeline> AnimationTimeline::createAcceleratedRepresentation()
+{
+    // Until we implement accelerated representations of other timeline types,
+    // we should only ever call DocumentTimeline::createAcceleratedRepresentation().
+    ASSERT_NOT_REACHED();
+    return AcceleratedTimeline::create(m_acceleratedTimelineIdentifier, 0_s);
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -31,6 +31,11 @@
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+#include "AcceleratedTimeline.h"
+#include "TimelineIdentifier.h"
+#endif
+
 namespace WebCore {
 
 class AnimationTimelinesController;
@@ -74,12 +79,28 @@ public:
 
     static void updateGlobalPosition(WebAnimation&);
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void clearAcceleratedRepresentation() { m_acceleratedRepresentation = nullptr; }
+    AcceleratedTimeline& acceleratedRepresentation();
+#endif
+
 protected:
     AnimationTimeline(std::optional<WebAnimationTime> = std::nullopt);
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    virtual Ref<AcceleratedTimeline> createAcceleratedRepresentation();
+#endif
+
     AnimationCollection m_animations;
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    TimelineIdentifier m_acceleratedTimelineIdentifier;
+#endif
+
 private:
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    RefPtr<AcceleratedTimeline> m_acceleratedRepresentation;
+#endif
     std::optional<WebAnimationTime> m_currentTime;
     std::optional<WebAnimationTime> m_duration;
 };

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -375,8 +375,17 @@ bool AnimationTimelinesController::isPendingTimelineAttachment(const WebAnimatio
 AcceleratedEffectStackUpdater& AnimationTimelinesController::acceleratedEffectStackUpdater()
 {
     if (!m_acceleratedEffectStackUpdater)
-        m_acceleratedEffectStackUpdater = makeUnique<AcceleratedEffectStackUpdater>(m_document.get());
+        m_acceleratedEffectStackUpdater = makeUnique<AcceleratedEffectStackUpdater>();
     return *m_acceleratedEffectStackUpdater;
+}
+
+void AnimationTimelinesController::updateAcceleratedEffectStacks()
+{
+    if (!m_acceleratedEffectStackUpdater)
+        return;
+    for (Ref timeline : m_timelines)
+        timeline->clearAcceleratedRepresentation();
+    m_acceleratedEffectStackUpdater->updateEffectStacks();
 }
 #endif
 

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -71,8 +71,9 @@ public:
     bool animationsAreSuspended() const { return m_isSuspended; }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    AcceleratedEffectStackUpdater* existingAcceleratedEffectStackUpdater() const { return m_acceleratedEffectStackUpdater.get(); }
     AcceleratedEffectStackUpdater& acceleratedEffectStackUpdater();
+    AcceleratedEffectStackUpdater* existingAcceleratedEffectStackUpdater() const { return m_acceleratedEffectStackUpdater.get(); }
+    void updateAcceleratedEffectStacks();
 #endif
 
 private:

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -94,6 +94,10 @@ private:
     bool isDocumentTimeline() const final { return true; }
 
     AnimationTimelinesController* controller() const override;
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    Ref<AcceleratedTimeline> createAcceleratedRepresentation() override;
+#endif
+
     void applyPendingAcceleratedAnimations();
     void scheduleInvalidationTaskIfNeeded();
     void scheduleAnimationResolution();

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -28,6 +28,7 @@
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
 #include <WebCore/AcceleratedEffectValues.h>
+#include <WebCore/AcceleratedTimeline.h>
 #include <WebCore/AnimationEffectTiming.h>
 #include <WebCore/CompositeOperation.h>
 #include <WebCore/KeyframeInterpolation.h>
@@ -73,8 +74,8 @@ public:
         OptionSet<AcceleratedEffectProperty> m_animatedProperties;
     };
 
-    static RefPtr<AcceleratedEffect> create(const KeyframeEffect&, const IntRect&, const AcceleratedEffectValues&, OptionSet<AcceleratedEffectProperty>&);
-    WEBCORE_EXPORT static Ref<AcceleratedEffect> create(AnimationEffectTiming, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WebAnimationTime> startTime, std::optional<WebAnimationTime> holdTime);
+    static RefPtr<AcceleratedEffect> create(const KeyframeEffect&, const TimelineIdentifier&, const IntRect&, const AcceleratedEffectValues&, OptionSet<AcceleratedEffectProperty>&);
+    WEBCORE_EXPORT static Ref<AcceleratedEffect> create(AnimationEffectTiming, TimelineIdentifier&&, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WebAnimationTime> startTime, std::optional<WebAnimationTime> holdTime);
 
     virtual ~AcceleratedEffect() = default;
 
@@ -85,6 +86,8 @@ public:
 
     // Encoding and decoding support
     const AnimationEffectTiming& timing() const { return m_timing; }
+    const RefPtr<AcceleratedTimeline>& timeline() const { return m_timeline; }
+    const TimelineIdentifier& timelineIdentifier() const { return m_timelineIdentifier; }
     const Vector<Keyframe>& keyframes() const { return m_keyframes; }
     WebAnimationType animationType() const { return m_animationType; }
     CompositeOperation compositeOperation() const final { return m_compositeOperation; }
@@ -100,8 +103,8 @@ public:
     bool animatesTransformRelatedProperty() const;
 
 private:
-    AcceleratedEffect(const KeyframeEffect&, const IntRect&, const OptionSet<AcceleratedEffectProperty>&);
-    explicit AcceleratedEffect(AnimationEffectTiming, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WebAnimationTime> startTime, std::optional<WebAnimationTime> holdTime);
+    AcceleratedEffect(const KeyframeEffect&, const TimelineIdentifier&, const IntRect&, const OptionSet<AcceleratedEffectProperty>&);
+    explicit AcceleratedEffect(AnimationEffectTiming, TimelineIdentifier&&, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WebAnimationTime> startTime, std::optional<WebAnimationTime> holdTime);
     explicit AcceleratedEffect(const AcceleratedEffect&, OptionSet<AcceleratedEffectProperty>&);
 
     void validateFilters(const AcceleratedEffectValues& baseValues, OptionSet<AcceleratedEffectProperty>&);
@@ -113,6 +116,8 @@ private:
     const TimingFunction* timingFunctionForKeyframe(const KeyframeInterpolation::Keyframe&) const final;
 
     AnimationEffectTiming m_timing;
+    RefPtr<AcceleratedTimeline> m_timeline;
+    TimelineIdentifier m_timelineIdentifier;
     Vector<Keyframe> m_keyframes;
     WebAnimationType m_animationType { WebAnimationType::WebAnimation };
     CompositeOperation m_compositeOperation { CompositeOperation::Replace };

--- a/Source/WebCore/platform/animation/AcceleratedTimeline.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedTimeline.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AcceleratedTimeline.h"
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedTimeline);
+
+Ref<AcceleratedTimeline> AcceleratedTimeline::create(const TimelineIdentifier& identifier, Seconds originTime)
+{
+    return adoptRef(*new AcceleratedTimeline(identifier, originTime));
+}
+
+AcceleratedTimeline::AcceleratedTimeline(const TimelineIdentifier& identifier, Seconds originTime)
+    : m_identifier(identifier)
+    , m_originTime(originTime)
+{
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/platform/animation/AcceleratedTimeline.h
+++ b/Source/WebCore/platform/animation/AcceleratedTimeline.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include "TimelineIdentifier.h"
+#include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class AcceleratedTimeline : public RefCounted<AcceleratedTimeline> {
+    WTF_MAKE_TZONE_ALLOCATED(AcceleratedTimeline);
+public:
+    WEBCORE_EXPORT static Ref<AcceleratedTimeline> create(const TimelineIdentifier&, Seconds originTime);
+
+    // Encoding support.
+    const TimelineIdentifier& identifier() const { return m_identifier; }
+    const Seconds originTime() const { return m_originTime; }
+
+    WEBCORE_EXPORT virtual ~AcceleratedTimeline() = default;
+
+private:
+    AcceleratedTimeline(const TimelineIdentifier&, Seconds originTime);
+
+    TimelineIdentifier m_identifier;
+    Seconds m_originTime;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/platform/animation/TimelineIdentifier.h
+++ b/Source/WebCore/platform/animation/TimelineIdentifier.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include <wtf/ObjectIdentifier.h>
+
+namespace WebCore {
+
+struct TimelineIdentifierType;
+using TimelineIdentifier = ObjectIdentifier<TimelineIdentifierType>;
+
+}
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -47,6 +47,10 @@ class RenderLayerCompositor;
 class TiledBacking;
 class TransformationMatrix;
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+class AcceleratedTimeline;
+#endif
+
 enum CompositingLayerType {
     NormalCompositingLayer, // non-tiled layer with backing store
     TiledCompositingLayer, // tiled layer (always has backing store)
@@ -192,7 +196,7 @@ public:
     void resumeAnimations();
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    bool updateAcceleratedEffectsAndBaseValues();
+    bool updateAcceleratedEffectsAndBaseValues(HashSet<Ref<AcceleratedTimeline>>&);
 #endif
 
     WEBCORE_EXPORT LayoutRect compositedBounds() const;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -445,6 +445,7 @@ def serialized_identifiers():
         'WebCore::TextCheckingRequestIdentifier',
         'WebCore::TextManipulationItemIdentifier',
         'WebCore::TextManipulationTokenIdentifier',
+        'WebCore::TimelineIdentifier',
         'WebCore::IDBDatabaseConnectionIdentifier',
         'WebCore::IDBResourceObjectIdentifier',
         'WebCore::UserGestureTokenIdentifierID',
@@ -682,6 +683,7 @@ def conditions_for_header(header):
         '<WebCore/PlaybackTargetClientContextIdentifier.h>': ["ENABLE(WIRELESS_PLAYBACK_TARGET)"],
         '<WebCore/SoupNetworkProxySettings.h>': ["USE(SOUP)"],
         '<WebCore/SelectionData.h>': ["PLATFORM(GTK)", "PLATFORM(WPE)"],
+        '<WebCore/TimelineIdentifier.h>': ["ENABLE(THREADED_ANIMATION_RESOLUTION)"],
         '<WebCore/VideoFrameCV.h>': ["PLATFORM(COCOA)", ],
     }
     if not header in conditions:

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -487,6 +487,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebCore::TextCheckingRequestIdentifier"_s,
         "WebCore::TextManipulationItemIdentifier"_s,
         "WebCore::TextManipulationTokenIdentifier"_s,
+        "WebCore::TimelineIdentifier"_s,
         "WebCore::IDBDatabaseConnectionIdentifier"_s,
         "WebCore::IDBResourceObjectIdentifier"_s,
         "WebCore::UserGestureTokenIdentifierID"_s,

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -163,7 +163,7 @@ header: "RemoteLayerBackingStore.h"
 #endif
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    Seconds m_acceleratedTimelineTimeOrigin;
+    HashSet<Ref<WebCore::AcceleratedTimeline>> m_timelines;
 #endif
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -54,8 +54,7 @@
 #endif
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-#include <WebCore/AcceleratedEffect.h>
-#include <WebCore/AcceleratedEffectValues.h>
+#include <WebCore/AcceleratedTimeline.h>
 #endif
 
 #if ENABLE(MODEL_ELEMENT)
@@ -270,13 +269,13 @@ public:
     void setDynamicViewportSizeUpdateID(DynamicViewportSizeUpdateID resizeID) { m_dynamicViewportSizeUpdateID = resizeID; }
 #endif
 
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    Seconds acceleratedTimelineTimeOrigin() const { return m_acceleratedTimelineTimeOrigin; }
-    void setAcceleratedTimelineTimeOrigin(Seconds timeOrigin) { m_acceleratedTimelineTimeOrigin = timeOrigin; }
-#endif
-
     const std::optional<WebCore::FixedContainerEdges>& fixedContainerEdges() const { return m_fixedContainerEdges; }
     void setFixedContainerEdges(const WebCore::FixedContainerEdges& edges) { m_fixedContainerEdges = edges; }
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelines() const { return m_timelines; }
+    void setTimelines(const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelines) { m_timelines = timelines; }
+#endif
 
 private:
     friend struct IPC::ArgumentCoder<RemoteLayerTreeTransaction, void>;
@@ -335,7 +334,7 @@ private:
     std::optional<DynamicViewportSizeUpdateID> m_dynamicViewportSizeUpdateID;
 #endif
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    Seconds m_acceleratedTimelineTimeOrigin;
+    HashSet<Ref<WebCore::AcceleratedTimeline>> m_timelines;
 #endif
 };
 

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -133,6 +133,9 @@ template: struct WebCore::ProcessIdentifierType
 template: struct WebCore::ScrollingNodeIDType
 template: struct WebCore::SharedWorkerObjectIdentifierType
 template: struct WebCore::SleepDisablerIdentifierType
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+template: struct WebCore::TimelineIdentifierType
+#endif
 template: struct WebCore::UserGestureTokenIdentifierType
 template: struct WebCore::UserMediaRequestIdentifierType
 template: struct WebCore::WebTransportStreamIdentifierType

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6570,6 +6570,11 @@ struct WebCore::AnimationEffectTiming {
     [NotSerialized] std::optional<Seconds> specifiedIterationDuration;
 };
 
+[RefCounted] class WebCore::AcceleratedTimeline {
+    WebCore::TimelineIdentifier identifier();
+    Seconds originTime();
+};
+
 header: <WebCore/AcceleratedEffect.h>
 [CustomHeader, Nested] class WebCore::AcceleratedEffect::Keyframe {
     double offset();
@@ -6581,6 +6586,8 @@ header: <WebCore/AcceleratedEffect.h>
 
 [RefCounted] class WebCore::AcceleratedEffect {
     WebCore::AnimationEffectTiming timing();
+    [NotSerialized] RefPtr<WebCore::AcceleratedTimeline> timeline();
+    WebCore::TimelineIdentifier timelineIdentifier();
     Vector<WebCore::AcceleratedEffect::Keyframe> keyframes();
     WebCore::WebAnimationType animationType();
     WebCore::CompositeOperation compositeOperation();

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -677,6 +677,7 @@ UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm @nonARC
 UIProcess/RemoteLayerTree/RemoteAnimation.cpp
 UIProcess/RemoteLayerTree/RemoteAnimationStack.mm @nonARC
 UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
+UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.cpp
 UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm @nonARC
 UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm @nonARC
 UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm @nonARC

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
@@ -39,13 +39,14 @@ static WebCore::WebAnimationTime computeCurrentTime(Seconds originTime, Monotoni
     return now.secondsSinceEpoch() - originTime;
 }
 
-Ref<RemoteAnimationTimeline> RemoteAnimationTimeline::create(Seconds originTime, MonotonicTime now)
+Ref<RemoteAnimationTimeline> RemoteAnimationTimeline::create(const WebCore::AcceleratedTimeline& input, MonotonicTime now)
 {
-    return adoptRef(*new RemoteAnimationTimeline(originTime, computeCurrentTime(originTime, now)));
+    return adoptRef(*new RemoteAnimationTimeline(input.identifier(), input.originTime(), computeCurrentTime(input.originTime(), now)));
 }
 
-RemoteAnimationTimeline::RemoteAnimationTimeline(Seconds originTime, WebCore::WebAnimationTime currentTime)
-    : m_originTime(originTime)
+RemoteAnimationTimeline::RemoteAnimationTimeline(WebCore::TimelineIdentifier identifier, Seconds originTime, WebCore::WebAnimationTime currentTime)
+    : m_identifier(identifier)
+    , m_originTime(originTime)
     , m_currentTime(currentTime)
 {
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
+#include <WebCore/AcceleratedTimeline.h>
+#include <WebCore/TimelineIdentifier.h>
 #include <WebCore/WebAnimationTime.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
@@ -36,14 +38,16 @@ namespace WebKit {
 class RemoteAnimationTimeline final : public RefCounted<RemoteAnimationTimeline> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RemoteAnimationTimeline);
 public:
-    static Ref<RemoteAnimationTimeline> create(Seconds, MonotonicTime);
+    static Ref<RemoteAnimationTimeline> create(const WebCore::AcceleratedTimeline&, MonotonicTime);
 
     void updateCurrentTime(MonotonicTime);
     const WebCore::WebAnimationTime& currentTime() const { return m_currentTime; }
+    const WebCore::TimelineIdentifier& identifier() const { return m_identifier; }
 
 private:
-    RemoteAnimationTimeline(Seconds, WebCore::WebAnimationTime);
+    RemoteAnimationTimeline(WebCore::TimelineIdentifier, Seconds, WebCore::WebAnimationTime);
 
+    WebCore::TimelineIdentifier m_identifier;
     Seconds m_originTime;
     WebCore::WebAnimationTime m_currentTime;
 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "RemoteAnimationTimelineRegistry.h"
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#import "RemoteAnimationTimeline.h"
+#import <WebCore/AcceleratedTimeline.h>
+#import <wtf/MonotonicTime.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAnimationTimelineRegistry);
+
+void RemoteAnimationTimelineRegistry::update(WebCore::ProcessIdentifier processIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelineRepresentations, MonotonicTime now)
+{
+    // If there are no active timelines for this process identifier, simply remove that entry.
+    if (timelineRepresentations.isEmpty()) {
+        m_timelines.remove(processIdentifier);
+        return;
+    }
+
+    // Populate the list of active timelines, creating new timelines as necessary.
+    HashSet<Ref<RemoteAnimationTimeline>> activeTimelines;
+    for (auto& timelineRepresentation : timelineRepresentations) {
+        if (RefPtr existingTimeline = get(processIdentifier, timelineRepresentation->identifier()))
+            activeTimelines.add(existingTimeline.releaseNonNull());
+        else
+            activeTimelines.add(RemoteAnimationTimeline::create(timelineRepresentation, now));
+    }
+
+    // Replace the timelines, which will clear any remaining timeline.
+    m_timelines.set(processIdentifier, WTFMove(activeTimelines));
+}
+
+RemoteAnimationTimeline* RemoteAnimationTimelineRegistry::get(WebCore::ProcessIdentifier processIdentifier, const WebCore::TimelineIdentifier& timelineIdentifier) const
+{
+    auto it = m_timelines.find(processIdentifier);
+    if (it == m_timelines.end())
+        return nullptr;
+
+    for (auto& timeline : it->value) {
+        if (timeline->identifier() == timelineIdentifier)
+            return timeline.ptr();
+    }
+
+    return nullptr;
+}
+
+void RemoteAnimationTimelineRegistry::advanceCurrentTime(MonotonicTime now)
+{
+    for (auto& timelines : m_timelines.values()) {
+        for (auto& timeline : timelines)
+            timeline->updateCurrentTime(now);
+    }
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include <wtf/TZoneMalloc.h>
+
+namespace WebKit {
+
+class RemoteAnimationTimelineRegistry {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteAnimationTimelineRegistry);
+public:
+    RemoteAnimationTimelineRegistry() = default;
+
+    bool isEmpty() const { return m_timelines.isEmpty(); }
+    void update(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime);
+    RemoteAnimationTimeline* get(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&) const;
+    void advanceCurrentTime(MonotonicTime);
+
+private:
+    HashMap<WebCore::ProcessIdentifier, HashSet<Ref<RemoteAnimationTimeline>>> m_timelines;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -83,8 +83,8 @@ public:
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
-    void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds originTime, MonotonicTime now);
-    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const;
+    void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime);
+    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&) const;
 #endif
 
     // For testing.

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -844,16 +844,16 @@ void RemoteLayerTreeDrawingAreaProxy::animationsWereRemovedFromNode(RemoteLayerT
         page->checkedScrollingCoordinatorProxy()->animationsWereRemovedFromNode(node);
 }
 
-void RemoteLayerTreeDrawingAreaProxy::registerTimelineIfNecessary(WebCore::ProcessIdentifier processIdentifier, Seconds originTime, MonotonicTime now)
+void RemoteLayerTreeDrawingAreaProxy::updateTimelineRegistration(WebCore::ProcessIdentifier processIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelineRepresentations, MonotonicTime now)
 {
     if (RefPtr page = this->page())
-        page->checkedScrollingCoordinatorProxy()->registerTimelineIfNecessary(processIdentifier, originTime, now);
+        page->checkedScrollingCoordinatorProxy()->updateTimelineRegistration(processIdentifier, timelineRepresentations, now);
 }
 
-const RemoteAnimationTimeline* RemoteLayerTreeDrawingAreaProxy::timeline(WebCore::ProcessIdentifier processIdentifier) const
+const RemoteAnimationTimeline* RemoteLayerTreeDrawingAreaProxy::timeline(WebCore::ProcessIdentifier processIdentifier, const WebCore::TimelineIdentifier& timelineIdentifier) const
 {
     if (RefPtr page = this->page())
-        return page->checkedScrollingCoordinatorProxy()->timeline(processIdentifier);
+        return page->checkedScrollingCoordinatorProxy()->timeline(processIdentifier, timelineIdentifier);
     return nullptr;
 }
 #endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -87,7 +87,7 @@ public:
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
-    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const;
+    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&) const;
 #endif
 
     void detachFromDrawingArea();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -198,7 +198,9 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
     }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    Ref { *m_drawingArea }->registerTimelineIfNecessary(processIdentifier, transaction.acceleratedTimelineTimeOrigin(), MonotonicTime::now());
+    // FIXME: with site isolation, a single process can send multiple transactions.
+    // https://bugs.webkit.org/show_bug.cgi?id=301261
+    Ref { *m_drawingArea }->updateTimelineRegistration(processIdentifier, transaction.timelines(), MonotonicTime::now());
 #endif
 
     for (auto& changedLayer : transaction.changedLayerProperties()) {
@@ -517,9 +519,9 @@ void RemoteLayerTreeHost::animationsWereRemovedFromNode(RemoteLayerTreeNode& nod
     protectedDrawingArea()->animationsWereRemovedFromNode(node);
 }
 
-const RemoteAnimationTimeline* RemoteLayerTreeHost::timeline(WebCore::ProcessIdentifier processIdentifier) const
+const RemoteAnimationTimeline* RemoteLayerTreeHost::timeline(WebCore::ProcessIdentifier processIdentifier, const WebCore::TimelineIdentifier& timelineIdentifier) const
 {
-    return protectedDrawingArea()->timeline(processIdentifier);
+    return protectedDrawingArea()->timeline(processIdentifier, timelineIdentifier);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -317,7 +317,7 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
         return;
 
     Ref animationStack = RemoteAnimationStack::create(effects.map([&](const Ref<AcceleratedEffect>& effect) {
-        RefPtr timeline = host.timeline(m_layerID.processIdentifier());
+        RefPtr timeline = host.timeline(m_layerID.processIdentifier(), effect->timelineIdentifier());
         ASSERT(timeline);
         return RemoteAnimation::create(Ref { effect }.get(), *timeline);
     }), baseValues.clone(), layer.get().bounds);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -145,8 +145,8 @@ public:
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     virtual void animationsWereAddedToNode(RemoteLayerTreeNode&) { }
     virtual void animationsWereRemovedFromNode(RemoteLayerTreeNode&) { }
-    virtual void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds, MonotonicTime) { }
-    virtual const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const { return nullptr; }
+    virtual void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) { }
+    virtual const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&) const { return nullptr; }
 #endif
 
     String scrollingTreeAsText() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -31,7 +31,7 @@
 #include <wtf/TZoneMalloc.h>
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-#import "RemoteAnimationTimeline.h"
+#import "RemoteAnimationTimelineRegistry.h"
 #endif
 
 OBJC_CLASS UIScrollView;
@@ -75,8 +75,8 @@ public:
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
-    void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds, MonotonicTime) override;
-    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const override;
+    void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) override;
+    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&) const override;
     void updateAnimations();
 #endif
 
@@ -106,7 +106,7 @@ private:
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     HashSet<WebCore::PlatformLayerIdentifier> m_animatedNodeLayerIDs;
-    HashMap<WebCore::ProcessIdentifier, Ref<RemoteAnimationTimeline>> m_timelines;
+    std::unique_ptr<RemoteAnimationTimelineRegistry> m_timelineRegistry;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -77,8 +77,8 @@ private:
 
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
-    void registerTimelineIfNecessary(WebCore::ProcessIdentifier, Seconds, MonotonicTime) override;
-    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier) const override;
+    void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) override;
+    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&) const override;
 #else
     void willCommitLayerAndScrollingTrees() override;
     void didCommitLayerAndScrollingTrees() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -319,14 +319,14 @@ void RemoteScrollingCoordinatorProxyMac::animationsWereRemovedFromNode(RemoteLay
     m_eventDispatcher->animationsWereRemovedFromNode(node);
 }
 
-void RemoteScrollingCoordinatorProxyMac::registerTimelineIfNecessary(WebCore::ProcessIdentifier processIdentifier, Seconds originTime, MonotonicTime now)
+void RemoteScrollingCoordinatorProxyMac::updateTimelineRegistration(WebCore::ProcessIdentifier processIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelineRepresentations, MonotonicTime now)
 {
-    m_eventDispatcher->registerTimelineIfNecessary(processIdentifier, originTime, now);
+    m_eventDispatcher->updateTimelineRegistration(processIdentifier, timelineRepresentations, now);
 }
 
-const RemoteAnimationTimeline* RemoteScrollingCoordinatorProxyMac::timeline(WebCore::ProcessIdentifier processIdentifier) const
+const RemoteAnimationTimeline* RemoteScrollingCoordinatorProxyMac::timeline(WebCore::ProcessIdentifier processIdentifier, const WebCore::TimelineIdentifier& timelineIdentifier) const
 {
-    return m_eventDispatcher->timeline(processIdentifier);
+    return m_eventDispatcher->timeline(processIdentifier, timelineIdentifier);
 }
 #endif
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1556,6 +1556,7 @@
 		7121A3CF2B73728B00C8F7A4 /* CAFrameRateRangeUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 7121A3CE2B73727B00C8F7A4 /* CAFrameRateRangeUtilities.h */; };
 		7134A3DA2603B92500624BD3 /* WKModelInteractionGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7134A3D92603B80E00624BD3 /* WKModelInteractionGestureRecognizer.h */; };
 		7137BA8025F1542000914EE3 /* ModelElementController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7137BA7F25F1540C00914EE3 /* ModelElementController.h */; };
+		71983F112EA6398D00594BCE /* RemoteAnimationTimelineRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 71983F0F2EA6397000594BCE /* RemoteAnimationTimelineRegistry.h */; };
 		71A676A622C62325007D6295 /* WKTouchActionGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A676A422C62318007D6295 /* WKTouchActionGestureRecognizer.h */; };
 		71BAA73325FFD09800D7CD5D /* WKModelView.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BAA73125FFCCBA00D7CD5D /* WKModelView.h */; };
 		71C9EC9F2CF9FB6400B8AF06 /* RemoteAnimationTimeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C9EC9D2CF9F93600B8AF06 /* RemoteAnimationTimeline.h */; };
@@ -6686,6 +6687,8 @@
 		7177AD5C2743D7A9002F103B /* ARKitInlinePreviewModelPlayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARKitInlinePreviewModelPlayer.h; sourceTree = "<group>"; };
 		7177AD662743F66C002F103B /* ARKitInlinePreviewModelPlayerIOS.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ARKitInlinePreviewModelPlayerIOS.mm; sourceTree = "<group>"; };
 		7177AD672743F66C002F103B /* ARKitInlinePreviewModelPlayerIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARKitInlinePreviewModelPlayerIOS.h; sourceTree = "<group>"; };
+		71983F0F2EA6397000594BCE /* RemoteAnimationTimelineRegistry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteAnimationTimelineRegistry.h; sourceTree = "<group>"; };
+		71983F102EA6397000594BCE /* RemoteAnimationTimelineRegistry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteAnimationTimelineRegistry.cpp; sourceTree = "<group>"; };
 		71A676A422C62318007D6295 /* WKTouchActionGestureRecognizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKTouchActionGestureRecognizer.h; path = ios/WKTouchActionGestureRecognizer.h; sourceTree = "<group>"; };
 		71A676A522C62318007D6295 /* WKTouchActionGestureRecognizer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKTouchActionGestureRecognizer.mm; path = ios/WKTouchActionGestureRecognizer.mm; sourceTree = "<group>"; };
 		71BAA73125FFCCBA00D7CD5D /* WKModelView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKModelView.h; path = ios/WKModelView.h; sourceTree = "<group>"; };
@@ -11404,6 +11407,8 @@
 				71371D1F2B1F89C10092C32D /* RemoteAnimationStack.mm */,
 				71C9EC9E2CF9F93600B8AF06 /* RemoteAnimationTimeline.cpp */,
 				71C9EC9D2CF9F93600B8AF06 /* RemoteAnimationTimeline.h */,
+				71983F102EA6397000594BCE /* RemoteAnimationTimelineRegistry.cpp */,
+				71983F0F2EA6397000594BCE /* RemoteAnimationTimelineRegistry.h */,
 				1AB16AE01648656D00290D62 /* RemoteLayerTreeDrawingAreaProxy.h */,
 				0FF24A2F1879E4FE003ABF0C /* RemoteLayerTreeDrawingAreaProxy.messages.in */,
 				1AB16ADF1648656D00290D62 /* RemoteLayerTreeDrawingAreaProxy.mm */,
@@ -17984,6 +17989,7 @@
 				71F62F752D076DEE00B591D2 /* RemoteAnimation.h in Headers */,
 				71E29A342B20610C0010F3C9 /* RemoteAnimationStack.h in Headers */,
 				71C9EC9F2CF9FB6400B8AF06 /* RemoteAnimationTimeline.h in Headers */,
+				71983F112EA6398D00594BCE /* RemoteAnimationTimelineRegistry.h in Headers */,
 				9B1229D223FF2BCC008CA751 /* RemoteAudioDestinationIdentifier.h in Headers */,
 				9B1229CD23FF25F2008CA751 /* RemoteAudioDestinationManager.h in Headers */,
 				9B5BEC2A240101580070C6EF /* RemoteAudioDestinationProxy.h in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5030,10 +5030,10 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
 
     Ref page = *corePage();
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    if (auto* document = localRootFrame->document()) {
+    if (RefPtr document = localRootFrame->document()) {
         if (CheckedPtr timelinesController = document->timelinesController()) {
             if (auto* acceleratedEffectStackUpdater = timelinesController->existingAcceleratedEffectStackUpdater())
-                layerTransaction.setAcceleratedTimelineTimeOrigin(acceleratedEffectStackUpdater->timeOrigin());
+                layerTransaction.setTimelines(acceleratedEffectStackUpdater->timelines());
         }
     }
 #endif


### PR DESCRIPTION
#### fc079ac269fc721cf297c0db0bd27e1b44443b49
<pre>
[threaded-animation-resolution] upload timelines through the remote layer tree transaction
<a href="https://bugs.webkit.org/show_bug.cgi?id=300992">https://bugs.webkit.org/show_bug.cgi?id=300992</a>
<a href="https://rdar.apple.com/162873561">rdar://162873561</a>

Reviewed by Matt Woodrow.

We introduced timelines for remote layer tree animations in 301615@main. Currently we create
such timelines, as `RemoteAnimationTimeline` objects, in the UI process exclusively based on
the origin time provided through the remote layer tree transaction.

In this patch we create a system such that timelines in the web process can be sent through
the remote layer tree transaction along with animation effects such that we may express several
timeline types down the line.

To that end, `AnimationTimeline` now exposes an `acceleratedRepresentation()` method that be
overridden by subclasses. Initially, only the `DocumentTimeline` implements an override to create
the monotonic timeline type we currently support in the remote layer tree.

These timelines are then gathered as we gather accelerated animation effects in
`AnimationTimelinesController::updateAcceleratedEffectStacks()` and sent up as a new property
in the remote layer tree transaction.

Upon reception in the UI process, remote animation timelines are created based on this data and,
using a unique identifier, are then associated with the remote animations that are created from
the transaction.

This further paves the way for supporting progress-based timelines.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp:
(WebCore::AcceleratedEffectStackUpdater::updateEffectStacks):
(WebCore::AcceleratedEffectStackUpdater::AcceleratedEffectStackUpdater): Deleted.
* Source/WebCore/animation/AcceleratedEffectStackUpdater.h:
(WebCore::AcceleratedEffectStackUpdater::timelines const):
(WebCore::AcceleratedEffectStackUpdater::timeOrigin const): Deleted.
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::AnimationTimeline):
(WebCore::AnimationTimeline::acceleratedRepresentation):
(WebCore::AnimationTimeline::createAcceleratedRepresentation):
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::clearAcceleratedRepresentation):
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::acceleratedEffectStackUpdater):
(WebCore::AnimationTimelinesController::updateAcceleratedEffectStacks):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::applyPendingAcceleratedAnimations):
(WebCore::DocumentTimeline::createAcceleratedRepresentation):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::create):
(WebCore::AcceleratedEffect::clone const):
(WebCore::AcceleratedEffect::AcceleratedEffect):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
(WebCore::AcceleratedEffect::timeline const):
(WebCore::AcceleratedEffect::timelineIdentifier const):
* Source/WebCore/platform/animation/AcceleratedTimeline.cpp: Added.
(WebCore::AcceleratedTimeline::create):
(WebCore::AcceleratedTimeline::AcceleratedTimeline):
* Source/WebCore/platform/animation/AcceleratedTimeline.h: Added.
(WebCore::AcceleratedTimeline::identifier const):
(WebCore::AcceleratedTimeline::originTime const):
* Source/WebCore/platform/animation/TimelineIdentifier.h: Added.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
(conditions_for_header):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::serializedIdentifiers):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
(WebKit::RemoteLayerTreeTransaction::timelines const):
(WebKit::RemoteLayerTreeTransaction::setTimelines):
(WebKit::RemoteLayerTreeTransaction::acceleratedTimelineTimeOrigin const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setAcceleratedTimelineTimeOrigin): Deleted.
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp:
(WebKit::RemoteAnimationTimeline::create):
(WebKit::RemoteAnimationTimeline::RemoteAnimationTimeline):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.cpp: Added.
(WebKit::RemoteAnimationTimelineRegistry::update):
(WebKit::RemoteAnimationTimelineRegistry::get const):
(WebKit::RemoteAnimationTimelineRegistry::advanceCurrentTime):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.h: Added.
(WebKit::RemoteAnimationTimelineRegistry::isEmpty const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::updateTimelineRegistration):
(WebKit::RemoteLayerTreeDrawingAreaProxy::timeline const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::registerTimelineIfNecessary): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
(WebKit::RemoteLayerTreeHost::timeline const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::updateTimelineRegistration):
(WebKit::RemoteScrollingCoordinatorProxy::timeline const):
(WebKit::RemoteScrollingCoordinatorProxy::registerTimelineIfNecessary): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateTimelineRegistration):
(WebKit::RemoteScrollingCoordinatorProxyIOS::timeline const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateAnimations):
(WebKit::RemoteScrollingCoordinatorProxyIOS::registerTimelineIfNecessary): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::updateTimelineRegistration):
(WebKit::RemoteLayerTreeEventDispatcher::timeline):
(WebKit::RemoteLayerTreeEventDispatcher::updateAnimations):
(WebKit::RemoteLayerTreeEventDispatcher::registerTimelineIfNecessary): Deleted.
(WebKit::RemoteLayerTreeEventDispatcher::timeline const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::updateTimelineRegistration):
(WebKit::RemoteScrollingCoordinatorProxyMac::timeline const):
(WebKit::RemoteScrollingCoordinatorProxyMac::registerTimelineIfNecessary): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willCommitLayerTree):

Canonical link: <a href="https://commits.webkit.org/301942@main">https://commits.webkit.org/301942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a97096434dc66f7fc459ff5496af48d35791103d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134641 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79121 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97105 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77585 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/126915 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32348 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78014 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137125 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41784 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105628 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105279 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50797 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51808 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19947 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54160 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60247 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53394 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56851 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55153 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->