### PR TITLE
[Win] Update vcpkg dependencies October 2025

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "dbe35ceb30c688bf72e952ab23778e009a578f18",
+    "baseline": "071f676f662b8d36a2f1762c63516e60b99d375b",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -96,5 +96,11 @@
         "woff2"
       ]
     }
-  }
+  },
+  "overrides": [
+    {
+        "name": "ngtcp2",
+        "version": "1.12.0"
+    }
+  ]
 }


### PR DESCRIPTION
#### 7c779935c530fc8369d49c5577dad856b2673990
<pre>
[Win] Update vcpkg dependencies October 2025
<a href="https://bugs.webkit.org/show_bug.cgi?id=301006">https://bugs.webkit.org/show_bug.cgi?id=301006</a>

Reviewed by Yusuke Suzuki.

Update baseline for vcpkg. Kept baseline the same for WebKitRequirements
due to issues with newer curl 8.16.0 and WebKitTestRunnerWS. Pinned
ngtcp2 to older 1.12.0 as required by curl.

Remove trailing content check in XMLDocumentParser
This isn&apos;t needed anymore after the following libxml fix:
<a href="https://gitlab.gnome.org/GNOME/libxml2/-/commit/8c5848bd">https://gitlab.gnome.org/GNOME/libxml2/-/commit/8c5848bd</a>

More context here: <a href="https://gitlab.gnome.org/GNOME/libxml2/-/issues/767">https://gitlab.gnome.org/GNOME/libxml2/-/issues/767</a>

Also remove internal initialization required before libxml2 2.13.

The old code is kept behind an #if to support ports that build WebKit
with an older version of libxml2.

Canonical link: <a href="https://commits.webkit.org/302123@main">https://commits.webkit.org/302123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/894f7453af07c005633f8071d3011abe8e4d867a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135390 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79531 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97454 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65358 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78023 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/121 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32788 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78699 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108507 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137873 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105982 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105719 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26961 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29582 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52327 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/204 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61665 "Found 11 new failures in WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/123 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->