### PR TITLE
Prepare Source/WebKit for clang static analyzer update (part 3)

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -124,8 +124,8 @@ static NSString *dataTypesToString(NSSet *dataTypes)
 {
     auto result = adoptNS([[NSMutableString alloc] initWithFormat:@"<%@: %p; displayName = %@; dataTypes = { %@ }", RetainPtr { NSStringFromClass(self.class) }.get(), self, self.displayName, dataTypesToString(self.dataTypes)]);
 
-    if (auto* dataSize = self._dataSize)
-        [result appendFormat:@"; _dataSize = { %llu bytes }", dataSize.totalSize];
+    if (RetainPtr<_WKWebsiteDataSize> dataSize = self._dataSize)
+        [result appendFormat:@"; _dataSize = { %llu bytes }", dataSize.get().totalSize];
 
     [result appendString:@">"];
     return result.autorelease();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -222,13 +222,13 @@ private:
         HashMap<WTF::String, bool> result;
         RetainPtr permissions = [m_delegate.get() notificationPermissionsForWebsiteDataStore:m_dataStore.get().get()];
         for (NSString *key in permissions.get()) {
-            NSNumber *value = permissions.get()[key];
+            RetainPtr<NSNumber> value = permissions.get()[key];
             auto originString = WebCore::SecurityOriginData::fromURL(URL(key)).toString();
             if (originString.isEmpty()) {
                 RELEASE_LOG(Push, "[WKWebsiteDataStoreDelegate notificationPermissionsForWebsiteDataStore:] returned a URL string that could not be parsed into a security origin. Skipping.");
                 continue;
             }
-            result.set(originString, value.boolValue);
+            result.set(originString, value.get().boolValue);
         }
 
         return result;
@@ -619,8 +619,8 @@ struct WKWebsiteData {
         }
 
         NSString *unsupportedPrefix = @"This API does not support fetching: ";
-        NSString *unsupportedMessage = [unsupportedPrefix stringByAppendingString:dataType];
-        NSDictionary *userInfo = @{ NSLocalizedDescriptionKey : unsupportedMessage, };
+        RetainPtr<NSString> unsupportedMessage = [unsupportedPrefix stringByAppendingString:dataType];
+        NSDictionary *userInfo = @{ NSLocalizedDescriptionKey : unsupportedMessage.get(), };
 
         completionHandler(nullptr, adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:userInfo]).get());
 
@@ -745,7 +745,7 @@ struct WKWebsiteData {
             _WKWebsiteDataTypeAlternativeServices
         ];
 
-        allWebsiteDataTypes.get() = [[self allWebsiteDataTypes] setByAddingObjectsFromArray:privateTypes];
+        allWebsiteDataTypes.get() = [retainPtr([self allWebsiteDataTypes]) setByAddingObjectsFromArray:privateTypes];
     });
 
     return allWebsiteDataTypes.get().get();

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -283,11 +283,11 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
     URL manifestURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"manifest_url"];
     URL startURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"start_url"];
     URL manifestId = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"manifestId"];
-    WebCore::CocoaColor *backgroundColor = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"background_color"];
-    WebCore::CocoaColor *themeColor = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"theme_color"];
-    NSArray<NSString *> *categories = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [NSString class]]] forKey:@"categories"];
-    NSArray<_WKApplicationManifestIcon *> *icons = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [_WKApplicationManifestIcon class]]] forKey:@"icons"];
-    NSArray<_WKApplicationManifestIcon *> *shortcuts = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [_WKApplicationManifestShortcut class], [_WKApplicationManifestIcon class]]] forKey:@"shortcuts"];
+    RetainPtr<WebCore::CocoaColor> backgroundColor = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"background_color"];
+    RetainPtr<WebCore::CocoaColor> themeColor = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"theme_color"];
+    RetainPtr<NSArray<NSString *>> categories = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [NSString class]]] forKey:@"categories"];
+    RetainPtr<NSArray<_WKApplicationManifestIcon *>> icons = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [_WKApplicationManifestIcon class]]] forKey:@"icons"];
+    RetainPtr<NSArray<_WKApplicationManifestIcon *>> shortcuts = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [_WKApplicationManifestShortcut class], [_WKApplicationManifestIcon class]]] forKey:@"shortcuts"];
 
     WebCore::ApplicationManifest coreApplicationManifest {
         WTFMove(rawJSON),
@@ -302,11 +302,11 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
         WTFMove(manifestURL),
         WTFMove(startURL),
         WTFMove(manifestId),
-        WebCore::roundAndClampToSRGBALossy(RetainPtr { backgroundColor.CGColor }.get()),
-        WebCore::roundAndClampToSRGBALossy(RetainPtr { themeColor.CGColor }.get()),
-        makeVector<String>(categories),
-        makeVector<WebCore::ApplicationManifest::Icon>(icons),
-        makeVector<WebCore::ApplicationManifest::Shortcut>(shortcuts),
+        WebCore::roundAndClampToSRGBALossy(RetainPtr { backgroundColor.get().CGColor }.get()),
+        WebCore::roundAndClampToSRGBALossy(RetainPtr { themeColor.get().CGColor }.get()),
+        makeVector<String>(categories.get()),
+        makeVector<WebCore::ApplicationManifest::Icon>(icons.get()),
+        makeVector<WebCore::ApplicationManifest::Shortcut>(shortcuts.get()),
     };
 
     API::Object::constructInWrapper<API::ApplicationManifest>(self, WTFMove(coreApplicationManifest));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
@@ -186,7 +186,7 @@ static const NSInteger InvalidAttachmentErrorCode = 2;
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p id='%@'>", [self class], self, self.uniqueIdentifier];
+    return [NSString stringWithFormat:@"<%@ %p id='%@'>", [self class], self, retainPtr(self.uniqueIdentifier).get()];
 }
 
 - (BOOL)isConnected

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.mm
@@ -44,15 +44,15 @@
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    _WKAutomationSessionConfiguration *configuration = [(_WKAutomationSessionConfiguration *)[[self class] allocWithZone:zone] init];
+    RetainPtr<_WKAutomationSessionConfiguration> configuration = adoptNS([(_WKAutomationSessionConfiguration *)[[self class] allocWithZone:zone] init]);
 
-    configuration.acceptInsecureCertificates = self.acceptInsecureCertificates;
-    configuration.allowsInsecureMediaCapture = self.allowsInsecureMediaCapture;
-    configuration.suppressesICECandidateFiltering = self.suppressesICECandidateFiltering;
-    configuration.alwaysAllowAutoplay = self.alwaysAllowAutoplay;
-    configuration.siteIsolationEnabled = self.siteIsolationEnabled;
+    configuration.get().acceptInsecureCertificates = self.acceptInsecureCertificates;
+    configuration.get().allowsInsecureMediaCapture = self.allowsInsecureMediaCapture;
+    configuration.get().suppressesICECandidateFiltering = self.suppressesICECandidateFiltering;
+    configuration.get().alwaysAllowAutoplay = self.alwaysAllowAutoplay;
+    configuration.get().siteIsolationEnabled = self.siteIsolationEnabled;
 
-    return configuration;
+    return configuration.leakRef();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
@@ -63,8 +63,8 @@ IGNORE_WARNINGS_END
 
 + (instancetype)downloadWithDownload:(WKDownload *)download
 {
-    if (_WKDownload *wrapper = [downloadWrapperMapSingleton() objectForKey:download])
-        return wrapper;
+    if (RetainPtr<_WKDownload> wrapper = [downloadWrapperMapSingleton() objectForKey:download])
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[_WKDownload alloc] initWithDownload2:download]);
     [downloadWrapperMapSingleton() setObject:wrapper.get() forKey:download];
     return wrapper.autorelease();

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
@@ -44,7 +44,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p; name = %@; key = %@; defaultValue = %s >", NSStringFromClass(self.class), self, self.name, self.key, self.defaultValue ? "on" : "off"];
+    return [NSString stringWithFormat:@"<%@: %p; name = %@; key = %@; defaultValue = %s >", NSStringFromClass(self.class), self, retainPtr(self.name).get(), retainPtr(self.key).get(), self.defaultValue ? "on" : "off"];
 }
 
 - (NSString *)name

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
@@ -200,18 +200,18 @@ Ref<WebKit::WebInspectorUIProxy> protectedInspector(_WKInspector *inspector)
 - (void)printErrorToConsole:(NSString *)error
 {
     // FIXME: This should use a new message source rdar://problem/34658378
-    [self.webView evaluateJavaScript:adoptNS([[NSString alloc] initWithFormat:@"console.error(\"%@\");", error]).get() completionHandler:nil];
+    [retainPtr(self.webView) evaluateJavaScript:adoptNS([[NSString alloc] initWithFormat:@"console.error(\"%@\");", error]).get() completionHandler:nil];
 }
 
 // MARK: _WKInspectorPrivate methods
 
 - (void)_setDiagnosticLoggingDelegate:(id<_WKDiagnosticLoggingDelegate>)delegate
 {
-    auto inspectorWebView = self.inspectorWebView;
+    RetainPtr<WKWebView> inspectorWebView = self.inspectorWebView;
     if (!inspectorWebView)
         return;
 
-    inspectorWebView._diagnosticLoggingDelegate = delegate;
+    inspectorWebView.get()._diagnosticLoggingDelegate = delegate;
     protectedInspector(self)->setDiagnosticLoggingAvailable(!!delegate);
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
@@ -97,7 +97,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    _WKInspectorConfiguration *configuration = [(_WKInspectorConfiguration *)[[self class] allocWithZone:zone] init];
+    RetainPtr<_WKInspectorConfiguration> configuration = adoptNS([(_WKInspectorConfiguration *)[[self class] allocWithZone:zone] init]);
 
     for (auto pair : _configuration->urlSchemeHandlers()) {
         Ref handler = downcast<WebKit::WebURLSchemeHandlerCocoa>(pair.first.get());
@@ -110,7 +110,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (auto* groupIdentifier = self.groupIdentifier)
         [configuration setGroupIdentifier:groupIdentifier];
 
-    return configuration;
+    return configuration.leakRef();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.mm
@@ -102,15 +102,15 @@
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    _WKInspectorDebuggableInfo *debuggableInfo = [(_WKInspectorDebuggableInfo *)[[self class] allocWithZone:zone] init];
+    RetainPtr<_WKInspectorDebuggableInfo> debuggableInfo = adoptNS([(_WKInspectorDebuggableInfo *)[[self class] allocWithZone:zone] init]);
 
-    debuggableInfo.debuggableType = self.debuggableType;
-    debuggableInfo.targetPlatformName = self.targetPlatformName;
-    debuggableInfo.targetBuildVersion = self.targetBuildVersion;
-    debuggableInfo.targetProductVersion = self.targetProductVersion;
-    debuggableInfo.targetIsSimulator = self.targetIsSimulator;
+    debuggableInfo.get().debuggableType = self.debuggableType;
+    debuggableInfo.get().targetPlatformName = self.targetPlatformName;
+    debuggableInfo.get().targetBuildVersion = self.targetBuildVersion;
+    debuggableInfo.get().targetProductVersion = self.targetProductVersion;
+    debuggableInfo.get().targetIsSimulator = self.targetIsSimulator;
 
-    return debuggableInfo;
+    return debuggableInfo.leakRef();
 }
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorTesting.mm
@@ -35,12 +35,12 @@
 
 static NSString *JavaScriptSnippetToOpenURLExternally(NSURL *url)
 {
-    return [NSString stringWithFormat:@"InspectorFrontendHost.openURLExternally(\"%@\")", url.absoluteString];
+    return [NSString stringWithFormat:@"InspectorFrontendHost.openURLExternally(\"%@\")", retainPtr(url.absoluteString).get()];
 }
 
 static NSString *JavaScriptSnippetToFetchURL(NSURL *url)
 {
-    return [NSString stringWithFormat:@"fetch(\"%@\")", url.absoluteString];
+    return [NSString stringWithFormat:@"fetch(\"%@\")", retainPtr(url.absoluteString).get()];
 }
 
 @implementation _WKInspector (WKTesting)
@@ -63,7 +63,7 @@ static NSString *JavaScriptSnippetToFetchURL(NSURL *url)
     else {
         // Force the navigation request to be handled naturally through the
         // internal NavigationDelegate of WKInspectorViewController.
-        [self.inspectorWebView loadRequest:[NSURLRequest requestWithURL:url]];
+        [retainPtr(self.inspectorWebView) loadRequest:[NSURLRequest requestWithURL:url]];
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
@@ -347,7 +347,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     RetainPtr description = adoptNS([[NSString alloc] initWithFormat:@"<%@: %p", NSStringFromClass(self.class), self]);
 
     if (!_processPoolConfiguration->injectedBundlePath().isEmpty())
-        return [description stringByAppendingFormat:@"; injectedBundleURL: \"%@\">", [self injectedBundleURL]];
+        return [description stringByAppendingFormat:@"; injectedBundleURL: \"%@\">", retainPtr([self injectedBundleURL]).get()];
 
     return [description stringByAppendingString:@">"];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
@@ -150,64 +150,64 @@ static _WKResourceLoadInfoResourceType toWKResourceLoadInfoResourceType(WebKit::
     if (!(self = [super init]))
         return nil;
 
-    NSNumber *resourceLoadID = [coder decodeObjectOfClass:[NSNumber class] forKey:@"resourceLoadID"];
+    RetainPtr<NSNumber> resourceLoadID = [coder decodeObjectOfClass:[NSNumber class] forKey:@"resourceLoadID"];
     if (!resourceLoadID) {
         [self release];
         return nil;
     }
 
-    _WKFrameHandle *frame = [coder decodeObjectOfClass:[_WKFrameHandle class] forKey:@"frame"];
+    RetainPtr<_WKFrameHandle> frame = [coder decodeObjectOfClass:[_WKFrameHandle class] forKey:@"frame"];
     if (!frame) {
         [self release];
         return nil;
     }
 
-    _WKFrameHandle *parentFrame = [coder decodeObjectOfClass:[_WKFrameHandle class] forKey:@"parentFrame"];
+    RetainPtr<_WKFrameHandle> parentFrame = [coder decodeObjectOfClass:[_WKFrameHandle class] forKey:@"parentFrame"];
     // parentFrame is nullable, so decoding null is ok.
 
-    NSUUID *documentID = [coder decodeObjectOfClass:NSUUID.class forKey:@"documentID"];
+    RetainPtr<NSUUID> documentID = [coder decodeObjectOfClass:NSUUID.class forKey:@"documentID"];
     // documentID is nullable, so decoding null is ok.
 
-    NSURL *originalURL = [coder decodeObjectOfClass:[NSURL class] forKey:@"originalURL"];
+    RetainPtr<NSURL> originalURL = [coder decodeObjectOfClass:[NSURL class] forKey:@"originalURL"];
     if (!originalURL) {
         [self release];
         return nil;
     }
 
-    NSString *originalHTTPMethod = [coder decodeObjectOfClass:[NSString class] forKey:@"originalHTTPMethod"];
+    RetainPtr<NSString> originalHTTPMethod = [coder decodeObjectOfClass:[NSString class] forKey:@"originalHTTPMethod"];
     if (!originalHTTPMethod) {
         [self release];
         return nil;
     }
 
-    NSDate *eventTimestamp = [coder decodeObjectOfClass:[NSDate class] forKey:@"eventTimestamp"];
+    RetainPtr<NSDate> eventTimestamp = [coder decodeObjectOfClass:[NSDate class] forKey:@"eventTimestamp"];
     if (!eventTimestamp) {
         [self release];
         return nil;
     }
 
-    NSNumber *loadedFromCache = [coder decodeObjectOfClass:[NSNumber class] forKey:@"loadedFromCache"];
+    RetainPtr<NSNumber> loadedFromCache = [coder decodeObjectOfClass:[NSNumber class] forKey:@"loadedFromCache"];
     if (!loadedFromCache) {
         [self release];
         return nil;
     }
 
-    NSNumber *type = [coder decodeObjectOfClass:[NSNumber class] forKey:@"type"];
+    RetainPtr<NSNumber> type = [coder decodeObjectOfClass:[NSNumber class] forKey:@"type"];
     if (!type) {
         [self release];
         return nil;
     }
 
     WebKit::ResourceLoadInfo info {
-        ObjectIdentifier<WebKit::NetworkResourceLoadIdentifierType>(resourceLoadID.unsignedLongLongValue),
+        ObjectIdentifier<WebKit::NetworkResourceLoadIdentifierType>(resourceLoadID.get().unsignedLongLongValue),
         frame->_frameHandle->frameID(),
         parentFrame ? parentFrame->_frameHandle->frameID() : std::nullopt,
-        documentID ? WTF::UUID::fromNSUUID(documentID) : std::nullopt,
-        originalURL,
-        originalHTTPMethod,
-        WallTime::fromRawSeconds(eventTimestamp.timeIntervalSince1970),
-        static_cast<bool>(loadedFromCache.boolValue),
-        static_cast<WebKit::ResourceLoadInfo::Type>(type.unsignedCharValue),
+        documentID ? WTF::UUID::fromNSUUID(documentID.get()) : std::nullopt,
+        originalURL.get(),
+        originalHTTPMethod.get(),
+        WallTime::fromRawSeconds(eventTimestamp.get().timeIntervalSince1970),
+        static_cast<bool>(loadedFromCache.get().boolValue),
+        static_cast<WebKit::ResourceLoadInfo::Type>(type.get().unsignedCharValue),
     };
 
     API::Object::constructInWrapper<API::ResourceLoadInfo>(self, WTFMove(info));
@@ -218,12 +218,12 @@ static _WKResourceLoadInfoResourceType toWKResourceLoadInfoResourceType(WebKit::
 - (void)encodeWithCoder:(NSCoder *)coder
 {
     [coder encodeObject:@(self.resourceLoadID) forKey:@"resourceLoadID"];
-    [coder encodeObject:self.frame forKey:@"frame"];
-    [coder encodeObject:self.parentFrame forKey:@"parentFrame"];
-    [coder encodeObject:self.documentID forKey:@"documentID"];
-    [coder encodeObject:self.originalURL forKey:@"originalURL"];
-    [coder encodeObject:self.originalHTTPMethod forKey:@"originalHTTPMethod"];
-    [coder encodeObject:self.eventTimestamp forKey:@"eventTimestamp"];
+    [coder encodeObject:retainPtr(self.frame).get() forKey:@"frame"];
+    [coder encodeObject:retainPtr(self.parentFrame).get() forKey:@"parentFrame"];
+    [coder encodeObject:retainPtr(self.documentID).get() forKey:@"documentID"];
+    [coder encodeObject:retainPtr(self.originalURL).get() forKey:@"originalURL"];
+    [coder encodeObject:retainPtr(self.originalHTTPMethod).get() forKey:@"originalHTTPMethod"];
+    [coder encodeObject:retainPtr(self.eventTimestamp).get() forKey:@"eventTimestamp"];
     [coder encodeObject:@(self.loadedFromCache) forKey:@"loadedFromCache"];
     [coder encodeObject:@(static_cast<unsigned char>(_info->resourceLoadType())) forKey:@"type"];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationItem.mm
@@ -90,9 +90,9 @@ NSString * const _WKTextManipulationItemErrorItemKey = @"item";
 
     __block BOOL tokensAreEqual = YES;
     NSUInteger count = std::min(self.tokens.count, otherItem.tokens.count);
-    [self.tokens enumerateObjectsAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, count)] options:0 usingBlock:^(_WKTextManipulationToken *token, NSUInteger index, BOOL* stop) {
-        _WKTextManipulationToken *otherToken = otherItem.tokens[index];
-        if (![token isEqualToTextManipulationToken:otherToken includingContentEquality:includingContentEquality]) {
+    [retainPtr(self.tokens) enumerateObjectsAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, count)] options:0 usingBlock:^(_WKTextManipulationToken *token, NSUInteger index, BOOL* stop) {
+        RetainPtr<_WKTextManipulationToken> otherToken = otherItem.tokens[index];
+        if (![token isEqualToTextManipulationToken:otherToken.get() includingContentEquality:includingContentEquality]) {
             tokensAreEqual = NO;
             *stop = YES;
         }
@@ -114,12 +114,12 @@ NSString * const _WKTextManipulationItemErrorItemKey = @"item";
 - (NSString *)_descriptionPreservingPrivacy:(BOOL)preservePrivacy
 {
     NSMutableArray<NSString *> *recursiveDescriptions = [NSMutableArray array];
-    [self.tokens enumerateObjectsUsingBlock:^(_WKTextManipulationToken *token, NSUInteger index, BOOL* stop) {
-        NSString *description = preservePrivacy ? token.description : token.debugDescription;
-        [recursiveDescriptions addObject:description];
+    [retainPtr(self.tokens) enumerateObjectsUsingBlock:^(_WKTextManipulationToken *token, NSUInteger index, BOOL* stop) {
+        RetainPtr<NSString> description = preservePrivacy ? token.description : token.debugDescription;
+        [recursiveDescriptions addObject:description.get()];
     }];
-    RetainPtr tokenDescription = adoptNS([[NSString alloc] initWithFormat:@"[\n\t%@\n]", [recursiveDescriptions componentsJoinedByString:@",\n\t"]]);
-    return [NSString stringWithFormat:@"<%@: %p; identifier = %@ tokens = %@>", self.class, self, self.identifier, tokenDescription.get()];
+    RetainPtr tokenDescription = adoptNS([[NSString alloc] initWithFormat:@"[\n\t%@\n]", retainPtr([recursiveDescriptions componentsJoinedByString:@",\n\t"]).get()]);
+    return [NSString stringWithFormat:@"<%@: %p; identifier = %@ tokens = %@>", self.class, self, retainPtr(self.identifier).get(), tokenDescription.get()];
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationToken.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationToken.mm
@@ -84,10 +84,10 @@ static BOOL isEqualOrBothNil(id a, id b)
     if (!otherToken)
         return NO;
 
-    BOOL equalIdentifiers = isEqualOrBothNil(self.identifier, otherToken.identifier);
+    BOOL equalIdentifiers = isEqualOrBothNil(retainPtr(self.identifier).get(), retainPtr(otherToken.identifier).get());
     BOOL equalExclusion = self.isExcluded == otherToken.isExcluded;
-    BOOL equalContent = !includingContentEquality || isEqualOrBothNil(self.content, otherToken.content);
-    BOOL equalUserInfo = isEqualOrBothNil(self.userInfo, otherToken.userInfo);
+    BOOL equalContent = !includingContentEquality || isEqualOrBothNil(retainPtr(self.content).get(), retainPtr(otherToken.content).get());
+    BOOL equalUserInfo = isEqualOrBothNil(retainPtr(self.userInfo).get(), retainPtr(otherToken.userInfo).get());
 
     return equalIdentifiers && equalExclusion && equalContent && equalUserInfo;
 }
@@ -104,11 +104,11 @@ static BOOL isEqualOrBothNil(id a, id b)
 
 - (NSString *)_descriptionPreservingPrivacy:(BOOL)preservePrivacy
 {
-    NSMutableString *description = [NSMutableString stringWithFormat:@"<%@: %p; identifier = %@; isExcluded = %i", self.class, self, self.identifier, self.isExcluded];
+    RetainPtr description = [NSMutableString stringWithFormat:@"<%@: %p; identifier = %@; isExcluded = %i", self.class, self, retainPtr(self.identifier).get(), self.isExcluded];
     if (preservePrivacy)
         [description appendFormat:@"; content length = %lu", (unsigned long)self.content.length];
     else
-        [description appendFormat:@"; content = %@; user info = %@", self.content, self.userInfo];
+        [description appendFormat:@"; content = %@; user info = %@", retainPtr(self.content).get(), retainPtr(self.userInfo).get()];
 
     [description appendString:@">"];
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextRun.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextRun.mm
@@ -57,7 +57,7 @@
 - (NSString *)debugDescription
 {
     auto rect = self.rectInWebView;
-    return [NSString stringWithFormat:@"'%@' at {{%.0f, %.0f}, {%.0f, %.0f}}", self.text, rect.origin.x, rect.origin.y, rect.size.width, rect.size.height];
+    return [NSString stringWithFormat:@"'%@' at {{%.0f, %.0f}, {%.0f, %.0f}}", retainPtr(self.text).get(), rect.origin.x, rect.origin.y, rect.size.width, rect.size.height];
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm
@@ -318,7 +318,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!self.layer.sublayers.count)
         return nil;
 
-    return [self.layer.sublayers objectAtIndex:0];
+    return [retainPtr(self.layer.sublayers) objectAtIndex:0];
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserContentExtensionStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserContentExtensionStore.mm
@@ -42,15 +42,16 @@ static NSError *toUserContentRuleListStoreError(const NSError *error)
         return nil;
 
     ASSERT(error.domain == WKErrorDomain);
+    RetainPtr<NSDictionary<NSString *, id>> userInfo = error.userInfo;
     switch (error.code) {
     case WKErrorContentRuleListStoreLookUpFailed:
-        return [NSError errorWithDomain:_WKUserContentExtensionsDomain code:_WKUserContentExtensionStoreErrorLookupFailed userInfo:error.userInfo];
+        return [NSError errorWithDomain:_WKUserContentExtensionsDomain code:_WKUserContentExtensionStoreErrorLookupFailed userInfo:userInfo.get()];
     case WKErrorContentRuleListStoreVersionMismatch:
-        return [NSError errorWithDomain:_WKUserContentExtensionsDomain code:_WKUserContentExtensionStoreErrorVersionMismatch userInfo:error.userInfo];
+        return [NSError errorWithDomain:_WKUserContentExtensionsDomain code:_WKUserContentExtensionStoreErrorVersionMismatch userInfo:userInfo.get()];
     case WKErrorContentRuleListStoreCompileFailed:
-        return [NSError errorWithDomain:_WKUserContentExtensionsDomain code:_WKUserContentExtensionStoreErrorCompileFailed userInfo:error.userInfo];
+        return [NSError errorWithDomain:_WKUserContentExtensionsDomain code:_WKUserContentExtensionStoreErrorCompileFailed userInfo:userInfo.get()];
     case WKErrorContentRuleListStoreRemoveFailed:
-        return [NSError errorWithDomain:_WKUserContentExtensionsDomain code:_WKUserContentExtensionStoreErrorRemoveFailed userInfo:error.userInfo];
+        return [NSError errorWithDomain:_WKUserContentExtensionsDomain code:_WKUserContentExtensionStoreErrorRemoveFailed userInfo:userInfo.get()];
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm
@@ -53,11 +53,11 @@ static RetainPtr<NSUUID> uuidFromPushPartition(NSString *pushPartition)
         return nil;
 
     RetainPtr uuidString = adoptNS([[NSString alloc] initWithFormat:@"%@-%@-%@-%@-%@",
-        [pushPartition substringWithRange:NSMakeRange(0, 8)],
-        [pushPartition substringWithRange:NSMakeRange(8, 4)],
-        [pushPartition substringWithRange:NSMakeRange(12, 4)],
-        [pushPartition substringWithRange:NSMakeRange(16, 4)],
-        [pushPartition substringWithRange:NSMakeRange(20, 12)]]);
+        retainPtr([pushPartition substringWithRange:NSMakeRange(0, 8)]).get(),
+        retainPtr([pushPartition substringWithRange:NSMakeRange(8, 4)]).get(),
+        retainPtr([pushPartition substringWithRange:NSMakeRange(12, 4)]).get(),
+        retainPtr([pushPartition substringWithRange:NSMakeRange(16, 4)]).get(),
+        retainPtr([pushPartition substringWithRange:NSMakeRange(20, 12)]).get()]);
     return adoptNS([[NSUUID alloc] initWithUUIDString:uuidString.get()]);
 }
 
@@ -71,26 +71,26 @@ static RetainPtr<NSUUID> uuidFromPushPartition(NSString *pushPartition)
 
 + (_WKWebPushAction *)webPushActionWithDictionary:(NSDictionary *)dictionary
 {
-    NSNumber *version = dictionary[WebKit::WebPushD::pushActionVersionKeySingleton()];
+    RetainPtr<NSNumber> version = dictionary[WebKit::WebPushD::pushActionVersionKeySingleton()];
     if (!version || ![version isKindOfClass:[NSNumber class]])
         return nil;
 
-    NSString *pushPartition = dictionary[WebKit::WebPushD::pushActionPartitionKeySingleton()];
+    RetainPtr<NSString> pushPartition = dictionary[WebKit::WebPushD::pushActionPartitionKeySingleton()];
     if (!pushPartition || ![pushPartition isKindOfClass:[NSString class]])
         return nil;
 
-    RetainPtr uuid = uuidFromPushPartition(pushPartition);
+    RetainPtr uuid = uuidFromPushPartition(pushPartition.get());
     if (!uuid)
         return nil;
 
-    NSString *type = dictionary[WebKit::WebPushD::pushActionTypeKeySingleton()];
+    RetainPtr<NSString> type = dictionary[WebKit::WebPushD::pushActionTypeKeySingleton()];
     if (!type || ![type isKindOfClass:[NSString class]])
         return nil;
 
     RetainPtr result = adoptNS([[_WKWebPushAction alloc] init]);
-    result.get().version = version;
+    result.get().version = version.get();
     result.get().webClipIdentifier = uuid.get();
-    result.get().type = type;
+    result.get().type = type.get();
 
     return result.autorelease();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -87,8 +87,8 @@ static void checkURLArgument(NSURL *url)
     if (!directory)
         [NSException raise:NSInvalidArgumentException format:@"Directory is nil"];
 
-    NSString *path = directory.path;
-    API::Object::constructInWrapper<WebKit::WebsiteDataStoreConfiguration>(self, path, path);
+    RetainPtr<NSString> path = directory.path;
+    API::Object::constructInWrapper<WebKit::WebsiteDataStoreConfiguration>(self, path.get(), path.get());
 
     return self;
 }

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -170,7 +170,7 @@ static WebCore::FloatBoxExtent coreBoxExtentsFromEdgeInsets(NSEdgeInsets insets)
     if (self.hidden)
         return NO;
 
-    _windowSnapshotReadinessHandler = makeBlockPtr([self.window _holdResizeSnapshotWithReason:@"full screen"]);
+    _windowSnapshotReadinessHandler = makeBlockPtr([retainPtr(self.window) _holdResizeSnapshotWithReason:@"full screen"]);
     if (!_windowSnapshotReadinessHandler)
         return NO;
 
@@ -874,7 +874,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (NSArray<NSString *> *)accessibilityParameterizedAttributeNames
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    NSArray<NSString *> *names = [super accessibilityParameterizedAttributeNames];
+    RetainPtr<NSArray<NSString *>> names = [super accessibilityParameterizedAttributeNames];
     return [names arrayByAddingObject:@"AXConvertRelativeFrame"];
 }
 
@@ -990,19 +990,24 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return _textFinderClient.get();
 }
 
+- (RetainPtr<WKTextFinderClient>)_protectedTextFinderClient
+{
+    return [self _ensureTextFinderClient];
+}
+
 - (void)findMatchesForString:(NSString *)targetString relativeToMatch:(id <NSTextFinderAsynchronousDocumentFindMatch>)relativeMatch findOptions:(NSTextFinderAsynchronousDocumentFindOptions)findOptions maxResults:(NSUInteger)maxResults resultCollector:(void (^)(NSArray *matches, BOOL didWrap))resultCollector
 {
-    [[self _ensureTextFinderClient] findMatchesForString:targetString relativeToMatch:relativeMatch findOptions:findOptions maxResults:maxResults resultCollector:resultCollector];
+    [[self _protectedTextFinderClient] findMatchesForString:targetString relativeToMatch:relativeMatch findOptions:findOptions maxResults:maxResults resultCollector:resultCollector];
 }
 
 - (void)replaceMatches:(NSArray *)matches withString:(NSString *)replacementString inSelectionOnly:(BOOL)selectionOnly resultCollector:(void (^)(NSUInteger replacementCount))resultCollector
 {
-    [[self _ensureTextFinderClient] replaceMatches:matches withString:replacementString inSelectionOnly:selectionOnly resultCollector:resultCollector];
+    [[self _protectedTextFinderClient] replaceMatches:matches withString:replacementString inSelectionOnly:selectionOnly resultCollector:resultCollector];
 }
 
 - (void)scrollFindMatchToVisible:(id<NSTextFinderAsynchronousDocumentFindMatch>)match
 {
-    [[self _ensureTextFinderClient] scrollFindMatchToVisible:match];
+    [[self _protectedTextFinderClient] scrollFindMatchToVisible:match];
 }
 
 - (NSView *)documentContainerView
@@ -1012,12 +1017,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)getSelectedText:(void (^)(NSString *selectedTextString))completionHandler
 {
-    [[self _ensureTextFinderClient] getSelectedText:completionHandler];
+    [[self _protectedTextFinderClient] getSelectedText:completionHandler];
 }
 
 - (void)selectFindMatch:(id <NSTextFinderAsynchronousDocumentFindMatch>)findMatch completionHandler:(void (^)(void))completionHandler
 {
-    [[self _ensureTextFinderClient] selectFindMatch:findMatch completionHandler:completionHandler];
+    [[self _protectedTextFinderClient] selectFindMatch:findMatch completionHandler:completionHandler];
 }
 
 #if ENABLE(DRAG_SUPPORT)
@@ -1293,7 +1298,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_web_prepareForImmediateActionAnimation
 {
-    id <WKUIDelegatePrivate> uiDelegate = (id <WKUIDelegatePrivate>)[self UIDelegate];
+    RetainPtr<id <WKUIDelegatePrivate>> uiDelegate = (id <WKUIDelegatePrivate>)[self UIDelegate];
     if ([uiDelegate respondsToSelector:@selector(_prepareForImmediateActionAnimationForWebView:)])
         [uiDelegate _prepareForImmediateActionAnimationForWebView:self];
     else
@@ -1302,7 +1307,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_web_cancelImmediateActionAnimation
 {
-    id <WKUIDelegatePrivate> uiDelegate = (id <WKUIDelegatePrivate>)[self UIDelegate];
+    RetainPtr<id <WKUIDelegatePrivate>> uiDelegate = (id <WKUIDelegatePrivate>)[self UIDelegate];
     if ([uiDelegate respondsToSelector:@selector(_cancelImmediateActionAnimationForWebView:)])
         [uiDelegate _cancelImmediateActionAnimationForWebView:self];
     else
@@ -1311,7 +1316,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_web_completeImmediateActionAnimation
 {
-    id <WKUIDelegatePrivate> uiDelegate = (id <WKUIDelegatePrivate>)[self UIDelegate];
+    RetainPtr<id <WKUIDelegatePrivate>> uiDelegate = (id <WKUIDelegatePrivate>)[self UIDelegate];
     if ([uiDelegate respondsToSelector:@selector(_completeImmediateActionAnimationForWebView:)])
         [uiDelegate _completeImmediateActionAnimationForWebView:self];
     else
@@ -1349,7 +1354,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (WKDragDestinationAction)_web_dragDestinationActionForDraggingInfo:(id <NSDraggingInfo>)draggingInfo
 {
-    id <WKUIDelegatePrivate> uiDelegate = (id <WKUIDelegatePrivate>)[self UIDelegate];
+    RetainPtr<id <WKUIDelegatePrivate>> uiDelegate = (id <WKUIDelegatePrivate>)[self UIDelegate];
     if ([uiDelegate respondsToSelector:@selector(_webView:dragDestinationActionMaskForDraggingInfo:)])
         return [uiDelegate _webView:self dragDestinationActionMaskForDraggingInfo:draggingInfo];
 
@@ -1361,7 +1366,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_web_didPerformDragOperation:(BOOL)handled
 {
-    id <WKUIDelegatePrivate> uiDelegate = (id <WKUIDelegatePrivate>)self.UIDelegate;
+    RetainPtr<id <WKUIDelegatePrivate>> uiDelegate = (id <WKUIDelegatePrivate>)self.UIDelegate;
     if ([uiDelegate respondsToSelector:@selector(_webView:didPerformDragOperation:)])
         [uiDelegate _webView:self didPerformDragOperation:handled];
 }

--- a/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
@@ -43,7 +43,7 @@ void AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc(IPC::C
     auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), ClientCertificateAuthentication::XPCMessageNameKey, ClientCertificateAuthentication::XPCMessageNameValue);
     xpc_dictionary_set_uint64(message.get(), ClientCertificateAuthentication::XPCChallengeIDKey, challengeID.toUInt64());
-    xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey, RetainPtr { secKeyProxyStore.get() }.get().endpoint._endpoint);
+    xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey, retainPtr(RetainPtr { secKeyProxyStore.get() }.get().endpoint._endpoint).get());
     auto certificateDataArray = adoptOSObject(xpc_array_create(nullptr, 0));
     RetainPtr nsCredential = credential.nsCredential();
     for (id certificate in nsCredential.get().certificates) {

--- a/Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
+++ b/Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
@@ -83,7 +83,7 @@ std::optional<String> WebAutomationSession::platformGenerateLocalFilePathForRemo
 
     RetainPtr temporaryDirectory = FileSystem::createTemporaryDirectory(@"WebDriver");
     RetainPtr remoteFile = adoptNS([[NSURL alloc] initFileURLWithPath:remoteFilePath.createNSString().get() isDirectory:NO]);
-    RetainPtr localFilePath = [temporaryDirectory stringByAppendingPathComponent:remoteFile.get().lastPathComponent];
+    RetainPtr localFilePath = [temporaryDirectory stringByAppendingPathComponent:retainPtr(remoteFile.get().lastPathComponent).get()];
 
     NSError *fileWriteError;
     [fileContents.get() writeToFile:localFilePath.get() options:NSDataWritingAtomic error:&fileWriteError];

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -857,9 +857,9 @@ void WebAutomationSession::platformSimulateWheelInteraction(WebPageProxy& page, 
     locationOnScreen = CGPointMake(locationOnScreen.x, NSScreen.screens.firstObject.frame.size.height - locationOnScreen.y);
     CGEventSetLocation(cgScrollEvent.get(), locationOnScreen);
 
-    NSEvent *scrollEvent = [[NSEvent eventWithCGEvent:cgScrollEvent.get()] _eventRelativeToWindow:window.get()];
+    RetainPtr<NSEvent> scrollEvent = [[NSEvent eventWithCGEvent:cgScrollEvent.get()] _eventRelativeToWindow:window.get()];
 
-    sendSynthesizedEventsToPage(page, @[scrollEvent]);
+    sendSynthesizedEventsToPage(page, @[scrollEvent.get()]);
 }
 
 #endif // ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)

--- a/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
@@ -72,7 +72,7 @@ RefPtr<WebCore::SharedBuffer> AuxiliaryProcessProxy::fetchAudioComponentServerRe
 
 Vector<String> AuxiliaryProcessProxy::platformOverrideLanguages() const
 {
-    static const NeverDestroyed<Vector<String>> overrideLanguages = makeVector<String>([[NSUserDefaults standardUserDefaults] stringArrayForKey:@"AppleLanguages"]);
+    static const NeverDestroyed<Vector<String>> overrideLanguages = makeVector<String>(retainPtr([[NSUserDefaults standardUserDefaults] stringArrayForKey:@"AppleLanguages"]).get());
     return overrideLanguages;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
@@ -78,7 +78,7 @@ static String localizedProviderShortName(SSBServiceLookupResult *result)
 
 static void replace(NSMutableAttributedString *string, NSString *toReplace, NSString *replaceWith)
 {
-    [string replaceCharactersInRange:[string.string rangeOfString:toReplace] withString:replaceWith];
+    [string replaceCharactersInRange:[retainPtr(string.string) rangeOfString:toReplace] withString:replaceWith];
 }
 
 static void addLinkAndReplace(NSMutableAttributedString *string, NSString *toReplace, NSString *replaceWith, NSURL *linkTarget)
@@ -88,7 +88,7 @@ static void addLinkAndReplace(NSMutableAttributedString *string, NSString *toRep
         NSLinkAttributeName: linkTarget,
         NSUnderlineStyleAttributeName: @1
     } range:NSMakeRange(0, replaceWith.length)];
-    [string replaceCharactersInRange:[string.string rangeOfString:toReplace] withAttributedString:stringWithLink.get()];
+    [string replaceCharactersInRange:[retainPtr(string.string) rangeOfString:toReplace] withAttributedString:stringWithLink.get()];
 }
 
 static RetainPtr<NSURL> reportAnErrorURL(const URL& url, SSBServiceLookupResult *result)
@@ -163,7 +163,7 @@ static NSMutableAttributedString *browsingDetailsText(const URL& url, SSBService
         replace(malwareDescription.get(), @"%safeBrowsingProvider%", localizedProviderDisplayName(result).createNSString().get());
         auto statusLink = adoptNS([[NSMutableAttributedString alloc] initWithString:RetainPtr { WEB_UI_NSSTRING(@"the status of “%site%”", "Part of malware description") }.get()]);
         replace(statusLink.get(), @"%site%", url.host().createNSString().get());
-        addLinkAndReplace(malwareDescription.get(), statusStringToReplace, [statusLink string], malwareDetailsURL(url, result).get());
+        addLinkAndReplace(malwareDescription.get(), statusStringToReplace, retainPtr([statusLink string]).get(), malwareDetailsURL(url, result).get());
 
         auto ifYouUnderstand = adoptNS([[NSMutableAttributedString alloc] initWithString:RetainPtr { WEB_UI_NSSTRING(@"If you understand the risks involved, you can %visit-this-unsafe-site-link%.", "Action from safe browsing warning") }.get()]);
         addLinkAndReplace(ifYouUnderstand.get(), @"%visit-this-unsafe-site-link%", RetainPtr { WEB_UI_NSSTRING(@"visit this unsafe website", "Action from safe browsing warning") }.get(), confirmMalware ? BrowsingWarning::confirmMalwareSentinel().get() : BrowsingWarning::visitUnsafeWebsiteSentinel().get());

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -226,7 +226,7 @@ void alertForPermission(WebPageProxy& page, MediaPermissionReason reason, const 
     button.get().keyEquivalent = @"";
     button = [alert addButtonWithTitle:doNotAllowButtonString.get()];
     button.get().keyEquivalent = @"\E";
-    [alert beginSheetModalForWindow:[webView window] completionHandler:[completionBlock](NSModalResponse returnCode) {
+    [alert beginSheetModalForWindow:retainPtr([webView window]).get() completionHandler:[completionBlock](NSModalResponse returnCode) {
         auto shouldAllow = returnCode == NSAlertFirstButtonReturn;
         completionBlock(shouldAllow);
     }];

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -606,7 +606,7 @@ void NavigationState::NavigationClient::decidePolicyForNavigationAction(WebPageP
             // A file URL shouldn't fall through to here, but if it did,
             // it would be a security risk to open it.
             if (![[nsURLRequest URL] isFileURL])
-                [[NSWorkspace sharedWorkspace] openURL:[nsURLRequest URL]];
+                [[NSWorkspace sharedWorkspace] openURL:retainPtr([nsURLRequest URL]).get()];
 #endif
 
             listener->ignore();
@@ -777,7 +777,7 @@ void NavigationState::NavigationClient::decidePolicyForNavigationResponse(WebPag
         RetainPtr<NSURL> url = navigationResponse->response().protectedNSURLResponse().get().URL;
         if ([url isFileURL]) {
             BOOL isDirectory = NO;
-            BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:url.get().path isDirectory:&isDirectory];
+            BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:retainPtr(url.get().path).get() isDirectory:&isDirectory];
 
             if (exists && !isDirectory && navigationResponse->canShowMIMEType())
                 listener->use();
@@ -930,7 +930,7 @@ static RetainPtr<NSError> createErrorWithRecoveryAttempter(WKWebView *webView, c
     if (RetainPtr<NSDictionary> originalUserInfo = originalError.userInfo)
         [userInfo addEntriesFromDictionary:originalUserInfo.get()];
 
-    return adoptNS([[NSError alloc] initWithDomain:originalError.domain code:originalError.code userInfo:userInfo.get()]);
+    return adoptNS([[NSError alloc] initWithDomain:retainPtr(originalError.domain).get() code:originalError.code userInfo:userInfo.get()]);
 }
 
 void NavigationState::NavigationClient::didFailProvisionalNavigationWithError(WebPageProxy& page, FrameInfoData&& frameInfo, API::Navigation* navigation, const URL& url, const WebCore::ResourceError& error, API::Object*)

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -221,7 +221,7 @@ void PageClientImplCocoa::removeDictationAlternatives(WebCore::DictationContext 
 
 Vector<String> PageClientImplCocoa::dictationAlternatives(WebCore::DictationContext dictationContext)
 {
-    return makeVector<String>(RetainPtr { platformDictationAlternatives(dictationContext) }.get().alternativeStrings);
+    return makeVector<String>(retainPtr(RetainPtr { platformDictationAlternatives(dictationContext) }.get().alternativeStrings).get());
 }
 
 PlatformTextAlternatives *PageClientImplCocoa::platformDictationAlternatives(WebCore::DictationContext dictationContext)

--- a/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm
@@ -163,7 +163,7 @@ WebCore::WritingTools::Session::CompositionType convertToWebCompositionSessionTy
 
 std::optional<WebCore::WritingTools::Context> convertToWebContext(WTContext *context)
 {
-    auto contextUUID = WTF::UUID::fromNSUUID(context.uuid);
+    auto contextUUID = WTF::UUID::fromNSUUID(retainPtr(context.uuid).get());
     if (!contextUUID)
         return std::nullopt;
 
@@ -172,7 +172,7 @@ std::optional<WebCore::WritingTools::Context> convertToWebContext(WTContext *con
 
 std::optional<WebCore::WritingTools::Session> convertToWebSession(WTSession *session)
 {
-    auto sessionUUID = WTF::UUID::fromNSUUID(session.uuid);
+    auto sessionUUID = WTF::UUID::fromNSUUID(retainPtr(session.uuid).get());
     if (!sessionUUID)
         return std::nullopt;
 
@@ -181,7 +181,7 @@ std::optional<WebCore::WritingTools::Session> convertToWebSession(WTSession *ses
 
 std::optional<WebCore::WritingTools::TextSuggestion> convertToWebTextSuggestion(WTTextSuggestion *suggestion)
 {
-    auto suggestionUUID = WTF::UUID::fromNSUUID(suggestion.uuid);
+    auto suggestionUUID = WTF::UUID::fromNSUUID(retainPtr(suggestion.uuid).get());
     if (!suggestionUUID)
         return std::nullopt;
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -265,7 +265,7 @@ void SOAuthorizationSession::continueStartAfterDecidePolicy(const SOAuthorizatio
 
     RetainPtr nsRequest = m_navigationAction->request().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody);
     AUTHORIZATIONSESSION_RELEASE_LOG("continueStartAfterGetAuthorizationHints: Beginning authorization with AppSSO.");
-    [m_soAuthorization beginAuthorizationWithURL:nsRequest.get().URL httpHeaders:nsRequest.get().allHTTPHeaderFields httpBody:nsRequest.get().HTTPBody];
+    [m_soAuthorization beginAuthorizationWithURL:retainPtr(nsRequest.get().URL).get() httpHeaders:retainPtr(nsRequest.get().allHTTPHeaderFields).get() httpBody:retainPtr(nsRequest.get().HTTPBody).get()];
 }
 
 void SOAuthorizationSession::fallBackToWebPath()
@@ -330,7 +330,7 @@ void SOAuthorizationSession::complete(NSHTTPURLResponse *httpResponse, NSData *d
     }
 
     // Set cookies.
-    auto cookies = toCookieVector([NSHTTPCookie cookiesWithResponseHeaderFields:httpResponse.allHeaderFields forURL:response.url().createNSURL().get()]);
+    auto cookies = toCookieVector([NSHTTPCookie cookiesWithResponseHeaderFields:retainPtr(httpResponse.allHeaderFields).get() forURL:response.url().createNSURL().get()]);
 
     AUTHORIZATIONSESSION_RELEASE_LOG("complete: (httpStatusCode=%d, hasCookies=%d, hasData=%d)", response.httpStatusCode(), !cookies.isEmpty(), !!data.length);
 

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -890,9 +890,8 @@ bool UIDelegate::UIClient::focusFromServiceWorker(WebKit::WebPageProxy& proxy)
         if (!webView || !webView.get().window)
             return false;
 
-
-        [webView.get().window makeKeyAndOrderFront:nil];
-        [[webView window] makeFirstResponder:webView.get()];
+        [retainPtr(webView.get().window) makeKeyAndOrderFront:nil];
+        [retainPtr([webView window]) makeFirstResponder:webView.get()];
         return true;
 #else
         return false;
@@ -1729,7 +1728,7 @@ std::optional<double> UIDelegate::UIClient::dataDetectionReferenceDate()
         return std::nullopt;
 
 #if ENABLE(DATA_DETECTION)
-    return WebCore::DataDetection::extractReferenceDate([static_cast<id<WKUIDelegatePrivate>>(delegate) _dataDetectionContextForWebView:uiDelegate->m_webView.get().get()]);
+    return WebCore::DataDetection::extractReferenceDate(retainPtr([static_cast<id<WKUIDelegatePrivate>>(delegate) _dataDetectionContextForWebView:uiDelegate->m_webView.get().get()]).get());
 #else
     return std::nullopt;
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -111,7 +111,7 @@ static RetainPtr<NSString> nameForFileURLWithTypeIdentifier(NSURL *url, NSString
         return localizedName;
     }
 
-    return [[NSFileManager defaultManager] displayNameAtPath:url.path];
+    return [[NSFileManager defaultManager] displayNameAtPath:retainPtr(url.path).get()];
 }
 
 static RetainPtr<LPLinkMetadata> placeholderMetadataWithFileURL(NSURL *url)
@@ -368,7 +368,7 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
     else {
         NSPoint location = [NSEvent mouseLocation];
         NSRect mouseLocationRect = NSMakeRect(location.x, location.y, 1.0, 1.0);
-        NSRect mouseLocationInWindow = [webView.get().window convertRectFromScreen:mouseLocationRect];
+        NSRect mouseLocationInWindow = [retainPtr(webView.get().window) convertRectFromScreen:mouseLocationRect];
         presentationRect = [webView convertRect:mouseLocationInWindow fromView:nil];
     }
 

--- a/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
@@ -82,7 +82,7 @@
     [result setDrawsBackground:NO];
 
     if ((NSUInteger)row < [_siteList count]) {
-        [[result textStorage].mutableString setString:_siteList.get()[row]];
+        [retainPtr([result textStorage].mutableString) setString:retainPtr(_siteList.get()[row]).get()];
         [result textStorage].font = [NSFont systemFontOfSize:[NSFont smallSystemFontSize]];
         [result textStorage].foregroundColor = NSColor.whiteColor;
     }
@@ -97,7 +97,7 @@
         frame.size.height -= _tableView.get().frame.size.height;
     else
         frame.size.height += _tableView.get().frame.size.height;
-    [_alert.get().window setFrame:frame display:YES];
+    [retainPtr(_alert.get().window) setFrame:frame display:YES];
     [_alert layout];
 }
 @end
@@ -223,14 +223,14 @@ void displayStorageAccessAlert(WKWebView *webView, NSString *alertTitle, NSStrin
 
         NSRect frame = alert.get().window.frame;
         frame.size.width += 100.;
-        [alert.get().window setFrame:frame display:YES];
+        [retainPtr(alert.get().window) setFrame:frame display:YES];
 
         [alert setAccessoryView:accessoryStackView.get()];
         [alert layout];
     }
     [alert addButtonWithTitle:allowButtonString.get()];
     [alert addButtonWithTitle:doNotAllowButtonString.get()];
-    [alert beginSheetModalForWindow:webView.window completionHandler:makeBlockPtr([ssoSiteList, completionBlock](NSModalResponse returnCode) {
+    [alert beginSheetModalForWindow:retainPtr(webView.window).get() completionHandler:makeBlockPtr([ssoSiteList, completionBlock](NSModalResponse returnCode) {
         auto shouldAllow = returnCode == NSAlertFirstButtonReturn;
         completionBlock(shouldAllow);
     }).get()];

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -931,7 +931,7 @@ void WebPageProxy::startApplePayAMSUISession(URL&& originatingURL, ApplePayAMSUI
         return;
     }
 
-    RetainPtr amsRequest = adoptNS([allocAMSEngagementRequestInstance() initWithRequestDictionary:dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[request.engagementRequest.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil])]);
+    RetainPtr amsRequest = adoptNS([allocAMSEngagementRequestInstance() initWithRequestDictionary:dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:retainPtr([request.engagementRequest.createNSString() dataUsingEncoding:NSUTF8StringEncoding]).get() options:0 error:nil])]);
     [amsRequest setOriginatingURL:originatingURL.createNSURL().get()];
 
     auto amsBag = retainPtr([getAMSUIEngagementTaskClassSingleton() createBagForSubProfile]);
@@ -1046,7 +1046,7 @@ NSDictionary *WebPageProxy::contentsOfUserInterfaceItem(NSString *userInterfaceI
 bool WebPageProxy::isQuarantinedAndNotUserApproved(const String& fileURLString)
 {
     RetainPtr fileURL = adoptNS([[NSURL alloc] initWithString:fileURLString.createNSString().get()]);
-    if ([fileURL.get().pathExtension caseInsensitiveCompare:@"webarchive"] != NSOrderedSame)
+    if ([retainPtr(fileURL.get().pathExtension) caseInsensitiveCompare:@"webarchive"] != NSOrderedSame)
         return false;
 
     qtn_file_t qf = qtn_file_alloc();

--- a/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
@@ -108,7 +108,7 @@ static RetainPtr<id> debugUserDefaultsValue(const String& identifier, const Stri
 
     if (!object) {
         // Allow debug preferences to be set globally, using the debug key prefix.
-        object = [standardUserDefaults objectForKey:[globalDebugKeyPrefix.createNSString() stringByAppendingString:key.createNSString().get()]];
+        object = [standardUserDefaults objectForKey:retainPtr([globalDebugKeyPrefix.createNSString() stringByAppendingString:key.createNSString().get()]).get()];
     }
 
     return object;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -841,7 +841,7 @@ void WebProcessPool::registerNotificationObservers()
     m_systemSleepListener = PAL::SystemSleepListener::create(*this);
     // Listen for enhanced accessibility changes and propagate them to the WebProcess.
     m_enhancedAccessibilityObserver = [[NSNotificationCenter defaultCenter] addObserverForName:WebKitApplicationDidChangeAccessibilityEnhancedUserInterfaceNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *note) {
-        setEnhancedAccessibility([[[note userInfo] objectForKey:@"AXEnhancedUserInterface"] boolValue]);
+        setEnhancedAccessibility([[retainPtr([note userInfo]) objectForKey:@"AXEnhancedUserInterface"] boolValue]);
     }];
 
     m_automaticTextReplacementNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSSpellCheckerDidChangeAutomaticTextReplacementNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
@@ -864,7 +864,7 @@ void WebProcessPool::registerNotificationObservers()
         textCheckerStateChanged();
     }];
 
-    m_accessibilityDisplayOptionsNotificationObserver = [[NSWorkspace.sharedWorkspace notificationCenter] addObserverForName:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
+    m_accessibilityDisplayOptionsNotificationObserver = [retainPtr([NSWorkspace.sharedWorkspace notificationCenter]) addObserverForName:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
         screenPropertiesChanged();
     }];
 
@@ -1022,7 +1022,7 @@ void WebProcessPool::unregisterNotificationObservers()
     [[NSNotificationCenter defaultCenter] removeObserver:m_automaticSpellingCorrectionNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_automaticQuoteSubstitutionNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_automaticDashSubstitutionNotificationObserver.get()];
-    [[NSWorkspace.sharedWorkspace notificationCenter] removeObserver:m_accessibilityDisplayOptionsNotificationObserver.get()];
+    [retainPtr([NSWorkspace.sharedWorkspace notificationCenter]) removeObserver:m_accessibilityDisplayOptionsNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_scrollerStyleNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_deactivationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_didChangeScreenParametersNotificationObserver.get()];
@@ -1111,7 +1111,7 @@ void WebProcessPool::clearPermanentCredentialsForProtectionSpace(WebCore::Protec
     for (NSString* user in credentials.get()) {
         RetainPtr<NSURLCredential> credential = credentials.get()[user];
         if (credential.get().persistence == NSURLCredentialPersistencePermanent)
-            [sharedStorage removeCredential:credentials.get()[user] forProtectionSpace:space.get()];
+            [sharedStorage removeCredential:retainPtr(credentials.get()[user]).get() forProtectionSpace:space.get()];
     }
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
@@ -377,49 +377,49 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
     [NSLayoutConstraint activateConstraints:@[
 #if HAVE(SAFE_BROWSING)
 #if PLATFORM(WATCHOS)
-        [[[box leadingAnchor] anchorWithOffsetToAnchor:[warningViewIcon leadingAnchor]] constraintEqualToAnchor:[[warningViewIcon trailingAnchor] anchorWithOffsetToAnchor:[box trailingAnchor]]],
-        [[[box leadingAnchor] anchorWithOffsetToAnchor:[title leadingAnchor]] constraintEqualToConstant:marginSize],
-        [[[warningViewIcon bottomAnchor] anchorWithOffsetToAnchor:[title topAnchor]] constraintEqualToConstant:marginSize],
-        [[[box topAnchor] anchorWithOffsetToAnchor:[warningViewIcon topAnchor]] constraintEqualToConstant:marginSize + self.frame.size.height / 2],
+        [retainPtr([retainPtr([box leadingAnchor]) anchorWithOffsetToAnchor:retainPtr([warningViewIcon leadingAnchor]).get()]) constraintEqualToAnchor:retainPtr([retainPtr([warningViewIcon trailingAnchor]) anchorWithOffsetToAnchor:retainPtr([box trailingAnchor]).get()]).get()],
+        [retainPtr([retainPtr([box leadingAnchor]) anchorWithOffsetToAnchor:retainPtr([title leadingAnchor]).get()]) constraintEqualToConstant:marginSize],
+        [retainPtr([retainPtr([warningViewIcon bottomAnchor]) anchorWithOffsetToAnchor:retainPtr([title topAnchor]).get()]) constraintEqualToConstant:marginSize],
+        [retainPtr([retainPtr([box topAnchor]) anchorWithOffsetToAnchor:retainPtr([warningViewIcon topAnchor]).get()]) constraintEqualToConstant:marginSize + self.frame.size.height / 2],
 #else
-        [[[box leadingAnchor] anchorWithOffsetToAnchor:[warningViewIcon leadingAnchor]] constraintEqualToConstant:marginSize],
-        [[[box leadingAnchor] anchorWithOffsetToAnchor:[title leadingAnchor]] constraintEqualToConstant:marginSize * 1.5 + warningSymbolPointSize],
-        [[[title topAnchor] anchorWithOffsetToAnchor:[warningViewIcon topAnchor]] constraintEqualToAnchor:[[warningViewIcon bottomAnchor] anchorWithOffsetToAnchor:[title bottomAnchor]]],
-        [[[box topAnchor] anchorWithOffsetToAnchor:[title topAnchor]] constraintEqualToConstant:marginSize],
+        [retainPtr([retainPtr([box leadingAnchor]) anchorWithOffsetToAnchor:retainPtr([warningViewIcon leadingAnchor]).get()]) constraintEqualToConstant:marginSize],
+        [retainPtr([retainPtr([box leadingAnchor]) anchorWithOffsetToAnchor:retainPtr([title leadingAnchor]).get()]) constraintEqualToConstant:marginSize * 1.5 + warningSymbolPointSize],
+        [retainPtr([retainPtr([title topAnchor]) anchorWithOffsetToAnchor:retainPtr([warningViewIcon topAnchor]).get()]) constraintEqualToAnchor:retainPtr([retainPtr([warningViewIcon bottomAnchor]) anchorWithOffsetToAnchor:retainPtr([title bottomAnchor]).get()]).get()],
+        [retainPtr([retainPtr([box topAnchor]) anchorWithOffsetToAnchor:retainPtr([title topAnchor]).get()]) constraintEqualToConstant:marginSize],
 #endif
-        [[[title bottomAnchor] anchorWithOffsetToAnchor:[warning topAnchor]] constraintEqualToConstant:marginSize],
-        [[self.topAnchor anchorWithOffsetToAnchor:[box topAnchor]] constraintEqualToAnchor:[[box bottomAnchor] anchorWithOffsetToAnchor:self.bottomAnchor] multiplier:topToBottomMarginMultiplier],
+        [retainPtr([retainPtr([title bottomAnchor]) anchorWithOffsetToAnchor:retainPtr([warning topAnchor]).get()]) constraintEqualToConstant:marginSize],
+        [retainPtr([retainPtr(self.topAnchor) anchorWithOffsetToAnchor:retainPtr([box topAnchor]).get()]) constraintEqualToAnchor:retainPtr([retainPtr([box bottomAnchor]) anchorWithOffsetToAnchor:retainPtr(self.bottomAnchor).get()]).get() multiplier:topToBottomMarginMultiplier],
 #endif // HAVE(SAFE_BROWSING)
     ]];
 
 #if HAVE(SAFE_BROWSING)
     [NSLayoutConstraint activateConstraints:@[
-        [[self.leftAnchor anchorWithOffsetToAnchor:[box leftAnchor]] constraintEqualToAnchor:[[box rightAnchor] anchorWithOffsetToAnchor:self.rightAnchor]],
+        [retainPtr([retainPtr(self.leftAnchor) anchorWithOffsetToAnchor:retainPtr([box leftAnchor]).get()]) constraintEqualToAnchor:retainPtr([retainPtr([box rightAnchor]) anchorWithOffsetToAnchor:retainPtr(self.rightAnchor).get()]).get()],
 
-        [[box widthAnchor] constraintLessThanOrEqualToConstant:maxWidth],
-        [[box widthAnchor] constraintLessThanOrEqualToAnchor:self.widthAnchor],
+        [retainPtr([box widthAnchor]) constraintLessThanOrEqualToConstant:maxWidth],
+        [retainPtr([box widthAnchor]) constraintLessThanOrEqualToAnchor:retainPtr(self.widthAnchor).get()],
 
-        [[[box leadingAnchor] anchorWithOffsetToAnchor:[warning leadingAnchor]] constraintEqualToConstant:marginSize],
+        [retainPtr([retainPtr([box leadingAnchor]) anchorWithOffsetToAnchor:retainPtr([warning leadingAnchor]).get()]) constraintEqualToConstant:marginSize],
 
-        [[[title trailingAnchor] anchorWithOffsetToAnchor:[box trailingAnchor]] constraintGreaterThanOrEqualToConstant:marginSize],
-        [[[warning trailingAnchor] anchorWithOffsetToAnchor:[box trailingAnchor]] constraintGreaterThanOrEqualToConstant:marginSize],
-        [[goBack.get().trailingAnchor anchorWithOffsetToAnchor:[box trailingAnchor]] constraintEqualToConstant:marginSize],
+        [retainPtr([retainPtr([title trailingAnchor]) anchorWithOffsetToAnchor:retainPtr([box trailingAnchor]).get()]) constraintGreaterThanOrEqualToConstant:marginSize],
+        [retainPtr([retainPtr([warning trailingAnchor]) anchorWithOffsetToAnchor:retainPtr([box trailingAnchor]).get()]) constraintGreaterThanOrEqualToConstant:marginSize],
+        [retainPtr([retainPtr(goBack.get().trailingAnchor) anchorWithOffsetToAnchor:retainPtr([box trailingAnchor]).get()]) constraintEqualToConstant:marginSize],
 
-        [[[warning bottomAnchor] anchorWithOffsetToAnchor:goBack.get().topAnchor] constraintEqualToConstant:marginSize],
+        [retainPtr([retainPtr([warning bottomAnchor]) anchorWithOffsetToAnchor:retainPtr(goBack.get().topAnchor).get()]) constraintEqualToConstant:marginSize],
     ]];
 
     bool needsVerticalButtonLayout = buttonSize(primaryButton.get()).width + buttonSize(goBack.get()).width + 3 * marginSize > self.frame.size.width;
     if (needsVerticalButtonLayout) {
         [NSLayoutConstraint activateConstraints:@[
-            [[primaryButton.get().trailingAnchor anchorWithOffsetToAnchor:[box trailingAnchor]] constraintEqualToConstant:marginSize],
-            [[goBack.get().bottomAnchor anchorWithOffsetToAnchor:primaryButton.get().topAnchor] constraintEqualToConstant:marginSize],
-            [[goBack.get().bottomAnchor anchorWithOffsetToAnchor:[box bottomAnchor]] constraintEqualToConstant:marginSize * 2 + buttonSize(primaryButton.get()).height],
+            [retainPtr([retainPtr(primaryButton.get().trailingAnchor) anchorWithOffsetToAnchor:retainPtr([box trailingAnchor]).get()]) constraintEqualToConstant:marginSize],
+            [retainPtr([retainPtr(goBack.get().bottomAnchor) anchorWithOffsetToAnchor:retainPtr(primaryButton.get().topAnchor).get()]) constraintEqualToConstant:marginSize],
+            [retainPtr([retainPtr(goBack.get().bottomAnchor) anchorWithOffsetToAnchor:retainPtr([box bottomAnchor]).get()]) constraintEqualToConstant:marginSize * 2 + buttonSize(primaryButton.get()).height],
         ]];
     } else {
         [NSLayoutConstraint activateConstraints:@[
-            [[primaryButton.get().trailingAnchor anchorWithOffsetToAnchor:goBack.get().leadingAnchor] constraintEqualToConstant:marginSize],
-            [goBack.get().topAnchor constraintEqualToAnchor:primaryButton.get().topAnchor],
-            [[goBack.get().bottomAnchor anchorWithOffsetToAnchor:[box bottomAnchor]] constraintEqualToConstant:marginSize],
+            [retainPtr([retainPtr(primaryButton.get().trailingAnchor) anchorWithOffsetToAnchor:retainPtr(goBack.get().leadingAnchor).get()]) constraintEqualToConstant:marginSize],
+            [retainPtr(goBack.get().topAnchor) constraintEqualToAnchor:retainPtr(primaryButton.get().topAnchor).get()],
+            [retainPtr([retainPtr(goBack.get().bottomAnchor) anchorWithOffsetToAnchor:retainPtr([box bottomAnchor]).get()]) constraintEqualToConstant:marginSize],
         ]];
     }
 #if !PLATFORM(MAC)
@@ -469,17 +469,17 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
     [bottom addSubview:details.get()];
 #if HAVE(SAFE_BROWSING)
     [NSLayoutConstraint activateConstraints:@[
-        [box.get().widthAnchor constraintEqualToAnchor:[bottom widthAnchor]],
-        [box.get().bottomAnchor constraintEqualToAnchor:[bottom topAnchor]],
-        [box.get().leadingAnchor constraintEqualToAnchor:[bottom leadingAnchor]],
-        [[line widthAnchor] constraintEqualToAnchor:[bottom widthAnchor]],
-        [[line leadingAnchor] constraintEqualToAnchor:[bottom leadingAnchor]],
-        [[line topAnchor] constraintEqualToAnchor:[bottom topAnchor]],
-        [[line heightAnchor] constraintEqualToConstant:1],
-        [[[bottom topAnchor] anchorWithOffsetToAnchor:[details topAnchor]] constraintEqualToConstant:marginSize],
-        [[[details bottomAnchor] anchorWithOffsetToAnchor:[bottom bottomAnchor]] constraintEqualToConstant:marginSize],
-        [[[bottom leadingAnchor] anchorWithOffsetToAnchor:[details leadingAnchor]] constraintEqualToConstant:marginSize],
-        [[[details trailingAnchor] anchorWithOffsetToAnchor:[bottom trailingAnchor]] constraintEqualToConstant:marginSize],
+        [retainPtr(box.get().widthAnchor) constraintEqualToAnchor:retainPtr([bottom widthAnchor]).get()],
+        [retainPtr(box.get().bottomAnchor) constraintEqualToAnchor:retainPtr([bottom topAnchor]).get()],
+        [retainPtr(box.get().leadingAnchor) constraintEqualToAnchor:retainPtr([bottom leadingAnchor]).get()],
+        [retainPtr([line widthAnchor]) constraintEqualToAnchor:retainPtr([bottom widthAnchor]).get()],
+        [retainPtr([line leadingAnchor]) constraintEqualToAnchor:retainPtr([bottom leadingAnchor]).get()],
+        [retainPtr([line topAnchor]) constraintEqualToAnchor:retainPtr([bottom topAnchor]).get()],
+        [retainPtr([line heightAnchor]) constraintEqualToConstant:1],
+        [retainPtr([retainPtr([bottom topAnchor]) anchorWithOffsetToAnchor:retainPtr([details topAnchor]).get()]) constraintEqualToConstant:marginSize],
+        [retainPtr([retainPtr([details bottomAnchor]) anchorWithOffsetToAnchor:retainPtr([bottom bottomAnchor]).get()]) constraintEqualToConstant:marginSize],
+        [retainPtr([retainPtr([bottom leadingAnchor]) anchorWithOffsetToAnchor:retainPtr([details leadingAnchor]).get()]) constraintEqualToConstant:marginSize],
+        [retainPtr([retainPtr([details trailingAnchor]) anchorWithOffsetToAnchor:retainPtr([bottom trailingAnchor]).get()]) constraintEqualToConstant:marginSize],
     ]];
 #endif
     [self layoutText];
@@ -581,7 +581,7 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
         [alert setInformativeText:RetainPtr { WEB_UI_NSSTRING(@"Merely visiting a site is sufficient for malware to install itself and harm your computer.", "Malware confirmation dialog") }.get()];
         [alert addButtonWithTitle:RetainPtr { WEB_UI_NSSTRING(@"Cancel", "Cancel") }.get()];
         [alert addButtonWithTitle:RetainPtr { WEB_UI_NSSTRING(@"Continue", "Continue") }.get()];
-        [alert beginSheetModalForWindow:self.window completionHandler:makeBlockPtr([weakSelf = WeakObjCPtr<_WKWarningView>(self), alert](NSModalResponse returnCode) {
+        [alert beginSheetModalForWindow:retainPtr(self.window).get() completionHandler:makeBlockPtr([weakSelf = WeakObjCPtr<_WKWarningView>(self), alert](NSModalResponse returnCode) {
             if (auto strongSelf = weakSelf.get()) {
                 if (returnCode == NSAlertSecondButtonReturn && strongSelf->_completionHandler)
                     strongSelf->_completionHandler(WebKit::ContinueUnsafeLoad::Yes);
@@ -623,7 +623,7 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
     [string addAttributes:@{ NSForegroundColorAttributeName : foregroundColor.get() } range:NSMakeRange(0, [string length])];
     [self setBackgroundColor:colorForItem(WarningItem::BoxBackground, warning).get()];
     [self setLinkTextAttributes:@{ NSForegroundColorAttributeName : foregroundColor.get() }];
-    [self.textStorage appendAttributedString:string.get()];
+    [retainPtr(self.textStorage) appendAttributedString:string.get()];
     self.editable = NO;
 #if !PLATFORM(MAC)
     self.scrollEnabled = NO;
@@ -635,8 +635,8 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
 - (SizeType)intrinsicContentSize
 {
 #if PLATFORM(MAC)
-    [self.layoutManager ensureLayoutForTextContainer:self.textContainer];
-    return { NSViewNoIntrinsicMetric, [self.layoutManager usedRectForTextContainer:self.textContainer].size.height };
+    [retainPtr(self.layoutManager) ensureLayoutForTextContainer:retainPtr(self.textContainer).get()];
+    return { NSViewNoIntrinsicMetric, [retainPtr(self.layoutManager) usedRectForTextContainer:retainPtr(self.textContainer).get()].size.height };
 #elif HAVE(SAFE_BROWSING)
     auto width = std::min<CGFloat>(maxWidth, [_warning frame].size.width) - 2 * marginSize;
     constexpr auto noHeightConstraint = CGFLOAT_MAX;


### PR DESCRIPTION
#### dfbf21ae69710baca9f33427bff49ed97ca45583
<pre>
Prepare Source/WebKit for clang static analyzer update (part 3)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301064">https://bugs.webkit.org/show_bug.cgi?id=301064</a>

Reviewed by Geoffrey Garen.

Deployed more smart pointers to prepare Source/WebKit for a future clang static analyzer update.

No new tests since there should be no behavioral difference.

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
(-[WKWebsiteDataRecord description]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore fetchDataOfTypes:completionHandler:]):
(+[WKWebsiteDataStore _allWebsiteDataTypesIncludingPrivate]):
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifest initWithCoder:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm:
(-[_WKAttachment description]):
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.mm:
(-[_WKAutomationSessionConfiguration copyWithZone:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm:
(+[_WKDownload downloadWithDownload:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm:
(-[_WKFeature description]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm:
(-[_WKInspector printErrorToConsole:]):
(-[_WKInspector _setDiagnosticLoggingDelegate:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm:
(-[_WKInspectorConfiguration copyWithZone:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.mm:
(-[_WKInspectorDebuggableInfo copyWithZone:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorTesting.mm:
(JavaScriptSnippetToOpenURLExternally):
(JavaScriptSnippetToFetchURL):
(-[_WKInspector _openURLExternallyForTesting:useFrontendAPI:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm:
(-[_WKProcessPoolConfiguration description]):
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm:
(-[_WKResourceLoadInfo initWithCoder:]):
(-[_WKResourceLoadInfo encodeWithCoder:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationItem.mm:
(-[_WKTextManipulationItem isEqualToTextManipulationItem:includingContentEquality:]):
(-[_WKTextManipulationItem _descriptionPreservingPrivacy:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationToken.mm:
(-[_WKTextManipulationToken isEqualToTextManipulationToken:includingContentEquality:]):
(-[_WKTextManipulationToken _descriptionPreservingPrivacy:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextRun.mm:
(-[_WKTextRun debugDescription]):
* Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm:
(-[_WKThumbnailView _thumbnailLayer]):
* Source/WebKit/UIProcess/API/Cocoa/_WKUserContentExtensionStore.mm:
(toUserContentRuleListStoreError):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(getAllLocalAuthenticatorCredentialsImpl):
(+[_WKWebAuthenticationPanel setDisplayNameForLocalCredentialWithGroupAndID:credential:displayName:]):
(+[_WKWebAuthenticationPanel setNameForLocalCredentialWithGroupAndID:credential:name:]):
(+[_WKWebAuthenticationPanel exportLocalAuthenticatorCredentialWithGroupAndID:credential:error:]):
(publicKeyCredentialUserEntity):
(publicKeyCredentialDescriptors):
(+[_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:]):
(+[_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm:
(uuidFromPushPartition):
(+[_WKWebPushAction webPushActionWithDictionary:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration initWithDirectory:]):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _holdWindowResizeSnapshotIfNeeded]):
(-[WKWebView ALLOW_DEPRECATED_IMPLEMENTATIONS_END]):
(-[WKWebView _protectedTextFinderClient]):
(-[WKWebView findMatchesForString:relativeToMatch:findOptions:maxResults:resultCollector:]):
(-[WKWebView replaceMatches:withString:inSelectionOnly:resultCollector:]):
(-[WKWebView scrollFindMatchToVisible:]):
(-[WKWebView getSelectedText:]):
(-[WKWebView selectFindMatch:completionHandler:]):
(-[WKWebView _web_prepareForImmediateActionAnimation]):
(-[WKWebView _web_cancelImmediateActionAnimation]):
(-[WKWebView _web_completeImmediateActionAnimation]):
(-[WKWebView _web_dragDestinationActionForDraggingInfo:]):
(-[WKWebView _web_didPerformDragOperation:]):
* Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm:
(WebKit::AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc):
* Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm:
(WebKit::WebAutomationSession::platformGenerateLocalFilePathForRemoteFile):
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::WebAutomationSession::platformSimulateWheelInteraction):
* Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm:
(WebKit::AuxiliaryProcessProxy::platformOverrideLanguages const):
* Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm:
(WebKit::replace):
(WebKit::addLinkAndReplace):
(WebKit::browsingDetailsText):
* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::alertForPermission):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationResponse):
(WebKit::createErrorWithRecoveryAttempter):
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::dictationAlternatives):
* Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm:
(WebKit::convertToWebContext):
(WebKit::convertToWebSession):
(WebKit::convertToWebTextSuggestion):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::continueStartAfterDecidePolicy):
(WebKit::SOAuthorizationSession::complete):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::focusFromServiceWorker):
(WebKit::UIDelegate::UIClient::dataDetectionReferenceDate):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::createLayerWithID):
(WebKit::VideoPresentationManagerProxy::createLayerHostViewWithID):
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(nameForFileURLWithTypeIdentifier):
(-[WKShareSheet presentWithShareDataArray:inRect:]):
* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm:
(-[_WKSSOSiteList tableView:viewForTableColumn:row:]):
(-[_WKSSOSiteList toggleTableViewContents:]):
(WebKit::displayStorageAccessAlert):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::startApplePayAMSUISession):
(WebKit::WebPageProxy::isQuarantinedAndNotUserApproved):
* Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm:
(WebKit::debugUserDefaultsValue):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::unregisterNotificationObservers):
(WebKit::WebProcessPool::clearPermanentCredentialsForProtectionSpace):
* Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm:
(-[_WKWarningView addContent]):
(-[_WKWarningView showDetailsClicked]):
(-[_WKWarningView clickedOnLink:]):
(-[_WKWarningViewTextView initWithAttributedString:forWarning:]):
(-[_WKWarningViewTextView intrinsicContentSize]):

Canonical link: <a href="https://commits.webkit.org/301826@main">https://commits.webkit.org/301826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1b8be86e52bd34f1e0ff323e5835a6963dfd407

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127169 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78724 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/58a87ab9-43e3-46b1-b927-3b4a939bcaa6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96779 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/de015d42-2b30-4a48-be27-1e4446cf79dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77284 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7a5bb680-0e30-43ff-93b5-50a5066f3ea4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77613 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136716 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105299 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104986 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50510 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28955 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51391 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19897 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53766 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59852 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54748 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->