### PR TITLE
DOM timers installed during a microtask checkpoint should not inherit DOM timer nesting level from the task scope.

### DIFF
--- a/LayoutTests/fast/dom/timer-in-microtask-does-not-inherit-nesting-level-expected.txt
+++ b/LayoutTests/fast/dom/timer-in-microtask-does-not-inherit-nesting-level-expected.txt
@@ -1,0 +1,13 @@
+Tests that a timer that is scheduled during a microtask checkpoint does not inherit the nesting level of the timer task that just finished running.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.timerNestingLevel() is 2
+PASS internals.timerNestingLevel() is 0
+PASS internals.timerNestingLevel() is 1
+PASS internals.timerNestingLevel() is 2
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/timer-in-microtask-does-not-inherit-nesting-level.html
+++ b/LayoutTests/fast/dom/timer-in-microtask-does-not-inherit-nesting-level.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+jsTestIsAsync = true;
+description("Tests that a timer that is scheduled during a microtask checkpoint does not inherit the nesting level of the timer task that just finished running.");
+
+if (!window.testRunner || !window.internals) {
+    testFailed("Test requires internals.");
+    finishJSTest();
+}
+
+setTimeout(() => {
+    setTimeout(() => {
+        shouldBe("internals.timerNestingLevel()", "2");
+        queueMicrotask(() => {
+            shouldBe("internals.timerNestingLevel()", "0");     // not 2
+            setTimeout(() => {
+                shouldBe("internals.timerNestingLevel()", "1"); // not 3
+                setTimeout(() => {
+                    shouldBe("internals.timerNestingLevel()", "2"); // timers should still nest in a microtask context.
+                    finishJSTest();
+                }, 10);
+            }, 10);
+        });
+    }, 10);
+}, 10);
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/timers/timer-nesting-not-inherited-in-microtask-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/timers/timer-nesting-not-inherited-in-microtask-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test requires performance.now() to measure approximate timing of callbacks.
+PASS Test that a timer scheduled during a microtask checkpoint does not inherit the timer nesting level of the task that just ran.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/timers/timer-nesting-not-inherited-in-microtask.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/timers/timer-nesting-not-inherited-in-microtask.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+// queue a microtask after the timer has reached the spec-defined maximum nesting level. Then we ensure
+// the new timer did not inherit the nesting level from the outer timer task by checking that the sub-4ms
+// timeout was not clamped to 4ms.
+
+test(() => {
+    assert_equals(typeof performance.now, "function");
+}, "Test requires performance.now() to measure approximate timing of callbacks.");
+
+
+let t = async_test("Test that a timer scheduled during a microtask checkpoint does not inherit the timer nesting level of the task that just ran.");
+
+var rescheduleTimeoutCalledCount = 0;
+function rescheduleTimeout()
+{
+    if (++rescheduleTimeoutCalledCount > 15)
+        return t.done();
+    else if (rescheduleTimeoutCalledCount > 5) {
+        queueMicrotask(() => {
+            const checkNotNestedScheduledAt = performance.now();
+            setTimeout(() => {
+                const approximateDelay = performance.now() - checkNotNestedScheduledAt;
+                t.step(() => assert_less_than(approximateDelay, 4, "Timer should not be clamped to 4ms"));
+            }, 1);
+        });
+    }
+    setTimeout(rescheduleTimeout, 8);
+}
+
+window.addEventListener("load", () => setTimeout(rescheduleTimeout, 8));
+</script>
+</html>

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -260,6 +260,7 @@ void EventLoop::queueMicrotask(JSC::QueuedTask&& microtask)
 
 void EventLoop::performMicrotaskCheckpoint()
 {
+    MicrotaskCheckpointScope microtaskCheckpointScope(*this);
     microtaskQueue().performMicrotaskCheckpoint();
 }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1569,6 +1569,11 @@ void Internals::setUserAgentPart(Element& element, const AtomString& part)
     return element.setUserAgentPart(part);
 }
 
+int Internals::timerNestingLevel()
+{
+    return scriptExecutionContext()->timerNestingLevel();
+}
+
 ExceptionOr<bool> Internals::isTimerThrottled(int timeoutId)
 {
     auto* timer = scriptExecutionContext()->findTimeout(timeoutId);

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -294,6 +294,7 @@ public:
     void setUserAgentPart(Element&, const AtomString&);
 
     // DOMTimers throttling testing.
+    int timerNestingLevel();
     ExceptionOr<bool> isTimerThrottled(int timeoutId);
     String requestAnimationFrameThrottlingReasons() const;
     double requestAnimationFrameInterval() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -910,6 +910,7 @@ enum ContentsFormat {
     undefined setCanvasNoiseInjectionSalt(HTMLCanvasElement element, unsigned long long salt);
     boolean doesCanvasHavePendingCanvasNoiseInjection(HTMLCanvasElement element);
 
+    long timerNestingLevel();
     // Query if a timer is currently throttled, to debug timer throttling.
     boolean isTimerThrottled(long timerHandle);
 


### PR DESCRIPTION
#### 85dc29aff870bcdfb8cb451f463ef0c33628870c
<pre>
DOM timers installed during a microtask checkpoint should not inherit DOM timer nesting level from the task scope.
<a href="https://rdar.apple.com/162893146">rdar://162893146</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301008">https://bugs.webkit.org/show_bug.cgi?id=301008</a>

Reviewed by Ryosuke Niwa.

DOM timers installed during microtask checkpoints are inheriting the nesting level of the previously ran task.

Take, for example, this WPT-sourced code:

  self.delay = ms =&gt; new Promise(resolve =&gt; step_timeout(resolve, ms));
  self.flushAsyncEvents = () =&gt; delay(0).then(() =&gt; delay(0)).then(() =&gt; delay(0)).then(() =&gt; delay(0));

Where `step_timeout` is a wrapper around setTimeout.

Each of these promise resolutions will occur during a microtask checkpoint. They install new zero delay DOM timers.
Currently WebKit will have them inherit the timer nesting level of the last timer that was on the stack during
the last task that ran. However, this is incorrect according to the HTML spec. Step 3 of the
&quot;timer initialization steps&quot; [0] states that we should set the nesting level only if the currently executing task was
a task that was created using these initialization steps. For example:

  setTimeout(() =&gt; setTimeout(callback, 0), 0);

The inner setTimeout would be nested as it is created while executing the task for the outer setTimeout.

However, the promise resolution callbacks in the earlier example are run during a microtask checkpoint after the DOM timer&apos;s
task finishes running. According to the &quot;perform a microtask checkpoint&quot; steps [1] the Event Loop&apos;s current task is set to the
microtask that is about to execute, which means we are not fulfilling the requirement in [0] to inherit the nesting level
and so we should consider these timeouts unnested.

The reason for this behavior is because DOMTimerFireState is a RAII class which sets the ScriptExecutionContext&apos;s timer nesting
level for the entire scope of DOMTimer::fired. Since microtask checkpoints are running after the task has completed, but before
returning to the DOMTimer::fired frame, all new timers installed during the microtask get the nesting level +1 of the DOMTimerFireState.

This patch fixes this by introducing a new MicrotaskCheckpointScope object which will reset the nesting level on entry and restore
the level on exit.

[0] <a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps">https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps</a>
[1] <a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a>

* LayoutTests/fast/dom/timer-in-microtask-does-not-inherit-nesting-level-expected.txt: Added.
* LayoutTests/fast/dom/timer-in-microtask-does-not-inherit-nesting-level.html: Added.
    Add tests to ensure DOM timer nesting works when rescheduling DOM timers but the level
    does not get inherited when a microtask is scheduling a DOM timer.

* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/timers/timer-nesting-not-inherited-in-microtask-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/timers/timer-nesting-not-inherited-in-microtask.html: Added.
   Add a similar test to the internal one, except this is testing the web-observable behavior.

* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::performMicrotaskCheckpoint):
* Source/WebCore/dom/Microtasks.h:
    Add a MicrotaskCheckpointScope object to save the state
    of DOM timer nesting during a microtask checkpoint.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::timerNestingLevel):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
    Expose ScriptExecutionContext::timerNestingLevel to LayoutTests.

Canonical link: <a href="https://commits.webkit.org/301979@main">https://commits.webkit.org/301979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef03a7636c667d38680daf1b334be3eede40130e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79197 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/970ba232-8fce-44cf-bf7a-6df2e06482a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97162 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a319866b-086e-4ec4-b84d-27614450a6f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77643 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e2bb32ad-b7ae-499d-9d43-4bdff7f1aa59) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32432 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78270 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137393 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105682 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105334 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26868 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50858 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29288 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51898 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54236 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60412 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53471 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56927 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55229 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->