### PR TITLE
GARDENING: REGRESSION(iOS 26): TLSVersion tests fail on iOS 26

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TLSDeprecation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TLSDeprecation.mm
@@ -138,9 +138,15 @@
 
 namespace TestWebKitAPI {
 
+// TLSVersion broke on iOS 26 https://bugs.webkit.org/show_bug.cgi?id=301010
+#define BUG_301010 (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 260000 && !USE(APPLE_INTERNAL_SDK))
 const uint16_t tls1_1 = 0x0302;
 
+#if BUG_301010
+TEST(TLSVersion, DISABLED_DefaultBehavior)
+#else
 TEST(TLSVersion, DefaultBehavior)
+#endif
 {
     HTTPServer server(HTTPServer::respondWithOK, HTTPServer::Protocol::HttpsWithLegacyTLS);
     auto delegate = adoptNS([TestNavigationDelegate new]);
@@ -173,7 +179,11 @@ RetainPtr<WKWebView> makeWebViewWith(WKWebsiteDataStore *store, RetainPtr<TestNa
 
 #if HAVE(TLS_VERSION_DURING_CHALLENGE)
 
+#if BUG_301010
+TEST(TLSVersion, DISABLED_NetworkSession)
+#else
 TEST(TLSVersion, NetworkSession)
+#endif
 {
     HTTPServer server(HTTPServer::respondWithOK, HTTPServer::Protocol::HttpsWithLegacyTLS);
     auto delegate = adoptNS([TestNavigationDelegate new]);
@@ -213,7 +223,11 @@ TEST(TLSVersion, NetworkSession)
     }
 }
 
+#if BUG_301010
+TEST(TLSVersion, DISABLED_ShouldAllowDeprecatedTLS)
+#else
 TEST(TLSVersion, ShouldAllowDeprecatedTLS)
+#endif
 {
     HTTPServer server(HTTPServer::respondWithOK, HTTPServer::Protocol::HttpsWithLegacyTLS);
     {
@@ -247,7 +261,11 @@ TEST(TLSVersion, ShouldAllowDeprecatedTLS)
     }
 }
 
+#if BUG_301010
+TEST(TLSVersion, DISABLED_Preconnect)
+#else
 TEST(TLSVersion, Preconnect)
+#endif
 {
     bool connectionAttempted = false;
     HTTPServer server([&](const Connection&) {
@@ -294,7 +312,11 @@ static std::pair<RetainPtr<WKWebView>, RetainPtr<TestNavigationDelegate>> webVie
     return { webView, delegate };
 }
 
+#if BUG_301010
+TEST(TLSVersion, DISABLED_NegotiatedLegacyTLS)
+#else
 TEST(TLSVersion, NegotiatedLegacyTLS)
+#endif
 {
     HTTPServer server({
         { "/"_s, { "hello"_s } }
@@ -322,7 +344,11 @@ TEST(TLSVersion, NegotiatedLegacyTLS)
     [webView removeObserver:observer.get() forKeyPath:@"_negotiatedLegacyTLS"];
 }
 
+#if BUG_301010
+TEST(TLSVersion, DISABLED_NavigateBack)
+#else
 TEST(TLSVersion, NavigateBack)
+#endif
 {
     HTTPServer legacyTLSServer({
         { "/"_s, { "hello"_s } }
@@ -352,7 +378,11 @@ TEST(TLSVersion, NavigateBack)
     [webView removeObserver:observer.get() forKeyPath:@"_negotiatedLegacyTLS"];
 }
 
+#if BUG_301010
+TEST(TLSVersion, DISABLED_BackForwardNegotiatedLegacyTLS)
+#else
 TEST(TLSVersion, BackForwardNegotiatedLegacyTLS)
+#endif
 {
     HTTPServer secureServer({
         { "/"_s, { "hello"_s }}
@@ -388,7 +418,11 @@ TEST(TLSVersion, BackForwardNegotiatedLegacyTLS)
     EXPECT_TRUE([webView _negotiatedLegacyTLS]);
 }
 
+#if BUG_301010
+TEST(TLSVersion, DISABLED_Subresource)
+#else
 TEST(TLSVersion, Subresource)
+#endif
 {
     HTTPServer legacyTLSServer({
         { "/"_s, { "hello"_s } }
@@ -420,7 +454,11 @@ TEST(TLSVersion, Subresource)
     [webView removeObserver:observer.get() forKeyPath:@"_negotiatedLegacyTLS"];
 }
 
+#if BUG_301010
+TEST(TLSVersion, DISABLED_DidNegotiateModernTLS)
+#else
 TEST(TLSVersion, DidNegotiateModernTLS)
+#endif
 {
     HTTPServer server({
         { "/"_s, { "hello"_s }}
@@ -441,7 +479,11 @@ TEST(TLSVersion, DidNegotiateModernTLS)
 
 #if HAVE(TLS_VERSION_DURING_CHALLENGE)
 
+#if BUG_301010
+TEST(TLSVersion, DISABLED_LegacySubresources)
+#else
 TEST(TLSVersion, LegacySubresources)
+#endif
 {
     HTTPServer legacyServer({
         { "/frame"_s, { "shouldn't load with fastServerTrustEvaluationEnabled"_s }}


### PR DESCRIPTION
#### 2c09400f1139797615957bb1b0309e02fb23d8f0
<pre>
GARDENING: REGRESSION(iOS 26): TLSVersion tests fail on iOS 26
<a href="https://bugs.webkit.org/show_bug.cgi?id=301010">https://bugs.webkit.org/show_bug.cgi?id=301010</a>
<a href="https://rdar.apple.com/162894817">rdar://162894817</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/TLSDeprecation.mm:
(TestWebKitAPI::TEST(TLSVersion, DefaultBehavior)):
(TestWebKitAPI::TEST(TLSVersion, NetworkSession)):
(TestWebKitAPI::TEST(TLSVersion, ShouldAllowDeprecatedTLS)):
(TestWebKitAPI::TEST(TLSVersion, Preconnect)):
(TestWebKitAPI::TEST(TLSVersion, NegotiatedLegacyTLS)):
(TestWebKitAPI::TEST(TLSVersion, NavigateBack)):
(TestWebKitAPI::TEST(TLSVersion, BackForwardNegotiatedLegacyTLS)):
(TestWebKitAPI::TEST(TLSVersion, Subresource)):
(TestWebKitAPI::TEST(TLSVersion, DidNegotiateModernTLS)):
(TestWebKitAPI::TEST(TLSVersion, LegacySubresources)):

Canonical link: <a href="https://commits.webkit.org/301748@main">https://commits.webkit.org/301748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c24c5c0c9f05da84ee425dbf939b1463b74e866

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126930 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133934 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ceca6ac9-94a5-4eec-8b9e-e863786b24a5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128801 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/47187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55098 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/86fe784f-b032-44e4-b82d-8a7a502448a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129878 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/47187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/113544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77102 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/58726e12-d15c-4f82-b0f6-77f934a83f0d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/47187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77328 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/47187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/32030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136459 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/53590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/41259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54093 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/109907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104796 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50311 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19856 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53522 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54522 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->