### PR TITLE
Account for scrollbar height in grid layout height calculation

### DIFF
--- a/LayoutTests/fast/css-grid-layout/grid-item-nested-sizing-scroll-expected.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-nested-sizing-scroll-expected.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<style>
+.grid {
+  inline-size: 300px;
+  block-size: 300px;
+}
+
+.viewport {
+  overflow: auto;
+  inline-size: 100%;
+  block-size: 100%;
+}
+
+.viewport::-webkit-scrollbar {
+  inline-size: 10px;
+  block-size: 10px;
+}
+
+.viewport::-webkit-scrollbar-track {
+  background-color: gray;
+}
+
+.viewport::-webkit-scrollbar-thumb {
+  background-color: black;
+}
+
+.content {
+  background-color: green;
+  inline-size: 500px;
+  block-size: 100%;
+}
+</style>
+
+<p>Test PASS if you see 290x500 content that is NOT vertically scrollable</p>
+
+<div class="grid">
+  <div class="viewport">
+    <div class="content"></div>
+  </div>
+</div>

--- a/LayoutTests/fast/css-grid-layout/grid-item-nested-sizing-scroll.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-nested-sizing-scroll.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<style>
+.grid {
+  inline-size: 300px;
+  block-size: 300px;
+  display: grid;
+  grid-template-rows: 100%;
+  grid-template-columns: 100%;
+}
+
+.viewport {
+  overflow: auto;
+  display: grid;
+  grid-template-rows: 100%;
+}
+
+.viewport::-webkit-scrollbar {
+  inline-size: 10px;
+  block-size: 10px;
+}
+
+.viewport::-webkit-scrollbar-track {
+  background-color: gray;
+}
+
+.viewport::-webkit-scrollbar-thumb {
+  background-color: black;
+}
+
+.content {
+  background-color: green;
+  inline-size: 500px;
+}
+</style>
+
+<p>Test PASS if you see 290x500 content that is NOT vertically scrollable</p>
+
+<div class="grid">
+  <div class="viewport">
+    <div class="content"></div>
+  </div>
+</div>

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -414,7 +414,7 @@ const std::optional<LayoutUnit> RenderGrid::availableLogicalHeightForContentBox(
         return { };
 
     if (auto overridingLogicalHeight = this->overridingBorderBoxLogicalHeight())
-        return constrainContentBoxLogicalHeightByMinMax(*overridingLogicalHeight - borderAndPaddingLogicalHeight(), { });
+        return constrainContentBoxLogicalHeightByMinMax(*overridingLogicalHeight - borderAndPaddingLogicalHeight() - scrollbarLogicalHeight(), { });
     return availableLogicalHeight(AvailableLogicalHeightType::ExcludeMarginBorderPadding);
 }
 


### PR DESCRIPTION
#### 30b2329a80ec6dabe1102059f293d277cdebf932
<pre>
Account for scrollbar height in grid layout height calculation
<a href="https://bugs.webkit.org/show_bug.cgi?id=191461">https://bugs.webkit.org/show_bug.cgi?id=191461</a>

Reviewed by NOBODY (OOPS!).

Fixed an issue where `RenderGrid::availableLogicalHeightForContentBox` did not account for
scrollbar height when an overridingSize was present.

Test: fast/css-grid-layout/grid-item-nested-sizing-scroll.html

* LayoutTests/fast/css-grid-layout/grid-item-nested-sizing-scroll-expected.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-nested-sizing-scroll.html: Added.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::availableLogicalHeightForContentBox const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35f2ea59b1442d12e8c5c5ef6a32b93c1e34c026

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134089 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78649 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96707 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64751 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77217 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31923 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77481 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136615 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105227 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110148 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104916 "Found 1 new API test failure: WebKitGTK/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50445 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28865 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51284 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59547 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52912 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54670 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->