### PR TITLE
Implement IPC error string reporting in testing for IPC::Connection

### DIFF
--- a/LayoutTests/ipc/get-error-string-expected.txt
+++ b/LayoutTests/ipc/get-error-string-expected.txt
@@ -1,0 +1,3 @@
+
+PASS IPC error string retrieval after validation failure
+

--- a/LayoutTests/ipc/get-error-string.html
+++ b/LayoutTests/ipc/get-error-string.html
@@ -1,0 +1,56 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Test that IPC error strings can be retrieved after validation failures</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+promise_test(async (t) => {        
+    if (!window.IPC) {
+        done();
+        return;
+    }
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    // IPCTester has a CheckTestParameter message which has the following validations:
+    //  - Parameter validation for `value > 10`
+    //  - MESSAGE_CHECK for `value < 100`
+
+    // Test case 1: Value = 10, that should fail IPC validation
+    CoreIPC.GPU.IPCTester.CheckTestParameter(0, { param: { value: 10 } });
+    CoreIPC.GPU.GPUConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, (reply) => {
+        const errorString = reply.error;
+        assert_true(errorString != "", "Error string should be set for value 10 (IPC validation failure)");
+        assert_true(errorString.includes("Validation failed") && errorString.includes("value > 10"), 
+                    `Error string should contain IPC validator message for value 10, got: "${errorString}"`);
+    });
+
+    // Test case 2: Value = 99, boundary value that should pass both validations
+    CoreIPC.GPU.IPCTester.CheckTestParameter(0, { param: { value: 99 } });
+    CoreIPC.GPU.GPUConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, (reply) => {
+        const errorString = reply.error;
+        assert_true(errorString == "", "Value 99 should pass validation");
+    });
+
+    // Test case 3: Value = 100, boundary value that should pass IPC validation but fail MESSAGE_CHECK
+    CoreIPC.GPU.IPCTester.CheckTestParameter(0, { param: { value: 100 } });
+    CoreIPC.GPU.GPUConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, (reply) => {
+        const errorString = reply.error; 
+        assert_true(errorString != "", "Error string should be set for value 100 (MESSAGE_CHECK failure)");
+        assert_true(errorString.includes("Message check failed") && errorString.includes("Test parameter must be less than 100"),
+            `Error string should contain MESSAGE_CHECK message for value 100, got: "${errorString}"`);
+    });
+
+    // Test case 4: Value = 200, should pass IPC validation but fail MESSAGE_CHECK
+    CoreIPC.GPU.IPCTester.CheckTestParameter(0, { param: { value: 200 } });
+    CoreIPC.GPU.GPUConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, (reply) => {
+        const errorString = reply.error;
+        assert_true(errorString != "", "Error string should be set for value 200 (MESSAGE_CHECK failure)");
+        assert_true(errorString.includes("Message check failed") && errorString.includes("Test parameter must be less than 100"),
+            `Error string should contain MESSAGE_CHECK message for value 200, got: "${errorString}"`);
+    });
+}, "IPC error string retrieval after validation failure");
+
+done();
+</script>
+</body>

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -323,6 +323,7 @@ $(PROJECT_DIR)/Shared/IPCConnectionTester.messages.in
 $(PROJECT_DIR)/Shared/IPCStreamTester.messages.in
 $(PROJECT_DIR)/Shared/IPCStreamTesterProxy.messages.in
 $(PROJECT_DIR)/Shared/IPCTester.messages.in
+$(PROJECT_DIR)/Shared/IPCTester.serialization.in
 $(PROJECT_DIR)/Shared/IPCTesterReceiver.messages.in
 $(PROJECT_DIR)/Shared/ImageOptions.serialization.in
 $(PROJECT_DIR)/Shared/InspectorExtensionTypes.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -732,6 +732,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/GoToBackForwardItemParameters.serialization.in \
 	Shared/ImageOptions.serialization.in \
 	Shared/InspectorExtensionTypes.serialization.in \
+	Shared/IPCTester.serialization.in \
 	Shared/ios/CursorContext.serialization.in \
 	Shared/ios/DynamicViewportSizeUpdate.serialization.in \
 	Shared/ios/GestureTypes.serialization.in \

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -1384,6 +1384,15 @@ void GPUConnectionToWebProcess::setPresentingApplicationAuditToken(WebCore::Page
 }
 #endif
 
+#if ENABLE(IPC_TESTING_API)
+void GPUConnectionToWebProcess::takeInvalidMessageStringForTesting(CompletionHandler<void(String&&)>&& callback)
+{
+    ASCIILiteral error = connection().takeErrorString();
+    String errorString = !error.isNull() ? String::fromUTF8(error) : emptyString();
+    callback(WTFMove(errorString));
+}
+#endif
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -276,6 +276,10 @@ public:
     void setMediaEnvironment(WebCore::PageIdentifier, const String&);
 #endif
 
+#if ENABLE(IPC_TESTING_API)
+    void takeInvalidMessageStringForTesting(CompletionHandler<void(String&&)>&&);
+#endif
+
     bool isAlwaysOnLoggingAllowed() const;
 
 #if USE(AUDIO_SESSION)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -69,6 +69,10 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
 #if ENABLE(EXTENSION_CAPABILITIES)
     SetMediaEnvironment(WebCore::PageIdentifier pageIdentifier, String mediaEnvironment);
 #endif
+
+#if ENABLE(IPC_TESTING_API)
+    TakeInvalidMessageStringForTesting() -> (String error) Synchronous
+#endif
 }
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1836,6 +1836,15 @@ void NetworkConnectionToWebProcess::shouldOffloadIFrameForHost(const String& hos
 }
 #endif
 
+#if ENABLE(IPC_TESTING_API)
+void NetworkConnectionToWebProcess::takeInvalidMessageStringForTesting(CompletionHandler<void(String&&)>&& callback)
+{
+    ASCIILiteral error = connection().takeErrorString();
+    String errorString = !error.isNull() ? String::fromUTF8(error) : emptyString();
+    callback(WTFMove(errorString));
+}
+#endif
+
 } // namespace WebKit
 
 #undef CONNECTION_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -303,6 +303,9 @@ private:
     void sendH2Ping(NetworkResourceLoadParameters&&, CompletionHandler<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>&&);
     void preconnectTo(std::optional<WebCore::ResourceLoaderIdentifier> preconnectionIdentifier, NetworkResourceLoadParameters&&);
     void isResourceLoadFinished(WebCore::ResourceLoaderIdentifier, CompletionHandler<void(bool)>&&);
+#if ENABLE(IPC_TESTING_API)
+    void takeInvalidMessageStringForTesting(CompletionHandler<void(String&&)>&&);
+#endif
 
     void removeLoadIdentifier(WebCore::ResourceLoaderIdentifier);
     void pageLoadCompleted(WebCore::PageIdentifier);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -157,4 +157,8 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
 #if ENABLE(CONTENT_EXTENSIONS)
     ShouldOffloadIFrameForHost(String host) -> (bool wasGranted)
 #endif
+
+#if ENABLE(IPC_TESTING_API)
+    TakeInvalidMessageStringForTesting() -> (String error) Synchronous
+#endif
 }

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -40,6 +40,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
+#include <wtf/text/ASCIILiteral.h>
 
 #if PLATFORM(MAC)
 #include "ImportanceAssertion.h"
@@ -111,6 +112,16 @@ public:
 
 #if PLATFORM(MAC)
     void setImportanceAssertion(ImportanceAssertion&&);
+#endif
+
+#if ENABLE(IPC_TESTING_API)
+    bool hasErrorString() const { return !m_errorString.isNull(); }
+    void setErrorString(ASCIILiteral error)
+    {
+        if (!hasErrorString())
+            m_errorString = error;
+    }
+    ASCIILiteral takeErrorString() { return std::exchange(m_errorString, ASCIILiteral { nullptr }); }
 #endif
 
     static std::unique_ptr<Decoder> unwrapForTesting(Decoder&);
@@ -205,6 +216,10 @@ private:
     Markable<SyncRequestID> m_syncRequestID;
 
     Vector<uint32_t> m_indicesOfObjectsFailingDecoding;
+
+#if ENABLE(IPC_TESTING_API)
+    ASCIILiteral m_errorString;
+#endif
 };
 
 template<>

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -301,8 +301,9 @@ void StreamServerConnection::dispatchDidReceiveInvalidMessage(Decoder& message)
     invalidate();
 }
 
-void StreamServerConnection::markCurrentlyDispatchedMessageAsInvalid()
+void StreamServerConnection::markCurrentlyDispatchedMessageAsInvalid(ASCIILiteral error)
 {
+    UNUSED_PARAM(error);
     ASSERT(m_isDispatchingMessage);
     m_didReceiveInvalidMessage = true;
 }

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -105,7 +105,7 @@ public:
         HasMoreMessages
     };
     DispatchResult dispatchStreamMessages(size_t messageLimit);
-    void markCurrentlyDispatchedMessageAsInvalid();
+    void markCurrentlyDispatchedMessageAsInvalid(ASCIILiteral error);
 
     void open(Client&, StreamConnectionWorkQueue&);
     void invalidate();
@@ -206,15 +206,15 @@ void StreamServerConnection::sendAsyncReply(AsyncReplyID asyncReplyID, Arguments
     m_connection->sendAsyncReply<T>(asyncReplyID, std::forward<Arguments>(arguments)...);
 }
 
-inline void markCurrentlyDispatchedMessageAsInvalid(StreamServerConnection& connection)
+inline void markCurrentlyDispatchedMessageAsInvalid(StreamServerConnection& connection, ASCIILiteral error)
 {
-    connection.markCurrentlyDispatchedMessageAsInvalid();
+    connection.markCurrentlyDispatchedMessageAsInvalid(error);
 }
 
-inline void markCurrentlyDispatchedMessageAsInvalid(const RefPtr<StreamServerConnection>& connection)
+inline void markCurrentlyDispatchedMessageAsInvalid(const RefPtr<StreamServerConnection>& connection, ASCIILiteral error)
 {
     if (connection)
-        connection->markCurrentlyDispatchedMessageAsInvalid();
+        connection->markCurrentlyDispatchedMessageAsInvalid(error);
 }
 
 }

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -971,8 +971,12 @@ def decode_type(type, serialized_types):
                 result.append('    if (!decoder.isValid()) [[unlikely]]')
                 result.append('        return std::nullopt;')
                 result.append('')
-                result.append(f'    if (!({validator}))')
+                result.append(f'    if (!({validator})) {{')
+                result.append('#if ENABLE(IPC_TESTING_API)')
+                result.append(f'        decoder.setErrorString("Validation failed: {validator}"_s);')
+                result.append('#endif')
                 result.append('        return std::nullopt;')
+                result.append(f'    }}')
                 continue
             else:
                 match = re.search(r'Validator', attribute)

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm
@@ -92,7 +92,7 @@ void RemoteObjectRegistry::callReplyBlock(IPC::Connection& connection, uint64_t 
         [m_remoteObjectRegistry.get() _callReplyWithID:replyID blockInvocation:blockInvocation];
     } @catch (NSException *exception) {
         NSLog(@"Warning: Exception caught during handling of received message, marking message invalid .\nException: %@", exception);
-        IPC::markCurrentlyDispatchedMessageAsInvalid(connection);
+        IPC::markCurrentlyDispatchedMessageAsInvalid(connection, "Exception caught during handling of RemoteObjectRegistry message"_s);
     }
 }
 

--- a/Source/WebKit/Shared/IPCTester.cpp
+++ b/Source/WebKit/Shared/IPCTester.cpp
@@ -34,6 +34,8 @@
 #include "IPCTesterMessages.h"
 #include "IPCTesterReceiverMessages.h"
 #include "IPCUtilities.h"
+#include "Logging.h"
+#include "TestParameter.h"
 
 #include <WebCore/ExceptionData.h>
 #include <atomic>
@@ -245,6 +247,11 @@ void IPCTester::stopIfNeeded()
 void IPCTester::emptyMessageWithReply(CompletionHandler<void(uint64_t)>&& completionHandler)
 {
     completionHandler(0x1);
+}
+
+void IPCTester::checkTestParameter(IPC::Connection& connection, TestParameter param)
+{
+    MESSAGE_CHECK_WITH_MESSAGE_BASE(param.value < 100, connection, "Test parameter must be less than 100");
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -49,6 +49,7 @@ namespace WebKit {
 
 class IPCConnectionTester;
 class IPCStreamTester;
+struct TestParameter;
 
 // Main test interface for initiating various IPC test activities.
 class IPCTester final : public IPC::MessageReceiver, public RefCounted<IPCTester> {
@@ -82,6 +83,7 @@ private:
     void asyncOptionalExceptionData(IPC::Connection&, bool sendEngaged, CompletionHandler<void(std::optional<WebCore::ExceptionData>, String)>&&);
     void emptyMessage() { }
     void emptyMessageWithReply(CompletionHandler<void(uint64_t)>&&);
+    void checkTestParameter(IPC::Connection&, TestParameter);
     void stopIfNeeded();
 
     RefPtr<WorkQueue> m_testQueue;

--- a/Source/WebKit/Shared/IPCTester.messages.in
+++ b/Source/WebKit/Shared/IPCTester.messages.in
@@ -49,6 +49,7 @@ messages -> IPCTester {
 
     EmptyMessage()
     EmptyMessageWithReply() -> (uint64_t valueq)
+    CheckTestParameter(struct WebKit::TestParameter param)
 }
 
 #endif

--- a/Source/WebKit/Shared/IPCTester.serialization.in
+++ b/Source/WebKit/Shared/IPCTester.serialization.in
@@ -1,0 +1,30 @@
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(IPC_TESTING_API)
+
+header: "TestParameter.h"
+struct WebKit::TestParameter {
+    [Validator='*value > 10'] uint32_t value;
+};
+
+#endif

--- a/Source/WebKit/Shared/TestParameter.h
+++ b/Source/WebKit/Shared/TestParameter.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(IPC_TESTING_API)
+
+#include <cstdint>
+
+namespace WebKit {
+
+struct TestParameter {
+    uint32_t value;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -118,6 +118,7 @@
 #include <wtf/URLHash.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakListHashSet.h>
+#include <wtf/text/ASCIILiteral.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextStream.h>
@@ -3228,6 +3229,15 @@ void WebProcessProxy::sendWasmDebuggerResponse(const String& response)
 
     debuggable->sendResponseToFrontend(response);
 }
+
+#if ENABLE(IPC_TESTING_API)
+void WebProcessProxy::takeInvalidMessageStringForTesting(CompletionHandler<void(String&&)>&& callback)
+{
+    ASCIILiteral error = protectedConnection()->takeErrorString();
+    String errorString = !error.isNull() ? String::fromUTF8(error) : emptyString();
+    callback(WTFMove(errorString));
+}
+#endif
 
 #endif // ENABLE(REMOTE_INSPECTOR) && ENABLE(WEBASSEMBLY)
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -593,6 +593,10 @@ public:
     void sendWasmDebuggerResponse(const String& response);
 #endif
 
+#if ENABLE(IPC_TESTING_API)
+    void takeInvalidMessageStringForTesting(CompletionHandler<void(String&&)>&&);
+#endif
+
 private:
     Type type() const final { return Type::WebContent; }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -116,4 +116,8 @@ messages -> WebProcessProxy WantsDispatchMessage {
 
     DidPostMessage(WebKit::WebPageProxyIdentifier pageID, WebKit::UserContentControllerIdentifier identifier, struct WebKit::FrameInfoData frameInfoData, WebKit::ScriptMessageHandlerIdentifier messageHandlerID, WebKit::JavaScriptEvaluationResult message) -> (Expected<WebKit::JavaScriptEvaluationResult, String> reply)
     DidPostLegacySynchronousMessage(WebKit::WebPageProxyIdentifier pageID, WebKit::UserContentControllerIdentifier identifier, struct WebKit::FrameInfoData frameInfoData, WebKit::ScriptMessageHandlerIdentifier messageHandlerID, WebKit::JavaScriptEvaluationResult message) -> (Expected<WebKit::JavaScriptEvaluationResult, String> reply) Synchronous
+
+#if ENABLE(IPC_TESTING_API)
+    TakeInvalidMessageStringForTesting() -> (String error) Synchronous
+#endif
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6800,6 +6800,7 @@
 		7B483F1E25CDDA9B00120486 /* MessageReceiveQueues.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueues.h; sourceTree = "<group>"; };
 		7B50E97F2771F6CE003DAAC4 /* IPCTester.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPCTester.cpp; sourceTree = "<group>"; };
 		7B50E9802771F6CF003DAAC4 /* IPCTester.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCTester.h; sourceTree = "<group>"; };
+		7B50E9812771F6CF003DAAC5 /* TestParameter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestParameter.h; sourceTree = "<group>"; };
 		7B5A3DA027A7DC1A006C6F97 /* RemoteVideoFrameIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteVideoFrameIdentifier.h; sourceTree = "<group>"; };
 		7B5A3DA227A7DC1A006C6F97 /* RemoteVideoFrameProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteVideoFrameProxy.h; sourceTree = "<group>"; };
 		7B5A3DA327A7DC6C006C6F97 /* RemoteVideoFrameProxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteVideoFrameProxy.cpp; sourceTree = "<group>"; };
@@ -10092,6 +10093,7 @@
 				83F9644B1FA0F76200C47750 /* SharedStringHashTableReadOnly.cpp */,
 				83F9644C1FA0F76300C47750 /* SharedStringHashTableReadOnly.h */,
 				932CA81B283C35EB00C20BEB /* StorageAreaIdentifier.h */,
+				7B50E9812771F6CF003DAAC5 /* TestParameter.h */,
 				07E2C0782C13FC0100BE6743 /* TextAnimationTypes.serialization.in */,
 				1A5E4DA312D3BD3D0099A2BB /* TextCheckerState.h */,
 				F4217F1D2E8EFF8A0036AAC1 /* TextExtractionToStringConversion.cpp */,

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -1436,11 +1436,11 @@ public:
         } else {
             // Cause a validation error, MESSAGE_CHECK.
             serverClient().setAsyncMessageHandler([] (IPC::Connection& connection, IPC::Decoder&) {
-                connection.markCurrentlyDispatchedMessageAsInvalid();
+                connection.markCurrentlyDispatchedMessageAsInvalid("async message check"_s);
                 return true;
             });
             serverClient().setSyncMessageHandler([] (IPC::Connection& connection, IPC::Decoder&, UniqueRef<IPC::Encoder>&) {
-                connection.markCurrentlyDispatchedMessageAsInvalid();
+                connection.markCurrentlyDispatchedMessageAsInvalid("sync message check"_s);
                 return true;
             });
         }

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -644,11 +644,11 @@ public:
         } else {
             // Cause a validation error, MESSAGE_CHECK.
             m_mockServerReceiver->setAsyncMessageHandler([] (IPC::StreamServerConnection& connection, IPC::Decoder&) {
-                connection.markCurrentlyDispatchedMessageAsInvalid();
+                connection.markCurrentlyDispatchedMessageAsInvalid("async stream message check"_s);
                 return true;
             });
             m_mockServerReceiver->setSyncMessageHandler([] (IPC::StreamServerConnection& connection, IPC::Decoder&) {
-                connection.markCurrentlyDispatchedMessageAsInvalid();
+                connection.markCurrentlyDispatchedMessageAsInvalid("sync stream message check"_s);
                 return true;
             });
         }


### PR DESCRIPTION
#### 2837e1eaeb3d3d5e7ac3bb0535c8ef1b9ee4fddb
<pre>
Implement IPC error string reporting in testing for IPC::Connection
<a href="https://rdar.apple.com/163035367">rdar://163035367</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301095">https://bugs.webkit.org/show_bug.cgi?id=301095</a>

Reviewed by Kimmo Kinnunen.

This patch introduces the first part of a feature to enable error reporting over IPC for validation failures and MESSAGE_CHECKs. This feature currently only supports the base IPC::Connection, and not stream connections at this time.

It adds error string tracking to the IPC Decoder and Connection, and propagates these during decoding. Error strings are stored until they are read by WebContent by calling the appropriate TakeInvalidMessageStringForTesting message on the underlying IPC connection. This allows tests to trigger specific error conditions and check the resulting string to make sure the expected condition was reached.

This patch also adds the IPCTester.CheckTestParameter method and the ipc/get-error-string.html test to demonstrate the use of this feature.

This feature is only enabled for builds using the IPC Testing API.

Tests: ipc/get-error-string.html
       Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
       Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp

* LayoutTests/ipc/get-error-string-expected.txt: Added.
* LayoutTests/ipc/get-error-string.html: Added.
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::takeInvalidMessageStringForTesting):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::takeInvalidMessageStringForTesting):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::dispatchMessageReceiverMessage):
(IPC::Connection::dispatchMessage):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::hasErrorString const):
(IPC::Connection::setErrorString):
(IPC::Connection::takeErrorString):
(IPC::Connection::markCurrentlyDispatchedMessageAsInvalid):
(IPC::markCurrentlyDispatchedMessageAsInvalid):
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::hasErrorString const):
(IPC::Decoder::setErrorString):
(IPC::Decoder::takeErrorString):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::markCurrentlyDispatchedMessageAsInvalid):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::markCurrentlyDispatchedMessageAsInvalid):
* Source/WebKit/Scripts/generate-serializers.py:
(decode_type):
* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm:
(WebKit::RemoteObjectRegistry::callReplyBlock):
* Source/WebKit/Shared/IPCTester.cpp:
(WebKit::IPCTester::checkTestParameter):
* Source/WebKit/Shared/IPCTester.h:
* Source/WebKit/Shared/IPCTester.messages.in:
* Source/WebKit/Shared/IPCTester.serialization.in: Added.
* Source/WebKit/Shared/TestParameter.h: Added.
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::takeInvalidMessageStringForTesting):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:

Canonical link: <a href="https://commits.webkit.org/302528@main">https://commits.webkit.org/302528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b66fd047a690afc660ddca19efebc29c941cc301

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80639 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fffd0010-024c-45bb-83c4-8a41d6b8030a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98422 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66322 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/126c9174-106a-40b4-9cc0-946e6bb30226) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79073 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9cf5b7ee-93aa-41a5-967f-9738ee1d7fba) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/128600 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79905 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109501 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139100 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1248 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106952 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106790 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27217 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1070 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30634 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53913 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1369 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64725 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1192 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1229 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1292 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->