### PR TITLE
Add prototype string matcher API

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1586,6 +1586,9 @@ set(WebCore_NON_SVG_IDL_FILES
     page/WebKitJSHandle.idl
     page/WebKitPoint.idl
     page/WebKitSerializedNode.idl
+    page/WebKitStringMatcher.idl
+    page/WebKitStringMatcherOptions.idl
+    page/WebKitStringMatchersNamespace.idl
     page/WindowEventHandlers.idl
     page/WindowLocalStorage.idl
     page/WindowOrWorkerGlobalScope+Crypto.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1966,6 +1966,9 @@ $(PROJECT_DIR)/page/WebKitJSHandle.idl
 $(PROJECT_DIR)/page/WebKitNamespace.idl
 $(PROJECT_DIR)/page/WebKitPoint.idl
 $(PROJECT_DIR)/page/WebKitSerializedNode.idl
+$(PROJECT_DIR)/page/WebKitStringMatcher.idl
+$(PROJECT_DIR)/page/WebKitStringMatcherOptions.idl
+$(PROJECT_DIR)/page/WebKitStringMatchersNamespace.idl
 $(PROJECT_DIR)/page/WindowEventHandlers.idl
 $(PROJECT_DIR)/page/WindowLocalStorage.idl
 $(PROJECT_DIR)/page/WindowOrWorkerGlobalScope+Crypto.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3404,6 +3404,12 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitPoint.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitPoint.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitSerializedNode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitSerializedNode.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitStringMatcher.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitStringMatcher.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitStringMatcherOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitStringMatcherOptions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitStringMatchersNamespace.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitStringMatchersNamespace.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebLock.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebLock.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebLockGrantedCallback.cpp
@@ -3762,6 +3768,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/WebCore_BUILTINS_DEPENDENCIES_LIST
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/WebCore_BUILTINS_SOURCES_LIST
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/WebKitFontFamilyNames.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/WebKitFontFamilyNames.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/WebKitStringMatchersNamespace.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/WebKitStringMatchersNamespace.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/WorkerGlobalScopeConstructors.idl
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/WorkletGlobalScopeConstructors.idl
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/WritableStreamDefaultControllerBuiltins.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1635,6 +1635,9 @@ JS_BINDING_IDLS := \
     $(WebCore)/page/WindowOrWorkerGlobalScope.idl \
     $(WebCore)/page/WindowPostMessageOptions.idl \
     $(WebCore)/page/WindowSessionStorage.idl \
+    $(WebCore)/page/WebKitStringMatcher.idl \
+    $(WebCore)/page/WebKitStringMatcherOptions.idl \
+    $(WebCore)/page/WebKitStringMatchersNamespace.idl \
     $(WebCore)/page/WorkerNavigator.idl \
     $(WebCore)/page/csp/CSPViolationReportBody.idl \
     $(WebCore)/plugins/DOMMimeType.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2195,6 +2195,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/WebKitJSHandle.h
     page/WebKitNamespace.h
     page/WebKitSerializedNode.h
+    page/WebKitStringMatcher.h
     page/WheelEventDeltaFilter.h
     page/WheelEventTestMonitor.h
     page/WindowFeatures.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2233,6 +2233,8 @@ page/VisitedLinkStore.cpp
 page/VisualViewport.cpp
 page/WebKitJSHandle.cpp
 page/WebKitSerializedNode.cpp
+page/WebKitStringMatchersNamespace.cpp
+page/WebKitStringMatcher.cpp
 page/WheelEventDeltaFilter.cpp
 page/WheelEventTestMonitor.cpp
 page/WindowFeatures.cpp
@@ -4896,6 +4898,9 @@ JSStorage.cpp
 JSStorageEvent.cpp
 JSStorageManager.cpp
 JSStreamPipeOptions.cpp
+JSWebKitStringMatcher.cpp
+JSWebKitStringMatchersNamespace.cpp
+JSWebKitStringMatcherOptions.cpp
 JSStringCallback.cpp
 JSStructuredSerializeOptions.cpp
 JSStyleMedia.cpp

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -592,6 +592,8 @@ class EmptyUserContentProvider final : public UserContentProvider {
 #if ENABLE(USER_MESSAGE_HANDLERS)
     void forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const final { }
 #endif
+    bool hasStringMatchersForWorld(const DOMWrapperWorld&) const final { return false; }
+    WebKitStringMatcher* stringMatcher(const DOMWrapperWorld&, const String&) const final { return nullptr; }
 #if ENABLE(CONTENT_EXTENSIONS)
     const ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() const final { static NeverDestroyed<ContentExtensions::ContentExtensionsBackend> backend; return backend.get(); };
 #endif

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -868,7 +868,10 @@ bool LocalDOMWindow::shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld& world, J
         }
     });
 
-    return hasUserMessageHandler;
+    if (hasUserMessageHandler)
+        return true;
+
+    return userContentProvider->hasStringMatchersForWorld(world);
 }
 
 WebKitNamespace* LocalDOMWindow::webkitNamespace()

--- a/Source/WebCore/page/UserContentController.h
+++ b/Source/WebCore/page/UserContentController.h
@@ -55,6 +55,8 @@ private:
 #if ENABLE(USER_MESSAGE_HANDLERS)
     void forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const final;
 #endif
+    bool hasStringMatchersForWorld(const DOMWrapperWorld&) const override { return false; }
+    WebKitStringMatcher* stringMatcher(const DOMWrapperWorld&, const String&) const override { return nullptr; }
 #if ENABLE(CONTENT_EXTENSIONS)
     const ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() const override { return m_contentExtensionBackend; }
 #endif

--- a/Source/WebCore/page/UserContentProvider.h
+++ b/Source/WebCore/page/UserContentProvider.h
@@ -54,6 +54,7 @@ class UserContentProvider;
 class UserMessageHandlerDescriptor;
 class UserScript;
 class UserStyleSheet;
+class WebKitStringMatcher;
 
 class UserContentProviderInvalidationClient : public CanMakeWeakPtr<UserContentProviderInvalidationClient> {
 public:
@@ -74,6 +75,8 @@ public:
 #if ENABLE(USER_MESSAGE_HANDLERS)
     virtual void forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const = 0;
 #endif
+    virtual bool hasStringMatchersForWorld(const DOMWrapperWorld&) const = 0;
+    virtual WebKitStringMatcher* stringMatcher(const DOMWrapperWorld&, const String&) const = 0;
 #if ENABLE(CONTENT_EXTENSIONS)
     virtual const ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() const = 0;
 #endif

--- a/Source/WebCore/page/WebKitNamespace.cpp
+++ b/Source/WebCore/page/WebKitNamespace.cpp
@@ -34,6 +34,7 @@
 #include "Logging.h"
 #include "WebKitJSHandle.h"
 #include "WebKitSerializedNode.h"
+#include "WebKitStringMatchersNamespace.h"
 #include <JavaScriptCore/JSCellInlines.h>
 
 #define WEBKIT_NAMESPACE_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - WebKitNamespace::" fmt, this, ##__VA_ARGS__)
@@ -48,6 +49,7 @@ namespace WebCore {
 WebKitNamespace::WebKitNamespace(LocalDOMWindow& window, UserContentProvider& userContentProvider)
     : LocalDOMWindowProperty(&window)
     , m_messageHandlerNamespace(UserMessageHandlersNamespace::create(*window.protectedFrame(), userContentProvider))
+    , m_stringMatchers(WebKitStringMatchersNamespace::create(*window.protectedFrame(), userContentProvider))
 {
     ASSERT(window.frame());
 }
@@ -66,7 +68,12 @@ UserMessageHandlersNamespace* WebKitNamespace::messageHandlers()
     }
 #endif
 
-    return &m_messageHandlerNamespace.get();
+    return m_messageHandlerNamespace.ptr();
+}
+
+WebKitStringMatchersNamespace& WebKitNamespace::stringMatchers()
+{
+    return m_stringMatchers;
 }
 
 Ref<WebKitJSHandle> WebKitNamespace::createJSHandle(JSC::JSGlobalObject& globalObject, JSC::Strong<JSC::JSObject> object)

--- a/Source/WebCore/page/WebKitNamespace.h
+++ b/Source/WebCore/page/WebKitNamespace.h
@@ -43,6 +43,7 @@ class UserContentProvider;
 class UserMessageHandlersNamespace;
 class WebKitJSHandle;
 class WebKitSerializedNode;
+class WebKitStringMatchersNamespace;
 
 class WebKitNamespace : public LocalDOMWindowProperty, public RefCounted<WebKitNamespace> {
 public:
@@ -54,6 +55,7 @@ public:
     virtual ~WebKitNamespace();
 
     UserMessageHandlersNamespace* messageHandlers();
+    WebKitStringMatchersNamespace& stringMatchers();
     Ref<WebKitJSHandle> createJSHandle(JSC::JSGlobalObject&, JSC::Strong<JSC::JSObject>);
 
     struct SerializedNodeInit {
@@ -65,6 +67,7 @@ private:
     explicit WebKitNamespace(LocalDOMWindow&, UserContentProvider&);
 
     const Ref<UserMessageHandlersNamespace> m_messageHandlerNamespace;
+    const Ref<WebKitStringMatchersNamespace> m_stringMatchers;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -31,6 +31,7 @@
     Exposed=Window
 ] interface WebKitNamespace {
     readonly attribute UserMessageHandlersNamespace messageHandlers;
+    readonly attribute WebKitStringMatchersNamespace stringMatchers;
     [EnabledForGlobalObject=allowsJSHandleCreation, CallWith=CurrentGlobalObject] WebKitJSHandle createJSHandle(object object);
     [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init);
 };

--- a/Source/WebCore/page/WebKitStringMatcher.cpp
+++ b/Source/WebCore/page/WebKitStringMatcher.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebKitStringMatcher.h"
+
+#include "WebKitStringMatcherOptions.h"
+#include <JavaScriptCore/APICast.h>
+#include <JavaScriptCore/JSCJSValue.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WebKitStringMatcher::~WebKitStringMatcher() = default;
+
+template<typename CodeUnit>
+Vector<WebKitStringMatcher::MatchInfo> match(std::span<const CodeUnit> input, std::span<const WebKitStringMatcher::State> states, std::span<const WebKitStringMatcher::Transition> transitions, const WebKitStringMatcherOptions& options)
+{
+    Vector<WebKitStringMatcher::MatchInfo> result;
+
+    size_t start = options.searchReverse ? input.size() - 1 : 0;
+    size_t end = options.searchReverse ? -1 : input.size();
+    size_t increment = options.searchReverse ? -1 : 1;
+
+    for (size_t i = start; i < end; i += increment) {
+        size_t stateIndex { 0 };
+        for (size_t stringIndex = i; stringIndex < input.size(); stringIndex++) {
+            auto& state = states[stateIndex];
+            CodeUnit codeUnit = input[stringIndex];
+            bool foundMatch { false };
+            for (uint16_t transitionIndex = state.transitionsBeginIndexOrMatchIdentifier; transitionIndex < state.transitionsEndIndexOrMatchSentinel; transitionIndex++) {
+                auto& transition = transitions[transitionIndex];
+                if (codeUnit == transition.codeUnitToCheck) {
+                    stateIndex = transition.stateIndexToTransitionToIfMatched;
+                    foundMatch = true;
+                    break;
+                }
+            }
+            if (!foundMatch)
+                break;
+            while (states[stateIndex].transitionsEndIndexOrMatchSentinel == WebKitStringMatcher::State::matchSentinel) {
+                result.append(WebKitStringMatcher::MatchInfo {
+                    states[stateIndex].transitionsBeginIndexOrMatchIdentifier,
+                    i,
+                    stringIndex
+                });
+                if (!options.matchAll)
+                    return result;
+                stateIndex++;
+            }
+        }
+    }
+
+    return result;
+}
+
+Vector<WebKitStringMatcher::MatchInfo> WebKitStringMatcher::match(std::span<const char16_t> input, const WebKitStringMatcherOptions& options)
+{
+    return WebCore::match(input, states(), transitions(), options);
+}
+
+Vector<WebKitStringMatcher::MatchInfo> WebKitStringMatcher::match(std::span<const Latin1Character> input, const WebKitStringMatcherOptions& options)
+{
+    return WebCore::match(input, states(), transitions(), options);
+}
+
+JSC::JSValue WebKitStringMatcher::match(JSC::JSGlobalObject& globalObject, const String& input, const WebKitStringMatcherOptions& options)
+{
+    auto result = input.is8Bit() ? match(input.span8(), options) : match(input.span16(), options);
+    JSContextRef context = ::toRef(&globalObject);
+    Vector<JSValueRef> values;
+    for (auto& matchInfo : result) {
+        JSObjectRef object = JSObjectMake(context, nullptr, nullptr);
+        JSObjectSetProperty(context, object, OpaqueJSString::tryCreate("substring"_s).get(), JSValueMakeString(context, OpaqueJSString::tryCreate(input.substring(matchInfo.substringBeginIndex, matchInfo.substringEndIndex - matchInfo.substringBeginIndex + 1)).get()), 0, 0);
+        JSObjectSetProperty(context, object, OpaqueJSString::tryCreate("index"_s).get(), JSValueMakeNumber(context, matchInfo.substringBeginIndex), 0, 0);
+        JSObjectSetProperty(context, object, OpaqueJSString::tryCreate("identifier"_s).get(), JSValueMakeNumber(context, matchInfo.identifier), 0, 0);
+        if (!options.matchAll)
+            return ::toJS(&globalObject, JSObjectMakeArray(context, 1, &object, nullptr));
+        values.append(object);
+    }
+    return ::toJS(&globalObject, JSObjectMakeArray(context, values.size(), values.span().data(), nullptr));
+}
+
+struct WebKitStringMatcher::Trie {
+    Trie(const Vector<std::pair<String, uint16_t>>&);
+
+    bool operator==(const Trie&) const = default;
+    struct Node;
+    using Edges = HashMap<uint32_t, Node, WTF::IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+    struct Node : public CanMakeCheckedPtr<Node> {
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(Node);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Node);
+    public:
+        bool operator==(const Node&) const = default;
+        bool traverse(const Function<bool(const Node&)>& visitor) const;
+
+        Vector<uint16_t> identifiers;
+        Edges edges;
+    };
+
+    struct SerializedDFA {
+        bool operator==(const SerializedDFA&) const = default;
+
+        Vector<std::optional<WebKitStringMatcher::State>> states;
+        Vector<WebKitStringMatcher::Transition> transitions;
+    };
+    std::optional<SerializedDFA> serialize() const;
+
+    Node root;
+};
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(WebKitStringMatcher::Trie::Node);
+
+bool WebKitStringMatcher::Trie::Node::traverse(const Function<bool(const Node&)>& visitor) const
+{
+    if (!visitor(*this))
+        return false;
+    for (CheckedRef child : edges.values()) {
+        if (!child->traverse(visitor))
+            return false;
+    }
+    return true;
+}
+
+WebKitStringMatcher::Trie::Trie(const Vector<std::pair<String, uint16_t>>& stringsAndIdentifiers)
+{
+    for (auto& [string, identifier] : stringsAndIdentifiers) {
+        CheckedRef node { root };
+        for (auto codeUnit : StringView(string).codeUnits()) {
+            uint32_t key = codeUnit & std::numeric_limits<uint16_t>::max();
+            RELEASE_ASSERT(Edges::isValidKey(key));
+            auto addResult = node.get().edges.ensure(key, [] {
+                return Trie::Node { };
+            });
+            node = addResult.iterator->value;
+        }
+        node.get().identifiers.append(identifier);
+    }
+}
+
+auto WebKitStringMatcher::Trie::serialize() const -> std::optional<SerializedDFA>
+{
+    Vector<std::optional<WebKitStringMatcher::State>> states;
+    Vector<WebKitStringMatcher::Transition> transitions;
+
+    HashMap<CheckedRef<const Trie::Node>, uint16_t> nodeToStateIndex;
+    bool serializedStates = root.traverse([&] (const Trie::Node& node) {
+        ASSERT(!nodeToStateIndex.contains(&node));
+        if (states.size() > std::numeric_limits<uint16_t>::max())
+            return false;
+        nodeToStateIndex.set(node, static_cast<uint16_t>(states.size()));
+        for (auto& identifier : node.identifiers)
+            states.append(WebKitStringMatcher::State { identifier, WebKitStringMatcher::State::matchSentinel });
+        states.append(std::nullopt);
+        return true;
+    });
+    if (!serializedStates)
+        return std::nullopt;
+
+    bool success = root.traverse([&] (const Trie::Node& node) {
+        size_t transitionsBegin = transitions.size();
+        for (auto& [codeUnit, child] : node.edges) {
+            RELEASE_ASSERT(codeUnit <= std::numeric_limits<uint16_t>::max());
+            transitions.append(WebKitStringMatcher::Transition { static_cast<uint16_t>(codeUnit), nodeToStateIndex.get(&child) });
+        }
+        size_t transitionsEnd = transitions.size();
+        ASSERT(nodeToStateIndex.contains(&node));
+        size_t stateIndex = nodeToStateIndex.get(&node) + node.identifiers.size();
+        ASSERT(!states[stateIndex]);
+        if (transitionsBegin > std::numeric_limits<uint16_t>::max() || transitionsEnd > std::numeric_limits<uint16_t>::max())
+            return false;
+        states[stateIndex] = WebKitStringMatcher::State {
+            static_cast<uint16_t>(transitionsBegin),
+            static_cast<uint16_t>(transitionsEnd)
+        };
+        return true;
+    });
+    if (!success)
+        return std::nullopt;
+
+#if ASSERT_ENABLED
+    for (auto& state : states)
+        ASSERT(state);
+#endif
+
+    return { { WTFMove(states), WTFMove(transitions) } };
+}
+
+std::optional<Vector<uint16_t>> WebKitStringMatcher::dataForMatchingStrings(const Vector<std::pair<String, uint16_t>>& vector)
+{
+    Trie trie(vector);
+    auto dfa = trie.serialize();
+    if (!dfa)
+        return std::nullopt;
+
+    size_t statesSize = dfa->states.size();
+    size_t transitionsSize = dfa->transitions.size();
+    RELEASE_ASSERT(statesSize <= std::numeric_limits<uint16_t>::max());
+    RELEASE_ASSERT(transitionsSize <= std::numeric_limits<uint16_t>::max());
+
+    Vector<uint16_t> data;
+
+    constexpr size_t headerSize { 4 };
+    data.reserveInitialCapacity(headerSize + statesSize * 2 + transitionsSize * 2);
+
+    data.append(0);
+    data.append(0);
+    data.append(statesSize);
+    data.append(transitionsSize);
+
+    for (auto& state : dfa->states) {
+        data.append(state->transitionsBeginIndexOrMatchIdentifier);
+        data.append(state->transitionsEndIndexOrMatchSentinel);
+    }
+    for (auto& transition : dfa->transitions) {
+        data.append(transition.codeUnitToCheck);
+        data.append(transition.stateIndexToTransitionToIfMatched);
+    }
+
+    return { WTFMove(data) };
+}
+
+std::optional<std::pair<std::span<const WebKitStringMatcher::State>, std::span<const WebKitStringMatcher::Transition>>> WebKitStringMatcher::statesAndTransitionsFromVersionedData(std::span<const uint8_t> bytes)
+{
+#if CPU(BIG_ENDIAN)
+    UNUSED_PARAM(bytes);
+    return std::nullopt;
+#else
+    static_assert(sizeof(State) == sizeof(Transition));
+    static_assert(sizeof(State) == sizeof(uint32_t));
+    if (bytes.size() % sizeof(State))
+        return std::nullopt;
+    auto integers = spanReinterpretCast<const uint32_t>(bytes);
+    constexpr uint32_t currentVersion { 0 };
+    constexpr size_t headerLength { 2 };
+    if (integers.size() < headerLength || integers[0] != currentVersion)
+        return std::nullopt;
+    uint32_t secondInteger = integers[1];
+    size_t stateLength = static_cast<uint16_t>(secondInteger);
+    size_t transitionLength = static_cast<uint16_t>(secondInteger >> 16);
+    if (integers.size() != headerLength + stateLength + transitionLength)
+        return std::nullopt;
+    auto states = spanReinterpretCast<const State>(integers.subspan(headerLength, stateLength));
+    auto transitions = spanReinterpretCast<const Transition>(integers.subspan(headerLength + stateLength));
+    return { { states, transitions } };
+#endif
+}
+
+}

--- a/Source/WebCore/page/WebKitStringMatcher.h
+++ b/Source/WebCore/page/WebKitStringMatcher.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <span>
+#include <wtf/RefCounted.h>
+#include <wtf/text/Latin1Character.h>
+
+namespace JSC {
+class JSGlobalObject;
+class JSValue;
+}
+
+namespace WebCore {
+
+struct WebKitStringMatcherOptions;
+
+class WEBCORE_EXPORT WebKitStringMatcher : public RefCounted<WebKitStringMatcher> {
+public:
+    struct State {
+        // a transitionsEndIndexOrMatchSentinel of 0 means transitionsBeginIndexOrMatchIdentifier is an identifier
+        // and jump to the next State without progressing through the string.
+        static constexpr uint16_t matchSentinel { 0 };
+
+        uint16_t transitionsBeginIndexOrMatchIdentifier { 0 };
+        uint16_t transitionsEndIndexOrMatchSentinel { 0 };
+    };
+
+    struct Transition {
+        uint16_t codeUnitToCheck { 0 };
+        uint16_t stateIndexToTransitionToIfMatched { 0 };
+    };
+
+    virtual ~WebKitStringMatcher();
+
+    static std::optional<Vector<uint16_t>> dataForMatchingStrings(const Vector<std::pair<String, uint16_t>>&);
+    static std::optional<std::pair<std::span<const State>, std::span<const Transition>>> statesAndTransitionsFromVersionedData(std::span<const uint8_t>);
+
+    struct MatchInfo {
+        uint16_t identifier { 0 };
+        size_t substringBeginIndex { 0 };
+        size_t substringEndIndex { 0 };
+    };
+    Vector<MatchInfo> match(std::span<const char16_t>, const WebKitStringMatcherOptions&);
+    Vector<MatchInfo> match(std::span<const Latin1Character>, const WebKitStringMatcherOptions&);
+    JSC::JSValue match(JSC::JSGlobalObject&, const String&, const WebKitStringMatcherOptions&);
+
+private:
+    struct Trie;
+
+    virtual std::span<const State> states() const = 0;
+    virtual std::span<const Transition> transitions() const = 0;
+};
+
+}

--- a/Source/WebCore/page/WebKitStringMatcher.idl
+++ b/Source/WebCore/page/WebKitStringMatcher.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    LegacyNoInterfaceObject,
+    SkipVTableValidation,
+] interface WebKitStringMatcher {
+    [CallWith=CurrentGlobalObject] any match(DOMString string, optional WebKitStringMatcherOptions options = { });
+};

--- a/Source/WebCore/page/WebKitStringMatcherOptions.h
+++ b/Source/WebCore/page/WebKitStringMatcherOptions.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+struct WebKitStringMatcherOptions {
+    bool matchAll { true };
+    bool searchReverse { false };
+};
+
+}

--- a/Source/WebCore/page/WebKitStringMatcherOptions.idl
+++ b/Source/WebCore/page/WebKitStringMatcherOptions.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+dictionary WebKitStringMatcherOptions {
+    boolean matchAll = true;
+    boolean searchReverse = false;
+};

--- a/Source/WebCore/page/WebKitStringMatchersNamespace.cpp
+++ b/Source/WebCore/page/WebKitStringMatchersNamespace.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebKitStringMatchersNamespace.h"
+
+#include "LocalFrame.h"
+#include "UserContentProvider.h"
+
+namespace WebCore {
+
+WebKitStringMatchersNamespace::WebKitStringMatchersNamespace(LocalFrame& frame, UserContentProvider& provider)
+    : m_userContentProvider(provider)
+    , m_frame(frame) { }
+
+WebKitStringMatchersNamespace::~WebKitStringMatchersNamespace() = default;
+
+WebKitStringMatcher* WebKitStringMatchersNamespace::namedItem(DOMWrapperWorld& world, const AtomString& name)
+{
+    RefPtr frame = m_frame.get();
+    if (!frame)
+        return nullptr;
+    RefPtr provider = frame->userContentProvider();
+    if (!provider)
+        return nullptr;
+    return provider->stringMatcher(world, String(name));
+}
+
+Vector<AtomString> WebKitStringMatchersNamespace::supportedPropertyNames() const
+{
+    // Prevent JS from iterating available matchers.
+    return { };
+}
+
+bool WebKitStringMatchersNamespace::isSupportedPropertyName(const AtomString&)
+{
+    // Prevent JS from iterating available matchers.
+    return false;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/WebKitStringMatchersNamespace.h
+++ b/Source/WebCore/page/WebKitStringMatchersNamespace.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class Document;
+class DOMWrapperWorld;
+class LocalFrame;
+class UserContentProvider;
+class WebKitStringMatcher;
+
+class WebKitStringMatchersNamespace : public RefCounted<WebKitStringMatchersNamespace> {
+public:
+    static Ref<WebKitStringMatchersNamespace> create(LocalFrame& frame, UserContentProvider& userContentProvider)
+    {
+        return adoptRef(*new WebKitStringMatchersNamespace(frame, userContentProvider));
+    }
+
+    ~WebKitStringMatchersNamespace();
+
+    Vector<AtomString> supportedPropertyNames() const;
+    WebKitStringMatcher* namedItem(DOMWrapperWorld&, const AtomString&);
+    bool isSupportedPropertyName(const AtomString&);
+
+private:
+    explicit WebKitStringMatchersNamespace(LocalFrame&, UserContentProvider&);
+
+    const Ref<UserContentProvider> m_userContentProvider;
+    const WeakPtr<LocalFrame> m_frame;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/WebKitStringMatchersNamespace.idl
+++ b/Source/WebCore/page/WebKitStringMatchersNamespace.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    LegacyNoInterfaceObject
+] interface WebKitStringMatchersNamespace {
+    [CallWith=World] getter WebKitStringMatcher ([AtomString] DOMString name);
+};

--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -1999,6 +1999,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKStringMatcher {
+    header "_WKStringMatcher.h"
+    export *
+  }
+
   explicit module _WKSystemPreferences {
     header "_WKSystemPreferences.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -2905,6 +2905,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKStringMatcher {
+    header "_WKStringMatcher.h"
+    export *
+  }
+
   explicit module _WKSystemPreferences {
     header "_WKSystemPreferences.h"
     export *

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1482,6 +1482,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebKit::WebPushD::PushMessageForTesting': ['"PushMessageForTesting.h"'],
         'WebKit::WebPushD::WebPushDaemonConnectionConfiguration': ['"WebPushDaemonConnectionConfiguration.h"'],
         'WebKit::WebScriptMessageHandlerData': ['"WebUserContentControllerDataTypes.h"'],
+        'WebKit::WebStringMatcherData': ['"WebUserContentControllerDataTypes.h"'],
         'WebKit::WebTransportSessionIdentifier': ['"WebTransportSession.h"'],
         'WebKit::WebUserScriptData': ['"WebUserContentControllerDataTypes.h"'],
         'WebKit::WebUserStyleSheetData': ['"WebUserContentControllerDataTypes.h"'],

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -173,6 +173,7 @@ public:
         ScriptMessage,
         SerializedNode,
         SpeechRecognitionPermissionCallback,
+        StringMatcher,
         TextChecker,
         TextRun,
         URLSchemeTask,

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -90,6 +90,7 @@
 #import "_WKResourceLoadStatisticsFirstPartyInternal.h"
 #import "_WKResourceLoadStatisticsThirdPartyInternal.h"
 #import "_WKSerializedNodeInternal.h"
+#import "_WKStringMatcherInternal.h"
 #import "_WKTargetedElementInfoInternal.h"
 #import "_WKTargetedElementRequestInternal.h"
 #import "_WKTextRunInternal.h"
@@ -532,6 +533,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     case Type::JSHandle:
         SUPPRESS_RETAINPTR_CTOR_ADOPT wrapper = [_WKJSHandle alloc];
+        break;
+
+    case Type::StringMatcher:
+        SUPPRESS_RETAINPTR_CTOR_ADOPT wrapper = [_WKStringMatcher alloc];
         break;
 
     default:

--- a/Source/WebKit/Shared/UserContentControllerParameters.h
+++ b/Source/WebKit/Shared/UserContentControllerParameters.h
@@ -37,6 +37,7 @@ struct UserContentControllerParameters {
     Vector<WebUserScriptData> userScripts;
     Vector<WebUserStyleSheetData> userStyleSheets;
     Vector<WebScriptMessageHandlerData> messageHandlers;
+    Vector<WebStringMatcherData> stringMatchers;
 #if ENABLE(CONTENT_EXTENSIONS)
     Vector<std::pair<WebCompiledContentRuleListData, URL>> contentRuleLists;
 #endif

--- a/Source/WebKit/Shared/UserContentControllerParameters.serialization.in
+++ b/Source/WebKit/Shared/UserContentControllerParameters.serialization.in
@@ -25,6 +25,7 @@
     Vector<WebKit::WebUserScriptData> userScripts;
     Vector<WebKit::WebUserStyleSheetData> userStyleSheets;
     Vector<WebKit::WebScriptMessageHandlerData> messageHandlers;
+    Vector<WebKit::WebStringMatcherData> stringMatchers;
 #if ENABLE(CONTENT_EXTENSIONS)
     Vector<std::pair<WebKit::WebCompiledContentRuleListData, URL>> contentRuleLists;
 #endif

--- a/Source/WebKit/Shared/WebUserContentControllerDataTypes.cpp
+++ b/Source/WebKit/Shared/WebUserContentControllerDataTypes.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebUserContentControllerDataTypes.h"
+
+#include <WebCore/SharedMemory.h>
+
+namespace WebKit {
+
+WebStringMatcherData::WebStringMatcherData(const RefPtr<WebCore::SharedMemory>& data, ContentWorldData&& worldData, const String& name)
+    : data(data)
+    , worldData(WTFMove(worldData))
+    , name(name) { }
+
+WebStringMatcherData::WebStringMatcherData(std::optional<WebCore::SharedMemoryHandle>&& handle, ContentWorldData&& worldData, String&& name)
+    : data(handle ? WebCore::SharedMemory::map(WTFMove(*handle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr)
+    , worldData(WTFMove(worldData))
+    , name(WTFMove(name)) { }
+
+WebStringMatcherData::~WebStringMatcherData() = default;
+
+std::optional<WebCore::SharedMemoryHandle> WebStringMatcherData::sharedMemoryHandle() const
+{
+    RefPtr sharedMemory = data;
+    if (!sharedMemory)
+        return std::nullopt;
+    return sharedMemory->createHandle(WebCore::SharedMemory::Protection::ReadOnly);
+}
+
+} // namespace WebKit

--- a/Source/WebKit/Shared/WebUserContentControllerDataTypes.h
+++ b/Source/WebKit/Shared/WebUserContentControllerDataTypes.h
@@ -33,6 +33,11 @@
 #include <WebCore/UserScript.h>
 #include <WebCore/UserStyleSheet.h>
 
+namespace WebCore {
+class SharedMemory;
+class SharedMemoryHandle;
+}
+
 namespace WebKit {
 
 struct WebUserScriptData {
@@ -49,6 +54,17 @@ struct WebUserStyleSheetData {
 
 struct WebScriptMessageHandlerData {
     ScriptMessageHandlerIdentifier identifier;
+    ContentWorldData worldData;
+    String name;
+};
+
+struct WebStringMatcherData {
+    WebStringMatcherData(const RefPtr<WebCore::SharedMemory>&, ContentWorldData&&, const String&);
+    WebStringMatcherData(std::optional<WebCore::SharedMemoryHandle>&&, ContentWorldData&&, String&&);
+    ~WebStringMatcherData();
+    std::optional<WebCore::SharedMemoryHandle> sharedMemoryHandle() const;
+
+    RefPtr<WebCore::SharedMemory> data;
     ContentWorldData worldData;
     String name;
 };

--- a/Source/WebKit/Shared/WebUserContentControllerDataTypes.serialization.in
+++ b/Source/WebKit/Shared/WebUserContentControllerDataTypes.serialization.in
@@ -27,16 +27,20 @@ header: "WebUserContentControllerDataTypes.h"
     WebCore::UserScript userScript;
 }
 
-header: "WebUserContentControllerDataTypes.h"
 [CustomHeader, DebugDecodingFailure] struct WebKit::WebUserStyleSheetData {
     WebKit::UserStyleSheetIdentifier identifier;
     WebKit::ContentWorldData worldData;
     WebCore::UserStyleSheet userStyleSheet;
 }
 
-header: "WebUserContentControllerDataTypes.h"
 [CustomHeader, DebugDecodingFailure] struct WebKit::WebScriptMessageHandlerData {
     WebKit::ScriptMessageHandlerIdentifier identifier;
+    WebKit::ContentWorldData worldData;
+    String name;
+}
+
+[CustomHeader] struct WebKit::WebStringMatcherData {
+    std::optional<WebCore::SharedMemoryHandle> sharedMemoryHandle();
     WebKit::ContentWorldData worldData;
     String name;
 }

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -275,6 +275,7 @@ Shared/WebPreferencesDefaultValues.cpp
 Shared/WebPreferencesStore.cpp
 Shared/WebPushMessage.cpp
 Shared/WebTouchEvent.cpp
+Shared/WebUserContentControllerDataTypes.cpp
 Shared/WebWheelEventCoalescer.cpp
 Shared/WebWheelEvent.cpp
 Shared/WebsiteAutoplayPolicy.cpp
@@ -507,6 +508,7 @@ UIProcess/API/APIOpenPanelParameters.cpp
 UIProcess/API/APIScriptMessage.cpp
 UIProcess/API/APISerializedNode.cpp
 UIProcess/API/APISessionState.cpp
+UIProcess/API/APIStringMatcher.cpp
 UIProcess/API/APITargetedElementInfo.cpp
 UIProcess/API/APITargetedElementRequest.cpp
 UIProcess/API/APITextRun.cpp
@@ -874,6 +876,7 @@ WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
 WebProcess/Storage/WebSharedWorkerObjectConnection.cpp
 WebProcess/Storage/WebSharedWorkerProvider.cpp
 
+WebProcess/UserContent/SharedMemoryStringMatcher.cpp
 WebProcess/UserContent/WebUserContentController.cpp
 
 WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -306,6 +306,7 @@ UIProcess/API/Cocoa/_WKResourceLoadInfo.mm @nonARC
 UIProcess/API/Cocoa/_WKSerializedNode.mm @nonARC
 UIProcess/API/Cocoa/_WKSessionState.mm @nonARC
 UIProcess/API/Cocoa/_WKSpatialBackdropSource.mm @nonARC
+UIProcess/API/Cocoa/_WKStringMatcher.mm @nonARC
 UIProcess/API/Cocoa/_WKSystemPreferences.mm @nonARC
 UIProcess/API/Cocoa/_WKTargetedElementInfo.mm @nonARC
 UIProcess/API/Cocoa/_WKTargetedElementRequest.mm @nonARC

--- a/Source/WebKit/UIProcess/API/APIStringMatcher.cpp
+++ b/Source/WebKit/UIProcess/API/APIStringMatcher.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "APIStringMatcher.h"
+
+#include <WebCore/SharedBuffer.h>
+#include <WebCore/SharedMemory.h>
+
+namespace API {
+
+StringMatcher::StringMatcher(RefPtr<WebCore::SharedMemory>&& sharedMemory)
+    : m_sharedMemory(WTFMove(sharedMemory)) { }
+
+StringMatcher::StringMatcher(Ref<WebCore::SharedBuffer>&& sharedBuffer)
+    : m_sharedBuffer(WTFMove(sharedBuffer)) { }
+
+RefPtr<WebCore::SharedMemory> StringMatcher::sharedMemory()
+{
+    if (m_sharedBuffer && !m_sharedMemory)
+        m_sharedMemory = WebCore::SharedMemory::copyBuffer(*m_sharedBuffer);
+    return m_sharedMemory;
+}
+
+// FIXME: Remove this non-SharedMemory support when it is no longer useful for helping Safari transition away from the injected bundle.
+RefPtr<WebCore::SharedBuffer> StringMatcher::sharedBuffer()
+{
+    return m_sharedBuffer;
+}
+
+StringMatcher::~StringMatcher() = default;
+
+} // namespace API

--- a/Source/WebKit/UIProcess/API/APIStringMatcher.h
+++ b/Source/WebKit/UIProcess/API/APIStringMatcher.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "APIObject.h"
+#include <WebCore/SharedBuffer.h>
+
+namespace WebCore {
+class SharedBuffer;
+class SharedMemory;
+}
+
+namespace API {
+
+class StringMatcher final : public ObjectImpl<Object::Type::StringMatcher> {
+public:
+    explicit StringMatcher(RefPtr<WebCore::SharedMemory>&&);
+    explicit StringMatcher(Ref<WebCore::SharedBuffer>&&);
+    virtual ~StringMatcher();
+
+    RefPtr<WebCore::SharedMemory> sharedMemory();
+    RefPtr<WebCore::SharedBuffer> sharedBuffer();
+
+private:
+
+    RefPtr<WebCore::SharedMemory> m_sharedMemory;
+    RefPtr<WebCore::SharedBuffer> m_sharedBuffer;
+};
+
+} // namespace API
+
+SPECIALIZE_TYPE_TRAITS_API_OBJECT(StringMatcher);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -41,6 +41,7 @@
 #import "WebPageProxy.h"
 #import "WebScriptMessageHandler.h"
 #import "WebUserContentControllerProxy.h"
+#import "_WKStringMatcherInternal.h"
 #import "_WKUserContentFilterInternal.h"
 #import "_WKUserContentWorldInternal.h"
 #import "_WKUserStyleSheetInternal.h"
@@ -311,6 +312,16 @@ private:
 - (void)_removeAllUserStyleSheetsAssociatedWithContentWorld:(WKContentWorld *)contentWorld
 {
     protectedUserContentControllerProxy(self)->removeAllUserStyleSheets(Ref { *contentWorld->_contentWorld });
+}
+
+- (void)_addStringMatcher:(_WKStringMatcher *)matcher contentWorld:(WKContentWorld *)world name:(NSString *)name
+{
+    protectedUserContentControllerProxy(self)->addStringMatcher(Ref { *matcher->_matcher }, Ref { *world->_contentWorld }, name);
+}
+
+- (void)_removeStringMatcherWithName:(NSString *)name contentWorld:(WKContentWorld *)world
+{
+    protectedUserContentControllerProxy(self)->removeStringMatcher(Ref { *world->_contentWorld }, name);
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerPrivate.h
@@ -27,6 +27,7 @@
 
 @class WKContentWorld;
 @class WKUserScript;
+@class _WKStringMatcher;
 @class _WKUserContentFilter;
 @class _WKUserContentWorld;
 @class _WKUserStyleSheet;
@@ -44,6 +45,9 @@
 - (void)_removeUserContentFilter:(NSString *)userContentFilterName WK_API_AVAILABLE(macos(10.11), ios(9.0));
 - (void)_removeAllUserContentFilters WK_API_AVAILABLE(macos(10.11), ios(9.0));
 - (void)_addContentRuleList:(WKContentRuleList *)contentRuleList extensionBaseURL:(NSURL *)extensionBaseURL WK_API_AVAILABLE(macos(13.0), ios(16.0));
+
+- (void)_addStringMatcher:(_WKStringMatcher *)matcher contentWorld:(WKContentWorld *)world name:(NSString *)name WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_removeStringMatcherWithName:(NSString *)name contentWorld:(WKContentWorld *)world WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @property (nonatomic, readonly, copy) NSArray<_WKUserStyleSheet *> *_userStyleSheets WK_API_AVAILABLE(macos(10.12), ios(10.0));
 - (void)_addUserStyleSheet:(_WKUserStyleSheet *)userStyleSheet WK_API_AVAILABLE(macos(10.12), ios(10.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKStringMatcher.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKStringMatcher.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+@interface _WKStringMatcher : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
+- (nullable instancetype)initWithData:(NSData *)data;
+- (nullable instancetype)initWithDataInFile:(NSURL *)fileURL;
++ (nullable NSData *)matcherDataForStringsAndIdentifiers:(NSDictionary<NSString *, NSNumber *> *)strings;
+
+// FIXME: Remove this when it is no longer useful for helping Safari transition away from the injected bundle.
+- (NSArray *)resultsForMatchingCharacters:(const unichar*)characters length:(size_t)length matchAll:(BOOL)matchAll searchReverse:(BOOL)searchReverse;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKStringMatcher.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKStringMatcher.mm
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "_WKStringMatcherInternal.h"
+
+#import "NetworkCacheData.h"
+#import "SharedMemoryStringMatcher.h"
+#import "WKNSData.h"
+#import <WebCore/SharedBuffer.h>
+#import <WebCore/SharedMemory.h>
+#import <WebCore/WebCoreObjCExtras.h>
+#import <WebCore/WebKitStringMatcher.h>
+#import <WebCore/WebKitStringMatcherOptions.h>
+#import <wtf/FileSystem.h>
+
+@implementation _WKStringMatcher
+
+- (instancetype)initWithData:(NSData *)data
+{
+    if (!(self = [super init]))
+        return nil;
+
+    Ref sharedBuffer = WebCore::SharedBuffer::create(data);
+    if (!WebCore::WebKitStringMatcher::statesAndTransitionsFromVersionedData(sharedBuffer->span()))
+        return nil;
+    API::Object::constructInWrapper<API::StringMatcher>(self, WTFMove(sharedBuffer));
+
+    return self;
+}
+
+- (instancetype)initWithDataInFile:(NSURL *)fileURL
+{
+    if (!(self = [super init]))
+        return nil;
+
+    RELEASE_ASSERT(fileURL.isFileURL);
+    NSString *path = fileURL.path;
+    if (!FileSystem::makeSafeToUseMemoryMapForPath(path))
+        return nil;
+    auto fileData = WebKit::NetworkCache::mapFile(path);
+    if (fileData.isNull())
+        return nil;
+    RefPtr sharedMemory = fileData.tryCreateSharedMemory();
+    if (!sharedMemory)
+        return nil;
+    if (!WebCore::WebKitStringMatcher::statesAndTransitionsFromVersionedData(sharedMemory->span()))
+        return nil;
+    API::Object::constructInWrapper<API::StringMatcher>(self, WTFMove(sharedMemory));
+
+    return self;
+}
+
+- (void)dealloc
+{
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKStringMatcher.class, self))
+        return;
+    SUPPRESS_UNRETAINED_ARG _matcher->API::StringMatcher::~StringMatcher();
+    [super dealloc];
+}
+
++ (NSData *)matcherDataForStringsAndIdentifiers:(NSDictionary<NSString *, NSNumber *> *)stringsAndIdentifiers
+{
+    __block Vector<std::pair<String, uint16_t>> vector;
+    [stringsAndIdentifiers enumerateKeysAndObjectsUsingBlock:^(NSString *string, NSNumber *identifier, BOOL *stop) {
+        vector.append({ string, identifier.unsignedShortValue });
+    }];
+    auto dfa = WebCore::WebKitStringMatcher::dataForMatchingStrings(vector);
+    if (!dfa)
+        return nil;
+    return wrapper(API::Data::create(spanReinterpretCast<const uint8_t>(dfa->span()))).autorelease();
+}
+
+// FIXME: Remove this when it is no longer useful for helping Safari transition away from the injected bundle.
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+- (NSArray *)resultsForMatchingCharacters:(const unichar*)characters length:(size_t)length matchAll:(BOOL)matchAll searchReverse:(BOOL)searchReverse
+{
+    RefPtr matcher = WebKit::SharedMemoryStringMatcher::create(Ref { *_matcher }->sharedBuffer());
+    if (!matcher) {
+        ASSERT_NOT_REACHED();
+        return @[];
+    }
+
+    std::span<const char16_t> characterSpan { reinterpret_cast<const char16_t*>(characters), length };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    auto matches = matcher->match(characterSpan, WebCore::WebKitStringMatcherOptions {
+        !!matchAll,
+        !!searchReverse
+    });
+    NSMutableArray *result = [NSMutableArray arrayWithCapacity:matches.size()];
+    for (auto& matchInfo : matches) {
+        [result addObject:@{
+            @"substring": adoptNS([[NSString alloc] initWithCharacters:characters + matchInfo.substringBeginIndex length:matchInfo.substringEndIndex - matchInfo.substringBeginIndex + 1]).get(),
+            @"index": @(matchInfo.substringBeginIndex),
+            @"identifier": @(matchInfo.identifier)
+        }];
+    }
+    return result;
+}
+
+- (API::Object&)_apiObject
+{
+    return *_matcher;
+}
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKStringMatcherInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKStringMatcherInternal.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "APIStringMatcher.h"
+#import "WKObject.h"
+#import "_WKStringMatcher.h"
+#import <wtf/AlignedStorage.h>
+
+namespace WebKit {
+
+template<> struct WrapperTraits<API::StringMatcher> {
+    using WrapperClass = _WKStringMatcher;
+};
+
+}
+
+@interface _WKStringMatcher () <WKObject> {
+@package
+    AlignedStorage<API::StringMatcher> _matcher;
+}
+@end

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -45,6 +45,7 @@ namespace API {
 class Array;
 class ContentRuleList;
 class ContentWorld;
+class StringMatcher;
 class UserScript;
 class UserStyleSheet;
 }
@@ -58,11 +59,14 @@ class WebProcessProxy;
 class WebCompiledContentRuleListData;
 class WebScriptMessageHandler;
 
+struct ContentWorldIdentifierType;
 struct FrameInfoData;
 struct UserContentControllerParameters;
 struct WebPageCreationParameters;
 
 enum class InjectUserScriptImmediately : bool;
+
+using ContentWorldIdentifier = WebCore::ProcessQualified<ObjectIdentifier<ContentWorldIdentifierType>>;
 
 class WebUserContentControllerProxy : public API::ObjectImpl<API::Object::Type::UserContentController>, public CanMakeWeakPtr<WebUserContentControllerProxy>, public Identified<UserContentControllerIdentifier> {
 public:
@@ -102,6 +106,9 @@ public:
     void removeAllUserStyleSheets();
 #endif
 
+    void addStringMatcher(API::StringMatcher&, API::ContentWorld&, const String&);
+    void removeStringMatcher(API::ContentWorld&, const String&);
+
     // Returns false if there was a name conflict.
     bool addUserScriptMessageHandler(WebScriptMessageHandler&);
     void removeUserMessageHandlerForName(const String&, API::ContentWorld&);
@@ -133,6 +140,7 @@ private:
     const Ref<API::Array> m_userScripts;
     const Ref<API::Array> m_userStyleSheets;
     HashMap<ScriptMessageHandlerIdentifier, Ref<WebScriptMessageHandler>> m_scriptMessageHandlers;
+    HashMap<std::pair<WebKit::ContentWorldIdentifier, String>, Ref<API::StringMatcher>> m_stringMatchers;
 
 #if ENABLE(CONTENT_EXTENSIONS)
     WeakHashSet<NetworkProcessProxy> m_networkProcesses;

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -30,6 +30,7 @@
 
 #import "AppKitSPI.h"
 #import "WebPageProxy.h"
+#import "WebPreferencesDefaultValues.h"
 #import <WebCore/IntRect.h>
 #import <WebCore/LocalizedStrings.h>
 #import <pal/spi/mac/NSColorSPI.h>

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2620,6 +2620,7 @@
 		FABBBC862D35B59A00820017 /* UnifiedSource139.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FABBBC822D35B59A00820017 /* UnifiedSource139.cpp */; };
 		FABBDEA12B85557500EFAFC4 /* CoreIPCNSURLCredential.mm in Sources */ = {isa = PBXBuildFile; fileRef = FABBDE9E2B85550100EFAFC4 /* CoreIPCNSURLCredential.mm */; };
 		FAC7C0C22D712E2900E7297E /* CoreIPCNumber.mm in Sources */ = {isa = PBXBuildFile; fileRef = FAC7C0C12D712AAF00E7297E /* CoreIPCNumber.mm */; };
+		FADAF3C82EA2F54D001ACE2E /* _WKStringMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = FADAF3C32EA2E992001ACE2E /* _WKStringMatcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FAE61CE62D0A5608000D238D /* UnifiedSource132.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CDF2D0A5606000D238D /* UnifiedSource132.cpp */; };
 		FAE61CE72D0A5608000D238D /* UnifiedSource134.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CE02D0A5606000D238D /* UnifiedSource134.cpp */; };
 		FAE61CE82D0A5608000D238D /* UnifiedSource136.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CE12D0A5606000D238D /* UnifiedSource136.cpp */; };
@@ -8748,6 +8749,7 @@
 		FA1A7DE42E012DB3005E394B /* RemotePageVideoPresentationManagerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemotePageVideoPresentationManagerProxy.h; sourceTree = "<group>"; };
 		FA1A7DE52E012DB3005E394B /* RemotePageVideoPresentationManagerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemotePageVideoPresentationManagerProxy.cpp; sourceTree = "<group>"; };
 		FA1ED3F32B76B90700C90F3B /* CoreIPCCFType.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCCFType.mm; sourceTree = "<group>"; };
+		FA2D15472EA340A9008AA494 /* WebUserContentControllerDataTypes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebUserContentControllerDataTypes.cpp; sourceTree = "<group>"; };
 		FA2F854B2E60CA7D00D0ECA8 /* _WKNSStringExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKNSStringExtras.h; sourceTree = "<group>"; };
 		FA2F854C2E60CA7D00D0ECA8 /* _WKNSStringExtras.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKNSStringExtras.mm; sourceTree = "<group>"; };
 		FA2F854D2E60CA7D00D0ECA8 /* _WKNSURLExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKNSURLExtras.h; sourceTree = "<group>"; };
@@ -8871,6 +8873,11 @@
 		FAC8498E2A9E92DF00D407EF /* WebTransportSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebTransportSession.h; path = Network/WebTransportSession.h; sourceTree = "<group>"; };
 		FAD05DAE2DCBD89800330C10 /* DragInitiationResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DragInitiationResult.h; path = ios/DragInitiationResult.h; sourceTree = "<group>"; };
 		FAD05DAF2DCBD8E100330C10 /* DragInitiationResult.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = DragInitiationResult.serialization.in; path = ios/DragInitiationResult.serialization.in; sourceTree = "<group>"; };
+		FADAF3C32EA2E992001ACE2E /* _WKStringMatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKStringMatcher.h; sourceTree = "<group>"; };
+		FADAF3C42EA2E992001ACE2E /* _WKStringMatcher.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKStringMatcher.mm; sourceTree = "<group>"; };
+		FADAF3C52EA2E992001ACE2E /* _WKStringMatcherInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKStringMatcherInternal.h; sourceTree = "<group>"; };
+		FADAF3C62EA2EAA1001ACE2E /* APIStringMatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIStringMatcher.h; sourceTree = "<group>"; };
+		FADAF3C72EA2EAA1001ACE2E /* APIStringMatcher.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = APIStringMatcher.cpp; sourceTree = "<group>"; };
 		FAE61CDF2D0A5606000D238D /* UnifiedSource132.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource132.cpp; sourceTree = "<group>"; };
 		FAE61CE02D0A5606000D238D /* UnifiedSource134.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource134.cpp; sourceTree = "<group>"; };
 		FAE61CE12D0A5606000D238D /* UnifiedSource136.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource136.cpp; sourceTree = "<group>"; };
@@ -8880,6 +8887,8 @@
 		FAE61CE52D0A5607000D238D /* UnifiedSource131.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource131.cpp; sourceTree = "<group>"; };
 		FAF27D2E2D2850D400F1F0BB /* CoreIPCPKSecureElementPass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPKSecureElementPass.h; sourceTree = "<group>"; };
 		FAF27D2F2D2850D400F1F0BB /* CoreIPCPKSecureElementPass.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPKSecureElementPass.mm; sourceTree = "<group>"; };
+		FAFE235B2EAA99A90062DDA9 /* SharedMemoryStringMatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SharedMemoryStringMatcher.h; sourceTree = "<group>"; };
+		FAFE235C2EAA99A90062DDA9 /* SharedMemoryStringMatcher.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SharedMemoryStringMatcher.cpp; sourceTree = "<group>"; };
 		FAFFC3572E2AB10000CCC89C /* _WKSerializedNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKSerializedNode.h; sourceTree = "<group>"; };
 		FAFFC3582E2AB10000CCC89C /* _WKSerializedNode.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKSerializedNode.mm; sourceTree = "<group>"; };
 		FAFFC3592E2AB10000CCC89C /* _WKSerializedNodeInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKSerializedNodeInternal.h; sourceTree = "<group>"; };
@@ -10193,6 +10202,7 @@
 				C0337DD7127A51B6008FF4F4 /* WebTouchEvent.cpp */,
 				0F4001002527D73C00E91DA7 /* WebTouchEvent.h */,
 				5CD748B523C8EB190092A999 /* WebURLSchemeHandlerIdentifier.h */,
+				FA2D15472EA340A9008AA494 /* WebUserContentControllerDataTypes.cpp */,
 				7C065F2A1C8CD95F00C2D950 /* WebUserContentControllerDataTypes.h */,
 				527D1AEC2AD0A5BB00D145E5 /* WebUserContentControllerDataTypes.serialization.in */,
 				C0337DD0127A2980008FF4F4 /* WebWheelEvent.cpp */,
@@ -10222,6 +10232,8 @@
 			children = (
 				4111436320F677B10026F912 /* InjectUserScriptImmediately.h */,
 				2D13C8BD2B552E68004EF65E /* InjectUserScriptImmediately.serialization.in */,
+				FAFE235C2EAA99A90062DDA9 /* SharedMemoryStringMatcher.cpp */,
+				FAFE235B2EAA99A90062DDA9 /* SharedMemoryStringMatcher.h */,
 				1AAF08AB1926936700B6390C /* WebUserContentController.cpp */,
 				1AAF08AC1926936700B6390C /* WebUserContentController.h */,
 				1AAF08B419269E2400B6390C /* WebUserContentController.messages.in */,
@@ -12480,6 +12492,9 @@
 				CA33440B2D1673FB007473A1 /* _WKSpatialBackdropSource.h */,
 				CA33440D2D16748F007473A1 /* _WKSpatialBackdropSource.mm */,
 				CA33440E2D1680F9007473A1 /* _WKSpatialBackdropSourceInternal.h */,
+				FADAF3C32EA2E992001ACE2E /* _WKStringMatcher.h */,
+				FADAF3C42EA2E992001ACE2E /* _WKStringMatcher.mm */,
+				FADAF3C52EA2E992001ACE2E /* _WKStringMatcherInternal.h */,
 				8644890A27B47020007A1C66 /* _WKSystemPreferences.h */,
 				8644890C27B47045007A1C66 /* _WKSystemPreferences.mm */,
 				8644890E27B5CB43007A1C66 /* _WKSystemPreferencesInternal.h */,
@@ -15446,6 +15461,8 @@
 				FAFFC35A2E2AB12400CCC89C /* APISerializedNode.h */,
 				1AFDE65F1954E9B100C48FFA /* APISessionState.cpp */,
 				1AFDE6601954E9B100C48FFA /* APISessionState.h */,
+				FADAF3C72EA2EAA1001ACE2E /* APIStringMatcher.cpp */,
+				FADAF3C62EA2EAA1001ACE2E /* APIStringMatcher.h */,
 				F454C12E2BA3AFFD00871551 /* APITargetedElementInfo.cpp */,
 				F454C12D2BA3AFFD00871551 /* APITargetedElementInfo.h */,
 				F4500D882BE02D6A0081A5F1 /* APITargetedElementRequest.cpp */,
@@ -17315,6 +17332,7 @@
 				1A002D43196B337000B9AD44 /* _WKSessionStateInternal.h in Headers */,
 				CA33440C2D1673FC007473A1 /* _WKSpatialBackdropSource.h in Headers */,
 				CA33440F2D1680F9007473A1 /* _WKSpatialBackdropSourceInternal.h in Headers */,
+				FADAF3C82EA2F54D001ACE2E /* _WKStringMatcher.h in Headers */,
 				8644890B27B47020007A1C66 /* _WKSystemPreferences.h in Headers */,
 				8644890F27B5CB43007A1C66 /* _WKSystemPreferencesInternal.h in Headers */,
 				F4D985C82690FC1200BBCCBE /* _WKTapHandlingResult.h in Headers */,

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -38,7 +38,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-using WorldMap = HashMap<SingleThreadWeakRef<DOMWrapperWorld>, WeakRef<InjectedBundleScriptWorld>>;
+using WorldMap = HashMap<SingleThreadWeakRef<const DOMWrapperWorld>, WeakRef<InjectedBundleScriptWorld>>;
 
 static WorldMap& allWorlds()
 {
@@ -69,7 +69,7 @@ Ref<InjectedBundleScriptWorld> InjectedBundleScriptWorld::getOrCreate(DOMWrapper
     return adoptRef(*new InjectedBundleScriptWorld(ContentWorldIdentifier::generate(), world, uniqueWorldName()));
 }
 
-RefPtr<InjectedBundleScriptWorld> InjectedBundleScriptWorld::get(WebCore::DOMWrapperWorld& world)
+RefPtr<InjectedBundleScriptWorld> InjectedBundleScriptWorld::get(const WebCore::DOMWrapperWorld& world)
 {
     if (&world == &mainThreadNormalWorldSingleton())
         return normalWorldSingleton();

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -48,7 +48,7 @@ public:
     static Ref<InjectedBundleScriptWorld> create(ContentWorldIdentifier, Type = Type::Internal);
     static Ref<InjectedBundleScriptWorld> create(ContentWorldIdentifier, const String& name, Type = Type::Internal);
     static Ref<InjectedBundleScriptWorld> getOrCreate(WebCore::DOMWrapperWorld&);
-    static RefPtr<InjectedBundleScriptWorld> get(WebCore::DOMWrapperWorld&);
+    static RefPtr<InjectedBundleScriptWorld> get(const WebCore::DOMWrapperWorld&);
     static InjectedBundleScriptWorld* find(const String&);
     static InjectedBundleScriptWorld& normalWorldSingleton();
 

--- a/Source/WebKit/WebProcess/UserContent/SharedMemoryStringMatcher.cpp
+++ b/Source/WebKit/WebProcess/UserContent/SharedMemoryStringMatcher.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SharedMemoryStringMatcher.h"
+
+#include <WebCore/SharedBuffer.h>
+#include <WebCore/SharedMemory.h>
+#include <WebCore/WebKitStringMatcher.h>
+
+namespace WebKit {
+
+RefPtr<SharedMemoryStringMatcher> SharedMemoryStringMatcher::create(RefPtr<WebCore::SharedMemory>&& data)
+{
+    if (!data) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+    auto statesAndTransitions = WebKitStringMatcher::statesAndTransitionsFromVersionedData(data->span());
+    if (!statesAndTransitions) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+    auto [states, transitions] = *statesAndTransitions;
+    return adoptRef(*new SharedMemoryStringMatcher(data.releaseNonNull(), states, transitions));
+}
+
+SharedMemoryStringMatcher::SharedMemoryStringMatcher(Ref<WebCore::SharedMemory>&& sharedMemory, std::span<const State> states, std::span<const Transition> transitions)
+    : m_sharedMemory(WTFMove(sharedMemory))
+    , m_states(states)
+    , m_transitions(transitions)
+{
+}
+
+// FIXME: Remove this non-SharedMemory support when it is no longer useful for helping Safari transition away from the injected bundle.
+RefPtr<SharedMemoryStringMatcher> SharedMemoryStringMatcher::create(RefPtr<WebCore::SharedBuffer>&& data)
+{
+    if (!data) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+    auto statesAndTransitions = WebKitStringMatcher::statesAndTransitionsFromVersionedData(data->span());
+    if (!statesAndTransitions) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+    auto [states, transitions] = *statesAndTransitions;
+    return adoptRef(*new SharedMemoryStringMatcher(data.releaseNonNull(), states, transitions));
+}
+
+SharedMemoryStringMatcher::SharedMemoryStringMatcher(Ref<WebCore::SharedBuffer>&& sharedBuffer, std::span<const State> states, std::span<const Transition> transitions)
+    : m_sharedBuffer(WTFMove(sharedBuffer))
+    , m_states(states)
+    , m_transitions(transitions)
+{
+}
+
+}

--- a/Source/WebKit/WebProcess/UserContent/SharedMemoryStringMatcher.h
+++ b/Source/WebKit/WebProcess/UserContent/SharedMemoryStringMatcher.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/WebKitStringMatcher.h>
+#include <wtf/Ref.h>
+
+namespace WebCore {
+class SharedBuffer;
+class SharedMemory;
+}
+
+namespace WebKit {
+
+class SharedMemoryStringMatcher final : public WebCore::WebKitStringMatcher {
+public:
+    static RefPtr<SharedMemoryStringMatcher> create(RefPtr<WebCore::SharedMemory>&&);
+    static RefPtr<SharedMemoryStringMatcher> create(RefPtr<WebCore::SharedBuffer>&&);
+
+private:
+    SharedMemoryStringMatcher(Ref<WebCore::SharedMemory>&&, std::span<const State>, std::span<const Transition>);
+    SharedMemoryStringMatcher(Ref<WebCore::SharedBuffer>&&, std::span<const State>, std::span<const Transition>);
+
+    std::span<const WebCore::WebKitStringMatcher::State> states() const final { return m_states; }
+    std::span<const WebCore::WebKitStringMatcher::Transition> transitions() const final { return m_transitions; }
+
+    const RefPtr<WebCore::SharedBuffer> m_sharedBuffer;
+    const RefPtr<WebCore::SharedMemory> m_sharedMemory;
+    const std::span<const WebCore::WebKitStringMatcher::State> m_states;
+    const std::span<const WebCore::WebKitStringMatcher::Transition> m_transitions;
+};
+
+}

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
@@ -67,6 +67,9 @@ public:
     void removeUserStyleSheets(InjectedBundleScriptWorld&);
     void removeAllUserContent();
 
+    bool hasStringMatchersForWorld(const WebCore::DOMWrapperWorld&) const final;
+    WebCore::WebKitStringMatcher* stringMatcher(const WebCore::DOMWrapperWorld&, const String&) const final;
+
     InjectedBundleScriptWorld* worldForIdentifier(ContentWorldIdentifier);
 
     void addContentWorldIfNecessary(const ContentWorldData&);
@@ -105,6 +108,9 @@ private:
     void removeAllUserScriptMessageHandlersForWorlds(const Vector<ContentWorldIdentifier>&);
     void removeAllUserScriptMessageHandlers();
 
+    void addStringMatcher(WebStringMatcherData&&);
+    void removeStringMatcher(ContentWorldIdentifier, const String&);
+
 #if ENABLE(CONTENT_EXTENSIONS)
     void removeContentRuleList(const String& name);
     void removeAllContentRuleLists();
@@ -134,6 +140,7 @@ private:
 #if ENABLE(CONTENT_EXTENSIONS)
     WebCore::ContentExtensions::ContentExtensionsBackend m_contentExtensionBackend;
 #endif
+    HashMap<ContentWorldIdentifier, HashMap<String, RefPtr<WebCore::WebKitStringMatcher>>> m_stringMatchers;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in
@@ -41,6 +41,9 @@ messages -> WebUserContentController {
     RemoveAllUserScriptMessageHandlersForWorlds(Vector<WebKit::ContentWorldIdentifier> worldIdentifiers);
     RemoveAllUserScriptMessageHandlers();
 
+    AddStringMatcher(struct WebKit::WebStringMatcherData data)
+    RemoveStringMatcher(WebKit::ContentWorldIdentifier worldIdentifier, String name);
+
 #if ENABLE(CONTENT_EXTENSIONS)
     AddContentRuleLists(Vector<std::pair<WebKit::WebCompiledContentRuleListData, URL>> contentFilters);
     RemoveContentRuleList(String name);

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -272,6 +272,7 @@ Tests/WebKitCocoa/SpeechRecognition.mm @nonARC
 Tests/WebKitCocoa/StopSuspendResumeAllMedia.mm @nonARC
 Tests/WebKitCocoa/StorageQuota.mm @nonARC
 Tests/WebKitCocoa/StoreBlobThenDelete.mm @nonARC
+Tests/WebKitCocoa/StringMatcher.mm @nonARC
 Tests/WebKitCocoa/SwitchInputTests.mm @nonARC
 Tests/WebKitCocoa/SystemColors.mm @nonARC
 Tests/WebKitCocoa/SystemPreview.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -4380,6 +4380,7 @@
 		F6FDDDD214241AD4004F1729 /* PrivateBrowsingPushStateNoHistoryCallback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrivateBrowsingPushStateNoHistoryCallback.cpp; sourceTree = "<group>"; };
 		F6FDDDD514241C48004F1729 /* push-state.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "push-state.html"; sourceTree = "<group>"; };
 		FA049D0F2BCF22210099C221 /* LoadAndDecodeImage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LoadAndDecodeImage.mm; sourceTree = "<group>"; };
+		FA4F24EB2E99923700B2247F /* StringMatcher.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = StringMatcher.mm; sourceTree = "<group>"; };
 		FA58F4572E1E062B0098E1C8 /* JSHandle.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSHandle.mm; sourceTree = "<group>"; };
 		FA65EFFC2C87F43C00A0A123 /* CoroutineUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoroutineUtilities.h; sourceTree = "<group>"; };
 		FA65F0042C87F4CF00A0A123 /* NetworkConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkConnection.h; sourceTree = "<group>"; };
@@ -5021,6 +5022,7 @@
 				CDC0932D21C993440030C4B0 /* StopSuspendResumeAllMedia.mm */,
 				414AD6852285D1B000777F2D /* StorageQuota.mm */,
 				515BE1701D428BD100DD7C68 /* StoreBlobThenDelete.mm */,
+				FA4F24EB2E99923700B2247F /* StringMatcher.mm */,
 				E5194E5F2D1C67AA0006B52F /* SwitchInputTests.mm */,
 				1C734B5220788C4800F430EA /* SystemColors.mm */,
 				31B76E4223298E2B007FED2C /* SystemPreview.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
@@ -32,6 +32,7 @@
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/WKWebpagePreferencesPrivate.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <wtf/Vector.h>
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/StringMatcher.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/StringMatcher.mm
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "TestWKWebView.h"
+#import <WebKit/WKUserContentControllerPrivate.h>
+#import <WebKit/_WKStringMatcher.h>
+
+TEST(StringMatcher, MatcherData)
+{
+    constexpr size_t alphabetLength = 'z' - 'a' + 1;
+    NSMutableDictionary<NSString *, NSNumber *> *dictionary = [NSMutableDictionary dictionaryWithCapacity:alphabetLength * alphabetLength * alphabetLength * ('d' - 'a' + 1)];
+    for (char first = 'a'; first < 'z'; first++) {
+        for (char second = 'a'; second < 'z'; second++) {
+            for (char third = 'a'; third < 'z'; third++) {
+                for (char fourth = 'a'; fourth < 'd'; fourth++)
+                    [dictionary setObject:@0 forKey:[NSString stringWithFormat:@"%c%c%c%c", first, second, third, fourth]];
+            }
+        }
+    }
+    EXPECT_NULL([_WKStringMatcher matcherDataForStringsAndIdentifiers:dictionary]);
+
+    EXPECT_NULL(adoptNS([[_WKStringMatcher alloc] initWithData:NSData.data]).get());
+
+    NSData *data = [_WKStringMatcher matcherDataForStringsAndIdentifiers:@{ @"abc": @37 }];
+    std::array<uint8_t, 40> expected {
+        // header
+        0, 0, 0, 0, // version
+        5, 0, // state count
+        3, 0, // transition count
+
+        // states
+        0, 0, 1, 0,
+        1, 0, 2, 0,
+        2, 0, 3, 0,
+        37, 0, 0, 0, // sentinel indicating match of string with identifier 37
+        3, 0, 3, 0,
+
+        // transitions
+        'a', 0, 1, 0,
+        'b', 0, 2, 0,
+        'c', 0, 3, 0,
+    };
+    EXPECT_TRUE([data isEqual:[NSData dataWithBytes:expected.data() length:expected.size()]]);
+}
+
+TEST(StringMatcher, MatchResults)
+{
+    RetainPtr matcher = adoptNS([[_WKStringMatcher alloc] initWithData:[_WKStringMatcher matcherDataForStringsAndIdentifiers:@{
+        @"aba": @30,
+        @"ba": @20,
+        @"abcd": @40,
+        @"e": @10
+    }]]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration.get().userContentController _addStringMatcher:matcher.get() contentWorld:WKContentWorld.pageWorld name:@"testMatcher"];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    auto checkMatch = [=] (const char* input, NSArray *expected, const char* options = "", bool matchAll = true, bool searchReverse = false) {
+        NSArray *actual = [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"window.webkit.stringMatchers.testMatcher.match('%s'%s)", input, options]];
+        EXPECT_TRUE([actual isEqual:expected]);
+
+        size_t inputLength = strlen(input);
+        constexpr size_t maxTestStringLength { 7 };
+        std::array<unichar, maxTestStringLength> unichars;
+        for (size_t i = 0; i < inputLength; i++)
+            unichars[i] = input[i];
+        NSArray *actualFromNativeInterface = [matcher resultsForMatchingCharacters:unichars.data() length:strlen(input) matchAll:matchAll searchReverse:searchReverse];
+        EXPECT_TRUE([actualFromNativeInterface isEqual:expected]);
+    };
+    checkMatch("aabcdef", @[
+        @{ @"substring": @"abcd", @"index": @1, @"identifier": @40 },
+        @{ @"substring": @"e", @"index": @5, @"identifier": @10 }
+    ]);
+    checkMatch("aabcd", @[
+        @{ @"substring": @"abcd", @"index": @1, @"identifier": @40 }
+    ]);
+    checkMatch("aba", @[
+        @{ @"substring": @"aba", @"index": @0, @"identifier": @30 },
+        @{ @"substring": @"ba", @"index": @1, @"identifier": @20 }
+    ]);
+    checkMatch("abaa", @[
+        @{ @"substring": @"aba", @"index": @0, @"identifier": @30 },
+        @{ @"substring": @"ba", @"index": @1, @"identifier": @20 }
+    ]);
+    checkMatch("ababcd", @[
+        @{ @"substring": @"aba", @"index": @0, @"identifier": @30 },
+        @{ @"substring": @"ba", @"index": @1, @"identifier": @20 },
+        @{ @"substring": @"abcd", @"index": @2, @"identifier": @40 }
+    ]);
+    checkMatch("e", @[
+        @{ @"substring": @"e", @"index": @0, @"identifier": @10 },
+    ]);
+    checkMatch("ee", @[
+        @{ @"substring": @"e", @"index": @0, @"identifier": @10 },
+        @{ @"substring": @"e", @"index": @1, @"identifier": @10 },
+    ]);
+    checkMatch("ababcd", @[ @{ @"substring": @"abcd", @"index": @2, @"identifier": @40 } ], ", { 'searchReverse': true, 'matchAll': false }", false, true);
+    checkMatch("ababcd", @[ @{ @"substring": @"aba", @"index": @0, @"identifier": @30 } ], ", { 'matchAll': false }", false);
+    checkMatch("ababcd", @[
+        @{ @"substring": @"abcd", @"index": @2, @"identifier": @40 },
+        @{ @"substring": @"ba", @"index": @1, @"identifier": @20 },
+        @{ @"substring": @"aba", @"index": @0, @"identifier": @30 }
+    ], ", { 'searchReverse': true }", true, true);
+    checkMatch("a", @[ ]);
+    checkMatch("a", @[ ], ", { 'searchReverse': true, 'matchAll': false }", false, true);
+}
+
+TEST(StringMatcher, IDLExposed)
+{
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"!!window.WebKitStringMatcher"] boolValue]);
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"!!window.WebKitStringMatcherOptions"] boolValue]);
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"!!window.WebKitStringMatchersNamespace"] boolValue]);
+}
+
+TEST(StringMatcher, CharacterEdgeCases)
+{
+    RetainPtr matcher = adoptNS([[_WKStringMatcher alloc] initWithData:[_WKStringMatcher matcherDataForStringsAndIdentifiers:@{
+        @"\uffff": @1,
+        @"\ufffe": @1,
+        @"\u0000": @1,
+        @"\u0001": @1
+    }]]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration.get().userContentController _addStringMatcher:matcher.get() contentWorld:WKContentWorld.pageWorld name:@"testMatcher"];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    NSArray *actual = [webView objectByEvaluatingJavaScript:@"window.webkit.stringMatchers.testMatcher.match('\\u0000\\u0001\\ufffe\\uffff')"];
+    NSArray *expected = @[
+        @{ @"substring": @"\u0000", @"index": @0, @"identifier": @1 },
+        @{ @"substring": @"\u0001", @"index": @1, @"identifier": @1 },
+        @{ @"substring": @"\ufffe", @"index": @2, @"identifier": @1 },
+        @{ @"substring": @"\uffff", @"index": @3, @"identifier": @1 }
+    ];
+    EXPECT_TRUE([actual isEqual:expected]);
+}


### PR DESCRIPTION
#### 5e5036cfc5f23e8cc1381e199696a67afa2e62b3
<pre>
Add prototype string matcher API
<a href="https://bugs.webkit.org/show_bug.cgi?id=300829">https://bugs.webkit.org/show_bug.cgi?id=300829</a>
<a href="https://rdar.apple.com/162715982">rdar://162715982</a>

Reviewed by Ryosuke Niwa.

Safari has some sets of strings it searches for as substrings of longer strings.
It needs to do the searches quickly with as little startup time as possible.
Arno experimented with using regular expressions instead, but that
had too much start up time because there are thousands of strings being searched
for.  I experimented with using a typical DFA with one transition per code unit,
but that had 200x as many transitions as this and didn&apos;t fit as well into a CPU&apos;s
L1 cache.  Instead, this PR introduces a trie-based finite state machine that starts
at the root with every code point in the input string.  I slightly changed the format
of the DFA from what is currently in use in Safari to create a primitive that can match
substrings of each other, such as matching &quot;aba&quot; and &quot;ba&quot; and reporting that both
were matched instead of only reporting the shortest one being matched.

This new primitive doesn&apos;t actually enable anything that can&apos;t functionally be done
with regular expressions, but for large sets of regular expressions that are used
over and over again in one process then another, this allows a reduction in time
spent compiling the regular expressions.

Even less useful than something that doesn&apos;t enable new behavior is a native API
that allows string matching on strings.  I added such an interface,
resultsForMatchingCharacters:length:matchAll:searchReverse:, but only temporarily
as a way for Safari to incrementally transition away from the injected bundle use
by having a native matcher that behaves exactly the same as _WKStringMatcher.
Once the transition is complete, this will be removed.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::shouldHaveWebKitNamespaceForWorld):
* Source/WebCore/page/UserContentController.h:
* Source/WebCore/page/UserContentProvider.h:
* Source/WebCore/page/WebKitNamespace.cpp:
(WebCore::WebKitNamespace::WebKitNamespace):
(WebCore::WebKitNamespace::messageHandlers):
(WebCore::WebKitNamespace::stringMatchers):
* Source/WebCore/page/WebKitNamespace.h:
* Source/WebCore/page/WebKitNamespace.idl:
* Source/WebCore/page/WebKitStringMatcher.cpp: Added.
(WebCore::match):
(WebCore::WebKitStringMatcher::match):
(WebCore::WebKitStringMatcher::Trie::Node::traverse const):
(WebCore::WebKitStringMatcher::Trie::Trie):
(WebCore::WebKitStringMatcher::Trie::serialize const):
(WebCore::WebKitStringMatcher::dataForMatchingStrings):
(WebCore::WebKitStringMatcher::statesAndTransitionsFromVersionedData):
* Source/WebCore/page/WebKitStringMatcher.h: Copied from Source/WebKit/Shared/WebUserContentControllerDataTypes.h.
* Source/WebCore/page/WebKitStringMatcher.idl: Copied from Source/WebKit/Shared/UserContentControllerParameters.h.
* Source/WebCore/page/WebKitStringMatcherOptions.h: Copied from Source/WebKit/Shared/UserContentControllerParameters.h.
* Source/WebCore/page/WebKitStringMatcherOptions.idl: Copied from Source/WebKit/Shared/UserContentControllerParameters.h.
* Source/WebCore/page/WebKitStringMatchersNamespace.cpp: Copied from Source/WebKit/Shared/WebUserContentControllerDataTypes.h.
(WebCore::WebKitStringMatchersNamespace::WebKitStringMatchersNamespace):
(WebCore::WebKitStringMatchersNamespace::namedItem):
(WebCore::WebKitStringMatchersNamespace::supportedPropertyNames const):
(WebCore::WebKitStringMatchersNamespace::isSupportedPropertyName):
* Source/WebCore/page/WebKitStringMatchersNamespace.h: Copied from Source/WebKit/Shared/WebUserContentControllerDataTypes.h.
(WebCore::WebKitStringMatchersNamespace::create):
* Source/WebCore/page/WebKitStringMatchersNamespace.idl: Copied from Source/WebKit/Shared/UserContentControllerParameters.h.
* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/API/APIObject.h:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/Shared/UserContentControllerParameters.h:
* Source/WebKit/Shared/UserContentControllerParameters.serialization.in:
* Source/WebKit/Shared/WebUserContentControllerDataTypes.cpp: Copied from Source/WebKit/Shared/UserContentControllerParameters.h.
(WebKit::WebStringMatcherData::WebStringMatcherData):
(WebKit::WebStringMatcherData::sharedMemoryHandle const):
* Source/WebKit/Shared/WebUserContentControllerDataTypes.h:
* Source/WebKit/Shared/WebUserContentControllerDataTypes.serialization.in:
* Source/WebKit/Sources.txt:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/APIStringMatcher.cpp: Copied from Source/WebKit/Shared/UserContentControllerParameters.h.
(API::StringMatcher::StringMatcher):
(API::StringMatcher::sharedMemory):
(API::StringMatcher::sharedBuffer):
* Source/WebKit/UIProcess/API/APIStringMatcher.h: Copied from Source/WebKit/Shared/UserContentControllerParameters.h.
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
(-[WKUserContentController _addStringMatcher:contentWorld:name:]):
(-[WKUserContentController _removeStringMatcherWithName:contentWorld:]):
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKStringMatcher.h: Copied from Source/WebKit/Shared/UserContentControllerParameters.h.
* Source/WebKit/UIProcess/API/Cocoa/_WKStringMatcher.mm: Added.
(-[_WKStringMatcher initWithData:]):
(-[_WKStringMatcher initWithDataInFile:]):
(-[_WKStringMatcher dealloc]):
(+[_WKStringMatcher matcherDataForStringsAndIdentifiers:]):
(-[_WKStringMatcher resultsForMatchingCharacters:length:matchAll:searchReverse:]):
(-[_WKStringMatcher _apiObject]):
* Source/WebKit/UIProcess/API/Cocoa/_WKStringMatcherInternal.h: Copied from Source/WebKit/Shared/UserContentControllerParameters.h.
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::parametersForProcess const):
(WebKit::WebUserContentControllerProxy::addStringMatcher):
(WebKit::WebUserContentControllerProxy::removeStringMatcher):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::get):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/UserContent/SharedMemoryStringMatcher.cpp: Added.
(WebKit::SharedMemoryStringMatcher::create):
(WebKit::SharedMemoryStringMatcher::SharedMemoryStringMatcher):
* Source/WebKit/WebProcess/UserContent/SharedMemoryStringMatcher.h: Added.
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::getOrCreate):
(WebKit::WebUserContentController::removeContentWorld):
(WebKit::WebUserContentController::addStringMatcher):
(WebKit::WebUserContentController::removeStringMatcher):
(WebKit::WebUserContentController::hasStringMatchersForWorld const):
(WebKit::WebUserContentController::stringMatcher const):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/StringMatcher.mm: Added.
(TEST(StringMatcher, MatcherData)):
(TEST(StringMatcher, MatchResults)):
(TEST(StringMatcher, IDLExposed)):
(TEST(StringMatcher, CharacterEdgeCases)):

Canonical link: <a href="https://commits.webkit.org/302111@main">https://commits.webkit.org/302111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78481358d619e4c789a2502c104af5439179bab1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135415 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/483051f2-de79-49d9-94cc-55b806c706d9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/201 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7304309a-1aef-45e1-b3b8-8546d53684bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130993 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78043 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ed028bc3-db11-45df-8883-3b183878fa7e) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/127396 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78724 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137903 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/184 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105743 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/140 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52363 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20008 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/230 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/61697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/149 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/190 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->