### PR TITLE
[MSE/SourceBuffer] MediaSourcePrivate doesn't need to know about CDMInstance/CDMSession

### DIFF
--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -95,9 +95,6 @@ public:
     virtual WebCore::FloatSize videoLayerSize() const { return { }; }
     virtual void notifyVideoLayerSizeChanged(Function<void(const MediaTime&, FloatSize)>&&) { }
     virtual void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRightAnnotated&&) { }
-#if ENABLE(ENCRYPTED_MEDIA)
-    virtual void notifyInsufficientExternalProtectionChanged(Function<void(bool)>&&) { }
-#endif
 };
 
 class VideoFullscreenInterface {

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -268,16 +268,6 @@ const PlatformTimeRanges& MediaSourcePrivate::liveSeekableRange() const
     IGNORE_CLANG_WARNINGS_END
 }
 
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-void MediaSourcePrivate::setCDMSession(LegacyCDMSession* session)
-{
-    assertIsCurrent(m_dispatcher);
-
-    for (auto& sourceBuffer : m_sourceBuffers)
-        sourceBuffer->setCDMSession(session);
-}
-#endif
-
 void MediaSourcePrivate::ensureOnDispatcher(Function<void()>&& function) const
 {
     Ref dispatcher = m_dispatcher;

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -123,10 +123,6 @@ public:
     void setStreamingAllowed(bool value) { m_streamingAllowed = value; }
     bool streamingAllowed() const { return m_streamingAllowed; }
 
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    void setCDMSession(LegacyCDMSession*);
-#endif
-
 protected:
     MediaSourcePrivate(MediaSourcePrivateClient&, GuaranteedSerialFunctionDispatcher&);
     void ensureOnDispatcher(Function<void()>&&) const;

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -161,13 +161,8 @@ public:
     virtual uint64_t sourceBufferLogIdentifier() = 0;
 #endif
 
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    virtual void setCDMSession(LegacyCDMSession*) { }
-#endif
 #if ENABLE(ENCRYPTED_MEDIA)
-    virtual void setCDMInstance(CDMInstance*) { }
     virtual bool waitingForKey() const { return false; }
-    virtual void attemptToDecrypt() { }
 #endif
 
 protected:

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -139,9 +139,6 @@ public:
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() final;
     PlatformLayer* platformVideoLayer() const final;
     void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRightAnnotated&&) final;
-#if ENABLE(ENCRYPTED_MEDIA)
-    void notifyInsufficientExternalProtectionChanged(Function<void(bool)>&&) final;
-#endif
 
     // VideoFullscreenInterface
     void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&&) final;
@@ -272,9 +269,6 @@ private:
     Function<void()> m_notifyWhenRequiresFlushToResume;
     Function<void()> m_renderingModeChangedCallback;
     Function<void(const MediaTime&, FloatSize)> m_sizeChangedCallback;
-#if ENABLE(ENCRYPTED_MEDIA)
-    Function<void(bool)> m_insufficientExternalProtectionChangedCallback;
-#endif
 
     RetainPtr<id> m_currentTimeObserver;
     RetainPtr<id> m_performTaskObserver;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -140,8 +140,6 @@ public:
     void waitingForKeyChanged();
 #endif
 
-    void outputObscuredDueToInsufficientExternalProtectionChanged(bool);
-
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) || ENABLE(ENCRYPTED_MEDIA)
     void keyNeeded(const SharedBuffer&);
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -90,13 +90,7 @@ public:
     void flushAndReenqueueActiveVideoSourceBuffers();
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    void cdmInstanceAttached(CDMInstance&);
-    void cdmInstanceDetached(CDMInstance&);
-    void attemptToDecryptWithInstance(CDMInstance&);
     bool waitingForKey() const;
-
-    CDMInstance* cdmInstance() const { return m_cdmInstance.get(); }
-    void outputObscuredDueToInsufficientExternalProtectionChanged(bool);
 #endif
 
 #if !RELEASE_LOG_DISABLED
@@ -114,10 +108,6 @@ public:
 
     void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
 
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    void keyAdded();
-#endif
-
 private:
     friend class SourceBufferPrivateAVFObjC;
 
@@ -125,9 +115,6 @@ private:
     MediaPlayerPrivateMediaSourceAVFObjC* platformPlayer() const { return m_player.get(); }
 
     void notifyActiveSourceBuffersChanged() final;
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    void sourceBufferKeyNeeded(SourceBufferPrivateAVFObjC*, const SharedBuffer&);
-#endif
     void removeSourceBuffer(SourceBufferPrivate&) final;
 
     void setSourceBufferWithSelectedVideo(SourceBufferPrivateAVFObjC*);
@@ -136,11 +123,7 @@ private:
     void trackBufferedChanged(SourceBufferPrivate&, Vector<PlatformTimeRanges>&&) final;
 
     WeakPtr<MediaPlayerPrivateMediaSourceAVFObjC> m_player;
-    Deque<SourceBufferPrivateAVFObjC*> m_sourceBuffersNeedingSessions;
     SourceBufferPrivateAVFObjC* m_sourceBufferWithSelectedVideo { nullptr };
-#if ENABLE(ENCRYPTED_MEDIA)
-    RefPtr<CDMInstance> m_cdmInstance;
-#endif
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -101,10 +101,10 @@ public:
     bool needsVideoLayer() const;
 
 #if (ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)) || ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    void setCDMSession(LegacyCDMSession*) final;
-    void setCDMInstance(CDMInstance*) final;
-    void attemptToDecrypt() final;
     bool waitingForKey() const final { return m_waitingForKey; }
+#endif
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
+    RefPtr<SharedBuffer> initData() const { return m_initData; }
 #endif
 
     // Used by CDMSessionAVContentKeySession

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -313,7 +313,7 @@ void SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataFo
 
     m_protectedTrackID = trackID;
     m_initData = initData.copyRef();
-    mediaSource->sourceBufferKeyNeeded(this, initData);
+    player->keyNeeded(initData);
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
@@ -323,6 +323,8 @@ void SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataFo
             return;
         if (result) {
             protectedThis->m_waitingForKey = false;
+            if (RefPtr player = protectedThis->player())
+                player->waitingForKeyChanged();
             return;
         }
         switch (result.error()) {
@@ -526,34 +528,6 @@ void SourceBufferPrivateAVFObjC::trackDidChangeEnabled(AudioTrackPrivate& track,
     if (RefPtr player = this->player())
         player->addAudioTrack(trackIdentifier);
 }
-
-#if (ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)) || ENABLE(LEGACY_ENCRYPTED_MEDIA)
-void SourceBufferPrivateAVFObjC::setCDMSession(LegacyCDMSession* session)
-{
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    ALWAYS_LOG(LOGIDENTIFIER);
-    protectedRenderer()->setCDMSession(session);
-#else
-    UNUSED_PARAM(session);
-#endif
-}
-
-void SourceBufferPrivateAVFObjC::setCDMInstance(CDMInstance* instance)
-{
-#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    protectedRenderer()->setCDMInstance(instance);
-#else
-    UNUSED_PARAM(instance);
-#endif
-}
-
-void SourceBufferPrivateAVFObjC::attemptToDecrypt()
-{
-#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    protectedRenderer()->attemptToDecrypt();
-#endif
-}
-#endif // (ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)) || ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 std::optional<AudioVideoRenderer::TrackIdentifier> SourceBufferPrivateAVFObjC::trackIdentifierFor(TrackID trackId) const
 {


### PR DESCRIPTION
#### 85760d3ab1e8c259cb88e61891e9c37837752feb
<pre>
[MSE/SourceBuffer] MediaSourcePrivate doesn&apos;t need to know about CDMInstance/CDMSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=301073">https://bugs.webkit.org/show_bug.cgi?id=301073</a>
<a href="https://rdar.apple.com/163005164">rdar://163005164</a>

Reviewed by Eric Carlson.

The MediaPlayerPrivateMediaSourceAVFObjC had to communicate to all the
SourceBufferPrivateAVFObjC to notify them if a new CDMInstance or LegacyCDMSession
was attached to the player.
Now that the AudioVideoRenderer handles the decryption of MediaSample
the MediaSourcePrivateAVFObjC and all attached SourceBufferPrivateAVFObjCs
do not need to be notified that a CDM has been attached. This knowledge
is the responsibility of the MediaPlayerPrivate and its AudioVideoRenderer.
We can remove all associated code.

No change in observable behaviour, covered by existing tests.

* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::enqueueSample):
(WebCore::AudioVideoRendererAVFObjC::canEnqueueSample): Fix from 301391@main
didn&apos;t carry over in 301865@main. Causing seek with encrypted audio to never complete.
(WebCore::AudioVideoRendererAVFObjC::attachContentKeyToSampleIfNeeded):

Canonical link: <a href="https://commits.webkit.org/301921@main">https://commits.webkit.org/301921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4abc053e305371e76e62b0f948a42823bad2d4b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134571 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8ce58c09-3d9a-4f1f-9ee7-1ce7cd9c6457) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129367 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/47760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/55667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0383f769-53d0-4207-ad83-49b7774d6cae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130443 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/47760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/114176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/77528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9b4f7539-9fd0-4699-8642-757550bed96d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/47760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77945 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/47760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/32704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137056 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/54154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/55667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/54665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110532 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/105224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26823 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/54091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60178 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/53325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/55084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->