### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for TextTrackLoaderClient

### DIFF
--- a/Source/WebCore/html/track/LoadableTextTrack.h
+++ b/Source/WebCore/html/track/LoadableTextTrack.h
@@ -44,6 +44,9 @@ public:
     size_t trackElementIndex();
     HTMLTrackElement* trackElement() const { return m_trackElement.get(); }
 
+    void ref() const final { TextTrack::ref(); }
+    void deref() const final { TextTrack::deref(); }
+
 private:
     LoadableTextTrack(HTMLTrackElement&, const AtomString& kind, const AtomString& label, const AtomString& language);
 

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -46,8 +46,8 @@ class VTTRegionList;
 class TextTrack : public TrackBase, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(TextTrack);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
+    void ref() const override { TrackBase::ref(); }
+    void deref() const override { TrackBase::deref(); }
 
     static Ref<TextTrack> create(ScriptExecutionContext*, const AtomString& kind, TrackID, const AtomString& label, const AtomString& language);
     static Ref<TextTrack> create(ScriptExecutionContext*, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language);

--- a/Source/WebCore/loader/TextTrackLoader.cpp
+++ b/Source/WebCore/loader/TextTrackLoader.cpp
@@ -62,11 +62,11 @@ void TextTrackLoader::cueLoadTimerFired()
 {
     if (m_newCuesAvailable) {
         m_newCuesAvailable = false;
-        m_client->newCuesAvailable(*this);
+        protectedClient()->newCuesAvailable(*this);
     }
 
     if (m_state >= Finished)
-        m_client->cueLoadingCompleted(*this, m_state == Failed);
+        protectedClient()->cueLoadingCompleted(*this, m_state == Failed);
 }
 
 void TextTrackLoader::cancelLoad()
@@ -176,12 +176,12 @@ void TextTrackLoader::newCuesParsed()
 
 void TextTrackLoader::newRegionsParsed()
 {
-    m_client->newRegionsAvailable(*this);
+    protectedClient()->newRegionsAvailable(*this);
 }
 
 void TextTrackLoader::newStyleSheetsParsed()
 {
-    m_client->newStyleSheetsAvailable(*this);
+    protectedClient()->newStyleSheetsAvailable(*this);
 }
 
 void TextTrackLoader::fileFailedToParse()

--- a/Source/WebCore/loader/TextTrackLoader.h
+++ b/Source/WebCore/loader/TextTrackLoader.h
@@ -33,17 +33,9 @@
 #include "Timer.h"
 #include "WebVTTParser.h"
 #include <memory>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class TextTrackLoaderClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::TextTrackLoaderClient> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -53,7 +45,7 @@ class HTMLTrackElement;
 class TextTrackLoader;
 class VTTCue;
 
-class TextTrackLoaderClient : public CanMakeWeakPtr<TextTrackLoaderClient> {
+class TextTrackLoaderClient : public AbstractRefCountedAndCanMakeWeakPtr<TextTrackLoaderClient> {
 public:
     virtual ~TextTrackLoaderClient() = default;
     
@@ -95,6 +87,8 @@ private:
 
     Ref<Document> protectedDocument() const;
     CachedResourceHandle<CachedTextTrack> protectedResource() const;
+
+    Ref<TextTrackLoaderClient> protectedClient() const { return m_client.get(); }
 
     enum State { Idle, Loading, Finished, Failed };
 


### PR DESCRIPTION
#### b026c690a77b4fa143d17b2bede7bf35f6b4ed21
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for TextTrackLoaderClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=301062">https://bugs.webkit.org/show_bug.cgi?id=301062</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/html/track/LoadableTextTrack.h:
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/loader/TextTrackLoader.cpp:
(WebCore::TextTrackLoader::cueLoadTimerFired):
(WebCore::TextTrackLoader::newRegionsParsed):
(WebCore::TextTrackLoader::newStyleSheetsParsed):
* Source/WebCore/loader/TextTrackLoader.h:

Canonical link: <a href="https://commits.webkit.org/301795@main">https://commits.webkit.org/301795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38b44b0f8693704999f4f4e679be454f124a9a38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78629 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8c060420-7d79-4d61-88e4-8ae1e55a852f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96692 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64730 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/252cc16d-ff34-465c-8e28-0ae2fdedaa01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77203 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8c269a62-8cf2-443a-b934-bcffee7334d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36744 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31873 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77461 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107737 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136595 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105210 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104901 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26755 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50425 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28822 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51255 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53654 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59527 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52892 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56225 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54650 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->