### PR TITLE
flexbox container leads to complete freeze of WebKit

### DIFF
--- a/PerformanceTests/Layout/nested-column-flexboxes-branching.html
+++ b/PerformanceTests/Layout/nested-column-flexboxes-branching.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<head>
+<style>
+.flex {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    height: 100%;
+}
+</style>
+<script src="../resources/runner.js"></script>
+<script>
+function createFlexTree(depth) {
+    if (depth <= 0)
+        return "";
+    return '<div class="flex">' + createFlexTree(depth - 1) + '</div>'
+         + '<div class="flex">' + createFlexTree(depth - 1) + '</div>';
+}
+
+function startTest() {
+    var container = document.getElementById("container");
+    container.innerHTML = '<div class="flex">' + createFlexTree(10) + '</div>';
+    document.body.offsetHeight;
+
+    var index = 0;
+    PerfTestRunner.measureRunsPerSecond({
+        run: function() {
+            document.body.style.width = ++index % 2 ? "99%" : "98%";
+            document.body.offsetHeight;
+        },
+        done: function() {
+            container.style.display = "none";
+        }
+    });
+}
+</script>
+</head>
+<body onload="startTest()">
+<div id="container"></div>
+</body>

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1466,7 +1466,7 @@ void RenderFlexibleBox::performFlexLayout(RelayoutChildren relayoutChildren)
         remainingFreeSpace -= (lineItems.size() - 1) * gapBetweenItems;
 
         // This will std::move lineItems into a newly-created LineState.
-        layoutAndPlaceFlexItems(crossAxisOffset, lineItems, remainingFreeSpace, relayoutChildren, lineStates, gapBetweenItems);
+        layoutAndPlaceFlexItems(crossAxisOffset, lineItems, remainingFreeSpace, relayoutChildren, lineStates, gapBetweenItems, lineBreakLength);
     }
 
     if (!lineStates.isEmpty()) {
@@ -1493,6 +1493,7 @@ void RenderFlexibleBox::performFlexLayout(RelayoutChildren relayoutChildren)
 
     updateLogicalHeight();
     repositionLogicalHeightDependentFlexItems(lineStates, gapBetweenLines);
+    m_mainAxisContentExtentAtLastLayout = lineBreakLength;
 }
 
 std::optional<RenderFlexibleBox::FlexingLineData> RenderFlexibleBox::computeNextFlexLine(size_t& nextIndex, const FlexLayoutItems& allItems, LayoutUnit lineBreakLength, LayoutUnit gapBetweenItems)
@@ -1860,11 +1861,18 @@ void RenderFlexibleBox::maybeCacheFlexItemMainIntrinsicSize(RenderBox& flexItem,
     // flexItem.intrinsicContentLogicalHeight() and flexItem.scrollbarLogicalHeight(),
     // so if the child has intrinsic min/max/preferred size, run layout on it now to make sure
     // its logical height and scroll bars are up to date.
-    updateBlockChildDirtyBitsBeforeLayout(relayoutChildren, flexItem);
+    //
+    // Skip updateBlockChildDirtyBitsBeforeLayout if we have a cached intrinsic
+    // size and the child isn't otherwise dirty. That method (when relayoutChildren
+    // is No) only marks children dirty for percentage heights, which don't
+    // invalidate the cache since it was computed with FlexPercentResolveDisabler.
+    bool hasCachedIntrinsicSize = m_intrinsicSizeAlongMainAxis.contains(flexItem);
+    if (!hasCachedIntrinsicSize || flexItem.needsLayout() || relayoutChildren == RelayoutChildren::Yes)
+        updateBlockChildDirtyBitsBeforeLayout(relayoutChildren, flexItem);
     // Don't resolve percentages in children. This is especially important for the min-height calculation,
     // where we want percentages to be treated as auto. For flex-basis itself, this is not a problem because
     // by definition we have an indefinite flex basis here and thus percentages should not resolve.
-    if (flexItem.needsLayout() || !m_intrinsicSizeAlongMainAxis.contains(flexItem)) {
+    if (flexItem.needsLayout() || !hasCachedIntrinsicSize) {
         auto percentResolveDisableScope = FlexPercentResolveDisabler { view().frameView().layoutContext(), flexItem };
         flexItem.setChildNeedsLayout(MarkOnlyThis);
         flexItem.layoutIfNeeded();
@@ -2401,7 +2409,7 @@ static LayoutUnit contentAlignmentStartOverflow(LayoutUnit availableFreeSpace, C
     }
 }
 
-void RenderFlexibleBox::layoutAndPlaceFlexItems(LayoutUnit& crossAxisOffset, FlexLayoutItems& flexLayoutItems, LayoutUnit availableFreeSpace, RelayoutChildren relayoutChildren, FlexLineStates& lineStates, LayoutUnit gapBetweenItems)
+void RenderFlexibleBox::layoutAndPlaceFlexItems(LayoutUnit& crossAxisOffset, FlexLayoutItems& flexLayoutItems, LayoutUnit availableFreeSpace, RelayoutChildren relayoutChildren, FlexLineStates& lineStates, LayoutUnit gapBetweenItems, LayoutUnit mainAxisContentExtent)
 {
     LayoutUnit autoMarginOffset = autoMarginOffsetInMainAxis(flexLayoutItems, availableFreeSpace);
     LayoutUnit mainAxisOffset = flowAwareBorderStart() + flowAwarePaddingStart();
@@ -2450,11 +2458,27 @@ void RenderFlexibleBox::layoutAndPlaceFlexItems(LayoutUnit& crossAxisOffset, Fle
         // computeInnerFlexBaseSizeForFlexItem.
         bool forceFlexItemRelayout = relayoutChildren == RelayoutChildren::Yes && !m_relaidOutFlexItems.contains(flexItem);
         if (!forceFlexItemRelayout && flexItemHasPercentHeightDescendants(flexItem)) {
-            // Have to force another relayout even though the child is sized
-            // correctly, because its descendants are not sized correctly yet. Our
-            // previous layout of the child was done without an override height set.
-            // So, redo it here.
-            forceFlexItemRelayout = true;
+            auto needsRelayoutForPercentHeightDescendants = [&] {
+                // FIXME: Row flexboxes have issues with dirty bit tracking
+                // for flex items with percent-height descendants, making
+                // this check necessary.
+                if (!isColumnFlow())
+                    return true;
+                // First layout so no prior m_mainAxisContentExtentAtLastLayout
+                // to compare against.
+                if (!everHadLayout())
+                    return true;
+                // Container main axis extent changed since the last completed
+                // layout so percentage heights may resolve to new values.
+                if (mainAxisContentExtent != m_mainAxisContentExtentAtLastLayout)
+                    return true;
+                // Item's intrinsic size was recomputed in this pass, descendants
+                // were not yet sized with the correct override height.
+                if (m_relaidOutFlexItems.contains(flexLayoutItem.renderer))
+                    return true;
+                return false;
+            };
+            forceFlexItemRelayout = needsRelayoutForPercentHeightDescendants();
         }
         updateFlexItemDirtyBitsBeforeLayout(forceFlexItemRelayout, flexItem);
         if (!flexItem.needsLayout())

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -265,7 +265,7 @@ private:
     void resetAutoMarginsAndLogicalTopInCrossAxis(RenderBox& flexItem);
     void setOverridingMainSizeForFlexItem(RenderBox&, LayoutUnit);
     void prepareFlexItemForPositionedLayout(RenderBox& flexItem);
-    void layoutAndPlaceFlexItems(LayoutUnit& crossAxisOffset, FlexLayoutItems&, LayoutUnit availableFreeSpace, RelayoutChildren, FlexLineStates&, LayoutUnit gapBetweenItems);
+    void layoutAndPlaceFlexItems(LayoutUnit& crossAxisOffset, FlexLayoutItems&, LayoutUnit availableFreeSpace, RelayoutChildren, FlexLineStates&, LayoutUnit gapBetweenItems, LayoutUnit mainAxisContentExtent);
     void layoutColumnReverse(const FlexLayoutItems&, LayoutUnit crossAxisOffset, LayoutUnit availableFreeSpace, LayoutUnit gapBetweenItems);
     void alignFlexLines(FlexLineStates&, LayoutUnit gapBetweenLines);
     void alignFlexItems(FlexLineStates&);
@@ -315,6 +315,8 @@ private:
 
     LayoutUnit m_alignContentStartOverflow { 0 };
     LayoutUnit m_justifyContentStartOverflow { 0 };
+    // Updated at the end of performFlexLayout.
+    LayoutUnit m_mainAxisContentExtentAtLastLayout;
 
     // This is SizeIsUnknown outside of layoutBlock()
     SizeDefiniteness m_hasDefiniteHeight { SizeDefiniteness::Unknown };


### PR DESCRIPTION
#### fc6f33a5416ad3e3f003a734453f27308f927e1c
<pre>
flexbox container leads to complete freeze of WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=289072">https://bugs.webkit.org/show_bug.cgi?id=289072</a>
<a href="https://rdar.apple.com/146141220">rdar://146141220</a>

Reviewed by Sammy Gill.

In maybeCacheFlexItemMainIntrinsicSize, skip calling
updateBlockChildDirtyBitsBeforeLayout when we already
have a cached intrinsic size and the child doesn&apos;t need
layout for non-percentage reasons. This prevents
updateBlockChildDirtyBitsBeforeLayout from marking items
dirty solely due to percentage heights, which previously
caused each nested flex container to redundantly
re-layout all its descendants. Also skip setting
forceFlexItemRelayout to true unless the main axis size
has changed and we have already completed a layout pass
at the same container height.

A performance test is included to verify progression in
a pathological case with deep nesting. That microbenchmark
progresses from ~1.1 runs/s across 20 iterations to
~58 runs/s with this patch.

No functionality change should occur with this patch.

* PerformanceTests/Layout/nested-column-flexboxes-branching.html: Added.
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::performFlexLayout):
(WebCore::RenderFlexibleBox::maybeCacheFlexItemMainIntrinsicSize):
(WebCore::RenderFlexibleBox::layoutAndPlaceFlexItems):
* Source/WebCore/rendering/RenderFlexibleBox.h:

Canonical link: <a href="https://commits.webkit.org/309068@main">https://commits.webkit.org/309068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16fc8a8ac15a132b00583ce16cd9d01f377eb44a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114817 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81756 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95575 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16121 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13979 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5471 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160104 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3095 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13120 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122872 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123100 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33540 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77646 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18388 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10154 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21060 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84862 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20792 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20848 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->