### PR TITLE
[JSC] Implement `Promise.prototype.catch` in C++

### DIFF
--- a/JSTests/microbenchmarks/promise-prototype-catch.js
+++ b/JSTests/microbenchmarks/promise-prototype-catch.js
@@ -1,0 +1,3 @@
+for (let i = 0; i < 1e5; i++) {
+  Promise.reject(i).catch(() => { });
+}

--- a/Source/JavaScriptCore/builtins/PromisePrototype.js
+++ b/Source/JavaScriptCore/builtins/PromisePrototype.js
@@ -23,13 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-function catch(onRejected)
-{
-    "use strict";
-
-    return this.then(@undefined, onRejected);
-}
-
 function finally(onFinally)
 {
     "use strict";

--- a/Source/JavaScriptCore/inspector/InjectedScriptSource.js
+++ b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
@@ -753,7 +753,7 @@ let InjectedScript = class InjectedScript extends PrototypelessObjectBase
                     fakeDescriptor.symbol = symbol;
                 // Silence any possible unhandledrejection exceptions created from accessing a native accessor with a wrong this object.
                 if (@isPromise(fakeDescriptor.value) && InjectedScriptHost.isPromiseRejectedWithNativeGetterTypeError(fakeDescriptor.value))
-                    fakeDescriptor.value.@catch(function(){});
+                    fakeDescriptor.value.@then(@undefined, function(){});
                 return fakeDescriptor;
             } catch (e) {
                 let errorDescriptor = @createObjectWithoutPrototype(


### PR DESCRIPTION
#### c496281388179096571a5bf8d23d89bb74e986ac
<pre>
[JSC] Implement `Promise.prototype.catch` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=301022">https://bugs.webkit.org/show_bug.cgi?id=301022</a>

Reviewed by Yusuke Suzuki.

This patch changes to implement `Promise.prototype.catch` in C++ same as `Promise.prototype.then`.

DFG/FTL enabled:
                                         TipOfTree                  Patched

        promise-prototype-catch        6.8142+-0.5325     ^      5.4118+-0.4242        ^ definitely 1.2591x faster

DFG/FTL disabled:
                                         TipOfTree                  Patched

        promise-prototype-catch       17.1595+-0.6856     ^      6.0762+-0.3540        ^ definitely 2.8241x faster

Test: JSTests/microbenchmarks/promise-prototype-catch.js

* JSTests/microbenchmarks/promise-prototype-catch.js: Added.
(i.Promise.reject.i.catch):
* Source/JavaScriptCore/builtins/PromisePrototype.js:
(catch): Deleted.
* Source/JavaScriptCore/inspector/InjectedScriptSource.js:
(let.InjectedScript.prototype._forEachPropertyDescriptor.createFakeValueDescriptor):
* Source/JavaScriptCore/runtime/JSPromisePrototype.cpp:
(JSC::JSPromisePrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/301784@main">https://commits.webkit.org/301784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/350f30ba211d962f5765ee8ed6d3140ba6b40041

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78621 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96684 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64714 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77198 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36735 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31858 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77453 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119096 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107727 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136587 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125522 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41368 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105202 "46 flakes 80 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104893 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26747 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50417 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28808 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51246 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59519 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158559 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52884 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39659 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56217 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54642 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->