### PR TITLE
[Model element] Support `loading` attribute in GPU process model element

### DIFF
--- a/Source/WebCore/Modules/model-element/DDModelPlayer.mm
+++ b/Source/WebCore/Modules/model-element/DDModelPlayer.mm
@@ -162,9 +162,6 @@ void DDModelPlayer::load(Model& modelSource, LayoutSize size)
         Ref protectedThis = Ref { *this };
         [m_modelLoader setCallbacksWithModelAddedCallback:^(WebAddMeshRequest *addRequest) {
             ensureOnMainThreadWithProtectedThis([addRequest] (Ref<DDModelPlayer> protectedThis) {
-                if (RefPtr client = protectedThis->m_client.get())
-                    client->didFinishLoading(protectedThis.get());
-
                 if (protectedThis->m_currentModel)
                     protectedThis->m_currentModel->addMesh(toCpp(addRequest));
 
@@ -176,6 +173,9 @@ void DDModelPlayer::load(Model& modelSource, LayoutSize size)
                     protectedThis->m_currentModel->update(toCpp(updateRequest));
 
                 [protectedThis->m_modelLoader requestCompleted:updateRequest];
+
+                if (RefPtr client = protectedThis->m_client.get())
+                    client->didFinishLoading(protectedThis.get());
             });
         } textureAddedCallback:^(WebDDAddTextureRequest *addTexture) {
             ensureOnMainThreadWithProtectedThis([addTexture] (Ref<DDModelPlayer> protectedThis) {


### PR DESCRIPTION
#### 677cb7b05c89904d6942ea8cd33fc90f20178b35
<pre>
[Model element] Support `loading` attribute in GPU process model element
<a href="https://bugs.webkit.org/show_bug.cgi?id=299478">https://bugs.webkit.org/show_bug.cgi?id=299478</a>
<a href="https://rdar.apple.com/161268540">rdar://161268540</a>

Reviewed by Etienne Segonzac.

didFinishLoading() was being called too early, we need to wait
for the geometry to finish loading otherwise the model is not ready to render

Test: the following tests pass after this change:
* LayoutTests/model-element/resources/go-back-on-load.html
* LayoutTests/model-element/model-element-multiple-loads.html
* LayoutTests/model-element/model-element-error-and-load-events.html

* Source/WebCore/Modules/model-element/DDModelPlayer.mm:
(WebCore::DDModelPlayer::load):

Canonical link: <a href="https://commits.webkit.org/301833@main">https://commits.webkit.org/301833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de3240390fa4fec6a914a3ec33dda5290bb72fae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78511 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4e44b41f-43f4-43ee-a993-402c734cc6ff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96589 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64590 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d156814b-0e4e-4f79-9450-324d6b83f998) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77103 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/30ee1885-ff4d-4b4c-a829-a8bd62c7df28) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31702 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77329 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136460 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105105 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104797 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26770 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50312 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28651 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51071 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59392 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52764 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56098 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54523 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->