### PR TITLE
Mac full screen media controls do no match AVKit floating controls

### DIFF
--- a/LayoutTests/media/modern-media-controls/macos-fullscreen-media-controls/macos-fullscreen-media-controls-drag-is-prevented-over-button-expected.txt
+++ b/LayoutTests/media/modern-media-controls/macos-fullscreen-media-controls/macos-fullscreen-media-controls-drag-is-prevented-over-button-expected.txt
@@ -4,9 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS media.webkitDisplayingFullscreen became true
-PASS !!mediaControls.querySelector('.buttons-container.left') became true
-PASS mediaControls.querySelector('.buttons-container.left').style.width became "100px"
-PASS mediaControls.querySelector('.controls-bar').style.transform is ""
+PASS Controls did not move when dragging over a button
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/media/modern-media-controls/macos-fullscreen-media-controls/macos-fullscreen-media-controls-drag-is-prevented-over-button.html
+++ b/LayoutTests/media/modern-media-controls/macos-fullscreen-media-controls/macos-fullscreen-media-controls-drag-is-prevented-over-button.html
@@ -19,18 +19,48 @@ media.addEventListener("webkitbeginfullscreen", () => {
 media.addEventListener("webkitfullscreenchange", () => {
     shouldBecomeEqual("media.webkitDisplayingFullscreen", "true", () => {
         mediaControls = shadowRoot.lastChild;
-        shouldBecomeEqual("!!mediaControls.querySelector('.buttons-container.left')", "true", () => {
-            shouldBecomeEqualToString("mediaControls.querySelector('.buttons-container.left').style.width", "100px", () => {
-                const bounds = mediaControls.querySelector(".controls-bar").getBoundingClientRect();
-                eventSender.mouseMoveTo(bounds.left + 68, bounds.top + 20);
-                eventSender.mouseDown();
-                eventSender.mouseMoveTo(bounds.left + 18, bounds.top - 80);
-                eventSender.mouseUp();
+        
+        // Wait for the controls to be properly laid out
+        window.requestAnimationFrame(() => {
+            // Find any button to test with
+            const anyButton = mediaControls.querySelector('button');
+            if (!anyButton) {
+                testFailed("No buttons found to test");
+                finishJSTest();
+                return;
+            }
+            
+            const buttonBounds = anyButton.getBoundingClientRect();
+            
+            // Click directly in the center of the button
+            const buttonCenterX = buttonBounds.left + buttonBounds.width / 2;
+            const buttonCenterY = buttonBounds.top + buttonBounds.height / 2;
+            
+            // Store initial transform state
+            const controlsBar = mediaControls.querySelector('.controls-bar');
+            const initialTransform = controlsBar.style.transform || "";
+            
+            eventSender.mouseMoveTo(buttonCenterX, buttonCenterY);
+            eventSender.mouseDown();
+            eventSender.mouseMoveTo(buttonCenterX - 50, buttonCenterY - 100);
+            eventSender.mouseUp();
 
-                window.requestAnimationFrame(() => {
-                    shouldBeEqualToString("mediaControls.querySelector('.controls-bar').style.transform", "");
-                    finishJSTest();
-                });
+            window.requestAnimationFrame(() => {
+                // Check that transform hasn't changed significantly
+                const finalTransform = controlsBar.style.transform || "";
+                const noSignificantMovement = finalTransform === initialTransform ||
+                    finalTransform === "" ||
+                    finalTransform === "none" ||
+                    finalTransform.includes("translate(0px, 0px)") ||
+                    finalTransform.includes("translate3d(0px, 0px, 0px)");
+                
+                if (noSignificantMovement) {
+                    testPassed("Controls did not move when dragging over a button");
+                } else {
+                    testFailed("Controls moved when dragging over a button. Initial: '" + initialTransform + "', Final: '" + finalTransform + "'");
+                }
+                
+                finishJSTest();
             });
         });
     });
@@ -41,7 +71,7 @@ media.addEventListener("play", () => {
 
     window.requestAnimationFrame(() => {
         const bounds = mediaControls.querySelector("button.fullscreen").getBoundingClientRect();
-        eventSender.mouseMoveTo(bounds.left + 1, bounds.top + 1);
+        eventSender.mouseMoveTo(bounds.left + bounds.width / 2, bounds.top + bounds.height / 2);
         eventSender.mouseDown();
         eventSender.mouseUp();
     });

--- a/LayoutTests/platform/mac-sonoma-wk1/imported/w3c/web-platform-tests/media-source/mediasource-seek-during-pending-seek-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk1/imported/w3c/web-platform-tests/media-source/mediasource-seek-during-pending-seek-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test seeking to a new location before transitioning beyond HAVE_METADATA. assert_equals: Event types match. expected "seeked" but got "playing"
+PASS Test seeking to a new location before transitioning beyond HAVE_METADATA.
 PASS Test seeking to a new location during a pending seek.
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.css
@@ -54,6 +54,7 @@
 .media-controls.mac.fullscreen .buttons-container.left {
     top: 16px;
     height: 16px;
+    width: 100px !important;
 }
 
 .media-controls.mac.fullscreen .buttons-container.center {
@@ -74,6 +75,9 @@
     top: 18px;
 }
 
+.media-controls.mac.fullscreen .buttons-container.left .slider {
+    width: 60px;
+}
 /* Scrubber */
 
 .media-controls.mac.fullscreen .time-control {

--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.js
@@ -47,7 +47,6 @@ class MacOSFullscreenMediaControls extends MediaControls
         this.fullscreenButton.isFullscreen = true;
 
         this.volumeSlider = new Slider(this, "volume");
-        this.volumeSlider.width = 60;
 
         this._leftContainer = new ButtonsContainer({
             children: this._volumeControlsForCurrentDirection(),
@@ -168,7 +167,7 @@ class MacOSFullscreenMediaControls extends MediaControls
     _handleMousedown(event)
     {
         // We don't allow dragging when the interaction is initiated on an interactive element. 
-        if (event.target.localName === "button" || event.target.parentNode.localName === "button" || event.target.localName === "input")
+        if (event.target.localName === "button" || event.target.parentNode.localName === "button" || event.target.localName === "input" || event.target.closest("button") || event.target.closest(".buttons-container"))
             return;
 
         event.preventDefault();

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -551,6 +551,98 @@ static const String& macOSInlineMediaControlsStyleSheet()
 
     return macOSInlineMediaControlsStyleSheet;
 }
+
+static const String& macOSFullscreenMediaControlsStyleSheet()
+{
+    static NeverDestroyed<String> macOSFullscreenMediaControlsStyleSheet {
+        "/* Controls bar */"
+        ".media-controls.mac.fullscreen {"
+        "    --controls-bar-width: 458px; /* Keep in sync with `minVideoWidth`. */"
+        "    width: 100% !important;"
+        "    height: 100% !important;"
+        "}"
+        ".media-controls.mac.fullscreen > .controls-bar {"
+        "    left: calc((100% - var(--controls-bar-width)) / 2);"
+        "    bottom: 25px;"
+        "    width: var(--controls-bar-width);"
+        "    height: 100px;"
+        "    border-radius: 20px;"
+        "}"
+        ".media-controls.mac.fullscreen .controls-bar.bottom .background-tint > div {"
+        "    border-radius: 20px;"
+        "}"
+        "/* Volume controls */"
+        ".media-controls.mac.fullscreen:not(.uses-ltr-user-interface-layout-direction) .volume.slider {"
+        "    transform: scaleX(-1);"
+        "}"
+        "/* Button containers */"
+        ".media-controls.mac.fullscreen .buttons-container {"
+        "    height: 44px;"
+        "}"
+        ".media-controls.mac.fullscreen .buttons-container.left {"
+        "    top: 22.4px;"
+        "    height: 16px;"
+        "    width: 100px !important;"
+        "    left: 15.5px"
+        "}"
+        ".media-controls.mac.fullscreen .buttons-container.center {"
+        "    left: 50%;"
+        "    top: 9px;"
+        "    transform: translateX(-50%);"
+        "}"
+        "/* Make right container flush to the right */"
+        ".media-controls.mac.fullscreen .buttons-container.right {"
+        "    right: 11px;"
+        "    top: 5px;"
+        "}"
+        "/* Buttons placement for right container */"
+        ".media-controls.mac.fullscreen .buttons-container.right button {"
+        "    top: 18px;"
+        "}"
+        "/* Scrubber */"
+        ".media-controls.mac.fullscreen .time-control {"
+        "    position: absolute;"
+        "    left: 25px;"
+        "    top: 64px;"
+        "    height: 16px;"
+        "    width: 408px !important;"
+        "    display: flex;"
+        "    align-items: center;"
+        "}"
+        "/* Status Label */"
+        ".media-controls.mac.fullscreen > .controls-bar .status-label {"
+        "    position: absolute;"
+        "    left: 0;"
+        "    right: 0;"
+        "    bottom: 13px;"
+        "    font-size: 14px;"
+        "    text-align: center;"
+        "}"
+        ".media-controls.mac.fullscreen .buttons-container.left .slider {"
+        "    width: 78px;"
+        "}"
+        ".media-controls.mac.fullscreen .slider.default > .appearance {"
+        "    height: 6px;"
+        "}"
+        ".media-controls.mac.fullscreen .slider.default > .appearance > .fill > .primary {"
+        "    background-color: white;"
+        "}"
+        ".media-controls.mac.fullscreen .slider.default.allows-relative-scrubbing > .appearance > .fill > .primary {"
+        "    background-color: white;"
+        "}"
+        ".slider.default > .appearance > .fill > .knob.pill,"
+        ".media-controls.mac.fullscreen .buttons-container.left .slider.default > .appearance > .fill > .knob,"
+        ".media-controls.mac.fullscreen .time-control .slider.default > .appearance > .fill > .knob {"
+        "    top: -5px;"
+        "    width: 21px;"
+        "    height: 17px;"
+        "    border-radius: 8.5px;"
+        "    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);"
+        "    margin: -2px;"
+        "}"_s
+    };
+    return macOSFullscreenMediaControlsStyleSheet;
+}
 #endif // HAVE(MATERIAL_HOSTING)
 
 Vector<String, 2> RenderThemeCocoa::mediaControlsStyleSheets(const HTMLMediaElement& mediaElement)
@@ -566,8 +658,10 @@ Vector<String, 2> RenderThemeCocoa::mediaControlsStyleSheets(const HTMLMediaElem
     if (mediaElement.document().settings().hostedBlurMaterialInMediaControlsEnabled())
         mediaControlsStyleSheets.append(glassMaterialMediaControlsStyleSheet());
 
-    if (mediaElement.document().settings().mediaControlsMacInlineSizeSpecsEnabled())
+    if (mediaElement.document().settings().mediaControlsMacInlineSizeSpecsEnabled()) {
         mediaControlsStyleSheets.append(macOSInlineMediaControlsStyleSheet());
+        mediaControlsStyleSheets.append(macOSFullscreenMediaControlsStyleSheet());
+    }
 #else
     UNUSED_PARAM(mediaElement);
 #endif


### PR DESCRIPTION
#### faf60369ae617f3b553540c9dbaa5939de0dc1cc
<pre>
Mac full screen media controls do no match AVKit floating controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=301025">https://bugs.webkit.org/show_bug.cgi?id=301025</a>
<a href="https://rdar.apple.com/162909216">rdar://162909216</a>

Reviewed by Andy Estes.

Update macOS inline media controls to match AVKit&apos;s floating controls design. Increase bottom
control bar height and slider heights. Replace circular and bar shaped slider thumbs with
pill-shaped design for both time control scrubber and volume slider.

* LayoutTests/media/modern-media-controls/macos-fullscreen-media-controls/macos-fullscreen-media-controls-drag-is-prevented-over-button-expected.txt:
* LayoutTests/media/modern-media-controls/macos-fullscreen-media-controls/macos-fullscreen-media-controls-drag-is-prevented-over-button.html:
* LayoutTests/platform/mac-sonoma-wk1/imported/w3c/web-platform-tests/media-source/mediasource-seek-during-pending-seek-expected.txt:
* Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.css:
(.media-controls.mac.fullscreen .buttons-container.left):
(.media-controls.mac.fullscreen .buttons-container.left .slider):
* Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.js:
(MacOSFullscreenMediaControls.prototype._handleMousedown):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::macOSFullscreenMediaControlsStyleSheet):
(WebCore::RenderThemeCocoa::mediaControlsStyleSheets):

Canonical link: <a href="https://commits.webkit.org/303335@main">https://commits.webkit.org/303335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff96b583f39a26708b5691b646968689c0880bdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83928 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fba95830-0b9d-4538-bca6-269ea2127d44) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100921 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7d3f7838-6e98-449e-a229-e722d155247c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81711 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4f7e3921-0203-4999-b8f4-cd5da644897a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3066 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82755 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142182 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4183 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109290 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3644 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109462 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27740 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3173 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114516 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57404 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4237 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32910 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4068 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4328 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4196 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->