### PR TITLE
[macOS] Allow clients to force solid color hard pocket on the top scroll pocket

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3403,18 +3403,26 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
     return clonedScrollPocket;
 }
 
-- (BOOL)_alwaysPrefersSolidColorHardPocket
+- (void)_addReasonToPreferSolidColorHardPocket:(WebKit::PreferSolidColorHardPocketReason)reason
 {
-    return _alwaysPrefersSolidColorHardPocket;
-}
-
-- (void)_setAlwaysPrefersSolidColorHardPocket:(BOOL)value
-{
-    if (_alwaysPrefersSolidColorHardPocket == value)
+    if (_preferSolidColorHardPocketReasons.contains(reason))
         return;
 
-    _alwaysPrefersSolidColorHardPocket = value;
-    _impl->updatePrefersSolidColorHardPocket();
+    _preferSolidColorHardPocketReasons.add(WebKit::PreferSolidColorHardPocketReason::RequestedByClient);
+
+    if (_preferSolidColorHardPocketReasons.hasExactlyOneBitSet())
+        _impl->updatePrefersSolidColorHardPocket();
+}
+
+- (void)_removeReasonToPreferSolidColorHardPocket:(WebKit::PreferSolidColorHardPocketReason)reason
+{
+    if (!_preferSolidColorHardPocketReasons.contains(reason))
+        return;
+
+    _preferSolidColorHardPocketReasons.remove(WebKit::PreferSolidColorHardPocketReason::RequestedByClient);
+
+    if (!_preferSolidColorHardPocketReasons)
+        _impl->updatePrefersSolidColorHardPocket();
 }
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -152,6 +152,11 @@ enum class HideScrollPocketReason : uint8_t {
     ScrolledToTop       = 1 << 1,
     SiteSpecificQuirk   = 1 << 2,
 };
+
+enum class PreferSolidColorHardPocketReason : uint8_t {
+    AttachedInspector   = 1 << 0,
+    RequestedByClient   = 1 << 1,
+};
 }
 
 @class NSScrollPocket;
@@ -300,7 +305,7 @@ struct PerWebProcessState {
     BOOL _usesAutomaticContentInsetBackgroundFill;
     BOOL _shouldSuppressTopColorExtensionView;
 #if PLATFORM(MAC)
-    BOOL _alwaysPrefersSolidColorHardPocket;
+    OptionSet<WebKit::PreferSolidColorHardPocketReason> _preferSolidColorHardPocketReasons;
     BOOL _isGettingAdjustedColorForTopContentInsetColorFromDelegate;
     RetainPtr<NSColor> _overrideTopScrollEdgeEffectColor;
 #endif
@@ -580,7 +585,8 @@ struct PerWebProcessState {
 #if PLATFORM(MAC) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 - (NSColor *)_adjustedColorForTopContentInsetColorFromUIDelegate:(NSColor *)proposedColor;
 @property (nonatomic, readonly) RetainPtr<NSScrollPocket> _copyTopScrollPocket;
-@property (nonatomic, setter=_setAlwaysPrefersSolidColorHardPocket:) BOOL _alwaysPrefersSolidColorHardPocket;
+- (void)_addReasonToPreferSolidColorHardPocket:(WebKit::PreferSolidColorHardPocketReason)reason;
+- (void)_removeReasonToPreferSolidColorHardPocket:(WebKit::PreferSolidColorHardPocketReason)reason;
 #endif
 
 #if ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -925,6 +925,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
 @property (nonatomic, readonly) NSScrollPocket *_topScrollPocket WK_API_AVAILABLE(macos(26.0));
+@property (nonatomic, setter=_setPrefersSolidColorHardScrollPocket:) BOOL _prefersSolidColorHardScrollPocket WK_API_AVAILABLE(macos(WK_MAC_TBA));
 #endif
 
 - (void)_showWritingTools WK_API_AVAILABLE(macos(15.2));

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1665,7 +1665,20 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return _impl->topScrollPocket();
 }
 
-#endif
+- (BOOL)_prefersSolidColorHardScrollPocket
+{
+    return _preferSolidColorHardPocketReasons.contains(WebKit::PreferSolidColorHardPocketReason::RequestedByClient);
+}
+
+- (void)_setPrefersSolidColorHardScrollPocket:(BOOL)value
+{
+    if (value)
+        [self _addReasonToPreferSolidColorHardPocket:WebKit::PreferSolidColorHardPocketReason::RequestedByClient];
+    else
+        [self _removeReasonToPreferSolidColorHardPocket:WebKit::PreferSolidColorHardPocketReason::RequestedByClient];
+}
+
+#endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
 - (void)_setUsesAutomaticContentInsetBackgroundFill:(BOOL)value
 {

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -231,10 +231,15 @@ static void* const safeAreaInsetsKVOContext = (void*)&safeAreaInsetsKVOContext;
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     RetainPtr attachedView = [self _horizontallyAttachedInspectedWebView];
     [_webView _setOverrideTopScrollEdgeEffectColor:[attachedView _topScrollPocket].captureColor];
-    [_webView _setAlwaysPrefersSolidColorHardPocket:!!attachedView];
+
+    if (attachedView)
+        [_webView _addReasonToPreferSolidColorHardPocket:WebKit::PreferSolidColorHardPocketReason::AttachedInspector];
+    else
+        [_webView _removeReasonToPreferSolidColorHardPocket:WebKit::PreferSolidColorHardPocketReason::AttachedInspector];
+
     [_webView _setOverflowHeightForTopScrollEdgeEffect:[attachedView _overflowHeightForTopScrollEdgeEffect]];
     [_webView _updateHiddenScrollPocketEdges];
-#endif
+#endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 }
 
 - (WKWebView *)_horizontallyAttachedInspectedWebView

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -7174,7 +7174,7 @@ void WebViewImpl::updatePrefersSolidColorHardPocket()
         if (m_pageIsScrolledToTop)
             return YES;
 
-        if ([view _alwaysPrefersSolidColorHardPocket])
+        if (view->_preferSolidColorHardPocketReasons)
             return YES;
 
         return NO;


### PR DESCRIPTION
#### e9cbce21b93f42122a43cc3d9f420e4f2022f78f
<pre>
[macOS] Allow clients to force solid color hard pocket on the top scroll pocket
<a href="https://bugs.webkit.org/show_bug.cgi?id=301020">https://bugs.webkit.org/show_bug.cgi?id=301020</a>
<a href="https://rdar.apple.com/162881310">rdar://162881310</a>

Reviewed by Lily Spiniolas.

Expose `_alwaysPrefersSolidColorHardPocket` (currently an internal property on `WKWebView`) as
`_prefersSolidColorHardScrollPocket` for clients; see below for more details.

Note that setting this to `YES` guarantees a solid color hard pocket; however, setting this to `NO`
does not guarantee a non-solid hard pocket, since the engine may have other reasons to use a solid
color hard pocket.

Test: ObscuredContentInsets.PreferSolidColorHardPocket

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _addReasonToPreferSolidColorHardPocket:]):
(-[WKWebView _removeReasonToPreferSolidColorHardPocket:]):

Refactor this so that whether or not we should _really_ prefer solid color hard pocket depends on
the state of an `OptionSet&lt;PreferSolidColorHardPocketReason&gt;`, with two reason flags.

(-[WKWebView _alwaysPrefersSolidColorHardPocket]): Deleted.
(-[WKWebView _setAlwaysPrefersSolidColorHardPocket:]): Deleted.

Replace these with internal methods that add or remove the new `PreferSolidColorHardPocketReason`
flags.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _prefersSolidColorHardScrollPocket]):
(-[WKWebView _setPrefersSolidColorHardScrollPocket:]):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController didAttachOrDetach]):

Since we currently set this internal property from within the engine itself, we refactor this to add
the `PreferSolidColorHardPocketReason::AttachedInspector` reason flag, instead of overriding the new
property (which may have been set by the WebKit client).

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updatePrefersSolidColorHardPocket):

Make this check the `OptionSet&lt;PreferSolidColorHardPocketReason&gt;` instead of the value of the SPI
property, to account for both reasons.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm:
(TestWebKitAPI::TEST(ObscuredContentInsets, PreferSolidColorHardPocket)):

Add an API test to exercise this new method.

Canonical link: <a href="https://commits.webkit.org/301755@main">https://commits.webkit.org/301755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b63b0f6eb67f120bcdb863ff46480eb34a3ea48f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133944 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b5c46789-36df-4462-be86-54c3479b35cd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55108 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96595 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/447936f8-4b65-409e-9622-482e39ddf590) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77109 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3354105e-dabd-490a-af06-20eb87aa41d0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/31718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77338 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136469 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105112 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104804 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26726 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50320 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28666 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51080 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53532 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59401 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52773 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56107 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54532 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->