### PR TITLE
Prepare Source/WebKit for clang static analyzer update (part 2)

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObject.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObject.mm
@@ -49,7 +49,7 @@
 
 - (BOOL)conformsToProtocol:(Protocol *)protocol
 {
-    return [super conformsToProtocol:protocol] || protocol_conformsToProtocol([_interface protocol], protocol);
+    return [super conformsToProtocol:protocol] || protocol_conformsToProtocol(retainPtr([_interface protocol]).get(), protocol);
 }
 
 static const char* methodArgumentTypeEncodingForSelector(Protocol *protocol, SEL selector)

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -97,7 +97,7 @@ struct PendingReply {
     if (!_remoteObjectProxies)
         _remoteObjectProxies = [NSMapTable strongToWeakObjectsMapTable];
 
-    if (RetainPtr<id> remoteObjectProxy = [_remoteObjectProxies objectForKey:interface.identifier])
+    if (RetainPtr<id> remoteObjectProxy = [_remoteObjectProxies objectForKey:retainPtr(interface.identifier).get()])
         return remoteObjectProxy.autorelease();
 
     RetainPtr<NSString> identifier = adoptNS([interface.identifier copy]);
@@ -208,7 +208,7 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
     if (!targetMethodSignature)
         return nil;
 
-    return [targetMethodSignature _signatureForBlockAtArgumentIndex:blockIndex]._typeString;
+    return retainPtr([targetMethodSignature _signatureForBlockAtArgumentIndex:blockIndex]).get()._typeString;
 }
 
 - (void)_invokeMethod:(const WebKit::RemoteObjectInvocation&)remoteObjectInvocation
@@ -248,7 +248,7 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
         }
 
         RetainPtr<NSString> wireBlockSignature = [NSMethodSignature signatureWithObjCTypes:replyInfo->blockSignature.utf8().data()]._typeString;
-        RetainPtr<NSString> expectedBlockSignature = replyBlockSignature([interface protocol], invocation.get().selector, i);
+        RetainPtr<NSString> expectedBlockSignature = replyBlockSignature(retainPtr([interface protocol]).get(), invocation.get().selector, i);
 
         if (!expectedBlockSignature) {
             NSLog(@"_invokeMethod: Failed to validate reply block signature: could not find local signature");

--- a/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
+++ b/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
@@ -140,7 +140,7 @@ void WebPaymentCoordinatorProxy::platformHidePaymentUI()
     [[NSNotificationCenter defaultCenter] removeObserver:m_sheetWindowWillCloseObserver.get()];
     m_sheetWindowWillCloseObserver = nullptr;
 
-    [[m_sheetWindow sheetParent] endSheet:m_sheetWindow.get()];
+    [retainPtr([m_sheetWindow sheetParent]) endSheet:m_sheetWindow.get()];
 
     if (RefPtr authorizationPresenter = m_authorizationPresenter)
         authorizationPresenter->dismiss();

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -106,7 +106,7 @@ void AuxiliaryProcess::platformInitialize(const AuxiliaryProcessInitializationPa
 #endif
     floatingPointEnvironment.saveMainThreadEnvironment();
 
-    [[NSFileManager defaultManager] changeCurrentDirectoryPath:[[NSBundle mainBundle] bundlePath]];
+    [[NSFileManager defaultManager] changeCurrentDirectoryPath:retainPtr([[NSBundle mainBundle] bundlePath]).get()];
 
     setApplicationBundleIdentifier(parameters.clientBundleIdentifier);
 

--- a/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
+++ b/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
@@ -227,7 +227,7 @@ bool hasProhibitedUsageStrings()
 
     for (NSString *prohibitedString : prohibitedStrings) {
         if ([infoDictionary objectForKey:prohibitedString]) {
-            String message = adoptNS([[NSString alloc] initWithFormat:@"[In-App Browser Privacy] %@ used prohibited usage string %@.", [[NSBundle mainBundle] bundleIdentifier], prohibitedString]).get();
+            String message = adoptNS([[NSString alloc] initWithFormat:@"[In-App Browser Privacy] %@ used prohibited usage string %@.", retainPtr([[NSBundle mainBundle] bundleIdentifier]).get(), prohibitedString]).get();
             WTFLogAlways("%s", message.utf8().data());
             hasProhibitedUsageStrings = true;
             break;

--- a/Source/WebKit/Shared/Cocoa/WebIconUtilities.mm
+++ b/Source/WebKit/Shared/Cocoa/WebIconUtilities.mm
@@ -113,7 +113,7 @@ RetainPtr<CocoaImage> fallbackIconForFile(NSURL *file)
 
 #if PLATFORM(MAC)
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return [[NSWorkspace sharedWorkspace] iconForFileType:[@"." stringByAppendingString:file.pathExtension]];
+    return [[NSWorkspace sharedWorkspace] iconForFileType:retainPtr([@"." stringByAppendingString:retainPtr(file.pathExtension).get()]).get()];
 ALLOW_DEPRECATED_DECLARATIONS_END
 #else
     NSError *error = nil;

--- a/Source/WebKit/Shared/mac/PrintInfoMac.mm
+++ b/Source/WebKit/Shared/mac/PrintInfoMac.mm
@@ -33,7 +33,7 @@
 namespace WebKit {
 
 PrintInfo::PrintInfo(NSPrintInfo *printInfo)
-    : pageSetupScaleFactor([[[printInfo dictionary] objectForKey:NSPrintScalingFactor] floatValue])
+    : pageSetupScaleFactor([[retainPtr([printInfo dictionary]).get() objectForKey:NSPrintScalingFactor] floatValue])
     , availablePaperWidth([printInfo paperSize].width - [printInfo leftMargin] - [printInfo rightMargin])
     , availablePaperHeight([printInfo paperSize].height - [printInfo topMargin] - [printInfo bottomMargin])
     , margin(WebCore::narrowPrecisionToFloatFromCGFloat([printInfo topMargin]), WebCore::narrowPrecisionToFloatFromCGFloat([printInfo rightMargin]), WebCore::narrowPrecisionToFloatFromCGFloat([printInfo bottomMargin]), WebCore::narrowPrecisionToFloatFromCGFloat([printInfo leftMargin]))

--- a/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
@@ -145,7 +145,7 @@ RefPtr<WebCore::FragmentedSharedBuffer> Attachment::associatedElementData() cons
     if (m_associatedElementType == WebCore::AttachmentAssociatedElementType::None)
         return nullptr;
 
-    NSData *data = nil;
+    RetainPtr<NSData> data;
     {
         Locker locker { m_fileWrapperLock };
 
@@ -158,7 +158,7 @@ RefPtr<WebCore::FragmentedSharedBuffer> Attachment::associatedElementData() cons
     if (!data)
         return nullptr;
 
-    return WebCore::SharedBuffer::create(data);
+    return WebCore::SharedBuffer::create(data.get());
 }
 
 RetainPtr<NSData> Attachment::associatedElementNSData() const

--- a/Source/WebKit/UIProcess/API/Cocoa/APIContentRuleListStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIContentRuleListStoreCocoa.mm
@@ -39,17 +39,17 @@ WTF::String ContentRuleListStore::defaultStorePath()
     static NeverDestroyed<RetainPtr<NSURL>> contentRuleListStoreURL;
 
     dispatch_once(&onceToken, ^{
-        NSURL *url = [[NSFileManager defaultManager] URLForDirectory:NSLibraryDirectory inDomain:NSUserDomainMask appropriateForURL:nullptr create:NO error:nullptr];
+        RetainPtr<NSURL> url = [[NSFileManager defaultManager] URLForDirectory:NSLibraryDirectory inDomain:NSUserDomainMask appropriateForURL:nullptr create:NO error:nullptr];
         if (!url)
             RELEASE_ASSERT_NOT_REACHED();
 
         url = [url URLByAppendingPathComponent:@"WebKit" isDirectory:YES];
 
         if (!WebKit::processHasContainer()) {
-            NSString *bundleIdentifier = [NSBundle mainBundle].bundleIdentifier;
+            RetainPtr<NSString> bundleIdentifier = [NSBundle mainBundle].bundleIdentifier;
             if (!bundleIdentifier)
                 bundleIdentifier = [NSProcessInfo processInfo].processName;
-            url = [url URLByAppendingPathComponent:bundleIdentifier isDirectory:YES];
+            url = [url URLByAppendingPathComponent:bundleIdentifier.get() isDirectory:YES];
         }
         
         contentRuleListStoreURL.get() = [url URLByAppendingPathComponent:@"ContentRuleLists" isDirectory:YES];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
@@ -46,15 +46,15 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    _WKContentWorldConfiguration *clone = [(_WKContentWorldConfiguration *)[[self class] allocWithZone:zone] init];
+    RetainPtr clone = adoptNS([(_WKContentWorldConfiguration *)[[self class] allocWithZone:zone] init]);
 
-    clone.name = self.name;
-    clone.allowAccessToClosedShadowRoots = self.allowAccessToClosedShadowRoots;
-    clone.allowAutofill = self.allowAutofill;
-    clone.allowElementUserInfo = self.allowElementUserInfo;
-    clone.disableLegacyBuiltinOverrides = self.disableLegacyBuiltinOverrides;
+    clone.get().name = self.name;
+    clone.get().allowAccessToClosedShadowRoots = self.allowAccessToClosedShadowRoots;
+    clone.get().allowAutofill = self.allowAutofill;
+    clone.get().allowElementUserInfo = self.allowElementUserInfo;
+    clone.get().disableLegacyBuiltinOverrides = self.disableLegacyBuiltinOverrides;
 
-    return clone;
+    return clone.leakRef();
 }
 
 #pragma mark NSSecureCoding protocol implementation
@@ -66,7 +66,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (void)encodeWithCoder:(NSCoder *)coder
 {
-    [coder encodeObject:self.name forKey:@"name"];
+    [coder encodeObject:retainPtr(self.name).get() forKey:@"name"];
     [coder encodeBool:self.allowAccessToClosedShadowRoots forKey:@"allowAccessToClosedShadowRoots"];
     [coder encodeBool:self.allowAutofill forKey:@"allowAutofill"];
     [coder encodeBool:self.allowElementUserInfo forKey:@"allowElementUserInfo"];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
@@ -134,9 +134,9 @@ private:
             }
 
             NSFileManager *fileManager = [NSFileManager defaultManager];
-            if (![fileManager fileExistsAtPath:[destination URLByDeletingLastPathComponent].path])
+            if (![fileManager fileExistsAtPath:retainPtr([destination URLByDeletingLastPathComponent].path).get()])
                 return completionHandler(WebKit::AllowOverwrite::No, { });
-            if ([fileManager fileExistsAtPath:destination.path])
+            if ([fileManager fileExistsAtPath:retainPtr(destination.path).get()])
                 return completionHandler(WebKit::AllowOverwrite::No, { });
 
             protectedWrapper(download.get()).get().progress.fileURL = destination;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFindConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFindConfiguration.mm
@@ -45,13 +45,13 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    WKFindConfiguration *findConfiguration = [(WKFindConfiguration *)[[self class] allocWithZone:zone] init];
+    RetainPtr findConfiguration = adoptNS([(WKFindConfiguration *)[[self class] allocWithZone:zone] init]);
 
-    findConfiguration.backwards = _backwards;
-    findConfiguration.caseSensitive = _caseSensitive;
-    findConfiguration.wraps = _wraps;
+    findConfiguration.get().backwards = _backwards;
+    findConfiguration.get().caseSensitive = _caseSensitive;
+    findConfiguration.get().wraps = _wraps;
 
-    return findConfiguration;
+    return findConfiguration.leakRef();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFindResult.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFindResult.mm
@@ -49,9 +49,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    WKFindResult *findResult = [(WKFindResult *)[[self class] allocWithZone:zone] _initWithMatchFound:_matchFound];
-
-    return findResult;
+    return adoptNS([(WKFindResult *)[[self class] allocWithZone:zone] _initWithMatchFound:_matchFound]).leakRef();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -55,7 +55,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p; webView = %p; isMainFrame = %s; request = %@>", NSStringFromClass(self.class), self, self.webView, self.mainFrame ? "YES" : "NO", self.request];
+    return [NSString stringWithFormat:@"<%@: %p; webView = %p; isMainFrame = %s; request = %@>", NSStringFromClass(self.class), self, retainPtr(self.webView).get(), self.mainFrame ? "YES" : "NO", retainPtr(self.request).get()];
 }
 
 - (BOOL)isMainFrame

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -100,7 +100,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 #else
         0L, 0.0, 0.0,
 #endif
-        self.request, self.sourceFrame, self.targetFrame];
+        retainPtr(self.request).get(), retainPtr(self.sourceFrame).get(), retainPtr(self.targetFrame).get()];
 }
 
 - (WKFrameInfo *)sourceFrame

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -46,7 +46,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p; response = %@>", NSStringFromClass(self.class), self, self.response];
+    return [NSString stringWithFormat:@"<%@: %p; response = %@>", NSStringFromClass(self.class), self, retainPtr(self.response).get()];
 }
 
 - (BOOL)isForMainFrame

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPDFConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPDFConfiguration.mm
@@ -44,12 +44,12 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    WKPDFConfiguration *pdfConfiguration = [(WKPDFConfiguration *)[[self class] allocWithZone:zone] init];
+    RetainPtr pdfConfiguration = adoptNS([(WKPDFConfiguration *)[[self class] allocWithZone:zone] init]);
 
-    pdfConfiguration.rect = self.rect;
-    pdfConfiguration.allowTransparentBackground = self.allowTransparentBackground;
+    pdfConfiguration.get().rect = self.rect;
+    pdfConfiguration.get().allowTransparentBackground = self.allowTransparentBackground;
 
-    return pdfConfiguration;
+    return pdfConfiguration.leakRef();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -217,7 +217,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 + (NSURL *)_websiteDataURLForContainerWithURL:(NSURL *)containerURL bundleIdentifierIfNotInContainer:(NSString *)bundleIdentifier
 {
-    NSURL *url = [containerURL URLByAppendingPathComponent:@"Library" isDirectory:YES];
+    RetainPtr url = [containerURL URLByAppendingPathComponent:@"Library" isDirectory:YES];
     url = [url URLByAppendingPathComponent:@"WebKit" isDirectory:YES];
 
     if (!WebKit::processHasContainer() && bundleIdentifier)
@@ -277,8 +277,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     else
         [processPool->ensureProtectedBundleParameters() removeObjectForKey:parameter];
 
-    auto data = keyedArchiver.get().encodedData;
-    processPool->sendToAllProcesses(Messages::WebProcess::SetInjectedBundleParameter(parameter, span(data)));
+    RetainPtr<NSData> data = keyedArchiver.get().encodedData;
+    processPool->sendToAllProcesses(Messages::WebProcess::SetInjectedBundleParameter(parameter, span(data.get())));
 }
 
 - (void)_setObjectsForBundleParametersWithDictionary:(NSDictionary *)dictionary
@@ -296,8 +296,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     Ref processPool = *_processPool;
     [processPool->ensureProtectedBundleParameters() setValuesForKeysWithDictionary:copy.get()];
 
-    auto data = keyedArchiver.get().encodedData;
-    processPool->sendToAllProcesses(Messages::WebProcess::SetInjectedBundleParameters(span(data)));
+    RetainPtr<NSData> data = keyedArchiver.get().encodedData;
+    processPool->sendToAllProcesses(Messages::WebProcess::SetInjectedBundleParameters(span(data.get())));
 }
 
 #if !TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.mm
@@ -47,7 +47,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p; protocol = %@; host = %@; port = %li>", NSStringFromClass(self.class), self, self.protocol, self.host, (long)self.port];
+    return [NSString stringWithFormat:@"<%@: %p; protocol = %@; host = %@; port = %li>", NSStringFromClass(self.class), self, retainPtr(self.protocol).get(), retainPtr(self.host).get(), (long)self.port];
 }
 
 - (NSString *)protocol

--- a/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.mm
@@ -63,18 +63,18 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    WKSnapshotConfiguration *snapshotConfiguration = [(WKSnapshotConfiguration *)[[self class] allocWithZone:zone] init];
+    auto snapshotConfiguration = adoptNS([(WKSnapshotConfiguration *)[[self class] allocWithZone:zone] init]);
 
-    snapshotConfiguration.rect = self.rect;
-    snapshotConfiguration.snapshotWidth = self.snapshotWidth;
-    snapshotConfiguration.afterScreenUpdates = self.afterScreenUpdates;
+    snapshotConfiguration.get().rect = self.rect;
+    snapshotConfiguration.get().snapshotWidth = self.snapshotWidth;
+    snapshotConfiguration.get().afterScreenUpdates = self.afterScreenUpdates;
 
 #if PLATFORM(MAC)
-    snapshotConfiguration._includesSelectionHighlighting = self._includesSelectionHighlighting;
+    snapshotConfiguration.get()._includesSelectionHighlighting = self._includesSelectionHighlighting;
 #endif
-    snapshotConfiguration._usesTransparentBackground = self._usesTransparentBackground;
+    snapshotConfiguration.get()._usesTransparentBackground = self._usesTransparentBackground;
 
-    return snapshotConfiguration;
+    return snapshotConfiguration.leakRef();
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -323,7 +323,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
 - (void)_addScriptMessageHandler:(id <WKScriptMessageHandler>)scriptMessageHandler name:(NSString *)name contentWorld:(WKContentWorld *)contentWorld
 {
-    [self _addScriptMessageHandler:scriptMessageHandler name:name userContentWorld:contentWorld._userContentWorld];
+    [self _addScriptMessageHandler:scriptMessageHandler name:name userContentWorld:retainPtr(contentWorld._userContentWorld).get()];
 }
 
 - (void)_removeScriptMessageHandlerForName:(NSString *)name userContentWorld:(_WKUserContentWorld *)userContentWorld

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -329,9 +329,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    WKWebViewConfiguration *configuration = [(WKWebViewConfiguration *)[[self class] allocWithZone:zone] init];
+    RetainPtr configuration = adoptNS([(WKWebViewConfiguration *)[[self class] allocWithZone:zone] init]);
     [configuration _protectedPageConfiguration]->copyDataFrom(self._protectedPageConfiguration);
-    return configuration;
+    return configuration.leakRef();
 }
 
 - (void)setValue:(id)value forKey:(NSString *)key

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -134,7 +134,7 @@
 #if PLATFORM(IOS_FAMILY)
         dumpCALayer(ts, [_contentView layer], true);
 #else
-        dumpCALayer(ts, self.layer, true);
+        dumpCALayer(ts, retainPtr(self.layer).get(), true);
 #endif
     }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -403,7 +403,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 - (void)_setCustomHeaderFields:(NSArray<_WKCustomHeaderFields *> *)fields
 {
     Vector<WebCore::CustomHeaderFields> vector(fields.count, [fields](size_t i) {
-        _WKCustomHeaderFields *element = fields[i];
+        RetainPtr<_WKCustomHeaderFields> element = fields[i];
         return downcast<API::CustomHeaderFields>([element _apiObject]).coreFields();
     });
     protectedWebsitePolicies(self)->setCustomHeaderFields(WTFMove(vector));


### PR DESCRIPTION
#### 0c556b13ab1ea6861ffd38687f59775649b246ea
<pre>
Prepare Source/WebKit for clang static analyzer update (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301063">https://bugs.webkit.org/show_bug.cgi?id=301063</a>

Reviewed by Geoffrey Garen.

Deployed more smart pointers to prepare Source/WebKit for a future clang static analyzer update.

No new tests since there should be no behavioral difference.

* Source/WebKit/Shared/API/Cocoa/WKRemoteObject.mm:
(-[WKRemoteObject conformsToProtocol:]):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
(-[_WKRemoteObjectRegistry remoteObjectProxyWithInterface:]):
(replyBlockSignature):
(-[_WKRemoteObjectRegistry _invokeMethod:]):
* Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm:
(WebKit::WebPaymentCoordinatorProxy::platformHidePaymentUI):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::platformInitialize):
* Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm:
(WebKit::hasProhibitedUsageStrings):
* Source/WebKit/Shared/Cocoa/WebIconUtilities.mm:
(WebKit::fallbackIconForFile):
* Source/WebKit/Shared/mac/PrintInfoMac.mm:
(WebKit::PrintInfo::PrintInfo):
* Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm:
(API::Attachment::associatedElementData const):
* Source/WebKit/UIProcess/API/Cocoa/APIContentRuleListStoreCocoa.mm:
(API::ContentRuleListStore::defaultStorePath):
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(+[_WKAttributedStringWebViewCache invalidateGlobalConfigurationIfNeeded:]):
(+[_WKAttributedStringWebViewCache retrieveOrCreateWebView]):
(+[_WKAttributedStringWebViewCache cacheWebView:]):
(+[_WKAttributedStringWebViewCache purgeSingleWebView]):
(+[_WKAttributedStringWebViewCache purgeAllWebViews]):
(+[NSAttributedString loadFromHTMLWithFileURL:options:completionHandler:]):
(+[NSAttributedString loadFromHTMLWithString:options:completionHandler:]):
(+[NSAttributedString loadFromHTMLWithData:options:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm:
(-[_WKContentWorldConfiguration copyWithZone:]):
(-[_WKContentWorldConfiguration encodeWithCoder:]):
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKFindConfiguration.mm:
(-[WKFindConfiguration copyWithZone:]):
* Source/WebKit/UIProcess/API/Cocoa/WKFindResult.mm:
(-[WKFindResult copyWithZone:]):
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(-[WKFrameInfo description]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction description]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm:
(-[WKNavigationResponse description]):
* Source/WebKit/UIProcess/API/Cocoa/WKPDFConfiguration.mm:
(-[WKPDFConfiguration copyWithZone:]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(+[WKProcessPool _websiteDataURLForContainerWithURL:bundleIdentifierIfNotInContainer:]):
(-[WKProcessPool _setObject:forBundleParameter:]):
(-[WKProcessPool _setObjectsForBundleParametersWithDictionary:]):
* Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.mm:
(-[WKSecurityOrigin description]):
* Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.mm:
(-[WKSnapshotConfiguration copyWithZone:]):
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
(-[WKUserContentController _addScriptMessageHandler:name:contentWorld:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
(-[WKWebView _setupPageConfiguration:withPool:]):
(-[WKWebView initWithCoder:]):
(-[WKWebView encodeWithCoder:]):
(-[WKWebView loadHTMLString:baseURL:]):
(-[WKWebView resumeDownloadFromResumeData:completionHandler:]):
(-[WKWebView _evaluateJavaScript:asAsyncFunction:withSourceURL:withArguments:forceUserGesture:inFrame:inWorld:completionHandler:]):
(-[WKWebView _didInsertAttachment:withSource:]):
(-[WKWebView _didRemoveAttachment:]):
(-[WKWebView _didInvalidateDataForAttachment:]):
(-[WKWebView _storeAppHighlight:]):
(-[WKWebView _didChangeEditorState]):
(-[WKWebView loadSimulatedRequest:responseHTMLString:]):
(-[WKWebView loadFileRequest:allowingReadAccessToURL:]):
(-[WKWebView proofreadingSession:didReceiveSuggestions:processedRange:inContext:finished:]):
(-[WKWebView proofreadingSession:didUpdateState:forSuggestionWithUUID:inContext:]):
(-[WKWebView _proofreadingSessionShowDetailsForSuggestionWithUUID:relativeToRect:]):
(-[WKWebView _proofreadingSessionUpdateState:forSuggestionWithUUID:]):
(-[WKWebView _startTextManipulationsWithConfiguration:completion:]):
(-[WKWebView _completeTextManipulation:completion:]):
(-[WKWebView _completeTextManipulationForItems:completion:]):
(-[WKWebView _archiveWithConfiguration:completionHandler:]):
(-[WKWebView _createWebArchiveForFrames:rootFrame:completionHandler:]):
(-[WKWebView _performInteraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration copyWithZone:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _caLayerTreeAsText]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setCustomHeaderFields:]):

Canonical link: <a href="https://commits.webkit.org/301788@main">https://commits.webkit.org/301788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7bf7bbcca29e63ba3b69018929aa249a27538b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127075 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134077 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78637 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b5fa1f7c-3297-42a8-990f-54da08335092) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96698 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5e95261a-67df-4f11-a7e6-22ba29443ce8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113754 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77209 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ecdcdb6b-b4cd-4697-a26a-18e619948273) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36753 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31891 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77469 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136603 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105215 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104906 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50433 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28838 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51266 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19870 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53662 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59535 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52900 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56233 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54658 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->