### PR TITLE
The --site-isolation option in run-webkit-tests should only enable Site Isolation

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
@@ -159,7 +159,7 @@ class SingleTestRunner(object):
         self_comparison_header = self._port.get_option('self_compare_with_header')
         if self_comparison_header:
             return self._run_self_comparison_test(self_comparison_header)
-        if self._options.site_isolation:
+        if self._options.load_in_cross_origin_iframe:
             comparison_header = 'SiteIsolationEnabled=true runInCrossOriginFrame=true'
             if self._reference_files:
                 return self._run_self_comparison_test(comparison_header)

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -356,11 +356,11 @@ def parse_args(args):
             "--use-gpu-process", action="store_true", default=False,
             help=("Enable all GPU process related features, also set additional expectations and the result report flavor.")),
         optparse.make_option(
-            "--site-isolation", action="store_true", default=False,
-            help=("Run each test in a cross origin iframe with and without site isolation enabled and compare the results. Uses site-isolation test expectations")),
+            "--enable-site-isolation", action="store_true", default=False,
+            help=("Enable Site Isolation")),
         optparse.make_option(
             "--load-in-cross-origin-iframe", action="store_true", default=False,
-            help=("Run each test in a cross origin iframe.")),
+            help=("Run each test in a cross origin iframe with and without site isolation enabled and compare the results. Uses site-isolation test expectations")),
         optparse.make_option(
             "--no-use-gpu-process", action="store_true", default=False,
             help=("Disable GPU process for DOM rendering.")),
@@ -438,6 +438,13 @@ def parse_args(args):
             raise RuntimeError('--wpe-legacy-api implicitly sets the result flavor, this should not be overriden')
         options.result_report_flavor = 'wpe-legacy-api'
 
+    if options.enable_site_isolation:
+        host = Host()
+        host.initialize_scm()
+        if not options.internal_feature:
+            options.internal_feature = []
+        options.internal_feature.append('SiteIsolationEnabled')
+
     return options, args
 
 
@@ -487,15 +494,10 @@ def _set_up_derived_options(port, options):
             options.additional_platform_directory = []
         options.additional_platform_directory.insert(0, port.host.filesystem.join(host.scm().checkout_root, 'LayoutTests/platform/mac-gpup'))
 
-    if options.site_isolation:
-        if not options.load_in_cross_origin_iframe:
-            _log.warning("Option --site-isolation will set --load-in-cross-origin-iframe")
-        options.load_in_cross_origin_iframe = True
-
     if options.load_in_cross_origin_iframe:
         options.additional_header = 'runInCrossOriginFrame=true'
 
-    if port.port_name == "mac" and options.site_isolation:
+    if port.port_name == "mac" and options.load_in_cross_origin_iframe:
         host = Host()
         host.initialize_scm()
         options.additional_expectations.insert(0, port.host.filesystem.join(host.scm().checkout_root, 'LayoutTests/platform/mac-site-isolation/TestExpectations'))


### PR DESCRIPTION
#### 67d7208b67150c8d313f9f61fe7a46cf23d56fe8
<pre>
The --site-isolation option in run-webkit-tests should only enable Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=300993">https://bugs.webkit.org/show_bug.cgi?id=300993</a>
<a href="https://rdar.apple.com/162874305">rdar://162874305</a>

Reviewed by NOBODY (OOPS!).

Currently, this option is enabling tests to be run in a cross origin iframe, with and without Site Isolation
enabled. It may be clearer to rename the option to --enable-site-isolation and have it only enable Site
Isolation. We can instead use the --load-in-cross-origin-iframe option to run the tests in a cross origin
iframe, with Site Isolation on and off.

* Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py:
(SingleTestRunner):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args):
(_set_up_derived_options):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67d7208b67150c8d313f9f61fe7a46cf23d56fe8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133892 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78481 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3cb22d46-0b35-47d4-b8b8-e9d56921a7ab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55058 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96561 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9a1fb579-a466-4adb-add5-e987fa148774) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37733 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77075 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6b9ed298-a2db-4633-bf71-8d1048382938) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/126239 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77286 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107567 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136417 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105071 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104767 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50276 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51030 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53483 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52732 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56067 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54484 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->