### PR TITLE
SaferCPP: Simplify WebGL GraphicsCotentextGL accessors

### DIFF
--- a/Source/WebCore/html/canvas/ANGLEInstancedArrays.cpp
+++ b/Source/WebCore/html/canvas/ANGLEInstancedArrays.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(ANGLEInstancedArrays);
 ANGLEInstancedArrays::ANGLEInstancedArrays(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::ANGLEInstancedArrays)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_instanced_arrays"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_instanced_arrays"_s);
 }
 
 ANGLEInstancedArrays::~ANGLEInstancedArrays() = default;
@@ -51,21 +51,21 @@ void ANGLEInstancedArrays::drawArraysInstancedANGLE(GCGLenum mode, GCGLint first
 {
     if (isContextLost())
         return;
-    protectedContext()->drawArraysInstanced(mode, first, count, primcount);
+    context()->drawArraysInstanced(mode, first, count, primcount);
 }
 
 void ANGLEInstancedArrays::drawElementsInstancedANGLE(GCGLenum mode, GCGLsizei count, GCGLenum type, long long offset, GCGLsizei primcount)
 {
     if (isContextLost())
         return;
-    protectedContext()->drawElementsInstanced(mode, count, type, offset, primcount);
+    context()->drawElementsInstanced(mode, count, type, offset, primcount);
 }
 
 void ANGLEInstancedArrays::vertexAttribDivisorANGLE(GCGLuint index, GCGLuint divisor)
 {
     if (isContextLost())
         return;
-    protectedContext()->vertexAttribDivisor(index, divisor);
+    context()->vertexAttribDivisor(index, divisor);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.cpp
+++ b/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.cpp
@@ -65,7 +65,7 @@ CanvasFilterContextSwitcher::CanvasFilterContextSwitcher(CanvasRenderingContext2
 
 CanvasFilterContextSwitcher::~CanvasFilterContextSwitcher()
 {
-    protectedContext()->restore();
+    context()->restore();
 }
 
 FloatRect CanvasFilterContextSwitcher::expandedBounds() const

--- a/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.h
+++ b/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.h
@@ -45,7 +45,7 @@ public:
     FloatRect expandedBounds() const;
 
 private:
-    Ref<CanvasRenderingContext2DBase> protectedContext() const { return m_context.get(); }
+    Ref<CanvasRenderingContext2DBase> context() const { return m_context.get(); }
     WeakRef<CanvasRenderingContext2DBase> m_context;
 };
 

--- a/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp
+++ b/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp
@@ -71,7 +71,7 @@ GraphicsContext* CanvasLayerContextSwitcher::drawingContext() const
 
 FloatBoxExtent CanvasLayerContextSwitcher::outsets() const
 {
-    return toFloatBoxExtent(protectedContext()->calculateFilterOutsets(m_bounds));
+    return toFloatBoxExtent(context()->calculateFilterOutsets(m_bounds));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.h
+++ b/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.h
@@ -49,7 +49,7 @@ private:
     CanvasLayerContextSwitcher(CanvasRenderingContext2DBase&, const FloatRect& bounds, std::unique_ptr<GraphicsContextSwitcher>&&);
 
     FloatBoxExtent outsets() const;
-    Ref<CanvasRenderingContext2DBase> protectedContext() const { return m_context.get(); }
+    Ref<CanvasRenderingContext2DBase> context() const { return m_context.get(); }
 
     WeakRef<CanvasRenderingContext2DBase> m_context;
     GraphicsContext* m_effectiveDrawingContext;

--- a/Source/WebCore/html/canvas/EXTBlendMinMax.cpp
+++ b/Source/WebCore/html/canvas/EXTBlendMinMax.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTBlendMinMax);
 EXTBlendMinMax::EXTBlendMinMax(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTBlendMinMax)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_blend_minmax"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_blend_minmax"_s);
 }
 
 EXTBlendMinMax::~EXTBlendMinMax() = default;

--- a/Source/WebCore/html/canvas/EXTClipControl.cpp
+++ b/Source/WebCore/html/canvas/EXTClipControl.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTClipControl);
 EXTClipControl::EXTClipControl(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTClipControl)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_clip_control"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_clip_control"_s);
 }
 
 EXTClipControl::~EXTClipControl() = default;
@@ -51,7 +51,7 @@ void EXTClipControl::clipControlEXT(GCGLenum origin, GCGLenum depth)
 {
     if (isContextLost())
         return;
-    protectedContext()->protectedGraphicsContextGL()->clipControlEXT(origin, depth);
+    context()->graphicsContextGL()->clipControlEXT(origin, depth);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/EXTColorBufferFloat.cpp
+++ b/Source/WebCore/html/canvas/EXTColorBufferFloat.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTColorBufferFloat);
 EXTColorBufferFloat::EXTColorBufferFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTColorBufferFloat)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_color_buffer_float"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_color_buffer_float"_s);
 
     // https://github.com/KhronosGroup/WebGL/pull/2830
     // Spec requires EXT_float_blend to be turned on implicitly here.

--- a/Source/WebCore/html/canvas/EXTColorBufferHalfFloat.cpp
+++ b/Source/WebCore/html/canvas/EXTColorBufferHalfFloat.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTColorBufferHalfFloat);
 EXTColorBufferHalfFloat::EXTColorBufferHalfFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTColorBufferHalfFloat)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_color_buffer_half_float"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_color_buffer_half_float"_s);
 }
 
 EXTColorBufferHalfFloat::~EXTColorBufferHalfFloat() = default;

--- a/Source/WebCore/html/canvas/EXTConservativeDepth.cpp
+++ b/Source/WebCore/html/canvas/EXTConservativeDepth.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTConservativeDepth);
 EXTConservativeDepth::EXTConservativeDepth(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTConservativeDepth)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_conservative_depth"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_conservative_depth"_s);
 }
 
 EXTConservativeDepth::~EXTConservativeDepth() = default;

--- a/Source/WebCore/html/canvas/EXTDepthClamp.cpp
+++ b/Source/WebCore/html/canvas/EXTDepthClamp.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTDepthClamp);
 EXTDepthClamp::EXTDepthClamp(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTDepthClamp)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_depth_clamp"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_depth_clamp"_s);
 }
 
 EXTDepthClamp::~EXTDepthClamp() = default;

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -46,7 +46,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTDisjointTimerQuery);
 EXTDisjointTimerQuery::EXTDisjointTimerQuery(WebGLRenderingContext& context)
     : WebGLExtension(context, WebGLExtensionName::EXTDisjointTimerQuery)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_disjoint_timer_query"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_disjoint_timer_query"_s);
 }
 
 EXTDisjointTimerQuery::~EXTDisjointTimerQuery() = default;
@@ -60,7 +60,7 @@ RefPtr<WebGLTimerQueryEXT> EXTDisjointTimerQuery::createQueryEXT()
 {
     if (isContextLost())
         return nullptr;
-    return WebGLTimerQueryEXT::create(protectedContext().get());
+    return WebGLTimerQueryEXT::create(context().get());
 }
 
 void EXTDisjointTimerQuery::deleteQueryEXT(WebGLTimerQueryEXT* query)
@@ -85,10 +85,10 @@ void EXTDisjointTimerQuery::deleteQueryEXT(WebGLTimerQueryEXT* query)
     if (query == context->m_activeQuery) {
         context->m_activeQuery = nullptr;
         ASSERT(query->target() == GraphicsContextGL::TIME_ELAPSED_EXT);
-        context->protectedGraphicsContextGL()->endQueryEXT(GraphicsContextGL::TIME_ELAPSED_EXT);
+        context->graphicsContextGL()->endQueryEXT(GraphicsContextGL::TIME_ELAPSED_EXT);
     }
 
-    query->deleteObject(locker, context->protectedGraphicsContextGL().get());
+    query->deleteObject(locker, context->graphicsContextGL().get());
 }
 
 GCGLboolean EXTDisjointTimerQuery::isQueryEXT(WebGLTimerQueryEXT* query)
@@ -98,7 +98,7 @@ GCGLboolean EXTDisjointTimerQuery::isQueryEXT(WebGLTimerQueryEXT* query)
     Ref context = this->context();
     if (!context->validateIsWebGLObject(query))
         return false;
-    return context->protectedGraphicsContextGL()->isQueryEXT(query->object());
+    return context->graphicsContextGL()->isQueryEXT(query->object());
 }
 
 void EXTDisjointTimerQuery::beginQueryEXT(GCGLenum target, WebGLTimerQueryEXT& query)
@@ -133,7 +133,7 @@ void EXTDisjointTimerQuery::beginQueryEXT(GCGLenum target, WebGLTimerQueryEXT& q
 
     context->m_activeQuery = &query;
 
-    context->protectedGraphicsContextGL()->beginQueryEXT(target, query.object());
+    context->graphicsContextGL()->beginQueryEXT(target, query.object());
 }
 
 void EXTDisjointTimerQuery::endQueryEXT(GCGLenum target)
@@ -156,7 +156,7 @@ void EXTDisjointTimerQuery::endQueryEXT(GCGLenum target)
         return;
     }
 
-    context->protectedGraphicsContextGL()->endQueryEXT(target);
+    context->graphicsContextGL()->endQueryEXT(target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
     context->scriptExecutionContext()->eventLoop().queueMicrotask([query = WTFMove(context->m_activeQuery)] {
@@ -187,7 +187,7 @@ void EXTDisjointTimerQuery::queryCounterEXT(WebGLTimerQueryEXT& query, GCGLenum 
 
     query.setTarget(target);
 
-    context->protectedGraphicsContextGL()->queryCounterEXT(query.object(), target);
+    context->graphicsContextGL()->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
     context->scriptExecutionContext()->eventLoop().queueMicrotask([&] {
@@ -212,7 +212,7 @@ WebGLAny EXTDisjointTimerQuery::getQueryEXT(GCGLenum target, GCGLenum pname)
             return context->m_activeQuery;
         return nullptr;
     case GraphicsContextGL::QUERY_COUNTER_BITS_EXT:
-        return context->protectedGraphicsContextGL()->getQueryiEXT(target, pname);
+        return context->graphicsContextGL()->getQueryiEXT(target, pname);
     }
     context->synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getQueryEXT"_s, "invalid parameter name"_s);
     return nullptr;
@@ -241,11 +241,11 @@ WebGLAny EXTDisjointTimerQuery::getQueryObjectEXT(WebGLTimerQueryEXT& query, GCG
     case GraphicsContextGL::QUERY_RESULT_EXT:
         if (!query.isResultAvailable())
             return 0;
-        return static_cast<unsigned long long>(context->protectedGraphicsContextGL()->getQueryObjectui64EXT(query.object(), pname));
+        return static_cast<unsigned long long>(context->graphicsContextGL()->getQueryObjectui64EXT(query.object(), pname));
     case GraphicsContextGL::QUERY_RESULT_AVAILABLE_EXT:
         if (!query.isResultAvailable())
             return false;
-        return static_cast<bool>(context->protectedGraphicsContextGL()->getQueryObjectiEXT(query.object(), pname));
+        return static_cast<bool>(context->graphicsContextGL()->getQueryObjectiEXT(query.object(), pname));
     }
     context->synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getQueryObjectEXT"_s, "invalid parameter name"_s);
     return nullptr;

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTDisjointTimerQueryWebGL2);
 EXTDisjointTimerQueryWebGL2::EXTDisjointTimerQueryWebGL2(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTDisjointTimerQueryWebGL2)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_disjoint_timer_query"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_disjoint_timer_query"_s);
 }
 
 EXTDisjointTimerQueryWebGL2::~EXTDisjointTimerQueryWebGL2() = default;
@@ -74,7 +74,7 @@ void EXTDisjointTimerQueryWebGL2::queryCounterEXT(WebGLQuery& query, GCGLenum ta
 
     query.setTarget(target);
 
-    context->protectedGraphicsContextGL()->queryCounterEXT(query.object(), target);
+    context->graphicsContextGL()->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
     context->protectedScriptExecutionContext()->checkedEventLoop()->queueMicrotask([&] {

--- a/Source/WebCore/html/canvas/EXTFloatBlend.cpp
+++ b/Source/WebCore/html/canvas/EXTFloatBlend.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTFloatBlend);
 EXTFloatBlend::EXTFloatBlend(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTFloatBlend)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_float_blend"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_float_blend"_s);
 }
 
 EXTFloatBlend::~EXTFloatBlend() = default;

--- a/Source/WebCore/html/canvas/EXTFragDepth.cpp
+++ b/Source/WebCore/html/canvas/EXTFragDepth.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTFragDepth);
 EXTFragDepth::EXTFragDepth(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTFragDepth)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_frag_depth"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_frag_depth"_s);
 }
 
 EXTFragDepth::~EXTFragDepth() = default;

--- a/Source/WebCore/html/canvas/EXTPolygonOffsetClamp.cpp
+++ b/Source/WebCore/html/canvas/EXTPolygonOffsetClamp.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTPolygonOffsetClamp);
 EXTPolygonOffsetClamp::EXTPolygonOffsetClamp(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTPolygonOffsetClamp)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_polygon_offset_clamp"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_polygon_offset_clamp"_s);
 }
 
 EXTPolygonOffsetClamp::~EXTPolygonOffsetClamp() = default;
@@ -51,7 +51,7 @@ void EXTPolygonOffsetClamp::polygonOffsetClampEXT(GCGLfloat factor, GCGLfloat un
 {
     if (isContextLost())
         return;
-    protectedContext()->protectedGraphicsContextGL()->polygonOffsetClampEXT(factor, units, clamp);
+    context()->graphicsContextGL()->polygonOffsetClampEXT(factor, units, clamp);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/EXTRenderSnorm.cpp
+++ b/Source/WebCore/html/canvas/EXTRenderSnorm.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTRenderSnorm);
 EXTRenderSnorm::EXTRenderSnorm(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTRenderSnorm)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_render_snorm"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_render_snorm"_s);
 }
 
 EXTRenderSnorm::~EXTRenderSnorm() = default;

--- a/Source/WebCore/html/canvas/EXTShaderTextureLOD.cpp
+++ b/Source/WebCore/html/canvas/EXTShaderTextureLOD.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTShaderTextureLOD);
 EXTShaderTextureLOD::EXTShaderTextureLOD(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTShaderTextureLOD)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_shader_texture_lod"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_shader_texture_lod"_s);
 }
 
 EXTShaderTextureLOD::~EXTShaderTextureLOD() = default;

--- a/Source/WebCore/html/canvas/EXTTextureCompressionBPTC.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureCompressionBPTC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTTextureCompressionBPTC);
 EXTTextureCompressionBPTC::EXTTextureCompressionBPTC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureCompressionBPTC)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_compression_bptc"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_compression_bptc"_s);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RGBA_BPTC_UNORM_EXT);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT);

--- a/Source/WebCore/html/canvas/EXTTextureCompressionRGTC.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureCompressionRGTC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTTextureCompressionRGTC);
 EXTTextureCompressionRGTC::EXTTextureCompressionRGTC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureCompressionRGTC)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_compression_rgtc"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_compression_rgtc"_s);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RED_RGTC1_EXT);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SIGNED_RED_RGTC1_EXT);

--- a/Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTTextureFilterAnisotropic);
 EXTTextureFilterAnisotropic::EXTTextureFilterAnisotropic(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureFilterAnisotropic)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_filter_anisotropic"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_filter_anisotropic"_s);
 }
 
 EXTTextureFilterAnisotropic::~EXTTextureFilterAnisotropic() = default;

--- a/Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTTextureMirrorClampToEdge);
 EXTTextureMirrorClampToEdge::EXTTextureMirrorClampToEdge(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureMirrorClampToEdge)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_mirror_clamp_to_edge"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_mirror_clamp_to_edge"_s);
 }
 
 EXTTextureMirrorClampToEdge::~EXTTextureMirrorClampToEdge() = default;

--- a/Source/WebCore/html/canvas/EXTTextureNorm16.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureNorm16.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTTextureNorm16);
 EXTTextureNorm16::EXTTextureNorm16(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureNorm16)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_norm16"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_norm16"_s);
 }
 
 EXTTextureNorm16::~EXTTextureNorm16() = default;

--- a/Source/WebCore/html/canvas/EXTsRGB.cpp
+++ b/Source/WebCore/html/canvas/EXTsRGB.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EXTsRGB);
 EXTsRGB::EXTsRGB(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTsRGB)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_sRGB"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_sRGB"_s);
 }
 
 EXTsRGB::~EXTsRGB() = default;

--- a/Source/WebCore/html/canvas/KHRParallelShaderCompile.cpp
+++ b/Source/WebCore/html/canvas/KHRParallelShaderCompile.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(KHRParallelShaderCompile);
 KHRParallelShaderCompile::KHRParallelShaderCompile(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::KHRParallelShaderCompile)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_KHR_parallel_shader_compile"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_KHR_parallel_shader_compile"_s);
 }
 
 KHRParallelShaderCompile::~KHRParallelShaderCompile() = default;

--- a/Source/WebCore/html/canvas/NVShaderNoperspectiveInterpolation.cpp
+++ b/Source/WebCore/html/canvas/NVShaderNoperspectiveInterpolation.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(NVShaderNoperspectiveInterpolation);
 NVShaderNoperspectiveInterpolation::NVShaderNoperspectiveInterpolation(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::NVShaderNoperspectiveInterpolation)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_NV_shader_noperspective_interpolation"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_NV_shader_noperspective_interpolation"_s);
 }
 
 NVShaderNoperspectiveInterpolation::~NVShaderNoperspectiveInterpolation() = default;

--- a/Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp
+++ b/Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OESDrawBuffersIndexed);
 OESDrawBuffersIndexed::OESDrawBuffersIndexed(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESDrawBuffersIndexed)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_draw_buffers_indexed"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_draw_buffers_indexed"_s);
 }
 
 OESDrawBuffersIndexed::~OESDrawBuffersIndexed() = default;
@@ -51,42 +51,42 @@ void OESDrawBuffersIndexed::enableiOES(GCGLenum target, GCGLuint index)
 {
     if (isContextLost())
         return;
-    protectedContext()->protectedGraphicsContextGL()->enableiOES(target, index);
+    context()->graphicsContextGL()->enableiOES(target, index);
 }
 
 void OESDrawBuffersIndexed::disableiOES(GCGLenum target, GCGLuint index)
 {
     if (isContextLost())
         return;
-    protectedContext()->protectedGraphicsContextGL()->disableiOES(target, index);
+    context()->graphicsContextGL()->disableiOES(target, index);
 }
 
 void OESDrawBuffersIndexed::blendEquationiOES(GCGLuint buf, GCGLenum mode)
 {
     if (isContextLost())
         return;
-    protectedContext()->protectedGraphicsContextGL()->blendEquationiOES(buf, mode);
+    context()->graphicsContextGL()->blendEquationiOES(buf, mode);
 }
 
 void OESDrawBuffersIndexed::blendEquationSeparateiOES(GCGLuint buf, GCGLenum modeRGB, GCGLenum modeAlpha)
 {
     if (isContextLost())
         return;
-    protectedContext()->protectedGraphicsContextGL()->blendEquationSeparateiOES(buf, modeRGB, modeAlpha);
+    context()->graphicsContextGL()->blendEquationSeparateiOES(buf, modeRGB, modeAlpha);
 }
 
 void OESDrawBuffersIndexed::blendFunciOES(GCGLuint buf, GCGLenum src, GCGLenum dst)
 {
     if (isContextLost())
         return;
-    protectedContext()->protectedGraphicsContextGL()->blendFunciOES(buf, src, dst);
+    context()->graphicsContextGL()->blendFunciOES(buf, src, dst);
 }
 
 void OESDrawBuffersIndexed::blendFuncSeparateiOES(GCGLuint buf, GCGLenum srcRGB, GCGLenum dstRGB, GCGLenum srcAlpha, GCGLenum dstAlpha)
 {
     if (isContextLost())
         return;
-    protectedContext()->protectedGraphicsContextGL()->blendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
+    context()->graphicsContextGL()->blendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
 }
 
 void OESDrawBuffersIndexed::colorMaskiOES(GCGLuint buf, GCGLboolean red, GCGLboolean green, GCGLboolean blue, GCGLboolean alpha)
@@ -101,7 +101,7 @@ void OESDrawBuffersIndexed::colorMaskiOES(GCGLuint buf, GCGLboolean red, GCGLboo
         context->m_colorMask[2] = blue;
         context->m_colorMask[3] = alpha;
     }
-    context->protectedGraphicsContextGL()->colorMaskiOES(buf, red, green, blue, alpha);
+    context->graphicsContextGL()->colorMaskiOES(buf, red, green, blue, alpha);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/OESElementIndexUint.cpp
+++ b/Source/WebCore/html/canvas/OESElementIndexUint.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OESElementIndexUint);
 OESElementIndexUint::OESElementIndexUint(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESElementIndexUint)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_element_index_uint"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_element_index_uint"_s);
 }
 
 OESElementIndexUint::~OESElementIndexUint() = default;

--- a/Source/WebCore/html/canvas/OESFBORenderMipmap.cpp
+++ b/Source/WebCore/html/canvas/OESFBORenderMipmap.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OESFBORenderMipmap);
 OESFBORenderMipmap::OESFBORenderMipmap(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESFBORenderMipmap)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_fbo_render_mipmap"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_fbo_render_mipmap"_s);
 }
 
 OESFBORenderMipmap::~OESFBORenderMipmap() = default;

--- a/Source/WebCore/html/canvas/OESSampleVariables.cpp
+++ b/Source/WebCore/html/canvas/OESSampleVariables.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OESSampleVariables);
 OESSampleVariables::OESSampleVariables(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESSampleVariables)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_sample_variables"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_sample_variables"_s);
 }
 
 OESSampleVariables::~OESSampleVariables() = default;

--- a/Source/WebCore/html/canvas/OESShaderMultisampleInterpolation.cpp
+++ b/Source/WebCore/html/canvas/OESShaderMultisampleInterpolation.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OESShaderMultisampleInterpolation);
 OESShaderMultisampleInterpolation::OESShaderMultisampleInterpolation(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESShaderMultisampleInterpolation)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_shader_multisample_interpolation"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_shader_multisample_interpolation"_s);
 }
 
 OESShaderMultisampleInterpolation::~OESShaderMultisampleInterpolation() = default;

--- a/Source/WebCore/html/canvas/OESStandardDerivatives.cpp
+++ b/Source/WebCore/html/canvas/OESStandardDerivatives.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OESStandardDerivatives);
 OESStandardDerivatives::OESStandardDerivatives(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESStandardDerivatives)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_standard_derivatives"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_standard_derivatives"_s);
 }
 
 OESStandardDerivatives::~OESStandardDerivatives() = default;

--- a/Source/WebCore/html/canvas/OESTextureFloat.cpp
+++ b/Source/WebCore/html/canvas/OESTextureFloat.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OESTextureFloat);
 OESTextureFloat::OESTextureFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESTextureFloat)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_float"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_float"_s);
 
     // Spec requires WEBGL_color_buffer_float to be turned on implicitly here.
     // Enable it both in the backend and in WebKit.

--- a/Source/WebCore/html/canvas/OESTextureFloatLinear.cpp
+++ b/Source/WebCore/html/canvas/OESTextureFloatLinear.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OESTextureFloatLinear);
 OESTextureFloatLinear::OESTextureFloatLinear(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESTextureFloatLinear)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_float_linear"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_float_linear"_s);
 }
 
 OESTextureFloatLinear::~OESTextureFloatLinear() = default;

--- a/Source/WebCore/html/canvas/OESTextureHalfFloat.cpp
+++ b/Source/WebCore/html/canvas/OESTextureHalfFloat.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OESTextureHalfFloat);
 OESTextureHalfFloat::OESTextureHalfFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESTextureHalfFloat)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_half_float"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_half_float"_s);
 
     // Spec requires EXT_color_buffer_half_float to be turned on implicitly here.
     // Enable it both in the backend and in WebKit.

--- a/Source/WebCore/html/canvas/OESTextureHalfFloatLinear.cpp
+++ b/Source/WebCore/html/canvas/OESTextureHalfFloatLinear.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OESTextureHalfFloatLinear);
 OESTextureHalfFloatLinear::OESTextureHalfFloatLinear(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESTextureHalfFloatLinear)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_half_float_linear"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_half_float_linear"_s);
 }
 
 OESTextureHalfFloatLinear::~OESTextureHalfFloatLinear() = default;

--- a/Source/WebCore/html/canvas/OESVertexArrayObject.cpp
+++ b/Source/WebCore/html/canvas/OESVertexArrayObject.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OESVertexArrayObject);
 OESVertexArrayObject::OESVertexArrayObject(WebGLRenderingContext& context)
     : WebGLExtension(context, WebGLExtensionName::OESVertexArrayObject)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_vertex_array_object"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_vertex_array_object"_s);
 }
 
 OESVertexArrayObject::~OESVertexArrayObject() = default;
@@ -53,7 +53,7 @@ RefPtr<WebGLVertexArrayObjectOES> OESVertexArrayObject::createVertexArrayOES()
 {
     if (isContextLost())
         return nullptr;
-    return WebGLVertexArrayObjectOES::createUser(protectedContext().get());
+    return WebGLVertexArrayObjectOES::createUser(context().get());
 }
 
 void OESVertexArrayObject::deleteVertexArrayOES(WebGLVertexArrayObjectOES* arrayObject)
@@ -78,7 +78,7 @@ void OESVertexArrayObject::deleteVertexArrayOES(WebGLVertexArrayObjectOES* array
     if (!arrayObject->isDefaultObject() && arrayObject == context->m_boundVertexArrayObject)
         context->setBoundVertexArrayObject(locker, nullptr);
 
-    arrayObject->deleteObject(locker, context->protectedGraphicsContextGL().get());
+    arrayObject->deleteObject(locker, context->graphicsContextGL().get());
 }
 
 GCGLboolean OESVertexArrayObject::isVertexArrayOES(WebGLVertexArrayObjectOES* arrayObject)
@@ -88,7 +88,7 @@ GCGLboolean OESVertexArrayObject::isVertexArrayOES(WebGLVertexArrayObjectOES* ar
     Ref context = this->context();
     if (!context->validateIsWebGLObject(arrayObject))
         return false;
-    return context->protectedGraphicsContextGL()->isVertexArray(arrayObject->object());
+    return context->graphicsContextGL()->isVertexArray(arrayObject->object());
 }
 
 void OESVertexArrayObject::bindVertexArrayOES(WebGLVertexArrayObjectOES* arrayObject)

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -169,7 +169,7 @@ void WebGL2RenderingContext::initializeContextState()
 
 long long WebGL2RenderingContext::getInt64Parameter(GCGLenum pname)
 {
-    return protectedGraphicsContextGL()->getInteger64(pname);
+    return graphicsContextGL()->getInteger64(pname);
 }
 
 void WebGL2RenderingContext::initializeDefaultObjects()
@@ -180,7 +180,7 @@ void WebGL2RenderingContext::initializeDefaultObjects()
     if (!m_defaultVertexArrayObject)
         return;
     // The default VAO was removed in OpenGL 3.3 but not from WebGL 2; bind the default for WebGL to use.
-    protectedGraphicsContextGL()->bindVertexArray(m_defaultVertexArrayObject->object());
+    graphicsContextGL()->bindVertexArray(m_defaultVertexArrayObject->object());
 }
 
 bool WebGL2RenderingContext::validateBufferTarget(ASCIILiteral functionName, GCGLenum target)
@@ -536,7 +536,7 @@ void WebGL2RenderingContext::pixelStorei(GCGLenum pname, GCGLint param)
         WebGLRenderingContextBase::pixelStorei(pname, param);
         return;
     }
-    protectedGraphicsContextGL()->pixelStorei(pname, param);
+    graphicsContextGL()->pixelStorei(pname, param);
 }
 
 void WebGL2RenderingContext::bufferData(GCGLenum target, const ArrayBufferView& data, GCGLenum usage, GCGLuint srcOffset, GCGLuint length)
@@ -583,7 +583,7 @@ void WebGL2RenderingContext::copyBufferSubData(GCGLenum readTarget, GCGLenum wri
         return;
     }
 
-    protectedGraphicsContextGL()->copyBufferSubData(readTarget, writeTarget, checkedReadOffset, checkedWriteOffset, checkedSize);
+    graphicsContextGL()->copyBufferSubData(readTarget, writeTarget, checkedReadOffset, checkedWriteOffset, checkedSize);
 }
 
 void WebGL2RenderingContext::getBufferSubData(GCGLenum target, long long srcByteOffset, RefPtr<ArrayBufferView>&& dstData, GCGLuint dstOffset, GCGLuint length)
@@ -638,7 +638,7 @@ void WebGL2RenderingContext::getBufferSubData(GCGLenum target, long long srcByte
         return;
 
     // FIXME: Coalesce multiple getBufferSubData() calls to use a single map() call
-    protectedGraphicsContextGL()->getBufferSubData(target, srcByteOffset, dstData->mutableSpan().subspan(dstOffset * elementSize, copyLength * elementSize));
+    graphicsContextGL()->getBufferSubData(target, srcByteOffset, dstData->mutableSpan().subspan(dstOffset * elementSize, copyLength * elementSize));
 }
 
 void WebGL2RenderingContext::bindFramebuffer(GCGLenum target, WebGLFramebuffer* buffer)
@@ -668,7 +668,7 @@ void WebGL2RenderingContext::blitFramebuffer(GCGLint srcX0, GCGLint srcY0, GCGLi
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->blitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+    graphicsContextGL()->blitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
     markContextChangedAndNotifyCanvasObserver(CallerTypeOther);
 }
 
@@ -765,7 +765,7 @@ void WebGL2RenderingContext::invalidateFramebuffer(GCGLenum target, const Vector
     Vector<GCGLenum> translatedAttachments = attachments;
     if (!checkAndTranslateAttachments("invalidateFramebuffer"_s, target, translatedAttachments))
         return;
-    protectedGraphicsContextGL()->invalidateFramebuffer(target, translatedAttachments);
+    graphicsContextGL()->invalidateFramebuffer(target, translatedAttachments);
 }
 
 void WebGL2RenderingContext::invalidateSubFramebuffer(GCGLenum target, const Vector<GCGLenum>& attachments, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height)
@@ -776,7 +776,7 @@ void WebGL2RenderingContext::invalidateSubFramebuffer(GCGLenum target, const Vec
     Vector<GCGLenum> translatedAttachments = attachments;
     if (!checkAndTranslateAttachments("invalidateSubFramebuffer"_s, target, translatedAttachments))
         return;
-    protectedGraphicsContextGL()->invalidateSubFramebuffer(target, translatedAttachments, x, y, width, height);
+    graphicsContextGL()->invalidateSubFramebuffer(target, translatedAttachments, x, y, width, height);
 }
 
 void WebGL2RenderingContext::readBuffer(GCGLenum src)
@@ -796,7 +796,7 @@ void WebGL2RenderingContext::readBuffer(GCGLenum src)
         return;
     }
 
-    protectedGraphicsContextGL()->readBuffer(src);
+    graphicsContextGL()->readBuffer(src);
 }
 
 void WebGL2RenderingContext::renderbufferStorageMultisample(GCGLenum target, GCGLsizei samples, GCGLenum internalformat, GCGLsizei width, GCGLsizei height)
@@ -828,15 +828,15 @@ WebGLAny WebGL2RenderingContext::getTexParameter(GCGLenum target, GCGLenum pname
     case GraphicsContextGL::TEXTURE_COMPARE_MODE:
     case GraphicsContextGL::TEXTURE_IMMUTABLE_LEVELS:
     case GraphicsContextGL::TEXTURE_WRAP_R:
-        return protectedGraphicsContextGL()->getTexParameteri(target, pname);
+        return graphicsContextGL()->getTexParameteri(target, pname);
     case GraphicsContextGL::TEXTURE_IMMUTABLE_FORMAT:
-        return static_cast<bool>(protectedGraphicsContextGL()->getTexParameteri(target, pname));
+        return static_cast<bool>(graphicsContextGL()->getTexParameteri(target, pname));
     case GraphicsContextGL::TEXTURE_MIN_LOD:
     case GraphicsContextGL::TEXTURE_MAX_LOD:
-        return protectedGraphicsContextGL()->getTexParameterf(target, pname);
+        return graphicsContextGL()->getTexParameterf(target, pname);
     case GraphicsContextGL::DEPTH_STENCIL_TEXTURE_MODE_ANGLE:
         if (m_webglStencilTexturing)
-            return protectedGraphicsContextGL()->getTexParameteri(target, pname);
+            return graphicsContextGL()->getTexParameteri(target, pname);
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getTexParameter"_s, "invalid parameter name, WEBGL_stencil_texturing not enabled"_s);
         return nullptr;
     default:
@@ -856,7 +856,7 @@ void WebGL2RenderingContext::texStorage2D(GCGLenum target, GCGLsizei levels, GCG
     if (!validateForbiddenInternalFormats("texStorage2D"_s, internalFormat))
         return;
 
-    protectedGraphicsContextGL()->texStorage2D(target, levels, internalFormat, width, height);
+    graphicsContextGL()->texStorage2D(target, levels, internalFormat, width, height);
 }
 
 void WebGL2RenderingContext::texStorage3D(GCGLenum target, GCGLsizei levels, GCGLenum internalFormat, GCGLsizei width, GCGLsizei height, GCGLsizei depth)
@@ -871,7 +871,7 @@ void WebGL2RenderingContext::texStorage3D(GCGLenum target, GCGLsizei levels, GCG
     if (!validateForbiddenInternalFormats("texStorage3D"_s, internalFormat))
         return;
 
-    protectedGraphicsContextGL()->texStorage3D(target, levels, internalFormat, width, height, depth);
+    graphicsContextGL()->texStorage3D(target, levels, internalFormat, width, height, depth);
 }
 
 void WebGL2RenderingContext::texImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& data)
@@ -913,7 +913,7 @@ void WebGL2RenderingContext::texImage2D(GCGLenum target, GCGLint level, GCGLint 
     if (!validateTexFunc(TexImageFunctionID::TexImage2D, SourceUnpackBuffer, target, level, internalformat, width, height, 1, border, format, type, 0, 0, 0))
         return;
 
-    protectedGraphicsContextGL()->texImage2D(target, level, internalformat, width, height, border, format, type, offset);
+    graphicsContextGL()->texImage2D(target, level, internalformat, width, height, border, format, type, offset);
 }
 
 ExceptionOr<void> WebGL2RenderingContext::texImage2D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, TexImageSource&& source)
@@ -957,7 +957,7 @@ void WebGL2RenderingContext::texImage3D(GCGLenum target, GCGLint level, GCGLint 
     if (!validateTexFunc(TexImageFunctionID::TexImage3D, SourceUnpackBuffer, target, level, internalformat, width, height, depth, border, format, type, 0, 0, 0))
         return;
 
-    protectedGraphicsContextGL()->texImage3D(target, level, internalformat, width, height, depth, border, format, type,  offset);
+    graphicsContextGL()->texImage3D(target, level, internalformat, width, height, depth, border, format, type,  offset);
 }
 
 ExceptionOr<void> WebGL2RenderingContext::texImage3D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, TexImageSource&& source)
@@ -1043,7 +1043,7 @@ void WebGL2RenderingContext::texSubImage2D(GCGLenum target, GCGLint level, GCGLi
     if (!validateTexFunc(TexImageFunctionID::TexSubImage2D, SourceUnpackBuffer, target, level, 0, width, height, 1, 0, format, type, xoffset, yoffset, 0))
         return;
 
-    protectedGraphicsContextGL()->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, offset);
+    graphicsContextGL()->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, offset);
 }
 
 ExceptionOr<void> WebGL2RenderingContext::texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, TexImageSource&& source)
@@ -1087,7 +1087,7 @@ void WebGL2RenderingContext::texSubImage3D(GCGLenum target, GCGLint level, GCGLi
     if (!validateTexFunc(TexImageFunctionID::TexSubImage3D, SourceUnpackBuffer, target, level, 0, width, height, depth, 0, format, type, xoffset, yoffset, zoffset))
         return;
 
-    protectedGraphicsContextGL()->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, offset);
+    graphicsContextGL()->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, offset);
 }
 
 void WebGL2RenderingContext::texSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& srcData, GCGLuint srcOffset)
@@ -1125,7 +1125,7 @@ void WebGL2RenderingContext::copyTexSubImage3D(GCGLenum target, GCGLint level, G
     if (!validateTexture3DBinding("copyTexSubImage3D"_s, target))
         return;
     clearIfComposited(CallerTypeOther);
-    protectedGraphicsContextGL()->copyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height);
+    graphicsContextGL()->copyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height);
 }
 
 void WebGL2RenderingContext::compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, ArrayBufferView& srcData)
@@ -1153,7 +1153,7 @@ void WebGL2RenderingContext::compressedTexImage2D(GCGLenum target, GCGLint level
     }
     if (!validateTexture2DBinding("compressedTexImage2D"_s, target))
         return;
-    protectedGraphicsContextGL()->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, offset);
+    graphicsContextGL()->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, offset);
 }
 
 void WebGL2RenderingContext::compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, ArrayBufferView& srcData, GCGLuint srcOffset, GCGLuint srcLengthOverride)
@@ -1171,7 +1171,7 @@ void WebGL2RenderingContext::compressedTexImage2D(GCGLenum target, GCGLint level
     auto slice = sliceArrayBufferView("compressedTexImage2D"_s, srcData, srcOffset, srcLengthOverride);
     if (!slice)
         return;
-    protectedGraphicsContextGL()->compressedTexImage2D(target, level, internalformat, width, height, border, slice->byteLength(), slice->span());
+    graphicsContextGL()->compressedTexImage2D(target, level, internalformat, width, height, border, slice->byteLength(), slice->span());
 }
 
 void WebGL2RenderingContext::compressedTexImage3D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLsizei imageSize, GCGLint64 offset)
@@ -1186,7 +1186,7 @@ void WebGL2RenderingContext::compressedTexImage3D(GCGLenum target, GCGLint level
     }
     if (!validateTexture3DBinding("compressedTexImage3D"_s, target))
         return;
-    protectedGraphicsContextGL()->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, offset);
+    graphicsContextGL()->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, offset);
 }
 
 void WebGL2RenderingContext::compressedTexImage3D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, ArrayBufferView& srcData, GCGLuint srcOffset, GCGLuint srcLengthOverride)
@@ -1204,7 +1204,7 @@ void WebGL2RenderingContext::compressedTexImage3D(GCGLenum target, GCGLint level
     auto slice = sliceArrayBufferView("compressedTexImage3D"_s, srcData, srcOffset, srcLengthOverride);
     if (!slice)
         return;
-    protectedGraphicsContextGL()->compressedTexImage3D(target, level, internalformat, width, height, depth, border, slice->byteLength(), slice->span());
+    graphicsContextGL()->compressedTexImage3D(target, level, internalformat, width, height, depth, border, slice->byteLength(), slice->span());
 }
 
 void WebGL2RenderingContext::compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, ArrayBufferView& srcData)
@@ -1232,7 +1232,7 @@ void WebGL2RenderingContext::compressedTexSubImage2D(GCGLenum target, GCGLint le
     }
     if (!validateTexture2DBinding("compressedTexImage2D"_s, target))
         return;
-    protectedGraphicsContextGL()->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, offset);
+    graphicsContextGL()->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, offset);
 }
 
 void WebGL2RenderingContext::compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, ArrayBufferView& srcData, GCGLuint srcOffset, GCGLuint srcLengthOverride)
@@ -1250,7 +1250,7 @@ void WebGL2RenderingContext::compressedTexSubImage2D(GCGLenum target, GCGLint le
     auto slice = sliceArrayBufferView("compressedTexSubImage2D"_s, srcData, srcOffset, srcLengthOverride);
     if (!slice)
         return;
-    protectedGraphicsContextGL()->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, slice->byteLength(), slice->span());
+    graphicsContextGL()->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, slice->byteLength(), slice->span());
 }
 
 void WebGL2RenderingContext::compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLsizei imageSize, GCGLint64 offset)
@@ -1265,7 +1265,7 @@ void WebGL2RenderingContext::compressedTexSubImage3D(GCGLenum target, GCGLint le
     }
     if (!validateTexture3DBinding("compressedTexSubImage3D"_s, target))
         return;
-    protectedGraphicsContextGL()->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, offset);
+    graphicsContextGL()->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, offset);
 }
 
 void WebGL2RenderingContext::compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, ArrayBufferView& srcData, GCGLuint srcOffset, GCGLuint srcLengthOverride)
@@ -1283,7 +1283,7 @@ void WebGL2RenderingContext::compressedTexSubImage3D(GCGLenum target, GCGLint le
     auto slice = sliceArrayBufferView("compressedTexSubImage3D"_s, srcData, srcOffset, srcLengthOverride);
     if (!slice)
         return;
-    protectedGraphicsContextGL()->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, slice->byteLength(), slice->span());
+    graphicsContextGL()->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, slice->byteLength(), slice->span());
 }
 
 GCGLint WebGL2RenderingContext::getFragDataLocation(WebGLProgram& program, const String& name)
@@ -1292,35 +1292,35 @@ GCGLint WebGL2RenderingContext::getFragDataLocation(WebGLProgram& program, const
         return -1;
     if (!validateWebGLObject("getFragDataLocation"_s, program))
         return -1;
-    return protectedGraphicsContextGL()->getFragDataLocation(program.object(), name.utf8());
+    return graphicsContextGL()->getFragDataLocation(program.object(), name.utf8());
 }
 
 void WebGL2RenderingContext::uniform1ui(const WebGLUniformLocation* location, GCGLuint v0)
 {
     if (isContextLost() || !validateUniformLocation("uniform1ui"_s, location))
         return;
-    protectedGraphicsContextGL()->uniform1ui(location->location(), v0);
+    graphicsContextGL()->uniform1ui(location->location(), v0);
 }
 
 void WebGL2RenderingContext::uniform2ui(const WebGLUniformLocation* location, GCGLuint v0, GCGLuint v1)
 {
     if (isContextLost() || !validateUniformLocation("uniform2ui"_s, location))
         return;
-    protectedGraphicsContextGL()->uniform2ui(location->location(), v0, v1);
+    graphicsContextGL()->uniform2ui(location->location(), v0, v1);
 }
 
 void WebGL2RenderingContext::uniform3ui(const WebGLUniformLocation* location, GCGLuint v0, GCGLuint v1, GCGLuint v2)
 {
     if (isContextLost() || !validateUniformLocation("uniform3ui"_s, location))
         return;
-    protectedGraphicsContextGL()->uniform3ui(location->location(), v0, v1, v2);
+    graphicsContextGL()->uniform3ui(location->location(), v0, v1, v2);
 }
 
 void WebGL2RenderingContext::uniform4ui(const WebGLUniformLocation* location, GCGLuint v0, GCGLuint v1, GCGLuint v2, GCGLuint v3)
 {
     if (isContextLost() || !validateUniformLocation("uniform4ui"_s, location))
         return;
-    protectedGraphicsContextGL()->uniform4ui(location->location(), v0, v1, v2, v3);
+    graphicsContextGL()->uniform4ui(location->location(), v0, v1, v2, v3);
 }
 
 void WebGL2RenderingContext::uniform1uiv(const WebGLUniformLocation* location, Uint32List&& value, GCGLuint srcOffset, GCGLuint srcLength)
@@ -1330,7 +1330,7 @@ void WebGL2RenderingContext::uniform1uiv(const WebGLUniformLocation* location, U
     auto data = validateUniformParameters("uniform1uiv"_s, location, value, 1, srcOffset, srcLength);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniform1uiv(location->location(), data.value());
+    graphicsContextGL()->uniform1uiv(location->location(), data.value());
 }
 
 void WebGL2RenderingContext::uniform2uiv(const WebGLUniformLocation* location, Uint32List&& value, GCGLuint srcOffset, GCGLuint srcLength)
@@ -1340,7 +1340,7 @@ void WebGL2RenderingContext::uniform2uiv(const WebGLUniformLocation* location, U
     auto data = validateUniformParameters("uniform2uiv"_s, location, value, 2, srcOffset, srcLength);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniform2uiv(location->location(), data.value());
+    graphicsContextGL()->uniform2uiv(location->location(), data.value());
 }
 
 void WebGL2RenderingContext::uniform3uiv(const WebGLUniformLocation* location, Uint32List&& value, GCGLuint srcOffset, GCGLuint srcLength)
@@ -1350,7 +1350,7 @@ void WebGL2RenderingContext::uniform3uiv(const WebGLUniformLocation* location, U
     auto data = validateUniformParameters("uniform3uiv"_s, location, value, 3, srcOffset, srcLength);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniform3uiv(location->location(), data.value());
+    graphicsContextGL()->uniform3uiv(location->location(), data.value());
 }
 
 void WebGL2RenderingContext::uniform4uiv(const WebGLUniformLocation* location, Uint32List&& value, GCGLuint srcOffset, GCGLuint srcLength)
@@ -1360,7 +1360,7 @@ void WebGL2RenderingContext::uniform4uiv(const WebGLUniformLocation* location, U
     auto data = validateUniformParameters("uniform4uiv"_s, location, value, 4, srcOffset, srcLength);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniform4uiv(location->location(), data.value());
+    graphicsContextGL()->uniform4uiv(location->location(), data.value());
 }
 
 void WebGL2RenderingContext::uniformMatrix2x3fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, GCGLuint srcOffset, GCGLuint srcLength)
@@ -1370,7 +1370,7 @@ void WebGL2RenderingContext::uniformMatrix2x3fv(const WebGLUniformLocation* loca
     auto data = validateUniformMatrixParameters("uniformMatrix2x3fv"_s, location, transpose, v, 6, srcOffset, srcLength);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniformMatrix2x3fv(location->location(), transpose, data.value());
+    graphicsContextGL()->uniformMatrix2x3fv(location->location(), transpose, data.value());
 }
 
 void WebGL2RenderingContext::uniformMatrix3x2fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, GCGLuint srcOffset, GCGLuint srcLength)
@@ -1380,7 +1380,7 @@ void WebGL2RenderingContext::uniformMatrix3x2fv(const WebGLUniformLocation* loca
     auto data = validateUniformMatrixParameters("uniformMatrix3x2fv"_s, location, transpose, v, 6, srcOffset, srcLength);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniformMatrix3x2fv(location->location(), transpose, data.value());
+    graphicsContextGL()->uniformMatrix3x2fv(location->location(), transpose, data.value());
 }
 
 void WebGL2RenderingContext::uniformMatrix2x4fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, GCGLuint srcOffset, GCGLuint srcLength)
@@ -1390,7 +1390,7 @@ void WebGL2RenderingContext::uniformMatrix2x4fv(const WebGLUniformLocation* loca
     auto data = validateUniformMatrixParameters("uniformMatrix2x4fv"_s, location, transpose, v, 8, srcOffset, srcLength);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniformMatrix2x4fv(location->location(), transpose, data.value());
+    graphicsContextGL()->uniformMatrix2x4fv(location->location(), transpose, data.value());
 }
 
 void WebGL2RenderingContext::uniformMatrix4x2fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, GCGLuint srcOffset, GCGLuint srcLength)
@@ -1400,7 +1400,7 @@ void WebGL2RenderingContext::uniformMatrix4x2fv(const WebGLUniformLocation* loca
     auto data = validateUniformMatrixParameters("uniformMatrix4x2fv"_s, location, transpose, v, 8, srcOffset, srcLength);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniformMatrix4x2fv(location->location(), transpose, data.value());
+    graphicsContextGL()->uniformMatrix4x2fv(location->location(), transpose, data.value());
 }
 
 void WebGL2RenderingContext::uniformMatrix3x4fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, GCGLuint srcOffset, GCGLuint srcLength)
@@ -1410,7 +1410,7 @@ void WebGL2RenderingContext::uniformMatrix3x4fv(const WebGLUniformLocation* loca
     auto data = validateUniformMatrixParameters("uniformMatrix3x4fv"_s, location, transpose, v, 12, srcOffset, srcLength);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniformMatrix3x4fv(location->location(), transpose, data.value());
+    graphicsContextGL()->uniformMatrix3x4fv(location->location(), transpose, data.value());
 }
 
 void WebGL2RenderingContext::uniformMatrix4x3fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v, GCGLuint srcOffset, GCGLuint srcLength)
@@ -1420,14 +1420,14 @@ void WebGL2RenderingContext::uniformMatrix4x3fv(const WebGLUniformLocation* loca
     auto data = validateUniformMatrixParameters("uniformMatrix4x3fv"_s, location, transpose, v, 12, srcOffset, srcLength);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniformMatrix4x3fv(location->location(), transpose, data.value());
+    graphicsContextGL()->uniformMatrix4x3fv(location->location(), transpose, data.value());
 }
 
 void WebGL2RenderingContext::vertexAttribI4i(GCGLuint index, GCGLint x, GCGLint y, GCGLint z, GCGLint w)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->vertexAttribI4i(index, x, y, z, w);
+    graphicsContextGL()->vertexAttribI4i(index, x, y, z, w);
     if (index < m_vertexAttribValue.size()) {
         m_vertexAttribValue[index].type = GraphicsContextGL::INT;
         m_vertexAttribValue[index].iValue[0] = x;
@@ -1456,7 +1456,7 @@ void WebGL2RenderingContext::vertexAttribI4iv(GCGLuint index, Int32List&& list)
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "vertexAttribI4iv"_s, "index out of range"_s);
         return;
     }
-    protectedGraphicsContextGL()->vertexAttribI4iv(index, data.first<4>());
+    graphicsContextGL()->vertexAttribI4iv(index, data.first<4>());
     m_vertexAttribValue[index].type = GraphicsContextGL::INT;
     memcpySpan(std::span { m_vertexAttribValue[index].iValue }, data.first(4));
 }
@@ -1465,7 +1465,7 @@ void WebGL2RenderingContext::vertexAttribI4ui(GCGLuint index, GCGLuint x, GCGLui
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->vertexAttribI4ui(index, x, y, z, w);
+    graphicsContextGL()->vertexAttribI4ui(index, x, y, z, w);
     if (index < m_vertexAttribValue.size()) {
         m_vertexAttribValue[index].type = GraphicsContextGL::UNSIGNED_INT;
         m_vertexAttribValue[index].uiValue[0] = x;
@@ -1494,7 +1494,7 @@ void WebGL2RenderingContext::vertexAttribI4uiv(GCGLuint index, Uint32List&& list
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "vertexAttribI4uiv"_s, "index out of range"_s);
         return;
     }
-    protectedGraphicsContextGL()->vertexAttribI4uiv(index, data.first<4>());
+    graphicsContextGL()->vertexAttribI4uiv(index, data.first<4>());
     m_vertexAttribValue[index].type = GraphicsContextGL::UNSIGNED_INT;
     memcpySpan(std::span { m_vertexAttribValue[index].uiValue }, data.first(4));
 }
@@ -1552,7 +1552,7 @@ void WebGL2RenderingContext::vertexAttribIPointer(GCGLuint index, GCGLint size, 
     GCGLsizei bytesPerElement = size * typeSize;
 
     protectedBoundVertexArrayObject()->setVertexAttribState(locker, index, bytesPerElement, size, type, false, stride, static_cast<GCGLintptr>(offset), true, RefPtr { m_boundArrayBuffer.get() }.get());
-    protectedGraphicsContextGL()->vertexAttribIPointer(index, size, type, stride, offset);
+    graphicsContextGL()->vertexAttribIPointer(index, size, type, stride, offset);
 }
 
 void WebGL2RenderingContext::vertexAttribDivisor(GCGLuint index, GCGLuint divisor)
@@ -1594,7 +1594,7 @@ void WebGL2RenderingContext::drawRangeElements(GCGLenum mode, GCGLuint start, GC
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
 
-        protectedGraphicsContextGL()->drawRangeElements(mode, start, end, count, type, offset);
+        graphicsContextGL()->drawRangeElements(mode, start, end, count, type, offset);
     }
 
     markContextChangedAndNotifyCanvasObserver();
@@ -1632,7 +1632,7 @@ void WebGL2RenderingContext::drawBuffers(const Vector<GCGLenum>& buffers)
         }
         // Because the backbuffer is simulated on all current WebKit ports, we need to change BACK to COLOR_ATTACHMENT0.
         GCGLenum value[1] { (bufs[0] == GraphicsContextGL::BACK) ? GraphicsContextGL::COLOR_ATTACHMENT0 : GraphicsContextGL::NONE };
-        protectedGraphicsContextGL()->drawBuffers(value);
+        graphicsContextGL()->drawBuffers(value);
         setBackDrawBuffer(bufs[0]);
     } else {
         if (n > maxDrawBuffers()) {
@@ -1661,7 +1661,7 @@ void WebGL2RenderingContext::clearBufferiv(GCGLenum buffer, GCGLint drawbuffer, 
     // user-requested clearBuffer call because of scissor test side effects.
     clearIfComposited(CallerTypeDrawOrClear);
 
-    protectedGraphicsContextGL()->clearBufferiv(buffer, drawbuffer, data.value());
+    graphicsContextGL()->clearBufferiv(buffer, drawbuffer, data.value());
 }
 
 void WebGL2RenderingContext::clearBufferuiv(GCGLenum buffer, GCGLint drawbuffer, Uint32List&& values, GCGLuint srcOffset)
@@ -1675,7 +1675,7 @@ void WebGL2RenderingContext::clearBufferuiv(GCGLenum buffer, GCGLint drawbuffer,
     // This call is not applicable to the default framebuffer attachments
     // as they cannot have UINT type. Ignore any pending implicit clears.
 
-    protectedGraphicsContextGL()->clearBufferuiv(buffer, drawbuffer, data.value());
+    graphicsContextGL()->clearBufferuiv(buffer, drawbuffer, data.value());
 }
 
 void WebGL2RenderingContext::clearBufferfv(GCGLenum buffer, GCGLint drawbuffer, Float32List&& values, GCGLuint srcOffset)
@@ -1690,7 +1690,7 @@ void WebGL2RenderingContext::clearBufferfv(GCGLenum buffer, GCGLint drawbuffer, 
     // user-requested clearBuffer call because of scissor test side effects.
     clearIfComposited(CallerTypeDrawOrClear);
 
-    protectedGraphicsContextGL()->clearBufferfv(buffer, drawbuffer, data.value());
+    graphicsContextGL()->clearBufferfv(buffer, drawbuffer, data.value());
 
     // This might have been used to clear the color buffer of the default
     // back buffer. Notification is required to update the canvas.
@@ -1706,7 +1706,7 @@ void WebGL2RenderingContext::clearBufferfi(GCGLenum buffer, GCGLint drawbuffer, 
     // user-requested clearBuffer call because of scissor test side effects.
     clearIfComposited(CallerTypeDrawOrClear);
 
-    protectedGraphicsContextGL()->clearBufferfi(buffer, drawbuffer, depth, stencil);
+    graphicsContextGL()->clearBufferfi(buffer, drawbuffer, depth, stencil);
 }
 
 RefPtr<WebGLQuery> WebGL2RenderingContext::createQuery()
@@ -1726,7 +1726,7 @@ void WebGL2RenderingContext::deleteQuery(WebGLQuery* query)
     if (query->target()) {
         for (auto& activeQuery : m_activeQueries) {
             if (query == activeQuery) {
-                protectedGraphicsContextGL()->endQuery(query->target());
+                graphicsContextGL()->endQuery(query->target());
                 activeQuery = nullptr;
                 break;
             }
@@ -1741,7 +1741,7 @@ GCGLboolean WebGL2RenderingContext::isQuery(WebGLQuery* query)
         return false;
     if (!validateIsWebGLObject(query))
         return false;
-    return protectedGraphicsContextGL()->isQuery(query->object());
+    return graphicsContextGL()->isQuery(query->object());
 }
 
 std::optional<WebGL2RenderingContext::ActiveQueryKey> WebGL2RenderingContext::validateQueryTarget(ASCIILiteral functionName, GCGLenum target)
@@ -1783,7 +1783,7 @@ void WebGL2RenderingContext::beginQuery(GCGLenum target, WebGLQuery& query)
         return;
     }
     m_activeQueries[*activeQueryKey] = query;
-    protectedGraphicsContextGL()->beginQuery(target, query.object());
+    graphicsContextGL()->beginQuery(target, query.object());
     query.setTarget(target);
 }
 
@@ -1799,7 +1799,7 @@ void WebGL2RenderingContext::endQuery(GCGLenum target)
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "endQuery"_s, "query object of target is not active"_s);
         return;
     }
-    protectedGraphicsContextGL()->endQuery(target);
+    graphicsContextGL()->endQuery(target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
     protectedScriptExecutionContext()->checkedEventLoop()->queueMicrotask([query = WTFMove(m_activeQueries[*activeQueryKey])] {
@@ -1864,12 +1864,12 @@ WebGLAny WebGL2RenderingContext::getQueryParameter(WebGLQuery& query, GCGLenum p
         if (!query.isResultAvailable())
             return 0;
         if (query.target() == GraphicsContextGL::TIME_ELAPSED_EXT || query.target() == GraphicsContextGL::TIMESTAMP_EXT)
-            return static_cast<unsigned long long>(protectedGraphicsContextGL()->getQueryObjectui64EXT(query.object(), pname));
-        return protectedGraphicsContextGL()->getQueryObjectui(query.object(), pname);
+            return static_cast<unsigned long long>(graphicsContextGL()->getQueryObjectui64EXT(query.object(), pname));
+        return graphicsContextGL()->getQueryObjectui(query.object(), pname);
     case GraphicsContextGL::QUERY_RESULT_AVAILABLE:
         if (!query.isResultAvailable())
             return false;
-        return static_cast<bool>(protectedGraphicsContextGL()->getQueryObjectui(query.object(), pname));
+        return static_cast<bool>(graphicsContextGL()->getQueryObjectui(query.object(), pname));
     }
     synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getQueryParameter"_s, "invalid parameter name"_s);
     return nullptr;
@@ -1904,7 +1904,7 @@ GCGLboolean WebGL2RenderingContext::isSampler(WebGLSampler* sampler)
         return false;
     if (!validateIsWebGLObject(sampler))
         return false;
-    return protectedGraphicsContextGL()->isSampler(sampler->object());
+    return graphicsContextGL()->isSampler(sampler->object());
 }
 
 void WebGL2RenderingContext::bindSampler(GCGLuint unit, WebGLSampler* sampler)
@@ -1922,7 +1922,7 @@ void WebGL2RenderingContext::bindSampler(GCGLuint unit, WebGLSampler* sampler)
 
     if (m_boundSamplers[unit] == sampler)
         return;
-    protectedGraphicsContextGL()->bindSampler(unit, objectOrZero(sampler));
+    graphicsContextGL()->bindSampler(unit, objectOrZero(sampler));
     m_boundSamplers[unit] = sampler;
 }
 
@@ -1933,7 +1933,7 @@ void WebGL2RenderingContext::samplerParameteri(WebGLSampler& sampler, GCGLenum p
     if (!validateWebGLObject("samplerParameteri"_s, sampler))
         return;
 
-    protectedGraphicsContextGL()->samplerParameteri(sampler.object(), pname, value);
+    graphicsContextGL()->samplerParameteri(sampler.object(), pname, value);
 }
 
 void WebGL2RenderingContext::samplerParameterf(WebGLSampler& sampler, GCGLenum pname, GCGLfloat value)
@@ -1943,7 +1943,7 @@ void WebGL2RenderingContext::samplerParameterf(WebGLSampler& sampler, GCGLenum p
     if (!validateWebGLObject("samplerParameterf"_s, sampler))
         return;
 
-    protectedGraphicsContextGL()->samplerParameterf(sampler.object(), pname, value);
+    graphicsContextGL()->samplerParameterf(sampler.object(), pname, value);
 }
 
 WebGLAny WebGL2RenderingContext::getSamplerParameter(WebGLSampler& sampler, GCGLenum pname)
@@ -1961,17 +1961,17 @@ WebGLAny WebGL2RenderingContext::getSamplerParameter(WebGLSampler& sampler, GCGL
     case GraphicsContextGL::TEXTURE_WRAP_R:
     case GraphicsContextGL::TEXTURE_WRAP_S:
     case GraphicsContextGL::TEXTURE_WRAP_T:
-        return protectedGraphicsContextGL()->getSamplerParameteri(sampler.object(), pname);
+        return graphicsContextGL()->getSamplerParameteri(sampler.object(), pname);
     case GraphicsContextGL::TEXTURE_MAX_LOD:
     case GraphicsContextGL::TEXTURE_MIN_LOD:
-        return protectedGraphicsContextGL()->getSamplerParameterf(sampler.object(), pname);
+        return graphicsContextGL()->getSamplerParameterf(sampler.object(), pname);
     // EXT_texture_filter_anisotropic
     case GraphicsContextGL::TEXTURE_MAX_ANISOTROPY_EXT:
         if (!m_extTextureFilterAnisotropic) {
             synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getSamplerParameter"_s, "invalid parameter name, EXT_texture_filter_anisotropic not enabled"_s);
             return nullptr;
         }
-        return protectedGraphicsContextGL()->getSamplerParameterf(sampler.object(), pname);
+        return graphicsContextGL()->getSamplerParameterf(sampler.object(), pname);
     default:
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getSamplerParameter"_s, "invalid parameter name"_s);
         return nullptr;
@@ -2121,7 +2121,7 @@ GCGLboolean WebGL2RenderingContext::isTransformFeedback(WebGLTransformFeedback* 
         return false;
     if (!validateIsWebGLObject(feedbackObject))
         return false;
-    return protectedGraphicsContextGL()->isTransformFeedback(feedbackObject->object());
+    return graphicsContextGL()->isTransformFeedback(feedbackObject->object());
 }
 
 void WebGL2RenderingContext::bindTransformFeedback(GCGLenum target, WebGLTransformFeedback* feedbackObject)
@@ -2142,7 +2142,7 @@ void WebGL2RenderingContext::bindTransformFeedback(GCGLenum target, WebGLTransfo
     }
 
     RefPtr toBeBound = feedbackObject ? feedbackObject : m_defaultTransformFeedback.get();
-    protectedGraphicsContextGL()->bindTransformFeedback(target, toBeBound->object());
+    graphicsContextGL()->bindTransformFeedback(target, toBeBound->object());
     m_boundTransformFeedback = toBeBound;
 }
 
@@ -2187,7 +2187,7 @@ void WebGL2RenderingContext::beginTransformFeedback(GCGLenum primitiveMode)
         return;
     }
 
-    protectedGraphicsContextGL()->beginTransformFeedback(primitiveMode);
+    graphicsContextGL()->beginTransformFeedback(primitiveMode);
 
     Locker locker { objectGraphLock() };
     boundTransformFeedback->setProgram(locker, *currentProgram);
@@ -2205,7 +2205,7 @@ void WebGL2RenderingContext::endTransformFeedback()
         return;
     }
     
-    protectedGraphicsContextGL()->endTransformFeedback();
+    graphicsContextGL()->endTransformFeedback();
 
     m_boundTransformFeedback->setPaused(false);
     m_boundTransformFeedback->setActive(false);
@@ -2236,7 +2236,7 @@ void WebGL2RenderingContext::transformFeedbackVaryings(WebGLProgram& program, co
     auto varyingsUTF8 = varyings.map([](const String& value) {
         return value.utf8();
     });
-    protectedGraphicsContextGL()->transformFeedbackVaryings(program.object(), varyingsUTF8, bufferMode);
+    graphicsContextGL()->transformFeedbackVaryings(program.object(), varyingsUTF8, bufferMode);
 }
 
 RefPtr<WebGLActiveInfo> WebGL2RenderingContext::getTransformFeedbackVarying(WebGLProgram& program, GCGLuint index)
@@ -2249,7 +2249,7 @@ RefPtr<WebGLActiveInfo> WebGL2RenderingContext::getTransformFeedbackVarying(WebG
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "getTransformFeedbackVarying"_s, "program not linked"_s);
         return nullptr;
     }
-    auto info = protectedGraphicsContextGL()->getTransformFeedbackVarying(program.object(), index);
+    auto info = graphicsContextGL()->getTransformFeedbackVarying(program.object(), index);
     if (!info)
         return nullptr;
     return WebGLActiveInfo::create(String::fromUTF8(info->name.span()), info->type, info->size);
@@ -2271,7 +2271,7 @@ void WebGL2RenderingContext::pauseTransformFeedback()
     }
 
     m_boundTransformFeedback->setPaused(true);
-    protectedGraphicsContextGL()->pauseTransformFeedback();
+    graphicsContextGL()->pauseTransformFeedback();
 }
 
 void WebGL2RenderingContext::resumeTransformFeedback()
@@ -2289,7 +2289,7 @@ void WebGL2RenderingContext::resumeTransformFeedback()
     }
 
     m_boundTransformFeedback->setPaused(false);
-    protectedGraphicsContextGL()->resumeTransformFeedback();
+    graphicsContextGL()->resumeTransformFeedback();
 }
 
 bool WebGL2RenderingContext::isTransformFeedbackActiveAndNotPaused()
@@ -2347,7 +2347,7 @@ bool WebGL2RenderingContext::setIndexedBufferBinding(ASCIILiteral functionName, 
 void WebGL2RenderingContext::bindBufferBase(GCGLenum target, GCGLuint index, WebGLBuffer* buffer)
 {
     if (setIndexedBufferBinding("bindBufferBase"_s, target, index, buffer))
-        protectedGraphicsContextGL()->bindBufferBase(target, index, objectOrZero(buffer));
+        graphicsContextGL()->bindBufferBase(target, index, objectOrZero(buffer));
 }
 
 void WebGL2RenderingContext::bindBufferRange(GCGLenum target, GCGLuint index, WebGLBuffer* buffer, GCGLint64 offset, GCGLint64 size)
@@ -2361,7 +2361,7 @@ void WebGL2RenderingContext::bindBufferRange(GCGLenum target, GCGLuint index, We
         return;
     }
     if (setIndexedBufferBinding("bindBufferRange"_s, target, index, buffer))
-        protectedGraphicsContextGL()->bindBufferRange(target, index, objectOrZero(buffer), offset, size);
+        graphicsContextGL()->bindBufferRange(target, index, objectOrZero(buffer), offset, size);
 }
 
 WebGLAny WebGL2RenderingContext::getIndexedParameter(GCGLenum target, GCGLuint index)
@@ -2383,7 +2383,7 @@ WebGLAny WebGL2RenderingContext::getIndexedParameter(GCGLenum target, GCGLuint i
     case GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER_START:
     case GraphicsContextGL::UNIFORM_BUFFER_SIZE:
     case GraphicsContextGL::UNIFORM_BUFFER_START:
-        return static_cast<long long>(protectedGraphicsContextGL()->getInteger64i(target, index));
+        return static_cast<long long>(graphicsContextGL()->getInteger64i(target, index));
     case GraphicsContextGL::UNIFORM_BUFFER_BINDING:
         if (index >= m_boundIndexedUniformBuffers.size()) {
             synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "getIndexedParameter"_s, "index out of range"_s);
@@ -2408,7 +2408,7 @@ WebGLAny WebGL2RenderingContext::getIndexedParameter(GCGLenum target, GCGLuint i
         }
         if (target == GraphicsContextGL::COLOR_WRITEMASK)
             return getIndexedBooleanArrayParameter(target, index);
-        return protectedGraphicsContextGL()->getIntegeri(target, index);
+        return graphicsContextGL()->getIntegeri(target, index);
     default:
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getIndexedParameter"_s, "invalid parameter name"_s);
         return nullptr;
@@ -2419,7 +2419,7 @@ Vector<bool> WebGL2RenderingContext::getIndexedBooleanArrayParameter(GCGLenum pn
 {
     ASSERT(pname == GraphicsContextGL::COLOR_WRITEMASK);
     std::array<GCGLint, 4> value;
-    protectedGraphicsContextGL()->getIntegeri_v(pname, index, value);
+    graphicsContextGL()->getIntegeri_v(pname, index, value);
     return Vector<bool>(4, [&](size_t i) -> bool {
         return value[i];
     });
@@ -2497,7 +2497,7 @@ GCGLuint WebGL2RenderingContext::getUniformBlockIndex(WebGLProgram& program, con
         return 0;
     if (!validateWebGLObject("getUniformBlockIndex"_s, program))
         return 0;
-    return protectedGraphicsContextGL()->getUniformBlockIndex(program.object(), uniformBlockName.utf8());
+    return graphicsContextGL()->getUniformBlockIndex(program.object(), uniformBlockName.utf8());
 }
 
 WebGLAny WebGL2RenderingContext::getActiveUniformBlockParameter(WebGLProgram& program, GCGLuint uniformBlockIndex, GCGLenum pname)
@@ -2510,7 +2510,7 @@ WebGLAny WebGL2RenderingContext::getActiveUniformBlockParameter(WebGLProgram& pr
     case GraphicsContextGL::UNIFORM_BLOCK_BINDING:
     case GraphicsContextGL::UNIFORM_BLOCK_DATA_SIZE:
     case GraphicsContextGL::UNIFORM_BLOCK_ACTIVE_UNIFORMS:
-        return static_cast<GCGLuint>(protectedGraphicsContextGL()->getActiveUniformBlocki(program.object(), uniformBlockIndex, pname));
+        return static_cast<GCGLuint>(graphicsContextGL()->getActiveUniformBlocki(program.object(), uniformBlockIndex, pname));
     case GraphicsContextGL::UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES: {
         RefPtr context = m_context;
         GCGLint size = context->getActiveUniformBlocki(program.object(), uniformBlockIndex, GraphicsContextGL::UNIFORM_BLOCK_ACTIVE_UNIFORMS);
@@ -2520,7 +2520,7 @@ WebGLAny WebGL2RenderingContext::getActiveUniformBlockParameter(WebGLProgram& pr
     }
     case GraphicsContextGL::UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER:
     case GraphicsContextGL::UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER:
-        return static_cast<bool>(protectedGraphicsContextGL()->getActiveUniformBlocki(program.object(), uniformBlockIndex, pname));
+        return static_cast<bool>(graphicsContextGL()->getActiveUniformBlocki(program.object(), uniformBlockIndex, pname));
     default:
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getActiveUniformBlockParameter"_s, "invalid parameter name"_s);
         return nullptr;
@@ -2539,7 +2539,7 @@ String WebGL2RenderingContext::getActiveUniformBlockName(WebGLProgram& program, 
     }
     // Index not validated because the error will be set by the GraphicsContextGL and the return value will be
     // the expected null.
-    CString name = protectedGraphicsContextGL()->getActiveUniformBlockName(program.object(), index);
+    CString name = graphicsContextGL()->getActiveUniformBlockName(program.object(), index);
     return String::fromUTF8(name.span());
 }
 
@@ -2549,7 +2549,7 @@ void WebGL2RenderingContext::uniformBlockBinding(WebGLProgram& program, GCGLuint
         return;
     if (!validateWebGLObject("uniformBlockBinding"_s, program))
         return;
-    protectedGraphicsContextGL()->uniformBlockBinding(program.object(), uniformBlockIndex, uniformBlockBinding);
+    graphicsContextGL()->uniformBlockBinding(program.object(), uniformBlockIndex, uniformBlockBinding);
 }
 
 RefPtr<WebGLVertexArrayObject> WebGL2RenderingContext::createVertexArray()
@@ -2579,11 +2579,11 @@ void WebGL2RenderingContext::deleteVertexArray(WebGLVertexArrayObject* arrayObje
 
     if (!arrayObject->isDefaultObject() && arrayObject == m_boundVertexArrayObject) {
         // The default VAO was removed in OpenGL 3.3 but not from WebGL 2; bind the default for WebGL to use.
-        protectedGraphicsContextGL()->bindVertexArray(m_defaultVertexArrayObject->object());
+        graphicsContextGL()->bindVertexArray(m_defaultVertexArrayObject->object());
         setBoundVertexArrayObject(locker, m_defaultVertexArrayObject.get());
     }
 
-    arrayObject->deleteObject(locker, protectedGraphicsContextGL().get());
+    arrayObject->deleteObject(locker, graphicsContextGL().get());
 }
 
 GCGLboolean WebGL2RenderingContext::isVertexArray(WebGLVertexArrayObject* arrayObject)
@@ -2592,7 +2592,7 @@ GCGLboolean WebGL2RenderingContext::isVertexArray(WebGLVertexArrayObject* arrayO
         return false;
     if (!validateIsWebGLObject(arrayObject))
         return false;
-    return protectedGraphicsContextGL()->isVertexArray(arrayObject->object());
+    return graphicsContextGL()->isVertexArray(arrayObject->object());
 }
 
 void WebGL2RenderingContext::bindVertexArray(WebGLVertexArrayObject* arrayObject)
@@ -2604,10 +2604,10 @@ void WebGL2RenderingContext::bindVertexArray(WebGLVertexArrayObject* arrayObject
         return;
 
     if (arrayObject && !arrayObject->isDefaultObject() && arrayObject->object()) {
-        protectedGraphicsContextGL()->bindVertexArray(arrayObject->object());
+        graphicsContextGL()->bindVertexArray(arrayObject->object());
         setBoundVertexArrayObject(locker, arrayObject);
     } else {
-        protectedGraphicsContextGL()->bindVertexArray(m_defaultVertexArrayObject->object());
+        graphicsContextGL()->bindVertexArray(m_defaultVertexArrayObject->object());
         setBoundVertexArrayObject(locker, m_defaultVertexArrayObject.get());
     }
 }
@@ -2854,13 +2854,13 @@ WebGLAny WebGL2RenderingContext::getFramebufferAttachmentParameter(GCGLenum targ
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE:
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE:
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING:
-        return protectedGraphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
+        return graphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE:
         if (attachment == GraphicsContextGL::DEPTH_STENCIL_ATTACHMENT) {
             synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "component type cannot be queried for DEPTH_STENCIL_ATTACHMENT"_s);
             return nullptr;
         }
-        return protectedGraphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
+        return graphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
     }
 
     synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid parameter name"_s);
@@ -2908,7 +2908,7 @@ bool WebGL2RenderingContext::validateNonDefaultFramebufferAttachment(ASCIILitera
 GCGLint WebGL2RenderingContext::maxDrawBuffers()
 {
     if (!m_maxDrawBuffers)
-        m_maxDrawBuffers = protectedGraphicsContextGL()->getInteger(GraphicsContextGL::MAX_DRAW_BUFFERS);
+        m_maxDrawBuffers = graphicsContextGL()->getInteger(GraphicsContextGL::MAX_DRAW_BUFFERS);
     return m_maxDrawBuffers;
 }
 
@@ -2916,7 +2916,7 @@ GCGLint WebGL2RenderingContext::maxColorAttachments()
 {
     // DrawBuffers requires MAX_COLOR_ATTACHMENTS == MAX_DRAW_BUFFERS
     if (!m_maxColorAttachments)
-        m_maxColorAttachments = protectedGraphicsContextGL()->getInteger(GraphicsContextGL::MAX_DRAW_BUFFERS);
+        m_maxColorAttachments = graphicsContextGL()->getInteger(GraphicsContextGL::MAX_DRAW_BUFFERS);
     return m_maxColorAttachments;
 }
 
@@ -3037,9 +3037,9 @@ void WebGL2RenderingContext::renderbufferStorageImpl(GCGLenum target, GCGLsizei 
 void WebGL2RenderingContext::renderbufferStorageHelper(GCGLenum target, GCGLsizei samples, GCGLenum internalformat, GCGLsizei width, GCGLsizei height)
 {
     if (samples)
-        protectedGraphicsContextGL()->renderbufferStorageMultisample(target, samples, internalformat, width, height);
+        graphicsContextGL()->renderbufferStorageMultisample(target, samples, internalformat, width, height);
     else
-        protectedGraphicsContextGL()->renderbufferStorage(target, internalformat, width, height);
+        graphicsContextGL()->renderbufferStorage(target, internalformat, width, height);
 }
 
 GCGLuint WebGL2RenderingContext::maxTransformFeedbackSeparateAttribs() const
@@ -3331,7 +3331,7 @@ void WebGL2RenderingContext::uniform1fv(const WebGLUniformLocation* location, Fl
     auto result = validateUniformParameters("uniform1fv"_s, location, data, 1, srcOffset, srcLength);
     if (!result)
         return;
-    protectedGraphicsContextGL()->uniform1fv(location->location(), result.value());
+    graphicsContextGL()->uniform1fv(location->location(), result.value());
 }
 
 void WebGL2RenderingContext::uniform2fv(const WebGLUniformLocation* location, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
@@ -3341,7 +3341,7 @@ void WebGL2RenderingContext::uniform2fv(const WebGLUniformLocation* location, Fl
     auto result = validateUniformParameters("uniform2fv"_s, location, data, 2, srcOffset, srcLength);
     if (!result)
         return;
-    protectedGraphicsContextGL()->uniform2fv(location->location(), result.value());
+    graphicsContextGL()->uniform2fv(location->location(), result.value());
 }
 
 void WebGL2RenderingContext::uniform3fv(const WebGLUniformLocation* location, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
@@ -3351,7 +3351,7 @@ void WebGL2RenderingContext::uniform3fv(const WebGLUniformLocation* location, Fl
     auto result = validateUniformParameters("uniform3fv"_s, location, data, 3, srcOffset, srcLength);
     if (!result)
         return;
-    protectedGraphicsContextGL()->uniform3fv(location->location(), result.value());
+    graphicsContextGL()->uniform3fv(location->location(), result.value());
 }
 
 void WebGL2RenderingContext::uniform4fv(const WebGLUniformLocation* location, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
@@ -3361,7 +3361,7 @@ void WebGL2RenderingContext::uniform4fv(const WebGLUniformLocation* location, Fl
     auto result = validateUniformParameters("uniform4fv"_s, location, data, 4, srcOffset, srcLength);
     if (!result)
         return;
-    protectedGraphicsContextGL()->uniform4fv(location->location(), result.value());
+    graphicsContextGL()->uniform4fv(location->location(), result.value());
 }
 
 void WebGL2RenderingContext::uniform1iv(const WebGLUniformLocation* location, Int32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
@@ -3371,7 +3371,7 @@ void WebGL2RenderingContext::uniform1iv(const WebGLUniformLocation* location, In
     auto result = validateUniformParameters("uniform1iv"_s, location, data, 1, srcOffset, srcLength);
     if (!result)
         return;
-    protectedGraphicsContextGL()->uniform1iv(location->location(), result.value());
+    graphicsContextGL()->uniform1iv(location->location(), result.value());
 }
 
 void WebGL2RenderingContext::uniform2iv(const WebGLUniformLocation* location, Int32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
@@ -3381,7 +3381,7 @@ void WebGL2RenderingContext::uniform2iv(const WebGLUniformLocation* location, In
     auto result = validateUniformParameters("uniform2iv"_s, location, data, 2, srcOffset, srcLength);
     if (!result)
         return;
-    protectedGraphicsContextGL()->uniform2iv(location->location(), result.value());
+    graphicsContextGL()->uniform2iv(location->location(), result.value());
 }
 
 void WebGL2RenderingContext::uniform3iv(const WebGLUniformLocation* location, Int32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
@@ -3391,7 +3391,7 @@ void WebGL2RenderingContext::uniform3iv(const WebGLUniformLocation* location, In
     auto result = validateUniformParameters("uniform3iv"_s, location, data, 3, srcOffset, srcLength);
     if (!result)
         return;
-    protectedGraphicsContextGL()->uniform3iv(location->location(), result.value());
+    graphicsContextGL()->uniform3iv(location->location(), result.value());
 }
 
 void WebGL2RenderingContext::uniform4iv(const WebGLUniformLocation* location, Int32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
@@ -3401,7 +3401,7 @@ void WebGL2RenderingContext::uniform4iv(const WebGLUniformLocation* location, In
     auto result = validateUniformParameters("uniform4iv"_s, location, data, 4, srcOffset, srcLength);
     if (!result)
         return;
-    protectedGraphicsContextGL()->uniform4iv(location->location(), result.value());
+    graphicsContextGL()->uniform4iv(location->location(), result.value());
 }
 
 void WebGL2RenderingContext::uniformMatrix2fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
@@ -3411,7 +3411,7 @@ void WebGL2RenderingContext::uniformMatrix2fv(const WebGLUniformLocation* locati
     auto result = validateUniformMatrixParameters("uniformMatrix2fv"_s, location, transpose, data, 2*2, srcOffset, srcLength);
     if (!result)
         return;
-    protectedGraphicsContextGL()->uniformMatrix2fv(location->location(), transpose, result.value());
+    graphicsContextGL()->uniformMatrix2fv(location->location(), transpose, result.value());
 }
 
 void WebGL2RenderingContext::uniformMatrix3fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
@@ -3421,7 +3421,7 @@ void WebGL2RenderingContext::uniformMatrix3fv(const WebGLUniformLocation* locati
     auto result = validateUniformMatrixParameters("uniformMatrix3fv"_s, location, transpose, data, 3*3, srcOffset, srcLength);
     if (!result)
         return;
-    protectedGraphicsContextGL()->uniformMatrix3fv(location->location(), transpose, result.value());
+    graphicsContextGL()->uniformMatrix3fv(location->location(), transpose, result.value());
 }
 
 void WebGL2RenderingContext::uniformMatrix4fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& data, GCGLuint srcOffset, GCGLuint srcLength)
@@ -3431,7 +3431,7 @@ void WebGL2RenderingContext::uniformMatrix4fv(const WebGLUniformLocation* locati
     auto result = validateUniformMatrixParameters("uniformMatrix4fv"_s, location, transpose, data, 4*4, srcOffset, srcLength);
     if (!result)
         return;
-    protectedGraphicsContextGL()->uniformMatrix4fv(location->location(), transpose, result.value());
+    graphicsContextGL()->uniformMatrix4fv(location->location(), transpose, result.value());
 }
 
 void WebGL2RenderingContext::readPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& pixels)
@@ -3489,7 +3489,7 @@ void WebGL2RenderingContext::readPixels(GCGLint x, GCGLint y, GCGLsizei width, G
 
     clearIfComposited(CallerTypeOther);
 
-    protectedGraphicsContextGL()->readPixelsBufferObject(rect, format, type, offsetAndSkip.value(), m_packParameters.alignment, m_packParameters.rowLength);
+    graphicsContextGL()->readPixelsBufferObject(rect, format, type, offsetAndSkip.value(), m_packParameters.alignment, m_packParameters.rowLength);
 }
 
 void WebGL2RenderingContext::readPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, ArrayBufferView& dstData, GCGLuint dstOffset)

--- a/Source/WebCore/html/canvas/WebGLBlendFuncExtended.cpp
+++ b/Source/WebCore/html/canvas/WebGLBlendFuncExtended.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLBlendFuncExtended);
 WebGLBlendFuncExtended::WebGLBlendFuncExtended(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLBlendFuncExtended)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_blend_func_extended"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_blend_func_extended"_s);
 }
 
 WebGLBlendFuncExtended::~WebGLBlendFuncExtended() = default;

--- a/Source/WebCore/html/canvas/WebGLBuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLBuffer.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 RefPtr<WebGLBuffer> WebGLBuffer::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.protectedGraphicsContextGL()->createBuffer();
+    auto object = context.graphicsContextGL()->createBuffer();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLBuffer { context, object });

--- a/Source/WebCore/html/canvas/WebGLClipCullDistance.cpp
+++ b/Source/WebCore/html/canvas/WebGLClipCullDistance.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLClipCullDistance);
 WebGLClipCullDistance::WebGLClipCullDistance(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLClipCullDistance)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_clip_cull_distance"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_clip_cull_distance"_s);
 }
 
 WebGLClipCullDistance::~WebGLClipCullDistance() = default;

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureASTC.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureASTC.cpp
@@ -36,8 +36,8 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLCompressedTextureASTC);
 
 WebGLCompressedTextureASTC::WebGLCompressedTextureASTC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureASTC)
-    , m_isHDRSupported(context.protectedGraphicsContextGL()->supportsExtension("GL_KHR_texture_compression_astc_hdr"_s))
-    , m_isLDRSupported(context.protectedGraphicsContextGL()->supportsExtension("GL_KHR_texture_compression_astc_ldr"_s))
+    , m_isHDRSupported(context.graphicsContextGL()->supportsExtension("GL_KHR_texture_compression_astc_hdr"_s))
+    , m_isLDRSupported(context.graphicsContextGL()->supportsExtension("GL_KHR_texture_compression_astc_ldr"_s))
 {
     RefPtr graphicsContextGL = context.graphicsContextGL();
     graphicsContextGL->ensureExtensionEnabled("GL_KHR_texture_compression_astc_hdr"_s);

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureETC.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureETC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLCompressedTextureETC);
 WebGLCompressedTextureETC::WebGLCompressedTextureETC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureETC)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_compressed_texture_etc"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_compressed_texture_etc"_s);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_R11_EAC);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SIGNED_R11_EAC);

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureETC1.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureETC1.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLCompressedTextureETC1);
 WebGLCompressedTextureETC1::WebGLCompressedTextureETC1(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureETC1)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_compressed_ETC1_RGB8_texture"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_compressed_ETC1_RGB8_texture"_s);
 
     context.addCompressedTextureFormat(GraphicsContextGL::ETC1_RGB8_OES);
 }

--- a/Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLCompressedTexturePVRTC);
 WebGLCompressedTexturePVRTC::WebGLCompressedTexturePVRTC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTexturePVRTC)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_IMG_texture_compression_pvrtc"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_IMG_texture_compression_pvrtc"_s);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RGB_PVRTC_4BPPV1_IMG);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RGB_PVRTC_2BPPV1_IMG);

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLCompressedTextureS3TCsRGB);
 WebGLCompressedTextureS3TCsRGB::WebGLCompressedTextureS3TCsRGB(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureS3TCsRGB)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_compression_s3tc_srgb"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_compression_s3tc_srgb"_s);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SRGB_S3TC_DXT1_EXT);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT);

--- a/Source/WebCore/html/canvas/WebGLDebugShaders.cpp
+++ b/Source/WebCore/html/canvas/WebGLDebugShaders.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLDebugShaders);
 WebGLDebugShaders::WebGLDebugShaders(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLDebugShaders)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_translated_shader_source"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_translated_shader_source"_s);
 }
 
 WebGLDebugShaders::~WebGLDebugShaders() = default;
@@ -56,7 +56,7 @@ String WebGLDebugShaders::getTranslatedShaderSource(WebGLShader& shader)
     Ref context = this->context();
     if (!context->validateWebGLObject("getTranslatedShaderSource"_s, shader))
         return emptyString();
-    return String::fromUTF8(context->protectedGraphicsContextGL()->getTranslatedShaderSourceANGLE(shader.object()).span());
+    return String::fromUTF8(context->graphicsContextGL()->getTranslatedShaderSourceANGLE(shader.object()).span());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<WebGLDefaultFramebuffer> WebGLDefaultFramebuffer::create(WebGLRe
 WebGLDefaultFramebuffer::WebGLDefaultFramebuffer(WebGLRenderingContextBase& context)
     : m_context(context)
 {
-    auto attributes = context.protectedGraphicsContextGL()->contextAttributes();
+    auto attributes = context.graphicsContextGL()->contextAttributes();
     m_hasStencil = attributes.stencil;
     m_hasDepth = attributes.depth;
     if (!attributes.preserveDrawingBuffer) {
@@ -57,12 +57,12 @@ WebGLDefaultFramebuffer::WebGLDefaultFramebuffer(WebGLRenderingContextBase& cont
 
 IntSize WebGLDefaultFramebuffer::size() const
 {
-    return m_context->protectedGraphicsContextGL()->getInternalFramebufferSize();
+    return m_context->graphicsContextGL()->getInternalFramebufferSize();
 }
 
 void WebGLDefaultFramebuffer::reshape(IntSize size)
 {
-    m_context->protectedGraphicsContextGL()->reshape(size.width(), size.height());
+    m_context->graphicsContextGL()->reshape(size.width(), size.height());
 }
 
 void WebGLDefaultFramebuffer::markBuffersClear(GCGLbitfield clearBuffers)

--- a/Source/WebCore/html/canvas/WebGLDepthTexture.cpp
+++ b/Source/WebCore/html/canvas/WebGLDepthTexture.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLDepthTexture);
 WebGLDepthTexture::WebGLDepthTexture(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLDepthTexture)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_depth_texture"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_depth_texture"_s);
 }
 
 WebGLDepthTexture::~WebGLDepthTexture() = default;

--- a/Source/WebCore/html/canvas/WebGLDrawBuffers.cpp
+++ b/Source/WebCore/html/canvas/WebGLDrawBuffers.cpp
@@ -37,14 +37,14 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLDrawBuffers);
 WebGLDrawBuffers::WebGLDrawBuffers(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLDrawBuffers)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_draw_buffers"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_draw_buffers"_s);
 }
 
 WebGLDrawBuffers::~WebGLDrawBuffers() = default;
 
 bool WebGLDrawBuffers::supported(WebGLRenderingContextBase& context)
 {
-    return context.protectedGraphicsContextGL()->supportsExtension("GL_EXT_draw_buffers"_s);
+    return context.graphicsContextGL()->supportsExtension("GL_EXT_draw_buffers"_s);
 }
 
 void WebGLDrawBuffers::drawBuffersWEBGL(const Vector<GCGLenum>& buffers)
@@ -65,7 +65,7 @@ void WebGLDrawBuffers::drawBuffersWEBGL(const Vector<GCGLenum>& buffers)
         }
         // Because the backbuffer is simulated on all current WebKit ports, we need to change BACK to COLOR_ATTACHMENT0.
         GCGLenum value[1] { bufs[0] == GraphicsContextGL::BACK ? GraphicsContextGL::COLOR_ATTACHMENT0 : GraphicsContextGL::NONE };
-        context->protectedGraphicsContextGL()->drawBuffersEXT(value);
+        context->graphicsContextGL()->drawBuffersEXT(value);
         context->setBackDrawBuffer(bufs[0]);
     } else {
         if (n > context->maxDrawBuffers()) {

--- a/Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp
+++ b/Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLDrawInstancedBaseVertexBaseInstance);
 WebGLDrawInstancedBaseVertexBaseInstance::WebGLDrawInstancedBaseVertexBaseInstance(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLDrawInstancedBaseVertexBaseInstance)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_base_vertex_base_instance"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_base_vertex_base_instance"_s);
 }
 
 WebGLDrawInstancedBaseVertexBaseInstance::~WebGLDrawInstancedBaseVertexBaseInstance() = default;
@@ -66,7 +66,7 @@ void WebGLDrawInstancedBaseVertexBaseInstance::drawArraysInstancedBaseInstanceWE
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->protectedGraphicsContextGL()->drawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance);
+        context->graphicsContextGL()->drawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance);
     }
 
     context->markContextChangedAndNotifyCanvasObserver();
@@ -89,7 +89,7 @@ void WebGLDrawInstancedBaseVertexBaseInstance::drawElementsInstancedBaseVertexBa
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->protectedGraphicsContextGL()->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, offset, instanceCount, baseVertex, baseInstance);
+        context->graphicsContextGL()->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, offset, instanceCount, baseVertex, baseInstance);
     }
 
     context->markContextChangedAndNotifyCanvasObserver();

--- a/Source/WebCore/html/canvas/WebGLExtension.h
+++ b/Source/WebCore/html/canvas/WebGLExtension.h
@@ -115,13 +115,12 @@ protected:
 // if (isContextLost())
 //     return;
 //
-// followed by `Ref context = this->context();` or `protectedContext()->drawSomething(...);`.
+// followed by `Ref context = this->context();` or `context()->drawSomething(...);`.
 template<typename T>
 class WebGLExtension : public WebGLExtensionBase {
 public:
     void loseParentContext() { m_context = nullptr; }
-    T& context() { ASSERT(!isContextLost()); return *m_context.load(std::memory_order::relaxed); }
-    Ref<T> protectedContext() { return context(); }
+    Ref<T> context() { ASSERT(!isContextLost()); return *m_context.load(std::memory_order::relaxed); }
 
     // Only to be used by friend WebCoreOpaqueRoot root(const WebGLExtension<T>*) that cannot be a friend
     // due to C++ warning on some compilers.

--- a/Source/WebCore/html/canvas/WebGLLoseContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLLoseContext.cpp
@@ -45,14 +45,14 @@ void WebGLLoseContext::loseContext()
 {
     if (isContextLost())
         return;
-    protectedContext()->forceLostContext(WebGLRenderingContextBase::SyntheticLostContext);
+    context()->forceLostContext(WebGLRenderingContextBase::SyntheticLostContext);
 }
 
 void WebGLLoseContext::restoreContext()
 {
     if (isContextLost())
         return;
-    protectedContext()->forceRestoreContext();
+    context()->forceRestoreContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLMultiDraw);
 WebGLMultiDraw::WebGLMultiDraw(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLMultiDraw)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_multi_draw"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_multi_draw"_s);
 
     // Spec requires ANGLE_instanced_arrays to be turned on implicitly here.
     // Enable it both in the backend and in WebKit.
@@ -78,7 +78,7 @@ void WebGLMultiDraw::multiDrawArraysWEBGL(GCGLenum mode, Int32List&& firstsList,
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->protectedGraphicsContextGL()->multiDrawArraysANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), static_cast<size_t>(drawcount) });
+        context->graphicsContextGL()->multiDrawArraysANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), static_cast<size_t>(drawcount) });
     }
 
     context->markContextChangedAndNotifyCanvasObserver();
@@ -108,7 +108,7 @@ void WebGLMultiDraw::multiDrawArraysInstancedWEBGL(GCGLenum mode, Int32List&& fi
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->protectedGraphicsContextGL()->multiDrawArraysInstancedANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), static_cast<size_t>(drawcount) });
+        context->graphicsContextGL()->multiDrawArraysInstancedANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), static_cast<size_t>(drawcount) });
     }
 
     context->markContextChangedAndNotifyCanvasObserver();
@@ -137,7 +137,7 @@ void WebGLMultiDraw::multiDrawElementsWEBGL(GCGLenum mode, Int32List&& countsLis
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->protectedGraphicsContextGL()->multiDrawElementsANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), static_cast<size_t>(drawcount) }, type);
+        context->graphicsContextGL()->multiDrawElementsANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), static_cast<size_t>(drawcount) }, type);
     }
 
     context->markContextChangedAndNotifyCanvasObserver();
@@ -167,7 +167,7 @@ void WebGLMultiDraw::multiDrawElementsInstancedWEBGL(GCGLenum mode, Int32List&& 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->protectedGraphicsContextGL()->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), static_cast<size_t>(drawcount) }, type);
+        context->graphicsContextGL()->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), static_cast<size_t>(drawcount) }, type);
     }
 
     context->markContextChangedAndNotifyCanvasObserver();

--- a/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLMultiDrawInstancedBaseVertexBaseInstan
 WebGLMultiDrawInstancedBaseVertexBaseInstance::WebGLMultiDrawInstancedBaseVertexBaseInstance(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLMultiDrawInstancedBaseVertexBaseInstance)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_base_vertex_base_instance"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_base_vertex_base_instance"_s);
 
     // Spec requires WEBGL_multi_draw to be turned on implicitly here.
     // Enable it both in the backend and in WebKit.
@@ -79,7 +79,7 @@ void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawArraysInstancedBase
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->protectedGraphicsContextGL()->multiDrawArraysInstancedBaseInstanceANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), baseInstancesList.span().subspan(baseInstancesOffset).data(), static_cast<size_t>(drawcount) });
+        context->graphicsContextGL()->multiDrawArraysInstancedBaseInstanceANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), baseInstancesList.span().subspan(baseInstancesOffset).data(), static_cast<size_t>(drawcount) });
     }
 
     context->markContextChangedAndNotifyCanvasObserver();
@@ -111,7 +111,7 @@ void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawElementsInstancedBa
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->protectedGraphicsContextGL()->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), baseVerticesList.span().subspan(baseVerticesOffset).data(), baseInstancesList.span().subspan(baseInstancesOffset).data(), static_cast<size_t>(drawcount) }, type);
+        context->graphicsContextGL()->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), baseVerticesList.span().subspan(baseVerticesOffset).data(), baseInstancesList.span().subspan(baseInstancesOffset).data(), static_cast<size_t>(drawcount) }, type);
     }
 
     context->markContextChangedAndNotifyCanvasObserver();

--- a/Source/WebCore/html/canvas/WebGLObject.cpp
+++ b/Source/WebCore/html/canvas/WebGLObject.cpp
@@ -45,24 +45,19 @@ WebGLObject::WebGLObject(WebGLRenderingContextBase& context, PlatformGLObject ob
 
 WebGLObject::~WebGLObject() = default;
 
-WebGLRenderingContextBase* WebGLObject::context() const
+RefPtr<WebGLRenderingContextBase> WebGLObject::context() const
 {
     return m_context.get();
-}
-
-RefPtr<WebGLRenderingContextBase> WebGLObject::protectedContext() const
-{
-    return context();
 }
 
 Lock& WebGLObject::objectGraphLockForContext()
 {
     // Should not call this if the object or context has been deleted.
     ASSERT(m_context);
-    return protectedContext()->objectGraphLock();
+    return context()->objectGraphLock();
 }
 
-GraphicsContextGL* WebGLObject::graphicsContextGL() const
+RefPtr<GraphicsContextGL> WebGLObject::graphicsContextGL() const
 {
     return m_context ? m_context->graphicsContextGL() : nullptr;
 }
@@ -91,11 +86,11 @@ void WebGLObject::deleteObject(const AbstractLocker& locker, GraphicsContextGL* 
         return;
 
     if (!m_attachmentCount) {
-        if (!context3d)
-            context3d = graphicsContextGL();
-
-        if (context3d)
-            deleteObjectImpl(locker, context3d, m_object);
+        RefPtr<GraphicsContextGL> gl = context3d;
+        if (!gl)
+            gl = m_context->graphicsContextGL();
+        if (gl)
+            deleteObjectImpl(locker, gl.get(), m_object);
     }
 
     if (!m_attachmentCount)

--- a/Source/WebCore/html/canvas/WebGLObject.h
+++ b/Source/WebCore/html/canvas/WebGLObject.h
@@ -86,9 +86,8 @@ class WebGLObject : public RefCounted<WebGLObject> {
 public:
     virtual ~WebGLObject();
 
-    WebGLRenderingContextBase* context() const;
-    RefPtr<WebGLRenderingContextBase> protectedContext() const;
-    GraphicsContextGL* graphicsContextGL() const;
+    RefPtr<WebGLRenderingContextBase> context() const;
+    RefPtr<GraphicsContextGL> graphicsContextGL() const;
 
     PlatformGLObject object() const { return m_object; }
 

--- a/Source/WebCore/html/canvas/WebGLPolygonMode.cpp
+++ b/Source/WebCore/html/canvas/WebGLPolygonMode.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLPolygonMode);
 WebGLPolygonMode::WebGLPolygonMode(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLPolygonMode)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_polygon_mode"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_polygon_mode"_s);
     context.printToConsole(MessageLevel::Warning, "WebGL: non-portable extension enabled: WEBGL_polygon_mode"_s);
 }
 
@@ -52,7 +52,7 @@ void WebGLPolygonMode::polygonModeWEBGL(GCGLenum face, GCGLenum mode)
 {
     if (isContextLost())
         return;
-    protectedContext()->protectedGraphicsContextGL()->polygonModeANGLE(face, mode);
+    context()->graphicsContextGL()->polygonModeANGLE(face, mode);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLProgram.cpp
+++ b/Source/WebCore/html/canvas/WebGLProgram.cpp
@@ -57,7 +57,7 @@ Lock& WebGLProgram::instancesLock()
 
 RefPtr<WebGLProgram> WebGLProgram::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.protectedGraphicsContextGL()->createProgram();
+    auto object = context.graphicsContextGL()->createProgram();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLProgram { context, object });

--- a/Source/WebCore/html/canvas/WebGLProvokingVertex.cpp
+++ b/Source/WebCore/html/canvas/WebGLProvokingVertex.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLProvokingVertex);
 WebGLProvokingVertex::WebGLProvokingVertex(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLProvokingVertex)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_provoking_vertex"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_provoking_vertex"_s);
 }
 
 WebGLProvokingVertex::~WebGLProvokingVertex() = default;
@@ -51,7 +51,7 @@ void WebGLProvokingVertex::provokingVertexWEBGL(GCGLenum provokeMode)
 {
     if (isContextLost())
         return;
-    protectedContext()->protectedGraphicsContextGL()->provokingVertexANGLE(provokeMode);
+    context()->graphicsContextGL()->provokingVertexANGLE(provokeMode);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLQuery.cpp
+++ b/Source/WebCore/html/canvas/WebGLQuery.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
     
 RefPtr<WebGLQuery> WebGLQuery::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.protectedGraphicsContextGL()->createQuery();
+    auto object = context.graphicsContextGL()->createQuery();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLQuery { context, object });

--- a/Source/WebCore/html/canvas/WebGLRenderSharedExponent.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderSharedExponent.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLRenderSharedExponent);
 WebGLRenderSharedExponent::WebGLRenderSharedExponent(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLRenderSharedExponent)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_QCOM_render_shared_exponent"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_QCOM_render_shared_exponent"_s);
 }
 
 WebGLRenderSharedExponent::~WebGLRenderSharedExponent() = default;

--- a/Source/WebCore/html/canvas/WebGLRenderbuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderbuffer.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 RefPtr<WebGLRenderbuffer> WebGLRenderbuffer::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.protectedGraphicsContextGL()->createRenderbuffer();
+    auto object = context.graphicsContextGL()->createRenderbuffer();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLRenderbuffer { context, object });

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -300,13 +300,13 @@ WebGLAny WebGLRenderingContext::getFramebufferAttachmentParameter(GCGLenum targe
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE:
         if (!isTexture)
             break;
-        return protectedGraphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
+        return graphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT:
         if (!m_extsRGB) {
             synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid parameter name, EXT_sRGB not enabled"_s);
             return nullptr;
         }
-        return protectedGraphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
+        return graphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT:
         if (!m_extColorBufferHalfFloat && !m_webglColorBufferFloat) {
             synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid parameter name, EXT_color_buffer_half_float or WEBGL_color_buffer_float not enabled"_s);
@@ -316,7 +316,7 @@ WebGLAny WebGLRenderingContext::getFramebufferAttachmentParameter(GCGLenum targe
             synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "component type cannot be queried for DEPTH_STENCIL_ATTACHMENT"_s);
             return nullptr;
         }
-        return protectedGraphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
+        return graphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
     }
 
     synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid parameter name"_s);
@@ -325,7 +325,7 @@ WebGLAny WebGLRenderingContext::getFramebufferAttachmentParameter(GCGLenum targe
 
 long long WebGLRenderingContext::getInt64Parameter(GCGLenum pname)
 {
-    return protectedGraphicsContextGL()->getInteger64EXT(pname);
+    return graphicsContextGL()->getInteger64EXT(pname);
 }
 
 GCGLint WebGLRenderingContext::maxDrawBuffers()
@@ -346,7 +346,7 @@ GCGLint WebGLRenderingContext::maxColorAttachments()
     if (!supportsDrawBuffers())
         return 0;
     if (!m_maxColorAttachments)
-        m_maxColorAttachments = protectedGraphicsContextGL()->getInteger(GraphicsContextGL::MAX_COLOR_ATTACHMENTS_EXT);
+        m_maxColorAttachments = graphicsContextGL()->getInteger(GraphicsContextGL::MAX_COLOR_ATTACHMENTS_EXT);
     return m_maxColorAttachments;
 }
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -778,7 +778,7 @@ RefPtr<ImageBuffer> WebGLRenderingContextBase::surfaceBufferToImageBuffer(Surfac
     // Avoid leaking the WebGL content in the cases where a WebGL canvas element is drawn to a Context2D
     // canvas element repeatedly.
     buffer->flushDrawingContext();
-    protectedGraphicsContextGL()->drawSurfaceBufferToImageBuffer(toGCGLSurfaceBuffer(sourceBuffer), *buffer);
+    graphicsContextGL()->drawSurfaceBufferToImageBuffer(toGCGLSurfaceBuffer(sourceBuffer), *buffer);
     return buffer;
 }
 
@@ -828,7 +828,7 @@ RefPtr<VideoFrame> WebGLRenderingContextBase::surfaceBufferToVideoFrame(SurfaceB
         return nullptr;
     if (buffer == SurfaceBuffer::DrawingBuffer)
         clearIfComposited(CallerTypeOther);
-    return protectedGraphicsContextGL()->surfaceBufferToVideoFrame(toGCGLSurfaceBuffer(buffer));
+    return graphicsContextGL()->surfaceBufferToVideoFrame(toGCGLSurfaceBuffer(buffer));
 }
 #endif
 
@@ -839,7 +839,7 @@ RefPtr<ImageBuffer> WebGLRenderingContextBase::transferToImageBuffer()
         return nullptr;
     if (compositingResultsNeedUpdating())
         prepareForDisplay();
-    protectedGraphicsContextGL()->drawSurfaceBufferToImageBuffer(GraphicsContextGL::SurfaceBuffer::DisplayBuffer, *buffer);
+    graphicsContextGL()->drawSurfaceBufferToImageBuffer(GraphicsContextGL::SurfaceBuffer::DisplayBuffer, *buffer);
     // Any draw or read sees cleared drawing buffer.
     m_defaultFramebuffer->markAllBuffersDirty();
     // Next transfer uses the cleared drawing buffer.
@@ -894,7 +894,7 @@ void WebGLRenderingContextBase::setDrawingBufferColorSpace(PredefinedColorSpace 
     if (isContextLost())
         return;
 
-    protectedGraphicsContextGL()->setDrawingBufferColorSpace(toDestinationColorSpace(colorSpace));
+    graphicsContextGL()->setDrawingBufferColorSpace(toDestinationColorSpace(colorSpace));
 }
 
 unsigned WebGLRenderingContextBase::sizeInBytes(GCGLenum type)
@@ -933,7 +933,7 @@ void WebGLRenderingContextBase::activeTexture(GCGLenum texture)
         return;
     }
     m_activeTextureUnit = texture - GraphicsContextGL::TEXTURE0;
-    protectedGraphicsContextGL()->activeTexture(texture);
+    graphicsContextGL()->activeTexture(texture);
 }
 
 void WebGLRenderingContextBase::attachShader(WebGLProgram& program, WebGLShader& shader)
@@ -947,7 +947,7 @@ void WebGLRenderingContextBase::attachShader(WebGLProgram& program, WebGLShader&
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "attachShader"_s, "shader attachment already has shader"_s);
         return;
     }
-    protectedGraphicsContextGL()->attachShader(program.object(), shader.object());
+    graphicsContextGL()->attachShader(program.object(), shader.object());
     shader.onAttached();
 }
 
@@ -969,7 +969,7 @@ void WebGLRenderingContextBase::bindAttribLocation(WebGLProgram& program, GCGLui
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "bindAttribLocation"_s, "index out of range"_s);
         return;
     }
-    protectedGraphicsContextGL()->bindAttribLocation(program.object(), index, name.utf8());
+    graphicsContextGL()->bindAttribLocation(program.object(), index, name.utf8());
 }
 
 bool WebGLRenderingContextBase::validateBufferTarget(ASCIILiteral functionName, GCGLenum target)
@@ -1036,7 +1036,7 @@ void WebGLRenderingContextBase::bindBuffer(GCGLenum target, WebGLBuffer* buffer)
     if (!validateAndCacheBufferBinding(locker, "bindBuffer"_s, target, buffer))
         return;
 
-    protectedGraphicsContextGL()->bindBuffer(target, objectOrZero(buffer));
+    graphicsContextGL()->bindBuffer(target, objectOrZero(buffer));
 }
 
 void WebGLRenderingContextBase::bindFramebuffer(GCGLenum target, WebGLFramebuffer* buffer)
@@ -1067,7 +1067,7 @@ void WebGLRenderingContextBase::bindRenderbuffer(GCGLenum target, WebGLRenderbuf
         return;
     }
     m_renderbufferBinding = renderBuffer;
-    protectedGraphicsContextGL()->bindRenderbuffer(target, objectOrZero(renderBuffer));
+    graphicsContextGL()->bindRenderbuffer(target, objectOrZero(renderBuffer));
 }
 
 void WebGLRenderingContextBase::bindTexture(GCGLenum target, WebGLTexture* texture)
@@ -1094,7 +1094,7 @@ void WebGLRenderingContextBase::bindTexture(GCGLenum target, WebGLTexture* textu
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "bindTexture"_s, "invalid target"_s);
         return;
     }
-    protectedGraphicsContextGL()->bindTexture(target, objectOrZero(texture));
+    graphicsContextGL()->bindTexture(target, objectOrZero(texture));
 
     // Note: previously we used to automatically set the TEXTURE_WRAP_R
     // repeat mode to CLAMP_TO_EDGE for cube map textures, because OpenGL
@@ -1110,35 +1110,35 @@ void WebGLRenderingContextBase::blendColor(GCGLfloat red, GCGLfloat green, GCGLf
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->blendColor(red, green, blue, alpha);
+    graphicsContextGL()->blendColor(red, green, blue, alpha);
 }
 
 void WebGLRenderingContextBase::blendEquation(GCGLenum mode)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->blendEquation(mode);
+    graphicsContextGL()->blendEquation(mode);
 }
 
 void WebGLRenderingContextBase::blendEquationSeparate(GCGLenum modeRGB, GCGLenum modeAlpha)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->blendEquationSeparate(modeRGB, modeAlpha);
+    graphicsContextGL()->blendEquationSeparate(modeRGB, modeAlpha);
 }
 
 void WebGLRenderingContextBase::blendFunc(GCGLenum sfactor, GCGLenum dfactor)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->blendFunc(sfactor, dfactor);
+    graphicsContextGL()->blendFunc(sfactor, dfactor);
 }
 
 void WebGLRenderingContextBase::blendFuncSeparate(GCGLenum srcRGB, GCGLenum dstRGB, GCGLenum srcAlpha, GCGLenum dstAlpha)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->blendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
+    graphicsContextGL()->blendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
 }
 
 void WebGLRenderingContextBase::bufferData(GCGLenum target, long long size, GCGLenum usage)
@@ -1158,7 +1158,7 @@ void WebGLRenderingContextBase::bufferData(GCGLenum target, long long size, GCGL
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "bufferData"_s, "size more than 32-bits"_s);
         return;
     }
-    protectedGraphicsContextGL()->bufferData(target, static_cast<GCGLsizeiptr>(size), usage);
+    graphicsContextGL()->bufferData(target, static_cast<GCGLsizeiptr>(size), usage);
 }
 
 void WebGLRenderingContextBase::bufferData(GCGLenum target, std::optional<BufferDataSource>&& data, GCGLenum usage)
@@ -1203,7 +1203,7 @@ GCGLenum WebGLRenderingContextBase::checkFramebufferStatus(GCGLenum target)
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "checkFramebufferStatus"_s, "invalid target"_s);
         return 0;
     }
-    return protectedGraphicsContextGL()->checkFramebufferStatus(target);
+    return graphicsContextGL()->checkFramebufferStatus(target);
 }
 
 void WebGLRenderingContextBase::clear(GCGLbitfield mask)
@@ -1211,7 +1211,7 @@ void WebGLRenderingContextBase::clear(GCGLbitfield mask)
     if (isContextLost())
         return;
     if (!clearIfComposited(CallerTypeDrawOrClear, mask))
-        protectedGraphicsContextGL()->clear(mask);
+        graphicsContextGL()->clear(mask);
     markContextChangedAndNotifyCanvasObserver();
 }
 
@@ -1231,7 +1231,7 @@ void WebGLRenderingContextBase::clearColor(GCGLfloat r, GCGLfloat g, GCGLfloat b
     m_clearColor[1] = g;
     m_clearColor[2] = b;
     m_clearColor[3] = a;
-    protectedGraphicsContextGL()->clearColor(r, g, b, a);
+    graphicsContextGL()->clearColor(r, g, b, a);
 }
 
 void WebGLRenderingContextBase::clearDepth(GCGLfloat depth)
@@ -1239,7 +1239,7 @@ void WebGLRenderingContextBase::clearDepth(GCGLfloat depth)
     if (isContextLost())
         return;
     m_clearDepth = depth;
-    protectedGraphicsContextGL()->clearDepth(depth);
+    graphicsContextGL()->clearDepth(depth);
 }
 
 void WebGLRenderingContextBase::clearStencil(GCGLint s)
@@ -1247,7 +1247,7 @@ void WebGLRenderingContextBase::clearStencil(GCGLint s)
     if (isContextLost())
         return;
     m_clearStencil = s;
-    protectedGraphicsContextGL()->clearStencil(s);
+    graphicsContextGL()->clearStencil(s);
 }
 
 void WebGLRenderingContextBase::colorMask(GCGLboolean red, GCGLboolean green, GCGLboolean blue, GCGLboolean alpha)
@@ -1258,7 +1258,7 @@ void WebGLRenderingContextBase::colorMask(GCGLboolean red, GCGLboolean green, GC
     m_colorMask[1] = green;
     m_colorMask[2] = blue;
     m_colorMask[3] = alpha;
-    protectedGraphicsContextGL()->colorMask(red, green, blue, alpha);
+    graphicsContextGL()->colorMask(red, green, blue, alpha);
 }
 
 void WebGLRenderingContextBase::compileShader(WebGLShader& shader)
@@ -1267,7 +1267,7 @@ void WebGLRenderingContextBase::compileShader(WebGLShader& shader)
         return;
     if (!validateWebGLObject("compileShader"_s, shader))
         return;
-    protectedGraphicsContextGL()->compileShader(shader.object());
+    graphicsContextGL()->compileShader(shader.object());
 }
 
 void WebGLRenderingContextBase::compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, ArrayBufferView& data)
@@ -1276,7 +1276,7 @@ void WebGLRenderingContextBase::compressedTexImage2D(GCGLenum target, GCGLint le
         return;
     if (!validateTexture2DBinding("compressedTexImage2D"_s, target))
         return;
-    protectedGraphicsContextGL()->compressedTexImage2D(target, level, internalformat, width, height, border, data.byteLength(), data.span());
+    graphicsContextGL()->compressedTexImage2D(target, level, internalformat, width, height, border, data.byteLength(), data.span());
 }
 
 void WebGLRenderingContextBase::compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, ArrayBufferView& data)
@@ -1285,7 +1285,7 @@ void WebGLRenderingContextBase::compressedTexSubImage2D(GCGLenum target, GCGLint
         return;
     if (!validateTexture2DBinding("compressedTexSubImage2D"_s, target))
         return;
-    protectedGraphicsContextGL()->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, data.byteLength(), data.span());
+    graphicsContextGL()->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, data.byteLength(), data.span());
 }
 
 bool WebGLRenderingContextBase::validateSettableTexInternalFormat(ASCIILiteral functionName, GCGLenum internalFormat)
@@ -1316,7 +1316,7 @@ void WebGLRenderingContextBase::copyTexSubImage2D(GCGLenum target, GCGLint level
     if (!validateTexture2DBinding("copyTexSubImage2D"_s, target))
         return;
     clearIfComposited(CallerTypeOther);
-    protectedGraphicsContextGL()->copyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height);
+    graphicsContextGL()->copyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height);
 }
 
 RefPtr<WebGLBuffer> WebGLRenderingContextBase::createBuffer()
@@ -1374,7 +1374,7 @@ void WebGLRenderingContextBase::cullFace(GCGLenum mode)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->cullFace(mode);
+    graphicsContextGL()->cullFace(mode);
 }
 
 bool WebGLRenderingContextBase::deleteObject(const AbstractLocker& locker, WebGLObject* object)
@@ -1390,7 +1390,7 @@ bool WebGLRenderingContextBase::deleteObject(const AbstractLocker& locker, WebGL
     if (object->object())
         // We need to pass in context here because we want
         // things in this context unbound.
-        object->deleteObject(locker, protectedGraphicsContextGL().get());
+        object->deleteObject(locker, graphicsContextGL().get());
     return true;
 }
 
@@ -1439,7 +1439,7 @@ void WebGLRenderingContextBase::deleteFramebuffer(WebGLFramebuffer* framebuffer)
 
     if (framebuffer == m_framebufferBinding) {
         m_framebufferBinding = nullptr;
-        protectedGraphicsContextGL()->bindFramebuffer(GraphicsContextGL::FRAMEBUFFER, 0);
+        graphicsContextGL()->bindFramebuffer(GraphicsContextGL::FRAMEBUFFER, 0);
     }
 }
 
@@ -1504,7 +1504,7 @@ void WebGLRenderingContextBase::depthFunc(GCGLenum func)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->depthFunc(func);
+    graphicsContextGL()->depthFunc(func);
 }
 
 void WebGLRenderingContextBase::depthMask(GCGLboolean flag)
@@ -1512,14 +1512,14 @@ void WebGLRenderingContextBase::depthMask(GCGLboolean flag)
     if (isContextLost())
         return;
     m_depthMask = flag;
-    protectedGraphicsContextGL()->depthMask(flag);
+    graphicsContextGL()->depthMask(flag);
 }
 
 void WebGLRenderingContextBase::depthRange(GCGLfloat zNear, GCGLfloat zFar)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->depthRange(zNear, zFar);
+    graphicsContextGL()->depthRange(zNear, zFar);
 }
 
 void WebGLRenderingContextBase::detachShader(WebGLProgram& program, WebGLShader& shader)
@@ -1533,8 +1533,8 @@ void WebGLRenderingContextBase::detachShader(WebGLProgram& program, WebGLShader&
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "detachShader"_s, "shader not attached"_s);
         return;
     }
-    protectedGraphicsContextGL()->detachShader(program.object(), shader.object());
-    shader.onDetached(locker, protectedGraphicsContextGL().get());
+    graphicsContextGL()->detachShader(program.object(), shader.object());
+    shader.onDetached(locker, graphicsContextGL().get());
 }
 
 void WebGLRenderingContextBase::disable(GCGLenum cap)
@@ -1545,7 +1545,7 @@ void WebGLRenderingContextBase::disable(GCGLenum cap)
         m_scissorEnabled = false;
     if (cap == GraphicsContextGL::RASTERIZER_DISCARD)
         m_rasterizerDiscardEnabled = false;
-    protectedGraphicsContextGL()->disable(cap);
+    graphicsContextGL()->disable(cap);
 }
 
 void WebGLRenderingContextBase::disableVertexAttribArray(GCGLuint index)
@@ -1557,7 +1557,7 @@ void WebGLRenderingContextBase::disableVertexAttribArray(GCGLuint index)
         return;
     }
     protectedBoundVertexArrayObject()->setVertexAttribEnabled(index, false);
-    protectedGraphicsContextGL()->disableVertexAttribArray(index);
+    graphicsContextGL()->disableVertexAttribArray(index);
 }
 
 bool WebGLRenderingContextBase::validateVertexArrayObject(ASCIILiteral functionName)
@@ -1583,7 +1583,7 @@ void WebGLRenderingContextBase::drawArrays(GCGLenum mode, GCGLint first, GCGLsiz
 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
-        protectedGraphicsContextGL()->drawArrays(mode, first, count);
+        graphicsContextGL()->drawArrays(mode, first, count);
     }
 
     markContextChangedAndNotifyCanvasObserver();
@@ -1603,7 +1603,7 @@ void WebGLRenderingContextBase::drawElements(GCGLenum mode, GCGLsizei count, GCG
 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
-        protectedGraphicsContextGL()->drawElements(mode, count, type, static_cast<GCGLintptr>(offset));
+        graphicsContextGL()->drawElements(mode, count, type, static_cast<GCGLintptr>(offset));
     }
     markContextChangedAndNotifyCanvasObserver();
 }
@@ -1616,7 +1616,7 @@ void WebGLRenderingContextBase::enable(GCGLenum cap)
         m_scissorEnabled = true;
     if (cap == GraphicsContextGL::RASTERIZER_DISCARD)
         m_rasterizerDiscardEnabled = true;
-    protectedGraphicsContextGL()->enable(cap);
+    graphicsContextGL()->enable(cap);
 }
 
 void WebGLRenderingContextBase::enableVertexAttribArray(GCGLuint index)
@@ -1628,21 +1628,21 @@ void WebGLRenderingContextBase::enableVertexAttribArray(GCGLuint index)
         return;
     }
     protectedBoundVertexArrayObject()->setVertexAttribEnabled(index, true);
-    protectedGraphicsContextGL()->enableVertexAttribArray(index);
+    graphicsContextGL()->enableVertexAttribArray(index);
 }
 
 void WebGLRenderingContextBase::finish()
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->finish();
+    graphicsContextGL()->finish();
 }
 
 void WebGLRenderingContextBase::flush()
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->flush();
+    graphicsContextGL()->flush();
 }
 
 void WebGLRenderingContextBase::framebufferRenderbuffer(GCGLenum target, GCGLenum attachment, GCGLenum renderbuffertarget, WebGLRenderbuffer* buffer)
@@ -1712,7 +1712,7 @@ void WebGLRenderingContextBase::frontFace(GCGLenum mode)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->frontFace(mode);
+    graphicsContextGL()->frontFace(mode);
 }
 
 void WebGLRenderingContextBase::generateMipmap(GCGLenum target)
@@ -1721,7 +1721,7 @@ void WebGLRenderingContextBase::generateMipmap(GCGLenum target)
         return;
     if (!validateTextureBinding("generateMipmap"_s, target))
         return;
-    protectedGraphicsContextGL()->generateMipmap(target);
+    graphicsContextGL()->generateMipmap(target);
 }
 
 RefPtr<WebGLActiveInfo> WebGLRenderingContextBase::getActiveAttrib(WebGLProgram& program, GCGLuint index)
@@ -1818,7 +1818,7 @@ WebGLAny WebGLRenderingContextBase::getBufferParameter(GCGLenum target, GCGLenum
         return nullptr;
     }
 
-    GCGLint value = protectedGraphicsContextGL()->getBufferParameteri(target, pname);
+    GCGLint value = graphicsContextGL()->getBufferParameteri(target, pname);
     if (pname == GraphicsContextGL::BUFFER_SIZE)
         return value;
     return static_cast<unsigned>(value);
@@ -1833,7 +1833,7 @@ std::optional<WebGLContextAttributes> WebGLRenderingContextBase::getContextAttri
 
 bool WebGLRenderingContextBase::updateErrors()
 {
-    auto newErrors = protectedGraphicsContextGL()->getErrors();
+    auto newErrors = graphicsContextGL()->getErrors();
     if (!newErrors)
         return false;
     m_errors.add(newErrors);
@@ -2165,18 +2165,18 @@ WebGLAny WebGLRenderingContextBase::getProgramParameter(WebGLProgram& program, G
     case GraphicsContextGL::DELETE_STATUS:
         return program.isDeleted();
     case GraphicsContextGL::VALIDATE_STATUS:
-        return static_cast<bool>(protectedGraphicsContextGL()->getProgrami(program.object(), pname));
+        return static_cast<bool>(graphicsContextGL()->getProgrami(program.object(), pname));
     case GraphicsContextGL::LINK_STATUS:
         return program.linkStatus();
     case GraphicsContextGL::ATTACHED_SHADERS:
-        return protectedGraphicsContextGL()->getProgrami(program.object(), pname);
+        return graphicsContextGL()->getProgrami(program.object(), pname);
     case GraphicsContextGL::ACTIVE_ATTRIBUTES:
         return static_cast<GCGLint>(program.activeAttribs().size());
     case GraphicsContextGL::ACTIVE_UNIFORMS:
         return static_cast<GCGLint>(program.activeUniforms().size());
     case GraphicsContextGL::COMPLETION_STATUS_KHR:
         if (m_khrParallelShaderCompile)
-            return static_cast<bool>(protectedGraphicsContextGL()->getProgrami(program.object(), pname));
+            return static_cast<bool>(graphicsContextGL()->getProgrami(program.object(), pname));
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getProgramParameter"_s, "KHR_parallel_shader_compile not enabled"_s);
         return nullptr;
     default:
@@ -2185,7 +2185,7 @@ WebGLAny WebGLRenderingContextBase::getProgramParameter(WebGLProgram& program, G
             case GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER_MODE:
             case GraphicsContextGL::TRANSFORM_FEEDBACK_VARYINGS:
             case GraphicsContextGL::ACTIVE_UNIFORM_BLOCKS:
-                return protectedGraphicsContextGL()->getProgrami(program.object(), pname);
+                return graphicsContextGL()->getProgrami(program.object(), pname);
             default:
                 break;
             }
@@ -2201,7 +2201,7 @@ String WebGLRenderingContextBase::getProgramInfoLog(WebGLProgram& program)
         return { };
     if (!validateWebGLObject("getProgramInfoLog"_s, program))
         return { };
-    return ensureNotNull(protectedGraphicsContextGL()->getProgramInfoLog(program.object()));
+    return ensureNotNull(graphicsContextGL()->getProgramInfoLog(program.object()));
 }
 
 WebGLAny WebGLRenderingContextBase::getRenderbufferParameter(GCGLenum target, GCGLenum pname)
@@ -2264,7 +2264,7 @@ WebGLAny WebGLRenderingContextBase::getRenderbufferParameter(GCGLenum target, GC
     case GraphicsContextGL::RENDERBUFFER_ALPHA_SIZE:
     case GraphicsContextGL::RENDERBUFFER_DEPTH_SIZE:
     case GraphicsContextGL::RENDERBUFFER_STENCIL_SIZE:
-        return protectedGraphicsContextGL()->getRenderbufferParameteri(target, pname);
+        return graphicsContextGL()->getRenderbufferParameteri(target, pname);
     case GraphicsContextGL::RENDERBUFFER_INTERNAL_FORMAT:
         return m_renderbufferBinding->getInternalFormat();
     default:
@@ -2289,12 +2289,12 @@ WebGLAny WebGLRenderingContextBase::getShaderParameter(WebGLShader& shader, GCGL
     case GraphicsContextGL::DELETE_STATUS:
         return shader.isDeleted();
     case GraphicsContextGL::COMPILE_STATUS:
-        return static_cast<bool>(protectedGraphicsContextGL()->getShaderi(shader.object(), pname));
+        return static_cast<bool>(graphicsContextGL()->getShaderi(shader.object(), pname));
     case GraphicsContextGL::SHADER_TYPE:
-        return static_cast<unsigned>(protectedGraphicsContextGL()->getShaderi(shader.object(), pname));
+        return static_cast<unsigned>(graphicsContextGL()->getShaderi(shader.object(), pname));
     case GraphicsContextGL::COMPLETION_STATUS_KHR:
         if (m_khrParallelShaderCompile)
-            return static_cast<bool>(protectedGraphicsContextGL()->getShaderi(shader.object(), pname));
+            return static_cast<bool>(graphicsContextGL()->getShaderi(shader.object(), pname));
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getShaderParameter"_s, "KHR_parallel_shader_compile not enabled"_s);
         return nullptr;
     default:
@@ -2309,7 +2309,7 @@ String WebGLRenderingContextBase::getShaderInfoLog(WebGLShader& shader)
         return { };
     if (!validateWebGLObject("getShaderInfoLog"_s, shader))
         return { };
-    return ensureNotNull(protectedGraphicsContextGL()->getShaderInfoLog(shader.object()));
+    return ensureNotNull(graphicsContextGL()->getShaderInfoLog(shader.object()));
 }
 
 RefPtr<WebGLShaderPrecisionFormat> WebGLRenderingContextBase::getShaderPrecisionFormat(GCGLenum shaderType, GCGLenum precisionType)
@@ -2339,7 +2339,7 @@ RefPtr<WebGLShaderPrecisionFormat> WebGLRenderingContextBase::getShaderPrecision
 
     std::array<GCGLint, 2> range = { };
     GCGLint precision = 0;
-    protectedGraphicsContextGL()->getShaderPrecisionFormat(shaderType, precisionType, range, &precision);
+    graphicsContextGL()->getShaderPrecisionFormat(shaderType, precisionType, range, &precision);
     return WebGLShaderPrecisionFormat::create(range[0], range[1], precision);
 }
 
@@ -2365,10 +2365,10 @@ WebGLAny WebGLRenderingContextBase::getTexParameter(GCGLenum target, GCGLenum pn
     case GraphicsContextGL::TEXTURE_MIN_FILTER:
     case GraphicsContextGL::TEXTURE_WRAP_S:
     case GraphicsContextGL::TEXTURE_WRAP_T:
-        return static_cast<unsigned>(protectedGraphicsContextGL()->getTexParameteri(target, pname));
+        return static_cast<unsigned>(graphicsContextGL()->getTexParameteri(target, pname));
     case GraphicsContextGL::TEXTURE_MAX_ANISOTROPY_EXT: // EXT_texture_filter_anisotropic
         if (m_extTextureFilterAnisotropic)
-            return protectedGraphicsContextGL()->getTexParameterf(target, pname);
+            return graphicsContextGL()->getTexParameterf(target, pname);
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getTexParameter"_s, "invalid parameter name, EXT_texture_filter_anisotropic not enabled"_s);
         return nullptr;
     default:
@@ -2545,7 +2545,7 @@ WebGLAny WebGLRenderingContextBase::getUniform(WebGLProgram& program, WebGLUnifo
     case GraphicsContextGL::FLOAT: {
         std::array<GCGLfloat, 16> value = { };
         auto valueSpan = std::span { value }.first(length);
-        protectedGraphicsContextGL()->getUniformfv(program.object(), location, valueSpan);
+        graphicsContextGL()->getUniformfv(program.object(), location, valueSpan);
         if (length == 1)
             return value[0];
         return Float32Array::tryCreate(valueSpan);
@@ -2553,7 +2553,7 @@ WebGLAny WebGLRenderingContextBase::getUniform(WebGLProgram& program, WebGLUnifo
     case GraphicsContextGL::INT: {
         std::array<GCGLint, 4> value = { };
         auto valueSpan = std::span { value }.first(length);
-        protectedGraphicsContextGL()->getUniformiv(program.object(), location, valueSpan);
+        graphicsContextGL()->getUniformiv(program.object(), location, valueSpan);
         if (length == 1)
             return value[0];
         return Int32Array::tryCreate(valueSpan);
@@ -2561,7 +2561,7 @@ WebGLAny WebGLRenderingContextBase::getUniform(WebGLProgram& program, WebGLUnifo
     case GraphicsContextGL::UNSIGNED_INT: {
         std::array<GCGLuint, 4> value = { };
         auto valueSpan = std::span { value }.first(length);
-        protectedGraphicsContextGL()->getUniformuiv(program.object(), location, valueSpan);
+        graphicsContextGL()->getUniformuiv(program.object(), location, valueSpan);
         if (length == 1)
             return value[0];
         return Uint32Array::tryCreate(valueSpan);
@@ -2569,7 +2569,7 @@ WebGLAny WebGLRenderingContextBase::getUniform(WebGLProgram& program, WebGLUnifo
     case GraphicsContextGL::BOOL: {
         std::array<GCGLint, 4> value = { };
         auto valueSpan = std::span { value }.first(length);
-        protectedGraphicsContextGL()->getUniformiv(program.object(), location, valueSpan);
+        graphicsContextGL()->getUniformiv(program.object(), location, valueSpan);
         if (length > 1)
             return WTF::map(valueSpan, [](auto& integer) { return !!integer; });
         return !!value[0];
@@ -2659,7 +2659,7 @@ long long WebGLRenderingContextBase::getVertexAttribOffset(GCGLuint index, GCGLe
 {
     if (isContextLost())
         return 0;
-    return protectedGraphicsContextGL()->getVertexAttribOffset(index, pname);
+    return graphicsContextGL()->getVertexAttribOffset(index, pname);
 }
 
 // This function is used by InspectorCanvasAgent to list currently enabled extensions
@@ -2731,7 +2731,7 @@ void WebGLRenderingContextBase::hint(GCGLenum target, GCGLenum mode)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->hint(target, mode);
+    graphicsContextGL()->hint(target, mode);
 }
 
 GCGLboolean WebGLRenderingContextBase::isBuffer(WebGLBuffer* buffer)
@@ -2740,7 +2740,7 @@ GCGLboolean WebGLRenderingContextBase::isBuffer(WebGLBuffer* buffer)
         return false;
     if (!validateIsWebGLObject(buffer))
         return false;
-    return protectedGraphicsContextGL()->isBuffer(buffer->object());
+    return graphicsContextGL()->isBuffer(buffer->object());
 }
 
 bool WebGLRenderingContextBase::isContextLost() const
@@ -2752,7 +2752,7 @@ GCGLboolean WebGLRenderingContextBase::isEnabled(GCGLenum cap)
 {
     if (isContextLost() || !validateCapability("isEnabled"_s, cap))
         return 0;
-    return protectedGraphicsContextGL()->isEnabled(cap);
+    return graphicsContextGL()->isEnabled(cap);
 }
 
 GCGLboolean WebGLRenderingContextBase::isFramebuffer(WebGLFramebuffer* framebuffer)
@@ -2761,7 +2761,7 @@ GCGLboolean WebGLRenderingContextBase::isFramebuffer(WebGLFramebuffer* framebuff
         return false;
     if (!validateIsWebGLObject(framebuffer))
         return false;
-    return protectedGraphicsContextGL()->isFramebuffer(framebuffer->object());
+    return graphicsContextGL()->isFramebuffer(framebuffer->object());
 }
 
 GCGLboolean WebGLRenderingContextBase::isProgram(WebGLProgram* program)
@@ -2770,7 +2770,7 @@ GCGLboolean WebGLRenderingContextBase::isProgram(WebGLProgram* program)
         return false;
     if (!validateIsWebGLObject(program))
         return false;
-    return protectedGraphicsContextGL()->isProgram(program->object());
+    return graphicsContextGL()->isProgram(program->object());
 }
 
 GCGLboolean WebGLRenderingContextBase::isRenderbuffer(WebGLRenderbuffer* renderbuffer)
@@ -2779,7 +2779,7 @@ GCGLboolean WebGLRenderingContextBase::isRenderbuffer(WebGLRenderbuffer* renderb
         return false;
     if (!validateIsWebGLObject(renderbuffer))
         return false;
-    return protectedGraphicsContextGL()->isRenderbuffer(renderbuffer->object());
+    return graphicsContextGL()->isRenderbuffer(renderbuffer->object());
 }
 
 GCGLboolean WebGLRenderingContextBase::isShader(WebGLShader* shader)
@@ -2788,7 +2788,7 @@ GCGLboolean WebGLRenderingContextBase::isShader(WebGLShader* shader)
         return 0;
     if (!validateIsWebGLObject(shader))
         return false;
-    return protectedGraphicsContextGL()->isShader(shader->object());
+    return graphicsContextGL()->isShader(shader->object());
 }
 
 GCGLboolean WebGLRenderingContextBase::isTexture(WebGLTexture* texture)
@@ -2797,14 +2797,14 @@ GCGLboolean WebGLRenderingContextBase::isTexture(WebGLTexture* texture)
         return false;
     if (!validateIsWebGLObject(texture))
         return false;
-    return protectedGraphicsContextGL()->isTexture(texture->object());
+    return graphicsContextGL()->isTexture(texture->object());
 }
 
 void WebGLRenderingContextBase::lineWidth(GCGLfloat width)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->lineWidth(width);
+    graphicsContextGL()->lineWidth(width);
 }
 
 void WebGLRenderingContextBase::linkProgram(WebGLProgram& program)
@@ -2821,7 +2821,7 @@ bool WebGLRenderingContextBase::linkProgramWithoutInvalidatingAttribLocations(We
         return false;
     if (!validateWebGLObject("linkProgram"_s, program))
         return false;
-    protectedGraphicsContextGL()->linkProgram(program.object());
+    graphicsContextGL()->linkProgram(program.object());
     return true;
 }
 
@@ -2915,7 +2915,7 @@ void WebGLRenderingContextBase::pixelStorei(GCGLenum pname, GCGLint param)
                 // PACK parameters are client only, not sent to the m_context.
             } else {
                 m_unpackParameters.alignment = param;
-                protectedGraphicsContextGL()->pixelStorei(pname, param);
+                graphicsContextGL()->pixelStorei(pname, param);
             }
         } else {
             synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "pixelStorei"_s, "invalid parameter for alignment"_s);
@@ -2932,7 +2932,7 @@ void WebGLRenderingContextBase::polygonOffset(GCGLfloat factor, GCGLfloat units)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->polygonOffset(factor, units);
+    graphicsContextGL()->polygonOffset(factor, units);
 }
 
 void WebGLRenderingContextBase::readPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&& maybePixels)
@@ -2973,7 +2973,7 @@ void WebGLRenderingContextBase::readPixels(GCGLint x, GCGLint y, GCGLsizei width
     clearIfComposited(CallerTypeOther);
     auto data = pixels.mutableSpan().subspan(packSizes->initialSkipBytes, packSizes->imageBytes);
     const bool packReverseRowOrder = false;
-    protectedGraphicsContextGL()->readPixels(rect, format, type, data, m_packParameters.alignment, m_packParameters.rowLength, packReverseRowOrder);
+    graphicsContextGL()->readPixels(rect, format, type, data, m_packParameters.alignment, m_packParameters.rowLength, packReverseRowOrder);
 }
 
 void WebGLRenderingContextBase::renderbufferStorage(GCGLenum target, GCGLenum internalformat, GCGLsizei width, GCGLsizei height)
@@ -3026,14 +3026,14 @@ void WebGLRenderingContextBase::renderbufferStorageImpl(GCGLenum target, GCGLsiz
             synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "WEBGL_color_buffer_float not enabled"_s);
             return;
         }
-        protectedGraphicsContextGL()->renderbufferStorage(target, internalformat, width, height);
+        graphicsContextGL()->renderbufferStorage(target, internalformat, width, height);
         m_renderbufferBinding->setInternalFormat(internalformat);
         m_renderbufferBinding->setIsValid(true);
         m_renderbufferBinding->setSize(width, height);
         break;
     case GraphicsContextGL::DEPTH_STENCIL:
         if (isDepthStencilSupported())
-            protectedGraphicsContextGL()->renderbufferStorage(target, GraphicsContextGL::DEPTH24_STENCIL8, width, height);
+            graphicsContextGL()->renderbufferStorage(target, GraphicsContextGL::DEPTH24_STENCIL8, width, height);
         m_renderbufferBinding->setSize(width, height);
         m_renderbufferBinding->setIsValid(isDepthStencilSupported());
         m_renderbufferBinding->setInternalFormat(internalformat);
@@ -3048,7 +3048,7 @@ void WebGLRenderingContextBase::sampleCoverage(GCGLfloat value, GCGLboolean inve
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->sampleCoverage(value, invert);
+    graphicsContextGL()->sampleCoverage(value, invert);
 }
 
 void WebGLRenderingContextBase::scissor(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height)
@@ -3057,7 +3057,7 @@ void WebGLRenderingContextBase::scissor(GCGLint x, GCGLint y, GCGLsizei width, G
         return;
     if (!validateSize("scissor"_s, width, height))
         return;
-    protectedGraphicsContextGL()->scissor(x, y, width, height);
+    graphicsContextGL()->scissor(x, y, width, height);
 }
 
 void WebGLRenderingContextBase::shaderSource(WebGLShader& shader, const String& string)
@@ -3066,7 +3066,7 @@ void WebGLRenderingContextBase::shaderSource(WebGLShader& shader, const String& 
         return;
     if (!validateWebGLObject("shaderSource"_s, shader))
         return;
-    protectedGraphicsContextGL()->shaderSource(shader.object(), string.utf8());
+    graphicsContextGL()->shaderSource(shader.object(), string.utf8());
     shader.setSource(string);
 }
 
@@ -3074,14 +3074,14 @@ void WebGLRenderingContextBase::stencilFunc(GCGLenum func, GCGLint ref, GCGLuint
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->stencilFunc(func, ref, mask);
+    graphicsContextGL()->stencilFunc(func, ref, mask);
 }
 
 void WebGLRenderingContextBase::stencilFuncSeparate(GCGLenum face, GCGLenum func, GCGLint ref, GCGLuint mask)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->stencilFuncSeparate(face, func, ref, mask);
+    graphicsContextGL()->stencilFuncSeparate(face, func, ref, mask);
 }
 
 void WebGLRenderingContextBase::stencilMask(GCGLuint mask)
@@ -3089,7 +3089,7 @@ void WebGLRenderingContextBase::stencilMask(GCGLuint mask)
     if (isContextLost())
         return;
     m_stencilMask = mask;
-    protectedGraphicsContextGL()->stencilMask(mask);
+    graphicsContextGL()->stencilMask(mask);
 }
 
 void WebGLRenderingContextBase::stencilMaskSeparate(GCGLenum face, GCGLuint mask)
@@ -3098,21 +3098,21 @@ void WebGLRenderingContextBase::stencilMaskSeparate(GCGLenum face, GCGLuint mask
         return;
     if (face == GraphicsContextGL::FRONT_AND_BACK || face == GraphicsContextGL::FRONT)
         m_stencilMask = mask;
-    protectedGraphicsContextGL()->stencilMaskSeparate(face, mask);
+    graphicsContextGL()->stencilMaskSeparate(face, mask);
 }
 
 void WebGLRenderingContextBase::stencilOp(GCGLenum fail, GCGLenum zfail, GCGLenum zpass)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->stencilOp(fail, zfail, zpass);
+    graphicsContextGL()->stencilOp(fail, zfail, zpass);
 }
 
 void WebGLRenderingContextBase::stencilOpSeparate(GCGLenum face, GCGLenum fail, GCGLenum zfail, GCGLenum zpass)
 {
     if (isContextLost())
         return;
-    protectedGraphicsContextGL()->stencilOpSeparate(face, fail, zfail, zpass);
+    graphicsContextGL()->stencilOpSeparate(face, fail, zfail, zpass);
 }
 
 IntRect WebGLRenderingContextBase::sentinelEmptyRect()
@@ -3347,7 +3347,7 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSource(TexImageFunctionID f
         && !level) {
         if (RefPtr player = source.player()) {
             if (RefPtr videoFrame = player->videoFrameForCurrentTime()) {
-                if (protectedGraphicsContextGL()->copyTextureFromVideoFrame(*videoFrame, texture->object(), target, level, internalformat, format, type, m_unpackPremultiplyAlpha, m_unpackFlipY))
+                if (graphicsContextGL()->copyTextureFromVideoFrame(*videoFrame, texture->object(), target, level, internalformat, format, type, m_unpackPremultiplyAlpha, m_unpackFlipY))
                 return { };
             }
         }
@@ -3559,14 +3559,14 @@ void WebGLRenderingContextBase::texImageImpl(TexImageFunctionID functionID, GCGL
 
 void WebGLRenderingContextBase::texImage2DBase(GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, std::span<const uint8_t> pixels)
 {
-    protectedGraphicsContextGL()->texImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
+    graphicsContextGL()->texImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
 }
 
 void WebGLRenderingContextBase::texSubImage2DBase(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum internalFormat, GCGLenum format, GCGLenum type, std::span<const uint8_t> pixels)
 {
     ASSERT(!isContextLost());
     UNUSED_PARAM(internalFormat);
-    protectedGraphicsContextGL()->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
+    graphicsContextGL()->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
 }
 
 ASCIILiteral WebGLRenderingContextBase::texImageFunctionName(TexImageFunctionID functionID)
@@ -4086,7 +4086,7 @@ void WebGLRenderingContextBase::copyTexImage2D(GCGLenum target, GCGLint level, G
     if (!tex)
         return;
     clearIfComposited(CallerTypeOther);
-    protectedGraphicsContextGL()->copyTexImage2D(target, level, internalFormat, x, y, width, height, border);
+    graphicsContextGL()->copyTexImage2D(target, level, internalFormat, x, y, width, height, border);
 }
 
 ExceptionOr<void> WebGLRenderingContextBase::texImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLenum format, GCGLenum type, std::optional<TexImageSource> source)
@@ -4239,9 +4239,9 @@ void WebGLRenderingContextBase::texParameter(GCGLenum target, GCGLenum pname, GC
         return;
     }
     if (isFloat)
-        protectedGraphicsContextGL()->texParameterf(target, pname, paramf);
+        graphicsContextGL()->texParameterf(target, pname, paramf);
     else
-        protectedGraphicsContextGL()->texParameteri(target, pname, parami);
+        graphicsContextGL()->texParameteri(target, pname, parami);
 }
 
 void WebGLRenderingContextBase::texParameterf(GCGLenum target, GCGLenum pname, GCGLfloat param)
@@ -4275,7 +4275,7 @@ void WebGLRenderingContextBase::uniform1f(const WebGLUniformLocation* location, 
     if (isContextLost() || !validateUniformLocation("uniform1f"_s, location))
         return;
 
-    protectedGraphicsContextGL()->uniform1f(location->location(), x);
+    graphicsContextGL()->uniform1f(location->location(), x);
 }
 
 void WebGLRenderingContextBase::uniform2f(const WebGLUniformLocation* location, GCGLfloat x, GCGLfloat y)
@@ -4283,7 +4283,7 @@ void WebGLRenderingContextBase::uniform2f(const WebGLUniformLocation* location, 
     if (isContextLost() || !validateUniformLocation("uniform2f"_s, location))
         return;
 
-    protectedGraphicsContextGL()->uniform2f(location->location(), x, y);
+    graphicsContextGL()->uniform2f(location->location(), x, y);
 }
 
 void WebGLRenderingContextBase::uniform3f(const WebGLUniformLocation* location, GCGLfloat x, GCGLfloat y, GCGLfloat z)
@@ -4291,7 +4291,7 @@ void WebGLRenderingContextBase::uniform3f(const WebGLUniformLocation* location, 
     if (isContextLost() || !validateUniformLocation("uniform3f"_s, location))
         return;
 
-    protectedGraphicsContextGL()->uniform3f(location->location(), x, y, z);
+    graphicsContextGL()->uniform3f(location->location(), x, y, z);
 }
 
 void WebGLRenderingContextBase::uniform4f(const WebGLUniformLocation* location, GCGLfloat x, GCGLfloat y, GCGLfloat z, GCGLfloat w)
@@ -4299,14 +4299,14 @@ void WebGLRenderingContextBase::uniform4f(const WebGLUniformLocation* location, 
     if (isContextLost() || !validateUniformLocation("uniform4f"_s, location))
         return;
 
-    protectedGraphicsContextGL()->uniform4f(location->location(), x, y, z, w);
+    graphicsContextGL()->uniform4f(location->location(), x, y, z, w);
 }
 
 void WebGLRenderingContextBase::uniform1i(const WebGLUniformLocation* location, GCGLint x)
 {
     if (isContextLost() || !validateUniformLocation("uniform1i"_s, location))
         return;
-    protectedGraphicsContextGL()->uniform1i(location->location(), x);
+    graphicsContextGL()->uniform1i(location->location(), x);
 }
 
 void WebGLRenderingContextBase::uniform2i(const WebGLUniformLocation* location, GCGLint x, GCGLint y)
@@ -4314,7 +4314,7 @@ void WebGLRenderingContextBase::uniform2i(const WebGLUniformLocation* location, 
     if (isContextLost() || !validateUniformLocation("uniform2i"_s, location))
         return;
 
-    protectedGraphicsContextGL()->uniform2i(location->location(), x, y);
+    graphicsContextGL()->uniform2i(location->location(), x, y);
 }
 
 void WebGLRenderingContextBase::uniform3i(const WebGLUniformLocation* location, GCGLint x, GCGLint y, GCGLint z)
@@ -4322,7 +4322,7 @@ void WebGLRenderingContextBase::uniform3i(const WebGLUniformLocation* location, 
     if (isContextLost() || !validateUniformLocation("uniform3i"_s, location))
         return;
 
-    protectedGraphicsContextGL()->uniform3i(location->location(), x, y, z);
+    graphicsContextGL()->uniform3i(location->location(), x, y, z);
 }
 
 void WebGLRenderingContextBase::uniform4i(const WebGLUniformLocation* location, GCGLint x, GCGLint y, GCGLint z, GCGLint w)
@@ -4330,7 +4330,7 @@ void WebGLRenderingContextBase::uniform4i(const WebGLUniformLocation* location, 
     if (isContextLost() || !validateUniformLocation("uniform4i"_s, location))
         return;
 
-    protectedGraphicsContextGL()->uniform4i(location->location(), x, y, z, w);
+    graphicsContextGL()->uniform4i(location->location(), x, y, z, w);
 }
 
 void WebGLRenderingContextBase::uniform1fv(const WebGLUniformLocation* location, Float32List&& v)
@@ -4340,7 +4340,7 @@ void WebGLRenderingContextBase::uniform1fv(const WebGLUniformLocation* location,
     auto data = validateUniformParameters("uniform1fv"_s, location, v, 1);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniform1fv(location->location(), data.value());
+    graphicsContextGL()->uniform1fv(location->location(), data.value());
 }
 
 void WebGLRenderingContextBase::uniform2fv(const WebGLUniformLocation* location, Float32List&& v)
@@ -4350,7 +4350,7 @@ void WebGLRenderingContextBase::uniform2fv(const WebGLUniformLocation* location,
     auto data = validateUniformParameters("uniform2fv"_s, location, v, 2);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniform2fv(location->location(), data.value());
+    graphicsContextGL()->uniform2fv(location->location(), data.value());
 }
 
 void WebGLRenderingContextBase::uniform3fv(const WebGLUniformLocation* location, Float32List&& v)
@@ -4360,7 +4360,7 @@ void WebGLRenderingContextBase::uniform3fv(const WebGLUniformLocation* location,
     auto data = validateUniformParameters("uniform3fv"_s, location, v, 3);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniform3fv(location->location(), data.value());
+    graphicsContextGL()->uniform3fv(location->location(), data.value());
 }
 
 void WebGLRenderingContextBase::uniform4fv(const WebGLUniformLocation* location, Float32List&& v)
@@ -4370,7 +4370,7 @@ void WebGLRenderingContextBase::uniform4fv(const WebGLUniformLocation* location,
     auto data = validateUniformParameters("uniform4fv"_s, location, v, 4);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniform4fv(location->location(), data.value());
+    graphicsContextGL()->uniform4fv(location->location(), data.value());
 }
 
 void WebGLRenderingContextBase::uniform1iv(const WebGLUniformLocation* location, Int32List&& v)
@@ -4383,7 +4383,7 @@ void WebGLRenderingContextBase::uniform1iv(const WebGLUniformLocation* location,
 
     auto data = result.value();
 
-    protectedGraphicsContextGL()->uniform1iv(location->location(), data);
+    graphicsContextGL()->uniform1iv(location->location(), data);
 }
 
 void WebGLRenderingContextBase::uniform2iv(const WebGLUniformLocation* location, Int32List&& v)
@@ -4393,7 +4393,7 @@ void WebGLRenderingContextBase::uniform2iv(const WebGLUniformLocation* location,
     auto data = validateUniformParameters("uniform2iv"_s, location, v, 2);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniform2iv(location->location(), data.value());
+    graphicsContextGL()->uniform2iv(location->location(), data.value());
 }
 
 void WebGLRenderingContextBase::uniform3iv(const WebGLUniformLocation* location, Int32List&& v)
@@ -4403,7 +4403,7 @@ void WebGLRenderingContextBase::uniform3iv(const WebGLUniformLocation* location,
     auto data = validateUniformParameters("uniform3iv"_s, location, v, 3);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniform3iv(location->location(), data.value());
+    graphicsContextGL()->uniform3iv(location->location(), data.value());
 }
 
 void WebGLRenderingContextBase::uniform4iv(const WebGLUniformLocation* location, Int32List&& v)
@@ -4413,7 +4413,7 @@ void WebGLRenderingContextBase::uniform4iv(const WebGLUniformLocation* location,
     auto data = validateUniformParameters("uniform4iv"_s, location, v, 4);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniform4iv(location->location(), data.value());
+    graphicsContextGL()->uniform4iv(location->location(), data.value());
 }
 
 void WebGLRenderingContextBase::uniformMatrix2fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v)
@@ -4423,7 +4423,7 @@ void WebGLRenderingContextBase::uniformMatrix2fv(const WebGLUniformLocation* loc
     auto data = validateUniformMatrixParameters("uniformMatrix2fv"_s, location, transpose, v, 4);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniformMatrix2fv(location->location(), transpose, data.value());
+    graphicsContextGL()->uniformMatrix2fv(location->location(), transpose, data.value());
 }
 
 void WebGLRenderingContextBase::uniformMatrix3fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v)
@@ -4433,7 +4433,7 @@ void WebGLRenderingContextBase::uniformMatrix3fv(const WebGLUniformLocation* loc
     auto data = validateUniformMatrixParameters("uniformMatrix3fv"_s, location, transpose, v, 9);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniformMatrix3fv(location->location(), transpose, data.value());
+    graphicsContextGL()->uniformMatrix3fv(location->location(), transpose, data.value());
 }
 
 void WebGLRenderingContextBase::uniformMatrix4fv(const WebGLUniformLocation* location, GCGLboolean transpose, Float32List&& v)
@@ -4443,7 +4443,7 @@ void WebGLRenderingContextBase::uniformMatrix4fv(const WebGLUniformLocation* loc
     auto data = validateUniformMatrixParameters("uniformMatrix4fv"_s, location, transpose, v, 16);
     if (!data)
         return;
-    protectedGraphicsContextGL()->uniformMatrix4fv(location->location(), transpose, data.value());
+    graphicsContextGL()->uniformMatrix4fv(location->location(), transpose, data.value());
 }
 
 void WebGLRenderingContextBase::useProgram(WebGLProgram* program)
@@ -4469,9 +4469,9 @@ void WebGLRenderingContextBase::useProgram(WebGLProgram* program)
 
     if (m_currentProgram != program) {
         if (RefPtr currentProgram = m_currentProgram)
-            currentProgram->onDetached(locker, protectedGraphicsContextGL().get());
+            currentProgram->onDetached(locker, graphicsContextGL().get());
         m_currentProgram = program;
-        protectedGraphicsContextGL()->useProgram(objectOrZero(program));
+        graphicsContextGL()->useProgram(objectOrZero(program));
         if (program)
             program->onAttached();
     }
@@ -4483,7 +4483,7 @@ void WebGLRenderingContextBase::validateProgram(WebGLProgram& program)
         return;
     if (!validateWebGLObject("validateProgram"_s, program))
         return;
-    protectedGraphicsContextGL()->validateProgram(program.object());
+    graphicsContextGL()->validateProgram(program.object());
 }
 
 void WebGLRenderingContextBase::vertexAttrib1f(GCGLuint index, GCGLfloat v0)
@@ -4593,7 +4593,7 @@ void WebGLRenderingContextBase::vertexAttribPointer(GCGLuint index, GCGLint size
     }
     GCGLsizei bytesPerElement = size * typeSize;
     protectedBoundVertexArrayObject()->setVertexAttribState(locker, index, bytesPerElement, size, type, normalized, stride, static_cast<GCGLintptr>(offset), false, RefPtr { m_boundArrayBuffer.get() }.get());
-    protectedGraphicsContextGL()->vertexAttribPointer(index, size, type, normalized, stride, static_cast<GCGLintptr>(offset));
+    graphicsContextGL()->vertexAttribPointer(index, size, type, normalized, stride, static_cast<GCGLintptr>(offset));
 }
 
 void WebGLRenderingContextBase::viewport(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height)
@@ -4602,7 +4602,7 @@ void WebGLRenderingContextBase::viewport(GCGLint x, GCGLint y, GCGLsizei width, 
         return;
     if (!validateSize("viewport"_s, width, height))
         return;
-    protectedGraphicsContextGL()->viewport(x, y, width, height);
+    graphicsContextGL()->viewport(x, y, width, height);
 }
 
 void WebGLRenderingContextBase::forceLostContext(WebGLRenderingContextBase::LostContextMode mode)
@@ -4620,7 +4620,7 @@ void WebGLRenderingContextBase::forceLostContext(WebGLRenderingContextBase::Lost
     detachAndRemoveAllObjects();
     loseExtensions(mode);
 
-    protectedGraphicsContextGL()->getErrors();
+    graphicsContextGL()->getErrors();
 
     // Always defer the dispatch of the context lost event, to implement
     // the spec behavior of queueing a task.
@@ -4651,7 +4651,7 @@ RefPtr<GraphicsLayerContentsDisplayDelegate> WebGLRenderingContextBase::layerCon
 {
     if (isContextLost())
         return nullptr;
-    return protectedGraphicsContextGL()->layerContentsDisplayDelegate();
+    return graphicsContextGL()->layerContentsDisplayDelegate();
 }
 
 WeakPtr<WebGLRenderingContextBase> WebGLRenderingContextBase::createRefForContextObject()
@@ -4685,7 +4685,7 @@ void WebGLRenderingContextBase::resume()
 
 bool WebGLRenderingContextBase::getBooleanParameter(GCGLenum pname)
 {
-    return protectedGraphicsContextGL()->getBoolean(pname);
+    return graphicsContextGL()->getBoolean(pname);
 }
 
 Vector<bool> WebGLRenderingContextBase::getBooleanArrayParameter(GCGLenum pname)
@@ -4695,29 +4695,29 @@ Vector<bool> WebGLRenderingContextBase::getBooleanArrayParameter(GCGLenum pname)
         return { };
     }
     std::array<GCGLboolean, 4> value = { };
-    protectedGraphicsContextGL()->getBooleanv(pname, value);
+    graphicsContextGL()->getBooleanv(pname, value);
     return WTF::map(value, [](auto& boolean) -> bool { return boolean; });
 }
 
 float WebGLRenderingContextBase::getFloatParameter(GCGLenum pname)
 {
-    return protectedGraphicsContextGL()->getFloat(pname);
+    return graphicsContextGL()->getFloat(pname);
 }
 
 int WebGLRenderingContextBase::getIntParameter(GCGLenum pname)
 {
-    return protectedGraphicsContextGL()->getInteger(pname);
+    return graphicsContextGL()->getInteger(pname);
 }
 
 unsigned WebGLRenderingContextBase::getUnsignedIntParameter(GCGLenum pname)
 {
-    return protectedGraphicsContextGL()->getInteger(pname);
+    return graphicsContextGL()->getInteger(pname);
 }
 
 RefPtr<Float32Array> WebGLRenderingContextBase::getWebGLFloatArrayParameter(GCGLenum pname)
 {
     GCGLfloat value[4] = {0};
-    protectedGraphicsContextGL()->getFloatv(pname, value);
+    graphicsContextGL()->getFloatv(pname, value);
     unsigned length = 0;
     switch (pname) {
     case GraphicsContextGL::ALIASED_POINT_SIZE_RANGE:
@@ -4747,7 +4747,7 @@ RefPtr<Int32Array> WebGLRenderingContextBase::getWebGLIntArrayParameter(GCGLenum
         notImplemented();
     }
     GCGLint value[4] { };
-    protectedGraphicsContextGL()->getIntegerv(pname, value);
+    graphicsContextGL()->getIntegerv(pname, value);
     return Int32Array::tryCreate(value, 4);
 }
 
@@ -5114,16 +5114,16 @@ void WebGLRenderingContextBase::vertexAttribfImpl(ASCIILiteral functionName, GCG
     }
     switch (expectedSize) {
     case 1:
-        protectedGraphicsContextGL()->vertexAttrib1f(index, v0);
+        graphicsContextGL()->vertexAttrib1f(index, v0);
         break;
     case 2:
-        protectedGraphicsContextGL()->vertexAttrib2f(index, v0, v1);
+        graphicsContextGL()->vertexAttrib2f(index, v0, v1);
         break;
     case 3:
-        protectedGraphicsContextGL()->vertexAttrib3f(index, v0, v1, v2);
+        graphicsContextGL()->vertexAttrib3f(index, v0, v1, v2);
         break;
     case 4:
-        protectedGraphicsContextGL()->vertexAttrib4f(index, v0, v1, v2, v3);
+        graphicsContextGL()->vertexAttrib4f(index, v0, v1, v2, v3);
         break;
     }
     VertexAttribValue& attribValue = m_vertexAttribValue[index];
@@ -5156,16 +5156,16 @@ void WebGLRenderingContextBase::vertexAttribfvImpl(ASCIILiteral functionName, GC
     }
     switch (expectedSize) {
     case 1:
-        protectedGraphicsContextGL()->vertexAttrib1fv(index, data.first<1>());
+        graphicsContextGL()->vertexAttrib1fv(index, data.first<1>());
         break;
     case 2:
-        protectedGraphicsContextGL()->vertexAttrib2fv(index, data.first<2>());
+        graphicsContextGL()->vertexAttrib2fv(index, data.first<2>());
         break;
     case 3:
-        protectedGraphicsContextGL()->vertexAttrib3fv(index, data.first<3>());
+        graphicsContextGL()->vertexAttrib3fv(index, data.first<3>());
         break;
     case 4:
-        protectedGraphicsContextGL()->vertexAttrib4fv(index, data.first<4>());
+        graphicsContextGL()->vertexAttrib4fv(index, data.first<4>());
         break;
     }
     VertexAttribValue& attribValue = m_vertexAttribValue[index];
@@ -5338,7 +5338,7 @@ GCGLint WebGLRenderingContextBase::maxColorAttachments()
     if (!supportsDrawBuffers())
         return 0;
     if (!m_maxColorAttachments)
-        m_maxColorAttachments = protectedGraphicsContextGL()->getInteger(GraphicsContextGL::MAX_COLOR_ATTACHMENTS_EXT);
+        m_maxColorAttachments = graphicsContextGL()->getInteger(GraphicsContextGL::MAX_COLOR_ATTACHMENTS_EXT);
     return m_maxColorAttachments;
 }
 
@@ -5353,7 +5353,7 @@ void WebGLRenderingContextBase::setFramebuffer(const AbstractLocker&, GCGLenum t
     if (target == GraphicsContextGL::FRAMEBUFFER || target == GraphicsContextGL::DRAW_FRAMEBUFFER)
         m_framebufferBinding = buffer;
     auto fbo = buffer ? buffer->object() : m_defaultFramebuffer->object();
-    protectedGraphicsContextGL()->bindFramebuffer(target, fbo);
+    graphicsContextGL()->bindFramebuffer(target, fbo);
 }
 
 bool WebGLRenderingContextBase::supportsDrawBuffers()
@@ -5380,7 +5380,7 @@ void WebGLRenderingContextBase::drawArraysInstanced(GCGLenum mode, GCGLint first
 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
-        protectedGraphicsContextGL()->drawArraysInstanced(mode, first, count, primcount);
+        graphicsContextGL()->drawArraysInstanced(mode, first, count, primcount);
     }
 
     markContextChangedAndNotifyCanvasObserver();
@@ -5401,7 +5401,7 @@ void WebGLRenderingContextBase::drawElementsInstanced(GCGLenum mode, GCGLsizei c
 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
-        protectedGraphicsContextGL()->drawElementsInstanced(mode, count, type, static_cast<GCGLintptr>(offset), primcount);
+        graphicsContextGL()->drawElementsInstanced(mode, count, type, static_cast<GCGLintptr>(offset), primcount);
     }
 
     markContextChangedAndNotifyCanvasObserver();
@@ -5418,7 +5418,7 @@ void WebGLRenderingContextBase::vertexAttribDivisor(GCGLuint index, GCGLuint div
     }
 
     protectedBoundVertexArrayObject()->setVertexAttribDivisor(index, divisor);
-    protectedGraphicsContextGL()->vertexAttribDivisor(index, divisor);
+    graphicsContextGL()->vertexAttribDivisor(index, divisor);
 }
 
 template<typename T> void loseExtension(RefPtr<T> extension)
@@ -5615,7 +5615,7 @@ void WebGLRenderingContextBase::prepareForDisplay()
         return;
 
     clearIfComposited(CallerTypeOther);
-    protectedGraphicsContextGL()->prepareForDisplay();
+    graphicsContextGL()->prepareForDisplay();
     m_defaultFramebuffer->markAllUnpreservedBuffersDirty();
 
     m_compositingResultsNeedUpdating = false;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -425,8 +425,7 @@ public:
     using SimulatedEventForTesting = GraphicsContextGL::SimulatedEventForTesting;
     WEBCORE_EXPORT void simulateEventForTesting(SimulatedEventForTesting);
 
-    GraphicsContextGL* graphicsContextGL() const { return m_context.get(); }
-    RefPtr<GraphicsContextGL> protectedGraphicsContextGL() const { return m_context; }
+    RefPtr<GraphicsContextGL> graphicsContextGL() const { return m_context; }
 
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
 

--- a/Source/WebCore/html/canvas/WebGLSampler.cpp
+++ b/Source/WebCore/html/canvas/WebGLSampler.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 RefPtr<WebGLSampler> WebGLSampler::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.protectedGraphicsContextGL()->createSampler();
+    auto object = context.graphicsContextGL()->createSampler();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLSampler { context, object });

--- a/Source/WebCore/html/canvas/WebGLShader.cpp
+++ b/Source/WebCore/html/canvas/WebGLShader.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 RefPtr<WebGLShader> WebGLShader::create(WebGLRenderingContextBase& context, GCGLenum type)
 {
-    auto object = context.protectedGraphicsContextGL()->createShader(type);
+    auto object = context.graphicsContextGL()->createShader(type);
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLShader(context, object, type));

--- a/Source/WebCore/html/canvas/WebGLStencilTexturing.cpp
+++ b/Source/WebCore/html/canvas/WebGLStencilTexturing.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLStencilTexturing);
 WebGLStencilTexturing::WebGLStencilTexturing(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLStencilTexturing)
 {
-    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_stencil_texturing"_s);
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_stencil_texturing"_s);
 }
 
 WebGLStencilTexturing::~WebGLStencilTexturing() = default;

--- a/Source/WebCore/html/canvas/WebGLSync.cpp
+++ b/Source/WebCore/html/canvas/WebGLSync.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 RefPtr<WebGLSync> WebGLSync::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.protectedGraphicsContextGL()->fenceSync(GraphicsContextGL::SYNC_GPU_COMMANDS_COMPLETE, 0);
+    auto object = context.graphicsContextGL()->fenceSync(GraphicsContextGL::SYNC_GPU_COMMANDS_COMPLETE, 0);
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLSync { context, object });
@@ -69,7 +69,7 @@ void WebGLSync::updateCache(WebGLRenderingContextBase& context)
         return;
 
     m_allowCacheUpdate = false;
-    m_syncStatus = context.protectedGraphicsContextGL()->getSynci(m_sync, GraphicsContextGL::SYNC_STATUS);
+    m_syncStatus = context.graphicsContextGL()->getSynci(m_sync, GraphicsContextGL::SYNC_STATUS);
     if (m_syncStatus == GraphicsContextGL::UNSIGNALED)
         scheduleAllowCacheUpdate(context);
 }

--- a/Source/WebCore/html/canvas/WebGLTexture.cpp
+++ b/Source/WebCore/html/canvas/WebGLTexture.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 RefPtr<WebGLTexture> WebGLTexture::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.protectedGraphicsContextGL()->createTexture();
+    auto object = context.graphicsContextGL()->createTexture();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLTexture { context, object });

--- a/Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp
+++ b/Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 
 RefPtr<WebGLTimerQueryEXT> WebGLTimerQueryEXT::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.protectedGraphicsContextGL()->createQueryEXT();
+    auto object = context.graphicsContextGL()->createQueryEXT();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLTimerQueryEXT { context, object });

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 
 RefPtr<WebGLTransformFeedback> WebGLTransformFeedback::create(WebGL2RenderingContext& context)
 {
-    auto object = context.protectedGraphicsContextGL()->createTransformFeedback();
+    auto object = context.graphicsContextGL()->createTransformFeedback();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLTransformFeedback { context, object });

--- a/Source/WebCore/html/canvas/WebGLUtilities.h
+++ b/Source/WebCore/html/canvas/WebGLUtilities.h
@@ -114,14 +114,14 @@ public:
     {
         if (!m_context)
             return;
-        context.protectedGraphicsContextGL()->disable(GraphicsContextGL::RASTERIZER_DISCARD);
+        context.graphicsContextGL()->disable(GraphicsContextGL::RASTERIZER_DISCARD);
     }
 
     ~ScopedDisableRasterizerDiscard()
     {
         if (!m_context)
             return;
-        m_context->protectedGraphicsContextGL()->enable(GraphicsContextGL::RASTERIZER_DISCARD);
+        m_context->graphicsContextGL()->enable(GraphicsContextGL::RASTERIZER_DISCARD);
     }
 
 private:
@@ -138,9 +138,9 @@ public:
             return;
         GCGLenum value[1] { GraphicsContextGL::COLOR_ATTACHMENT0 };
         if (context.isWebGL2())
-            context.protectedGraphicsContextGL()->drawBuffers(value);
+            context.graphicsContextGL()->drawBuffers(value);
         else
-            context.protectedGraphicsContextGL()->drawBuffersEXT(value);
+            context.graphicsContextGL()->drawBuffersEXT(value);
     }
 
     ~ScopedEnableBackbuffer()
@@ -149,9 +149,9 @@ public:
             return;
         GCGLenum value[1] { GraphicsContextGL::NONE };
         if (m_context->isWebGL2())
-            m_context->protectedGraphicsContextGL()->drawBuffers(value);
+            m_context->graphicsContextGL()->drawBuffers(value);
         else
-            m_context->protectedGraphicsContextGL()->drawBuffersEXT(value);
+            m_context->graphicsContextGL()->drawBuffersEXT(value);
     }
 
 private:
@@ -166,14 +166,14 @@ public:
     {
         if (!m_context)
             return;
-        context.protectedGraphicsContextGL()->disable(GraphicsContextGL::SCISSOR_TEST);
+        context.graphicsContextGL()->disable(GraphicsContextGL::SCISSOR_TEST);
     }
 
     ~ScopedDisableScissorTest()
     {
         if (!m_context)
             return;
-        m_context->protectedGraphicsContextGL()->enable(GraphicsContextGL::SCISSOR_TEST);
+        m_context->graphicsContextGL()->enable(GraphicsContextGL::SCISSOR_TEST);
     }
 
 private:

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObject.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObject.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
     
 RefPtr<WebGLVertexArrayObject> WebGLVertexArrayObject::create(WebGLRenderingContextBase& context, Type type)
 {
-    auto object = context.protectedGraphicsContextGL()->createVertexArray();
+    auto object = context.graphicsContextGL()->createVertexArray();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLVertexArrayObject { context, object, type });

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
@@ -47,7 +47,7 @@ void WebGLVertexArrayObjectBase::setElementArrayBuffer(const AbstractLocker& loc
     if (buffer)
         buffer->onAttached();
     if (RefPtr boundElementArrayBuffer = m_boundElementArrayBuffer.get())
-        boundElementArrayBuffer->onDetached(locker, context()->protectedGraphicsContextGL().get());
+        boundElementArrayBuffer->onDetached(locker, graphicsContextGL().get());
     m_boundElementArrayBuffer = buffer;
     
 }
@@ -70,7 +70,7 @@ void WebGLVertexArrayObjectBase::setVertexAttribState(const AbstractLocker& lock
     if (buffer)
         buffer->onAttached();
     if (RefPtr bufferBinding = state.bufferBinding.get())
-        bufferBinding->onDetached(locker, context()->protectedGraphicsContextGL().get());
+        bufferBinding->onDetached(locker, graphicsContextGL().get());
     state.bufferBinding = buffer;
     if (!state.validateBinding())
         m_allEnabledAttribBuffersBoundCache = false;
@@ -88,14 +88,15 @@ void WebGLVertexArrayObjectBase::setVertexAttribState(const AbstractLocker& lock
 
 void WebGLVertexArrayObjectBase::unbindBuffer(const AbstractLocker& locker, WebGLBuffer& buffer)
 {
+    RefPtr gl = graphicsContextGL();
     if (RefPtr boundElementArrayBuffer = m_boundElementArrayBuffer.get(); boundElementArrayBuffer == &buffer) {
-        boundElementArrayBuffer->onDetached(locker, context()->protectedGraphicsContextGL().get());
+        boundElementArrayBuffer->onDetached(locker, gl.get());
         m_boundElementArrayBuffer = nullptr;
     }
     
     for (auto& state : m_vertexAttribState) {
         if (state.bufferBinding == &buffer) {
-            buffer.onDetached(locker, context()->protectedGraphicsContextGL().get());
+            buffer.onDetached(locker, gl.get());
             state.bufferBinding = nullptr;
             if (!state.validateBinding())
                 m_allEnabledAttribBuffersBoundCache = false;

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.cpp
@@ -40,7 +40,7 @@ Ref<WebGLVertexArrayObjectOES> WebGLVertexArrayObjectOES::createDefault(WebGLRen
 
 RefPtr<WebGLVertexArrayObjectOES> WebGLVertexArrayObjectOES::createUser(WebGLRenderingContextBase& context)
 {
-    auto object = context.protectedGraphicsContextGL()->createVertexArray();
+    auto object = context.graphicsContextGL()->createVertexArray();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLVertexArrayObjectOES { context, object, Type::User });


### PR DESCRIPTION
#### 4a6502e0590c6221736e35c3a743d8e41a841225
<pre>
SaferCPP: Simplify WebGL GraphicsCotentextGL accessors
<a href="https://bugs.webkit.org/show_bug.cgi?id=301076">https://bugs.webkit.org/show_bug.cgi?id=301076</a>
<a href="https://rdar.apple.com/163012711">rdar://163012711</a>

Reviewed by Dan Glastonbury.

No need for WebGLRenderingContextBase::graphicsContextGL() and
...::protectedGraphicsContextGL(). Name the protected variant as
graphicsContextGL().

* Source/WebCore/html/canvas/ANGLEInstancedArrays.cpp:
(WebCore::ANGLEInstancedArrays::ANGLEInstancedArrays):
(WebCore::ANGLEInstancedArrays::drawArraysInstancedANGLE):
(WebCore::ANGLEInstancedArrays::drawElementsInstancedANGLE):
(WebCore::ANGLEInstancedArrays::vertexAttribDivisorANGLE):
* Source/WebCore/html/canvas/CanvasFilterContextSwitcher.cpp:
(WebCore::CanvasFilterContextSwitcher::~CanvasFilterContextSwitcher):
* Source/WebCore/html/canvas/CanvasFilterContextSwitcher.h:
(WebCore::CanvasFilterContextSwitcher::context const):
(WebCore::CanvasFilterContextSwitcher::protectedContext const): Deleted.
* Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp:
(WebCore::CanvasLayerContextSwitcher::outsets const):
* Source/WebCore/html/canvas/CanvasLayerContextSwitcher.h:
(WebCore::CanvasLayerContextSwitcher::context const):
(WebCore::CanvasLayerContextSwitcher::protectedContext const): Deleted.
* Source/WebCore/html/canvas/EXTBlendMinMax.cpp:
(WebCore::EXTBlendMinMax::EXTBlendMinMax):
* Source/WebCore/html/canvas/EXTClipControl.cpp:
(WebCore::EXTClipControl::EXTClipControl):
(WebCore::EXTClipControl::clipControlEXT):
* Source/WebCore/html/canvas/EXTColorBufferFloat.cpp:
(WebCore::EXTColorBufferFloat::EXTColorBufferFloat):
* Source/WebCore/html/canvas/EXTColorBufferHalfFloat.cpp:
(WebCore::EXTColorBufferHalfFloat::EXTColorBufferHalfFloat):
* Source/WebCore/html/canvas/EXTConservativeDepth.cpp:
(WebCore::EXTConservativeDepth::EXTConservativeDepth):
* Source/WebCore/html/canvas/EXTDepthClamp.cpp:
(WebCore::EXTDepthClamp::EXTDepthClamp):
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp:
(WebCore::EXTDisjointTimerQuery::EXTDisjointTimerQuery):
(WebCore::EXTDisjointTimerQuery::createQueryEXT):
(WebCore::EXTDisjointTimerQuery::deleteQueryEXT):
(WebCore::EXTDisjointTimerQuery::isQueryEXT):
(WebCore::EXTDisjointTimerQuery::beginQueryEXT):
(WebCore::EXTDisjointTimerQuery::endQueryEXT):
(WebCore::EXTDisjointTimerQuery::queryCounterEXT):
(WebCore::EXTDisjointTimerQuery::getQueryEXT):
(WebCore::EXTDisjointTimerQuery::getQueryObjectEXT):
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp:
(WebCore::EXTDisjointTimerQueryWebGL2::EXTDisjointTimerQueryWebGL2):
(WebCore::EXTDisjointTimerQueryWebGL2::queryCounterEXT):
* Source/WebCore/html/canvas/EXTFloatBlend.cpp:
(WebCore::EXTFloatBlend::EXTFloatBlend):
* Source/WebCore/html/canvas/EXTFragDepth.cpp:
(WebCore::EXTFragDepth::EXTFragDepth):
* Source/WebCore/html/canvas/EXTPolygonOffsetClamp.cpp:
(WebCore::EXTPolygonOffsetClamp::EXTPolygonOffsetClamp):
(WebCore::EXTPolygonOffsetClamp::polygonOffsetClampEXT):
* Source/WebCore/html/canvas/EXTRenderSnorm.cpp:
(WebCore::EXTRenderSnorm::EXTRenderSnorm):
* Source/WebCore/html/canvas/EXTShaderTextureLOD.cpp:
(WebCore::EXTShaderTextureLOD::EXTShaderTextureLOD):
* Source/WebCore/html/canvas/EXTTextureCompressionBPTC.cpp:
(WebCore::EXTTextureCompressionBPTC::EXTTextureCompressionBPTC):
* Source/WebCore/html/canvas/EXTTextureCompressionRGTC.cpp:
(WebCore::EXTTextureCompressionRGTC::EXTTextureCompressionRGTC):
* Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.cpp:
(WebCore::EXTTextureFilterAnisotropic::EXTTextureFilterAnisotropic):
* Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.cpp:
(WebCore::EXTTextureMirrorClampToEdge::EXTTextureMirrorClampToEdge):
* Source/WebCore/html/canvas/EXTTextureNorm16.cpp:
(WebCore::EXTTextureNorm16::EXTTextureNorm16):
* Source/WebCore/html/canvas/EXTsRGB.cpp:
(WebCore::EXTsRGB::EXTsRGB):
* Source/WebCore/html/canvas/KHRParallelShaderCompile.cpp:
(WebCore::KHRParallelShaderCompile::KHRParallelShaderCompile):
* Source/WebCore/html/canvas/NVShaderNoperspectiveInterpolation.cpp:
(WebCore::NVShaderNoperspectiveInterpolation::NVShaderNoperspectiveInterpolation):
* Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp:
(WebCore::OESDrawBuffersIndexed::OESDrawBuffersIndexed):
(WebCore::OESDrawBuffersIndexed::enableiOES):
(WebCore::OESDrawBuffersIndexed::disableiOES):
(WebCore::OESDrawBuffersIndexed::blendEquationiOES):
(WebCore::OESDrawBuffersIndexed::blendEquationSeparateiOES):
(WebCore::OESDrawBuffersIndexed::blendFunciOES):
(WebCore::OESDrawBuffersIndexed::blendFuncSeparateiOES):
(WebCore::OESDrawBuffersIndexed::colorMaskiOES):
* Source/WebCore/html/canvas/OESElementIndexUint.cpp:
(WebCore::OESElementIndexUint::OESElementIndexUint):
* Source/WebCore/html/canvas/OESFBORenderMipmap.cpp:
(WebCore::OESFBORenderMipmap::OESFBORenderMipmap):
* Source/WebCore/html/canvas/OESSampleVariables.cpp:
(WebCore::OESSampleVariables::OESSampleVariables):
* Source/WebCore/html/canvas/OESShaderMultisampleInterpolation.cpp:
(WebCore::OESShaderMultisampleInterpolation::OESShaderMultisampleInterpolation):
* Source/WebCore/html/canvas/OESStandardDerivatives.cpp:
(WebCore::OESStandardDerivatives::OESStandardDerivatives):
* Source/WebCore/html/canvas/OESTextureFloat.cpp:
(WebCore::OESTextureFloat::OESTextureFloat):
* Source/WebCore/html/canvas/OESTextureFloatLinear.cpp:
(WebCore::OESTextureFloatLinear::OESTextureFloatLinear):
* Source/WebCore/html/canvas/OESTextureHalfFloat.cpp:
(WebCore::OESTextureHalfFloat::OESTextureHalfFloat):
* Source/WebCore/html/canvas/OESTextureHalfFloatLinear.cpp:
(WebCore::OESTextureHalfFloatLinear::OESTextureHalfFloatLinear):
* Source/WebCore/html/canvas/OESVertexArrayObject.cpp:
(WebCore::OESVertexArrayObject::OESVertexArrayObject):
(WebCore::OESVertexArrayObject::createVertexArrayOES):
(WebCore::OESVertexArrayObject::deleteVertexArrayOES):
(WebCore::OESVertexArrayObject::isVertexArrayOES):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::getInt64Parameter):
(WebCore::WebGL2RenderingContext::initializeDefaultObjects):
(WebCore::WebGL2RenderingContext::pixelStorei):
(WebCore::WebGL2RenderingContext::copyBufferSubData):
(WebCore::WebGL2RenderingContext::getBufferSubData):
(WebCore::WebGL2RenderingContext::blitFramebuffer):
(WebCore::WebGL2RenderingContext::invalidateFramebuffer):
(WebCore::WebGL2RenderingContext::invalidateSubFramebuffer):
(WebCore::WebGL2RenderingContext::readBuffer):
(WebCore::WebGL2RenderingContext::getTexParameter):
(WebCore::WebGL2RenderingContext::texStorage2D):
(WebCore::WebGL2RenderingContext::texStorage3D):
(WebCore::WebGL2RenderingContext::texImage2D):
(WebCore::WebGL2RenderingContext::texImage3D):
(WebCore::WebGL2RenderingContext::texSubImage2D):
(WebCore::WebGL2RenderingContext::texSubImage3D):
(WebCore::WebGL2RenderingContext::copyTexSubImage3D):
(WebCore::WebGL2RenderingContext::compressedTexImage2D):
(WebCore::WebGL2RenderingContext::compressedTexImage3D):
(WebCore::WebGL2RenderingContext::compressedTexSubImage2D):
(WebCore::WebGL2RenderingContext::compressedTexSubImage3D):
(WebCore::WebGL2RenderingContext::getFragDataLocation):
(WebCore::WebGL2RenderingContext::uniform1ui):
(WebCore::WebGL2RenderingContext::uniform2ui):
(WebCore::WebGL2RenderingContext::uniform3ui):
(WebCore::WebGL2RenderingContext::uniform4ui):
(WebCore::WebGL2RenderingContext::uniform1uiv):
(WebCore::WebGL2RenderingContext::uniform2uiv):
(WebCore::WebGL2RenderingContext::uniform3uiv):
(WebCore::WebGL2RenderingContext::uniform4uiv):
(WebCore::WebGL2RenderingContext::uniformMatrix2x3fv):
(WebCore::WebGL2RenderingContext::uniformMatrix3x2fv):
(WebCore::WebGL2RenderingContext::uniformMatrix2x4fv):
(WebCore::WebGL2RenderingContext::uniformMatrix4x2fv):
(WebCore::WebGL2RenderingContext::uniformMatrix3x4fv):
(WebCore::WebGL2RenderingContext::uniformMatrix4x3fv):
(WebCore::WebGL2RenderingContext::vertexAttribI4i):
(WebCore::WebGL2RenderingContext::vertexAttribI4iv):
(WebCore::WebGL2RenderingContext::vertexAttribI4ui):
(WebCore::WebGL2RenderingContext::vertexAttribI4uiv):
(WebCore::WebGL2RenderingContext::vertexAttribIPointer):
(WebCore::WebGL2RenderingContext::drawRangeElements):
(WebCore::WebGL2RenderingContext::drawBuffers):
(WebCore::WebGL2RenderingContext::clearBufferiv):
(WebCore::WebGL2RenderingContext::clearBufferuiv):
(WebCore::WebGL2RenderingContext::clearBufferfv):
(WebCore::WebGL2RenderingContext::clearBufferfi):
(WebCore::WebGL2RenderingContext::deleteQuery):
(WebCore::WebGL2RenderingContext::isQuery):
(WebCore::WebGL2RenderingContext::beginQuery):
(WebCore::WebGL2RenderingContext::endQuery):
(WebCore::WebGL2RenderingContext::getQueryParameter):
(WebCore::WebGL2RenderingContext::isSampler):
(WebCore::WebGL2RenderingContext::bindSampler):
(WebCore::WebGL2RenderingContext::samplerParameteri):
(WebCore::WebGL2RenderingContext::samplerParameterf):
(WebCore::WebGL2RenderingContext::getSamplerParameter):
(WebCore::WebGL2RenderingContext::isTransformFeedback):
(WebCore::WebGL2RenderingContext::bindTransformFeedback):
(WebCore::WebGL2RenderingContext::beginTransformFeedback):
(WebCore::WebGL2RenderingContext::endTransformFeedback):
(WebCore::WebGL2RenderingContext::transformFeedbackVaryings):
(WebCore::WebGL2RenderingContext::getTransformFeedbackVarying):
(WebCore::WebGL2RenderingContext::pauseTransformFeedback):
(WebCore::WebGL2RenderingContext::resumeTransformFeedback):
(WebCore::WebGL2RenderingContext::bindBufferBase):
(WebCore::WebGL2RenderingContext::bindBufferRange):
(WebCore::WebGL2RenderingContext::getIndexedParameter):
(WebCore::WebGL2RenderingContext::getIndexedBooleanArrayParameter):
(WebCore::WebGL2RenderingContext::getUniformIndices):
(WebCore::WebGL2RenderingContext::getActiveUniforms):
(WebCore::WebGL2RenderingContext::getUniformBlockIndex):
(WebCore::WebGL2RenderingContext::getActiveUniformBlockParameter):
(WebCore::WebGL2RenderingContext::getActiveUniformBlockName):
(WebCore::WebGL2RenderingContext::uniformBlockBinding):
(WebCore::WebGL2RenderingContext::deleteVertexArray):
(WebCore::WebGL2RenderingContext::isVertexArray):
(WebCore::WebGL2RenderingContext::bindVertexArray):
(WebCore::WebGL2RenderingContext::getFramebufferAttachmentParameter):
(WebCore::WebGL2RenderingContext::maxDrawBuffers):
(WebCore::WebGL2RenderingContext::maxColorAttachments):
(WebCore::WebGL2RenderingContext::renderbufferStorageHelper):
(WebCore::WebGL2RenderingContext::uniform1fv):
(WebCore::WebGL2RenderingContext::uniform2fv):
(WebCore::WebGL2RenderingContext::uniform3fv):
(WebCore::WebGL2RenderingContext::uniform4fv):
(WebCore::WebGL2RenderingContext::uniform1iv):
(WebCore::WebGL2RenderingContext::uniform2iv):
(WebCore::WebGL2RenderingContext::uniform3iv):
(WebCore::WebGL2RenderingContext::uniform4iv):
(WebCore::WebGL2RenderingContext::uniformMatrix2fv):
(WebCore::WebGL2RenderingContext::uniformMatrix3fv):
(WebCore::WebGL2RenderingContext::uniformMatrix4fv):
(WebCore::WebGL2RenderingContext::readPixels):
* Source/WebCore/html/canvas/WebGLBlendFuncExtended.cpp:
(WebCore::WebGLBlendFuncExtended::WebGLBlendFuncExtended):
* Source/WebCore/html/canvas/WebGLBuffer.cpp:
(WebCore::WebGLBuffer::create):
* Source/WebCore/html/canvas/WebGLClipCullDistance.cpp:
(WebCore::WebGLClipCullDistance::WebGLClipCullDistance):
* Source/WebCore/html/canvas/WebGLCompressedTextureASTC.cpp:
(WebCore::WebGLCompressedTextureASTC::WebGLCompressedTextureASTC):
* Source/WebCore/html/canvas/WebGLCompressedTextureETC.cpp:
(WebCore::WebGLCompressedTextureETC::WebGLCompressedTextureETC):
* Source/WebCore/html/canvas/WebGLCompressedTextureETC1.cpp:
(WebCore::WebGLCompressedTextureETC1::WebGLCompressedTextureETC1):
* Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.cpp:
(WebCore::WebGLCompressedTexturePVRTC::WebGLCompressedTexturePVRTC):
* Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.cpp:
(WebCore::WebGLCompressedTextureS3TCsRGB::WebGLCompressedTextureS3TCsRGB):
* Source/WebCore/html/canvas/WebGLDebugShaders.cpp:
(WebCore::WebGLDebugShaders::WebGLDebugShaders):
(WebCore::WebGLDebugShaders::getTranslatedShaderSource):
* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp:
(WebCore::WebGLDefaultFramebuffer::WebGLDefaultFramebuffer):
(WebCore::WebGLDefaultFramebuffer::size const):
(WebCore::WebGLDefaultFramebuffer::reshape):
* Source/WebCore/html/canvas/WebGLDepthTexture.cpp:
(WebCore::WebGLDepthTexture::WebGLDepthTexture):
* Source/WebCore/html/canvas/WebGLDrawBuffers.cpp:
(WebCore::WebGLDrawBuffers::WebGLDrawBuffers):
(WebCore::WebGLDrawBuffers::supported):
(WebCore::WebGLDrawBuffers::drawBuffersWEBGL):
* Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp:
(WebCore::WebGLDrawInstancedBaseVertexBaseInstance::WebGLDrawInstancedBaseVertexBaseInstance):
(WebCore::WebGLDrawInstancedBaseVertexBaseInstance::drawArraysInstancedBaseInstanceWEBGL):
(WebCore::WebGLDrawInstancedBaseVertexBaseInstance::drawElementsInstancedBaseVertexBaseInstanceWEBGL):
* Source/WebCore/html/canvas/WebGLExtension.h:
(WebCore::WebGLExtension::context):
(WebCore::WebGLExtension::protectedContext): Deleted.
* Source/WebCore/html/canvas/WebGLFramebuffer.cpp:
(WebCore::WebGLFramebuffer::create):
(WebCore::WebGLFramebuffer::createOpaque):
(WebCore::WebGLFramebuffer::setAttachmentForBoundFramebuffer):
(WebCore::WebGLFramebuffer::removeAttachmentFromBoundFramebuffer):
(WebCore::WebGLFramebuffer::isBound const):
(WebCore::WebGLFramebuffer::drawBuffersIfNecessary):
(WebCore::WebGLFramebuffer::setAttachmentInternal):
* Source/WebCore/html/canvas/WebGLLoseContext.cpp:
(WebCore::WebGLLoseContext::loseContext):
(WebCore::WebGLLoseContext::restoreContext):
* Source/WebCore/html/canvas/WebGLMultiDraw.cpp:
(WebCore::WebGLMultiDraw::WebGLMultiDraw):
(WebCore::WebGLMultiDraw::multiDrawArraysWEBGL):
(WebCore::WebGLMultiDraw::multiDrawArraysInstancedWEBGL):
(WebCore::WebGLMultiDraw::multiDrawElementsWEBGL):
(WebCore::WebGLMultiDraw::multiDrawElementsInstancedWEBGL):
* Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp:
(WebCore::WebGLMultiDrawInstancedBaseVertexBaseInstance::WebGLMultiDrawInstancedBaseVertexBaseInstance):
(WebCore::WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawArraysInstancedBaseInstanceWEBGL):
(WebCore::WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL):
* Source/WebCore/html/canvas/WebGLObject.cpp:
(WebCore::WebGLObject::context const):
(WebCore::WebGLObject::objectGraphLockForContext):
(WebCore::WebGLObject::graphicsContextGL const):
(WebCore::WebGLObject::deleteObject):
(WebCore::WebGLObject::protectedContext const): Deleted.
* Source/WebCore/html/canvas/WebGLObject.h:
* Source/WebCore/html/canvas/WebGLPolygonMode.cpp:
(WebCore::WebGLPolygonMode::WebGLPolygonMode):
(WebCore::WebGLPolygonMode::polygonModeWEBGL):
* Source/WebCore/html/canvas/WebGLProgram.cpp:
(WebCore::WebGLProgram::create):
* Source/WebCore/html/canvas/WebGLProvokingVertex.cpp:
(WebCore::WebGLProvokingVertex::WebGLProvokingVertex):
(WebCore::WebGLProvokingVertex::provokingVertexWEBGL):
* Source/WebCore/html/canvas/WebGLQuery.cpp:
(WebCore::WebGLQuery::create):
* Source/WebCore/html/canvas/WebGLRenderSharedExponent.cpp:
(WebCore::WebGLRenderSharedExponent::WebGLRenderSharedExponent):
* Source/WebCore/html/canvas/WebGLRenderbuffer.cpp:
(WebCore::WebGLRenderbuffer::create):
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
(WebCore::WebGLRenderingContext::getFramebufferAttachmentParameter):
(WebCore::WebGLRenderingContext::getInt64Parameter):
(WebCore::WebGLRenderingContext::maxColorAttachments):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::surfaceBufferToImageBuffer):
(WebCore::WebGLRenderingContextBase::surfaceBufferToVideoFrame):
(WebCore::WebGLRenderingContextBase::transferToImageBuffer):
(WebCore::WebGLRenderingContextBase::setDrawingBufferColorSpace):
(WebCore::WebGLRenderingContextBase::activeTexture):
(WebCore::WebGLRenderingContextBase::attachShader):
(WebCore::WebGLRenderingContextBase::bindAttribLocation):
(WebCore::WebGLRenderingContextBase::bindBuffer):
(WebCore::WebGLRenderingContextBase::bindRenderbuffer):
(WebCore::WebGLRenderingContextBase::bindTexture):
(WebCore::WebGLRenderingContextBase::blendColor):
(WebCore::WebGLRenderingContextBase::blendEquation):
(WebCore::WebGLRenderingContextBase::blendEquationSeparate):
(WebCore::WebGLRenderingContextBase::blendFunc):
(WebCore::WebGLRenderingContextBase::blendFuncSeparate):
(WebCore::WebGLRenderingContextBase::bufferData):
(WebCore::WebGLRenderingContextBase::checkFramebufferStatus):
(WebCore::WebGLRenderingContextBase::clear):
(WebCore::WebGLRenderingContextBase::clearColor):
(WebCore::WebGLRenderingContextBase::clearDepth):
(WebCore::WebGLRenderingContextBase::clearStencil):
(WebCore::WebGLRenderingContextBase::colorMask):
(WebCore::WebGLRenderingContextBase::compileShader):
(WebCore::WebGLRenderingContextBase::compressedTexImage2D):
(WebCore::WebGLRenderingContextBase::compressedTexSubImage2D):
(WebCore::WebGLRenderingContextBase::copyTexSubImage2D):
(WebCore::WebGLRenderingContextBase::cullFace):
(WebCore::WebGLRenderingContextBase::deleteObject):
(WebCore::WebGLRenderingContextBase::deleteFramebuffer):
(WebCore::WebGLRenderingContextBase::depthFunc):
(WebCore::WebGLRenderingContextBase::depthMask):
(WebCore::WebGLRenderingContextBase::depthRange):
(WebCore::WebGLRenderingContextBase::detachShader):
(WebCore::WebGLRenderingContextBase::disable):
(WebCore::WebGLRenderingContextBase::disableVertexAttribArray):
(WebCore::WebGLRenderingContextBase::drawArrays):
(WebCore::WebGLRenderingContextBase::drawElements):
(WebCore::WebGLRenderingContextBase::enable):
(WebCore::WebGLRenderingContextBase::enableVertexAttribArray):
(WebCore::WebGLRenderingContextBase::finish):
(WebCore::WebGLRenderingContextBase::flush):
(WebCore::WebGLRenderingContextBase::frontFace):
(WebCore::WebGLRenderingContextBase::generateMipmap):
(WebCore::WebGLRenderingContextBase::getActiveAttrib):
(WebCore::WebGLRenderingContextBase::getActiveUniform):
(WebCore::WebGLRenderingContextBase::getAttribLocation):
(WebCore::WebGLRenderingContextBase::getBufferParameter):
(WebCore::WebGLRenderingContextBase::updateErrors):
(WebCore::WebGLRenderingContextBase::getProgramParameter):
(WebCore::WebGLRenderingContextBase::getProgramInfoLog):
(WebCore::WebGLRenderingContextBase::getRenderbufferParameter):
(WebCore::WebGLRenderingContextBase::getShaderParameter):
(WebCore::WebGLRenderingContextBase::getShaderInfoLog):
(WebCore::WebGLRenderingContextBase::getShaderPrecisionFormat):
(WebCore::WebGLRenderingContextBase::getTexParameter):
(WebCore::WebGLRenderingContextBase::getUniform):
(WebCore::WebGLRenderingContextBase::getVertexAttribOffset):
(WebCore::WebGLRenderingContextBase::hint):
(WebCore::WebGLRenderingContextBase::isBuffer):
(WebCore::WebGLRenderingContextBase::isEnabled):
(WebCore::WebGLRenderingContextBase::isFramebuffer):
(WebCore::WebGLRenderingContextBase::isProgram):
(WebCore::WebGLRenderingContextBase::isRenderbuffer):
(WebCore::WebGLRenderingContextBase::isShader):
(WebCore::WebGLRenderingContextBase::isTexture):
(WebCore::WebGLRenderingContextBase::lineWidth):
(WebCore::WebGLRenderingContextBase::linkProgramWithoutInvalidatingAttribLocations):
(WebCore::WebGLRenderingContextBase::pixelStorei):
(WebCore::WebGLRenderingContextBase::polygonOffset):
(WebCore::WebGLRenderingContextBase::readPixels):
(WebCore::WebGLRenderingContextBase::renderbufferStorageImpl):
(WebCore::WebGLRenderingContextBase::sampleCoverage):
(WebCore::WebGLRenderingContextBase::scissor):
(WebCore::WebGLRenderingContextBase::shaderSource):
(WebCore::WebGLRenderingContextBase::stencilFunc):
(WebCore::WebGLRenderingContextBase::stencilFuncSeparate):
(WebCore::WebGLRenderingContextBase::stencilMask):
(WebCore::WebGLRenderingContextBase::stencilMaskSeparate):
(WebCore::WebGLRenderingContextBase::stencilOp):
(WebCore::WebGLRenderingContextBase::stencilOpSeparate):
(WebCore::WebGLRenderingContextBase::texImageSource):
(WebCore::WebGLRenderingContextBase::texImage2DBase):
(WebCore::WebGLRenderingContextBase::texSubImage2DBase):
(WebCore::WebGLRenderingContextBase::copyTexImage2D):
(WebCore::WebGLRenderingContextBase::texParameter):
(WebCore::WebGLRenderingContextBase::uniform1f):
(WebCore::WebGLRenderingContextBase::uniform2f):
(WebCore::WebGLRenderingContextBase::uniform3f):
(WebCore::WebGLRenderingContextBase::uniform4f):
(WebCore::WebGLRenderingContextBase::uniform1i):
(WebCore::WebGLRenderingContextBase::uniform2i):
(WebCore::WebGLRenderingContextBase::uniform3i):
(WebCore::WebGLRenderingContextBase::uniform4i):
(WebCore::WebGLRenderingContextBase::uniform1fv):
(WebCore::WebGLRenderingContextBase::uniform2fv):
(WebCore::WebGLRenderingContextBase::uniform3fv):
(WebCore::WebGLRenderingContextBase::uniform4fv):
(WebCore::WebGLRenderingContextBase::uniform1iv):
(WebCore::WebGLRenderingContextBase::uniform2iv):
(WebCore::WebGLRenderingContextBase::uniform3iv):
(WebCore::WebGLRenderingContextBase::uniform4iv):
(WebCore::WebGLRenderingContextBase::uniformMatrix2fv):
(WebCore::WebGLRenderingContextBase::uniformMatrix3fv):
(WebCore::WebGLRenderingContextBase::uniformMatrix4fv):
(WebCore::WebGLRenderingContextBase::useProgram):
(WebCore::WebGLRenderingContextBase::validateProgram):
(WebCore::WebGLRenderingContextBase::vertexAttribPointer):
(WebCore::WebGLRenderingContextBase::viewport):
(WebCore::WebGLRenderingContextBase::forceLostContext):
(WebCore::WebGLRenderingContextBase::layerContentsDisplayDelegate):
(WebCore::WebGLRenderingContextBase::getBooleanParameter):
(WebCore::WebGLRenderingContextBase::getBooleanArrayParameter):
(WebCore::WebGLRenderingContextBase::getFloatParameter):
(WebCore::WebGLRenderingContextBase::getIntParameter):
(WebCore::WebGLRenderingContextBase::getUnsignedIntParameter):
(WebCore::WebGLRenderingContextBase::getWebGLFloatArrayParameter):
(WebCore::WebGLRenderingContextBase::getWebGLIntArrayParameter):
(WebCore::WebGLRenderingContextBase::vertexAttribfImpl):
(WebCore::WebGLRenderingContextBase::vertexAttribfvImpl):
(WebCore::WebGLRenderingContextBase::maxColorAttachments):
(WebCore::WebGLRenderingContextBase::setFramebuffer):
(WebCore::WebGLRenderingContextBase::drawArraysInstanced):
(WebCore::WebGLRenderingContextBase::drawElementsInstanced):
(WebCore::WebGLRenderingContextBase::vertexAttribDivisor):
(WebCore::WebGLRenderingContextBase::prepareForDisplay):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::graphicsContextGL const):
(WebCore::WebGLRenderingContextBase::protectedGraphicsContextGL const): Deleted.
* Source/WebCore/html/canvas/WebGLSampler.cpp:
(WebCore::WebGLSampler::create):
* Source/WebCore/html/canvas/WebGLShader.cpp:
(WebCore::WebGLShader::create):
* Source/WebCore/html/canvas/WebGLStencilTexturing.cpp:
(WebCore::WebGLStencilTexturing::WebGLStencilTexturing):
* Source/WebCore/html/canvas/WebGLSync.cpp:
(WebCore::WebGLSync::create):
(WebCore::WebGLSync::updateCache):
* Source/WebCore/html/canvas/WebGLTexture.cpp:
(WebCore::WebGLTexture::create):
* Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp:
(WebCore::WebGLTimerQueryEXT::create):
* Source/WebCore/html/canvas/WebGLTransformFeedback.cpp:
(WebCore::WebGLTransformFeedback::create):
* Source/WebCore/html/canvas/WebGLUtilities.h:
(WebCore::ScopedDisableRasterizerDiscard::ScopedDisableRasterizerDiscard):
(WebCore::ScopedDisableRasterizerDiscard::~ScopedDisableRasterizerDiscard):
(WebCore::ScopedEnableBackbuffer::ScopedEnableBackbuffer):
(WebCore::ScopedEnableBackbuffer::~ScopedEnableBackbuffer):
(WebCore::ScopedDisableScissorTest::ScopedDisableScissorTest):
(WebCore::ScopedDisableScissorTest::~ScopedDisableScissorTest):
* Source/WebCore/html/canvas/WebGLVertexArrayObject.cpp:
(WebCore::WebGLVertexArrayObject::create):
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp:
(WebCore::WebGLVertexArrayObjectBase::setElementArrayBuffer):
(WebCore::WebGLVertexArrayObjectBase::setVertexAttribState):
(WebCore::WebGLVertexArrayObjectBase::unbindBuffer):
* Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.cpp:
(WebCore::WebGLVertexArrayObjectOES::createUser):

Canonical link: <a href="https://commits.webkit.org/302085@main">https://commits.webkit.org/302085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e584d38b46977c5df6b6bd5a3f5a48689094660

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79479 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/af7ad96a-36bb-462d-b7b6-16cb88abb1b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/96 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97407 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65311 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/37fc5b7e-364b-445c-88a3-c9743c5e37cc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/56 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114614 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77973 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/410886a5-fc6d-4a30-9412-ffecf0e14799) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/60 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32719 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78627 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137802 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/95 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/85 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105932 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105668 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26938 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/60 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29532 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52239 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/137 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/61584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/70 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/146 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/113 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->