### PR TITLE
Fix UniqueIDBDatabaseTransaction error: finished request count is bigger than total request count

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/ServerOpenDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/server/ServerOpenDBRequest.h
@@ -38,6 +38,8 @@ class IDBDatabaseInfo;
 
 namespace IDBServer {
 
+class UniqueIDBDatabaseTransaction;
+
 class ServerOpenDBRequest : public RefCounted<ServerOpenDBRequest> {
 public:
     static Ref<ServerOpenDBRequest> create(IDBConnectionToClient&, const IDBOpenRequestData&);
@@ -49,15 +51,15 @@ public:
     bool isDeleteRequest() const;
 
     void maybeNotifyRequestBlocked(uint64_t currentVersion);
-    void notifyDidDeleteDatabase(const IDBDatabaseInfo&);
-
-    uint64_t versionChangeID() const;
 
     void notifiedConnectionsOfVersionChange(HashSet<IDBDatabaseConnectionIdentifier>&& connectionIdentifiers);
     void connectionClosedOrFiredVersionChangeEvent(IDBDatabaseConnectionIdentifier);
     bool hasConnectionsPendingVersionChangeEvent() const { return !m_connectionsPendingVersionChangeEvent.isEmpty(); }
     bool hasNotifiedConnectionsOfVersionChange() const { return m_notifiedConnectionsOfVersionChange; }
 
+    void setVersionChangeTransaction(UniqueIDBDatabaseTransaction&);
+    void didDeleteDatabase(const IDBResultData&);
+    void didOpenDatabase(const IDBResultData&);
 
 private:
     ServerOpenDBRequest(IDBConnectionToClient&, const IDBOpenRequestData&);
@@ -69,6 +71,7 @@ private:
 
     bool m_notifiedConnectionsOfVersionChange { false };
     HashSet<IDBDatabaseConnectionIdentifier> m_connectionsPendingVersionChangeEvent;
+    RefPtr<UniqueIDBDatabaseTransaction> m_versionChangeTransaction;
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -643,5 +643,10 @@ void UniqueIDBDatabaseTransaction::didGenerateIndexKeyForRecord(IDBResourceIdent
     database->didGenerateIndexKeyForRecord(*this, indexInfo, key, value, recordID);
 }
 
+void UniqueIDBDatabaseTransaction::addOpenRequestResult(const IDBError& error)
+{
+    m_requestResults.append(error);
+}
+
 } // namespace IDBServer
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
@@ -89,6 +89,7 @@ public:
     WEBCORE_EXPORT void deleteRecord(const IDBRequestData&, const IDBKeyRangeData&);
     WEBCORE_EXPORT void openCursor(const IDBRequestData&, const IDBCursorInfo&);
     WEBCORE_EXPORT void iterateCursor(const IDBRequestData&, const IDBIterateCursorData&);
+    void addOpenRequestResult(const IDBError&);
 
     void didActivateInBackingStore(const IDBError&);
 


### PR DESCRIPTION
#### 4acb9114542c1ffdf4cca6d9b9390c2ce64c6768
<pre>
Fix UniqueIDBDatabaseTransaction error: finished request count is bigger than total request count
<a href="https://bugs.webkit.org/show_bug.cgi?id=301027">https://bugs.webkit.org/show_bug.cgi?id=301027</a>
<a href="https://rdar.apple.com/162913897">rdar://162913897</a>

Reviewed by Chris Dumez and Per Arne Vollan.

When running basic IndexedDB tests like storage/indexeddb/basics.html, there is error log about &quot;finished request count
bigger than total requested&quot; (printed from UniqueIDBDatabaseTransaction::shouldAbortDueToUnhandledRequestError). This
error means at the time a transaction is committed, the number of requests handled by IndexedDB server for the
transaction (&quot;total requested&quot;) is smaller than the number of request results processed by client (&quot;finished request
count&quot;). This cannot happen in normal case because client receives request results from server. The error could lead to
shouldAbortDueToUnhandledRequestError always returns false, without checking the errors in existing results.

The cause of the issue is that client counts result of open request for version change transaction, but server does not.
Normally, request will be submitted to UniqueIDBDatabaseTransaction, and it will update m_requestResults (the size of
m_requestResults is &quot;total requested&quot;) after result is available. However, for open requests, they are handled by
UniqueIDBDabase directly and the result is dispatched via ServerOpenDBRequest (so the transaction does not know about
the result). To fix this issue, this patch makes ServerOpenDBRequest keep track of its versions change transaction and
update the transaction about the open request result. (Note delete database request is not associated with a
transaction, so we don&apos;t need to update result for didDeleteDatabase). With this fix, running the test no longer prints
the error log.

* Source/WebCore/Modules/indexeddb/server/ServerOpenDBRequest.cpp:
(WebCore::IDBServer::ServerOpenDBRequest::setVersionChangeTransaction):
(WebCore::IDBServer::ServerOpenDBRequest::didDeleteDatabase):
(WebCore::IDBServer::ServerOpenDBRequest::didOpenDatabase):
(WebCore::IDBServer::ServerOpenDBRequest::notifyDidDeleteDatabase): Deleted.
* Source/WebCore/Modules/indexeddb/server/ServerOpenDBRequest.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::performCurrentOpenOperationAfterSpaceCheck):
(WebCore::IDBServer::UniqueIDBDatabase::didDeleteBackingStore):
(WebCore::IDBServer::UniqueIDBDatabase::startVersionChangeTransaction):
(WebCore::IDBServer::errorOpenDBRequestForUserDelete):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::addOpenRequestResult):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h:

Canonical link: <a href="https://commits.webkit.org/301820@main">https://commits.webkit.org/301820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88ce2086cc0bfa8fe2a1712a5df00479ccc7b540

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134253 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a7059850-3e6c-4773-8d6d-9491111b513b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129061 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/47443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/55353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96794 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/56b8023e-9f7b-425e-aa81-a9a908a733a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130137 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/47443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77299 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e0f892cc-6fa9-4c21-942b-97183af20367) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/47443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77633 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/47443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136736 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/53846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/55353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105317 "") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/54354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110269 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105002 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26766 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/28983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/53785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59872 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/53017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/54778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->