### PR TITLE
VideoLayerManagerObjC::m_videoInlineLayer will be constructed by default with a frame size of 0x0

### DIFF
--- a/Source/WebCore/platform/graphics/VideoLayerManager.h
+++ b/Source/WebCore/platform/graphics/VideoLayerManager.h
@@ -40,6 +40,7 @@ public:
 
     virtual PlatformLayer* videoInlineLayer() const = 0;
     virtual void setVideoLayer(PlatformLayer*, FloatSize) = 0;
+    virtual void setPresentationSize(FloatSize) = 0;
     virtual void didDestroyVideoLayer() = 0;
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -675,8 +675,9 @@ void AudioVideoRendererAVFObjC::setIsVisible(bool visible)
 
 void AudioVideoRendererAVFObjC::setPresentationSize(const IntSize& newSize)
 {
-    m_presentationSize = newSize;
-    updateDisplayLayerIfNeeded();
+    if (std::exchange(m_presentationSize, newSize) == newSize || !m_sampleBufferDisplayLayer)
+        return;
+    m_videoLayerManager->setPresentationSize(newSize);
 }
 
 void AudioVideoRendererAVFObjC::setShouldMaintainAspectRatio(bool shouldMaintainAspectRatio)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -286,8 +286,10 @@ void MediaPlayerPrivateMediaSourceAVFObjC::load(const URL&, const LoadOptions& o
 
     m_loadOptions = options;
     m_renderer->setPreferences(options.videoRendererPreferences);
-    if (RefPtr player = m_player.get())
+    if (RefPtr player = m_player.get()) {
+        m_renderer->setPresentationSize(player->presentationSize());
         m_renderer->renderingCanBeAcceleratedChanged(player->renderingCanBeAccelerated());
+    }
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::setResourceOwner(const ProcessIdentity& resourceOwner)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h
@@ -61,6 +61,7 @@ public:
     WEBCORE_EXPORT PlatformLayer* videoInlineLayer() const final;
 
     WEBCORE_EXPORT void setVideoLayer(PlatformLayer*, FloatSize) final;
+    WEBCORE_EXPORT void setPresentationSize(FloatSize) final;
     WEBCORE_EXPORT void didDestroyVideoLayer() final;
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
@@ -90,6 +90,11 @@ void VideoLayerManagerObjC::setVideoLayer(PlatformLayer *videoLayer, FloatSize c
     }
 }
 
+void VideoLayerManagerObjC::setPresentationSize(FloatSize contentSize)
+{
+    [m_videoInlineLayer setFrame:CGRectMake(0, 0, contentSize.width(), contentSize.height())];
+}
+
 void VideoLayerManagerObjC::didDestroyVideoLayer()
 {
     ALWAYS_LOG(LOGIDENTIFIER);

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -171,8 +171,6 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
         }
     });
 
-    m_renderer->renderingCanBeAcceleratedChanged(player->renderingCanBeAccelerated());
-
 #if HAVE(SPATIAL_TRACKING_LABEL)
     m_defaultSpatialTrackingLabel = player->defaultSpatialTrackingLabel();
     m_spatialTrackingLabel = player->spatialTrackingLabel();
@@ -263,6 +261,11 @@ void MediaPlayerPrivateWebM::load(const URL& url, const LoadOptions& options)
         m_parser->allowLimitedMatroska();
 
     m_renderer->setPreferences(options.videoRendererPreferences | VideoRendererPreference::PrefersDecompressionSession);
+
+    if (RefPtr player = m_player.get()) {
+        m_renderer->setPresentationSize(player->presentationSize());
+        m_renderer->renderingCanBeAcceleratedChanged(player->renderingCanBeAccelerated());
+    }
 
     doPreload();
 }


### PR DESCRIPTION
#### bd3982f18b935f1d15689d0604dc7dad05a8188c
<pre>
VideoLayerManagerObjC::m_videoInlineLayer will be constructed by default with a frame size of 0x0
<a href="https://bugs.webkit.org/show_bug.cgi?id=301011">https://bugs.webkit.org/show_bug.cgi?id=301011</a>
<a href="https://rdar.apple.com/162895471">rdar://162895471</a>

Reviewed by Eric Carlson.

It was possible for the VideoLayerManager&apos;s inline layer to be created with a frame size
of 0x0.
We reduce the chances of this happening by reading the player&apos;s presentation size
on creation and update the layer&apos;s frame size whenever the presentation size
change.

Covered by existing testts.
* Source/WebCore/platform/graphics/VideoLayerManager.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::setPresentationSize):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm:
(WebCore::VideoLayerManagerObjC::setPresentationSize):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::load):

Canonical link: <a href="https://commits.webkit.org/301761@main">https://commits.webkit.org/301761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/348c1083fba716b435bc95541614523715a63031

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133938 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78514 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7607691c-cc69-4d04-969b-fcb68e0e3e40) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96592 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64591 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eba2547b-3782-4e80-a496-d6b703d633fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77106 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ddb30e6f-7a39-427f-ac4c-d1a339a27314) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31706 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77332 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136463 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41262 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105109 "11 flakes 58 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104801 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26731 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50315 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28654 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51074 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59395 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52767 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56101 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54526 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->