### PR TITLE
[JSC] Avoid using `MarkedArgumentBuffer` in `createTuple`

### DIFF
--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -111,7 +111,7 @@ static ALWAYS_INLINE void forEachInMapStorage(VM& vm, JSGlobalObject* globalObje
             JSValue entryKey = JSMap::Helper::getIterationEntryKey(*storage);
             JSValue entryValue = JSMap::Helper::getIterationEntryValue(*storage);
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=298574
-            value = createTuple(globalObject, entryKey, entryValue);
+            value = constructArrayPair(globalObject, entryKey, entryValue);
             RETURN_IF_EXCEPTION(scope, void());
             break;
         }

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -2074,6 +2074,29 @@ JSArray* constructArrayNegativeIndexed(JSGlobalObject* globalObject, Structure* 
     return array;
 }
 
+JSArray* constructArrayPair(JSGlobalObject* globalObject, JSValue first, JSValue second)
+{
+    VM& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    ObjectInitializationScope initializationScope(vm);
+
+    IndexingType indexingType = ArrayWithUndecided;
+    indexingType = leastUpperBoundOfIndexingTypeAndValue(indexingType, first);
+    indexingType = leastUpperBoundOfIndexingTypeAndValue(indexingType, second);
+
+    Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(indexingType);
+
+    JSArray* array = JSArray::tryCreateUninitializedRestricted(initializationScope, structure, 2);
+    if (!array) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, throwScope);
+        return nullptr;
+    }
+    array->initializeIndex(initializationScope, 0, first);
+    array->initializeIndex(initializationScope, 1, second);
+
+    return array;
+}
+
 template<>
 void clearElement(double& element)
 {

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -422,6 +422,7 @@ inline bool isJSArray(JSValue v) { return v.isCell() && isJSArray(v.asCell()); }
 JS_EXPORT_PRIVATE JSArray* constructArray(JSGlobalObject*, Structure*, const ArgList& values);
 JS_EXPORT_PRIVATE JSArray* constructArray(JSGlobalObject*, Structure*, const JSValue* values, unsigned length);
 JS_EXPORT_PRIVATE JSArray* constructArrayNegativeIndexed(JSGlobalObject*, Structure*, const JSValue* values, unsigned length);
+JS_EXPORT_PRIVATE JSArray* constructArrayPair(JSGlobalObject*, JSValue first, JSValue second);
 
 ALWAYS_INLINE uint64_t toLength(JSGlobalObject*, JSObject*);
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -36,6 +36,7 @@
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSWeakObjectMapRefInternal.h>
 #include <JavaScriptCore/LinkTimeConstant.h>
+#include <JavaScriptCore/ObjectInitializationScope.h>
 #include <JavaScriptCore/ObjectPrototype.h>
 #include <JavaScriptCore/ParserModes.h>
 #include <JavaScriptCore/StrongInlines.h>
@@ -381,16 +382,6 @@ ALWAYS_INLINE JSArray* createPatternFilledArray(JSGlobalObject* globalObject, JS
         RETURN_IF_EXCEPTION(scope, { });
     }
     return array;
-}
-
-template<typename... Args>
-inline JSArray* createTuple(JSGlobalObject* globalObject, Args&&... args)
-{
-    MarkedArgumentBuffer buffer;
-    (buffer.append(std::forward<Args>(args)), ...);
-
-    ASSERT(!buffer.hasOverflowed());
-    return constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), buffer);
 }
 
 inline OptionSet<CodeGenerationMode> JSGlobalObject::defaultCodeGenerationMode() const

--- a/Source/JavaScriptCore/runtime/JSMapIterator.h
+++ b/Source/JavaScriptCore/runtime/JSMapIterator.h
@@ -117,7 +117,7 @@ public:
             value = result.key;
             break;
         case IterationKind::Entries:
-            value = createTuple(globalObject, result.key, result.value);
+            value = constructArrayPair(globalObject, result.key, result.value);
             break;
         }
         return true;

--- a/Source/JavaScriptCore/runtime/JSSetIterator.h
+++ b/Source/JavaScriptCore/runtime/JSSetIterator.h
@@ -111,7 +111,7 @@ public:
             value = nextKey;
             break;
         case IterationKind::Entries:
-            value = createTuple(globalObject, nextKey, nextKey);
+            value = constructArrayPair(globalObject, nextKey, nextKey);
             break;
         }
         return true;


### PR DESCRIPTION
#### 7e9dff0fcda41b9afa1e7d5a6328663e67523b3f
<pre>
[JSC] Avoid using `MarkedArgumentBuffer` in `createTuple`
<a href="https://bugs.webkit.org/show_bug.cgi?id=301078">https://bugs.webkit.org/show_bug.cgi?id=301078</a>

Reviewed by Yusuke Suzuki and Keith Miller.

createTupel creates an array from two JSValues. It has a fixed length
so there is no need to use a MarkedArgumentBuffer.

This patch changes to avoid using `MarkedArgumentBuffer` in `createTuple`.

* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInMapStorage):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::constructArrayPair):
* Source/JavaScriptCore/runtime/JSArray.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::createTuple):
* Source/JavaScriptCore/runtime/JSMapIterator.h:
* Source/JavaScriptCore/runtime/JSSetIterator.h:

Canonical link: <a href="https://commits.webkit.org/302067@main">https://commits.webkit.org/302067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4caf4619a1b171b44e1e95a736cf14696e869ff2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79134 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97117 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65035 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114268 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77597 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32365 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78027 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119614 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108135 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137138 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126040 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105641 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105292 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26924 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29248 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51822 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54173 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60260 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159078 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53407 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39763 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56864 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55166 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->