### PR TITLE
Prepare Source/WebKit for clang static analyzer update (part 5)

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -1871,14 +1871,14 @@ def generate_webkit_secure_coding_impl(serialized_types, headers):
             if member.has_container_contents():
                 if member.value_is_optional():
                     if member.dictionary_contents() is not None:
-                        result.append(f'    m_{member.type} = optionalVectorFromDictionary<{member.dictionary_contents()}>(({member.ns_type_pointer()})[dictionary objectForKey:@"{member.type}"]);')
+                        result.append(f'    m_{member.type} = optionalVectorFromDictionary<{member.dictionary_contents()}>(({member.ns_type_pointer()})retainPtr([dictionary objectForKey:@"{member.type}"]).get());')
                     if member.array_contents() is not None:
-                        result.append(f'    m_{member.type} = optionalVectorFromArray<{member.array_contents()}>(({member.ns_type_pointer()})[dictionary objectForKey:@"{member.type}"]);')
+                        result.append(f'    m_{member.type} = optionalVectorFromArray<{member.array_contents()}>(({member.ns_type_pointer()})retainPtr([dictionary objectForKey:@"{member.type}"]).get());')
                 else:
                     if member.dictionary_contents() is not None:
-                        result.append(f'    m_{member.type} = vectorFromDictionary<{member.dictionary_contents()}>(({member.ns_type_pointer()})[dictionary objectForKey:@"{member.type}"]);')
+                        result.append(f'    m_{member.type} = vectorFromDictionary<{member.dictionary_contents()}>(({member.ns_type_pointer()})retainPtr([dictionary objectForKey:@"{member.type}"]).get());')
                     if member.array_contents() is not None:
-                        result.append(f'    m_{member.type} = vectorFromArray<{member.array_contents()}>(({member.ns_type_pointer()})[dictionary objectForKey:@"{member.type}"]);')
+                        result.append(f'    m_{member.type} = vectorFromArray<{member.array_contents()}>(({member.ns_type_pointer()})retainPtr([dictionary objectForKey:@"{member.type}"]).get());')
             else:
                 result.append(f'    m_{member.type} = ({member.ns_type_pointer()})[dictionary objectForKey:@"{member.type}"];')
                 # FIXME: isKindOfClass call from type_check() can cause a static analysis false positive (https://github.com/llvm/llvm-project/issues/162979).

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
@@ -114,8 +114,8 @@ static const Seconds PostAnimationDelay { 100_ms };
 
 - (void)layoutSublayers
 {
-    auto* sublayers = [self sublayers];
-    
+    RetainPtr sublayers = [self sublayers];
+
     if ([sublayers count] != 1) {
         ASSERT_NOT_REACHED();
         return;
@@ -155,7 +155,7 @@ static const Seconds PostAnimationDelay { 100_ms };
     } else
         transform = CGAffineTransformMakeScale(targetVideoFrame.width() / sourceVideoFrame.width(), targetVideoFrame.height() / sourceVideoFrame.height());
 
-    auto* videoSublayer = [sublayers objectAtIndex:0];
+    RetainPtr videoSublayer = [sublayers objectAtIndex:0];
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
     [videoSublayer setPosition:CGPointMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds))];
@@ -182,14 +182,14 @@ static const Seconds PostAnimationDelay { 100_ms };
         return;
     }
 
-    auto* sublayers = [self sublayers];
+    RetainPtr sublayers = [self sublayers];
     if ([sublayers count] != 1) {
         ASSERT_NOT_REACHED();
         return;
     }
 
-    auto* videoSublayer = [sublayers objectAtIndex:0];
-    if (!CGRectIsEmpty(self.videoLayerFrame) && CGRectEqualToRect(self.videoLayerFrame, videoSublayer.bounds) && CGAffineTransformIsIdentity(videoSublayer.affineTransform))
+    RetainPtr videoSublayer = [sublayers objectAtIndex:0];
+    if (!CGRectIsEmpty(self.videoLayerFrame) && CGRectEqualToRect(self.videoLayerFrame, videoSublayer.get().bounds) && CGAffineTransformIsIdentity(videoSublayer.get().affineTransform))
         return;
 
     [CATransaction begin];

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
@@ -102,19 +102,19 @@
 - (JSValue *)jsCSSStyleDeclarationForCSSStyleDeclarationHandle:(WKWebProcessPlugInCSSStyleDeclarationHandle *)cssStyleDeclarationHandle inWorld:(WKWebProcessPlugInScriptWorld *)world
 {
     JSValueRef valueRef = _frame->jsWrapperForWorld(&[cssStyleDeclarationHandle _cssStyleDeclarationHandle], &[world _scriptWorld]);
-    return [JSValue valueWithJSValueRef:valueRef inContext:[self jsContextForWorld:world]];
+    return [JSValue valueWithJSValueRef:valueRef inContext:retainPtr([self jsContextForWorld:world]).get()];
 }
 
 - (JSValue *)jsNodeForNodeHandle:(WKWebProcessPlugInNodeHandle *)nodeHandle inWorld:(WKWebProcessPlugInScriptWorld *)world
 {
     JSValueRef valueRef = _frame->jsWrapperForWorld(&[nodeHandle _nodeHandle], &[world _scriptWorld]);
-    return [JSValue valueWithJSValueRef:valueRef inContext:[self jsContextForWorld:world]];
+    return [JSValue valueWithJSValueRef:valueRef inContext:retainPtr([self jsContextForWorld:world]).get()];
 }
 
 - (JSValue *)jsRangeForRangeHandle:(WKWebProcessPlugInRangeHandle *)rangeHandle inWorld:(WKWebProcessPlugInScriptWorld *)world
 {
     JSValueRef valueRef = _frame->jsWrapperForWorld(&[rangeHandle _rangeHandle], &[world _scriptWorld]);
-    return [JSValue valueWithJSValueRef:valueRef inContext:[self jsContextForWorld:world]];
+    return [JSValue valueWithJSValueRef:valueRef inContext:retainPtr([self jsContextForWorld:world]).get()];
 }
 
 - (WKWebProcessPlugInBrowserContextController *)_browserContextController

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -764,7 +764,7 @@ void PDFPluginBase::visibilityDidChange(bool)
 
 FloatSize PDFPluginBase::pdfDocumentSizeForPrinting() const
 {
-    return FloatSize { [[m_pdfDocument pageAtIndex:0] boundsForBox:kPDFDisplayBoxCropBox].size };
+    return FloatSize { [retainPtr([m_pdfDocument pageAtIndex:0]) boundsForBox:kPDFDisplayBoxCropBox].size };
 }
 
 void PDFPluginBase::invalidateRect(const IntRect& rect)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
@@ -75,10 +75,10 @@ Ref<Element> PDFPluginChoiceAnnotation::createAnnotationElement()
     element->setInlineStyleProperty(CSSPropertyColor, serializationForHTML(colorFromCocoaColor([choiceAnnotation fontColor])));
     element->setInlineStyleProperty(CSSPropertyFontFamily, [[choiceAnnotation font] familyName]);
 
-    NSArray *choices = [choiceAnnotation choices];
-    NSString *selectedChoice = [choiceAnnotation widgetStringValue];
+    RetainPtr<NSArray> choices = [choiceAnnotation choices];
+    RetainPtr<NSString> selectedChoice = [choiceAnnotation widgetStringValue];
 
-    for (NSString *choice in choices) {
+    for (NSString *choice in choices.get()) {
         auto choiceOption = document->createElement(optionTag, false);
         choiceOption->setAttributeWithoutSynchronization(valueAttr, choice);
         choiceOption->setTextContent(choice);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.mm
@@ -43,12 +43,12 @@ namespace WebKit {
 static bool hasActionsForResult(DDScannerResult *dataDetectorResult)
 {
     RetainPtr ddActionsManagerClass = PAL::getDDActionsManagerClassSingleton();
-    return [[ddActionsManagerClass.get() sharedManager] hasActionsForResult:RetainPtr { [dataDetectorResult coreResult] }.get() actionContext:nil];
+    return [retainPtr([ddActionsManagerClass.get() sharedManager]) hasActionsForResult:RetainPtr { [dataDetectorResult coreResult] }.get() actionContext:nil];
 }
 
 static bool resultIsPastDate(DDScannerResult *dataDetectorResult, PDFPage *pdfPage)
 {
-    RetainPtr referenceDate = [[[pdfPage document] documentAttributes] objectForKey:get_PDFKit_PDFDocumentCreationDateAttributeSingleton()];
+    RetainPtr referenceDate = [retainPtr([[pdfPage document] documentAttributes]) objectForKey:get_PDFKit_PDFDocumentCreationDateAttributeSingleton()];
     RetainPtr referenceTimeZone = adoptCF(CFTimeZoneCopyDefault());
     return PAL::softLink_DataDetectorsCore_DDResultIsPastDate(RetainPtr { [dataDetectorResult coreResult] }.get(), (CFDateRef)referenceDate.get(), (CFTimeZoneRef)referenceTimeZone.get());
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -197,8 +197,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     RetainPtr<NSMutableArray> visiblePageElements = adoptNS([[NSMutableArray alloc] init]);
     for (id page in [self accessibilityChildren]) {
-        id focusedElement = [page accessibilityFocusedUIElement];
-        if (focusedElement)
+        if ([page accessibilityFocusedUIElement])
             [visiblePageElements addObject:page];
     }
     return visiblePageElements.autorelease();
@@ -212,7 +211,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (NSRect)accessibilityFrame
 {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    id accessibilityParent = [self accessibilityParent];
+    RetainPtr<id> accessibilityParent = [self accessibilityParent];
     NSSize size = [[accessibilityParent accessibilityAttributeValue:NSAccessibilitySizeAttribute] sizeValue];
     NSPoint origin = [[accessibilityParent accessibilityAttributeValue:NSAccessibilityPositionAttribute] pointValue];
 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -342,9 +341,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (id)accessibilityHitTest:(NSPoint)point
 {
     for (id element in [self accessibilityChildren]) {
-        id result = [element accessibilityHitTest:point];
-        if (result)
-            return result;
+        if (RetainPtr<id> result = [element accessibilityHitTest:point])
+            return result.autorelease();
     }
     return self;
 }

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -304,11 +304,11 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
     NSFontManager *fontManager = [NSFontManager sharedFontManager];
     [attributedString enumerateAttributesInRange:NSMakeRange(0, [attributedString length]) options:0 usingBlock:^(NSDictionary *attributes, NSRange range, BOOL *stop) {
         RetainPtr<NSMutableDictionary> scaledAttributes = adoptNS([attributes mutableCopy]);
-        NSFont *font = [scaledAttributes objectForKey:NSFontAttributeName];
+        RetainPtr<NSFont> font = [scaledAttributes objectForKey:NSFontAttributeName];
         if (font)
-            font = [fontManager convertFont:font toSize:font.pointSize * pageScaleFactor()];
+            font = [fontManager convertFont:font.get() toSize:font.get().pointSize * pageScaleFactor()];
         if (font)
-            [scaledAttributes setObject:font forKey:NSFontAttributeName];
+            [scaledAttributes setObject:font.get() forKey:NSFontAttributeName];
         [scaledAttributedString addAttributes:scaledAttributes.get() range:range];
     }];
 #endif // PLATFORM(MAC)
@@ -521,7 +521,7 @@ void WebPage::resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier fra
         return completionHandler("NULL"_s);
 #if PLATFORM(MAC)
     if (RetainPtr coreObject = [m_mockAccessibilityElement accessibilityRootObjectWrapper:webFrame->protectedCoreLocalFrame().get()]) {
-        if (id hitTestResult = [coreObject accessibilityHitTest:point]) {
+        if (RetainPtr hitTestResult = [coreObject accessibilityHitTest:point]) {
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             completionHandler([hitTestResult accessibilityAttributeValue:@"AXInfoStringForTesting"]);
             ALLOW_DEPRECATED_DECLARATIONS_END
@@ -1266,7 +1266,7 @@ static void drawPDFPage(PDFDocument *pdfDocument, CFIndex pageIndex, CGContextRe
 
     CGContextScaleCTM(context, pageSetupScaleFactor, pageSetupScaleFactor);
 
-    PDFPage *pdfPage = [pdfDocument pageAtIndex:pageIndex];
+    RetainPtr<PDFPage> pdfPage = [pdfDocument pageAtIndex:pageIndex];
     NSRect cropBox = [pdfPage boundsForBox:kPDFDisplayBoxCropBox];
     if (NSIsEmptyRect(cropBox))
         cropBox = [pdfPage boundsForBox:kPDFDisplayBoxMediaBox];
@@ -1301,12 +1301,12 @@ static void drawPDFPage(PDFDocument *pdfDocument, CFIndex pageIndex, CGContextRe
         if (![[annotation valueForAnnotationKey:get_PDFKit_PDFAnnotationKeySubtypeSingleton()] isEqualToString:get_PDFKit_PDFAnnotationSubtypeLinkSingleton()])
             continue;
 
-        NSURL *url = annotation.URL;
+        RetainPtr<NSURL> url = annotation.URL;
         if (!url)
             continue;
 
         CGRect transformedRect = CGRectApplyAffineTransform(annotation.bounds, transform);
-        CGPDFContextSetURLForRect(context, (CFURLRef)url, transformedRect);
+        CGPDFContextSetURLForRect(context, (CFURLRef)url.get(), transformedRect);
     }
 
     CGContextRestoreGState(context);

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -148,8 +148,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (NSArray *)accessibilityChildren
 {
-    id wrapper = [self accessibilityRootObjectWrapper:[self focusedLocalFrame]];
-    return wrapper ? @[wrapper] : @[];
+    RetainPtr wrapper = [self accessibilityRootObjectWrapper:[self focusedLocalFrame]];
+    return wrapper ? @[wrapper.get()] : @[];
 }
 
 - (NSArray *)accessibilityChildrenInNavigationOrder
@@ -354,7 +354,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             }
         }
 
-        return [[protectedSelf accessibilityRootObjectWrapper:[protectedSelf focusedLocalFrame]] accessibilityHitTest:convertedPoint];
+        return [retainPtr([protectedSelf accessibilityRootObjectWrapper:[protectedSelf focusedLocalFrame]]) accessibilityHitTest:convertedPoint];
     });
 }
 ALLOW_DEPRECATED_DECLARATIONS_END

--- a/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
+++ b/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
@@ -174,10 +174,10 @@ Vector<WebCore::ValidatedDigitalCredentialRequest> DigitalCredentials::validateR
         RetainPtr iso18013Request = adoptNS([WebKit::allocWKISO18013RequestInstance() initWithEncryptionInfo:convertedEncryptionInfo.get() deviceRequest:convertedDeviceRequest.get()]);
 
         NSError *error = nil;
-        auto validatedISORequest = [validator validateISO18013Request:iso18013Request.get() origin:convertedTopOrigin.get() error:&error];
+        RetainPtr validatedISORequest = [validator validateISO18013Request:iso18013Request.get() origin:convertedTopOrigin.get() error:&error];
 
         if (validatedISORequest) {
-            auto validatedMobileDocumentRequest = buildValidatedRequest(validatedISORequest);
+            auto validatedMobileDocumentRequest = buildValidatedRequest(validatedISORequest.get());
             auto resultVariant = WTF::Variant<WebCore::ValidatedMobileDocumentRequest, WebCore::OpenID4VPRequest>(validatedMobileDocumentRequest);
             validatedRequests.append(WTFMove(resultVariant));
         } else if (error) {

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -282,10 +282,9 @@ id WebProcess::accessibilityFocusedUIElement()
         RetainPtr objectWrapper = object ? object->wrapper() : nil;
         if (objectWrapper) {
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            id associatedParent = [objectWrapper accessibilityAttributeValue:@"_AXAssociatedPluginParent"];
+            if (RetainPtr associatedParent = [objectWrapper accessibilityAttributeValue:@"_AXAssociatedPluginParent"])
+                objectWrapper = WTFMove(associatedParent);
             ALLOW_DEPRECATED_DECLARATIONS_END
-            if (associatedParent)
-                objectWrapper = associatedParent;
         }
         return objectWrapper.autorelease();
     }
@@ -1399,7 +1398,7 @@ void WebProcess::handlePreferenceChange(const String& domain, const String& key,
 {
     if (key == "AppleLanguages"_s) {
         // We need to set AppleLanguages for the volatile domain, similarly to what we do in XPCServiceMain.mm.
-        NSDictionary *existingArguments = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSArgumentDomain];
+        RetainPtr<NSDictionary> existingArguments = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSArgumentDomain];
         RetainPtr<NSMutableDictionary> newArguments = adoptNS([existingArguments mutableCopy]);
         [newArguments setValue:value forKey:@"AppleLanguages"];
         [[NSUserDefaults standardUserDefaults] setVolatileDomain:newArguments.get() forName:NSArgumentDomain];

--- a/Source/WebKit/webpushd/ApplePushServiceConnection.mm
+++ b/Source/WebKit/webpushd/ApplePushServiceConnection.mm
@@ -62,7 +62,7 @@
     ASSERT(isMainRunLoop());
 
     if (RefPtr connection = _connection.get())
-        connection->didReceivePushMessage(message.topic, message.userInfo);
+        connection->didReceivePushMessage(retainPtr(message.topic).get(), retainPtr(message.userInfo).get());
 }
 
 @end
@@ -100,7 +100,7 @@ void ApplePushServiceConnection::subscribe(const String& topic, const Vector<uin
             return;
 
         auto handler = protectedThis->m_subscribeHandlers.take(identifier);
-        handler(token.tokenURL, error);
+        handler(retainPtr(token.tokenURL).get(), error);
     }).get()];
 }
 
@@ -124,22 +124,22 @@ void ApplePushServiceConnection::unsubscribe(const String& topic, const Vector<u
 
 Vector<String> ApplePushServiceConnection::enabledTopics()
 {
-    return makeVector<String>([m_connection enabledTopics]);
+    return makeVector<String>(retainPtr([m_connection enabledTopics]).get());
 }
 
 Vector<String> ApplePushServiceConnection::ignoredTopics()
 {
-    return makeVector<String>([m_connection ignoredTopics]);
+    return makeVector<String>(retainPtr([m_connection ignoredTopics]).get());
 }
 
 Vector<String> ApplePushServiceConnection::opportunisticTopics()
 {
-    return makeVector<String>([m_connection opportunisticTopics]);
+    return makeVector<String>(retainPtr([m_connection opportunisticTopics]).get());
 }
 
 Vector<String> ApplePushServiceConnection::nonWakingTopics()
 {
-    return makeVector<String>([m_connection nonWakingTopics]);
+    return makeVector<String>(retainPtr([m_connection nonWakingTopics]).get());
 }
 
 void ApplePushServiceConnection::setEnabledTopics(Vector<String>&& topics)

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
@@ -107,7 +107,7 @@ static _WKMockUserNotificationCenter *centersByBundleIdentifier(NSString *bundle
 {
     RetainPtr toRemove = adoptNS([NSMutableArray new]);
     for (UNNotification *notification in m_notifications.get()) {
-        if ([identifiers containsObject:notification.request.identifier])
+        if ([identifiers containsObject:retainPtr(notification.request.identifier).get()])
             [toRemove addObject:notification];
     }
 


### PR DESCRIPTION
#### 48d015a51f161af584c9c111abfc11cf06fa83fe
<pre>
Prepare Source/WebKit for clang static analyzer update (part 5)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301072">https://bugs.webkit.org/show_bug.cgi?id=301072</a>

Reviewed by Geoffrey Garen.

Deployed more smart pointers to prepare Source/WebKit for a future clang static analyzer update.

No new tests since there should be no behavioral difference.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_webkit_secure_coding_impl):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKWindowVisibilityObserver dealloc]):
(-[WKWindowVisibilityObserver _windowDidBecomeKey:]):
(-[WKWindowVisibilityObserver _windowDidResignKey:]):
(-[WKWindowVisibilityObserver _windowDidChangeBackingProperties:]):
(-[WKTextListTouchBarViewController initWithWebViewImpl:]):
(-[WKTextTouchBarItemController setTextIsBold:]):
(-[WKTextTouchBarItemController setTextIsItalic:]):
(-[WKTextTouchBarItemController setTextIsUnderlined:]):
(-[WKTextTouchBarItemController _wkChangeTextStyle:]):
(-[WKTextTouchBarItemController setCurrentTextAlignment:]):
(-[WKTextTouchBarItemController _wkChangeTextAlignment:]):
(-[WKImageAnalysisOverlayViewDelegate observeValueForKeyPath:ofObject:change:context:]):
(WebKit::WebViewImpl::takeFocus):
(WebKit::WebViewImpl::windowDidChangeScreen):
(WebKit::WebViewImpl::viewDidMoveToWindow):
(WebKit::WebViewImpl::updateTitlebarAdjacencyState):
(WebKit::WebViewImpl::setFontForWebView):
(WebKit::WebViewImpl::notifyInputContextAboutDiscardedComposition):
(WebKit::WebViewImpl::writeSelectionToPasteboard):
(WebKit::WebViewImpl::validRequestorForSendAndReturnTypes):
(WebKit::WebViewImpl::handleAcceptedCandidate):
(WebKit::WebViewImpl::accessibilityRegisterUIProcessTokens):
(WebKit::WebViewImpl::accessibilityAttributeValue):
(WebKit::WebViewImpl::enterAcceleratedCompositingWithRootLayer):
(WebKit::WebViewImpl::draggingEntered):
(WebKit::WebViewImpl::draggingUpdated):
(WebKit::WebViewImpl::draggingExited):
(WebKit::handleLegacyFilesPromisePasteboard):
(WebKit::handleLegacyFilesPasteboard):
(WebKit::WebViewImpl::performDragOperation):
(WebKit::WebViewImpl::hitTestForDragTypes):
(WebKit::WebViewImpl::registerDraggedTypes):
(WebKit::WebViewImpl::setFileAndURLTypes):
(WebKit::pathWithUniqueFilenameForPath):
(WebKit::WebViewImpl::namesOfPromisedFilesDroppedAtDestination):
(WebKit::WebViewImpl::requestDOMPasteAccess):
(WebKit::WebViewImpl::firstRectForCharacterRange):
(WebKit::WebViewImpl::effectiveAppearanceIsDark):
(WebKit::WebViewImpl::updateTextTouchBar):
(WebKit::WebViewImpl::updateMediaTouchBar):
(WebKit::WebViewImpl::handleContextMenuTranslation):
* Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm:
(-[WKVideoLayerRemote layoutSublayers]):
(-[WKVideoLayerRemote resolveBounds]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm:
(-[WKWebProcessPlugInFrame jsCSSStyleDeclarationForCSSStyleDeclarationHandle:inWorld:]):
(-[WKWebProcessPlugInFrame jsNodeForNodeHandle:inWorld:]):
(-[WKWebProcessPlugInFrame jsRangeForRangeHandle:inWorld:]):
* Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm:
(WebKit::InjectedBundle::decodeBundleParameters):
(WebKit::InjectedBundle::initialize):
(WebKit::InjectedBundle::setBundleParameter):
(WebKit::InjectedBundle::setBundleParameters):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::pdfDocumentSizeForPrinting const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm:
(WebKit::PDFPluginChoiceAnnotation::createAnnotationElement):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.mm:
(WebKit::hasActionsForResult):
(WebKit::resultIsPastDate):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(-[WKPDFFormMutationObserver formChanged:]):
(WebKit::UnifiedPDFPlugin::pdfElementTypesForPagePoint const):
(WebKit::UnifiedPDFPlugin::followLinkAnnotation):
(WebKit::htmlDataFromSelection):
(WebKit::UnifiedPDFPlugin::performCopyEditingOperation const):
(WebKit::UnifiedPDFPlugin::extendCurrentSelectionIfNeeded):
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm:
(-[WKAccessibilityPDFDocumentObject accessibilityVisibleChildren]):
(-[WKAccessibilityPDFDocumentObject accessibilityFrame]):
(-[WKAccessibilityPDFDocumentObject accessibilityHitTest:]):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::dictionaryPopupInfoForRange):
(WebKit::WebPage::resolveAccessibilityHitTestForTesting):
(WebKit::drawPDFPage):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityChildren]):
(-[WKAccessibilityWebPageObject accessibilityHitTest:]):
* Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm:
(WebKit::DigitalCredentials::validateRequests):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
(WebKit::WebProcess::handlePreferenceChange):
* Source/WebKit/webpushd/ApplePushServiceConnection.mm:
(-[_WKAPSConnectionDelegate connection:didReceiveIncomingMessage:]):
(WebPushD::ApplePushServiceConnection::subscribe):
(WebPushD::ApplePushServiceConnection::enabledTopics):
(WebPushD::ApplePushServiceConnection::ignoredTopics):
(WebPushD::ApplePushServiceConnection::opportunisticTopics):
(WebPushD::ApplePushServiceConnection::nonWakingTopics):
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::makeRawPushMessage):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::injectEncryptedPushMessageForTesting):
(WebPushD::WebPushDaemon::getNotifications):
(WebPushD::WebPushDaemon::setAppBadge):
(WebPushD::WebPushDaemon::getAppBadgeForTesting):
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
(-[_WKMockUserNotificationCenter removePendingNotificationRequestsWithIdentifiers:]):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(pushMessageFromArguments):
(registerDaemonWithLaunchD):
(WebKit::WebPushToolMain):

Canonical link: <a href="https://commits.webkit.org/301815@main">https://commits.webkit.org/301815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb18e27d7c388e818b9a20ad0171b377a8e0a62d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134103 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78663 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1d98ad45-3d60-40a5-8c7d-c9965cc0e504) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96718 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64762 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f67d7204-30fc-4263-bb78-86cfb42c6196) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77228 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/acd8f1cf-286f-4800-a6f3-fbbba1c3a873) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/126452 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36774 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77495 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107771 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136629 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105240 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104928 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28886 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51306 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19888 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53688 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59561 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52926 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56259 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54684 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->