### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for ActivityStateChangeObserver

### DIFF
--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -252,7 +252,7 @@ void Geolocation::resetAllGeolocationPermission()
     if (m_allowGeolocation == InProgress) {
         RefPtr page = this->page();
         if (page)
-            GeolocationController::from(page.get())->cancelPermissionRequest(*this);
+            GeolocationController::checkedFrom(page.get())->cancelPermissionRequest(*this);
 
         // This return is not technically correct as GeolocationController::cancelPermissionRequest() should have cleared the active request.
         // Neither iOS nor macOS supports cancelPermissionRequest() (https://bugs.webkit.org/show_bug.cgi?id=89524), so we workaround that and let ongoing requests complete. :(
@@ -287,7 +287,7 @@ void Geolocation::stop()
 {
     RefPtr page = this->page();
     if (page && m_allowGeolocation == InProgress)
-        GeolocationController::from(page.get())->cancelPermissionRequest(*this);
+        GeolocationController::checkedFrom(page.get())->cancelPermissionRequest(*this);
     // The frame may be moving to a new page and we want to get the permissions from the new page's client.
     resetIsAllowed();
     cancelAllRequests();
@@ -303,7 +303,7 @@ GeolocationPosition* Geolocation::lastPosition()
     if (!page)
         return nullptr;
 
-    m_lastPosition = createGeolocationPosition(GeolocationController::from(page.get())->lastPosition());
+    m_lastPosition = createGeolocationPosition(GeolocationController::checkedFrom(page.get())->lastPosition());
 
     return m_lastPosition.get();
 }
@@ -656,7 +656,7 @@ void Geolocation::requestPermission()
     m_hasBeenRequested = true;
 
     // Ask the embedder: it maintains the geolocation challenge policy itself.
-    GeolocationController::from(page.get())->requestPermission(*this);
+    GeolocationController::checkedFrom(page.get())->requestPermission(*this);
 }
 
 void Geolocation::revokeAuthorizationTokenIfNecessary()
@@ -668,7 +668,7 @@ void Geolocation::revokeAuthorizationTokenIfNecessary()
     if (!page)
         return;
 
-    GeolocationController::from(page.get())->revokeAuthorizationToken(std::exchange(m_authorizationToken, String()));
+    GeolocationController::checkedFrom(page.get())->revokeAuthorizationToken(std::exchange(m_authorizationToken, String()));
 }
 
 void Geolocation::resetIsAllowed()
@@ -733,7 +733,7 @@ bool Geolocation::startUpdating(GeoNotifier* notifier)
     if (!page)
         return false;
 
-    GeolocationController::from(page.get())->addObserver(*this, notifier->options().enableHighAccuracy);
+    GeolocationController::checkedFrom(page.get())->addObserver(*this, notifier->options().enableHighAccuracy);
     return true;
 }
 
@@ -743,7 +743,7 @@ void Geolocation::stopUpdating()
     if (!page)
         return;
 
-    GeolocationController::from(page.get())->removeObserver(*this);
+    GeolocationController::checkedFrom(page.get())->removeObserver(*this);
 }
 
 void Geolocation::handlePendingPermissionNotifiers()

--- a/Source/WebCore/Modules/geolocation/GeolocationController.h
+++ b/Source/WebCore/Modules/geolocation/GeolocationController.h
@@ -42,9 +42,10 @@ class GeolocationClient;
 class GeolocationError;
 class GeolocationPositionData;
 
-class GeolocationController : public Supplement<Page>, private ActivityStateChangeObserver {
+class GeolocationController final : public Supplement<Page>, public ActivityStateChangeObserver {
     WTF_MAKE_TZONE_ALLOCATED(GeolocationController);
     WTF_MAKE_NONCOPYABLE(GeolocationController);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GeolocationController);
 public:
     GeolocationController(Page&, GeolocationClient&);
     ~GeolocationController();
@@ -65,6 +66,7 @@ public:
 
     WEBCORE_EXPORT static ASCIILiteral supplementName();
     static GeolocationController* from(Page* page) { return downcast<GeolocationController>(Supplement<Page>::from(page, supplementName())); }
+    static CheckedPtr<GeolocationController> checkedFrom(Page* page) { return from(page); }
 
     void revokeAuthorizationToken(const String&);
 

--- a/Source/WebCore/page/ActivityStateChangeObserver.h
+++ b/Source/WebCore/page/ActivityStateChangeObserver.h
@@ -26,24 +26,17 @@
 #pragma once
 
 #include <WebCore/ActivityState.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class ActivityStateChangeObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ActivityStateChangeObserver> : std::true_type { };
-}
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
-class ActivityStateChangeObserver : public CanMakeWeakPtr<ActivityStateChangeObserver> {
+class ActivityStateChangeObserver : public CanMakeWeakPtr<ActivityStateChangeObserver>, public CanMakeCheckedPtr<ActivityStateChangeObserver> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ActivityStateChangeObserver);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ActivityStateChangeObserver);
 public:
-    virtual ~ActivityStateChangeObserver()
-    {
-    }
+    virtual ~ActivityStateChangeObserver() = default;
     
     virtual void activityStateDidChange(OptionSet<ActivityState> oldActivityState, OptionSet<ActivityState> newActivityState) = 0;
 };

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1900,7 +1900,7 @@ void Page::didCommitLoad()
 #endif
 
 #if ENABLE(GEOLOCATION)
-    if (auto* geolocationController = GeolocationController::from(this))
+    if (CheckedPtr geolocationController = GeolocationController::from(this))
         geolocationController->didNavigatePage();
 #endif
 
@@ -3364,8 +3364,8 @@ void Page::setActivityState(OptionSet<ActivityState> activityState)
     if (changed.containsAny({ActivityState::IsVisible, ActivityState::IsVisuallyIdle, ActivityState::IsAudible, ActivityState::IsLoading, ActivityState::IsCapturingMedia }))
         updateTimerThrottlingState();
 
-    for (auto& observer : m_activityStateChangeObservers)
-        observer.activityStateDidChange(oldActivityState, m_activityState);
+    for (CheckedRef observer : m_activityStateChangeObservers)
+        observer->activityStateDidChange(oldActivityState, m_activityState);
 
     if (wasVisibleAndActive != isVisibleAndActive()) {
         if (RefPtr manager = mediaSessionManager())

--- a/Source/WebCore/platform/mock/GeolocationClientMock.cpp
+++ b/Source/WebCore/platform/mock/GeolocationClientMock.cpp
@@ -41,12 +41,8 @@
 namespace WebCore {
 
 GeolocationClientMock::GeolocationClientMock()
-    : m_controller(0)
-    , m_hasError(false)
-    , m_controllerTimer(*this, &GeolocationClientMock::controllerTimerFired)
+    : m_controllerTimer(*this, &GeolocationClientMock::controllerTimerFired)
     , m_permissionTimer(*this, &GeolocationClientMock::permissionTimerFired)
-    , m_isActive(false)
-    , m_permissionState(PermissionStateUnset)
 {
 }
 
@@ -55,7 +51,7 @@ GeolocationClientMock::~GeolocationClientMock()
     ASSERT(!m_isActive);
 }
 
-void GeolocationClientMock::setController(GeolocationController *controller)
+void GeolocationClientMock::setController(GeolocationController* controller)
 {
     ASSERT(controller && !m_controller);
     m_controller = controller;
@@ -172,14 +168,15 @@ void GeolocationClientMock::asyncUpdateController()
 
 void GeolocationClientMock::controllerTimerFired()
 {
-    ASSERT(m_controller);
+    CheckedPtr controller = m_controller.get();
+    ASSERT(controller);
 
     if (m_lastPosition) {
         ASSERT(!m_hasError);
-        m_controller->positionChanged(*m_lastPosition);
+        controller->positionChanged(*m_lastPosition);
     } else if (m_hasError) {
         auto geolocatioError = GeolocationError::create(GeolocationError::PositionUnavailable, m_errorMessage);
-        m_controller->errorOccurred(geolocatioError.get());
+        controller->errorOccurred(geolocatioError.get());
     }
 }
 

--- a/Source/WebCore/platform/mock/GeolocationClientMock.h
+++ b/Source/WebCore/platform/mock/GeolocationClientMock.h
@@ -83,19 +83,19 @@ private:
 
     void clearError();
 
-    GeolocationController* m_controller;
+    WeakPtr<GeolocationController> m_controller;
     std::optional<GeolocationPositionData> m_lastPosition;
-    bool m_hasError;
+    bool m_hasError { false };
     String m_errorMessage;
     Timer m_controllerTimer;
     Timer m_permissionTimer;
-    bool m_isActive;
+    bool m_isActive { false };
 
     enum PermissionState {
         PermissionStateUnset,
         PermissionStateAllowed,
         PermissionStateDenied,
-    } m_permissionState;
+    } m_permissionState { PermissionStateUnset };
 
     using GeolocationSet = HashSet<RefPtr<Geolocation>>;
     GeolocationSet m_pendingPermission;

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
@@ -158,7 +158,7 @@ void WebGeolocationManager::didChangePosition(const WebCore::RegistrableDomain& 
     if (auto it = m_pageSets.find(registrableDomain); it != m_pageSets.end()) {
         for (auto& page : copyToVector(it->value.pageSet)) {
             if (RefPtr corePage = page->corePage())
-                GeolocationController::from(corePage.get())->positionChanged(position);
+                GeolocationController::checkedFrom(corePage.get())->positionChanged(position);
         }
     }
 #else
@@ -176,7 +176,7 @@ void WebGeolocationManager::didFailToDeterminePosition(const WebCore::Registrabl
 
         for (auto& page : copyToVector(it->value.pageSet)) {
             if (RefPtr corePage = page->corePage())
-                GeolocationController::from(corePage.get())->errorOccurred(error.get());
+                GeolocationController::checkedFrom(corePage.get())->errorOccurred(error.get());
         }
     }
 #else


### PR DESCRIPTION
#### 0d06d701f0b934a54ebfef7809c4fb0839e911df
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for ActivityStateChangeObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=301060">https://bugs.webkit.org/show_bug.cgi?id=301060</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::resetAllGeolocationPermission):
(WebCore::Geolocation::stop):
(WebCore::Geolocation::lastPosition):
(WebCore::Geolocation::requestPermission):
(WebCore::Geolocation::revokeAuthorizationTokenIfNecessary):
(WebCore::Geolocation::startUpdating):
(WebCore::Geolocation::stopUpdating):
* Source/WebCore/Modules/geolocation/GeolocationController.h:
(WebCore::GeolocationController::from): Deleted.
(WebCore::GeolocationController::needsHighAccuracy const): Deleted.
* Source/WebCore/page/ActivityStateChangeObserver.h:
(WebCore::ActivityStateChangeObserver::~ActivityStateChangeObserver): Deleted.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCommitLoad):
(WebCore::Page::setActivityState):
* Source/WebCore/platform/mock/GeolocationClientMock.cpp:
(WebCore::GeolocationClientMock::GeolocationClientMock):
(WebCore::GeolocationClientMock::setController):
(WebCore::GeolocationClientMock::controllerTimerFired):
* Source/WebCore/platform/mock/GeolocationClientMock.h:
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp:
(WebKit::WebGeolocationManager::didChangePosition):
(WebKit::WebGeolocationManager::didFailToDeterminePosition):

Canonical link: <a href="https://commits.webkit.org/301796@main">https://commits.webkit.org/301796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5155d274bd58e29d94c073cad9ddc0b03013861

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127068 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134070 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78630 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/987940f3-60f4-4787-b4d6-52d2bdc7e4ae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96693 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64726 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ff24b360-cf0f-4648-9b36-8b3b80b7388d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77204 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ab70ebf0-cdd9-47b1-b31f-ad3161ca23b6) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31875 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77462 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136596 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105211 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104902 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26754 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50426 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28823 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51256 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59528 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158568 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52893 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/158568 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54651 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->