### PR TITLE
[WebAuthn] Reland enums should be DOMStrings

### DIFF
--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,12 +23,26 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-    ExportMacro=WEBCORE_EXPORT,
-    ImplementedAs=ResidentKeyRequirement
-] enum ResidentKeyRequirement {
-    "required",
-    "preferred",
-    "discouraged"
-};
+#include "config.h"
+#include "CredentialRequestOptions.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include "DocumentPage.h"
+#include "ExceptionOr.h"
+#include "FrameDestructionObserverInlines.h"
+#include "JSCredentialMediationRequirement.h"
+
+namespace WebCore {
+
+MediationRequirement CredentialRequestOptions::mediation() const
+{
+    if (auto parsed = parseEnumerationFromString<MediationRequirement>(mediationString))
+        return *parsed;
+    // Default value if string is invalid/unknown
+    return MediationRequirement::Optional;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
@@ -39,7 +39,8 @@ class AbortSignal;
 using CredentialMediationRequirement = MediationRequirement;
 
 struct CredentialRequestOptions {
-    MediationRequirement mediation;
+    String mediationString { "optional"_s };
+    WEBCORE_EXPORT MediationRequirement mediation() const;
     RefPtr<AbortSignal> signal;
     std::optional<PublicKeyCredentialRequestOptions> publicKey;
     std::optional<DigitalCredentialRequestOptions> digital;

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl
@@ -27,7 +27,7 @@
 [
     Conditional=WEB_AUTHN,
 ] dictionary CredentialRequestOptions {
-    CredentialMediationRequirement mediation = "optional";
+    [ImplementedAs=mediationString] DOMString mediation = "optional";
     AbortSignal signal;
     PublicKeyCredentialRequestOptions publicKey;
     // https://wicg.github.io/digital-identities/#extensions-to-credentialrequestoptions-dictionary

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -112,7 +112,7 @@ void DigitalCredential::discoverFromExternalSource(const Document& document, Cre
 {
     ASSERT(options.digital);
 
-    if (options.mediation != MediationRequirement::Required) {
+    if (options.mediation() != MediationRequirement::Required) {
         promise.reject(Exception { ExceptionCode::TypeError, "User mediation is required for DigitalCredential."_s });
         return;
     }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "Document.h"
+#include "DocumentPage.h"
 #include "LibWebRTCAudioModule.h"
 #include "LibWebRTCDtlsTransportBackend.h"
 #include "LibWebRTCProvider.h"

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.h
@@ -27,17 +27,18 @@
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
-#include <wtf/CompletionHandler.h>
-#include <wtf/RefPtr.h>
-
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 
 // See Bug 274508: Disable thread-safety-reference-return warnings in libwebrtc
 IGNORE_CLANG_WARNINGS_BEGIN("thread-safety-reference-return")
+IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
 #include <webrtc/pc/rtc_stats_collector.h>
+IGNORE_CLANG_WARNINGS_END
 IGNORE_CLANG_WARNINGS_END
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/CompletionHandler.h>
+#include <wtf/RefPtr.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/notifications/NotificationPayload.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationPayload.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "NotificationPayload.h"
 
+#include "ExceptionOr.h"
 #include "NotificationData.h"
 #include "NotificationJSONParser.h"
 

--- a/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.idl
+++ b/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.idl
@@ -25,6 +25,7 @@
 
 [
     Conditional=WEB_AUTHN,
+    ExportMacro=WEBCORE_EXPORT,
 ] enum AttestationConveyancePreference {
     "none",
     "indirect",

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAttachment.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAttachment.idl
@@ -25,6 +25,7 @@
 
 [
     Conditional=WEB_AUTHN,
+    ExportMacro=WEBCORE_EXPORT,
     ImplementedAs=AuthenticatorAttachment
 ] enum AuthenticatorAttachment {
     "platform",

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -289,7 +289,7 @@ void AuthenticatorCoordinator::discoverFromExternalSource(const Document& docume
     }
 
     // The request will be aborted in WebAuthenticatorCoordinatorProxy if conditional mediation is not available.
-    if (requestOptions.mediation != MediationRequirement::Conditional && !document.hasFocus()) {
+    if (requestOptions.mediation() != MediationRequirement::Conditional && !document.hasFocus()) {
         promise.reject(Exception { ExceptionCode::NotAllowedError, "The document is not focused."_s });
         return;
     }
@@ -385,12 +385,12 @@ void AuthenticatorCoordinator::discoverFromExternalSource(const Document& docume
             RefPtr frame = weakFrame.get();
             if (!frame)
                 return;
-            weakThis->m_client->getAssertion(*weakFrame, options, requestOptions.mediation, scopeCrossOriginParent, WTFMove(callback));
+            weakThis->m_client->getAssertion(*weakFrame, options, requestOptions.mediation(), scopeCrossOriginParent, WTFMove(callback));
         };
         return;
     }
     // Async operations are dispatched and handled in the messenger.
-    m_client->getAssertion(*frame, options, requestOptions.mediation, scopeCrossOriginParent, WTFMove(callback));
+    m_client->getAssertion(*frame, options, requestOptions.mediation(), scopeCrossOriginParent, WTFMove(callback));
 }
 
 void AuthenticatorCoordinator::isUserVerifyingPlatformAuthenticatorAvailable(const Document& document, DOMPromiseDeferred<IDLBoolean>&& promise) const

--- a/Source/WebCore/Modules/webauthn/AuthenticatorSelectionCriteria.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorSelectionCriteria.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AuthenticatorSelectionCriteria.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include "AuthenticatorAttachment.h"
+#include "JSAuthenticatorAttachment.h"
+#include "JSResidentKeyRequirement.h"
+#include "JSUserVerificationRequirement.h"
+#include "ResidentKeyRequirement.h"
+#include "UserVerificationRequirement.h"
+
+namespace WebCore {
+
+std::optional<AuthenticatorAttachment> AuthenticatorSelectionCriteria::authenticatorAttachment() const
+{
+    if (authenticatorAttachmentString.isEmpty())
+        return std::nullopt;
+    // parseEnumerationFromString returns std::nullopt for unknown values
+    return parseEnumerationFromString<AuthenticatorAttachment>(authenticatorAttachmentString);
+}
+
+std::optional<ResidentKeyRequirement> AuthenticatorSelectionCriteria::residentKey() const
+{
+    if (!residentKeyString)
+        return std::nullopt;
+    if (auto parsed = parseEnumerationFromString<ResidentKeyRequirement>(residentKeyString))
+        return *parsed;
+    // Default to preferred if invalid
+    return ResidentKeyRequirement::Preferred;
+}
+
+UserVerificationRequirement AuthenticatorSelectionCriteria::userVerification() const
+{
+    if (!userVerificationString)
+        return UserVerificationRequirement::Preferred; // Default
+    if (auto parsed = parseEnumerationFromString<UserVerificationRequirement>(userVerificationString))
+        return *parsed;
+    // Default to preferred if invalid
+    return UserVerificationRequirement::Preferred;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/AuthenticatorSelectionCriteria.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorSelectionCriteria.h
@@ -40,11 +40,16 @@ namespace WebCore {
 enum class AuthenticatorAttachment : uint8_t;
 
 struct AuthenticatorSelectionCriteria {
-    std::optional<AuthenticatorAttachment> authenticatorAttachment;
+    String authenticatorAttachmentString;
+    WEBCORE_EXPORT std::optional<AuthenticatorAttachment> authenticatorAttachment() const;
+
     // residentKey replaces requireResidentKey, see: https://www.w3.org/TR/webauthn-2/#dictionary-authenticatorSelection
-    std::optional<ResidentKeyRequirement> residentKey;
+    String residentKeyString;
+    WEBCORE_EXPORT std::optional<ResidentKeyRequirement> residentKey() const;
     bool requireResidentKey { false };
-    UserVerificationRequirement userVerification { UserVerificationRequirement::Preferred };
+
+    String userVerificationString { String { "preferred"_s } };
+    WEBCORE_EXPORT UserVerificationRequirement userVerification() const;
 };
 
 }

--- a/Source/WebCore/Modules/webauthn/AuthenticatorSelectionCriteria.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorSelectionCriteria.idl
@@ -28,8 +28,8 @@
     JSGenerateToNativeObject,
     JSGenerateToJSObject,
 ] dictionary AuthenticatorSelectionCriteria {
-    AuthenticatorAttachment      authenticatorAttachment;
-    ResidentKeyRequirement       residentKey;
+    [ImplementedAs=authenticatorAttachmentString] DOMString      authenticatorAttachment;
+    [ImplementedAs=residentKeyString]             DOMString      residentKey;
     boolean                      requireResidentKey = false;
-    UserVerificationRequirement  userVerification = "preferred";
+    [ImplementedAs=userVerificationString] DOMString  userVerification = "preferred";
 };

--- a/Source/WebCore/Modules/webauthn/AuthenticatorTransport.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorTransport.idl
@@ -25,6 +25,7 @@
 
 [
     Conditional=WEB_AUTHN,
+    ExportMacro=WEBCORE_EXPORT,
 ] enum AuthenticatorTransport {
     "usb",
     "nfc",

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
@@ -138,8 +138,9 @@ static ExceptionOr<PublicKeyCredentialDescriptor> fromJSON(PublicKeyCredentialDe
     else
         return Exception { ExceptionCode::EncodingError, makeString("Invalid encoding of credential ID: "_s, jsonOptions.id, " (It should be Base64URL encoded.)"_s) };
     for (auto transportString : jsonOptions.transports) {
-        if (auto transport = convertStringToAuthenticatorTransport(transportString))
-            descriptor.transports.append(*transport);
+        // Validate the transport string is recognized, then keep the string
+        if (convertStringToAuthenticatorTransport(transportString))
+            descriptor.transports.append(transportString);
     }
     return descriptor;
 }
@@ -262,8 +263,7 @@ ExceptionOr<PublicKeyCredentialCreationOptions> PublicKeyCredential::parseCreati
     options.excludeCredentials = excludeCredentials.releaseReturnValue();
 
     options.authenticatorSelection = jsonOptions.authenticatorSelection;
-    if (auto attestation = parseEnumerationFromString<AttestationConveyancePreference>(jsonOptions.attestation))
-        options.attestation = *attestation;
+    options.attestationString = jsonOptions.attestation;
     if (jsonOptions.extensions) {
         auto extensions = fromJSON(WTFMove(*jsonOptions.extensions));
         if (extensions.hasException())
@@ -287,8 +287,7 @@ ExceptionOr<PublicKeyCredentialRequestOptions> PublicKeyCredential::parseRequest
     if (allowCredentials.hasException())
         return allowCredentials.releaseException();
     options.allowCredentials = allowCredentials.releaseReturnValue();
-    if (auto userVerification = parseEnumerationFromString<UserVerificationRequirement>(jsonOptions.userVerification))
-        options.userVerification = *userVerification;
+    options.userVerificationString = jsonOptions.userVerification;
     if (jsonOptions.extensions) {
         auto extensions = fromJSON(WTFMove(*jsonOptions.extensions));
         if (extensions.hasException())

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,12 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-    ExportMacro=WEBCORE_EXPORT,
-    ImplementedAs=ResidentKeyRequirement
-] enum ResidentKeyRequirement {
-    "required",
-    "preferred",
-    "discouraged"
-};
+#include "config.h"
+#include "PublicKeyCredentialCreationOptions.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include "JSAttestationConveyancePreference.h"
+
+namespace WebCore {
+
+AttestationConveyancePreference PublicKeyCredentialCreationOptions::attestation() const
+{
+    if (auto parsed = parseEnumerationFromString<AttestationConveyancePreference>(attestationString))
+        return *parsed;
+    // Default value if string is invalid/unknown
+    return AttestationConveyancePreference::None;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.h
@@ -56,7 +56,8 @@ struct PublicKeyCredentialCreationOptions {
     std::optional<unsigned> timeout;
     Vector<PublicKeyCredentialDescriptor> excludeCredentials;
     std::optional<AuthenticatorSelectionCriteria> authenticatorSelection;
-    AttestationConveyancePreference attestation;
+    String attestationString { "none"_s };
+    WEBCORE_EXPORT AttestationConveyancePreference attestation() const;
     mutable std::optional<AuthenticationExtensionsClientInputs> extensions;
 #endif // ENABLE(WEB_AUTHN)
 };

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
@@ -37,7 +37,7 @@
     unsigned long timeout;
     sequence<PublicKeyCredentialDescriptor> excludeCredentials = [];
     AuthenticatorSelectionCriteria authenticatorSelection;
-    AttestationConveyancePreference attestation = "none";
+    [ImplementedAs=attestationString] DOMString attestation = "none";
     AuthenticationExtensionsClientInputs extensions;
 };
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h
@@ -36,7 +36,7 @@ namespace WebCore {
 struct PublicKeyCredentialDescriptor {
     PublicKeyCredentialType type;
     BufferSource id;
-    Vector<AuthenticatorTransport> transports;
+    Vector<String> transports;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.idl
@@ -30,5 +30,5 @@
 ] dictionary PublicKeyCredentialDescriptor {
     required PublicKeyCredentialType type;
     required [OverrideIDLType=IDLBufferSource] BufferSource id;
-    sequence<AuthenticatorTransport> transports;
+    sequence<DOMString> transports;
 };

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,12 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-    ExportMacro=WEBCORE_EXPORT,
-    ImplementedAs=ResidentKeyRequirement
-] enum ResidentKeyRequirement {
-    "required",
-    "preferred",
-    "discouraged"
-};
+#include "config.h"
+#include "PublicKeyCredentialRequestOptions.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include "JSUserVerificationRequirement.h"
+
+namespace WebCore {
+
+UserVerificationRequirement PublicKeyCredentialRequestOptions::userVerification() const
+{
+    if (auto parsed = parseEnumerationFromString<UserVerificationRequirement>(userVerificationString))
+        return *parsed;
+    // Default value if string is invalid/unknown
+    return UserVerificationRequirement::Preferred;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h
@@ -42,7 +42,8 @@ struct PublicKeyCredentialRequestOptions {
     std::optional<unsigned> timeout;
     mutable String rpId;
     Vector<PublicKeyCredentialDescriptor> allowCredentials;
-    UserVerificationRequirement userVerification { UserVerificationRequirement::Preferred };
+    String userVerificationString { "preferred"_s };
+    WEBCORE_EXPORT UserVerificationRequirement userVerification() const;
     mutable std::optional<AuthenticationExtensionsClientInputs> extensions;
     std::optional<AuthenticatorAttachment> authenticatorAttachment { }; // Not serialized over IPC.
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
@@ -32,6 +32,6 @@
     unsigned long timeout;
     DOMString rpId;
     sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-    UserVerificationRequirement userVerification = "preferred";
+    [ImplementedAs=userVerificationString] DOMString userVerification = "preferred";
     AuthenticationExtensionsClientInputs extensions;
 };

--- a/Source/WebCore/Modules/webauthn/UserVerificationRequirement.idl
+++ b/Source/WebCore/Modules/webauthn/UserVerificationRequirement.idl
@@ -25,6 +25,7 @@
 
 [
     Conditional=WEB_AUTHN,
+    ExportMacro=WEBCORE_EXPORT,
     ImplementedAs=UserVerificationRequirement
 ] enum UserVerificationRequirement {
     "required",

--- a/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp
@@ -158,16 +158,16 @@ Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<uint8_t>& hash, c
     CBORValue::MapValue optionMap;
     if (options.authenticatorSelection) {
         // Resident keys are not supported by default.
-        if (options.authenticatorSelection->residentKey) {
-            if (*options.authenticatorSelection->residentKey == ResidentKeyRequirement::Required
-                || (*options.authenticatorSelection->residentKey == ResidentKeyRequirement::Preferred && residentKeyAvailability == AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported))
+        if (auto residentKey = options.authenticatorSelection->residentKey()) {
+            if (*residentKey == ResidentKeyRequirement::Required
+                || (*residentKey == ResidentKeyRequirement::Preferred && residentKeyAvailability == AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported))
                 optionMap[CBORValue(kResidentKeyMapKey)] = CBORValue(true);
         } else if (options.authenticatorSelection->requireResidentKey)
             optionMap[CBORValue(kResidentKeyMapKey)] = CBORValue(true);
 
         // User verification is not required by default.
         bool requireUserVerification = false;
-        switch (options.authenticatorSelection->userVerification) {
+        switch (options.authenticatorSelection->userVerification()) {
         case UserVerificationRequirement::Required:
         case UserVerificationRequirement::Preferred:
             requireUserVerification = uvCapability == UVAvailability::kSupportedAndConfigured;
@@ -262,7 +262,7 @@ Vector<uint8_t> encodeGetAssertionRequestAsCBOR(const Vector<uint8_t>& hash, con
     CBORValue::MapValue optionMap;
     // User verification is not required by default.
     bool requireUserVerification = false;
-    switch (options.userVerification) {
+    switch (options.userVerification()) {
     case UserVerificationRequirement::Required:
     case UserVerificationRequirement::Preferred:
         requireUserVerification = uvCapability == UVAvailability::kSupportedAndConfigured;

--- a/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
@@ -85,7 +85,7 @@ static std::optional<Vector<uint8_t>> constructU2fSignCommand(const Vector<uint8
 
 bool isConvertibleToU2fRegisterCommand(const PublicKeyCredentialCreationOptions& request)
 {
-    if (request.authenticatorSelection && (request.authenticatorSelection->userVerification == UserVerificationRequirement::Required || request.authenticatorSelection->requireResidentKey))
+    if (request.authenticatorSelection && (request.authenticatorSelection->userVerification() == UserVerificationRequirement::Required || request.authenticatorSelection->requireResidentKey))
         return false;
     if (request.pubKeyCredParams.findIf([](auto& item) { return item.alg == COSE::ES256; }) == notFound)
         return false;
@@ -94,7 +94,7 @@ bool isConvertibleToU2fRegisterCommand(const PublicKeyCredentialCreationOptions&
 
 bool isConvertibleToU2fSignCommand(const PublicKeyCredentialRequestOptions& request)
 {
-    return (request.userVerification != UserVerificationRequirement::Required) && !request.allowCredentials.isEmpty();
+    return (request.userVerification() != UserVerificationRequirement::Required) && !request.allowCredentials.isEmpty();
 }
 
 std::optional<Vector<uint8_t>> convertToU2fRegisterCommand(const Vector<uint8_t>& clientDataHash, const PublicKeyCredentialCreationOptions& request)

--- a/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
@@ -31,6 +31,9 @@
 #include "DatabaseContext.h"
 #include "DatabaseTask.h"
 #include "DatabaseTracker.h"
+#include "Document.h"
+#include "DocumentPage.h"
+#include <WebCore/FrameDestructionObserver.h>
 #include "ExceptionOr.h"
 #include "Logging.h"
 #include "Page.h"

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -33,6 +33,8 @@
 #include "ThreadableWebSocketChannel.h"
 
 #include "ContentRuleListResults.h"
+#include "Document.h"
+#include "FrameDestructionObserverInlines.h"
 #include "DocumentLoader.h"
 #include "DocumentPage.h"
 #include "DocumentQuirks.h"

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
@@ -32,6 +32,7 @@
 #include "WebGL2RenderingContext.h"
 #include "WebGLRenderingContext.h"
 #include "WebGLRenderingContextBase.h"
+#include "WebXRSession.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -119,6 +119,7 @@ Modules/cookie-store/CookieStore.cpp
 Modules/cookie-store/CookieStoreManager.cpp
 Modules/cookie-store/ExtendableCookieChangeEvent.cpp
 Modules/credentialmanagement/BasicCredential.cpp
+Modules/credentialmanagement/CredentialRequestOptions.cpp
 Modules/credentialmanagement/CredentialsContainer.cpp
 Modules/credentialmanagement/NavigatorCredentials.cpp
 Modules/entriesapi/DOMFileSystem.cpp
@@ -458,7 +459,10 @@ Modules/webauthn/AuthenticatorAssertionResponse.cpp
 Modules/webauthn/AuthenticatorAttestationResponse.cpp
 Modules/webauthn/AuthenticatorCoordinator.cpp
 Modules/webauthn/AuthenticatorResponse.cpp
+Modules/webauthn/AuthenticatorSelectionCriteria.cpp
 Modules/webauthn/PublicKeyCredential.cpp
+Modules/webauthn/PublicKeyCredentialCreationOptions.cpp
+Modules/webauthn/PublicKeyCredentialRequestOptions.cpp
 Modules/webauthn/WebAuthenticationUtils.cpp
 Modules/webauthn/apdu/ApduCommand.cpp
 Modules/webauthn/apdu/ApduResponse.cpp

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1600,10 +1600,10 @@ struct WebCore::CurrentUserDetailsOptions {
 };
 
 struct WebCore::AuthenticatorSelectionCriteria {
-    std::optional<WebCore::AuthenticatorAttachment> authenticatorAttachment;
-    std::optional<WebCore::ResidentKeyRequirement> residentKey;
+    String authenticatorAttachmentString;
+    String residentKeyString;
     bool requireResidentKey;
-    WebCore::UserVerificationRequirement userVerification;
+    String userVerificationString;
 };
 
 struct WebCore::PublicKeyCredentialEntity {
@@ -1623,7 +1623,7 @@ struct WebCore::PublicKeyCredentialUserEntity : WebCore::PublicKeyCredentialEnti
 struct WebCore::PublicKeyCredentialDescriptor {
     WebCore::PublicKeyCredentialType type;
     WebCore::BufferSource id;
-    Vector<WebCore::AuthenticatorTransport> transports;
+    Vector<String> transports;
 };
 #endif // ENABLE(WEB_AUTHN)
 
@@ -1647,7 +1647,7 @@ struct WebCore::PublicKeyCredentialCreationOptions {
     std::optional<unsigned> timeout;
     Vector<WebCore::PublicKeyCredentialDescriptor> excludeCredentials;
     std::optional<WebCore::AuthenticatorSelectionCriteria> authenticatorSelection;
-    WebCore::AttestationConveyancePreference attestation;
+    String attestationString;
     std::optional<WebCore::AuthenticationExtensionsClientInputs> extensions;
 #endif // ENABLE(WEB_AUTHN)
 };
@@ -1658,7 +1658,7 @@ struct WebCore::PublicKeyCredentialRequestOptions {
     std::optional<unsigned> timeout;
     String rpId;
     Vector<WebCore::PublicKeyCredentialDescriptor> allowCredentials;
-    WebCore::UserVerificationRequirement userVerification;
+    String userVerificationString;
     std::optional<WebCore::AuthenticationExtensionsClientInputs> extensions;
     [NotSerialized] std::optional<WebCore::AuthenticatorAttachment> authenticatorAttachment;
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -106,9 +106,14 @@ constexpr std::array<uint8_t, 16> aaguid = { 0xFB, 0xFC, 0x30, 0x07, 0x15, 0x4E,
 
 constexpr char kLargeBlobMapKey[] = "largeBlob";
 
-static inline bool emptyTransportsOrContain(const Vector<AuthenticatorTransport>& transports, AuthenticatorTransport target)
+static inline bool emptyTransportsOrContain(const Vector<String>& transports, AuthenticatorTransport target)
 {
-    return transports.isEmpty() ? true : transports.contains(target);
+    if (transports.isEmpty())
+        return true;
+    return transports.containsIf([&](auto& transportString) {
+        auto transport = convertStringToAuthenticatorTransport(transportString);
+        return transport && *transport == target;
+    });
 }
 
 // A Base64 encoded string of the Credential ID is used as the key of the hash set.

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -286,7 +286,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForRegistration(con
 #if HAVE(SECURITY_KEY_API)
     bool includeSecurityKeyRequest = true;
     if (options.authenticatorSelection) {
-        if (auto attachment = options.authenticatorSelection->authenticatorAttachment) {
+        if (auto attachment = options.authenticatorSelection->authenticatorAttachment()) {
             switch (*attachment) {
             case WebCore::AuthenticatorAttachment::Platform:
                 includeSecurityKeyRequest = false;
@@ -304,13 +304,21 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForRegistration(con
     RetainPtr<NSMutableArray<ASAuthorizationPlatformPublicKeyCredentialDescriptor *>> platformExcludedCredentials = adoptNS([[NSMutableArray alloc] init]);
     RetainPtr<NSMutableArray<ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor *>> crossPlatformExcludedCredentials = adoptNS([[NSMutableArray alloc] init]);
     for (auto credential : options.excludeCredentials) {
-        if (credential.transports.contains(AuthenticatorTransport::Internal) || credential.transports.isEmpty())
+        bool hasInternal = credential.transports.containsIf([](auto& transportString) {
+            auto transport = convertStringToAuthenticatorTransport(transportString);
+            return transport && *transport == AuthenticatorTransport::Internal;
+        });
+
+        if (hasInternal || credential.transports.isEmpty())
             [platformExcludedCredentials addObject:adoptNS([allocASAuthorizationPlatformPublicKeyCredentialDescriptorInstance() initWithCredentialID:toNSData(credential.id).get()]).get()];
-        if (credential.transports.isEmpty() || !credential.transports.contains(AuthenticatorTransport::Internal)) {
+        if (credential.transports.isEmpty() || !hasInternal) {
             RetainPtr<NSMutableArray<ASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport>> transports = adoptNS([[NSMutableArray alloc] init]);
-            for (auto transport : credential.transports) {
-                if (auto asTransport = toASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport(transport))
-                    [transports addObject:asTransport.get()];
+            for (auto& transportString : credential.transports) {
+                auto transport = convertStringToAuthenticatorTransport(transportString);
+                if (transport) {
+                    if (auto asTransport = toASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport(*transport))
+                        [transports addObject:asTransport.get()];
+                }
             }
             [crossPlatformExcludedCredentials addObject:adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialDescriptorInstance() initWithCredentialID:toNSData(credential.id).get() transports:transports.get()]).get()];
         }
@@ -335,10 +343,10 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForRegistration(con
 #endif
 
         // Platform credentials may only support enterprise attestation.
-        if (options.attestation == AttestationConveyancePreference::Enterprise)
-            request.get().attestationPreference = toAttestationConveyancePreference(options.attestation).get();
+        if (options.attestation() == AttestationConveyancePreference::Enterprise)
+            request.get().attestationPreference = toAttestationConveyancePreference(options.attestation()).get();
         if (options.authenticatorSelection)
-            request.get().userVerificationPreference = toASUserVerificationPreference(options.authenticatorSelection->userVerification).get();
+            request.get().userVerificationPreference = toASUserVerificationPreference(options.authenticatorSelection->userVerification()).get();
         if (options.extensions && options.extensions->largeBlob) {
             // These are satisfied by validation in AuthenticatorCoordinator.
             ASSERT(!options.extensions->largeBlob->read && !options.extensions->largeBlob->write);
@@ -358,14 +366,14 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForRegistration(con
             // Despite the API naming, this returns an autoreleased value and there is no need to adopt.
             request = [provider createCredentialRegistrationRequestWithChallenge:toNSData(options.challenge).get() displayName:options.user.displayName.createNSString().get() name:options.user.name.createNSString().get() userID:toNSData(options.user.id).get()];
         }
-        request.get().attestationPreference = toAttestationConveyancePreference(options.attestation).get();
+        request.get().attestationPreference = toAttestationConveyancePreference(options.attestation()).get();
         RetainPtr<NSMutableArray<ASAuthorizationPublicKeyCredentialParameters *>> parameters = adoptNS([[NSMutableArray alloc] init]);
         for (auto alg : options.pubKeyCredParams)
             [parameters addObject:adoptNS([allocASAuthorizationPublicKeyCredentialParametersInstance() initWithAlgorithm:alg.alg]).get()];
         request.get().credentialParameters = parameters.get();
         if (options.authenticatorSelection) {
-            request.get().userVerificationPreference = toASUserVerificationPreference(options.authenticatorSelection->userVerification).get();
-            request.get().residentKeyPreference = toASResidentKeyPreference(options.authenticatorSelection->residentKey, options.authenticatorSelection->requireResidentKey).get();
+            request.get().userVerificationPreference = toASUserVerificationPreference(options.authenticatorSelection->userVerification()).get();
+            request.get().residentKeyPreference = toASResidentKeyPreference(options.authenticatorSelection->residentKey(), options.authenticatorSelection->requireResidentKey).get();
         }
         request.get().excludedCredentials = crossPlatformExcludedCredentials.get();
         [requests addObject:request.get()];
@@ -375,24 +383,27 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForRegistration(con
     return requests;
 }
 
-static inline bool isPlatformRequest(const Vector<AuthenticatorTransport>& transports)
+static inline bool isPlatformRequest(const Vector<String>& transports)
 {
-    return transports.isEmpty() || transports.containsIf([](auto transport) {
-        return transport == AuthenticatorTransport::Internal || transport == AuthenticatorTransport::Hybrid;
+    return transports.isEmpty() || transports.containsIf([](auto& transportString) {
+        auto transport = convertStringToAuthenticatorTransport(transportString);
+        return transport && (*transport == AuthenticatorTransport::Internal || *transport == AuthenticatorTransport::Hybrid);
     });
 }
 
-static inline bool isCrossPlatformRequest(const Vector<AuthenticatorTransport>& transports)
+static inline bool isCrossPlatformRequest(const Vector<String>& transports)
 {
-    return transports.isEmpty() || transports.containsIf([](auto transport) {
-        return transport != AuthenticatorTransport::Internal && transport != AuthenticatorTransport::Hybrid;
+    return transports.isEmpty() || transports.containsIf([](auto& transportString) {
+        auto transport = convertStringToAuthenticatorTransport(transportString);
+        return transport && (*transport != AuthenticatorTransport::Internal && *transport != AuthenticatorTransport::Hybrid);
     });
 }
 
-static inline bool allowsHybrid(const Vector<AuthenticatorTransport>& transports)
+static inline bool allowsHybrid(const Vector<String>& transports)
 {
-    return transports.isEmpty() || transports.containsIf([](auto transport) {
-        return transport == AuthenticatorTransport::Hybrid || transport == AuthenticatorTransport::Cable;
+    return transports.isEmpty() || transports.containsIf([](auto& transportString) {
+        auto transport = convertStringToAuthenticatorTransport(transportString);
+        return transport && (*transport == AuthenticatorTransport::Hybrid || *transport == AuthenticatorTransport::Cable);
     });
 }
 
@@ -407,9 +418,12 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
             [platformAllowedCredentials addObject:adoptNS([allocASAuthorizationPlatformPublicKeyCredentialDescriptorInstance() initWithCredentialID:toNSData(credential.id).get()]).get()];
         if (isCrossPlatformRequest(credential.transports)) {
             RetainPtr<NSMutableArray<ASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport>> transports = adoptNS([[NSMutableArray alloc] init]);
-            for (auto transport : credential.transports) {
-                if (auto asTransport = toASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport(transport))
-                    [transports addObject:asTransport.get()];
+            for (auto& transportString : credential.transports) {
+                auto transport = convertStringToAuthenticatorTransport(transportString);
+                if (transport) {
+                    if (auto asTransport = toASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport(*transport))
+                        [transports addObject:asTransport.get()];
+                }
             }
             [crossPlatformAllowedCredentials addObject:adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialDescriptorInstance() initWithCredentialID:toNSData(credential.id).get() transports:transports.get()]).get()];
         }
@@ -439,7 +453,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
             request.get().largeBlob = asLargeBlob.get();
         }
 
-        request.get().userVerificationPreference = toASUserVerificationPreference(options.userVerification).get();
+        request.get().userVerificationPreference = toASUserVerificationPreference(options.userVerification()).get();
 
         if (!allowHybrid)
             request.get().shouldShowHybridTransport = false;
@@ -769,35 +783,8 @@ static inline RetainPtr<ASCPublicKeyCredentialDescriptor> toASCDescriptor(Public
     if (transportCount) {
         transports = adoptNS([[NSMutableArray alloc] initWithCapacity:transportCount]);
 
-        for (AuthenticatorTransport transport : descriptor.transports) {
-            NSString *transportString = nil;
-            switch (transport) {
-            case AuthenticatorTransport::Usb:
-                transportString = @"usb";
-                break;
-            case AuthenticatorTransport::Nfc:
-                transportString = @"nfc";
-                break;
-            case AuthenticatorTransport::Ble:
-                transportString = @"ble";
-                break;
-            case AuthenticatorTransport::Internal:
-                transportString = @"internal";
-                break;
-            case AuthenticatorTransport::Cable:
-                transportString = @"cable";
-                break;
-            case AuthenticatorTransport::Hybrid:
-                transportString = @"hybrid";
-                break;
-            case AuthenticatorTransport::SmartCard:
-                transportString = @"smart-card";
-                break;
-            }
-
-            if (transportString)
-                [transports addObject:transportString];
-        }
+        for (auto& transportString : descriptor.transports)
+            [transports addObject:transportString.createNSString().get()];
     }
 
     return adoptNS([allocASCPublicKeyCredentialDescriptorInstance() initWithCredentialID:WebCore::toNSData(descriptor.id).get() transports:transports.get()]);
@@ -844,16 +831,16 @@ static RetainPtr<ASCCredentialRequestContext> configureRegistrationRequestContex
     std::optional<ResidentKeyRequirement> residentKeyRequirement;
     std::optional<AuthenticatorSelectionCriteria> authenticatorSelection = options.authenticatorSelection;
     if (authenticatorSelection) {
-        std::optional<AuthenticatorAttachment> attachment = authenticatorSelection->authenticatorAttachment;
+        std::optional<AuthenticatorAttachment> attachment = authenticatorSelection->authenticatorAttachment();
         if (attachment == AuthenticatorAttachment::Platform)
             requestTypes = ASCCredentialRequestTypePlatformPublicKeyRegistration;
         else if (attachment == AuthenticatorAttachment::CrossPlatform)
             requestTypes = ASCCredentialRequestTypeSecurityKeyPublicKeyRegistration;
 
-        userVerification = toNSString(authenticatorSelection->userVerification);
+        userVerification = toNSString(authenticatorSelection->userVerification());
 
         shouldRequireResidentKey = authenticatorSelection->requireResidentKey;
-        residentKeyRequirement = authenticatorSelection->residentKey;
+        residentKeyRequirement = authenticatorSelection->residentKey();
     }
     if (!LocalService::isAvailable())
         requestTypes &= ~ASCCredentialRequestTypePlatformPublicKeyRegistration;
@@ -878,7 +865,7 @@ static RetainPtr<ASCCredentialRequestContext> configureRegistrationRequestContex
         [credentialCreationOptions setResidentKeyPreference:toASCResidentKeyPreference(residentKeyRequirement, shouldRequireResidentKey)];
     else
         [credentialCreationOptions setShouldRequireResidentKey:shouldRequireResidentKey];
-    [credentialCreationOptions setAttestationPreference:toNSString(options.attestation).get()];
+    [credentialCreationOptions setAttestationPreference:toNSString(options.attestation()).get()];
 
     RetainPtr<NSMutableArray<NSNumber *>> supportedAlgorithmIdentifiers = adoptNS([[NSMutableArray alloc] initWithCapacity:options.pubKeyCredParams.size()]);
     for (PublicKeyCredentialParameters algorithmParameter : options.pubKeyCredParams)
@@ -956,7 +943,7 @@ static RetainPtr<ASCCredentialRequestContext> configurationAssertionRequestConte
     else if (attachment == AuthenticatorAttachment::CrossPlatform)
         requestTypes = ASCCredentialRequestTypeSecurityKeyPublicKeyAssertion;
 
-    userVerification = toNSString(options.userVerification);
+    userVerification = toNSString(options.userVerification());
 
     size_t allowedCredentialCount = options.allowCredentials.size();
     RetainPtr<NSMutableArray<ASCPublicKeyCredentialDescriptor *>> allowedCredentials;

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp
@@ -44,11 +44,11 @@ UserVerificationRequirement getUserVerificationRequirement(const Variant<PublicK
 {
     if (std::holds_alternative<PublicKeyCredentialCreationOptions>(options)) {
         if (auto authenticatorSelection = std::get<PublicKeyCredentialCreationOptions>(options).authenticatorSelection)
-            return authenticatorSelection->userVerification;
+            return authenticatorSelection->userVerification();
         return UserVerificationRequirement::Preferred;
     }
 
-    return std::get<PublicKeyCredentialRequestOptions>(options).userVerification;
+    return std::get<PublicKeyCredentialRequestOptions>(options).userVerification();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -180,7 +180,7 @@ void U2fAuthenticator::continueRegisterCommandAfterResponseReceived(ApduResponse
             U2F_RELEASE_LOG("continueRegisterCommandAfterResponseReceived: rp.id empty. Should not be.");
             ASSERT(false);
         }
-        auto response = readU2fRegisterResponse(options.rp.id, apduResponse.data(), AuthenticatorAttachment::CrossPlatform, { driver().transport() }, options.attestation);
+        auto response = readU2fRegisterResponse(options.rp.id, apduResponse.data(), AuthenticatorAttachment::CrossPlatform, { driver().transport() }, options.attestation());
         if (!response) {
             receiveRespond(ExceptionData { ExceptionCode::UnknownError, "Couldn't parse the U2F register response."_s });
             return;

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
@@ -61,9 +61,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParam)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialParameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    WebCore::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, true, UserVerificationRequirement::Preferred };
+    WebCore::AuthenticatorSelectionCriteria selection { "platform"_s, { }, true, "preferred"_s };
 
-    WebCore::PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    WebCore::PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(std::span { TestData::kClientDataHash });
@@ -85,9 +85,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamNoUVNoRK)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialParameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, false, UserVerificationRequirement::Discouraged };
+    AuthenticatorSelectionCriteria selection { "platform"_s, { }, false, "discouraged"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(std::span { TestData::kClientDataHash });
@@ -109,9 +109,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamUVRequiredButNotSup
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialParameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, false, UserVerificationRequirement::Required };
+    AuthenticatorSelectionCriteria selection { "platform"_s, { }, false, "required"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(std::span { TestData::kClientDataHash });
@@ -133,13 +133,13 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamWithPin)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialParameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, true, UserVerificationRequirement::Preferred };
+    AuthenticatorSelectionCriteria selection { "platform"_s, { }, true, "preferred"_s };
 
     PinParameters pin;
     pin.protocol = pin::kProtocolVersion;
     pin.auth.append(std::span { TestData::kCtap2PinAuth });
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(std::span { TestData::kClientDataHash });
@@ -161,13 +161,13 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKPreferred)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialParameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, ResidentKeyRequirement::Preferred, true, UserVerificationRequirement::Preferred };
+    AuthenticatorSelectionCriteria selection { "platform"_s, "preferred"_s, true, "preferred"_s };
 
     PinParameters pin;
     pin.protocol = pin::kProtocolVersion;
     pin.auth.append(std::span { TestData::kCtap2PinAuth });
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(std::span { TestData::kClientDataHash });
@@ -189,9 +189,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKPreferredNotSupported)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialParameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, ResidentKeyRequirement::Preferred, true, UserVerificationRequirement::Required };
+    AuthenticatorSelectionCriteria selection { "platform"_s, "preferred"_s, true, "required"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(std::span { TestData::kClientDataHash });
@@ -213,9 +213,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKDiscouraged)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialParameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, ResidentKeyRequirement::Discouraged, true, UserVerificationRequirement::Required };
+    AuthenticatorSelectionCriteria selection { "platform"_s, "discouraged"_s, true, "required"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(std::span { TestData::kClientDataHash });
@@ -237,7 +237,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithLargeBlob)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialParameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, false, UserVerificationRequirement::Discouraged };
+    AuthenticatorSelectionCriteria selection { "platform"_s, { }, false, "discouraged"_s };
     AuthenticationExtensionsClientInputs extensionInputs = {
         .appid = WTF::nullString(),
         .credProps = false,
@@ -249,7 +249,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithLargeBlob)
         .prf = std::nullopt,
     };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, extensionInputs };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, extensionInputs };
     Vector<uint8_t> hash;
     Vector<String> extensions = { "largeBlob"_s };
     hash.append(std::span { TestData::kClientDataHash });
@@ -271,7 +271,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithUnsupportedLargeBlob
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialParameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, false, UserVerificationRequirement::Discouraged };
+    AuthenticatorSelectionCriteria selection { "platform"_s, { }, false, "discouraged"_s };
     AuthenticationExtensionsClientInputs extensionInputs = {
         .appid = WTF::nullString(),
         .credProps = false,
@@ -283,7 +283,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithUnsupportedLargeBlob
         .prf = std::nullopt,
     };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, extensionInputs };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, extensionInputs };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(std::span { TestData::kClientDataHash });
@@ -320,7 +320,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequest)
     descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
@@ -358,7 +358,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestNoUV)
     descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
 
-    options.userVerification = UserVerificationRequirement::Discouraged;
+    options.userVerificationString = "discouraged"_s;
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
@@ -396,7 +396,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestUVRequiredButNotSupported)
     descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
@@ -434,7 +434,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestWithPin)
     descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     PinParameters pin;
     pin.protocol = pin::kProtocolVersion;
@@ -505,7 +505,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobRead)
         .prf = std::nullopt,
     };
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     Vector<uint8_t> hash;
     Vector<String> extensions = { "largeBlob"_s };
@@ -553,7 +553,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestUnsupportedLargeBlobRead)
         .prf = std::nullopt,
     };
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
@@ -605,7 +605,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobWrite)
         .prf = std::nullopt,
     };
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     Vector<uint8_t> hash;
     Vector<String> extensions;

--- a/Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp
@@ -148,7 +148,7 @@ TEST(U2fCommandConstructorTest, TestU2fRegisterUserVerificationRequirement)
 {
     auto makeCredentialParam = constructMakeCredentialRequest();
     AuthenticatorSelectionCriteria selection;
-    selection.userVerification = UserVerificationRequirement::Required;
+    selection.userVerificationString = "required"_s;
     makeCredentialParam.authenticatorSelection = WTFMove(selection);
 
     EXPECT_FALSE(isConvertibleToU2fRegisterCommand(makeCredentialParam));
@@ -216,7 +216,7 @@ TEST(U2fCommandConstructorTest, TestU2fSignUserVerificationRequirement)
     Vector<PublicKeyCredentialDescriptor> allowedList;
     allowedList.append(WTFMove(credentialDescriptor));
     getAssertionReq.allowCredentials = WTFMove(allowedList);
-    getAssertionReq.userVerification = UserVerificationRequirement::Required;
+    getAssertionReq.userVerificationString = "required"_s;
 
     EXPECT_FALSE(isConvertibleToU2fSignCommand(getAssertionReq));
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -1500,7 +1500,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimum)
     EXPECT_EQ(result.timeout, std::nullopt);
     EXPECT_EQ(result.excludeCredentials.size(), 0lu);
     EXPECT_EQ(result.authenticatorSelection, std::nullopt);
-    EXPECT_EQ(result.attestation, AttestationConveyancePreference::None);
+    EXPECT_EQ(result.attestation(), AttestationConveyancePreference::None);
     EXPECT_TRUE(result.extensions->appid.isNull());
 }
 
@@ -1547,11 +1547,11 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
     EXPECT_EQ(result.excludeCredentials[0].type, WebCore::PublicKeyCredentialType::PublicKey);
     EXPECT_TRUE(equalSpans(result.excludeCredentials[0].id.span(), std::span<const uint8_t> { identifier }));
 
-    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment, std::nullopt);
+    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment(), std::nullopt);
     EXPECT_EQ(result.authenticatorSelection->requireResidentKey, false);
-    EXPECT_EQ(result.authenticatorSelection->userVerification, UserVerificationRequirement::Preferred);
+    EXPECT_EQ(result.authenticatorSelection->userVerification(), UserVerificationRequirement::Preferred);
 
-    EXPECT_EQ(result.attestation, AttestationConveyancePreference::None);
+    EXPECT_EQ(result.attestation(), AttestationConveyancePreference::None);
     EXPECT_TRUE(result.extensions->appid.isNull());
 }
 
@@ -1613,16 +1613,16 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
     EXPECT_EQ(result.excludeCredentials[0].type, WebCore::PublicKeyCredentialType::PublicKey);
     EXPECT_TRUE(equalSpans(result.excludeCredentials[0].id.span(), std::span<const uint8_t> { identifier }));
     EXPECT_EQ(result.excludeCredentials[0].transports.size(), 4lu);
-    EXPECT_EQ(result.excludeCredentials[0].transports[0], AuthenticatorTransport::Usb);
-    EXPECT_EQ(result.excludeCredentials[0].transports[1], AuthenticatorTransport::Nfc);
-    EXPECT_EQ(result.excludeCredentials[0].transports[2], AuthenticatorTransport::Internal);
-    EXPECT_EQ(result.excludeCredentials[0].transports[3], AuthenticatorTransport::Hybrid);
+    EXPECT_WK_STREQ(result.excludeCredentials[0].transports[0], "usb");
+    EXPECT_WK_STREQ(result.excludeCredentials[0].transports[1], "nfc");
+    EXPECT_WK_STREQ(result.excludeCredentials[0].transports[2], "internal");
+    EXPECT_WK_STREQ(result.excludeCredentials[0].transports[3], "hybrid");
 
-    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment, AuthenticatorAttachment::Platform);
+    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment(), AuthenticatorAttachment::Platform);
     EXPECT_EQ(result.authenticatorSelection->requireResidentKey, true);
-    EXPECT_EQ(result.authenticatorSelection->userVerification, UserVerificationRequirement::Required);
+    EXPECT_EQ(result.authenticatorSelection->userVerification(), UserVerificationRequirement::Required);
 
-    EXPECT_EQ(result.attestation, AttestationConveyancePreference::Direct);
+    EXPECT_EQ(result.attestation(), AttestationConveyancePreference::Direct);
 }
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
@@ -1682,15 +1682,15 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
     EXPECT_EQ(result.excludeCredentials[0].type, WebCore::PublicKeyCredentialType::PublicKey);
     EXPECT_TRUE(equalSpans(result.excludeCredentials[0].id.span(), std::span<const uint8_t> { identifier }));
     EXPECT_EQ(result.excludeCredentials[0].transports.size(), 3lu);
-    EXPECT_EQ(result.excludeCredentials[0].transports[0], AuthenticatorTransport::Usb);
-    EXPECT_EQ(result.excludeCredentials[0].transports[1], AuthenticatorTransport::Nfc);
-    EXPECT_EQ(result.excludeCredentials[0].transports[2], AuthenticatorTransport::Internal);
+    EXPECT_WK_STREQ(result.excludeCredentials[0].transports[0], "usb");
+    EXPECT_WK_STREQ(result.excludeCredentials[0].transports[1], "nfc");
+    EXPECT_WK_STREQ(result.excludeCredentials[0].transports[2], "internal");
 
-    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment, AuthenticatorAttachment::CrossPlatform);
+    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment(), AuthenticatorAttachment::CrossPlatform);
     EXPECT_EQ(result.authenticatorSelection->requireResidentKey, true);
-    EXPECT_EQ(result.authenticatorSelection->userVerification, UserVerificationRequirement::Discouraged);
+    EXPECT_EQ(result.authenticatorSelection->userVerification(), UserVerificationRequirement::Discouraged);
 
-    EXPECT_EQ(result.attestation, AttestationConveyancePreference::Indirect);
+    EXPECT_EQ(result.attestation(), AttestationConveyancePreference::Indirect);
 }
 
 // FIXME rdar://145102423
@@ -1845,7 +1845,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMinimun)
     EXPECT_EQ(result.timeout, std::nullopt);
     EXPECT_TRUE(result.rpId.isNull());
     EXPECT_EQ(result.allowCredentials.size(), 0lu);
-    EXPECT_EQ(result.userVerification, UserVerificationRequirement::Preferred);
+    EXPECT_EQ(result.userVerification(), UserVerificationRequirement::Preferred);
     EXPECT_TRUE(result.extensions->appid.isNull());
 }
 
@@ -1869,7 +1869,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximumDefault)
     EXPECT_EQ(result.allowCredentials[0].type, WebCore::PublicKeyCredentialType::PublicKey);
     EXPECT_TRUE(equalSpans(result.allowCredentials[0].id.span(), std::span<const uint8_t> { identifier }));
 
-    EXPECT_EQ(result.userVerification, UserVerificationRequirement::Preferred);
+    EXPECT_EQ(result.userVerification(), UserVerificationRequirement::Preferred);
     EXPECT_TRUE(result.extensions->appid.isNull());
 }
 
@@ -1902,11 +1902,11 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximum)
     EXPECT_EQ(result.allowCredentials[0].type, WebCore::PublicKeyCredentialType::PublicKey);
     EXPECT_TRUE(equalSpans(result.allowCredentials[0].id.span(), std::span<const uint8_t> { identifier }));
     EXPECT_EQ(result.allowCredentials[0].transports.size(), 3lu);
-    EXPECT_EQ(result.allowCredentials[0].transports[0], AuthenticatorTransport::Usb);
-    EXPECT_EQ(result.allowCredentials[0].transports[1], AuthenticatorTransport::Nfc);
-    EXPECT_EQ(result.allowCredentials[0].transports[2], AuthenticatorTransport::Internal);
+    EXPECT_WK_STREQ(result.allowCredentials[0].transports[0], "usb");
+    EXPECT_WK_STREQ(result.allowCredentials[0].transports[1], "nfc");
+    EXPECT_WK_STREQ(result.allowCredentials[0].transports[2], "internal");
 
-    EXPECT_EQ(result.userVerification, UserVerificationRequirement::Required);
+    EXPECT_EQ(result.userVerification(), UserVerificationRequirement::Required);
     EXPECT_WK_STREQ(result.extensions->appid, "https//www.example.com/fido");
 }
 


### PR DESCRIPTION
#### 06adc1c85bf626a4bbece8777e75280008468b37
<pre>
[WebAuthn] Reland enums should be DOMStrings
<a href="https://rdar.apple.com/156713314">rdar://156713314</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301101">https://bugs.webkit.org/show_bug.cgi?id=301101</a>

Reviewed by Brent Fulgham.

WebAuthn enums should be DOMStrings instead, see the discussion on the spec [1]. If a value is not valid,
it should be treated as not present (which usually means it should be converted into the default). This
applies to AuthenticatorAttachment, ResidentKeyRequirement, UserVerificationRequirement, and AttestationConveyancePreference.
w3c/webauthn#1738

* Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.cpp: Copied from Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h.
(WebCore::CredentialRequestOptions::mediation const):
* Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h:
* Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl:
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::discoverFromExternalSource):
* Source/WebCore/Modules/webauthn/AuthenticatorSelectionCriteria.cpp: Added.
(WebCore::AuthenticatorSelectionCriteria::authenticatorAttachment const):
(WebCore::AuthenticatorSelectionCriteria::residentKey const):
(WebCore::AuthenticatorSelectionCriteria::userVerification const):
* Source/WebCore/Modules/webauthn/AuthenticatorSelectionCriteria.h:
* Source/WebCore/Modules/webauthn/AuthenticatorSelectionCriteria.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp:
(WebCore::fromJSON):
(WebCore::PublicKeyCredential::parseCreationOptionsFromJSON):
(WebCore::PublicKeyCredential::parseRequestOptionsFromJSON):
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.cpp: Copied from Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h.
(WebCore::PublicKeyCredentialCreationOptions::attestation const):
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.cpp: Copied from Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h.
(WebCore::PublicKeyCredentialRequestOptions::userVerification const):
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl:
* Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp:
(fido::encodeMakeCredentialRequestAsCBOR):
(fido::encodeGetAssertionRequestAsCBOR):
* Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp:
(fido::isConvertibleToU2fRegisterCommand):
(fido::isConvertibleToU2fSignCommand):
* Source/WebCore/Sources.txt:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(authenticatorTransports):
(authenticatorSelectionCriteria):
(+[_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:]):
(wkTransports):
(+[_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:]):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::WebCore::collectTransports):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForRegistration):
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForAssertion):
(WebKit::configureRegistrationRequestContext):
(WebKit::configurationAssertionRequestContext):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp:
(WebKit::getUserVerificationRequirement):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterResponseReceived):
(WebKit::CtapAuthenticator::continueGetAssertionAfterCheckAllowCredentials):
* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp:
(WebKit::U2fAuthenticator::continueRegisterCommandAfterResponseReceived):

Canonical link: <a href="https://commits.webkit.org/302002@main">https://commits.webkit.org/302002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38281d9336400c7db5ef9ff3f252423683cfac74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79252 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9ad419f0-251d-4e77-859b-8aa13da25b6b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55874 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97200 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 24 flakes 36 failures; Uploaded test results; 4 flakes 24 failures; Compiled WebKit; 24 failures; Passed layout tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65100 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/04b95b49-c5ca-403d-afde-d276d10a3e07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77682 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/402a3a52-b6ba-4b1d-b621-dda3d0b1ac54) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37153 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32482 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78325 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137449 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41905 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105722 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105373 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50896 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29325 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19963 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54291 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60467 "Found 2 new failures in Modules/indexeddb/server/UniqueIDBDatabase.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53526 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56982 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55284 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->