### PR TITLE
REGRESSION (Safari 26): `@font-face` / `FontFace.family` fails when font family name contains space (e.g. "Lato 2")

### DIFF
--- a/LayoutTests/fast/text/font-face-family-expected.txt
+++ b/LayoutTests/fast/text/font-face-family-expected.txt
@@ -1,13 +1,13 @@
-PASS new FontFace('a', 'url(garbage.otf)') is non-null.
-PASS new FontFace('4a', 'url(garbage.otf)') is non-null.
-PASS new FontFace('4"a', 'url(garbage.otf)') is non-null.
-PASS new FontFace('4\'a', 'url(garbage.otf)') is non-null.
-PASS new FontFace('4\'a"b', 'url(garbage.otf)') is non-null.
+PASS (new FontFace('a', 'url(garbage.otf)')).family is "a"
+PASS (new FontFace('4a', 'url(garbage.otf)')).family is "4a"
+PASS (new FontFace('4"a', 'url(garbage.otf)')).family is "4\"a"
+PASS (new FontFace('4\'a', 'url(garbage.otf)')).family is "4'a"
+PASS (new FontFace('4\'a"b', 'url(garbage.otf)')).family is "4'a\"b"
 PASS (new FontFace('ab', 'url(garbage.otf)')).family is "ab"
-PASS (new FontFace('"ab"', 'url(garbage.otf)')).family is "ab"
-PASS (new FontFace('a b', 'url(garbage.otf)')).family is "\"a b\""
-PASS (new FontFace('a b, c', 'url(garbage.otf)')).family is "normal"
-PASS (new FontFace('ab,c', 'url(garbage.otf)')).family is "normal"
+PASS (new FontFace('"ab"', 'url(garbage.otf)')).family is "\"ab\""
+PASS (new FontFace('a b', 'url(garbage.otf)')).family is "a b"
+PASS (new FontFace('a b, c', 'url(garbage.otf)')).family is "a b, c"
+PASS (new FontFace('ab,c', 'url(garbage.otf)')).family is "ab,c"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/text/font-face-family.html
+++ b/LayoutTests/fast/text/font-face-family.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
-shouldBeNonNull("new FontFace('a', 'url(garbage.otf)')");
-shouldBeNonNull("new FontFace('4a', 'url(garbage.otf)')");
-shouldBeNonNull("new FontFace('4\"a', 'url(garbage.otf)')");
-shouldBeNonNull("new FontFace('4\\'a', 'url(garbage.otf)')");
-shouldBeNonNull("new FontFace('4\\'a\"b', 'url(garbage.otf)')");
+// The family name passed in to create a FontFace should not be parsed or serialized, but just treated as a family name string.
+shouldBeEqualToString("(new FontFace('a', 'url(garbage.otf)')).family", "a");
+shouldBeEqualToString("(new FontFace('4a', 'url(garbage.otf)')).family", "4a");
+shouldBeEqualToString("(new FontFace('4\"a', 'url(garbage.otf)')).family", "4\"a");
+shouldBeEqualToString("(new FontFace('4\\'a', 'url(garbage.otf)')).family", "4'a");
+shouldBeEqualToString("(new FontFace('4\\'a\"b', 'url(garbage.otf)')).family", "4'a\"b");
 shouldBeEqualToString("(new FontFace('ab', 'url(garbage.otf)')).family", "ab");
-shouldBeEqualToString("(new FontFace('\"ab\"', 'url(garbage.otf)')).family", "ab");
-shouldBeEqualToString("(new FontFace('a b', 'url(garbage.otf)')).family", "\"a b\"");
-shouldBeEqualToString("(new FontFace('a b, c', 'url(garbage.otf)')).family", "normal");
-shouldBeEqualToString("(new FontFace('ab,c', 'url(garbage.otf)')).family", "normal");
+shouldBeEqualToString("(new FontFace('\"ab\"', 'url(garbage.otf)')).family", "\"ab\"");
+shouldBeEqualToString("(new FontFace('a b', 'url(garbage.otf)')).family", "a b");
+shouldBeEqualToString("(new FontFace('a b, c', 'url(garbage.otf)')).family", "a b, c");
+shouldBeEqualToString("(new FontFace('ab,c', 'url(garbage.otf)')).family", "ab,c");
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -351,7 +351,11 @@ void CSSFontFace::setDisplay(CSSValue& loadingBehaviorValue)
 
 String CSSFontFace::family() const
 {
-    return properties().getPropertyValue(CSSPropertyFontFamily);
+    RefPtr value = dynamicDowncast<CSSPrimitiveValue>(properties().getPropertyCSSValue(CSSPropertyFontFamily));
+    if (!value)
+        return { };
+    ASSERT(value->isFontFamily());
+    return value->stringValue();
 }
 
 String CSSFontFace::style() const

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -67,7 +67,7 @@ Ref<FontFace> FontFace::create(ScriptExecutionContext& context, const String& fa
 #endif
     bool dataRequiresAsynchronousLoading = true;
 
-    auto setFamilyResult = result->setFamily(context, family);
+    auto setFamilyResult = result->setFamily(family);
     if (setFamilyResult.hasException()) {
         result->setErrorState();
         return result;
@@ -179,13 +179,12 @@ FontFace::~FontFace()
     m_backing->removeClient(*this);
 }
 
-ExceptionOr<void> FontFace::setFamily(ScriptExecutionContext& context, const String& family)
+ExceptionOr<void> FontFace::setFamily(const String& family)
 {
-    if (auto value = CSSPropertyParserHelpers::parseFontFaceFontFamily(family, context)) {
-        m_backing->setFamily(*value);
-        return { };
-    }
-    return Exception { ExceptionCode::SyntaxError };
+    if (family.isEmpty())
+        return Exception { ExceptionCode::SyntaxError };
+    m_backing->setFamily(CSSPrimitiveValue::createFontFamily(family));
+    return { };
 }
 
 ExceptionOr<void> FontFace::setStyle(ScriptExecutionContext& context, const String& style)

--- a/Source/WebCore/css/FontFace.h
+++ b/Source/WebCore/css/FontFace.h
@@ -65,7 +65,7 @@ public:
     static Ref<FontFace> create(ScriptExecutionContext*, CSSFontFace&);
     virtual ~FontFace();
 
-    ExceptionOr<void> setFamily(ScriptExecutionContext&, const String&);
+    ExceptionOr<void> setFamily(const String&);
     ExceptionOr<void> setStyle(ScriptExecutionContext&, const String&);
     ExceptionOr<void> setWeight(ScriptExecutionContext&, const String&);
     ExceptionOr<void> setWidth(ScriptExecutionContext&, const String&);

--- a/Source/WebCore/css/FontFace.idl
+++ b/Source/WebCore/css/FontFace.idl
@@ -50,7 +50,7 @@ dictionary FontFaceDescriptors {
 ] interface FontFace {
     [CallWith=CurrentScriptExecutionContext] constructor(DOMString family, (DOMString or BinaryData) source, optional FontFaceDescriptors descriptors = {});
 
-    [SetterCallWith=CurrentScriptExecutionContext] attribute DOMString family;
+    attribute DOMString family;
     [SetterCallWith=CurrentScriptExecutionContext] attribute DOMString style;
     [SetterCallWith=CurrentScriptExecutionContext] attribute DOMString weight;
     [SetterCallWith=CurrentScriptExecutionContext] attribute DOMString width;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -497,30 +497,6 @@ RefPtr<CSSValue> consumeFontSizeAdjust(CSSParserTokenRange& range, CSS::Property
 
 // MARK: - @font-face
 
-// MARK: @font-face 'font-family'
-
-RefPtr<CSSValue> parseFontFaceFontFamily(const String& string, ScriptExecutionContext& context)
-{
-    // <'font-family'> = <family-name>
-    // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-family
-
-    CSSParserContext parserContext(parserMode(context));
-    CSSParser parser(parserContext, string);
-    CSSParserTokenRange range = parser.tokenizer()->tokenRange();
-
-    range.consumeWhitespace();
-
-    if (range.atEnd())
-        return nullptr;
-
-    auto state = CSS::PropertyParserState { .context = parserContext, .pool = context.cssValuePool() };
-    auto parsedValue = CSSPropertyParsing::consumeFontFaceFontFamily(range, state);
-    if (!parsedValue || !range.atEnd())
-        return nullptr;
-
-    return parsedValue;
-}
-
 // MARK: @font-face 'src'
 
 Vector<FontTechnology> consumeFontTech(CSSParserTokenRange& range, CSS::PropertyParserState&, bool singleValue)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
@@ -122,10 +122,6 @@ RefPtr<CSSValue> consumeFontSizeAdjust(CSSParserTokenRange&, CSS::PropertyParser
 
 // MARK: - @font-face descriptor consumers
 
-// MARK: @font-face 'font-family'
-// https://drafts.csswg.org/css-fonts-4/#font-family-desc
-RefPtr<CSSValue> parseFontFaceFontFamily(const String&, ScriptExecutionContext&);
-
 // MARK: @font-face 'src'
 // https://drafts.csswg.org/css-fonts-4/#src-desc
 RefPtr<CSSValueList> parseFontFaceSrc(const String&, ScriptExecutionContext&);


### PR DESCRIPTION
#### 3208096991b941e064c217b0a903a8374f2507a2
<pre>
REGRESSION (Safari 26): `@font-face` / `FontFace.family` fails when font family name contains space (e.g. &quot;Lato 2&quot;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=300620">https://bugs.webkit.org/show_bug.cgi?id=300620</a>
<a href="https://rdar.apple.com/162637501">rdar://162637501</a>

Reviewed by Tim Nguyen.

While the specification isn&apos;t clear enough on this, the FontFace interface should
treat the font family as just a string, without parsing or serializing steps.
This is the de facto standard since both Chrome and Firefox work this way, and
WebKit worked roughly this way before changes earlier this year.

Besides this bug fix it would be good to:
- make the specification correct and unambiguous on this point
- add tests to Web Platform Tests
- add tests covering FontFace family setter
- add tests covering FontFace with family from @font-face rule

* LayoutTests/fast/text/font-face-family-expected.txt: Updated to expect font
family name to be treated as a string, not parsed with the &lt;font-family&gt; syntax.
* LayoutTests/fast/text/font-face-family.html: Ditto.

* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::family const): Get the string value of the font family
property rather than serializing it. Code is slightly confusing because of the
way we share the StyleProperties between the font-family descriptor and the
font-family property, since the latter can contain a list of families, and
can include generic families rather than families specified by font name.

* Source/WebCore/css/FontFace.cpp:
(WebCore::FontFace::create): Updated since setFamily no longer requires a
ScriptExecutionContext argument since it no longer does any parsing.
(WebCore::FontFace::setFamily): Set from a string, without parsing.
Retains the &quot;empty string is a syntax error&quot; behavior, since we have a
test that expects it; would be easy to remove that too and allow empty
strings, but I&apos;d want to test the other browser engine behavior first,
and it&apos;s not urgent to deal with this edge case.
* Source/WebCore/css/FontFace.h: Removed the ScriptExecutionContext from
the setFamily function, since it no longer does parsing.
* Source/WebCore/css/FontFace.idl: Ditto.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
(WebCore::CSSPropertyParserHelpers::parseFontFaceFontFamily): Deleted.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h: Deleted
unneeded parseFontFaceFontFamily function declaration.

Canonical link: <a href="https://commits.webkit.org/301793@main">https://commits.webkit.org/301793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c11c915004dd15fbc9739a06fb812326a902661

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134082 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78642 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e9e98d8b-0fee-49bb-a8dd-e60f8929988d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55242 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64743 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bc7c3ddc-6f7d-4cb3-8887-515c45035522) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113771 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77214 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/44642cf3-0de8-41b3-ab97-a16203eabd3d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31905 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77474 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107754 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136608 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53735 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/41389 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110129 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50438 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28851 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51275 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19872 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53667 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59540 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52905 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56238 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54663 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->