### PR TITLE
Prepare Source/WebKit for clang static analyzer update (part 4)

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -148,7 +148,7 @@ SecStaticCodeRef WebExtension::bundleStaticCode() const
         return m_bundleStaticCode.get();
 
     SecStaticCodeRef staticCodeRef;
-    OSStatus error = SecStaticCodeCreateWithPath(bridge_cast(m_bundle.get().bundleURL), kSecCSDefaultFlags, &staticCodeRef);
+    OSStatus error = SecStaticCodeCreateWithPath(retainPtr(bridge_cast(m_bundle.get().bundleURL)).get(), kSecCSDefaultFlags, &staticCodeRef);
     if (error != noErr || !staticCodeRef) {
         if (staticCodeRef)
             CFRelease(staticCodeRef);

--- a/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -125,9 +125,9 @@ WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()
     [m_window setDelegate:m_objCAdapter.get()];
     [m_window setFrameAutosaveName:@"WKRemoteWebInspectorWindowFrame"];
 
-    NSView *contentView = m_window.get().contentView;
+    RetainPtr<NSView> contentView = m_window.get().contentView;
     RetainPtr webView = this->webView();
-    [webView setFrame:contentView.bounds];
+    [webView setFrame:contentView.get().bounds];
     [contentView addSubview:webView.get()];
 
     return webView->_page.get();
@@ -152,7 +152,7 @@ void RemoteWebInspectorUIProxy::platformCloseFrontendPageAndWindow()
 
 void RemoteWebInspectorUIProxy::platformResetState()
 {
-    [NSWindow removeFrameUsingName:[m_window frameAutosaveName]];
+    [NSWindow removeFrameUsingName:retainPtr([m_window frameAutosaveName]).get()];
 }
 
 void RemoteWebInspectorUIProxy::platformBringToFront()
@@ -260,7 +260,7 @@ void RemoteWebInspectorUIProxy::platformShowCertificate(const CertificateInfo& c
     [certificatePanel beginSheetForWindow:m_window.get() modalDelegate:nil didEndSelector:NULL contextInfo:nullptr trust:certificateInfo.trust().get() showGroup:YES];
 
     // This must be called after the trust panel has been displayed, because the certificateView doesn't exist beforehand.
-    SFCertificateView *certificateView = [certificatePanel certificateView];
+    RetainPtr certificateView = [certificatePanel certificateView];
     [certificateView setDisplayTrust:YES];
     [certificateView setEditableTrust:NO];
     [certificateView setDisplayDetails:YES];

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -154,32 +154,32 @@ static void* const safeAreaInsetsKVOContext = (void*)&safeAreaInsetsKVOContext;
     }
 #endif
 
-    WKPreferences *preferences = configuration.get().preferences;
-    preferences._allowFileAccessFromFileURLs = YES;
+    RetainPtr<WKPreferences> preferences = configuration.get().preferences;
+    preferences.get()._allowFileAccessFromFileURLs = YES;
     [configuration _setAllowUniversalAccessFromFileURLs:YES];
     [configuration _setAllowTopNavigationToDataURLs:YES];
-    preferences._storageBlockingPolicy = _WKStorageBlockingPolicyAllowAll;
-    preferences._javaScriptRuntimeFlags = 0;
+    preferences.get()._storageBlockingPolicy = _WKStorageBlockingPolicyAllowAll;
+    preferences.get()._javaScriptRuntimeFlags = 0;
 
 #ifndef NDEBUG
     // Allow developers to inspect the Web Inspector in debug builds without changing settings.
-    preferences._developerExtrasEnabled = YES;
-    preferences._logsPageMessagesToSystemConsoleEnabled = YES;
+    preferences.get()._developerExtrasEnabled = YES;
+    preferences.get()._logsPageMessagesToSystemConsoleEnabled = YES;
 #endif
 
-    preferences._diagnosticLoggingEnabled = YES;
+    preferences.get()._diagnosticLoggingEnabled = YES;
 
     // Disable Site Isolation for Web Inspector View.
-    preferences._siteIsolationEnabled = NO;
+    preferences.get()._siteIsolationEnabled = NO;
 
     [_configuration applyToWebViewConfiguration:configuration.get()];
 
     RetainPtr delegate = _delegate.get();
     if (!!delegate && [delegate respondsToSelector:@selector(inspectorViewControllerInspectorIsUnderTest:)]) {
         if ([delegate inspectorViewControllerInspectorIsUnderTest:self]) {
-            preferences._hiddenPageDOMTimerThrottlingEnabled = NO;
-            preferences._pageVisibilityBasedProcessSuppressionEnabled = NO;
-            preferences.inactiveSchedulingPolicy = WKInactiveSchedulingPolicyNone;
+            preferences.get()._hiddenPageDOMTimerThrottlingEnabled = NO;
+            preferences.get()._pageVisibilityBasedProcessSuppressionEnabled = NO;
+            preferences.get().inactiveSchedulingPolicy = WKInactiveSchedulingPolicyNone;
         }
     }
 
@@ -187,7 +187,7 @@ static void* const safeAreaInsetsKVOContext = (void*)&safeAreaInsetsKVOContext;
     // If not specified or the inspection level is >1, use the default strategy.
     // This ensures that Inspector^2 cannot be affected by client (mis)configuration.
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    auto* customProcessPool = configuration.get().processPool;
+    RetainPtr<WKProcessPool> customProcessPool = configuration.get().processPool;
     ALLOW_DEPRECATED_DECLARATIONS_END
     auto inspectorLevel = WebKit::inspectorLevelForPage(inspectedPage.get());
     auto useDefaultProcessPool = inspectorLevel > 1 || !customProcessPool;
@@ -299,8 +299,8 @@ static void* const safeAreaInsetsKVOContext = (void*)&safeAreaInsetsKVOContext;
 - (NSMenu *)_webView:(WKWebView *)webView contextMenu:(NSMenu *)menu forElement:(_WKContextMenuElementInfo *)element
 {
     for (NSInteger i = menu.numberOfItems - 1; i >= 0; --i) {
-        NSMenuItem *item = [menu itemAtIndex:i];
-        switch (item.tag) {
+        RetainPtr<NSMenuItem> item = [menu itemAtIndex:i];
+        switch (item.get().tag) {
         case kWKContextMenuItemTagOpenLinkInNewWindow:
         case kWKContextMenuItemTagOpenImageInNewWindow:
         case kWKContextMenuItemTagOpenFrameInNewWindow:

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorWKWebView.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorWKWebView.mm
@@ -59,6 +59,11 @@
     return _inspectorWKWebViewDelegate.getAutoreleased();
 }
 
+- (RetainPtr<id <WKInspectorWKWebViewDelegate>>)protectedInspectorWKWebViewDelegate
+{
+    return self.inspectorWKWebViewDelegate;
+}
+
 - (void)setInspectorWKWebViewDelegate:(id <WKInspectorWKWebViewDelegate>)delegate
 {
     if (!!_inspectorWKWebViewDelegate)
@@ -72,37 +77,37 @@
 
 - (IBAction)reload:(id)sender
 {
-    [self.inspectorWKWebViewDelegate inspectorWKWebViewReload:self];
+    [self.protectedInspectorWKWebViewDelegate inspectorWKWebViewReload:self];
 }
 
 - (IBAction)reloadFromOrigin:(id)sender
 {
-    [self.inspectorWKWebViewDelegate inspectorWKWebViewReloadFromOrigin:self];
+    [self.protectedInspectorWKWebViewDelegate inspectorWKWebViewReloadFromOrigin:self];
 }
 
 - (void)viewWillMoveToWindow:(NSWindow *)newWindow
 {
     [super viewWillMoveToWindow:newWindow];
-    [self.inspectorWKWebViewDelegate inspectorWKWebView:self willMoveToWindow:newWindow];
+    [self.protectedInspectorWKWebViewDelegate inspectorWKWebView:self willMoveToWindow:newWindow];
 }
 
 - (void)viewDidMoveToWindow
 {
     [super viewDidMoveToWindow];
-    [self.inspectorWKWebViewDelegate inspectorWKWebViewDidMoveToWindow:self];
+    [self.protectedInspectorWKWebViewDelegate inspectorWKWebViewDidMoveToWindow:self];
 }
 
 - (BOOL)becomeFirstResponder
 {
     BOOL result = [super becomeFirstResponder];
-    [self.inspectorWKWebViewDelegate inspectorWKWebViewDidBecomeActive:self];
+    [self.protectedInspectorWKWebViewDelegate inspectorWKWebViewDidBecomeActive:self];
     return result;
 }
 
 - (void)_handleWindowDidBecomeKey:(NSNotification *)notification
 {
     if (notification.object == self.window)
-        [self.inspectorWKWebViewDelegate inspectorWKWebViewDidBecomeActive:self];
+        [self.protectedInspectorWKWebViewDelegate inspectorWKWebViewDidBecomeActive:self];
 }
 
 @end

--- a/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
+++ b/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
@@ -202,7 +202,7 @@ void MediaUsageManagerCocoa::updateMediaUsage(WebCore::MediaSessionIdentifier id
         session->mediaUsageInfo = mediaUsageInfo;
 
     } @catch(NSException *exception) {
-        WTFLogAlways("MediaUsageManagerCocoa::updateMediaUsage caught exception: %@", [exception reason]);
+        WTFLogAlways("MediaUsageManagerCocoa::updateMediaUsage caught exception: %@", retainPtr([exception reason]).get());
     }
 }
 

--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
@@ -115,7 +115,7 @@ static NSArray<NSString *> *controlArray()
     _page = page;
     _deviceScaleFactor = page.deviceScaleFactor();
     _visible = YES;
-    [self _setupLayer:self.layer];
+    [self _setupLayer:retainPtr(self.layer).get()];
     [self setFrame:frame];
 
     WeakObjCPtr<WKPDFHUDView> weakSelf = self;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -280,7 +280,8 @@ RemoteLayerTreeNode* RemoteLayerTreeNode::forCALayer(CALayer *layer)
 NSString *RemoteLayerTreeNode::appendLayerDescription(NSString *description, CALayer *layer)
 {
     auto layerID = WebKit::RemoteLayerTreeNode::layerID(layer);
-    RetainPtr layerDescription = adoptNS([[NSString alloc] initWithFormat:@" layerID = %llu \"%@\"", layerID ? layerID->object().toUInt64() : 0, layer.name ? layer.name : @""]);
+    RetainPtr<NSString> name = layer.name ? layer.name : @"";
+    RetainPtr layerDescription = adoptNS([[NSString alloc] initWithFormat:@" layerID = %llu \"%@\"", layerID ? layerID->object().toUInt64() : 0, name.get()]);
     return [description stringByAppendingString:layerDescription.get()];
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
@@ -48,7 +48,7 @@
 
 - (NSString *)description
 {
-    return WebKit::RemoteLayerTreeNode::appendLayerDescription(super.description, self);
+    return WebKit::RemoteLayerTreeNode::appendLayerDescription(retainPtr(super.description).get(), self);
 }
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
@@ -158,7 +158,7 @@ void CcidService::updateSlots(NSArray *slots)
     callOnMainRunLoop([service = m_service, change = retainPtr(change)] () mutable {
         if (!service)
             return;
-        service->updateSlots(change.get()[NSKeyValueChangeNewKey]);
+        service->updateSlots(retainPtr(change.get()[NSKeyValueChangeNewKey]).get());
     });
 }
 @end

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
@@ -231,7 +231,7 @@ RetainPtr<NSArray> LocalConnection::getExistingCredentials(const String& rpId)
     // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
     SUPPRESS_RETAINPTR_CTOR_ADOPT RetainPtr nsAttributesArray = bridge_cast(adoptCF(checked_cf_cast<CFArrayRef>(attributesArrayRef)));
     return [nsAttributesArray sortedArrayUsingComparator:^(NSDictionary *a, NSDictionary *b) {
-        return [b[(id)kSecAttrModificationDate] compare:a[(id)kSecAttrModificationDate]];
+        return [retainPtr(b[(id)kSecAttrModificationDate]) compare:retainPtr(a[(id)kSecAttrModificationDate]).get()];
     }];
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
@@ -110,7 +110,7 @@ void NfcConnection::didDetectTags(NSArray *tags)
     // Therefore, we use tagID to detect if there are multiple physical tags.
     RetainPtr<NSData> tagID = ((NFTag *)tags[0]).tagID;
     for (NFTag *tag : tags) {
-        if ([tagID isEqualToData:tag.tagID])
+        if ([tagID isEqualToData:retainPtr(tag.tagID).get()])
             continue;
         service->didDetectMultipleTags();
         restartPolling();

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -616,10 +616,10 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
             } else if ([auth.get().credential isKindOfClass:getASAuthorizationPlatformPublicKeyCredentialRegistrationClassSingleton()]) {
                 response.isAuthenticatorAttestationResponse = true;
                 auto credential = retainPtr((ASAuthorizationPlatformPublicKeyCredentialRegistration *)auth.get().credential);
-                response.rawId = toArrayBuffer(credential.get().credentialID);
-                response.attestationObject = toArrayBuffer(credential.get().rawAttestationObject);
+                response.rawId = toArrayBuffer(retainPtr(credential.get().credentialID).get());
+                response.attestationObject = toArrayBuffer(retainPtr(credential.get().rawAttestationObject).get());
                 response.transports = { AuthenticatorTransport::Internal, AuthenticatorTransport::Hybrid };
-                response.clientDataJSON = toArrayBuffer(credential.get().rawClientDataJSON);
+                response.clientDataJSON = toArrayBuffer(retainPtr(credential.get().rawClientDataJSON).get());
 
                 attachment = fromASAuthorizationPublicKeyCredentialAttachment(credential.get().attachment);
 
@@ -636,9 +636,9 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
                     RefPtr<ArrayBuffer> first = nullptr;
                     RefPtr<ArrayBuffer> second = nullptr;
                     if (credential.get().prf.first)
-                        first = toArrayBuffer(credential.get().prf.first);
+                        first = toArrayBuffer(retainPtr(credential.get().prf.first).get());
                     if (credential.get().prf.second)
-                        second = toArrayBuffer(credential.get().prf.second);
+                        second = toArrayBuffer(retainPtr(credential.get().prf.second).get());
                     if (first)
                         extensionOutputs.prf = { credential.get().prf.isSupported, { { first, second } } };
                     else
@@ -650,11 +650,11 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
                     response.extensionOutputs = extensionOutputs;
             } else if ([auth.get().credential isKindOfClass:getASAuthorizationPlatformPublicKeyCredentialAssertionClassSingleton()]) {
                 auto credential = retainPtr((ASAuthorizationPlatformPublicKeyCredentialAssertion *)auth.get().credential);
-                response.rawId = toArrayBuffer(credential.get().credentialID);
-                response.authenticatorData = toArrayBuffer(credential.get().rawAuthenticatorData);
-                response.signature = toArrayBuffer(credential.get().signature);
-                response.userHandle = toArrayBufferNilIfEmpty(credential.get().userID);
-                response.clientDataJSON = toArrayBuffer(credential.get().rawClientDataJSON);
+                response.rawId = toArrayBuffer(retainPtr(credential.get().credentialID).get());
+                response.authenticatorData = toArrayBuffer(retainPtr(credential.get().rawAuthenticatorData).get());
+                response.signature = toArrayBuffer(retainPtr(credential.get().signature).get());
+                response.userHandle = toArrayBufferNilIfEmpty(retainPtr(credential.get().userID).get());
+                response.clientDataJSON = toArrayBuffer(retainPtr(credential.get().rawClientDataJSON).get());
 
                 attachment = fromASAuthorizationPublicKeyCredentialAttachment(credential.get().attachment);
 
@@ -664,17 +664,17 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
                     hasExtensionOutput = true;
                     RefPtr<ArrayBuffer> protector = nullptr;
                     if (credential.get().largeBlob.readData)
-                        protector = toArrayBuffer(credential.get().largeBlob.readData);
+                        protector = toArrayBuffer(retainPtr(credential.get().largeBlob.readData).get());
                     extensionOutputs.largeBlob = { std::nullopt, protector, credential.get().largeBlob.didWrite };
                 }
 
 #if HAVE(WEB_AUTHN_PRF_API)
                 if ([credential respondsToSelector:@selector(prf)] && credential.get().prf) {
                     hasExtensionOutput = true;
-                    RefPtr<ArrayBuffer> first = toArrayBuffer(credential.get().prf.first);
+                    RefPtr<ArrayBuffer> first = toArrayBuffer(retainPtr(credential.get().prf.first).get());
                     RefPtr<ArrayBuffer> second = nullptr;
                     if (credential.get().prf.second)
-                        second = toArrayBuffer(credential.get().prf.second);
+                        second = toArrayBuffer(retainPtr(credential.get().prf.second).get());
                     extensionOutputs.prf = { std::nullopt, { { first, second } } };
                 }
 #endif
@@ -684,21 +684,21 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
             } else if ([auth.get().credential isKindOfClass:getASAuthorizationSecurityKeyPublicKeyCredentialRegistrationClassSingleton()]) {
                 auto credential = retainPtr((ASAuthorizationSecurityKeyPublicKeyCredentialRegistration *)auth.get().credential);
                 response.isAuthenticatorAttestationResponse = true;
-                response.rawId = toArrayBuffer(credential.get().credentialID);
-                response.attestationObject = toArrayBuffer(credential.get().rawAttestationObject);
+                response.rawId = toArrayBuffer(retainPtr(credential.get().credentialID).get());
+                response.attestationObject = toArrayBuffer(retainPtr(credential.get().rawAttestationObject).get());
                 if ([credential respondsToSelector:@selector(transports)])
-                    response.transports = toTransports(credential.get().transports);
+                    response.transports = toTransports(retainPtr(credential.get().transports).get());
                 else
                     response.transports = { };
-                response.clientDataJSON = toArrayBuffer(credential.get().rawClientDataJSON);
+                response.clientDataJSON = toArrayBuffer(retainPtr(credential.get().rawClientDataJSON).get());
                 attachment = AuthenticatorAttachment::CrossPlatform;
             } else if ([auth.get().credential isKindOfClass:getASAuthorizationSecurityKeyPublicKeyCredentialAssertionClassSingleton()]) {
                 auto credential = retainPtr((ASAuthorizationSecurityKeyPublicKeyCredentialAssertion *)auth.get().credential);
-                response.rawId = toArrayBuffer(credential.get().credentialID);
-                response.authenticatorData = toArrayBuffer(credential.get().rawAuthenticatorData);
-                response.signature = toArrayBuffer(credential.get().signature);
-                response.userHandle = toArrayBufferNilIfEmpty(credential.get().userID);
-                response.clientDataJSON = toArrayBuffer(credential.get().rawClientDataJSON);
+                response.rawId = toArrayBuffer(retainPtr(credential.get().credentialID).get());
+                response.authenticatorData = toArrayBuffer(retainPtr(credential.get().rawAuthenticatorData).get());
+                response.signature = toArrayBuffer(retainPtr(credential.get().signature).get());
+                response.userHandle = toArrayBufferNilIfEmpty(retainPtr(credential.get().userID).get());
+                response.clientDataJSON = toArrayBuffer(retainPtr(credential.get().rawClientDataJSON).get());
                 attachment = AuthenticatorAttachment::CrossPlatform;
                 if ([credential respondsToSelector:@selector(appID)]) {
                     AuthenticationExtensionsClientOutputs extensionOutputs;
@@ -1052,14 +1052,14 @@ static inline void continueAfterRequest(RetainPtr<id <ASCCredentialProtocol>> cr
         response.isAuthenticatorAttestationResponse = true;
 
         ASCPlatformPublicKeyCredentialRegistration *registrationCredential = credential.get();
-        response.rawId = toArrayBuffer(registrationCredential.credentialID);
-        response.attestationObject = toArrayBuffer(registrationCredential.attestationObject);
-        response.clientDataJSON = toArrayBuffer(registrationCredential.rawClientDataJSON);
+        response.rawId = toArrayBuffer(retainPtr(registrationCredential.credentialID).get());
+        response.attestationObject = toArrayBuffer(retainPtr(registrationCredential.attestationObject).get());
+        response.clientDataJSON = toArrayBuffer(retainPtr(registrationCredential.rawClientDataJSON).get());
         rawAttachment = registrationCredential.attachment;
         if ([registrationCredential respondsToSelector:@selector(transports)])
-            response.transports = toAuthenticatorTransports(registrationCredential.transports);
+            response.transports = toAuthenticatorTransports(retainPtr(registrationCredential.transports).get());
         if ([registrationCredential respondsToSelector:@selector(extensionOutputsCBOR)])
-            response.extensionOutputs = toExtensionOutputs(registrationCredential.extensionOutputsCBOR);
+            response.extensionOutputs = toExtensionOutputs(retainPtr(registrationCredential.extensionOutputsCBOR).get());
     } else if ([credential isKindOfClass:getASCSecurityKeyPublicKeyCredentialRegistrationClassSingleton()]) {
         response.isAuthenticatorAttestationResponse = true;
 
@@ -1076,14 +1076,14 @@ static inline void continueAfterRequest(RetainPtr<id <ASCCredentialProtocol>> cr
         response.isAuthenticatorAttestationResponse = false;
 
         ASCPlatformPublicKeyCredentialAssertion *assertionCredential = credential.get();
-        response.rawId = toArrayBuffer(assertionCredential.credentialID);
-        response.authenticatorData = toArrayBuffer(assertionCredential.authenticatorData);
-        response.signature = toArrayBuffer(assertionCredential.signature);
-        response.userHandle = toArrayBufferNilIfEmpty(assertionCredential.userHandle);
-        response.clientDataJSON = toArrayBuffer(assertionCredential.rawClientDataJSON);
+        response.rawId = toArrayBuffer(retainPtr(assertionCredential.credentialID).get());
+        response.authenticatorData = toArrayBuffer(retainPtr(assertionCredential.authenticatorData).get());
+        response.signature = toArrayBuffer(retainPtr(assertionCredential.signature).get());
+        response.userHandle = toArrayBufferNilIfEmpty(retainPtr(assertionCredential.userHandle).get());
+        response.clientDataJSON = toArrayBuffer(retainPtr(assertionCredential.rawClientDataJSON).get());
         rawAttachment = assertionCredential.attachment;
         if ([assertionCredential respondsToSelector:@selector(extensionOutputsCBOR)])
-            response.extensionOutputs = toExtensionOutputs(assertionCredential.extensionOutputsCBOR);
+            response.extensionOutputs = toExtensionOutputs(retainPtr(assertionCredential.extensionOutputsCBOR).get());
     } else if ([credential isKindOfClass:getASCSecurityKeyPublicKeyCredentialAssertionClassSingleton()]) {
         response.isAuthenticatorAttestationResponse = false;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
@@ -183,7 +183,7 @@ RetainPtr<NSArray> MockLocalConnection::getExistingCredentials(const String& rpI
     // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
     SUPPRESS_RETAINPTR_CTOR_ADOPT RetainPtr nsAttributesArray = bridge_cast(adoptCF(checked_cf_cast<CFArrayRef>(attributesArrayRef)));
     return [nsAttributesArray sortedArrayUsingComparator:^(NSDictionary *a, NSDictionary *b) {
-        return [b[(id)kSecAttrModificationDate] compare:a[(id)kSecAttrModificationDate]];
+        return [retainPtr(b[(id)kSecAttrModificationDate]) compare:retainPtr(a[(id)kSecAttrModificationDate]).get()];
     }];
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -839,7 +839,8 @@ void WebsiteDataStore::initializeManagedDomains(ForceReinitialization forceReini
         bool isSafari = false;
 #if PLATFORM(MAC)
         isSafari = WTF::MacApplication::isSafari();
-        RetainPtr managedSitesPrefs = adoptNS([[NSDictionary alloc] initWithContentsOfFile:[adoptNS([[NSString alloc] initWithFormat:@"/Library/Managed Preferences/%@/%@.plist", RetainPtr { NSUserName() }.get(), managedSitesIdentifierSingleton()]) stringByStandardizingPath]]);
+        RetainPtr path = [adoptNS([[NSString alloc] initWithFormat:@"/Library/Managed Preferences/%@/%@.plist", RetainPtr { NSUserName() }.get(), managedSitesIdentifierSingleton()]) stringByStandardizingPath];
+        RetainPtr managedSitesPrefs = adoptNS([[NSDictionary alloc] initWithContentsOfFile:path.get()]);
         crossSiteTrackingPreventionRelaxedDomains = [managedSitesPrefs objectForKey:crossSiteTrackingPreventionRelaxedDomainsKeySingleton()];
         crossSiteTrackingPreventionRelaxedApps = [managedSitesPrefs objectForKey:crossSiteTrackingPreventionRelaxedAppsKeySingleton()];
 #elif !PLATFORM(MACCATALYST)

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -81,7 +81,7 @@ void DisplayCaptureSessionManager::alertForGetDisplayMedia(WebPageProxy& page, c
     button = [alert addButtonWithTitle:doNotAllowButtonString.get()];
     button.get().keyEquivalent = @"\E";
 
-    [alert beginSheetModalForWindow:[webView window] completionHandler:[completionBlock = makeBlockPtr(WTFMove(completionHandler))](NSModalResponse returnCode) {
+    [alert beginSheetModalForWindow:retainPtr([webView window]).get() completionHandler:[completionBlock = makeBlockPtr(WTFMove(completionHandler))](NSModalResponse returnCode) {
         DisplayCaptureSessionManager::CaptureSessionType result = DisplayCaptureSessionManager::CaptureSessionType::None;
         switch (returnCode) {
         case NSAlertFirstButtonReturn:

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -180,7 +180,7 @@ bool PageClientImpl::isViewFocused()
 
 void PageClientImpl::assistiveTechnologyMakeFirstResponder()
 {
-    [[m_view.get() window] makeFirstResponder:m_view.get().get()];
+    [retainPtr([m_view.get() window]) makeFirstResponder:m_view.get().get()];
 }
     
 void PageClientImpl::makeFirstResponder()
@@ -188,7 +188,7 @@ void PageClientImpl::makeFirstResponder()
     if (m_shouldSuppressFirstResponderChanges)
         return;
 
-    [[m_view.get() window] makeFirstResponder:m_view.get().get()];
+    [retainPtr([m_view.get() window]) makeFirstResponder:m_view.get().get()];
 }
     
 bool PageClientImpl::isViewVisible(NSView *view, NSWindow *viewWindow)
@@ -369,7 +369,7 @@ void PageClientImpl::registerEditCommand(Ref<WebEditCommandProxy>&& command, Und
 
 void PageClientImpl::registerInsertionUndoGrouping()
 {
-    registerInsertionUndoGroupingWithUndoManager([m_view.get() undoManager]);
+    registerInsertionUndoGroupingWithUndoManager(retainPtr([m_view.get() undoManager]).get());
 }
 
 void PageClientImpl::createPDFHUD(PDFPluginIdentifier identifier, WebCore::FrameIdentifier frameID, const WebCore::IntRect& rect)
@@ -399,12 +399,14 @@ void PageClientImpl::clearAllEditCommands()
 
 bool PageClientImpl::canUndoRedo(UndoOrRedo undoOrRedo)
 {
-    return (undoOrRedo == UndoOrRedo::Undo) ? [[m_view.get() undoManager] canUndo] : [[m_view.get() undoManager] canRedo];
+    RetainPtr undoManager = [m_view.get() undoManager];
+    return undoOrRedo == UndoOrRedo::Undo ? [undoManager canUndo] : [undoManager canRedo];
 }
 
 void PageClientImpl::executeUndoRedo(UndoOrRedo undoOrRedo)
 {
-    return (undoOrRedo == UndoOrRedo::Undo) ? [[m_view.get() undoManager] undo] : [[m_view.get() undoManager] redo];
+    RetainPtr undoManager = [m_view.get() undoManager];
+    return undoOrRedo == UndoOrRedo::Undo ? [undoManager undo] : [undoManager redo];
 }
 
 void PageClientImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Handle&& image, const std::optional<WebCore::NodeIdentifier>& nodeID)
@@ -437,12 +439,12 @@ void PageClientImpl::notifyInputContextAboutDiscardedComposition()
 
 FloatRect PageClientImpl::convertToDeviceSpace(const FloatRect& rect)
 {
-    return toDeviceSpace(rect, [m_view.get() window]);
+    return toDeviceSpace(rect, retainPtr([m_view.get() window]).get());
 }
 
 FloatRect PageClientImpl::convertToUserSpace(const FloatRect& rect)
 {
-    return toUserSpace(rect, [m_view.get() window]);
+    return toUserSpace(rect, retainPtr([m_view.get() window]).get());
 }
 
 void PageClientImpl::pinnedStateWillChange()
@@ -463,14 +465,14 @@ void PageClientImpl::drawPageBorderForPrinting(WebCore::FloatSize&& size)
 IntPoint PageClientImpl::screenToRootView(const IntPoint& point)
 {
     RetainPtr view = m_view.get();
-    NSPoint windowCoord = [[view window] convertPointFromScreen:point];
+    NSPoint windowCoord = [retainPtr([view window]) convertPointFromScreen:point];
     return IntPoint([view convertPoint:windowCoord fromView:nil]);
 }
 
 IntPoint PageClientImpl::rootViewToScreen(const IntPoint& point)
 {
     RetainPtr view = m_view.get();
-    return IntPoint([[view window] convertPointToScreen:[view convertPoint:point toView:nil]]);
+    return IntPoint([retainPtr([view window]) convertPointToScreen:[view convertPoint:point toView:nil]]);
 }
 
 IntRect PageClientImpl::rootViewToScreen(const IntRect& rect)
@@ -478,7 +480,7 @@ IntRect PageClientImpl::rootViewToScreen(const IntRect& rect)
     NSRect tempRect = rect;
     RetainPtr view = m_view.get();
     tempRect = [view convertRect:tempRect toView:nil];
-    tempRect.origin = [[view window] convertPointToScreen:tempRect.origin];
+    tempRect.origin = [retainPtr([view window]) convertPointToScreen:tempRect.origin];
     return enclosingIntRect(tempRect);
 }
 

--- a/Source/WebKit/UIProcess/mac/TextCheckerMac.mm
+++ b/Source/WebKit/UIProcess/mac/TextCheckerMac.mm
@@ -533,7 +533,7 @@ void TextChecker::getGuessesForWord(SpellDocumentTag spellDocumentTag, const Str
         [checker checkString:context.createNSString().get() range:NSMakeRange(0, context.length()) types:NSTextCheckingTypeOrthography options:options inSpellDocumentWithTag:spellDocumentTag orthography:&orthography wordCount:0];
         language = [checker languageForWordRange:NSMakeRange(0, context.length()) inString:context.createNSString().get() orthography:orthography];
     }
-    guesses = makeVector<String>([checker guessesForWordRange:NSMakeRange(0, word.length()) inString:word.createNSString().get() language:language.get() inSpellDocumentWithTag:spellDocumentTag]);
+    guesses = makeVector<String>(retainPtr([checker guessesForWordRange:NSMakeRange(0, word.length()) inString:word.createNSString().get() language:language.get() inSpellDocumentWithTag:spellDocumentTag]).get());
 }
 
 void TextChecker::learnWord(SpellDocumentTag, const String& word)

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -180,7 +180,7 @@
     if (!_page->mainFrame())
         return;
 
-    RefPtr { _page.get() }->performImmediateActionHitTestAtLocation(_page->mainFrame()->frameID(), [immediateActionRecognizer locationInView:immediateActionRecognizer.view]);
+    RefPtr { _page.get() }->performImmediateActionHitTestAtLocation(_page->mainFrame()->frameID(), [immediateActionRecognizer locationInView:retainPtr(immediateActionRecognizer.view).get()]);
 }
 
 - (void)immediateActionRecognizerWillBeginAnimation:(NSImmediateActionGestureRecognizer *)immediateActionRecognizer
@@ -442,7 +442,7 @@
         [self _clearImmediateActionState];
     }];
 
-    [_currentActionContext setHighlightFrame:[view.get().window convertRectToScreen:[view convertRect:_hitTestResultData.platformData.detectedDataBoundingBox toView:nil]]];
+    [_currentActionContext setHighlightFrame:[retainPtr(view.get().window) convertRectToScreen:[view convertRect:_hitTestResultData.platformData.detectedDataBoundingBox toView:nil]]];
 
     RetainPtr menuItems = [[PAL::getDDActionsManagerClassSingleton() sharedManager] menuItemsForResult:RetainPtr { [_currentActionContext mainResult] }.get() actionContext:_currentActionContext.get()];
 
@@ -474,7 +474,7 @@
         [self _clearImmediateActionState];
     }];
 
-    [_currentActionContext setHighlightFrame:[view.get().window convertRectToScreen:[view convertRect:_hitTestResultData.elementBoundingBox toView:nil]]];
+    [_currentActionContext setHighlightFrame:[retainPtr(view.get().window) convertRectToScreen:[view convertRect:_hitTestResultData.elementBoundingBox toView:nil]]];
 
     RefPtr<API::HitTestResult> hitTestResult = [self _webHitTestResult];
     if (!hitTestResult)

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -195,7 +195,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return 0;
 
     // Need to directly access the dictionary because -[NSPrintOperation pageRange] verifies pagination, potentially causing recursion.
-    return [[[[_printOperation.get() printInfo] dictionary] objectForKey:NSPrintFirstPage] unsignedIntegerValue];
+    return [retainPtr([retainPtr([retainPtr([_printOperation.get() printInfo]) dictionary]) objectForKey:NSPrintFirstPage]) unsignedIntegerValue];
 }
 
 - (NSUInteger)_lastPrintedPageNumber
@@ -206,8 +206,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return 0;
 
     // Need to directly access the dictionary because -[NSPrintOperation pageRange] verifies pagination, potentially causing recursion.
-    NSUInteger firstPage = [[[[_printOperation.get() printInfo] dictionary] objectForKey:NSPrintFirstPage] unsignedIntegerValue];
-    NSUInteger lastPage = [[[[_printOperation.get() printInfo] dictionary] objectForKey:NSPrintLastPage] unsignedIntegerValue];
+    NSUInteger firstPage = [[retainPtr([retainPtr([_printOperation.get() printInfo]) dictionary]) objectForKey:NSPrintFirstPage] unsignedIntegerValue];
+    NSUInteger lastPage = [[retainPtr([retainPtr([_printOperation.get() printInfo]) dictionary]) objectForKey:NSPrintLastPage] unsignedIntegerValue];
     if (lastPage - firstPage >= _printingPageRects.size())
         return _printingPageRects.size();
     return lastPage;
@@ -456,7 +456,7 @@ static void prepareDataForPrintingOnSecondaryThread(WKPrintingView *view)
 
 static RetainPtr<NSString> linkDestinationName(PDFDocument *document, PDFDestination *destination)
 {
-    return adoptNS([[NSString alloc] initWithFormat:@"%lu-%f-%f", (unsigned long)[document indexForPage:destination.page], destination.point.x, destination.point.y]);
+    return adoptNS([[NSString alloc] initWithFormat:@"%lu-%f-%f", (unsigned long)[document indexForPage:retainPtr(destination.page).get()], destination.point.x, destination.point.y]);
 }
 
 - (void)_drawPDFDocument:(PDFDocument *)pdfDocument page:(unsigned)page atPoint:(NSPoint)point
@@ -608,7 +608,7 @@ static RetainPtr<NSString> linkDestinationName(PDFDocument *document, PDFDestina
                 if (!destination)
                     continue;
 
-                unsigned destinationPageIndex = [_printedPagesPDFDocument indexForPage:destination.get().page];
+                unsigned destinationPageIndex = [_printedPagesPDFDocument indexForPage:retainPtr(destination.get().page).get()];
                 _linkDestinationsPerPage[destinationPageIndex].append(WTFMove(destination));
             }
         }

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm
@@ -99,7 +99,7 @@
     }
 
     RetainPtr<id<_WTTextEffect>> effect;
-    RetainPtr chunk = adoptNS([PAL::alloc_WTTextChunkInstance() initChunkWithIdentifier:uuid.UUIDString]);
+    RetainPtr chunk = adoptNS([PAL::alloc_WTTextChunkInstance() initChunkWithIdentifier:retainPtr(uuid.UUIDString).get()]);
 
     switch (data.style) {
     case WebCore::TextAnimationType::Initial:
@@ -189,7 +189,7 @@
 {
     RetainPtr effectData = [_chunkToEffect objectForKey:uuid];
     if (effectData) {
-        [_effectView removeEffect:[effectData effectID]];
+        [_effectView removeEffect:retainPtr([effectData effectID]).get()];
         [_chunkToEffect removeObjectForKey:uuid];
     }
 }
@@ -208,7 +208,7 @@
 {
     for (NSUUID *chunkID in [_chunkToEffect allKeys]) {
         RetainPtr effectData = [_chunkToEffect objectForKey:chunkID];
-        [_effectView removeEffect:[effectData effectID]];
+        [_effectView removeEffect:retainPtr([effectData effectID]).get()];
 
         if ([effectData type] != WebCore::TextAnimationType::Initial)
             [_chunkToEffect removeObjectForKey:chunkID];
@@ -228,7 +228,7 @@
 
 - (void)textPreviewsForChunk:(_WTTextChunk *)chunk completion:(void (^)(NSArray <_WTTextPreview *> *previews))completionHandler
 {
-    RetainPtr nsUUID = adoptNS([[NSUUID alloc] initWithUUIDString:chunk.identifier]);
+    RetainPtr nsUUID = adoptNS([[NSUUID alloc] initWithUUIDString:retainPtr(chunk.identifier).get()]);
     auto uuid = WTF::UUID::fromNSUUID(nsUUID.get());
     if (!uuid || !uuid->isValid()) {
         completionHandler(nil);
@@ -286,7 +286,7 @@
 
 - (void)updateIsTextVisible:(BOOL)isTextVisible forChunk:(_WTTextChunk *)chunk completion:(void (^)(void))completionHandler
 {
-    RetainPtr nsUUID = adoptNS([[NSUUID alloc] initWithUUIDString:chunk.identifier]);
+    RetainPtr nsUUID = adoptNS([[NSUUID alloc] initWithUUIDString:retainPtr(chunk.identifier).get()]);
     auto uuid = WTF::UUID::fromNSUUID(nsUUID.get());
     if (!uuid || !uuid->isValid()) {
         if (completionHandler)

--- a/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
@@ -191,7 +191,7 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
 }
 
 - (void)popoverDidClose:(NSNotification *)notification {
-    [self.webDelegate didClosePopover];
+    [retainPtr(self.webDelegate) didClosePopover];
 }
 
 - (NSView *)hitTest:(NSPoint)point
@@ -217,7 +217,7 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
         return self;
 
     [_popoverWell setAlphaValue:0.0];
-    [[view window].contentView addSubview:_popoverWell.get()];
+    [retainPtr([view window].contentView) addSubview:_popoverWell.get()];
 
     return self;
 }
@@ -236,7 +236,7 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
     if (suggestions.size()) {
         suggestedColors = adoptNS([[NSColorList alloc] init]);
         for (size_t i = 0; i < std::min(suggestions.size(), maxColorSuggestions); i++)
-            [suggestedColors insertColor:cocoaColor(suggestions.at(i)).get() key:@(i).stringValue atIndex:i];
+            [suggestedColors insertColor:cocoaColor(suggestions.at(i)).get() key:retainPtr(@(i).stringValue).get() atIndex:i];
     }
 
     [_popoverWell setSuggestedColors:suggestedColors.get()];
@@ -288,7 +288,7 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
     }
 
     if (RefPtr picker = _picker.get())
-        picker->didChooseColor(WebCore::colorFromCocoaColor([_popoverWell color]));
+        picker->didChooseColor(WebCore::colorFromCocoaColor(retainPtr([_popoverWell color]).get()));
 }
 
 - (void)setColor:(NSColor *)color

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -256,7 +256,7 @@ void WebContextMenuProxyMac::handleShareMenuItem()
 {
     RetainPtr shareMenuItem = createShareMenuItem(ShareMenuItemType::Popover);
     [shareMenuItem setMenu:m_menu.get()];
-    [[NSApplication sharedApplication] sendAction:[shareMenuItem action] to:[shareMenuItem target] from:shareMenuItem.get()];
+    [[NSApplication sharedApplication] sendAction:[shareMenuItem action] to:retainPtr([shareMenuItem target]).get() from:shareMenuItem.get()];
 }
 
 #if ENABLE(SERVICE_CONTROLS)
@@ -280,7 +280,7 @@ void WebContextMenuProxyMac::setupServicesMenu()
             RetainPtr cgImage = image->createPlatformImage(DontCopyBackingStore);
             auto nsImage = adoptNS([[NSImage alloc] initWithCGImage:cgImage.get() size:image->size()]);
 
-            itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:[nsImage TIFFRepresentation] typeIdentifier:UTTypeTIFF.identifier]);
+            itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:retainPtr([nsImage TIFFRepresentation]).get() typeIdentifier:UTTypeTIFF.identifier]);
         }
         items = @[ itemProvider.get() ];
         
@@ -304,7 +304,7 @@ void WebContextMenuProxyMac::setupServicesMenu()
     NSRect imageRect = m_context.controlledImageBounds();
     auto webView = m_webView.get();
     imageRect = [webView convertRect:imageRect toView:nil];
-    imageRect = [[webView window] convertRectToScreen:imageRect];
+    imageRect = [retainPtr([webView window]) convertRectToScreen:imageRect];
     [[WKSharingServicePickerDelegate sharedSharingServicePickerDelegate] setSourceFrame:imageRect];
     [[WKSharingServicePickerDelegate sharedSharingServicePickerDelegate] setAttachmentID:m_context.controlledImageAttachmentID()];
 
@@ -508,7 +508,7 @@ RetainPtr<NSMenuItem> WebContextMenuProxyMac::createShareMenuItem(ShareMenuItemT
         return nil;
 
     if (usePlaceholder) {
-        RetainPtr placeholder = adoptNS([[NSMenuItem alloc] initWithTitle:[shareMenuItem title] action:@selector(performShare:) keyEquivalent:@""]);
+        RetainPtr placeholder = adoptNS([[NSMenuItem alloc] initWithTitle:retainPtr([shareMenuItem title]).get() action:@selector(performShare:) keyEquivalent:@""]);
         [placeholder setTarget:[WKMenuTarget sharedMenuTarget]];
 #if ENABLE(CONTEXT_MENU_IMAGES_ON_MAC)
         [placeholder _setActionImage:[shareMenuItem _actionImage]];
@@ -759,7 +759,7 @@ void WebContextMenuProxyMac::getContextMenuFromItems(const Vector<WebContextMenu
     auto filteredItems = items;
     auto webView = m_webView.get();
 
-    bool isPopover = webView.get().window._childWindowOrderingPriority == NSWindowChildOrderingPriorityPopover;
+    bool isPopover = retainPtr(webView.get().window).get()._childWindowOrderingPriority == NSWindowChildOrderingPriorityPopover;
     bool isLookupDisabled = [NSUserDefaults.standardUserDefaults boolForKey:@"LULookupDisabled"];
 
     if (isLookupDisabled || isPopover) {

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -440,7 +440,7 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
     _table = nil;
     _scrollView = nil;
 
-    [[_presentingView window] removeChildWindow:_enclosingWindow.get()];
+    [retainPtr([_presentingView window]) removeChildWindow:_enclosingWindow.get()];
     [_enclosingWindow close];
     _enclosingWindow = nil;
 
@@ -478,9 +478,9 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
 - (void)showSuggestionsDropdown:(WebKit::WebDataListSuggestionsDropdownMac&)dropdown
 {
     _dropdown = dropdown;
-    [[_enclosingWindow contentView] addSubview:_scrollView.get()];
+    [retainPtr([_enclosingWindow contentView]) addSubview:_scrollView.get()];
     [_table reload];
-    [[_presentingView window] addChildWindow:_enclosingWindow.get() ordered:NSWindowAbove];
+    [retainPtr([_presentingView window]) addChildWindow:_enclosingWindow.get() ordered:NSWindowAbove];
     [_scrollView flashScrollers];
 
     // Notify accessibility clients of datalist becoming visible.

--- a/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
@@ -199,7 +199,7 @@ void WebDateTimePickerMac::didChooseDate(StringView date)
 
     RetainPtr presentingView = _presentingView.get();
 
-    NSRect windowRect = [[presentingView window] convertRectToScreen:[presentingView convertRect:params.anchorRectInRootView toView:nil]];
+    NSRect windowRect = [retainPtr([presentingView window]) convertRectToScreen:[presentingView convertRect:params.anchorRectInRootView toView:nil]];
     windowRect.origin.y = NSMinY(windowRect) - kCalendarHeight;
     windowRect.size.width = kCalendarWidth;
     windowRect.size.height = kCalendarHeight;
@@ -252,12 +252,13 @@ void WebDateTimePickerMac::didChooseDate(StringView date)
 {
     _picker = picker;
 
-    [[_enclosingWindow contentView] addSubview:_datePicker.get()];
-    [[_presentingView.get() window] addChildWindow:_enclosingWindow.get() ordered:NSWindowAbove];
+    [retainPtr([_enclosingWindow contentView]) addSubview:_datePicker.get()];
+    RetainPtr window = [_presentingView.get() window];
+    [window addChildWindow:_enclosingWindow.get() ordered:NSWindowAbove];
 
     if (_params.wasActivatedByKeyboard) {
         // Make the date picker first responder to enable keyboard interaction.
-        [[_presentingView.get() window] makeFirstResponder:_datePicker.get()];
+        [window makeFirstResponder:_datePicker.get()];
     }
 }
 
@@ -289,7 +290,7 @@ void WebDateTimePickerMac::didChooseDate(StringView date)
     [_enclosingWindow setAppearance:[NSAppearance appearanceNamed:_params.useDarkAppearance ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua]];
 
     if (_params.wasActivatedByKeyboard)
-        [[_presentingView.get() window] makeFirstResponder:_datePicker.get()];
+        [retainPtr([_presentingView.get() window]) makeFirstResponder:_datePicker.get()];
 }
 
 - (void)invalidate
@@ -300,17 +301,18 @@ void WebDateTimePickerMac::didChooseDate(StringView date)
     [_datePicker setDateTimePicker:nil];
 
     RetainPtr presentingView = _presentingView.get();
-    if ([[presentingView window] firstResponder] == _datePicker.get()) {
+    RetainPtr window = [presentingView window];
+    if ([window firstResponder] == _datePicker.get()) {
         // If the date picker was the first responder, restore first-respondership
         // to the webview so the user doesn't have to click on the webpage to
         // start moving focus with the keyboard inside web content.
-        [[presentingView window] makeFirstResponder:_presentingView.get().get()];
+        [window makeFirstResponder:_presentingView.get().get()];
     }
 
     _datePicker = nil;
     _dateFormatter = nil;
 
-    [[_presentingView.get() window] removeChildWindow:_enclosingWindow.get()];
+    [window removeChildWindow:_enclosingWindow.get()];
     [_enclosingWindow close];
     _enclosingWindow = nil;
 }
@@ -326,7 +328,7 @@ void WebDateTimePickerMac::didChooseDate(StringView date)
     if (sender != _datePicker)
         return;
 
-    String dateString = [_dateFormatter stringFromDate:[_datePicker dateValue]];
+    String dateString = [_dateFormatter stringFromDate:retainPtr([_datePicker dateValue]).get()];
     Ref { *_picker }->didChooseDate(StringView(dateString));
 
     if (_params.wasActivatedByKeyboard) {
@@ -335,7 +337,7 @@ void WebDateTimePickerMac::didChooseDate(StringView date)
         // which steals first-respondership from our date picker. The act of choosing a date
         // with the keyboard does not dismiss the date picker, so we need to make sure it regains
         // first respondership in case the user wishes to continue interacting with it.
-        [[_presentingView.get() window] makeFirstResponder:_datePicker.get()];
+        [retainPtr([_presentingView.get() window]) makeFirstResponder:_datePicker.get()];
     }
 }
 

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -96,7 +96,7 @@ void WebPopupMenuProxyMac::populate(const Vector<WebPopupItem>& items, NSFont *f
             [menuItem setAttributedTitle:string.get()];
             // We set the title as well as the attributed title here. The attributed title will be displayed in the menu,
             // but typeahead will use the non-attributed string that doesn't contain any leading or trailing whitespace.
-            [menuItem setTitle:[[string string] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]];
+            [menuItem setTitle:[retainPtr([string string]) stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]];
             [menuItem setEnabled:items[i].m_isEnabled];
             [menuItem setToolTip:items[i].m_toolTip.createNSString().get()];
         }
@@ -214,7 +214,7 @@ void WebPopupMenuProxyMac::showPopupMenu(const IntRect& rect, TextDirection text
 
     [NSApp postEvent:fakeEvent.get() atStart:YES];
     fakeEvent = [NSEvent mouseEventWithType:NSEventTypeMouseMoved
-                                   location:[[m_webView.get() window] convertPointFromScreen:[NSEvent mouseLocation]]
+                                   location:[retainPtr([m_webView.get() window]) convertPointFromScreen:[NSEvent mouseLocation]]
                               modifierFlags:[initiatingNSEvent modifierFlags]
                                   timestamp:[initiatingNSEvent timestamp]
                                windowNumber:[initiatingNSEvent windowNumber]


### PR DESCRIPTION
#### 1896e3407ed6e6116dc4e37c087b8cd1278457f1
<pre>
Prepare Source/WebKit for clang static analyzer update (part 4)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301071">https://bugs.webkit.org/show_bug.cgi?id=301071</a>

Reviewed by Geoffrey Garen.

Deployed more smart pointers to prepare Source/WebKit for a future clang static analyzer update.

No new tests since there should be no behavioral difference.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::bundleStaticCode const):
* Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm:
(WebKit::RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow):
(WebKit::RemoteWebInspectorUIProxy::platformResetState):
(WebKit::RemoteWebInspectorUIProxy::platformShowCertificate):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm:
(-[WKInspectorResourceURLSchemeHandler webView:startURLSchemeTask:]):
(-[WKInspectorResourceURLSchemeHandler webView:stopURLSchemeTask:]):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController webViewConfiguration]):
(-[WKInspectorViewController _webView:contextMenu:forElement:]):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorWKWebView.mm:
(-[WKInspectorWKWebView protectedInspectorWKWebViewDelegate]):
(-[WKInspectorWKWebView reload:]):
(-[WKInspectorWKWebView reloadFromOrigin:]):
(-[WKInspectorWKWebView viewWillMoveToWindow:]):
(-[WKInspectorWKWebView viewDidMoveToWindow]):
(-[WKInspectorWKWebView becomeFirstResponder]):
(-[WKInspectorWKWebView _handleWindowDidBecomeKey:]):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(-[WKWebInspectorUIProxyObjCAdapter inspectorViewController:willMoveToWindow:]):
(-[WKWebInspectorUIProxyObjCAdapter inspectorViewControllerDidMoveToWindow:]):
(-[WKWebInspectorUISaveController initWithSaveDatas:savePanel:]):
(-[WKWebInspectorUISaveController _updateSavePanel]):
(WebKit::WebInspectorUIProxy::showSavePanel):
(WebKit::WebInspectorUIProxy::platformCreateFrontendWindow):
(WebKit::WebInspectorUIProxy::platformBringToFront):
(WebKit::WebInspectorUIProxy::platformShowCertificate):
(WebKit::WebInspectorUIProxy::inspectedViewFrameDidChange):
(WebKit::WebInspectorUIProxy::platformAttach):
(WebKit::WebInspectorUIProxy::platformDetach):
(WebKit::WebInspectorUIProxy::platformStartWindowDrag):
* Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm:
(WebKit::MediaUsageManagerCocoa::updateMediaUsage):
* Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm:
(-[WKPDFHUDView initWithFrame:pluginIdentifier:frameIdentifier:page:]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::appendLayerDescription):
* Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm:
(-[WKCompositingLayer description]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm:
(-[_WKSmartCardSlotObserver observeValueForKeyPath:ofObject:change:context:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::getExistingCredentials):
(WebKit::LocalAuthenticator::processLargeBlobExtension):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm:
(WebKit::LocalConnection::getExistingCredentials):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm:
(WebKit::NfcConnection::didDetectTags):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::performRequest):
(WebKit::continueAfterRequest):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm:
(WebKit::MockLocalConnection::getExistingCredentials):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::initializeManagedDomains):
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::alertForGetDisplayMedia):
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::assistiveTechnologyMakeFirstResponder):
(WebKit::PageClientImpl::makeFirstResponder):
(WebKit::PageClientImpl::registerInsertionUndoGrouping):
(WebKit::PageClientImpl::canUndoRedo):
(WebKit::PageClientImpl::executeUndoRedo):
(WebKit::PageClientImpl::convertToDeviceSpace):
(WebKit::PageClientImpl::convertToUserSpace):
(WebKit::PageClientImpl::screenToRootView):
(WebKit::PageClientImpl::rootViewToScreen):
* Source/WebKit/UIProcess/mac/TextCheckerMac.mm:
(WebKit::TextChecker::getGuessesForWord):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController _continueEnteringFullscreenAfterPostingNotification:]):
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:completionHandler:]):
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
(-[WKFullScreenWindowController beganExitFullScreenWithInitialFrame:finalFrame:completionHandler:]):
(-[WKFullScreenWindowController _continueExitingFullscreenAfterPostingNotificationAndExitImmediately:]):
(-[WKFullScreenWindowController completeFinishExitFullScreenAnimation]):
(-[WKFullScreenWindowController _replaceView:with:]):
(-[WKFullScreenWindowController _startEnterFullScreenAnimationWithDuration:]):
(-[WKFullScreenWindowController _startExitFullScreenAnimationWithDuration:]):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController immediateActionRecognizerWillPrepare:]):
(-[WKImmediateActionController _animationControllerForDataDetectedText]):
(-[WKImmediateActionController _animationControllerForDataDetectedLink]):
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView _firstPrintedPageNumber]):
(-[WKPrintingView _lastPrintedPageNumber]):
(linkDestinationName):
(-[WKPrintingView drawRect:]):
* Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm:
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):
(-[WKTextAnimationManager removeTextAnimationForAnimationID:]):
(-[WKTextAnimationManager suppressTextAnimationType]):
(-[WKTextAnimationManager textPreviewsForChunk:completion:]):
(-[WKTextAnimationManager updateIsTextVisible:forChunk:completion:]):
* Source/WebKit/UIProcess/mac/WebColorPickerMac.mm:
(-[WKPopoverColorWell popoverDidClose:]):
(-[WKColorPopoverMac initWithFrame:inView:]):
(-[WKColorPopoverMac setAndShowPicker:withColor:supportsAlpha:suggestions:]):
(-[WKColorPopoverMac didChooseColor:]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::handleShareMenuItem):
(WebKit::WebContextMenuProxyMac::setupServicesMenu):
(WebKit::WebContextMenuProxyMac::createShareMenuItem):
(WebKit::WebContextMenuProxyMac::getContextMenuFromItems):
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
(-[WKDataListSuggestionsController invalidate]):
(-[WKDataListSuggestionsController showSuggestionsDropdown:]):
* Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm:
(-[WKDateTimePicker initWithParams:inView:]):
(-[WKDateTimePicker showPicker:]):
(-[WKDateTimePicker updatePicker:]):
(-[WKDateTimePicker invalidate]):
(-[WKDateTimePicker didChooseDate:]):
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::populate):
(WebKit::WebPopupMenuProxyMac::showPopupMenu):

Canonical link: <a href="https://commits.webkit.org/301828@main">https://commits.webkit.org/301828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56a61949db1f51484bf41dff0cf656e3c17a734c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127164 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134228 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78719 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b1685e4d-95f3-4e29-94e5-d9725849064f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96774 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64815 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2f5684dc-e7db-40d6-804f-7ee19196b019) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77280 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5430d5ba-41e6-4649-8ef1-311b41c23ad1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77608 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136711 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105294 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54324 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104981 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50503 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28950 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51386 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19899 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53747 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59847 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56324 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54743 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->