### PR TITLE
[MSE/FairPlay] Have AudioVideoRenderer manage CDMInstance/CDMSession

### DIFF
--- a/Source/WebCore/platform/PlatformMediaError.cpp
+++ b/Source/WebCore/platform/PlatformMediaError.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 String convertEnumerationToString(PlatformMediaError enumerationValue)
 {
-    static std::array<const NeverDestroyed<String>, 16> values {
+    static std::array<const NeverDestroyed<String>, 17> values {
         MAKE_STATIC_STRING_IMPL("AppendError"),
         MAKE_STATIC_STRING_IMPL("ClientDisconnected"),
         MAKE_STATIC_STRING_IMPL("BufferRemoved"),
@@ -49,6 +49,7 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
         MAKE_STATIC_STRING_IMPL("AudioDecodingError"),
         MAKE_STATIC_STRING_IMPL("VideoDecodingError"),
         MAKE_STATIC_STRING_IMPL("RequiresFlushToResume"),
+        MAKE_STATIC_STRING_IMPL("CDMInstanceKeyNeeded"),
     };
     static_assert(!static_cast<size_t>(PlatformMediaError::AppendError), "PlatformMediaError::AppendError is not 0 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::ClientDisconnected) == 1, "PlatformMediaError::ClientDisconnected is not 1 as expected");
@@ -66,6 +67,7 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
     static_assert(static_cast<size_t>(PlatformMediaError::AudioDecodingError) == 13, "PlatformMediaError::AudioDecodingError is not 13 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::VideoDecodingError) == 14, "PlatformMediaError::VideoDecodingError is not 14 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::RequiresFlushToResume) == 15, "PlatformMediaError::RequiresFlushToResume is not 15 as expected");
+    static_assert(static_cast<size_t>(PlatformMediaError::CDMInstanceKeyNeeded) == 16, "PlatformMediaError::CDMInstanceKeyNeeded is not 16 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }

--- a/Source/WebCore/platform/PlatformMediaError.h
+++ b/Source/WebCore/platform/PlatformMediaError.h
@@ -47,6 +47,7 @@ enum class PlatformMediaError : uint8_t {
     AudioDecodingError,
     VideoDecodingError,
     RequiresFlushToResume,
+    CDMInstanceKeyNeeded,
 };
 
 using MediaPromise = NativePromise<void, PlatformMediaError>;

--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -44,6 +44,7 @@ namespace WebCore {
 class CDMInstance;
 class FloatRect;
 class GraphicsContext;
+class LegacyCDMSession;
 class LayoutRect;
 class MediaSample;
 class NativeImage;
@@ -168,6 +169,12 @@ public:
 
 #if ENABLE(ENCRYPTED_MEDIA)
     virtual void setCDMInstance(CDMInstance*) { }
+    virtual Ref<MediaPromise> setInitData(Ref<SharedBuffer>) { return MediaPromise::createAndResolve(); }
+    virtual void attemptToDecrypt() { }
+#endif
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
+    virtual RefPtr<SharedBuffer> initData() const { return nullptr; }
+    virtual void setCDMSession(LegacyCDMSession*) { }
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -42,8 +42,6 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
-#include <wtf/WTFSemaphore.h>
-#include <wtf/threads/BinarySemaphore.h>
 
 OBJC_CLASS AVStreamDataParser;
 OBJC_CLASS AVSampleBufferAudioRenderer;
@@ -191,13 +189,10 @@ private:
 
     const Ref<SourceBufferParser> m_parser;
     Vector<Function<void()>> m_pendingTrackChangeTasks;
-    Deque<std::pair<TrackID, Ref<MediaSampleAVFObjC>>> m_blockedSamples;
-    Box<Semaphore> m_abortSemaphore;
     const Ref<WTF::WorkQueue> m_appendQueue;
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     RefPtr<SharedBuffer> m_initData;
-    ThreadSafeWeakPtr<CDMSessionAVContentKeySession> m_session;
 #endif
 
     std::optional<FloatSize> m_cachedSize;
@@ -207,17 +202,6 @@ private:
     std::optional<TrackID> m_protectedTrackID;
     Ref<AudioVideoRenderer> m_renderer;
     bool m_isSelectedForVideo { false };
-
-#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    using KeyIDs = Vector<Ref<SharedBuffer>>;
-    using TrackKeyIDsMap = StdUnorderedMap<TrackID, KeyIDs>;
-    TrackKeyIDsMap m_currentTrackIDs;
-
-    RefPtr<CDMInstanceFairPlayStreamingAVFObjC> m_cdmInstance;
-    UniqueRef<Observer<void()>> m_keyStatusesChangedObserver;
-    KeyIDs m_keyIDs;
-    const RetainPtr<AVStreamDataParser> m_streamDataParser;
-#endif
 
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;


### PR DESCRIPTION
#### 02963503fd1b3b0456000c1bfddf77c518f489f4
<pre>
[MSE/FairPlay] Have AudioVideoRenderer manage CDMInstance/CDMSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=300681">https://bugs.webkit.org/show_bug.cgi?id=300681</a>
<a href="https://rdar.apple.com/162583496">rdar://162583496</a>

Reviewed by Andy Estes.

Move MediaSample&apos;s CDM management from SourceBufferPrivateAVFObjC to
AudioVideoRendererAVFObjC.

No change in observable behaviour. Covered by existing tests.
Manually tested with Netflix and Disney+
* Source/WebCore/platform/PlatformMediaError.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/PlatformMediaError.h:
* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
(WebCore::TracksRendererManager::setInitData):
(WebCore::TracksRendererManager::attemptToDecrypt):
(WebCore::TracksRendererManager::initData const):
(WebCore::TracksRendererManager::setCDMSession):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC):
(WebCore::AudioVideoRendererAVFObjC::enqueueSample):
(WebCore::AudioVideoRendererAVFObjC::setCDMInstance):
(WebCore::AudioVideoRendererAVFObjC::setInitData):
(WebCore::AudioVideoRendererAVFObjC::attemptToDecrypt):
(WebCore::AudioVideoRendererAVFObjC::tryToEnqueueBlockedSamples):
(WebCore::AudioVideoRendererAVFObjC::canEnqueueSample):
(WebCore::AudioVideoRendererAVFObjC::attachContentKeyToSampleIfNeeded):
(WebCore::AudioVideoRendererAVFObjC::setCDMSession):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::SourceBufferPrivateAVFObjC):
(WebCore::SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataForTrackID):
(WebCore::SourceBufferPrivateAVFObjC::setCDMSession):
(WebCore::SourceBufferPrivateAVFObjC::setCDMInstance):
(WebCore::SourceBufferPrivateAVFObjC::attemptToDecrypt):
(WebCore::SourceBufferPrivateAVFObjC::canEnqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::didBecomeReadyForMoreSamples):
(WebCore::supportsAttachContentKey): Deleted.
(WebCore::m_streamDataParser): Deleted.
(WebCore::m_logIdentifier): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::trackIsBlocked const): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::tryToEnqueueBlockedSamples): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::attachContentKeyToSampleIfNeeded): Deleted.

Canonical link: <a href="https://commits.webkit.org/301865@main">https://commits.webkit.org/301865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52cddfd5a817f5d9b8b74c16042132807db2b3c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134379 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78870 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/728576d2-5682-4390-bb6e-37b335a6eab3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96893 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8fef607c-276d-40cd-86f8-8d84f4b433e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77387 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c8edb63f-d522-427d-9855-78cd9491544d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77761 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136862 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105408 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105091 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26789 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50612 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51542 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53911 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59998 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53143 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54904 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->