### PR TITLE
[GTK][WPE] Offer a BUILD_WEBKIT_PRE_SCRIPT environment variable, to execute a script prior to build-webkit

### DIFF
--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -241,6 +241,25 @@ if (isAppleCocoaWebKit()) {
 my $result = 0;
 
 if (isCMakeBuild() && !isAnyWindows()) {
+    if (defined $ENV{'BUILD_WEBKIT_PRE_SCRIPT'}) {
+        my $preScript = $ENV{'BUILD_WEBKIT_PRE_SCRIPT'};
+
+        if (! -e $preScript) {
+            die "Error: BUILD_WEBKIT_PRE_SCRIPT is set to '$preScript' but the file does not exist.\n";
+        }
+
+        if (! -x $preScript) {
+            die "Error: BUILD_WEBKIT_PRE_SCRIPT is set to '$preScript' but the file is not executable.\n";
+        }
+
+        print "Running pre-build script: $preScript\n";
+        my $exitCode = system($preScript);
+
+        if ($exitCode != 0) {
+            die "Error: Pre-build script '$preScript' failed with exit code " . ($exitCode >> 8) . ".\n";
+        }
+    }
+
     if (!canUseNinja() || defined($ENV{NUMBER_OF_PROCESSORS})) {
         # If the user environment is not setting a specific number of process,
         # then don't pass the number of jobs to Ninja. Because Ninja will


### PR DESCRIPTION
#### 78f2de6b87656ba70ba69b71ae948a6e5283871d
<pre>
[GTK][WPE] Offer a BUILD_WEBKIT_PRE_SCRIPT environment variable, to execute a script prior to build-webkit
<a href="https://bugs.webkit.org/show_bug.cgi?id=301080">https://bugs.webkit.org/show_bug.cgi?id=301080</a>

Reviewed by Carlos Alberto Lopez Perez.

If BUILD_WEBKIT_PRE_SCRIPT is set, verify it&apos;s pointing to an executable
script or complain. If it&apos;s unset, no actions are taken.

If it points to a valid executable, execute it before starting the
WebKit build. This is useful for the Gtk/WPE and the new SDK to support
remote ccache backends, where you need to execute a port knocking
procedure to activate the access to the ccache backend on the server.

* Tools/Scripts/build-webkit:

Canonical link: <a href="https://commits.webkit.org/301802@main">https://commits.webkit.org/301802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e88dffdfbe624c58aed65679d5fd8fb28220f65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37892 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134132 "Failed to checkout and rebase branch from PR 52649") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/128999 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/47376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55289 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/134132 "Failed to checkout and rebase branch from PR 52649") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130076 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/47376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113849 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/134132 "Failed to checkout and rebase branch from PR 52649") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/47376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77521 "Failed to checkout and rebase branch from PR 52649") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119165 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/47376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32331 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136656 "Failed to checkout and rebase branch from PR 52649") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125591 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/53781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/41427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/136656 "Failed to checkout and rebase branch from PR 52649") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/54287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110205 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/136656 "Failed to checkout and rebase branch from PR 52649") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19880 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/53711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158628 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/39679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/54707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->