### PR TITLE
Resync `html/semantics/selectors` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/WEB_FEATURES.yml
@@ -1,0 +1,20 @@
+features:
+- name: autofill
+  files:
+  - autofill.html
+- name: default
+  files:
+  - default.html
+- name: dir-pseudo
+  files:
+  - dir-*
+  - dir.html
+  - dir01.html
+- name: indeterminate
+  files:
+  - checked-indeterminate.window.js
+  - indeterminate*
+- name: read-write-pseudos
+  files:
+  - readwrite-readonly-type-change.html
+  - readwrite-readonly.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt
@@ -22,6 +22,8 @@ PASS The :read-only pseudo-class must not match elements that are editable
 PASS The :read-write pseudo-class must match elements that are editing hosts
 PASS The :read-only pseudo-class must not match elements that are editing hosts
 PASS The :read-write pseudo-class must match elements that are inside editing hosts, but not match inputs and textareas inside that aren't
+PASS The :read-only pseudo-class must match form-associated custom elements
+PASS The :read-write pseudo-class must match form-associated contenteditable custom elements
 
 
 
@@ -31,3 +33,4 @@ paragraph1.
 paragraph2.
 
 
+content content content content content

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html
@@ -5,6 +5,17 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="utils.js"></script>
+<script>
+  class CustomElement extends HTMLElement {
+    static formAssociated = true;
+
+    constructor() {
+      super();
+    }
+  }
+
+  window.customElements.define("custom-element", CustomElement);
+</script>
 <div id="log"></div>
 
 <div id=set0>
@@ -56,6 +67,14 @@
     <textarea id=ct3></textarea>
     <textarea id=ct4></textarea>
   </div>
+</div>
+
+<div id=set6>
+  <custom-element id=ce1>content</custom-element>
+  <custom-element id=ce2 contenteditable>content</custom-element>
+  <custom-element id=ce3 contenteditable readonly>content</custom-element>
+  <custom-element id=ce4 contenteditable disabled>content</custom-element>
+  <custom-element id=ce5 contenteditable readonly disabled>content</custom-element>
 </div>
 
 <script>
@@ -114,5 +133,10 @@
   document.designMode = "off";
 
   testSelectorIdsMatch("#set5 :read-write", ["cd1", "p3", "ci3", "ci4", "ct3", "ct4"], "The :read-write pseudo-class must match elements that are inside editing hosts, but not match inputs and textareas inside that aren't");
+
+  testSelectorIdsMatch("#set6 :read-only", ["ce1"], "The :read-only pseudo-class must match form-associated custom elements");
+
+  testSelectorIdsMatch("#set6 :read-write", ["ce2", "ce3", "ce4", "ce5"], "The :read-write pseudo-class must match form-associated contenteditable custom elements");
+
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/active-disabled.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/autofill.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked-indeterminate.window.js

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt
@@ -22,6 +22,8 @@ PASS The :read-only pseudo-class must not match elements that are editable
 PASS The :read-write pseudo-class must match elements that are editing hosts
 PASS The :read-only pseudo-class must not match elements that are editing hosts
 PASS The :read-write pseudo-class must match elements that are inside editing hosts, but not match inputs and textareas inside that aren't
+PASS The :read-only pseudo-class must match form-associated custom elements
+PASS The :read-write pseudo-class must match form-associated contenteditable custom elements
 
 
 
@@ -31,3 +33,4 @@ paragraph1.
 paragraph2.
 
 
+content content content content content


### PR DESCRIPTION
#### 797743585550cb824ddfa5a75176c2586dd45c25
<pre>
Resync `html/semantics/selectors` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=301042">https://bugs.webkit.org/show_bug.cgi?id=301042</a>
<a href="https://rdar.apple.com/162942846">rdar://162942846</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/19250d046daa69748ece904fb05c768713e045aa">https://github.com/web-platform-tests/wpt/commit/19250d046daa69748ece904fb05c768713e045aa</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/w3c-import.log:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt:

Canonical link: <a href="https://commits.webkit.org/301781@main">https://commits.webkit.org/301781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/662950b4c85e6686ef8e87d71e05c56e9588f5c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134045 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78605 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7cf2588b-ef44-4961-b81f-ed90d7d67894) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96669 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64686 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a246585c-4925-49a5-9695-1a5de0e0a2df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113682 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77179 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/58b057c5-4e7f-426c-b4fd-b24b50edeebd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31824 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77437 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136571 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105187 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104878 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26744 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50404 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28779 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51218 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53630 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52868 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56201 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54626 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->