### PR TITLE
Mute button disappears on MacOS inline if the video size is adjustable

### DIFF
--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-volume-container-mute-button-expected.txt
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-volume-container-mute-button-expected.txt
@@ -1,0 +1,21 @@
+Testing MacOSInlineMediaControls mute button visibility behavior with volume slider container.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS ready() became true
+
+Testing mute button visibility behavior:
+PASS isVolumeSliderContainerShowing() is true
+PASS mediaControls.muteButton.visible is true
+PASS isVolumeSliderContainerShowing() is false
+PASS mediaControls.muteButton.visible is false
+PASS isVolumeSliderContainerShowing() is true
+PASS mediaControls.muteButton.visible is true
+PASS isVolumeSliderContainerShowing() is false
+PASS mediaControls.muteButton.visible is true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-volume-container-mute-button.html
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-volume-container-mute-button.html
@@ -1,0 +1,85 @@
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../resources/media-controls-loader.js" type="text/javascript"></script>
+<script src="../resources/media-controls-utils.js" type="text/javascript"></script>
+<body>
+<script type="text/javascript">
+
+description("Testing <code>MacOSInlineMediaControls</code> mute button visibility behavior with volume slider container.");
+
+window.jsTestIsAsync = true;
+
+const mediaControls = new MacOSInlineMediaControls({ width: 150, height: 200 });
+
+mediaControls._host = {
+    isMediaControlsMacInlineSizeSpecsEnabled: true
+};
+
+if (mediaControls.playPauseButton) {
+    mediaControls.playPauseButton.enabled = true;
+}
+
+mediaControls.showsStartButton = false;
+mediaControls.visible = true;
+
+function isVolumeSliderContainerShowing() {
+    const children = mediaControls.children || [];
+    return children.includes(mediaControls._volumeSliderContainer);
+}
+
+function flushAllLayouts() {
+    for (let i = 0; i < 3; i++) {
+        scheduler.flushScheduledLayoutCallbacks();
+    }
+}
+
+function testMuteButtonVisibilityBehavior() {
+    debug("Testing mute button visibility behavior:");
+    
+    // Test 1: Volume container shows - mute button should be visible
+    mediaControls.needsLayout = true;
+    flushAllLayouts();
+    
+    shouldBeTrue("isVolumeSliderContainerShowing()", "Volume slider container should be showing");
+    shouldBeTrue("mediaControls.muteButton.visible", "Mute button should be visible when container shows");
+    
+    // Test 2: Width < 60 - special case forces mute button hidden
+    mediaControls.width = 10;
+    mediaControls.needsLayout = true;
+    flushAllLayouts();
+    
+    shouldBeFalse("isVolumeSliderContainerShowing()", "Volume slider container should be hidden");
+    shouldBeFalse("mediaControls.muteButton.visible", "Mute button should be hidden when width < 60 (forced)");
+    
+    // Test 3: Restore width - mute button becomes visible again
+    mediaControls.width = 150;
+    mediaControls.needsLayout = true;
+    flushAllLayouts();
+    
+    shouldBeTrue("isVolumeSliderContainerShowing()", "Volume slider container should show again");
+    shouldBeTrue("mediaControls.muteButton.visible", "Mute button should be visible when container is restored");
+    
+    // Test 4: showsStartButton hides container but doesn't force mute button hidden
+    mediaControls.showsStartButton = true;
+    mediaControls.needsLayout = true;
+    flushAllLayouts();
+    
+    shouldBeFalse("isVolumeSliderContainerShowing()", "Volume slider container should be hidden");
+    shouldBeTrue("mediaControls.muteButton.visible", "Mute button visibility is preserved when container is hidden by showsStartButton");
+}
+
+function ready() {
+    return mediaControls.muteButton && mediaControls.playPauseButton &&
+           mediaControls._volumeSliderContainer &&
+           mediaControls.muteButton.width > 0 && mediaControls.playPauseButton.width > 0;
+}
+
+shouldBecomeEqual("ready()", "true", () => {
+    debug("");
+    testMuteButtonVisibilityBehavior();
+    debug("");
+    finishJSTest();
+});
+
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js
@@ -139,10 +139,16 @@ class MacOSInlineMediaControls extends InlineMediaControls
                 this._volumeSliderContainer.children = [new BackgroundTint, this.volumeSlider, this.muteButton];
                 children.push(this._volumeSliderContainer);
                 this.children = children;
+
+                if (this.muteButton)
+                    this.muteButton.visible = true;
             } else if (!shouldShowVolumeContainer && children.includes(this._volumeSliderContainer)) {
                 const volumeContainerIndex = children.indexOf(this._volumeSliderContainer);
                 children.splice(volumeContainerIndex, 1);
                 this.children = children;
+
+                if (this.muteButton)
+                    this.muteButton.visible = false;
             }
         }
     }


### PR DESCRIPTION
#### 1ee271348b0259db20533d0608ac46594061ad69
<pre>
Mute button disappears on MacOS inline if the video size is adjustable
<a href="https://rdar.apple.com/162897286">rdar://162897286</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301016">https://bugs.webkit.org/show_bug.cgi?id=301016</a>

Reviewed by Jean-Yves Avenard.

Remove unconditional hiding of mute button when shouldShowVolumeContainer
is false. The mute button should remain visible for adjustable video sizes
even when the volume slider container is not displayed.

Test: media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-volume-container-mute-button.html
* LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-volume-container-mute-button-expected.txt: Added.
* LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-volume-container-mute-button.html: Added.
* Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js:
(MacOSInlineMediaControls.prototype.layout):

Canonical link: <a href="https://commits.webkit.org/301896@main">https://commits.webkit.org/301896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a15f030bcf696958a72840c2a23de0d0113033b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78740 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/19693ef7-646b-4d4f-8c91-4f854028c534) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96792 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64846 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0b8aadd9-cbfb-4fce-9688-6db604cbbfbd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77297 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/281759df-f740-4979-9a02-201e3e89699a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32075 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77629 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136732 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105309 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104997 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26811 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50523 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28979 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51407 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53781 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59868 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53013 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56432 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54774 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->