### PR TITLE
Prepare Source/WebKit for clang static analyzer update (part 1)

### DIFF
--- a/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
@@ -185,7 +185,7 @@ void LegacyCustomProtocolManager::didFailWithError(LegacyCustomProtocolID custom
     RetainPtr<NSError> nsError = error.nsError();
 
     dispatchOnInitializationRunLoop(protocol.get(), ^ {
-        [[protocol client] URLProtocol:protocol.get() didFailWithError:nsError.get()];
+        [retainPtr([protocol client]) URLProtocol:protocol.get() didFailWithError:nsError.get()];
     });
 
     removeCustomProtocol(customProtocolID);
@@ -200,7 +200,7 @@ void LegacyCustomProtocolManager::didLoadData(LegacyCustomProtocolID customProto
     RetainPtr nsData = toNSData(data);
 
     dispatchOnInitializationRunLoop(protocol.get(), ^ {
-        [[protocol client] URLProtocol:protocol.get() didLoadData:nsData.get()];
+        [retainPtr([protocol client]) URLProtocol:protocol.get() didLoadData:nsData.get()];
     });
 }
 
@@ -213,7 +213,7 @@ void LegacyCustomProtocolManager::didReceiveResponse(LegacyCustomProtocolID cust
     RetainPtr<NSURLResponse> nsResponse = response.nsURLResponse();
 
     dispatchOnInitializationRunLoop(protocol.get(), ^ {
-        [[protocol client] URLProtocol:protocol.get() didReceiveResponse:nsResponse.get() cacheStoragePolicy:toNSURLCacheStoragePolicy(cacheStoragePolicy)];
+        [retainPtr([protocol client]) URLProtocol:protocol.get() didReceiveResponse:nsResponse.get() cacheStoragePolicy:toNSURLCacheStoragePolicy(cacheStoragePolicy)];
     });
 }
 
@@ -224,7 +224,7 @@ void LegacyCustomProtocolManager::didFinishLoading(LegacyCustomProtocolID custom
         return;
 
     dispatchOnInitializationRunLoop(protocol.get(), ^ {
-        [[protocol client] URLProtocolDidFinishLoading:protocol.get()];
+        [retainPtr([protocol client]) URLProtocolDidFinishLoading:protocol.get()];
     });
 
     removeCustomProtocol(customProtocolID);
@@ -240,7 +240,7 @@ void LegacyCustomProtocolManager::wasRedirectedToRequest(LegacyCustomProtocolID 
     RetainPtr<NSURLResponse> nsRedirectResponse = redirectResponse.nsURLResponse();
 
     dispatchOnInitializationRunLoop(protocol.get(), [protocol, nsRequest, nsRedirectResponse]() {
-        [[protocol client] URLProtocol:protocol.get() wasRedirectedToRequest:nsRequest.get() redirectResponse:nsRedirectResponse.get()];
+        [retainPtr([protocol client]) URLProtocol:protocol.get() wasRedirectedToRequest:nsRequest.get() redirectResponse:nsRedirectResponse.get()];
     });
 }
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -422,7 +422,7 @@ void NetworkDataTaskCocoa::didReceiveResponse(WebCore::ResourceResponse&& respon
     if (isTopLevelNavigation())
         updateFirstPartyInfoForSession(response.url());
 #if ENABLE(NETWORK_ISSUE_REPORTING)
-    else if (NetworkIssueReporter::shouldReport([m_task _incompleteTaskMetrics])) {
+    else if (NetworkIssueReporter::shouldReport(retainPtr([m_task _incompleteTaskMetrics]).get())) {
         if (CheckedPtr session = networkSession())
             session->reportNetworkIssue(*m_webPageProxyID, firstRequest().url());
     }

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
@@ -54,7 +54,7 @@ MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(const
 #else
         auto archiver = adoptNS([WKKeyedCoder new]);
         [downcast<MediaPlaybackTargetContextCocoa>(context).outputContext() encodeWithCoder:archiver.get()];
-        auto dictionary = [archiver accumulatedDictionary];
+        RetainPtr dictionary = [archiver accumulatedDictionary];
         m_contextID = checked_objc_cast<NSString>([dictionary objectForKey:@"AVOutputContextSerializationKeyContextID"]);
         m_contextType = checked_objc_cast<NSString>([dictionary objectForKey:@"AVOutputContextSerializationKeyContextType"]);
 #endif


### PR DESCRIPTION
#### 067c542a676f710943a0f8f64feb57792de2dd3d
<pre>
Prepare Source/WebKit for clang static analyzer update (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301046">https://bugs.webkit.org/show_bug.cgi?id=301046</a>

Reviewed by Geoffrey Garen.

Deployed more smart pointers to prepare Source/WebKit for a future clang static analyzer update.

No new tests since there should be no behavioral difference.

* Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm:
(WebKit::LegacyCustomProtocolManager::didFailWithError):
(WebKit::LegacyCustomProtocolManager::didLoadData):
(WebKit::LegacyCustomProtocolManager::didReceiveResponse):
(WebKit::LegacyCustomProtocolManager::didFinishLoading):
(WebKit::LegacyCustomProtocolManager::wasRedirectedToRequest):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::didReceiveResponse):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(downgradeRequest):
(-[WKNetworkSessionDelegate URLSession:task:_schemeUpgraded:completionHandler:]):
(-[WKNetworkSessionDelegate URLSession:task:didReceiveChallenge:completionHandler:]):
(-[WKNetworkSessionDelegate URLSession:task:didCompleteWithError:]):
(-[WKNetworkSessionDelegate URLSession:task:didFinishCollectingMetrics:]):
(-[WKNetworkSessionDelegate URLSession:dataTask:didReceiveResponse:completionHandler:]):
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
(WebKit::SessionSet::isolatedSession):
(WebKit::NetworkSessionCocoa::clearProxyConfigData):
(WebKit::NetworkSessionCocoa::setProxyConfigData):
* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:
(WebKit::floatQuads):
(WebKit::makeTextRecognitionResult):
(WebKit::requestVisualTranslation):
(WebKit::requestPayloadForQRCode):
(WebKit::recognizeText):
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm:
(WebKit::MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(-[WKWebPrivacyNotificationListener didUpdate:]):
(WebKit::LinkDecorationFilteringController::updateList):
(WebKit::requestLinkDecorationFilteringData):
(WebKit::quirkDomainsDictToMap):
(WebKit::StorageAccessPromptQuirkController::updateList):
(WebKit::StorageAccessUserAgentStringQuirkController::updateList):
(WebKit::configureForAdvancedPrivacyProtections):
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::actionForMenuItem):
(WebKit::menuItemForTelephoneNumber):
(WebKit::menuForTelephoneNumber):

Canonical link: <a href="https://commits.webkit.org/301786@main">https://commits.webkit.org/301786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07c8c80e2776820a726ad06cf59091f5f83e57db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134025 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78586 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/de27b570-7bb6-4712-8e73-182e3e25f412) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96654 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64664 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/30e1f365-a1f5-40bf-b1ca-fd4dde65a11e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113655 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77164 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c758144-e454-40c8-8426-9e5442f64ea2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36694 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77417 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136551 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105169 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104860 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50381 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28753 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51195 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19869 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53608 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59481 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52847 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56181 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54606 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->