### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for PageGroup

### DIFF
--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -255,7 +255,7 @@ void MediaControlTextTrackContainerElement::updateActiveCuesFontSize()
     if (!mediaElement)
         return;
 
-    float fontScale = document().page()->group().ensureProtectedCaptionPreferences()->captionFontSizeScaleAndImportance(m_fontSizeIsImportant);
+    float fontScale = document().page()->checkedGroup()->ensureProtectedCaptionPreferences()->captionFontSizeScaleAndImportance(m_fontSizeIsImportant);
 
     // Caption fonts are defined as |size vh| units, so there's no need to
     // scale by display size. Since |vh| is a decimal percentage, multiply
@@ -291,7 +291,7 @@ void MediaControlTextTrackContainerElement::updateTextStrokeStyle()
     bool important;
 
     // FIXME: find a way to set this property in the stylesheet like the other user style preferences, see <https://bugs.webkit.org/show_bug.cgi?id=169874>.
-    if (document().page()->group().ensureProtectedCaptionPreferences()->captionStrokeWidthForFont(m_fontSize, language, strokeWidth, important))
+    if (document().page()->checkedGroup()->ensureProtectedCaptionPreferences()->captionStrokeWidthForFont(m_fontSize, language, strokeWidth, important))
         setInlineStyleProperty(CSSPropertyStrokeWidth, strokeWidth, CSSUnitType::CSS_PX, important ? IsImportant::Yes : IsImportant::No);
 }
 

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -179,7 +179,7 @@ void CaptionUserPreferences::setUserPrefersTextDescriptions(bool preference)
 
 void CaptionUserPreferences::captionPreferencesChanged()
 {
-    m_pageGroup->captionPreferencesChanged();
+    CheckedRef { m_pageGroup.get() }->captionPreferencesChanged();
 }
 
 Vector<String> CaptionUserPreferences::preferredLanguages() const

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1058,10 +1058,10 @@ void Page::goToItemForNavigationAPI(LocalFrame& frame, HistoryItem& item, FrameL
 
 void Page::setGroupName(const String& name)
 {
-    if (m_group && !m_group->name().isEmpty()) {
-        ASSERT(m_group != m_singlePageGroup.get());
+    if (CheckedPtr group = m_group.get(); group && !group->name().isEmpty()) {
+        ASSERT(group != m_singlePageGroup.get());
         ASSERT(!m_singlePageGroup);
-        m_group->removePage(*this);
+        group->removePage(*this);
     }
 
     if (name.isEmpty())
@@ -1069,7 +1069,7 @@ void Page::setGroupName(const String& name)
     else {
         m_singlePageGroup = nullptr;
         m_group = PageGroup::pageGroup(name);
-        m_group->addPage(*this);
+        CheckedRef { *m_group }->addPage(*this);
     }
 }
 
@@ -2019,6 +2019,11 @@ PageGroup& Page::group()
     if (!m_group)
         initGroup();
     return *m_group;
+}
+
+CheckedRef<PageGroup> Page::checkedGroup()
+{
+    return group();
 }
     
 void Page::setVerticalScrollElasticity(ScrollElasticity elasticity)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -462,6 +462,7 @@ public:
     WEBCORE_EXPORT const String& groupName() const;
 
     WEBCORE_EXPORT PageGroup& group();
+    WEBCORE_EXPORT CheckedRef<PageGroup> checkedGroup();
 
     BroadcastChannelRegistry& broadcastChannelRegistry() { return m_broadcastChannelRegistry; }
     WEBCORE_EXPORT Ref<BroadcastChannelRegistry> protectedBroadcastChannelRegistry() const;

--- a/Source/WebCore/page/PageGroup.h
+++ b/Source/WebCore/page/PageGroup.h
@@ -25,19 +25,11 @@
 
 #pragma once
 
+#include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
-
-namespace WebCore {
-class PageGroup;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PageGroup> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -46,9 +38,10 @@ class Page;
 class CaptionUserPreferences;
 #endif
 
-class PageGroup : public CanMakeWeakPtr<PageGroup> {
+class PageGroup final : public CanMakeWeakPtr<PageGroup>, public CanMakeCheckedPtr<PageGroup> {
     WTF_MAKE_TZONE_ALLOCATED(PageGroup);
     WTF_MAKE_NONCOPYABLE(PageGroup);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageGroup);
 public:
     WEBCORE_EXPORT explicit PageGroup(const String& name);
     explicit PageGroup(Page&);

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -506,7 +506,7 @@ void PlaybackSessionModelMediaElement::updateMediaSelectionOptions()
     if (!mediaElement->document().page())
         return;
 
-    auto& captionPreferences = mediaElement->document().page()->group().ensureCaptionPreferences();
+    auto& captionPreferences = mediaElement->document().page()->checkedGroup()->ensureCaptionPreferences();
     auto* textTracks = mediaElement->textTracks();
     if (textTracks && textTracks->length())
         m_legibleTracksForMenu = captionPreferences.sortedTrackListForMenu(textTracks, { TextTrack::Kind::Subtitles, TextTrack::Kind::Captions, TextTrack::Kind::Descriptions });
@@ -716,7 +716,7 @@ Vector<MediaSelectionOption> PlaybackSessionModelMediaElement::audioMediaSelecti
     if (!mediaElement || !mediaElement->document().page())
         return { };
 
-    auto& captionPreferences = mediaElement->document().page()->group().ensureCaptionPreferences();
+    auto& captionPreferences = mediaElement->document().page()->checkedGroup()->ensureCaptionPreferences();
     return m_audioTracksForMenu.map([&](auto& audioTrack) {
         return captionPreferences.mediaSelectionOptionForTrack(audioTrack.get());
     });
@@ -739,7 +739,7 @@ Vector<MediaSelectionOption> PlaybackSessionModelMediaElement::legibleMediaSelec
     if (!mediaElement || !mediaElement->document().page())
         return { };
 
-    auto& captionPreferences = mediaElement->document().page()->group().ensureCaptionPreferences();
+    auto& captionPreferences = mediaElement->document().page()->checkedGroup()->ensureCaptionPreferences();
     return m_legibleTracksForMenu.map([&](auto& track) {
         return captionPreferences.mediaSelectionOptionForTrack(track.get());
     });

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -445,7 +445,7 @@ ExceptionOr<void> InternalSettings::setShouldDisplayTrackKind(TrackKind kind, bo
     if (!m_page)
         return Exception { ExceptionCode::InvalidAccessError };
 #if ENABLE(VIDEO)
-    auto& captionPreferences = m_page->group().ensureCaptionPreferences();
+    auto& captionPreferences = m_page->checkedGroup()->ensureCaptionPreferences();
     switch (kind) {
     case TrackKind::Subtitles:
         captionPreferences.setUserPrefersSubtitles(enabled);
@@ -469,7 +469,7 @@ ExceptionOr<bool> InternalSettings::shouldDisplayTrackKind(TrackKind kind)
     if (!m_page)
         return Exception { ExceptionCode::InvalidAccessError };
 #if ENABLE(VIDEO)
-    auto& captionPreferences = m_page->group().ensureCaptionPreferences();
+    auto& captionPreferences = m_page->checkedGroup()->ensureCaptionPreferences();
     switch (kind) {
     case TrackKind::Subtitles:
         return captionPreferences.userPrefersSubtitles();


### PR DESCRIPTION
#### 08916ff9d786d9d41019282a1a336a6ff494f658
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for PageGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=301052">https://bugs.webkit.org/show_bug.cgi?id=301052</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateActiveCuesFontSize):
(WebCore::MediaControlTextTrackContainerElement::updateTextStrokeStyle):
* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::CaptionUserPreferences::captionPreferencesChanged):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setGroupName):
(WebCore::Page::checkedGroup):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageGroup.h:
(WebCore::PageGroup::pages const): Deleted.
(WebCore::PageGroup::name): Deleted.
(WebCore::PageGroup::identifier): Deleted.
(WebCore::PageGroup::captionPreferences const): Deleted.
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::updateMediaSelectionOptions):
(WebCore::PlaybackSessionModelMediaElement::audioMediaSelectionOptions const):
(WebCore::PlaybackSessionModelMediaElement::legibleMediaSelectionOptions const):
* Source/WebCore/testing/InternalSettings.cpp:
(WebCore::InternalSettings::setShouldDisplayTrackKind):
(WebCore::InternalSettings::shouldDisplayTrackKind):

Canonical link: <a href="https://commits.webkit.org/301789@main">https://commits.webkit.org/301789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0bf56362a4eecfcfa2938f2bfa19c92b518b165

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134052 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78612 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9d4241ed-4a58-4bdf-bba3-78f116397a2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96678 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64701 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ea0eef7a-c701-4f66-a008-ed78a7ef34ef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77188 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c2b7f3eb-db3a-4572-bbec-6ec10f6a0603) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36727 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31850 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77444 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119087 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136578 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105196 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26749 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50410 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28794 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51228 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53637 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59510 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52875 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56208 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54633 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->