### PR TITLE
WebGL: GL_ANGLE_pack_reverse_row_order is not used even if it exists

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -616,7 +616,7 @@ void WebGLRenderingContextBase::initializeContextState()
     m_supportedTexImageSourceInternalFormats.addAll(supportedFormatsES2);
     m_supportedTexImageSourceFormats.addAll(supportedFormatsES2);
     m_supportedTexImageSourceTypes.addAll(supportedTypesES2);
-    m_packReverseRowOrderSupported = enableSupportedExtension("GL_ANGLE_reverse_row_order"_s);
+    m_packReverseRowOrderSupported = context->isExtensionEnabled("GL_ANGLE_pack_reverse_row_order"_s);
 }
 
 void WebGLRenderingContextBase::initializeDefaultObjects()
@@ -5419,17 +5419,6 @@ void WebGLRenderingContextBase::vertexAttribDivisor(GCGLuint index, GCGLuint div
 
     protectedBoundVertexArrayObject()->setVertexAttribDivisor(index, divisor);
     protectedGraphicsContextGL()->vertexAttribDivisor(index, divisor);
-}
-
-bool WebGLRenderingContextBase::enableSupportedExtension(ASCIILiteral extensionNameLiteral)
-{
-    ASSERT(m_context);
-    CString extensionName { extensionNameLiteral };
-    RefPtr context = m_context;
-    if (!context->supportsExtension(extensionName))
-        return false;
-    context->ensureExtensionEnabled(extensionName);
-    return true;
 }
 
 template<typename T> void loseExtension(RefPtr<T> extension)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -584,7 +584,6 @@ protected:
     RefPtr<Image> videoFrameToImage(HTMLVideoElement&, ASCIILiteral functionName);
 #endif
 
-    bool enableSupportedExtension(ASCIILiteral extensionNameLiteral);
     void loseExtensions(LostContextMode);
 
     virtual void uncacheDeletedBuffer(const AbstractLocker&, WebGLBuffer*);

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -198,19 +198,25 @@ bool GraphicsContextGLANGLE::initialize()
         usedDisplays().add(m_displayObj);
     }
 
-    if (supportsExtension("GL_KHR_debug"_s)) {
-        ensureExtensionEnabled("GL_KHR_debug"_s);
-        GL_Enable(DEBUG_OUTPUT);
-        GL_Enable(DEBUG_OUTPUT_SYNCHRONOUS);
-        GL_DebugMessageControlKHR(DONT_CARE, DONT_CARE, DONT_CARE, 0, nullptr, 0);
-        GL_DebugMessageControlKHR(DEBUG_SOURCE_API, DONT_CARE, DONT_CARE, 0, nullptr, 1);
-        auto debugMessageCallback = [](GCGLenum, GCGLenum type, GCGLenum id, GCGLenum severity, GCGLsizei length, const GCGLchar* message, const void* context) {
-            auto* gl = reinterpret_cast<const GraphicsContextGLANGLE*>(context);
-            if (gl->m_client)
-                gl->m_client->addDebugMessage(type, id, severity, CString { unsafeMakeSpan(message, length) });
-        };
-        GL_DebugMessageCallbackKHR(debugMessageCallback, this);
-    }
+    bool khrDebugIsSupported = enableExtension("GL_KHR_debug"_s);
+    ASSERT_UNUSED(khrDebugIsSupported, khrDebugIsSupported);
+    GL_Enable(DEBUG_OUTPUT);
+    GL_Enable(DEBUG_OUTPUT_SYNCHRONOUS);
+    GL_DebugMessageControlKHR(DONT_CARE, DONT_CARE, DONT_CARE, 0, nullptr, 0);
+    GL_DebugMessageControlKHR(DEBUG_SOURCE_API, DONT_CARE, DONT_CARE, 0, nullptr, 1);
+    auto debugMessageCallback = [](GCGLenum, GCGLenum type, GCGLenum id, GCGLenum severity, GCGLsizei length, const GCGLchar* message, const void* context) {
+        auto* gl = reinterpret_cast<const GraphicsContextGLANGLE*>(context);
+        if (gl->m_client)
+            gl->m_client->addDebugMessage(type, id, severity, CString { unsafeMakeSpan(message, length) });
+    };
+    GL_DebugMessageCallbackKHR(debugMessageCallback, this);
+
+    bool packReverseRowOrderIsSupported = enableExtension("GL_ANGLE_pack_reverse_row_order"_s);
+#if PLATFORM(COCOA)
+    ASSERT_UNUSED(packReverseRowOrderIsSupported, packReverseRowOrderIsSupported);
+#else
+    UNUSED_VARIABLE(packReverseRowOrderIsSupported);
+#endif
 
     ASSERT(GL_GetError() == NO_ERROR);
 


### PR DESCRIPTION
#### 5647a3a9be2234dab019d69bf388790473794638
<pre>
WebGL: GL_ANGLE_pack_reverse_row_order is not used even if it exists
<a href="https://bugs.webkit.org/show_bug.cgi?id=301079">https://bugs.webkit.org/show_bug.cgi?id=301079</a>
<a href="https://rdar.apple.com/163013354">rdar://163013354</a>

Reviewed by Dan Glastonbury.

Fix a typo in the extension name.
Move the requesting to the GPUP side, to simplify the extension
requesting features.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::enableSupportedExtension): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::initialize):

Canonical link: <a href="https://commits.webkit.org/302084@main">https://commits.webkit.org/302084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bad585813077c350499d2ae9a26f0d9b1711a9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79484 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e84a165d-94de-47c9-9299-0d783d1c76a9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129822 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97406 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65308 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9d58ee35-792b-4e8b-8d66-7fb174b52268) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/62 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77972 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3fbe0c20-242c-44ee-8947-679a92782c2c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/65 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32722 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78632 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108424 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137807 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/87 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105935 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105671 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26937 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/66 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29535 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52244 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/142 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/61589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/75 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/151 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/118 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->