### PR TITLE
Address remaining safer CPP warnings in WebKit/UIProcess

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,8 +1,4 @@
 Shared/API/Cocoa/_WKRemoteObjectInterface.h
-UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.h
-UIProcess/API/Cocoa/_WKNotificationData.mm
-UIProcess/API/Cocoa/_WKSpatialBackdropSource.h
-[ Mac ] UIProcess/API/Cocoa/WKView.h
 [ iOS ] Platform/ios/PaymentAuthorizationController.mm
 [ iOS ] UIProcess/API/Cocoa/WKPreviewActionItem.h
 [ iOS ] UIProcess/API/Cocoa/WKSnapshotConfiguration.h

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,6 +1,4 @@
 Platform/IPC/ArgumentCoders.h
-UIProcess/API/Cocoa/WKUserScript.mm
-UIProcess/API/Cocoa/_WKFrameTreeNode.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -12,7 +12,6 @@ Shared/Cocoa/WKNSURLRequest.mm
 Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
 Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
 Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
-UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
 WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm

--- a/Source/WebKit/UIProcess/API/APIUserScript.h
+++ b/Source/WebKit/UIProcess/API/APIUserScript.h
@@ -50,7 +50,7 @@ public:
     
 private:
     WebCore::UserScript m_userScript;
-    Ref<ContentWorld> m_world;
+    const Ref<ContentWorld> m_world;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKView.h
@@ -29,6 +29,7 @@
 
 #import <Cocoa/Cocoa.h>
 #import <WebKit/WKDeclarationSpecifiers.h>
+#import <wtf/Compiler.h>
 
 #if !defined(WK_UNUSED_INSTANCE_VARIABLE)
 #define WK_UNUSED_INSTANCE_VARIABLE
@@ -44,7 +45,7 @@
 WK_CLASS_DEPRECATED_WITH_REPLACEMENT("WKWebView", macos(10.10, 10.14.4), ios(8.0, 12.2))
 @interface WKView : NSView <NSTextInputClient> {
 @private
-    WK_UNUSED_INSTANCE_VARIABLE WKViewData *_data;
+    WK_UNUSED_INSTANCE_VARIABLE WKViewData *_data SUPPRESS_UNRETAINED_MEMBER; /* This variable is unused so it is fine not to use a smart pointer */
     WK_UNUSED_INSTANCE_VARIABLE unsigned _unused;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -122,7 +122,7 @@ static NSString *dataTypesToString(NSSet *dataTypes)
 
 - (NSString *)description
 {
-    auto result = adoptNS([[NSMutableString alloc] initWithFormat:@"<%@: %p; displayName = %@; dataTypes = { %@ }", RetainPtr { NSStringFromClass(self.class) }.get(), self, self.displayName, dataTypesToString(self.dataTypes)]);
+    auto result = adoptNS([[NSMutableString alloc] initWithFormat:@"<%@: %p; displayName = %@; dataTypes = { %@ }", RetainPtr { NSStringFromClass(self.class) }.get(), self, self.displayName, RetainPtr { dataTypesToString(self.dataTypes) }.get()]);
 
     if (RetainPtr<_WKWebsiteDataSize> dataSize = self._dataSize)
         [result appendFormat:@"; _dataSize = { %llu bytes }", dataSize.get().totalSize];

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.mm
@@ -30,16 +30,20 @@
 #import "_WKAuthenticatorResponseInternal.h"
 #import <wtf/RetainPtr.h>
 
-@implementation _WKAuthenticatorAssertionResponse
+@implementation _WKAuthenticatorAssertionResponse {
+    RetainPtr<NSData> m_authenticatorData;
+    RetainPtr<NSData> m_signature;
+    RetainPtr<NSData> m_userHandle;
+}
 
 - (instancetype)initWithClientDataJSON:(NSData *)clientDataJSON rawId:(NSData *)rawId extensions:(RetainPtr<_WKAuthenticationExtensionsClientOutputs>&&)extensions authenticatorData:(NSData *)authenticatorData signature:(NSData *)signature userHandle:(NSData *)userHandle attachment:(_WKAuthenticatorAttachment)attachment
 {
     if (!(self = [super initWithClientDataJSON:clientDataJSON rawId:rawId extensions:WTFMove(extensions) attachment:attachment]))
         return nil;
 
-    _authenticatorData = [authenticatorData retain];
-    _signature = [signature retain];
-    _userHandle = [userHandle retain];
+    m_authenticatorData = authenticatorData;
+    m_signature = signature;
+    m_userHandle = userHandle;
     return self;
 }
 
@@ -48,17 +52,29 @@
     if (!(self = [super initWithClientDataJSON:clientDataJSON rawId:rawId extensionOutputsCBOR:extensionOutputsCBOR attachment:attachment]))
         return nil;
 
-    _authenticatorData = [authenticatorData retain];
-    _signature = [signature retain];
-    _userHandle = [userHandle retain];
+    m_authenticatorData = authenticatorData;
+    m_signature = signature;
+    m_userHandle = userHandle;
     return self;
+}
+
+- (NSData *)authenticatorData
+{
+    return m_authenticatorData.get();
+}
+
+- (NSData *)signature
+{
+    return m_signature.get();
+}
+
+- (NSData *)userHandle
+{
+    return m_userHandle.get();
 }
 
 - (void)dealloc
 {
-    SUPPRESS_UNRETAINED_ARG [_authenticatorData release];
-    SUPPRESS_UNRETAINED_ARG [_signature release];
-    SUPPRESS_UNRETAINED_ARG [_userHandle release];
     [super dealloc];
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm
@@ -53,7 +53,7 @@
 - (NSArray<_WKFrameTreeNode *> *)childFrames
 {
     return createNSArray(_node->childFrames(), [&] (auto& child) {
-        return wrapper(API::FrameTreeNode::create(WebKit::FrameTreeNodeData(child), _node->protectedPage()));
+        return wrapper(API::FrameTreeNode::create(WebKit::FrameTreeNodeData(child), Ref { *_node }->protectedPage()));
     }).autorelease();
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
@@ -49,7 +49,7 @@ static NSString *dataKey = @"data";
 @property (nonatomic, readwrite) _WKNotificationAlert alert;
 @property (nonatomic, readwrite) NSData *data;
 @property (nonatomic, readwrite) NSURL *serviceWorkerRegistrationURL;
-@property (nonatomic, readwrite) NSUUID *notificationUUID;
+@property (nonatomic, readwrite) NSUUID *uuid;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSpatialBackdropSource.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSpatialBackdropSource.mm
@@ -28,7 +28,11 @@
 
 #import <WebCore/SpatialBackdropSource.h>
 
-@implementation _WKSpatialBackdropSource
+@implementation _WKSpatialBackdropSource {
+    RetainPtr<NSURL> m_sourceURL;
+    RetainPtr<NSURL> m_modelURL;
+    RetainPtr<NSURL> m_environmentMapURL;
+}
 
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
 - (instancetype)initWithSpatialBackdropSource:(const WebCore::SpatialBackdropSource&) spatialBackdropSource
@@ -36,21 +40,33 @@
     if (!(self = [super init]))
         return nil;
 
-    _sourceURL = [spatialBackdropSource.m_sourceURL.createNSURL() copy];
-    _modelURL = [spatialBackdropSource.m_modelURL.createNSURL() copy];
+    m_sourceURL = spatialBackdropSource.m_sourceURL.createNSURL();
+    m_modelURL = spatialBackdropSource.m_modelURL.createNSURL();
     if (spatialBackdropSource.m_environmentMapURL)
-        _environmentMapURL = [spatialBackdropSource.m_environmentMapURL.value().createNSURL() copy];
+        m_environmentMapURL = spatialBackdropSource.m_environmentMapURL.value().createNSURL();
 
     return self;
 }
 
 - (void)dealloc
 {
-    [_sourceURL release];
-    [_modelURL release];
-    [_environmentMapURL release];
     [super dealloc];
 }
 #endif
+
+- (NSURL *)sourceURL
+{
+    return m_sourceURL.get();
+}
+
+- (NSURL *)modelURL
+{
+    return m_modelURL.get();
+}
+
+- (NSURL *)environmentMapURL
+{
+    return m_environmentMapURL.get();
+}
 
 @end


### PR DESCRIPTION
#### 36be3b0371f68bae9c11f5300f02e4314bbc9375
<pre>
Address remaining safer CPP warnings in WebKit/UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=301077">https://bugs.webkit.org/show_bug.cgi?id=301077</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/APIUserScript.h:
* Source/WebKit/UIProcess/API/Cocoa/WKView.h:
(WK_CLASS_DEPRECATED_WITH_REPLACEMENT):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
(-[WKWebsiteDataRecord description]):
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.mm:
(-[_WKAuthenticatorAssertionResponse initWithClientDataJSON:rawId:extensions:authenticatorData:signature:userHandle:attachment:]):
(-[_WKAuthenticatorAssertionResponse initWithClientDataJSON:rawId:extensionOutputsCBOR:authenticatorData:signature:userHandle:attachment:]):
(-[_WKAuthenticatorAssertionResponse authenticatorData]):
(-[_WKAuthenticatorAssertionResponse signature]):
(-[_WKAuthenticatorAssertionResponse userHandle]):
(-[_WKAuthenticatorAssertionResponse dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm:
(-[_WKFrameTreeNode childFrames]):
* Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKSpatialBackdropSource.mm:
(-[_WKSpatialBackdropSource initWithSpatialBackdropSource:]):
(-[_WKSpatialBackdropSource dealloc]):
(-[_WKSpatialBackdropSource sourceURL]):
(-[_WKSpatialBackdropSource modelURL]):
(-[_WKSpatialBackdropSource environmentMapURL]):

Canonical link: <a href="https://commits.webkit.org/301845@main">https://commits.webkit.org/301845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d1421776048f86427323a3e190396093c876daa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134320 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/90f59a84-6751-48e5-b70e-36eee0c368eb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96848 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dd8b5f84-8831-4617-8d45-cd0657b673c2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130204 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/38026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77346 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6aecc8a3-da29-42a5-bf28-be61a8ebfedf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77700 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136803 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53915 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/41538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105364 "Failed to checkout and rebase branch from PR 52648") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105049 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26775 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50571 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51478 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59939 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/53084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54845 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->