### PR TITLE
Share more code between BlobResourceHandle and NetworkDataTaskBlob

### DIFF
--- a/Source/WebCore/fileapi/AsyncFileStream.cpp
+++ b/Source/WebCore/fileapi/AsyncFileStream.cpp
@@ -54,7 +54,7 @@ struct AsyncFileStream::Internals {
     explicit Internals(FileStreamClient&);
 
     FileStream stream;
-    FileStreamClient& client;
+    WeakRef<FileStreamClient> client;
     std::atomic_bool destroyed { false };
 };
 
@@ -126,7 +126,7 @@ void AsyncFileStream::perform(Function<Function<void(FileStreamClient&)>(FileStr
         callOnMainThread([&internals, mainThreadWork = operation(internals.stream)] {
             if (internals.destroyed)
                 return;
-            mainThreadWork(internals.client);
+            mainThreadWork(Ref { internals.client.get() });
         });
     });
 }

--- a/Source/WebCore/platform/FileStreamClient.h
+++ b/Source/WebCore/platform/FileStreamClient.h
@@ -28,12 +28,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef FileStreamClient_h
-#define FileStreamClient_h
+#pragma once
+
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
-class FileStreamClient {
+class FileStreamClient : public AbstractRefCountedAndCanMakeWeakPtr<FileStreamClient> {
 public:
     virtual void didOpen(bool) { } // false signals failure.
     virtual void didGetSize(long long) { } // -1 signals failure.
@@ -46,5 +47,3 @@ protected:
 };
 
 } // namespace WebCore
-
-#endif // FileStreamClient_h

--- a/Source/WebCore/platform/network/ResourceHandle.cpp
+++ b/Source/WebCore/platform/network/ResourceHandle.cpp
@@ -182,6 +182,11 @@ ResourceRequest& ResourceHandle::firstRequest()
     return d->m_firstRequest;
 }
 
+const ResourceRequest& ResourceHandle::firstRequest() const
+{
+    return d->m_firstRequest;
+}
+
 NetworkingContext* ResourceHandle::context() const
 {
     return d->m_context.get();

--- a/Source/WebCore/platform/network/ResourceHandle.h
+++ b/Source/WebCore/platform/network/ResourceHandle.h
@@ -151,6 +151,7 @@ public:
     WEBCORE_EXPORT void setDefersLoading(bool);
 
     WEBCORE_EXPORT ResourceRequest& firstRequest();
+    WEBCORE_EXPORT const ResourceRequest& firstRequest() const;
     const String& lastHTTPMethod() const;
 
     void failureTimerFired();

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -61,23 +61,27 @@ static constexpr auto httpPartialContentText = "Partial Content"_s;
 
 static constexpr auto webKitBlobResourceDomain = "WebKitBlobResource"_s;
 
-NetworkDataTaskBlob::NetworkDataTaskBlob(NetworkSession& session, NetworkDataTaskClient& client, const ResourceRequest& request, const Vector<RefPtr<WebCore::BlobDataFileReference>>& fileReferences, const RefPtr<SecurityOrigin>& topOrigin)
-    : NetworkDataTask(session, client, request, StoredCredentialsPolicy::DoNotUse, false, false, false)
-    , m_stream(makeUnique<AsyncFileStream>(*this))
-    , m_fileReferences(fileReferences)
-    , m_networkProcess(session.networkProcess())
+static RefPtr<BlobData> blobDataFrom(NetworkSession& session, const WebCore::ResourceRequest& request, const SecurityOrigin* topOrigin)
 {
-    for (auto& fileReference : m_fileReferences)
-        fileReference->prepareForFileAccess();
-
     // We use request.firstPartyForCookies() to indicate if the request originated from the DOM or WebView API.
     ASSERT(topOrigin || request.firstPartyForCookies().isEmpty());
+
     std::optional<SecurityOriginData> topOriginData = topOrigin ? std::optional { topOrigin->data() } : std::nullopt;
     if (!topOriginData && !request.firstPartyForCookies().isEmpty() && request.firstPartyForCookies().isValid()) {
         RELEASE_LOG(Network, "Got request for blob without topOrigin but request specifies firstPartyForCookies");
         topOriginData = SecurityOriginData::fromURLWithoutStrictOpaqueness(request.firstPartyForCookies());
     }
-    m_blobData = session.blobRegistry().blobDataFromURL(request.url(), topOriginData);
+    return session.blobRegistry().blobDataFromURL(request.url(), topOriginData);
+}
+
+NetworkDataTaskBlob::NetworkDataTaskBlob(NetworkSession& session, NetworkDataTaskClient& client, const ResourceRequest& request, const Vector<RefPtr<WebCore::BlobDataFileReference>>& fileReferences, const RefPtr<SecurityOrigin>& topOrigin)
+    : NetworkDataTask(session, client, request, StoredCredentialsPolicy::DoNotUse, false, false, false)
+    , BlobResourceHandleBase(true /* async */, blobDataFrom(session, request, topOrigin.get()))
+    , m_fileReferences(fileReferences)
+    , m_networkProcess(session.networkProcess())
+{
+    for (auto& fileReference : m_fileReferences)
+        fileReference->prepareForFileAccess();
 
     LOG(NetworkSession, "%p - Created NetworkDataTaskBlob for %s", this, request.url().string().utf8().data());
 }
@@ -97,11 +101,8 @@ void NetworkDataTaskBlob::clearStream()
 
     m_state = State::Completed;
 
-    if (m_fileOpened) {
-        m_fileOpened = false;
-        m_stream->close();
-    }
-    m_stream = nullptr;
+    closeFileIfOpen();
+    clearAsyncStream();
 }
 
 void NetworkDataTaskBlob::resume()
@@ -112,35 +113,7 @@ void NetworkDataTaskBlob::resume()
 
     m_state = State::Running;
 
-    RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }] {
-        if (m_state == State::Canceling || m_state == State::Completed || !m_client) {
-            clearStream();
-            return;
-        }
-
-        if (!equalLettersIgnoringASCIICase(m_firstRequest.httpMethod(), "get"_s)) {
-            didFail(Error::MethodNotAllowed);
-            return;
-        }
-
-        // If the blob data is not found, fail now.
-        if (!m_blobData) {
-            didFail(Error::NotFoundError);
-            return;
-        }
-
-        // Parse the "Range" header we care about.
-        if (String range = m_firstRequest.httpHeaderField(HTTPHeaderName::Range); !range.isNull()) {
-            m_range = parseRange(range, RangeAllowWhitespace::Yes);
-            if (!m_range) {
-                didFail(Error::RangeError);
-                return;
-            }
-            m_isRangeRequest = true;
-        }
-
-        getSizeForNext();
-    });
+    start();
 }
 
 void NetworkDataTaskBlob::cancel()
@@ -150,10 +123,7 @@ void NetworkDataTaskBlob::cancel()
 
     m_state = State::Canceling;
 
-    if (m_fileOpened) {
-        m_fileOpened = false;
-        m_stream->close();
-    }
+    closeFileIfOpen();
 
     if (isDownload())
         cleanDownloadFiles();
@@ -165,88 +135,14 @@ void NetworkDataTaskBlob::invalidateAndCancel()
     clearStream();
 }
 
-void NetworkDataTaskBlob::getSizeForNext()
+bool NetworkDataTaskBlob::erroredOrAborted() const
 {
-    ASSERT(RunLoop::isMain());
-
-    // Do we finish validating and counting size for all items?
-    if (m_sizeItemCount >= m_blobData->items().size()) {
-        if (auto error = seek()) {
-            didFail(*error);
-            return;
-        }
-        dispatchDidReceiveResponse();
-        return;
-    }
-
-    const BlobDataItem& item = m_blobData->items().at(m_sizeItemCount);
-    switch (item.type()) {
-    case BlobDataItem::Type::Data:
-        didGetSize(item.length());
-        break;
-    case BlobDataItem::Type::File:
-        // Files know their sizes, but asking the stream to verify that the file wasn't modified.
-        m_stream->getSize(item.protectedFile()->path(), item.protectedFile()->expectedModificationTime());
-        break;
-    default:
-        ASSERT_NOT_REACHED();
-    }
+    return m_state == State::Canceling || m_state == State::Completed || (!m_client && !isDownload());
 }
 
-void NetworkDataTaskBlob::didGetSize(long long size)
+void NetworkDataTaskBlob::didReceiveResponse(ResourceResponse&& response)
 {
-    ASSERT(RunLoop::isMain());
-    Ref protectedThis { *this };
-
-    if (m_state == State::Canceling || m_state == State::Completed || (!m_client && !isDownload())) {
-        clearStream();
-        return;
-    }
-
-    // If the size is -1, it means the file has been moved or changed. Fail now.
-    if (size == -1) {
-        didFail(Error::NotFoundError);
-        return;
-    }
-
-    // The size passed back is the size of the whole file. If the underlying item is a sliced file, we need to use the slice length.
-    const BlobDataItem& item = m_blobData->items().at(m_sizeItemCount);
-    uint64_t updatedSize = static_cast<uint64_t>(item.length());
-
-    // Cache the size.
-    m_itemLengthList.append(updatedSize);
-
-    // Count the size.
-    m_totalSize += updatedSize;
-    m_totalRemainingSize += updatedSize;
-    ++m_sizeItemCount;
-
-    // Continue with the next item.
-    getSizeForNext();
-}
-
-void NetworkDataTaskBlob::dispatchDidReceiveResponse()
-{
-    LOG(NetworkSession, "%p - NetworkDataTaskBlob::dispatchDidReceiveResponse()", this);
-
-    Ref<NetworkDataTaskBlob> protectedThis(*this);
-    ResourceResponse response(URL { m_firstRequest.url() }, extractMIMETypeFromMediaType(m_blobData->contentType()), m_totalRemainingSize, String());
-    response.setHTTPStatusCode(m_isRangeRequest ? httpPartialContent : httpOK);
-    response.setHTTPStatusText(m_isRangeRequest ? httpPartialContentText : httpOKText);
-
-    response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
-    response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toString());
-    response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
-    addPolicyContainerHeaders(response, m_blobData->policyContainer());
-
-    if (m_isRangeRequest)
-        response.setHTTPHeaderField(HTTPHeaderName::ContentRange, ParsedContentRange(*m_range->start, *m_range->end, m_totalSize).headerValue());
-
-    // FIXME: If a resource identified with a blob: URL is a File object, user agents must use that file's name attribute,
-    // as if the response had a Content-Disposition header with the filename parameter set to the File's name attribute.
-    // Notably, this will affect a name suggested in "File Save As".
-
-    didReceiveResponse(WTFMove(response), NegotiatedLegacyTLS::No, PrivateRelayed::No, std::nullopt, [this, protectedThis = Ref { *this }](PolicyAction policyAction) {
+    NetworkDataTask::didReceiveResponse(WTFMove(response), NegotiatedLegacyTLS::No, PrivateRelayed::No, std::nullopt, [this, protectedThis = Ref { *this }](PolicyAction policyAction) {
         LOG(NetworkSession, "%p - NetworkDataTaskBlob::didReceiveResponse completionHandler (%s)", this, toString(policyAction).characters());
 
         if (m_state == State::Canceling || m_state == State::Completed) {
@@ -256,8 +152,8 @@ void NetworkDataTaskBlob::dispatchDidReceiveResponse()
 
         switch (policyAction) {
         case PolicyAction::Use:
-            m_buffer.resize(bufferSize);
-            read();
+            buffer().resize(bufferSize);
+            readAsync();
             break;
         case PolicyAction::LoadWillContinueInAnotherProcess:
             ASSERT_NOT_REACHED();
@@ -271,120 +167,16 @@ void NetworkDataTaskBlob::dispatchDidReceiveResponse()
     });
 }
 
-void NetworkDataTaskBlob::read()
+bool NetworkDataTaskBlob::didReceiveData(std::span<const uint8_t> data)
 {
-    ASSERT(RunLoop::isMain());
-
-    while (m_totalRemainingSize && m_readItemCount < m_blobData->items().size()) {
-        const BlobDataItem& item = m_blobData->items().at(m_readItemCount);
-        switch (item.type()) {
-        case BlobDataItem::Type::Data:
-            if (!readData(item))
-                return; // error occurred
-            break;
-        case BlobDataItem::Type::File:
-            readFile(item);
-            return;
-        }
-    }
-    didFinish();
-}
-
-bool NetworkDataTaskBlob::readData(const BlobDataItem& item)
-{
-    ASSERT(item.data());
-
-    ASSERT(m_currentItemReadSize <= static_cast<uint64_t>(item.length()));
-    uint64_t bytesToRead = item.length() - m_currentItemReadSize;
-    if (bytesToRead > m_totalRemainingSize)
-        bytesToRead = m_totalRemainingSize;
-
-    RefPtr data = item.data();
-    auto dataSpan = data->span().subspan(item.offset() + m_currentItemReadSize, static_cast<uint64_t>(bytesToRead));
-    m_currentItemReadSize = 0;
-
-    return consumeData(dataSpan);
-}
-
-void NetworkDataTaskBlob::readFile(const BlobDataItem& item)
-{
-    ASSERT(m_stream);
-
-    if (m_fileOpened) {
-        m_stream->read(m_buffer.mutableSpan());
-        return;
-    }
-
-    uint64_t bytesToRead = m_itemLengthList[m_readItemCount] - m_currentItemReadSize;
-    if (bytesToRead > m_totalRemainingSize)
-        bytesToRead = static_cast<int>(m_totalRemainingSize);
-    m_stream->openForRead(item.protectedFile()->path(), item.offset() + m_currentItemReadSize, bytesToRead);
-    m_fileOpened = true;
-    m_currentItemReadSize = 0;
-}
-
-void NetworkDataTaskBlob::didOpen(bool success)
-{
-    if (m_state == State::Canceling || m_state == State::Completed || (!m_client && !isDownload())) {
-        clearStream();
-        return;
-    }
-
-    if (!success) {
-        didFail(Error::NotReadableError);
-        return;
-    }
-
-    Ref<NetworkDataTaskBlob> protectedThis(*this);
-    read();
-}
-
-void NetworkDataTaskBlob::didRead(int bytesRead)
-{
-    if (m_state == State::Canceling || m_state == State::Completed || (!m_client && !isDownload())) {
-        clearStream();
-        return;
-    }
-
-    if (bytesRead < 0) {
-        didFail(Error::NotReadableError);
-        return;
-    }
-
-    Ref<NetworkDataTaskBlob> protectedThis(*this);
-    if (consumeData(m_buffer.subspan(0, bytesRead)))
-        read();
-}
-
-bool NetworkDataTaskBlob::consumeData(std::span<const uint8_t> data)
-{
-    m_totalRemainingSize -= data.size();
-
-    if (!data.empty()) {
-        if (m_downloadFile) {
-            if (!writeDownload(data))
-                return false;
-        } else {
-            ASSERT(m_client);
-            protectedClient()->didReceiveData(SharedBuffer::create(data));
-        }
-    }
-
-    if (m_fileOpened) {
-        // When the current item is a file item, the reading is completed only if bytesRead is 0.
-        if (data.empty()) {
-            // Close the file.
-            m_fileOpened = false;
-            m_stream->close();
-
-            // Move to the next item.
-            m_readItemCount++;
-        }
+    ASSERT(!data.empty());
+    if (m_downloadFile) {
+        if (!writeDownload(data))
+            return false;
     } else {
-        // Otherwise, we read the current text item as a whole and move to the next item.
-        m_readItemCount++;
+        ASSERT(m_client);
+        protectedClient()->didReceiveData(SharedBuffer::create(data));
     }
-
     return true;
 }
 
@@ -427,8 +219,8 @@ void NetworkDataTaskBlob::download()
 
     ASSERT(!m_client);
 
-    m_buffer.resize(bufferSize);
-    read();
+    buffer().resize(bufferSize);
+    readAsync();
 }
 
 bool NetworkDataTaskBlob::writeDownload(std::span<const uint8_t> data)
@@ -443,7 +235,7 @@ bool NetworkDataTaskBlob::writeDownload(std::span<const uint8_t> data)
     m_downloadBytesWritten += *bytesWritten;
     RefPtr download = m_networkProcess->checkedDownloadManager()->download(*m_pendingDownloadID);
     ASSERT(download);
-    download->didReceiveData(*bytesWritten, m_downloadBytesWritten, m_totalSize);
+    download->didReceiveData(*bytesWritten, m_downloadBytesWritten, totalSize());
     return true;
 }
 


### PR DESCRIPTION
#### 7b3d928b91bddb673246051e0b68b19ed8444293
<pre>
Share more code between BlobResourceHandle and NetworkDataTaskBlob
<a href="https://bugs.webkit.org/show_bug.cgi?id=301032">https://bugs.webkit.org/show_bug.cgi?id=301032</a>

Reviewed by Darin Adler.

* Source/WebCore/fileapi/AsyncFileStream.cpp:
(WebCore::AsyncFileStream::perform):
* Source/WebCore/platform/FileStreamClient.h:
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandleBase::BlobResourceHandleBase):
(WebCore::BlobResourceHandleBase::closeFileIfOpen):
(WebCore::BlobResourceHandleBase::clearAsyncStream):
(WebCore::BlobResourceHandleBase::blobData const):
(WebCore::BlobResourceHandleBase::syncStream const):
(WebCore::BlobResourceHandleBase::asyncStream const):
(WebCore::BlobResourceHandle::BlobResourceHandle):
(WebCore::BlobResourceHandle::cancel):
(WebCore::BlobResourceHandleBase::start):
(WebCore::BlobResourceHandleBase::doStart):
(WebCore::BlobResourceHandleBase::getSizeForNext):
(WebCore::BlobResourceHandleBase::didGetSize):
(WebCore::BlobResourceHandleBase::seek):
(WebCore::BlobResourceHandle::readSync):
(WebCore::BlobResourceHandle::readDataSync):
(WebCore::BlobResourceHandle::readFileSync):
(WebCore::BlobResourceHandleBase::readAsync):
(WebCore::BlobResourceHandleBase::readDataAsync):
(WebCore::BlobResourceHandleBase::readFileAsync):
(WebCore::BlobResourceHandleBase::didOpen):
(WebCore::BlobResourceHandleBase::didRead):
(WebCore::BlobResourceHandleBase::consumeData):
(WebCore::BlobResourceHandle::shouldAbortDispatchDidReceiveResponse):
(WebCore::BlobResourceHandleBase::dispatchDidReceiveResponse):
(WebCore::BlobResourceHandle::didReceiveResponse):
(WebCore::BlobResourceHandle::didReceiveData):
(WebCore::BlobResourceHandle::didFail):
(WebCore::BlobResourceHandle::didFinish):
(): Deleted.
(WebCore::BlobResourceHandle::start): Deleted.
(WebCore::BlobResourceHandle::doStart): Deleted.
(WebCore::BlobResourceHandle::getSizeForNext): Deleted.
(WebCore::BlobResourceHandle::didGetSize): Deleted.
(WebCore::BlobResourceHandle::readAsync): Deleted.
(WebCore::BlobResourceHandle::readDataAsync): Deleted.
(WebCore::BlobResourceHandle::readFileAsync): Deleted.
(WebCore::BlobResourceHandle::didOpen): Deleted.
(WebCore::BlobResourceHandle::didRead): Deleted.
(WebCore::BlobResourceHandle::consumeData): Deleted.
(WebCore::BlobResourceHandle::failed): Deleted.
(WebCore::BlobResourceHandle::notifyResponse): Deleted.
(WebCore::BlobResourceHandle::notifyResponseOnSuccess): Deleted.
(WebCore::BlobResourceHandle::notifyReceiveData): Deleted.
(WebCore::BlobResourceHandle::notifyFail): Deleted.
(WebCore::BlobResourceHandle::notifyFinish): Deleted.
* Source/WebCore/platform/network/BlobResourceHandle.h:
(WebCore::BlobResourceHandleBase::isFileOpen const):
(WebCore::BlobResourceHandleBase::setIsFileOpen):
(WebCore::BlobResourceHandleBase::async const):
(WebCore::BlobResourceHandleBase::totalSize):
(WebCore::BlobResourceHandleBase::totalRemainingSize const):
(WebCore::BlobResourceHandleBase::currentItemReadSize const):
(WebCore::BlobResourceHandleBase::setCurrentItemReadSize):
(WebCore::BlobResourceHandleBase::decrementTotalRemainingSizeBy):
(WebCore::BlobResourceHandleBase::readItemCount const):
(WebCore::BlobResourceHandleBase::incrementReadItemCount):
(WebCore::BlobResourceHandleBase::lengthOfItemBeingRead const):
(WebCore::BlobResourceHandleBase::buffer):
(WebCore::BlobResourceHandleBase::buffer const):
(WebCore::BlobResourceHandleBase::shouldAbortDispatchDidReceiveResponse):
(WebCore::BlobResourceHandleBase::clearStream):
* Source/WebCore/platform/network/ResourceHandle.cpp:
(WebCore::ResourceHandle::firstRequest const):
* Source/WebCore/platform/network/ResourceHandle.h:
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::blobDataFrom):
(WebKit::NetworkDataTaskBlob::NetworkDataTaskBlob):
(WebKit::NetworkDataTaskBlob::clearStream):
(WebKit::NetworkDataTaskBlob::resume):
(WebKit::NetworkDataTaskBlob::cancel):
(WebKit::NetworkDataTaskBlob::erroredOrAborted const):
(WebKit::NetworkDataTaskBlob::didReceiveResponse):
(WebKit::NetworkDataTaskBlob::didReceiveData):
(WebKit::NetworkDataTaskBlob::download):
(WebKit::NetworkDataTaskBlob::writeDownload):
(WebKit::NetworkDataTaskBlob::getSizeForNext): Deleted.
(WebKit::NetworkDataTaskBlob::didGetSize): Deleted.
(WebKit::NetworkDataTaskBlob::dispatchDidReceiveResponse): Deleted.
(WebKit::NetworkDataTaskBlob::read): Deleted.
(WebKit::NetworkDataTaskBlob::readData): Deleted.
(WebKit::NetworkDataTaskBlob::readFile): Deleted.
(WebKit::NetworkDataTaskBlob::didOpen): Deleted.
(WebKit::NetworkDataTaskBlob::didRead): Deleted.
(WebKit::NetworkDataTaskBlob::consumeData): Deleted.
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h:

Canonical link: <a href="https://commits.webkit.org/301798@main">https://commits.webkit.org/301798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3abd59ca2a5ad3e1646f75ec795f406ff8e378f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134099 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78659 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d88d54ce-57cb-47cd-8e75-866add760e51) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96716 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64760 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d335bc0f-3dac-4222-bc48-7db1506ba857) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113818 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77226 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fcc30fd4-c363-4238-874c-afa617757539) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36772 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31943 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77491 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136625 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105236 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104925 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26757 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50452 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51301 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53684 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59557 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52922 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56255 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54680 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->