### PR TITLE
REGRESSION(301753@main): Broke TestWebKitAPI.IndexedDB.DeleteRecovery on Debug

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBDeleteRecovery.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBDeleteRecovery.mm
@@ -50,12 +50,7 @@
 
 @end
 
-// REGRESSION(301753@main): Broke TestWebKitAPI.IndexedDB.DeleteRecovery on Debug https://bugs.webkit.org/show_bug.cgi?id=301097
-#if !defined(NDEBUG)
-TEST(IndexedDB, DISABLED_DeleteRecovery)
-#else
 TEST(IndexedDB, DeleteRecovery)
-#endif
 {
     RetainPtr<IDBDeleteRecoveryMessageHandler> handler = adoptNS([[IDBDeleteRecoveryMessageHandler alloc] init]);
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### 44890a3e7dbf92f5fd478d8dd140d30d331e731b
<pre>
REGRESSION(301753@main): Broke TestWebKitAPI.IndexedDB.DeleteRecovery on Debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=301097">https://bugs.webkit.org/show_bug.cgi?id=301097</a>
<a href="https://rdar.apple.com/163038603">rdar://163038603</a>

Reviewed by Per Arne Vollan.

301753@main changes encoding format for database name with metadata verion upgrade: i.e. if it is old metadata version,
SQLiteIDBBackingStore should read the database name in old format from database; and if it is new metadata version,
SQLiteIDBBackingStore should read the database name in new format. However, there is a place that
(`SQLiteIDBBackingStore::databaseNameAndVersionFromFile`) always reads the name in new format, without checking metadata
version, and this has led the test to fail.

To fix this, introduce databaseMetadataVersionAndNameFromDatabase that reads database name based on metadata version,
and make databaseNameAndVersionFromFile invoke databaseMetadataVersionAndNameFromDatabase.

* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::databaseMetadataVersionAndNameFromDatabase):
(WebCore::IDBServer::migrateIDBDatabaseInfoTableIfNecessary):
(WebCore::IDBServer::SQLiteIDBBackingStore::databaseNameAndVersionFromFile):
(WebCore::IDBServer::getDatabaseNameFromDatabase): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBDeleteRecovery.mm:
(TEST(IndexedDB, DeleteRecovery)):

Canonical link: <a href="https://commits.webkit.org/301816@main">https://commits.webkit.org/301816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8091cda8d94c7d63e7bece53e14d54ece5fe683c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78713 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3540ed16-2fad-4f0e-96e6-4c45539f4d90) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96766 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64809 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4fa1daa4-b8a5-4c1b-b02a-5b18c5419385) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77272 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/da626fb5-b62b-4bfc-ae93-e20edd81e705) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32003 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77602 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/107825 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136705 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53810 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105287 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104974 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26764 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50501 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28939 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51380 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53741 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59841 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52975 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56310 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54737 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->