### PR TITLE
[Swift in WebKit] Enable Swift in

### DIFF
--- a/Source/WTF/Configurations/WTF.xcconfig
+++ b/Source/WTF/Configurations/WTF.xcconfig
@@ -65,3 +65,24 @@ GENERATE_WTF_MODULEMAP[sdk=macosx26.3*] = $(WK_NOT_$(DEPLOYMENT_LOCATION));
 
 GENERATE_WTF_MODULEMAP[sdk=iphone*] = $(GENERATE_WTF_MODULEMAP$(WK_IOS_26));
 GENERATE_WTF_MODULEMAP_IOS_SINCE_26 = YES;
+
+SCRIPT_OUTPUT_DIR = $(SCRIPT_OUTPUT_DIR__$(DEPLOYMENT_LOCATION:default=NO));
+SCRIPT_OUTPUT_DIR__NO = $(TARGET_BUILD_DIR);
+SCRIPT_OUTPUT_DIR__YES = $(DSTROOT);
+
+USE_HEADERMAP = NO;
+USER_HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT);
+
+SWIFT_VERSION = 6.0;
+SWIFT_VERSION[sdk=macosx14*] = 5.0;
+
+SWIFT_OPTIMIZATION_LEVEL = -O;
+SWIFT_OPTIMIZATION_LEVEL[config=Debug] = -Onone;
+
+OTHER_SWIFT_FLAGS = $(inherited) -Xcc -std=c++2b -Xfrontend -experimental-spi-only-imports -no-verify-emitted-module-interface -Xfrontend -enable-experimental-concurrency -Xfrontend -enable-upcoming-feature -Xfrontend IsolatedDefaultValues;
+
+SWIFT_OBJC_INTEROP_MODE = objcxx;
+
+BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+SWIFT_INSTALL_OBJC_HEADER = NO;
+SWIFT_LIBRARY_LEVEL = spi;

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07FB5E5C2EA5E86400603B46 /* wtf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FB5E5B2EA5E86400603B46 /* wtf.swift */; };
 		0F0C03D029981BEB0064230A /* EmbeddedFixedVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0C03CF29981BEB0064230A /* EmbeddedFixedVector.cpp */; };
 		0F0C03D8299820EB0064230A /* WeakPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0C03D7299820EB0064230A /* WeakPtr.cpp */; };
 		0F0C03E7299828E60064230A /* BloomFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0C03E6299828E50064230A /* BloomFilter.cpp */; };
@@ -1077,6 +1078,8 @@
 /* Begin PBXFileReference section */
 		077CD86A1FD9CFD200828587 /* Logger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Logger.h; sourceTree = "<group>"; };
 		077CD86B1FD9CFD300828587 /* LoggerHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoggerHelper.h; sourceTree = "<group>"; };
+		07FB5E572EA5A86300603B46 /* wtf.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = wtf.modulemap; sourceTree = "<group>"; };
+		07FB5E5B2EA5E86400603B46 /* wtf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wtf.swift; sourceTree = "<group>"; };
 		0F0C03CF29981BEB0064230A /* EmbeddedFixedVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EmbeddedFixedVector.cpp; sourceTree = "<group>"; };
 		0F0C03D7299820EB0064230A /* WeakPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WeakPtr.cpp; sourceTree = "<group>"; };
 		0F0C03E6299828E50064230A /* BloomFilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BloomFilter.cpp; sourceTree = "<group>"; };
@@ -2792,6 +2795,8 @@
 				E388886E20C9095100E632BC /* WorkerPool.h */,
 				E4A0AD371A96245500536DF6 /* WorkQueue.cpp */,
 				E4A0AD381A96245500536DF6 /* WorkQueue.h */,
+				07FB5E572EA5A86300603B46 /* wtf.modulemap */,
+				07FB5E5B2EA5E86400603B46 /* wtf.swift */,
 				FE05FAFE1FE5007500093230 /* WTFAssertions.cpp */,
 				FE032AD02463E43B0012D7C7 /* WTFConfig.cpp */,
 				FE032AD12463E43B0012D7C7 /* WTFConfig.h */,
@@ -4180,7 +4185,7 @@
 				DD07DF4C2A7DB6640091EACE /* Symlink public SDK headers */,
 				DD3DC85D27A4BF87007E5B61 /* Headers */,
 				DDA35E4929CA74D4006C1018 /* Generate TAPI filelist */,
-				DDC9D68C2DEBE87000E175C0 /* Generate modulemap */,
+				07FB5E582EA5A93700603B46 /* Install Module Maps */,
 				5D247B5E14689B8600E78B76 /* Sources */,
 				5D247B5F14689B8600E78B76 /* Frameworks */,
 			);
@@ -4225,6 +4230,9 @@
 				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 1140;
 				TargetAttributes = {
+					5D247B6114689B8600E78B76 = {
+						LastSwiftMigration = 2630;
+					};
 					DDF3081D27C44EFE006A526F = {
 						CreatedOnToolsVersion = 13.3;
 					};
@@ -4250,6 +4258,26 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		07FB5E582EA5A93700603B46 /* Install Module Maps */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(PROJECT_DIR)/wtf/wtf.modulemap",
+			);
+			name = "Install Module Maps";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SCRIPT_OUTPUT_DIR)$(WTF_INSTALL_PATH_PREFIX)$(WK_LIBRARY_HEADERS_FOLDER_PATH)/wtf/module.modulemap",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "eval install -o \\$INSTALL_OWNER -g \\$INSTALL_GROUP -m \\$INSTALL_MODE_FLAG \\\"\\$SCRIPT_INPUT_FILE_0\\\" \\\"\\$SCRIPT_OUTPUT_FILE_0\\\"\n\n";
+		};
 		520CF9492BDA9B4800C27FD2 /* Generate clangd configuration file */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -4314,29 +4342,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ ${DEPLOYMENT_LOCATION} != YES ]; then\n    \"${SCRIPT_INPUT_FILE_0}\" --from=\"${WK_HEADERS_VFS_FILE}\" --install-dir=\"${BUILT_PRODUCTS_DIR}${PRIVATE_HEADERS_FOLDER_PATH}\" --relative-to=\"${SRCROOT}/wtf\" > \"${SCRIPT_OUTPUT_FILE_0}\"\nelse\n    \"${SRCROOT}/Scripts/generate-tapi-filelist.py\" --from=\"${DSTROOT}${PRIVATE_HEADERS_FOLDER_PATH}\" --install-dir=\"<SDKROOT>${PRIVATE_HEADERS_FOLDER_PATH}\" --relative-to=\"${DSTROOT}${PRIVATE_HEADERS_FOLDER_PATH}\" > \"${SCRIPT_OUTPUT_FILE_1}\"\nfi\n";
-		};
-		DDC9D68C2DEBE87000E175C0 /* Generate modulemap */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Scripts/modulemap-from-tapi-filelist.py",
-				"$(BUILT_PRODUCTS_DIR)/$(PRIVATE_HEADERS_FOLDER_PATH)/WTF.json",
-				"$(SRCROOT)/Configurations/modulemap.toml",
-			);
-			name = "Generate modulemap";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(PRIVATE_HEADERS_FOLDER_PATH)/module.modulemap",
-				"$(DSTROOT)/$(PRIVATE_HEADERS_FOLDER_PATH)/module.modulemap",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ \"${GENERATE_WTF_MODULEMAP}\" != YES ] && [ \"${DEPLOYMENT_LOCATION}\" != YES ]; then\nrm -f \"${SCRIPT_OUTPUT_FILE_0}\"\nelif [ \"${GENERATE_WTF_MODULEMAP}\" != YES ]; then\nrm -f \"${SCRIPT_OUTPUT_FILE_1}\"\nelif [ \"${DEPLOYMENT_LOCATION}\" != YES ]; then\n\"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_INPUT_FILE_1}\" --config \"${SCRIPT_INPUT_FILE_2}\" --relative-to \"${BUILT_PRODUCTS_DIR}${PRIVATE_HEADERS_FOLDER_PATH}\" > \"${SCRIPT_OUTPUT_FILE_0}\"\nelse\n\"${SCRIPT_INPUT_FILE_0}\" ${DSTROOT}/${PRIVATE_HEADERS_FOLDER_PATH}/WTF.json --config \"${SCRIPT_INPUT_FILE_2}\" --relative-to \"<SDKROOT>/${PRIVATE_HEADERS_FOLDER_PATH}\" > \"${SCRIPT_OUTPUT_FILE_1}\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -4546,6 +4551,7 @@
 				E388886F20C9095100E632BC /* WorkerPool.cpp in Sources */,
 				E4A0AD391A96245500536DF6 /* WorkQueue.cpp in Sources */,
 				E4A0AD3D1A96253C00536DF6 /* WorkQueueCocoa.cpp in Sources */,
+				07FB5E5C2EA5E86400603B46 /* wtf.swift in Sources */,
 				FE05FAFF1FE5007500093230 /* WTFAssertions.cpp in Sources */,
 				FE032AD22463E43B0012D7C7 /* WTFConfig.cpp in Sources */,
 				E36BA9DE29E275DB00300057 /* WTFProcess.cpp in Sources */,
@@ -4591,6 +4597,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B7314689C4700E78B76 /* WTF.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -4598,6 +4607,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B7314689C4700E78B76 /* WTF.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -4613,6 +4624,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B7314689C4700E78B76 /* WTF.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Production;
 		};

--- a/Source/WTF/wtf/AutodrainedPool.h
+++ b/Source/WTF/wtf/AutodrainedPool.h
@@ -29,8 +29,8 @@
 #pragma once
 
 #if defined(__OBJC__) && !defined(__clang_tapi__)
-#error Please use @autoreleasepool instead of AutodrainedPool.
-#endif
+#pragma message "Please use @autoreleasepool instead of AutodrainedPool."
+#else
 
 #include <wtf/Noncopyable.h>
 
@@ -62,3 +62,5 @@ private:
 } // namespace WTF
 
 using WTF::AutodrainedPool;
+
+#endif

--- a/Source/WTF/wtf/RefTrackerMixin.cpp
+++ b/Source/WTF/wtf/RefTrackerMixin.cpp
@@ -18,7 +18,7 @@
  */
 
 #include "config.h"
-#include "RefTrackerMixin.h"
+#include <wtf/RefTrackerMixin.h>
 
 #include <ranges>
 

--- a/Source/WTF/wtf/RefTrackerMixin.h
+++ b/Source/WTF/wtf/RefTrackerMixin.h
@@ -19,12 +19,12 @@
 
 #pragma once
 
-#include "Compiler.h"
-#include "DataLog.h"
-#include "HashMap.h"
-#include "Lock.h"
-#include "StackShot.h"
-#include "StackTrace.h"
+#include <wtf/Compiler.h>
+#include <wtf/DataLog.h>
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
+#include <wtf/StackShot.h>
+#include <wtf/StackTrace.h>
 
 #include <atomic>
 

--- a/Source/WTF/wtf/SIMDUTF.cpp
+++ b/Source/WTF/wtf/SIMDUTF.cpp
@@ -33,7 +33,7 @@ IGNORE_WARNINGS_BEGIN("cast-align")
 IGNORE_WARNINGS_BEGIN("documentation")
 IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage")
 
-#include "simdutf_impl.cpp.h"
+#include "simdutf/simdutf_impl.cpp.h"
 
 IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END

--- a/Source/WTF/wtf/cocoa/AutodrainedPool.cpp
+++ b/Source/WTF/wtf/cocoa/AutodrainedPool.cpp
@@ -27,7 +27,7 @@
  */
 
 #import "config.h"
-#import "AutodrainedPool.h"
+#import <wtf/AutodrainedPool.h>
 
 #import <wtf/spi/cocoa/objcSPI.h>
 

--- a/Source/WTF/wtf/cocoa/CrashReporter.cpp
+++ b/Source/WTF/wtf/cocoa/CrashReporter.cpp
@@ -24,7 +24,7 @@
 */
 
 #include "config.h"
-#include "CrashReporter.h"
+#include <wtf/cocoa/CrashReporter.h>
 
 #include <wtf/NeverDestroyed.h>
 #include <wtf/spi/cocoa/CrashReporterClientSPI.h>

--- a/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
@@ -24,11 +24,11 @@
 */
 
 #import "config.h"
-#import "SystemTracing.h"
+#import <wtf/SystemTracing.h>
 
 #if HAVE(OS_SIGNPOST)
 
-#import "ContinuousTime.h"
+#import <wtf/ContinuousTime.h>
 #import <dispatch/dispatch.h>
 #import <mach/mach_time.h>
 

--- a/Source/WTF/wtf/cocoa/UUIDCocoa.mm
+++ b/Source/WTF/wtf/cocoa/UUIDCocoa.mm
@@ -24,10 +24,10 @@
  */
 
 #import "config.h"
-#import "UUID.h"
+#import <wtf/UUID.h>
 
-#import "RetainPtr.h"
-#import "TypeCastsCocoa.h"
+#import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
@@ -27,7 +27,7 @@
  */
 
 #include "config.h"
-#include "FileHandle.h"
+#include <wtf/FileHandle.h>
 
 #include <sys/file.h>
 #include <sys/stat.h>

--- a/Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp
+++ b/Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp
@@ -24,7 +24,7 @@
  */
 
 #include "config.h"
-#include "MappedFileData.h"
+#include <wtf/MappedFileData.h>
 
 namespace WTF::FileSystemImpl {
 

--- a/Source/WTF/wtf/spi/cf/CFPrivSPI.h
+++ b/Source/WTF/wtf/spi/cf/CFPrivSPI.h
@@ -35,8 +35,8 @@ DECLARE_SYSTEM_HEADER
 
 #endif
 
-extern "C" {
+WTF_EXTERN_C_BEGIN
 
 CF_EXPORT const char *_CFProcessPath(void);
 
-}
+WTF_EXTERN_C_END

--- a/Source/WTF/wtf/spi/cf/CFRunLoopSPI.h
+++ b/Source/WTF/wtf/spi/cf/CFRunLoopSPI.h
@@ -35,8 +35,8 @@ DECLARE_SYSTEM_HEADER
 
 #endif
 
-extern "C" {
+WTF_EXTERN_C_BEGIN
 
 CF_EXPORT Boolean _CFRunLoopSetPerCalloutAutoreleasepoolEnabled(Boolean enabled) API_AVAILABLE(macos(10.16), ios(14.0), watchos(7.0), tvos(14.0));
 
-}
+WTF_EXTERN_C_END

--- a/Source/WTF/wtf/spi/cf/CFStringSPI.h
+++ b/Source/WTF/wtf/spi/cf/CFStringSPI.h
@@ -36,7 +36,7 @@ DECLARE_SYSTEM_HEADER
 
 #else
 
-extern "C" {
+WTF_EXTERN_C_BEGIN
 
 typedef CF_ENUM(CFIndex, CFStringCharacterClusterType)
 {
@@ -45,14 +45,13 @@ typedef CF_ENUM(CFIndex, CFStringCharacterClusterType)
     kCFStringBackwardDeletionCluster = 4
 };
 
-}
+WTF_EXTERN_C_END
 
 #endif
 
-extern "C" {
+WTF_EXTERN_C_BEGIN
 
 CFRange CFStringGetRangeOfCharacterClusterAtIndex(CFStringRef, CFIndex charIndex, CFStringCharacterClusterType);
 void _CFStringGetUserDefaultEncoding(UInt32* scriptValue, UInt32* regionValue);
 
-}
-
+WTF_EXTERN_C_END

--- a/Source/WTF/wtf/spi/darwin/ProcessMemoryFootprint.h
+++ b/Source/WTF/wtf/spi/darwin/ProcessMemoryFootprint.h
@@ -43,6 +43,8 @@
 #    endif
 #endif
 
+#ifdef __cplusplus
+
 struct ProcessMemoryFootprint {
 public:
     uint64_t current;
@@ -74,5 +76,7 @@ public:
 #endif
     }
 };
+
+#endif // __cplusplus
 
 #endif

--- a/Source/WTF/wtf/text/cocoa/StringImplCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/StringImplCocoa.mm
@@ -19,9 +19,9 @@
  */
 
 #import "config.h"
-#import "StringImpl.h"
+#import <wtf/text/StringImpl.h>
 
-#import "RetainPtr.h"
+#import <wtf/RetainPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/wtf.modulemap
+++ b/Source/WTF/wtf/wtf.modulemap
@@ -1,0 +1,39 @@
+module wtf [system] {
+    explicit module System {
+        header "Assertions.h"
+        header "Compiler.h"
+        header "ExportMacros.h"
+        header "Platform.h"
+        header "PlatformCallingConventions.h"
+        header "PlatformCPU.h"
+        header "PlatformEnable.h"
+        header "PlatformEnableCocoa.h"
+        header "PlatformHave.h"
+        header "PlatformLegacy.h"
+        header "PlatformOS.h"
+        header "PlatformUse.h"
+        export *
+    }
+
+    explicit module SPI {
+        umbrella "spi"
+
+        explicit module * {
+            export *
+        }
+    }
+
+    explicit module Cxx {
+        umbrella "."
+
+        requires cplusplus20
+
+        explicit module * {
+            export *
+        }
+    }
+
+    export *
+
+    link "wtf"
+}

--- a/Source/WTF/wtf/wtf.swift
+++ b/Source/WTF/wtf/wtf.swift
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+// Since libraries do not have module verification, this file exists to do
+// at least some minimal validation that the bmalloc module is configured properly.
+
+#if canImport(wtf.Cxx)
+import wtf.Cxx
+#endif

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -25,6 +25,7 @@
 
 import Metal
 import WebGPU_Internal
+import wtf.Cxx.text.TextStream
 public typealias WTFString = String
 public typealias String = Swift.String
 // FIXME: rdar://140819194

--- a/Source/bmalloc/Configurations/bmalloc.xcconfig
+++ b/Source/bmalloc/Configurations/bmalloc.xcconfig
@@ -54,3 +54,19 @@ STRIP_INSTALLED_PRODUCT = NO;
 // Used to generate headers filelist for TAPI in JavaScriptCore. CPP_HEADERMAP_PRODUCT_HEADERS_VFS_FILE
 // is not exported to script phases, so it must be bound to a different name.
 WK_HEADERS_VFS_FILE = $(CPP_HEADERMAP_PRODUCT_HEADERS_VFS_FILE);
+
+INSTALLHDRS_SCRIPT_PHASE = YES;
+
+SWIFT_VERSION = 6.0;
+SWIFT_VERSION[sdk=macosx14*] = 5.0;
+
+SWIFT_OPTIMIZATION_LEVEL = -O;
+SWIFT_OPTIMIZATION_LEVEL[config=Debug] = -Onone;
+
+OTHER_SWIFT_FLAGS = $(inherited) -Xcc -std=c++2b -Xfrontend -experimental-spi-only-imports -no-verify-emitted-module-interface -Xfrontend -enable-experimental-concurrency -Xfrontend -enable-upcoming-feature -Xfrontend IsolatedDefaultValues;
+
+SWIFT_OBJC_INTEROP_MODE = objcxx;
+
+BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+SWIFT_INSTALL_OBJC_HEADER = NO;
+SWIFT_LIBRARY_LEVEL = spi;

--- a/Source/bmalloc/Configurations/module.modulemap
+++ b/Source/bmalloc/Configurations/module.modulemap
@@ -6,7 +6,7 @@ module bmalloc [system] {
     // exported as part of the WebKit SPI, and therefore these headers need to be
     // buildable as a clang module.
     explicit module bmalloc_cpp {
-        requires cplusplus11
+        requires cplusplus20
         header "Algorithm.h"
         header "BAssert.h"
         header "BCompiler.h"

--- a/Source/bmalloc/bmalloc.swift
+++ b/Source/bmalloc/bmalloc.swift
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+// Since libraries do not have module verification, this file exists to do
+// at least some minimal validation that the bmalloc module is configured properly.
+
+#if canImport(bmalloc.bmalloc_cpp)
+import bmalloc.bmalloc_cpp
+#endif

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -21,6 +21,12 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		0100000C37BABA0A0A993999 /* pas_mte_config.c in Sources */ = {isa = PBXBuildFile; fileRef = 0100000A37BABA0A0A993999 /* pas_mte_config.c */; };
+		0100000C37BABA0A0A999999 /* pas_mte.c in Sources */ = {isa = PBXBuildFile; fileRef = 0100000A37BABA0A0A999999 /* pas_mte.c */; };
+		0100000D37BABA0A0A991999 /* pas_zero_memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A991999 /* pas_zero_memory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0100000D37BABA0A0A993999 /* pas_mte_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A993999 /* pas_mte_config.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0100000D37BABA0A0A999999 /* pas_mte.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A999999 /* pas_mte.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		07FB5E3D2EA4B31B00603B46 /* bmalloc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FB5E3C2EA4B31B00603B46 /* bmalloc.swift */; };
 		0F26A7A5205483130090A141 /* PerProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F26A7A42054830D0090A141 /* PerProcess.cpp */; };
 		0F5167741FAD685C008236A8 /* bmalloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5167731FAD6852008236A8 /* bmalloc.cpp */; };
 		0F5414442CFD832E0025EAD0 /* bmalloc_heap_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5414432CFD832E0025EAD0 /* bmalloc_heap_internal.h */; };
@@ -605,11 +611,6 @@
 		DD4BEDE229CBA49700398E35 /* minalign32_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F18F84125C3467700721C2A /* minalign32_heap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BEDE329CBA49700398E35 /* pas_compact_expendable_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 2C48133C27406A3E006CAB55 /* pas_compact_expendable_memory.c */; };
 		DD4BEDE429CBA49700398E35 /* pas_status_reporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC40A1B2451498400876DA0 /* pas_status_reporter.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		0100000C37BABA0A0A999999 /* pas_mte.c in Sources */ = {isa = PBXBuildFile; fileRef = 0100000A37BABA0A0A999999 /* pas_mte.c */; };
-		0100000D37BABA0A0A999999 /* pas_mte.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A999999 /* pas_mte.h */; settings = {ATTRIBUTES = (Private, ); };};
-		0100000C37BABA0A0A993999 /* pas_mte_config.c in Sources */ = {isa = PBXBuildFile; fileRef = 0100000A37BABA0A0A993999 /* pas_mte_config.c */; };
-		0100000D37BABA0A0A993999 /* pas_mte_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A993999 /* pas_mte_config.h */; settings = {ATTRIBUTES = (Private, ); };};
-		0100000D37BABA0A0A991999 /* pas_zero_memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A991999 /* pas_zero_memory.h */; settings = {ATTRIBUTES = (Private, ); };};
 		DD4BEDE529CBA49700398E35 /* pagesize64k_heap_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F18F83F25C3467700721C2A /* pagesize64k_heap_config.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BEDE629CBA49700398E35 /* iso_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC409292451494300876DA0 /* iso_heap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BEDE729CBA49700398E35 /* minalign32_heap_config.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F18F84425C3467700721C2A /* minalign32_heap_config.c */; };
@@ -747,6 +748,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0100000A37BABA0A0A993999 /* pas_mte_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_mte_config.c; path = libpas/src/libpas/pas_mte_config.c; sourceTree = "<group>"; };
+		0100000A37BABA0A0A999999 /* pas_mte.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_mte.c; path = libpas/src/libpas/pas_mte.c; sourceTree = "<group>"; };
+		0100000B37BABA0A0A991999 /* pas_zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_zero_memory.h; path = libpas/src/libpas/pas_zero_memory.h; sourceTree = "<group>"; };
+		0100000B37BABA0A0A993999 /* pas_mte_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_mte_config.h; path = libpas/src/libpas/pas_mte_config.h; sourceTree = "<group>"; };
+		0100000B37BABA0A0A999999 /* pas_mte.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_mte.h; path = libpas/src/libpas/pas_mte.h; sourceTree = "<group>"; };
+		07FB5E3C2EA4B31B00603B46 /* bmalloc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = bmalloc.swift; sourceTree = "<group>"; };
 		0F18F83C25C3467700721C2A /* pas_segregated_exclusive_view_inlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_segregated_exclusive_view_inlines.h; path = libpas/src/libpas/pas_segregated_exclusive_view_inlines.h; sourceTree = "<group>"; };
 		0F18F83D25C3467700721C2A /* minalign32_heap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = minalign32_heap.c; path = libpas/src/libpas/minalign32_heap.c; sourceTree = "<group>"; };
 		0F18F83E25C3467700721C2A /* pagesize64k_heap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pagesize64k_heap.c; path = libpas/src/libpas/pagesize64k_heap.c; sourceTree = "<group>"; };
@@ -1353,11 +1360,6 @@
 		2C48133B27406A3E006CAB55 /* pas_large_expendable_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_large_expendable_memory.c; path = libpas/src/libpas/pas_large_expendable_memory.c; sourceTree = "<group>"; };
 		2C48133C27406A3E006CAB55 /* pas_compact_expendable_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_compact_expendable_memory.c; path = libpas/src/libpas/pas_compact_expendable_memory.c; sourceTree = "<group>"; };
 		2C48133D27406A3E006CAB55 /* pas_compact_expendable_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_compact_expendable_memory.h; path = libpas/src/libpas/pas_compact_expendable_memory.h; sourceTree = "<group>"; };
-		0100000A37BABA0A0A999999 /* pas_mte.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_mte.c; path = libpas/src/libpas/pas_mte.c; sourceTree = "<group>"; };
-		0100000B37BABA0A0A999999 /* pas_mte.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_mte.h; path = libpas/src/libpas/pas_mte.h; sourceTree = "<group>"; };
-		0100000A37BABA0A0A993999 /* pas_mte_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_mte_config.c; path = libpas/src/libpas/pas_mte_config.c; sourceTree = "<group>"; };
-		0100000B37BABA0A0A993999 /* pas_mte_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_mte_config.h; path = libpas/src/libpas/pas_mte_config.h; sourceTree = "<group>"; };
-		0100000B37BABA0A0A991999 /* pas_zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_zero_memory.h; path = libpas/src/libpas/pas_zero_memory.h; sourceTree = "<group>"; };
 		2C48133E27406A3E006CAB55 /* pas_expendable_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_expendable_memory.h; path = libpas/src/libpas/pas_expendable_memory.h; sourceTree = "<group>"; };
 		2C48133F27406A3E006CAB55 /* pas_large_expendable_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_large_expendable_memory.h; path = libpas/src/libpas/pas_large_expendable_memory.h; sourceTree = "<group>"; };
 		2C91E551271CE47A00D67FF9 /* pas_size_lookup_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_size_lookup_mode.h; path = libpas/src/libpas/pas_size_lookup_mode.h; sourceTree = "<group>"; };
@@ -2079,6 +2081,7 @@
 			children = (
 				0F5167731FAD6852008236A8 /* bmalloc.cpp */,
 				1448C2FE18F3754300502839 /* bmalloc.h */,
+				07FB5E3C2EA4B31B00603B46 /* bmalloc.swift */,
 				1448C2FF18F3754300502839 /* mbmalloc.cpp */,
 			);
 			name = api;
@@ -2904,6 +2907,7 @@
 				14F271C318EA3978008C152F /* Allocator.cpp in Sources */,
 				6599C5CC1EC3F15900A2F7BB /* AvailableMemory.cpp in Sources */,
 				0F5167741FAD685C008236A8 /* bmalloc.cpp in Sources */,
+				07FB5E3D2EA4B31B00603B46 /* bmalloc.swift in Sources */,
 				14F271C418EA397B008C152F /* Cache.cpp in Sources */,
 				0F74B93F1F89713E00B935D3 /* CryptoRandom.cpp in Sources */,
 				14F271C518EA397E008C152F /* Deallocator.cpp in Sources */,


### PR DESCRIPTION
#### 748b2469662a65a02a6aae7eb2e938a19535ba8a
<pre>
[Swift in WebKit] Enable Swift in WTF
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Enable Swift and Swift-Cxx interop in WTF. In addition to enabling the possibility of using
Swift directly in WTF, it serves two important immediate-term purposes:

1. The module verifier tool does not currently support libraries, such as WTF and bmalloc. Compiling a
Swift file in WTF itself allows for at least a minimal means of verification (specifically, successful
compilation of this file indicates a necessary but not sufficient condition).

2. Enabling interop in WTF is an effective stepping stone to more complex projects like JSC
and WebCore, particularly because it is lower on the WebKit stack.

Notably, doing so uncovered several existing issues in the existing WTF module, which this fixes.

* Source/WTF/Configurations/WTF.xcconfig:

- Define `SCRIPT_OUTPUT_DIR` to be the destination of where the module map will be. More details on this
will follow in the below comments.

- Set `USE_HEADERMAP` to `NO`; it&apos;s generally a good idea to have header maps enabled, however this
causes issues with how the module map resolves the files within it, as it causes duplicate definition errors
between the source location and the build products location.

- Define `USER_HEADER_SEARCH_PATHS` so that `config.h` can be included as-is without having to specify a relative
path to the file each time.

- Enable Swift.

* Source/WTF/WTF.xcodeproj/project.pbxproj:

- Remove the script phase that generated the module map now that it is no longer needed.

- Previously, the WTF module map was generated through a Python script which installed the module map directly
in the built products location. Now that the module map is a proper normal file in the source directory, add a
build phase to copy and install it in the built products location.

* Source/WTF/wtf/AutodrainedPool.h:

This file should be able to be included in all environments per module rules, so just compile out the actual
contents of it without producing an error.

* Source/WTF/wtf/RefTrackerMixin.cpp:
* Source/WTF/wtf/RefTrackerMixin.h:
* Source/WTF/wtf/SIMDUTF.cpp:
* Source/WTF/wtf/cocoa/AutodrainedPool.cpp:
* Source/WTF/wtf/cocoa/CrashReporter.cpp:
* Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp:
* Source/WTF/wtf/cocoa/UUIDCocoa.mm:
* Source/WTF/wtf/posix/FileHandlePOSIX.cpp:
* Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp:
* Source/WTF/wtf/spi/cf/CFPrivSPI.h:
* Source/WTF/wtf/spi/cf/CFRunLoopSPI.h:
* Source/WTF/wtf/spi/cf/CFStringSPI.h:
* Source/WTF/wtf/spi/darwin/ProcessMemoryFootprint.h:
* Source/WTF/wtf/text/cocoa/StringImplCocoa.mm:

- The vast majority of wtf properly includes it&apos;s own headers using angle bracket includes
instead of quoted includes, but there are a handful of files that do not do this, so fix those.

- There are also some Objective-C header files missing compatibility with C, so fix those too.

* Source/WTF/wtf/wtf.modulemap: Added.

Now for the interesting part!

The existing generated module map had a few issues that prevented it from working properly:

- Some sub-modules were inconsistently and erroneously separated organizationally from the others.
- Some inferred sub-modules were incorrectly requiring C++ when they did not actually need it.
- This was generated in a build phase, which means it is absent in the source directory and was being
generated too late for Swift code within WTF itself to be able to use it, causing compilation issues.

There were also some non-breaking issues:

- Canonically, library modules should be located in the source directory with the filename being
&quot;&lt;library&gt;.modulemap&quot;, in this case &quot;wtf.modulemap&quot;. This also makes it substantially easier to actually
locate and comprehend the module map, and greatly reduces build complexity.

- Library modules should also be organized somewhat thematically, potentially using umbrellas. The current
approach did not facilitate this; instead, it separated sub-modules based on ad-hoc issues and created them
manually using a script.

To fix and address these issues, the `wtf.modulemap` is introduced, and here&apos;s how it works:

Line 1: `module wtf [system]`:

This defines a top-level module named `wtf`. Notably, this does not have the `framework` specifier since `wtf` is just a library. It has the `system` annotation applied since it will be part of the SDK.

Lines 2-14: `explicit module System`:

This defines an explicit sub-module of `wtf` named `System`, which thematically groups the set of headers that define platform or OS specific macros and behaviors. The `explicit` qualifier means that clients need to specify `wtf.Cxx` directly.

Line 15: `export *`

This exports all the headers in the module, including any transitive headers they themselves depend on.

Line 18: `explicit module SPI`

This defines an explicit sub-module named `SPI` which corresponds to the set of headers that forward declare system SPIs. Since these are Objective-C interfaces, they do not require C++.

Line 19: `umbrella &quot;spi&quot;`

This specifies the umbrella directory for the module, in this case the `spi` subdirectory of `wtf`. This means that the module is responsible for all headers in that directory.

Line 21: `explicit module *`

This creates inferred explicit submodules, one for each header in the umbrella directory (equivalent to defining each submodule manually).

Line 26: `explicit module Cxx`

This is the main sub-module for `wtf`; it has to be a sub-module since most WTF
headers require C++ and do not have compilation guards for it, so the requirement
is specified in the module itself. The `Cxx` name is used to match the convention
of how C-families are usually named from Swift.

Line 27: `umbrella &quot;.&quot;`

This specifies the umbrella directory for the module, which in this case is the entire directory of `wtf`. Note that this implicitly excludes the headers that were previously specified in prior sub-modules.

Line 36: `export *`

Export all sub-modules from this modules.

Line 38: `link &quot;wtf&quot;`

Libraries need to explicitly link themselves in their module maps, unlike frameworks.

* Source/WTF/wtf/wtf.swift: Added.

Create a basic Swift file as minimal validation of the module map.

* Source/WebGPU/WebGPU/CommandEncoder.swift:

This uses the `wtf` module, but was not importing it, so now it is.
</pre>
----------------------------------------------------------------------
#### aaacbe5d5dfe950994df0b3dc2282de1071ea101
<pre>
[Swift in WebKit] Enable Swift in bmalloc
<a href="https://bugs.webkit.org/show_bug.cgi?id=301054">https://bugs.webkit.org/show_bug.cgi?id=301054</a>
<a href="https://rdar.apple.com/162959248">rdar://162959248</a>

Reviewed by NOBODY (OOPS!).

Enable Swift and Swift-Cxx interop in bmalloc. In addition to enabling the possibility of using
Swift directly in bmalloc, it serves two important immediate-term purposes:

1. The module verifier tool does not currently support libraries, such as WTF and bmalloc. Compiling a
Swift file in bmalloc itself allows for at least a minimal means of verification (specifically, successful
compilation of this file indicates a necessary but not sufficient condition).

2. Enabling interop in bmalloc is an effective stepping stone to more complex projects like WTF
and WebCore, particularly because it is lower on the WebKit stack.

* Source/bmalloc/Configurations/bmalloc.xcconfig:
* Source/bmalloc/Configurations/module.modulemap:
* Source/bmalloc/bmalloc.swift: Added.
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/748b2469662a65a02a6aae7eb2e938a19535ba8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127094 "1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46730 "Hash 748b2469 for PR 52636 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37842 "Hash 748b2469 for PR 52636 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78656 "Built successfully") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47346 "Hash 748b2469 for PR 52636 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55256 "Hash 748b2469 for PR 52636 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96714 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64758 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a16be799-594c-444a-bce0-90025a4e7442) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130042 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/47346 "Hash 748b2469 for PR 52636 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/37842 "Hash 748b2469 for PR 52636 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77224 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8f066e50-9e59-4925-91dd-b2382cf3c436) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/47346 "Hash 748b2469 for PR 52636 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/37842 "Hash 748b2469 for PR 52636 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77488 "Built successfully") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119131 "Hash 748b2469 for PR 52636 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/47346 "Hash 748b2469 for PR 52636 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/37842 "Hash 748b2469 for PR 52636 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136622 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125557 "Hash 748b2469 for PR 52636 does not build (failure)") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53749 "Hash 748b2469 for PR 52636 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/55256 "Hash 748b2469 for PR 52636 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105234 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54253 "Hash 748b2469 for PR 52636 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/37842 "Hash 748b2469 for PR 52636 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104923 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/37842 "Hash 748b2469 for PR 52636 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51296 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53681 "Hash 748b2469 for PR 52636 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59554 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158594 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52919 "Hash 748b2469 for PR 52636 does not build (failure)") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39668 "Passed tests") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56252 "Hash 748b2469 for PR 52636 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54677 "Hash 748b2469 for PR 52636 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->