### PR TITLE
[CSS Zoom] Rename 'enableEvaluationTimeZoom' flag

### DIFF
--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -68,7 +68,7 @@ FontDescription::FontDescription()
     , m_fontStyleAxis(enumToUnderlyingType(FontStyleAxis::slnt))
     , m_shouldAllowUserInstalledFonts(enumToUnderlyingType(AllowUserInstalledFonts::No))
     , m_shouldDisableLigaturesForSpacing(false)
-    , m_enableEvaluationTimeZoom(false)
+    , m_evaluationTimeZoomEnabled(false)
 {
 }
 

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -48,7 +48,7 @@ public:
 
     float computedSize() const { return m_computedSize; }
     float usedZoomFactor() const { return m_usedZoomFactor; }
-    float computedSizeForRangeZoomOption(CSS::RangeZoomOptions option) const { return (enableEvaluationTimeZoom() && option == CSS::RangeZoomOptions::Unzoomed) ? unzoomedComputedSize() : computedSize(); }
+    float computedSizeForRangeZoomOption(CSS::RangeZoomOptions option) const { return (evaluationTimeZoomEnabled() && option == CSS::RangeZoomOptions::Unzoomed) ? unzoomedComputedSize() : computedSize(); }
     float unzoomedComputedSize() const { return m_computedSize / m_usedZoomFactor; }
     // Adjusted size regarding @font-face size-adjust but not regarding font-size-adjust. The latter adjustment is done with updateSizeWithFontSizeAdjust() after the font's creation.
     float adjustedSizeForFontFace(float) const;
@@ -62,7 +62,7 @@ public:
     UScriptCode script() const { return static_cast<UScriptCode>(m_script); }
     const AtomString& computedLocale() const { return m_locale; } // This is what you should be using for things like text shaping and font fallback
     const AtomString& specifiedLocale() const { return m_specifiedLocale; } // This is what you should be using for web-exposed things like -webkit-locale
-    bool enableEvaluationTimeZoom() const { return m_enableEvaluationTimeZoom; }
+    bool evaluationTimeZoomEnabled() const { return m_evaluationTimeZoomEnabled; }
 
     FontOrientation orientation() const { return static_cast<FontOrientation>(m_orientation); }
     NonCJKGlyphOrientation nonCJKGlyphOrientation() const { return static_cast<NonCJKGlyphOrientation>(m_nonCJKGlyphOrientation); }
@@ -145,7 +145,7 @@ public:
     void setShouldDisableLigaturesForSpacing(bool shouldDisableLigaturesForSpacing) { m_shouldDisableLigaturesForSpacing = shouldDisableLigaturesForSpacing; }
     void setFontPalette(const FontPalette& fontPalette) { m_fontPalette = fontPalette; }
     void setFontSizeAdjust(FontSizeAdjust fontSizeAdjust) { m_sizeAdjust = fontSizeAdjust; }
-    void setEnableEvaluationTimeZoom(bool enableEvaluationTimeZoom) { m_enableEvaluationTimeZoom = enableEvaluationTimeZoom; }
+    void setEvaluationTimeZoomEnabled(bool evaluationTimeZoomEnabled) { m_evaluationTimeZoomEnabled = evaluationTimeZoomEnabled; }
 
 
     static AtomString platformResolveGenericFamily(UScriptCode, const AtomString& locale, const AtomString& familyName);
@@ -193,7 +193,7 @@ private:
     PREFERRED_TYPE(FontStyleAxis) unsigned m_fontStyleAxis : 1;
     PREFERRED_TYPE(AllowUserInstalledFonts) unsigned m_shouldAllowUserInstalledFonts : 1; // If this description is allowed to match a user-installed font
     PREFERRED_TYPE(bool) unsigned m_shouldDisableLigaturesForSpacing : 1; // If letter-spacing is nonzero, we need to disable ligatures, which affects font preparation
-    PREFERRED_TYPE(bool) unsigned m_enableEvaluationTimeZoom : 1;
+    PREFERRED_TYPE(bool) unsigned m_evaluationTimeZoomEnabled : 1;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -420,9 +420,9 @@ void RenderStyle::copyContentFrom(const RenderStyle& other)
     m_nonInheritedData.access().miscData.access().content = other.m_nonInheritedData->miscData->content;
 }
 
-void RenderStyle::setEnableEvaluationTimeZoom(bool value)
+void RenderStyle::setEvaluationTimeZoomEnabled(bool value)
 {
-    SET_VAR(m_rareInheritedData, enableEvaluationTimeZoom, value);
+    SET_VAR(m_rareInheritedData, evaluationTimeZoomEnabled, value);
 }
 
 void RenderStyle::setDeviceScaleFactor(float value)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1803,8 +1803,8 @@ public:
     inline void setVisitedLinkFill(Style::SVGPaint&&);
     static inline Style::SVGPaint initialFill();
 
-    inline bool enableEvaluationTimeZoom() const;
-    void setEnableEvaluationTimeZoom(bool);
+    inline bool evaluationTimeZoomEnabled() const;
+    void setEvaluationTimeZoomEnabled(bool);
 
     inline float deviceScaleFactor() const;
     void setDeviceScaleFactor(float);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -1412,9 +1412,9 @@ inline bool RenderStyle::fontCascadeEqual(const RenderStyle& other) const
         || m_inheritedData->fontData->fontCascade == other.m_inheritedData->fontData->fontCascade;
 }
 
-inline bool RenderStyle::enableEvaluationTimeZoom() const
+inline bool RenderStyle::evaluationTimeZoomEnabled() const
 {
-    return m_rareInheritedData->enableEvaluationTimeZoom;
+    return m_rareInheritedData->evaluationTimeZoomEnabled;
 }
 
 inline float RenderStyle::deviceScaleFactor() const
@@ -1432,7 +1432,7 @@ inline Style::ZoomFactor RenderStyle::usedZoomForLength() const
     if (useSVGZoomRulesForLength())
         return Style::ZoomFactor(1.0f, deviceScaleFactor());
 
-    if (enableEvaluationTimeZoom())
+    if (evaluationTimeZoomEnabled())
         return Style::ZoomFactor(usedZoom(), deviceScaleFactor());
 
     return Style::ZoomFactor(1.0f, deviceScaleFactor());

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -151,7 +151,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , autoRevealsWhenFound(false)
     , insideDefaultButton(false)
     , insideSubmitButton(false)
-    , enableEvaluationTimeZoom(false)
+    , evaluationTimeZoomEnabled(false)
 #if HAVE(CORE_MATERIAL)
     , usedAppleVisualEffectForSubtree(static_cast<unsigned>(AppleVisualEffect::None))
 #endif
@@ -256,7 +256,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , autoRevealsWhenFound(o.autoRevealsWhenFound)
     , insideDefaultButton(o.insideDefaultButton)
     , insideSubmitButton(o.insideSubmitButton)
-    , enableEvaluationTimeZoom(o.enableEvaluationTimeZoom)
+    , evaluationTimeZoomEnabled(o.evaluationTimeZoomEnabled)
 #if HAVE(CORE_MATERIAL)
     , usedAppleVisualEffectForSubtree(o.usedAppleVisualEffectForSubtree)
 #endif
@@ -397,7 +397,7 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && listStyleImage == o.listStyleImage
         && listStyleType == o.listStyleType
         && blockEllipsis == o.blockEllipsis
-        && enableEvaluationTimeZoom == o.enableEvaluationTimeZoom
+        && evaluationTimeZoomEnabled == o.evaluationTimeZoomEnabled
         && deviceScaleFactor == o.deviceScaleFactor;
 }
 
@@ -556,7 +556,7 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT(listStyleType);
     LOG_IF_DIFFERENT(blockEllipsis);
 
-    LOG_IF_DIFFERENT(enableEvaluationTimeZoom);
+    LOG_IF_DIFFERENT(evaluationTimeZoomEnabled);
 }
 #endif
 

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -195,7 +195,7 @@ public:
     PREFERRED_TYPE(bool) unsigned autoRevealsWhenFound : 1;
     PREFERRED_TYPE(bool) unsigned insideDefaultButton : 1;
     PREFERRED_TYPE(bool) unsigned insideSubmitButton : 1;
-    PREFERRED_TYPE(bool) unsigned enableEvaluationTimeZoom : 1;
+    PREFERRED_TYPE(bool) unsigned evaluationTimeZoomEnabled : 1;
 #if HAVE(CORE_MATERIAL)
     PREFERRED_TYPE(AppleVisualEffect) unsigned usedAppleVisualEffectForSubtree : 5;
 #endif

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -443,7 +443,7 @@ inline float zoomWithTextZoomFactor(BuilderState& builderState)
 {
     if (auto* frame = builderState.document().frame()) {
         float textZoomFactor = builderState.style().textZoom() != TextZoom::Reset ? frame->textZoomFactor() : 1.0f;
-        auto usedZoom = shouldUseEvaluationTimeZoom(builderState) ? 1.0f : builderState.style().usedZoom();
+        auto usedZoom = evaluationTimeZoomEnabled(builderState) ? 1.0f : builderState.style().usedZoom();
         return usedZoom * textZoomFactor;
     }
     return builderState.cssToLengthConversionData().zoom();

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -87,8 +87,8 @@ RenderStyle resolveForDocument(const Document& document)
         fontDescription.setSpecifiedLocale(document.contentLanguage());
         fontDescription.setOneFamily(standardFamily);
         fontDescription.setShouldAllowUserInstalledFonts(settings.shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);
-        // FIXME: We need enableEvaluationTimeZoom to be accessible from FontDescription, not only from RenderStyle. Would it be weird to move it to FontDescription (which is already accessible from RenderStyle)?
-        fontDescription.setEnableEvaluationTimeZoom(document.settings().evaluationTimeZoomEnabled());
+        // FIXME: We need evaluationTimeZoomEnabled to be accessible from FontDescription, not only from RenderStyle. Would it be weird to move it to FontDescription (which is already accessible from RenderStyle)?
+        fontDescription.setEvaluationTimeZoomEnabled(document.settings().evaluationTimeZoomEnabled());
 
         fontDescription.setKeywordSizeFromIdentifier(CSSValueMedium);
         int size = fontSizeForKeyword(CSSValueMedium, false, document);
@@ -110,7 +110,7 @@ RenderStyle resolveForDocument(const Document& document)
     fontCascade.update(WTFMove(fontSelector));
     documentStyle.setFontCascade(WTFMove(fontCascade));
 
-    documentStyle.setEnableEvaluationTimeZoom(document.settings().evaluationTimeZoomEnabled());
+    documentStyle.setEvaluationTimeZoomEnabled(document.settings().evaluationTimeZoomEnabled());
 
     documentStyle.setDeviceScaleFactor(document.deviceScaleFactor());
 

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
@@ -57,7 +57,7 @@ auto CSSValueConversion<LineWidth>::operator()(BuilderState& state, const CSSVal
         }
     }
 
-    if (shouldUseEvaluationTimeZoom(state))
+    if (evaluationTimeZoomEnabled(state))
         return toStyleFromCSSValue<LineWidth::Length>(state, value);
 
     // Any original result that was >= 1 should not be allowed to fall below 1. This keeps border lines from vanishing.

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -78,7 +78,7 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSPr
     // values and raw numbers to percentages.
     if (primitiveValue.isPercentage()) {
         // FIXME: percentage should not be restricted to an integer here.
-        auto textZoom = shouldUseEvaluationTimeZoom(state) ? conversionData.zoom() : 1.0f;
+        auto textZoom = evaluationTimeZoomEnabled(state) ? conversionData.zoom() : 1.0f;
         return LineHeight::Fixed {
             CSS::clampToRange<LineHeight::Fixed::range, float>((state.style().fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption()) * primitiveValue.resolveAsPercentage<int>(conversionData) * textZoom) / 100.0, minValueForCssLength, maxValueForCssLength)
         };

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
@@ -71,7 +71,7 @@ template<LengthWrapperBaseDerived T> struct CSSValueConversion<T> {
                 ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
                 : builderState.cssToLengthConversionData();
         } else if constexpr (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            if (shouldUseEvaluationTimeZoom(builderState))
+            if (evaluationTimeZoomEnabled(builderState))
                 return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, T::Fixed::range.zoomOptions);
 
             return builderState.useSVGZoomRulesForLength()

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword+Conversions.h
@@ -40,7 +40,7 @@ template<auto R, typename V, CSS::PrimitiveKeyword... Ks> struct ToCSS<Primitive
                 if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Default) {
                     return CSS::LengthPercentageRaw<R, V> { length.unit, adjustForZoom(length.unresolvedValue(), style) };
                 } else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-                    if (shouldUseEvaluationTimeZoom(style))
+                    if (evaluationTimeZoomEnabled(style))
                         return CSS::LengthPercentageRaw<R, V> { length.unit, length.unresolvedValue() };
 
                     return CSS::LengthPercentageRaw<R, V> { length.unit, adjustForZoom(length.unresolvedValue(), style) };

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
@@ -104,7 +104,7 @@ template<auto R, typename V> struct CSSValueConversion<Length<R, V>> {
                 ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
                 : builderState.cssToLengthConversionData();
         } else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            if (shouldUseEvaluationTimeZoom(builderState))
+            if (evaluationTimeZoomEnabled(builderState))
                 return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, R.zoomOptions);
 
             return builderState.useSVGZoomRulesForLength()
@@ -189,7 +189,7 @@ template<auto R, typename V> struct CSSValueConversion<LengthPercentage<R, V>> {
                 ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
                 : builderState.cssToLengthConversionData();
         } else if constexpr (LengthPercentage<R, V>::Dimension::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            if (shouldUseEvaluationTimeZoom(builderState))
+            if (evaluationTimeZoomEnabled(builderState))
                 return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
 
             return builderState.useSVGZoomRulesForLength()

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
@@ -66,12 +66,12 @@ float adjustForZoom(float value, const RenderStyle& style)
     return adjustFloatForAbsoluteZoom(value, style);
 }
 
-bool shouldUseEvaluationTimeZoom(const RenderStyle& style)
+bool evaluationTimeZoomEnabled(const RenderStyle& style)
 {
-    return style.enableEvaluationTimeZoom();
+    return style.evaluationTimeZoomEnabled();
 }
 
-bool shouldUseEvaluationTimeZoom(const BuilderState& state)
+bool evaluationTimeZoomEnabled(const BuilderState& state)
 {
     return state.document().settings().evaluationTimeZoomEnabled();
 }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -39,8 +39,8 @@ namespace Style {
 
 // Out of line to avoid inclusion of RenderStyleInlines.h
 float adjustForZoom(float, const RenderStyle&);
-bool shouldUseEvaluationTimeZoom(const RenderStyle&);
-bool shouldUseEvaluationTimeZoom(const BuilderState&);
+bool evaluationTimeZoomEnabled(const RenderStyle&);
+bool evaluationTimeZoomEnabled(const BuilderState&);
 
 // MARK: Conversion Data specialization
 
@@ -59,7 +59,7 @@ template<auto R, typename V> struct ConversionDataSpecializer<CSS::LengthRaw<R, 
                 ? state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
                 : state.cssToLengthConversionData();
         } else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            if (shouldUseEvaluationTimeZoom(state))
+            if (evaluationTimeZoomEnabled(state))
                 return state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, R.zoomOptions);
 
             return state.useSVGZoomRulesForLength()
@@ -253,7 +253,7 @@ template<auto R, typename V> struct ToCSS<Length<R, V>> {
         if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Default) {
             return CSS::LengthRaw<R, V> { value.unit, adjustForZoom(value.unresolvedValue(), style) };
         } else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            if (shouldUseEvaluationTimeZoom(style))
+            if (evaluationTimeZoomEnabled(style))
                 return CSS::LengthRaw<R, V> { value.unit, value.unresolvedValue() };
 
             return CSS::LengthRaw<R, V> { value.unit, adjustForZoom(value.unresolvedValue(), style) };


### PR DESCRIPTION
#### a7f9455f5fa5c6ab72e972909771f61cc60ff7d2
<pre>
[CSS Zoom] Rename &apos;enableEvaluationTimeZoom&apos; flag
<a href="https://rdar.apple.com/163031740">rdar://163031740</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301093">https://bugs.webkit.org/show_bug.cgi?id=301093</a>

Reviewed by Matthieu Dubet and Antoine Quint.

Renaming &apos;enableEvaluationTimeZoom&apos; to `evaluationTimeZoomEnabled`
for a better conformity with WebKit&apos;s convention.

* Source/WebCore/platform/graphics/FontDescription.cpp:
(WebCore::m_evaluationTimeZoom):
(WebCore::m_enableEvaluationTimeZoom): Deleted.
* Source/WebCore/platform/graphics/FontDescription.h:
(WebCore::FontDescription::computedSizeForRangeZoomOption const):
(WebCore::FontDescription::evaluationTimeZoom const):
(WebCore::FontDescription::setEvaluationTimeZoom):
(WebCore::FontDescription::enableEvaluationTimeZoom const): Deleted.
(WebCore::FontDescription::setEnableEvaluationTimeZoom): Deleted.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setEvaluationTimeZoom):
(WebCore::RenderStyle::setEnableEvaluationTimeZoom): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::evaluationTimeZoom const):
(WebCore::RenderStyle::usedZoomForLength const):
(WebCore::RenderStyle::enableEvaluationTimeZoom const): Deleted.
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
(WebCore::StyleRareInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp:
(WebCore::Style::shouldUseEvaluationTimeZoom):

Canonical link: <a href="https://commits.webkit.org/301886@main">https://commits.webkit.org/301886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ec28e80c06254d1a8df742e8043cd05dd565a9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134426 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78917 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6966f087-c471-408f-b08b-25f776a074ed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96931 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9c7f1742-4d36-4f70-89b0-319aab1e9dc6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77425 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/611e8fb3-b87e-48d8-8cec-9db5f215d4d7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77808 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136909 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105451 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105128 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26805 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50648 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51600 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60045 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53191 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54951 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->