### PR TITLE
Resync `html/the-xhtml-syntax` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -11980,7 +11980,6 @@
         "web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/adopt-while-parsing.xhtml",
         "web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/data-xhtml-with-dtd-ref.html",
         "web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/xhtml-mathml-dtd-entity.htm",
-        "web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-support.htm",
         "web-platform-tests/html/webappapis/dynamic-markup-insertion/document-write/047-1.html",
         "web-platform-tests/html/webappapis/dynamic-markup-insertion/document-write/empty.html",
         "web-platform-tests/html/webappapis/dynamic-markup-insertion/document-write/module-delayed-iframe.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/simple-style.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/simple-style.css
@@ -1,0 +1,1 @@
+:root { z-index: 3 }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/w3c-import.log
@@ -15,4 +15,5 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/entities.json
+/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/simple-style.css
 /LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/xhtml-mathml-dtd-entity.htm

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/xhtml-mathml-dtd-entity.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/xhtml-mathml-dtd-entity.htm
@@ -20,7 +20,6 @@
       // Next line because some browsers include the partial parsed result in the parser error returned document.
       parent.assert_equals(root.firstChild.nodeType, 3/*Text*/, friendlyMime + " parsing the entity reference caused a parse error;");
       var text = root.firstChild.data;
-      parent.assert_equals(text.length,expectedString.length);
       for (var i = 0, len = expectedString.length; i < len; i++) {
         parent.assert_equals(text.charCodeAt(i),expectedString.charCodeAt(i));
       }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/w3c-import.log
@@ -31,3 +31,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-7.htm
 /LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-8.htm
 /LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-9.htm
+/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xml-stylesheet-blocking.xhtml

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xml-stylesheet-blocking-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xml-stylesheet-blocking-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL xml-stylesheet blocks script execution and rendering assert_equals: XML processing instruction should've blocked script execution and rendering expected "3" but got "auto"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xml-stylesheet-blocking.xhtml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xml-stylesheet-blocking.xhtml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/css" href="support/simple-style.css?pipe=trickle(d2)"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <script><![CDATA[
+      window.observedZIndex = getComputedStyle(document.documentElement).zIndex;
+    ]]></script>
+    <title>xml-stylesheet blocks script execution and rendering</title>
+    <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1986042" />
+    <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io" />
+    <link rel="author" title="Mozilla" href="https://mozilla.org" />
+    <script src="/resources/testharness.js"/>
+    <script src="/resources/testharnessreport.js"/>
+  </head>
+  <body>
+    <script><![CDATA[
+    test(function() {
+      assert_equals(window.observedZIndex, "3", "XML processing instruction should've blocked script execution and rendering");
+    });
+    ]]></script>
+  </body>
+</html>


### PR DESCRIPTION
#### 919691a4ebb09a93c2dc093686cdc284e35ff623
<pre>
Resync `html/the-xhtml-syntax` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=301043">https://bugs.webkit.org/show_bug.cgi?id=301043</a>
<a href="https://rdar.apple.com/162943182">rdar://162943182</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/19250d046daa69748ece904fb05c768713e045aa">https://github.com/web-platform-tests/wpt/commit/19250d046daa69748ece904fb05c768713e045aa</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/simple-style.css: Added.
(:root):
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/xhtml-mathml-dtd-entity.htm:
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xml-stylesheet-blocking-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xml-stylesheet-blocking.xhtml: Added.

Canonical link: <a href="https://commits.webkit.org/301778@main">https://commits.webkit.org/301778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6733eb85114bb61fbf6341e62dfe5fecc0276170

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78583 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1e5c9899-d25d-49c3-9458-8cf91ba0ed74) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96650 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64661 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b794efd9-8e64-4af2-8039-2f37a18b137b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77160 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0098e52b-4e21-4231-8daf-03b11414f5db) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36693 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31797 "Found 1 new test failure: inspector/animation/lifecycle-css-transition.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77414 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136548 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41332 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105166 "16 flakes 56 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110012 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104857 "Found 1 new API test failure: WebKitGTK/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26741 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28752 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51192 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53605 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52844 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56178 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54603 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->