### PR TITLE
ASSERTION FAILED: checkedPtrCountWithoutThreadCheck() in SQLiteStorageArea:: createAndPopulateInitialDatabaseInfo

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -431,25 +431,21 @@ std::unique_ptr<IDBDatabaseInfo> SQLiteIDBBackingStore::createAndPopulateInitial
 
     if (!sqliteDB->executeCommand("CREATE TABLE IDBDatabaseInfo (key TEXT NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT REPLACE, value TEXT NOT NULL ON CONFLICT FAIL);"_s)) {
         LOG_ERROR("Could not create IDBDatabaseInfo table in database (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
-        closeSQLiteDB();
         return nullptr;
     }
 
     if (!sqliteDB->executeCommand(v2ObjectStoreInfoSchema)) {
         LOG_ERROR("Could not create ObjectStoreInfo table in database (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
-        closeSQLiteDB();
         return nullptr;
     }
 
     if (!sqliteDB->executeCommand(indexInfoTableSchema())) {
         LOG_ERROR("Could not create IndexInfo table in database (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
-        closeSQLiteDB();
         return nullptr;
     }
 
     if (!sqliteDB->executeCommand("CREATE TABLE KeyGenerators (objectStoreID INTEGER NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT REPLACE, currentKey INTEGER NOT NULL ON CONFLICT FAIL);"_s)) {
         LOG_ERROR("Could not create KeyGenerators table in database (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
-        closeSQLiteDB();
         return nullptr;
     }
 
@@ -459,7 +455,6 @@ std::unique_ptr<IDBDatabaseInfo> SQLiteIDBBackingStore::createAndPopulateInitial
             || CheckedRef { *sql }->bindInt(1, currentMetadataVersion) != SQLITE_OK
             || CheckedRef { *sql }->step() != SQLITE_DONE) {
             LOG_ERROR("Could not insert database metadata version into IDBDatabaseInfo table (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
-            closeSQLiteDB();
             return nullptr;
         }
     }
@@ -469,7 +464,6 @@ std::unique_ptr<IDBDatabaseInfo> SQLiteIDBBackingStore::createAndPopulateInitial
             || CheckedRef { *sql }->bindBlob(1, m_identifier.databaseName()) != SQLITE_OK
             || CheckedRef { *sql }->step() != SQLITE_DONE) {
             LOG_ERROR("Could not insert database name into IDBDatabaseInfo table (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
-            closeSQLiteDB();
             return nullptr;
         }
     }
@@ -481,14 +475,12 @@ std::unique_ptr<IDBDatabaseInfo> SQLiteIDBBackingStore::createAndPopulateInitial
             || CheckedRef { *sql }->bindText(1, String::number(0)) != SQLITE_OK
             || CheckedRef { *sql }->step() != SQLITE_DONE) {
             LOG_ERROR("Could not insert default version into IDBDatabaseInfo table (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
-            closeSQLiteDB();
             return nullptr;
         }
     }
 
     if (!sqliteDB->executeCommand("INSERT INTO IDBDatabaseInfo VALUES ('MaxObjectStoreID', 1);"_s)) {
         LOG_ERROR("Could not insert default version into IDBDatabaseInfo table (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
-        closeSQLiteDB();
         return nullptr;
     }
 


### PR DESCRIPTION
#### 8414bf071128e3595500bf190a4d6d43f37beb65
<pre>
ASSERTION FAILED: checkedPtrCountWithoutThreadCheck() in SQLiteStorageArea:: createAndPopulateInitialDatabaseInfo
<a href="https://rdar.apple.com/162891393">rdar://162891393</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301007">https://bugs.webkit.org/show_bug.cgi?id=301007</a>

Reviewed by Per Arne Vollan and Chris Dumez.

I got the assertion faliure when running API test IndexedDB.IndexedDBFileHashCollision on debug build. The cause is that
SQLiteIDBBackingStore::createAndPopulateInitialDatabaseInfo sets m_database to null (with closeSQLiteDB after
m_database is captured in a local CheckedPtr variable sqliteDB. When the CheckedPtr variable is destroyed at function
exit, the assertion will be hit as the SQLiteDatabase object is already gone.

To fix this, avoid resetting m_database by removing closeSQLiteDB() calls in createAndPopulateInitialDatabaseInfo. This
is viable because the only caller of createAndPopulateInitialDatabaseInfo (i.e. getOrEstablishDatabaseInfo) will invoke
closeSQLiteDB when createAndPopulateInitialDatabaseInfo returns nullptr.

* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::createAndPopulateInitialDatabaseInfo):

Canonical link: <a href="https://commits.webkit.org/301758@main">https://commits.webkit.org/301758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6067fed118bebead536a324b047d2ce7ef938ac0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133906 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78492 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/57b4be1e-b7c7-47c7-8fd7-a39d86714d0e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96570 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64576 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113510 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77084 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bf1ba1bf-a825-442c-8431-28a3a4d0b8a7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31684 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77300 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136431 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105085 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104780 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26729 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50294 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28631 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51045 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59363 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52744 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56078 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54497 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->