### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for AudioSourceProviderClient

### DIFF
--- a/Source/WTF/wtf/AbstractRefCountedAndCanMakeWeakPtr.h
+++ b/Source/WTF/wtf/AbstractRefCountedAndCanMakeWeakPtr.h
@@ -30,16 +30,16 @@
 
 namespace WTF {
 
-template<typename T>
-class AbstractRefCountedAndCanMakeWeakPtr : public AbstractRefCounted, public CanMakeWeakPtr<T> {
+template<typename T, WeakPtrFactoryInitialization initializationMode = WeakPtrFactoryInitialization::Lazy>
+class AbstractRefCountedAndCanMakeWeakPtr : public AbstractRefCounted, public CanMakeWeakPtr<T, initializationMode> {
 public:
     // FIXME: Remove this workaround for false negatives in clang static analyezr.
     virtual void ref() const = 0;
     virtual void deref() const = 0;
 };
 
-template<typename T>
-class AbstractRefCountedAndCanMakeSingleThreadWeakPtr : public AbstractRefCounted, public CanMakeSingleThreadWeakPtr<T> {
+template<typename T, WeakPtrFactoryInitialization initializationMode = WeakPtrFactoryInitialization::Lazy>
+class AbstractRefCountedAndCanMakeSingleThreadWeakPtr : public AbstractRefCounted, public CanMakeSingleThreadWeakPtr<T, initializationMode> {
 public:
     // FIXME: Remove this workaround for false negatives in clang static analyezr.
     virtual void ref() const = 0;

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
@@ -51,10 +51,12 @@ public:
     HTMLMediaElement& mediaElement() { return m_mediaElement; }
 
     // AudioNode
-    void process(size_t framesToProcess) override;
+    void process(size_t framesToProcess) final;
     
     // AudioSourceProviderClient
-    void setFormat(size_t numberOfChannels, float sampleRate) override;
+    void setFormat(size_t numberOfChannels, float sampleRate) final;
+    void ref() const final { AudioNode::ref(); }
+    void deref() const final { AudioNode::deref(); }
 
     Lock& processLock() WTF_RETURNS_LOCK(m_processLock) { return m_processLock; }
 

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.h
@@ -48,6 +48,9 @@ public:
 
     MediaStream& mediaStream() { return m_mediaStream; }
 
+    void ref() const final { AudioNode::ref(); }
+    void deref() const final { AudioNode::deref(); }
+
 private:
     MediaStreamAudioSourceNode(BaseAudioContext&, MediaStream&, Ref<WebAudioSourceProvider>&&);
 

--- a/Source/WebCore/platform/audio/AudioSourceProviderClient.h
+++ b/Source/WebCore/platform/audio/AudioSourceProviderClient.h
@@ -25,20 +25,12 @@
 #ifndef AudioSourceProviderClient_h
 #define AudioSourceProviderClient_h
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class AudioSourceProviderClient;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AudioSourceProviderClient> : std::true_type { };
-}
-
-namespace WebCore {
-
-class AudioSourceProviderClient : public CanMakeWeakPtr<AudioSourceProviderClient, WeakPtrFactoryInitialization::Eager> {
+class AudioSourceProviderClient : public AbstractRefCountedAndCanMakeWeakPtr<AudioSourceProviderClient, WeakPtrFactoryInitialization::Eager> {
 public:
     virtual void setFormat(size_t numberOfChannels, float sampleRate) = 0;
 protected:

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -341,8 +341,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     callOnMainThread([weakThis = m_weakFactory.createWeakPtr(*this), numberOfChannels, sampleRate] {
         auto* self = weakThis.get();
-        if (self && self->m_client)
-            self->m_client->setFormat(numberOfChannels, sampleRate);
+        if (!self)
+            return;
+        if (RefPtr client = self->m_client.get())
+            client->setFormat(numberOfChannels, sampleRate);
     });
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
@@ -49,6 +49,9 @@ public:
 
     void newAudioSamples(uint64_t startFrame, uint64_t endFrame, bool);
 
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
 private:
     RemoteAudioSourceProviderProxy(WebCore::MediaPlayerIdentifier, Ref<IPC::Connection>&&);
     std::unique_ptr<WebCore::CARingBuffer> configureAudioStorage(const WebCore::CAAudioStreamDescription&, size_t frameCount);


### PR DESCRIPTION
#### a8c437b6be03b702b983c77a272fba5993f1cf32
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for AudioSourceProviderClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=301085">https://bugs.webkit.org/show_bug.cgi?id=301085</a>

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/AbstractRefCountedAndCanMakeWeakPtr.h:
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h:
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.h:
* Source/WebCore/platform/audio/AudioSourceProviderClient.h:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::prepare):
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h:

Canonical link: <a href="https://commits.webkit.org/301846@main">https://commits.webkit.org/301846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b3e09d46a884f63bea1dd34a1c6957e5974b7cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134161 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78694 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1815f8d8-bbce-4641-9fd3-b312a148745a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96753 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64792 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/71e5508e-c884-490c-ae00-19f746b77685) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77260 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9c03f43c-900d-49ec-951f-b90c30cfa75c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/31982 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77547 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119176 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136683 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125602 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105274 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104960 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26778 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50486 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28921 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51346 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53722 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59689 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158639 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52954 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39681 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56289 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54717 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->