### PR TITLE
[iPad] Bsky.com video posts can't enter fullscreen mode

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5878,6 +5878,11 @@ void Document::flushDeferredScrollEvents()
     runScrollSteps();
 }
 
+void Document::flushDeferredIntersectionObservations()
+{
+    scheduleRenderingUpdate(RenderingUpdateStep::IntersectionObservations);
+}
+
 void Document::invalidateScrollbars()
 {
     if (RefPtr frameView = view())
@@ -10275,6 +10280,10 @@ void Document::updateIntersectionObservations(const Vector<WeakPtr<IntersectionO
 {
     RefPtr frameView = view();
     if (!frameView)
+        return;
+
+    RefPtr page = this->page();
+    if (!page || page->shouldDeferIntersectionObservations())
         return;
 
     bool needsLayout = frameView->layoutContext().isLayoutPending() || (renderView() && renderView()->needsLayout());

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1662,6 +1662,7 @@ public:
     void setNeedsVisualViewportScrollEvent();
     void runScrollSteps();
     void flushDeferredScrollEvents();
+    void flushDeferredIntersectionObservations();
 
     void invalidateScrollbars();
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5805,6 +5805,19 @@ void Page::flushDeferredScrollEvents()
     });
 }
 
+void Page::startDeferringIntersectionObservations()
+{
+    m_shouldDeferIntersectionObservations = true;
+}
+
+void Page::flushDeferredIntersectionObservations()
+{
+    m_shouldDeferIntersectionObservations = false;
+    forEachDocument([&] (Document& document) {
+        document.flushDeferredIntersectionObservations();
+    });
+}
+
 bool Page::reportScriptTrackingPrivacy(const URL& url, ScriptTrackingPrivacyCategory category)
 {
     return !url.isEmpty() && m_scriptTrackingPrivacyReports.add({ url, category }).isNewEntry;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1339,6 +1339,10 @@ public:
     WEBCORE_EXPORT void startDeferringScrollEvents();
     WEBCORE_EXPORT void flushDeferredScrollEvents();
 
+    bool shouldDeferIntersectionObservations() const { return m_shouldDeferIntersectionObservations; }
+    WEBCORE_EXPORT void startDeferringIntersectionObservations();
+    WEBCORE_EXPORT void flushDeferredIntersectionObservations();
+
     bool reportScriptTrackingPrivacy(const URL&, ScriptTrackingPrivacyCategory);
     bool shouldAllowScriptAccess(const URL&, const SecurityOrigin& topOrigin, ScriptTrackingPrivacyCategory) const;
     bool requiresScriptTrackingPrivacyProtections(const URL&) const;
@@ -1833,6 +1837,7 @@ private:
 
     bool m_shouldDeferResizeEvents { false };
     bool m_shouldDeferScrollEvents { false };
+    bool m_shouldDeferIntersectionObservations { false };
 
     Ref<DocumentSyncData> m_topDocumentSyncData;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10236,6 +10236,16 @@ void WebPageProxy::flushDeferredScrollEvents()
     internals().protectedPage()->send(Messages::WebPage::FlushDeferredScrollEvents());
 }
 
+void WebPageProxy::startDeferringIntersectionObservations()
+{
+    internals().protectedPage()->send(Messages::WebPage::StartDeferringIntersectionObservations());
+}
+
+void WebPageProxy::flushDeferredIntersectionObservations()
+{
+    internals().protectedPage()->send(Messages::WebPage::FlushDeferredIntersectionObservations());
+}
+
 bool WebPageProxy::isProcessingKeyboardEvents() const
 {
     return !internals().keyEventQueue.isEmpty();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1366,6 +1366,9 @@ public:
     void startDeferringScrollEvents();
     void flushDeferredScrollEvents();
 
+    void startDeferringIntersectionObservations();
+    void flushDeferredIntersectionObservations();
+
     bool isProcessingMouseEvents() const;
     void processNextQueuedMouseEvent();
     void sendMouseEvent(WebCore::FrameIdentifier, const NativeWebMouseEvent&, std::optional<Vector<SandboxExtensionHandle>>&&);

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1065,6 +1065,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     page->setSuppressVisibilityUpdates(true);
     page->startDeferringResizeEvents();
     page->startDeferringScrollEvents();
+    page->startDeferringIntersectionObservations();
 
     _viewState.store(webView.get());
 
@@ -1212,6 +1213,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             page->setSuppressVisibilityUpdates(false);
             page->flushDeferredResizeEvents();
             page->flushDeferredScrollEvents();
+            page->flushDeferredIntersectionObservations();
 
             [_fullscreenViewController showBanner];
 
@@ -1443,6 +1445,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (auto page = [self._webView _page]) {
         page->flushDeferredResizeEvents();
         page->flushDeferredScrollEvents();
+        page->flushDeferredIntersectionObservations();
     }
 
     RefPtr videoPresentationInterface = self._videoPresentationManager ? self._videoPresentationManager->controlsManagerInterface() : nullptr;
@@ -1465,6 +1468,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             page->setNeedsDOMWindowResizeEvent();
             page->flushDeferredResizeEvents();
             page->flushDeferredScrollEvents();
+            page->flushDeferredIntersectionObservations();
         }
 
         _exitRequested = NO;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3685,6 +3685,16 @@ void WebPage::flushDeferredScrollEvents()
     protectedCorePage()->flushDeferredScrollEvents();
 }
 
+void WebPage::startDeferringIntersectionObservations()
+{
+    protectedCorePage()->startDeferringIntersectionObservations();
+}
+
+void WebPage::flushDeferredIntersectionObservations()
+{
+    protectedCorePage()->flushDeferredIntersectionObservations();
+}
+
 void WebPage::flushDeferredDidReceiveMouseEvent()
 {
     if (auto info = std::exchange(m_deferredDidReceiveMouseEvent, std::nullopt))

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1959,6 +1959,9 @@ public:
     void startDeferringScrollEvents();
     void flushDeferredScrollEvents();
 
+    void startDeferringIntersectionObservations();
+    void flushDeferredIntersectionObservations();
+
     void flushDeferredDidReceiveMouseEvent();
 
     void generateTestReport(String&& message, String&& group);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -627,6 +627,9 @@ messages -> WebPage WantsAsyncDispatchMessage {
     StartDeferringScrollEvents();
     FlushDeferredScrollEvents();
 
+    StartDeferringIntersectionObservations();
+    FlushDeferredIntersectionObservations();
+
     FlushDeferredDidReceiveMouseEvent()
 
     PerformHitTestForMouseEvent(WebKit::WebMouseEvent event) -> (struct WebKit::WebHitTestResultData hitTestResult, OptionSet<WebKit::WebEventModifier> modifiers)

--- a/Tools/TestWebKitAPI/TestElementFullscreenDelegate.h
+++ b/Tools/TestWebKitAPI/TestElementFullscreenDelegate.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <WebKit/_WKFullscreenDelegate.h>
+
+@interface TestElementFullscreenDelegate : NSObject <_WKFullscreenDelegate>
+- (void)waitForDidEnterElementFullscreen;
+- (void)waitForWillEnterElementFullscreen;
+@end

--- a/Tools/TestWebKitAPI/TestElementFullscreenDelegate.mm
+++ b/Tools/TestWebKitAPI/TestElementFullscreenDelegate.mm
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "TestElementFullscreenDelegate.h"
+
+#import "PlatformUtilities.h"
+
+@implementation TestElementFullscreenDelegate {
+    bool _didEnterElementFullscreen;
+    bool _willEnterElementFullscreen;
+}
+
+- (void)waitForDidEnterElementFullscreen
+{
+    _didEnterElementFullscreen = false;
+    TestWebKitAPI::Util::run(&_didEnterElementFullscreen);
+}
+
+- (void)waitForWillEnterElementFullscreen
+{
+    _willEnterElementFullscreen = false;
+    TestWebKitAPI::Util::run(&_willEnterElementFullscreen);
+}
+
+#if PLATFORM(IOS)
+- (void)_webViewWillEnterElementFullscreen:(WKWebView *)webView
+#else
+- (void)_webViewWillEnterFullscreen:(NSView *)webView
+#endif
+{
+    _willEnterElementFullscreen = true;
+}
+
+#if PLATFORM(IOS_FAMILY)
+- (void)_webViewDidEnterElementFullscreen:(WKWebView *)webView
+#else
+- (void)_webViewDidEnterFullscreen:(NSView *)webView
+#endif
+{
+    _didEnterElementFullscreen = true;
+}
+
+@end
+

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1319,7 +1319,10 @@
 		CDC0932B21C872C10030C4B0 /* ScrollingDoesNotPauseMedia.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDC0932A21C872C10030C4B0 /* ScrollingDoesNotPauseMedia.mm */; };
 		CDC8E48D1BC5CB4500594FEC /* AudioSessionCategoryIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDC8E4851BC5B19400594FEC /* AudioSessionCategoryIOS.mm */; };
 		CDC9442E1EF1FC080059C3C4 /* MediaStreamTrackDetached.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDC9442C1EF1FC080059C3C4 /* MediaStreamTrackDetached.mm */; };
+		CDC94E402EA0B94800149E34 /* CaptionPreferencesTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDC94E3E2EA0B94800149E34 /* CaptionPreferencesTests.mm */; };
 		CDCFA7AA1E45183200C2433D /* SampleMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDCFA7A91E45122F00C2433D /* SampleMap.cpp */; };
+		CDD99F362EA2F02D003FAFB8 /* ElementFullscreenIntersectionObserver.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDD99F352EA2F02D003FAFB8 /* ElementFullscreenIntersectionObserver.mm */; };
+		CDD99F402EA2F3E8003FAFB8 /* TestElementFullscreenDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDD99F3F2EA2F3E8003FAFB8 /* TestElementFullscreenDelegate.mm */; };
 		CDDFA89E2DBD6BFF00312417 /* spatial-audio-experience-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDDFA89D2DBD6BFF00312417 /* spatial-audio-experience-with-audio.html */; };
 		CDE4E4E52B7E787900B3AE35 /* InWindowFullscreen.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDE4E4E42B7E787900B3AE35 /* InWindowFullscreen.mm */; };
 		CDE77D2525A6591C00D4115E /* FullscreenPointerLeave.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDE77D2425A6591C00D4115E /* FullscreenPointerLeave.mm */; };
@@ -3970,10 +3973,15 @@
 		CDC8E48C1BC5C96200594FEC /* video-without-audio.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "video-without-audio.mp4"; sourceTree = "<group>"; };
 		CDC9442B1EF1FBD20059C3C4 /* mediastreamtrack-detached.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "mediastreamtrack-detached.html"; sourceTree = "<group>"; };
 		CDC9442C1EF1FC080059C3C4 /* MediaStreamTrackDetached.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaStreamTrackDetached.mm; sourceTree = "<group>"; };
+		CDC94E352EA0B4E700149E34 /* SoftLinkShim.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SoftLinkShim.h; sourceTree = "<group>"; };
+		CDC94E3E2EA0B94800149E34 /* CaptionPreferencesTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CaptionPreferencesTests.mm; sourceTree = "<group>"; };
 		CDCF78A7244A2EDB00480311 /* FullscreenAlert.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenAlert.mm; sourceTree = "<group>"; };
 		CDCFA7A91E45122F00C2433D /* SampleMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SampleMap.cpp; sourceTree = "<group>"; };
 		CDCFFEC022E268D500DF4223 /* NoPauseWhenSwitchingTabs.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NoPauseWhenSwitchingTabs.mm; sourceTree = "<group>"; };
 		CDD68F0C22C18317000CF0AE /* WKWebViewCloseAllMediaPresentations.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewCloseAllMediaPresentations.mm; sourceTree = "<group>"; };
+		CDD99F352EA2F02D003FAFB8 /* ElementFullscreenIntersectionObserver.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ElementFullscreenIntersectionObserver.mm; sourceTree = "<group>"; };
+		CDD99F3E2EA2F3E8003FAFB8 /* TestElementFullscreenDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestElementFullscreenDelegate.h; sourceTree = "<group>"; };
+		CDD99F3F2EA2F3E8003FAFB8 /* TestElementFullscreenDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TestElementFullscreenDelegate.mm; sourceTree = "<group>"; };
 		CDDC7C6825FFF6D000224278 /* FullscreenRemoveNodeBeforeEnter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenRemoveNodeBeforeEnter.mm; sourceTree = "<group>"; };
 		CDDFA89D2DBD6BFF00312417 /* spatial-audio-experience-with-audio.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "spatial-audio-experience-with-audio.html"; sourceTree = "<group>"; };
 		CDE195B21CFE0ADE0053D256 /* FullscreenTopContentInset.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = FullscreenTopContentInset.html; sourceTree = "<group>"; };
@@ -4537,6 +4545,7 @@
 				BC575BBF126F5752006F0F12 /* PlatformUtilities.cpp */,
 				BC131883117114A800B69727 /* PlatformUtilities.h */,
 				BC90951B125533D700083756 /* PlatformWebView.h */,
+				CDC94E352EA0B4E700149E34 /* SoftLinkShim.h */,
 				BCB9E7FA112359A300A137E0 /* Test.h */,
 				EB4D320727C045430081A8E4 /* TestNotificationProvider.cpp */,
 				EB4D320827C045440081A8E4 /* TestNotificationProvider.h */,
@@ -4605,6 +4614,8 @@
 				5CE7594722A883A500C12409 /* TestContextMenuDriver.mm */,
 				DF6BC4702534E120008F63CC /* TestDownloadDelegate.h */,
 				DF6BC46F2534E120008F63CC /* TestDownloadDelegate.mm */,
+				CDD99F3E2EA2F3E8003FAFB8 /* TestElementFullscreenDelegate.h */,
+				CDD99F3F2EA2F3E8003FAFB8 /* TestElementFullscreenDelegate.mm */,
 				99C607F426FD5A1E00A0953F /* TestInspectorURLSchemeHandler.h */,
 				99C607F526FD5A1F00A0953F /* TestInspectorURLSchemeHandler.mm */,
 				5C72E8CD244FFCE300381EB7 /* TestLegacyDownloadDelegate.h */,
@@ -4796,6 +4807,7 @@
 				0F1D13EF2D2F564B00967D50 /* DrawingToPDF.mm */,
 				A15502281E05020B00A24C57 /* DuplicateCompletionHandlerCalls.mm */,
 				F44D06461F395C4D001A0E29 /* EditorStateTests.mm */,
+				CDD99F352EA2F02D003FAFB8 /* ElementFullscreenIntersectionObserver.mm */,
 				F4DADCF62BABA65B008B398F /* ElementTargetingTests.mm */,
 				E502E42E2D39B79500C3D56D /* ElementTextPreview.mm */,
 				869429BF2E53635100E0DA9D /* EnhancedSecurity.mm */,
@@ -6818,6 +6830,7 @@
 			children = (
 				7BE875FB2919457B00B15289 /* AudioStreamDescriptionCocoa.mm */,
 				0711DF51226A95FB003DD2F7 /* AVFoundationSoftLinkTest.mm */,
+				CDC94E3E2EA0B94800149E34 /* CaptionPreferencesTests.mm */,
 				31F865E526701E73003BFC6D /* CoreCryptoSPI.h */,
 				510A667A27D2FC7A00D22629 /* CoreMediaUtilities.mm */,
 				751B05D51F8EAC1A0028A09E /* DatabaseTrackerTest.mm */,
@@ -7988,6 +8001,7 @@
 				D2E870752D9A96F50010AA23 /* TestCocoaImageAndCocoaColor.mm in Sources */,
 				5CE7594922A883D200C12409 /* TestContextMenuDriver.mm in Sources */,
 				F46128CB211D475100D9FADB /* TestDraggingInfo.mm in Sources */,
+				CDD99F402EA2F3E8003FAFB8 /* TestElementFullscreenDelegate.mm in Sources */,
 				F4E0A2B82122847400AF7C7F /* TestFilePromiseReceiver.mm in Sources */,
 				F4F5BB5221667BAA002D06B9 /* TestFontOptions.mm in Sources */,
 				7BA3936C271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm in Sources */,
@@ -8143,6 +8157,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CDC94E402EA0B94800149E34 /* CaptionPreferencesTests.mm in Sources */,
 				2E7765CD16C4D80A00BA2BB1 /* mainIOS.mm in Sources */,
 				2E7765CF16C4D81100BA2BB1 /* mainMac.mm in Sources */,
 			);
@@ -8193,6 +8208,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A18898FB2CA9F1ED00FEB09A /* AppCommon.mm in Sources */,
+				CDD99F362EA2F02D003FAFB8 /* ElementFullscreenIntersectionObserver.mm in Sources */,
 				A18898FF2CA9F88600FEB09A /* main.mm in Sources */,
 				A17C58172C9AA132009DD0B5 /* main.mm in Sources */,
 			);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementFullscreenIntersectionObserver.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementFullscreenIntersectionObserver.mm
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "PlatformUtilities.h"
+#import "TestElementFullscreenDelegate.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WebKit.h>
+
+TEST(ElementFullscreen, IntersectionObserver)
+{
+    // This test must run in TestWebKitAPI.app
+    if (![NSBundle.mainBundle.bundleIdentifier isEqualToString:@"org.webkit.TestWebKitAPI"])
+        return;
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration preferences].elementFullscreenEnabled = YES;
+    RetainPtr fullscreenDelegate = adoptNS([[TestElementFullscreenDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView _setFullscreenDelegate:fullscreenDelegate.get()];
+
+    [webView synchronouslyLoadHTMLString:
+        @"<div style=\"height: 300%\"><div id=target style=\"height: 50%\"; }</div>"
+        "<script>"
+        "let observer = new IntersectionObserver(entries => { entries.forEach(entry => {"
+        "    let log = target.appendChild(document.createElement('div'));"
+        "    log.innerText = `intersecting(${entry.isIntersecting});"
+        "};"
+        "target.scrollIntoView();"
+        "</script>"];
+
+    [webView evaluateJavaScript:@"target.requestFullscreen()" completionHandler:nil];
+    [fullscreenDelegate waitForDidEnterElementFullscreen];
+
+    auto contents = [webView stringByEvaluatingJavaScript:@"target.innerText"];
+    EXPECT_STREQ(contents.UTF8String, "intersecting(true)");
+}

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm
@@ -26,60 +26,16 @@
 #import "config.h"
 
 #import "PlatformUtilities.h"
+#import "TestElementFullscreenDelegate.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WebKit.h>
-#import <WebKit/_WKFullscreenDelegate.h>
 
 #if PLATFORM(IOS_FAMILY)
 @interface UIScrollView ()
 @property (nonatomic, getter=isZoomEnabled) BOOL zoomEnabled;
 @end
 #endif
-
-@interface TestElementFullscreenDelegate : NSObject <_WKFullscreenDelegate>
-- (void)waitForDidEnterElementFullscreen;
-- (void)waitForWillEnterElementFullscreen;
-@end
-
-@implementation TestElementFullscreenDelegate {
-    bool _didEnterElementFullscreen;
-    bool _willEnterElementFullscreen;
-}
-
-- (void)waitForDidEnterElementFullscreen
-{
-    _didEnterElementFullscreen = false;
-    TestWebKitAPI::Util::run(&_didEnterElementFullscreen);
-}
-
-- (void)waitForWillEnterElementFullscreen
-{
-    _willEnterElementFullscreen = false;
-    TestWebKitAPI::Util::run(&_willEnterElementFullscreen);
-}
-
-#pragma mark WKUIDelegate
-
-#if PLATFORM(IOS)
-- (void)_webViewWillEnterElementFullscreen:(WKWebView *)webView
-#else
-- (void)_webViewWillEnterFullscreen:(NSView *)webView
-#endif
-{
-    _willEnterElementFullscreen = true;
-}
-
-#if PLATFORM(IOS_FAMILY)
-- (void)_webViewDidEnterElementFullscreen:(WKWebView *)webView
-#else
-- (void)_webViewDidEnterFullscreen:(NSView *)webView
-#endif
-{
-    _didEnterElementFullscreen = true;
-}
-
-@end
 
 #if PLATFORM(IOS_FAMILY)
 TEST(ElementFullscreen, ScrollViewSetToInitialScale)


### PR DESCRIPTION
#### 1ede5ce1bc22f7fd38c9d58bc0655f443eff8612
<pre>
[iPad] Bsky.com video posts can&apos;t enter fullscreen mode
<a href="https://rdar.apple.com/139744548">rdar://139744548</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301014">https://bugs.webkit.org/show_bug.cgi?id=301014</a>

Reviewed by Eric Carlson.

In a synthetic testcase (<a href="https://jernoble.github.io/samples/bin/element-fullscreen/viewport-visibility-during-fullscreen.html)">https://jernoble.github.io/samples/bin/element-fullscreen/viewport-visibility-during-fullscreen.html)</a>
we see that entering fullscreen after scrolling away from the initial viewport will
result in multiple IntersectionObserver callbacks, some of which will say that the
fullscreen element no longer intersects with the viewport. This behavior causes clients
which use IntersectionObserver to tear down their video playback when scrolled out
of view to tear down the very element (or its parent) that is going into fullscreen.

We already suspend scroll and resize events during fullscreen transitions, and doing
the same for IntersectionObserver callbacks does allow bsky.com posts to sucessfully
enter into fullscreen also.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementFullscreenIntersectionObserver.mm

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::flushDeferredIntersectionObservations):
(WebCore::Document::updateIntersectionObservations):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::startDeferringIntersectionObservations):
(WebCore::Page::flushDeferredIntersectionObservations):
* Source/WebCore/page/Page.h:
(WebCore::Page::shouldDeferIntersectionObservations const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::startDeferringIntersectionObservations):
(WebKit::WebPageProxy::flushDeferredIntersectionObservations):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _enterFullScreen:windowScene:completionHandler:]):
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:completionHandler:]):
(-[WKFullScreenWindowController _completedExitFullScreen:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::startDeferringIntersectionObservations):
(WebKit::WebPage::flushDeferredIntersectionObservations):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/TestElementFullscreenDelegate.h: Added.
* Tools/TestWebKitAPI/TestElementFullscreenDelegate.mm: Added.
(-[TestElementFullscreenDelegate waitForDidEnterElementFullscreen]):
(-[TestElementFullscreenDelegate waitForWillEnterElementFullscreen]):
(-[TestElementFullscreenDelegate _webViewWillEnterElementFullscreen:_webViewWillEnterFullscreen:]):
(-[TestElementFullscreenDelegate _webViewDidEnterElementFullscreen:_webViewDidEnterFullscreen:]):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementFullscreenIntersectionObserver.mm: Added.
(TEST(ElementFullscreen, IntersectionObserver)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm:
(-[TestElementFullscreenDelegate waitForDidEnterElementFullscreen]): Deleted.
(-[TestElementFullscreenDelegate waitForWillEnterElementFullscreen]): Deleted.
(-[TestElementFullscreenDelegate _webViewWillEnterElementFullscreen:_webViewWillEnterFullscreen:]): Deleted.
(-[TestElementFullscreenDelegate _webViewDidEnterElementFullscreen:_webViewDidEnterFullscreen:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/301756@main">https://commits.webkit.org/301756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72f8ede2d0266064ed172f5fdde2d6014b6923b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78505 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/11e0d625-be21-4c65-964b-b3b3b6ccca3b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96587 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64589 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dcdcbbf6-a186-4b0f-ba03-f786f69a22ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77101 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f61c8acd-6209-413b-81f3-5b21c708bfaf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36621 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31703 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77320 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107595 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136451 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105108 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/126347 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104800 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26727 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50317 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28652 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51063 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59383 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52758 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56092 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54515 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->