### PR TITLE
[WebXR] Implement XRWebGLBinding constructor

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/idlharness.https.window-expected.txt
@@ -4,116 +4,116 @@ PASS idl_test validation
 PASS Partial interface XRRenderState: original interface defined
 PASS Partial interface XRRenderState: valid exposure set
 PASS Partial interface XRRenderState: member names are unique
-FAIL XRCompositionLayer interface: existence and properties of interface object assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface object length assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface object name assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface: existence and properties of interface prototype object assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface: attribute layout assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface: attribute blendTextureSourceAlpha assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface: attribute forceMonoPresentation assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface: attribute opacity assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface: attribute mipLevels assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface: attribute quality assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface: attribute needsRedraw assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRCompositionLayer interface: operation destroy() assert_own_property: self does not have own property "XRCompositionLayer" expected property "XRCompositionLayer" missing
-FAIL XRProjectionLayer interface: existence and properties of interface object assert_own_property: self does not have own property "XRProjectionLayer" expected property "XRProjectionLayer" missing
-FAIL XRProjectionLayer interface object length assert_own_property: self does not have own property "XRProjectionLayer" expected property "XRProjectionLayer" missing
-FAIL XRProjectionLayer interface object name assert_own_property: self does not have own property "XRProjectionLayer" expected property "XRProjectionLayer" missing
-FAIL XRProjectionLayer interface: existence and properties of interface prototype object assert_own_property: self does not have own property "XRProjectionLayer" expected property "XRProjectionLayer" missing
-FAIL XRProjectionLayer interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "XRProjectionLayer" expected property "XRProjectionLayer" missing
-FAIL XRProjectionLayer interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "XRProjectionLayer" expected property "XRProjectionLayer" missing
-FAIL XRProjectionLayer interface: attribute textureWidth assert_own_property: self does not have own property "XRProjectionLayer" expected property "XRProjectionLayer" missing
-FAIL XRProjectionLayer interface: attribute textureHeight assert_own_property: self does not have own property "XRProjectionLayer" expected property "XRProjectionLayer" missing
-FAIL XRProjectionLayer interface: attribute textureArrayLength assert_own_property: self does not have own property "XRProjectionLayer" expected property "XRProjectionLayer" missing
-FAIL XRProjectionLayer interface: attribute ignoreDepthValues assert_own_property: self does not have own property "XRProjectionLayer" expected property "XRProjectionLayer" missing
-FAIL XRProjectionLayer interface: attribute fixedFoveation assert_own_property: self does not have own property "XRProjectionLayer" expected property "XRProjectionLayer" missing
-FAIL XRProjectionLayer interface: attribute deltaPose assert_own_property: self does not have own property "XRProjectionLayer" expected property "XRProjectionLayer" missing
-FAIL XRQuadLayer interface: existence and properties of interface object assert_own_property: self does not have own property "XRQuadLayer" expected property "XRQuadLayer" missing
-FAIL XRQuadLayer interface object length assert_own_property: self does not have own property "XRQuadLayer" expected property "XRQuadLayer" missing
-FAIL XRQuadLayer interface object name assert_own_property: self does not have own property "XRQuadLayer" expected property "XRQuadLayer" missing
-FAIL XRQuadLayer interface: existence and properties of interface prototype object assert_own_property: self does not have own property "XRQuadLayer" expected property "XRQuadLayer" missing
-FAIL XRQuadLayer interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "XRQuadLayer" expected property "XRQuadLayer" missing
-FAIL XRQuadLayer interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "XRQuadLayer" expected property "XRQuadLayer" missing
-FAIL XRQuadLayer interface: attribute space assert_own_property: self does not have own property "XRQuadLayer" expected property "XRQuadLayer" missing
-FAIL XRQuadLayer interface: attribute transform assert_own_property: self does not have own property "XRQuadLayer" expected property "XRQuadLayer" missing
-FAIL XRQuadLayer interface: attribute width assert_own_property: self does not have own property "XRQuadLayer" expected property "XRQuadLayer" missing
-FAIL XRQuadLayer interface: attribute height assert_own_property: self does not have own property "XRQuadLayer" expected property "XRQuadLayer" missing
-FAIL XRQuadLayer interface: attribute onredraw assert_own_property: self does not have own property "XRQuadLayer" expected property "XRQuadLayer" missing
-FAIL XRCylinderLayer interface: existence and properties of interface object assert_own_property: self does not have own property "XRCylinderLayer" expected property "XRCylinderLayer" missing
-FAIL XRCylinderLayer interface object length assert_own_property: self does not have own property "XRCylinderLayer" expected property "XRCylinderLayer" missing
-FAIL XRCylinderLayer interface object name assert_own_property: self does not have own property "XRCylinderLayer" expected property "XRCylinderLayer" missing
-FAIL XRCylinderLayer interface: existence and properties of interface prototype object assert_own_property: self does not have own property "XRCylinderLayer" expected property "XRCylinderLayer" missing
-FAIL XRCylinderLayer interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "XRCylinderLayer" expected property "XRCylinderLayer" missing
-FAIL XRCylinderLayer interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "XRCylinderLayer" expected property "XRCylinderLayer" missing
-FAIL XRCylinderLayer interface: attribute space assert_own_property: self does not have own property "XRCylinderLayer" expected property "XRCylinderLayer" missing
-FAIL XRCylinderLayer interface: attribute transform assert_own_property: self does not have own property "XRCylinderLayer" expected property "XRCylinderLayer" missing
-FAIL XRCylinderLayer interface: attribute radius assert_own_property: self does not have own property "XRCylinderLayer" expected property "XRCylinderLayer" missing
-FAIL XRCylinderLayer interface: attribute centralAngle assert_own_property: self does not have own property "XRCylinderLayer" expected property "XRCylinderLayer" missing
-FAIL XRCylinderLayer interface: attribute aspectRatio assert_own_property: self does not have own property "XRCylinderLayer" expected property "XRCylinderLayer" missing
-FAIL XRCylinderLayer interface: attribute onredraw assert_own_property: self does not have own property "XRCylinderLayer" expected property "XRCylinderLayer" missing
-FAIL XREquirectLayer interface: existence and properties of interface object assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XREquirectLayer interface object length assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XREquirectLayer interface object name assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XREquirectLayer interface: existence and properties of interface prototype object assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XREquirectLayer interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XREquirectLayer interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XREquirectLayer interface: attribute space assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XREquirectLayer interface: attribute transform assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XREquirectLayer interface: attribute radius assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XREquirectLayer interface: attribute centralHorizontalAngle assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XREquirectLayer interface: attribute upperVerticalAngle assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XREquirectLayer interface: attribute lowerVerticalAngle assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XREquirectLayer interface: attribute onredraw assert_own_property: self does not have own property "XREquirectLayer" expected property "XREquirectLayer" missing
-FAIL XRCubeLayer interface: existence and properties of interface object assert_own_property: self does not have own property "XRCubeLayer" expected property "XRCubeLayer" missing
-FAIL XRCubeLayer interface object length assert_own_property: self does not have own property "XRCubeLayer" expected property "XRCubeLayer" missing
-FAIL XRCubeLayer interface object name assert_own_property: self does not have own property "XRCubeLayer" expected property "XRCubeLayer" missing
-FAIL XRCubeLayer interface: existence and properties of interface prototype object assert_own_property: self does not have own property "XRCubeLayer" expected property "XRCubeLayer" missing
-FAIL XRCubeLayer interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "XRCubeLayer" expected property "XRCubeLayer" missing
-FAIL XRCubeLayer interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "XRCubeLayer" expected property "XRCubeLayer" missing
-FAIL XRCubeLayer interface: attribute space assert_own_property: self does not have own property "XRCubeLayer" expected property "XRCubeLayer" missing
-FAIL XRCubeLayer interface: attribute orientation assert_own_property: self does not have own property "XRCubeLayer" expected property "XRCubeLayer" missing
-FAIL XRCubeLayer interface: attribute onredraw assert_own_property: self does not have own property "XRCubeLayer" expected property "XRCubeLayer" missing
-FAIL XRSubImage interface: existence and properties of interface object assert_own_property: self does not have own property "XRSubImage" expected property "XRSubImage" missing
-FAIL XRSubImage interface object length assert_own_property: self does not have own property "XRSubImage" expected property "XRSubImage" missing
-FAIL XRSubImage interface object name assert_own_property: self does not have own property "XRSubImage" expected property "XRSubImage" missing
-FAIL XRSubImage interface: existence and properties of interface prototype object assert_own_property: self does not have own property "XRSubImage" expected property "XRSubImage" missing
-FAIL XRSubImage interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "XRSubImage" expected property "XRSubImage" missing
-FAIL XRSubImage interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "XRSubImage" expected property "XRSubImage" missing
-FAIL XRSubImage interface: attribute viewport assert_own_property: self does not have own property "XRSubImage" expected property "XRSubImage" missing
-FAIL XRWebGLSubImage interface: existence and properties of interface object assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface object length assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface object name assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: existence and properties of interface prototype object assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: attribute colorTexture assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: attribute depthStencilTexture assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: attribute motionVectorTexture assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: attribute imageIndex assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: attribute colorTextureWidth assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: attribute colorTextureHeight assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: attribute depthStencilTextureWidth assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: attribute depthStencilTextureHeight assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: attribute motionVectorTextureWidth assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLSubImage interface: attribute motionVectorTextureHeight assert_own_property: self does not have own property "XRWebGLSubImage" expected property "XRWebGLSubImage" missing
-FAIL XRWebGLBinding interface: existence and properties of interface object assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface object length assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface object name assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: existence and properties of interface prototype object assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: attribute nativeProjectionScaleFactor assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: attribute usesDepthValues assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: operation createProjectionLayer(optional XRProjectionLayerInit) assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: operation createQuadLayer(optional XRQuadLayerInit) assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: operation createCylinderLayer(optional XRCylinderLayerInit) assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: operation createEquirectLayer(optional XREquirectLayerInit) assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: operation createCubeLayer(optional XRCubeLayerInit) assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: operation getSubImage(XRCompositionLayer, XRFrame, optional XREye) assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: operation getViewSubImage(XRProjectionLayer, XRView) assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
-FAIL XRWebGLBinding interface: operation foveateBoundTexture(GLenum, float) assert_own_property: self does not have own property "XRWebGLBinding" expected property "XRWebGLBinding" missing
+PASS XRCompositionLayer interface: existence and properties of interface object
+PASS XRCompositionLayer interface object length
+PASS XRCompositionLayer interface object name
+PASS XRCompositionLayer interface: existence and properties of interface prototype object
+PASS XRCompositionLayer interface: existence and properties of interface prototype object's "constructor" property
+PASS XRCompositionLayer interface: existence and properties of interface prototype object's @@unscopables property
+PASS XRCompositionLayer interface: attribute layout
+PASS XRCompositionLayer interface: attribute blendTextureSourceAlpha
+PASS XRCompositionLayer interface: attribute forceMonoPresentation
+PASS XRCompositionLayer interface: attribute opacity
+PASS XRCompositionLayer interface: attribute mipLevels
+PASS XRCompositionLayer interface: attribute quality
+PASS XRCompositionLayer interface: attribute needsRedraw
+PASS XRCompositionLayer interface: operation destroy()
+PASS XRProjectionLayer interface: existence and properties of interface object
+PASS XRProjectionLayer interface object length
+PASS XRProjectionLayer interface object name
+PASS XRProjectionLayer interface: existence and properties of interface prototype object
+PASS XRProjectionLayer interface: existence and properties of interface prototype object's "constructor" property
+PASS XRProjectionLayer interface: existence and properties of interface prototype object's @@unscopables property
+PASS XRProjectionLayer interface: attribute textureWidth
+PASS XRProjectionLayer interface: attribute textureHeight
+PASS XRProjectionLayer interface: attribute textureArrayLength
+PASS XRProjectionLayer interface: attribute ignoreDepthValues
+PASS XRProjectionLayer interface: attribute fixedFoveation
+PASS XRProjectionLayer interface: attribute deltaPose
+PASS XRQuadLayer interface: existence and properties of interface object
+PASS XRQuadLayer interface object length
+PASS XRQuadLayer interface object name
+PASS XRQuadLayer interface: existence and properties of interface prototype object
+PASS XRQuadLayer interface: existence and properties of interface prototype object's "constructor" property
+PASS XRQuadLayer interface: existence and properties of interface prototype object's @@unscopables property
+PASS XRQuadLayer interface: attribute space
+PASS XRQuadLayer interface: attribute transform
+PASS XRQuadLayer interface: attribute width
+PASS XRQuadLayer interface: attribute height
+PASS XRQuadLayer interface: attribute onredraw
+PASS XRCylinderLayer interface: existence and properties of interface object
+PASS XRCylinderLayer interface object length
+PASS XRCylinderLayer interface object name
+PASS XRCylinderLayer interface: existence and properties of interface prototype object
+PASS XRCylinderLayer interface: existence and properties of interface prototype object's "constructor" property
+PASS XRCylinderLayer interface: existence and properties of interface prototype object's @@unscopables property
+PASS XRCylinderLayer interface: attribute space
+PASS XRCylinderLayer interface: attribute transform
+PASS XRCylinderLayer interface: attribute radius
+PASS XRCylinderLayer interface: attribute centralAngle
+PASS XRCylinderLayer interface: attribute aspectRatio
+PASS XRCylinderLayer interface: attribute onredraw
+PASS XREquirectLayer interface: existence and properties of interface object
+PASS XREquirectLayer interface object length
+PASS XREquirectLayer interface object name
+PASS XREquirectLayer interface: existence and properties of interface prototype object
+PASS XREquirectLayer interface: existence and properties of interface prototype object's "constructor" property
+PASS XREquirectLayer interface: existence and properties of interface prototype object's @@unscopables property
+PASS XREquirectLayer interface: attribute space
+PASS XREquirectLayer interface: attribute transform
+PASS XREquirectLayer interface: attribute radius
+PASS XREquirectLayer interface: attribute centralHorizontalAngle
+PASS XREquirectLayer interface: attribute upperVerticalAngle
+PASS XREquirectLayer interface: attribute lowerVerticalAngle
+PASS XREquirectLayer interface: attribute onredraw
+PASS XRCubeLayer interface: existence and properties of interface object
+PASS XRCubeLayer interface object length
+PASS XRCubeLayer interface object name
+PASS XRCubeLayer interface: existence and properties of interface prototype object
+PASS XRCubeLayer interface: existence and properties of interface prototype object's "constructor" property
+PASS XRCubeLayer interface: existence and properties of interface prototype object's @@unscopables property
+PASS XRCubeLayer interface: attribute space
+PASS XRCubeLayer interface: attribute orientation
+PASS XRCubeLayer interface: attribute onredraw
+PASS XRSubImage interface: existence and properties of interface object
+PASS XRSubImage interface object length
+PASS XRSubImage interface object name
+PASS XRSubImage interface: existence and properties of interface prototype object
+PASS XRSubImage interface: existence and properties of interface prototype object's "constructor" property
+PASS XRSubImage interface: existence and properties of interface prototype object's @@unscopables property
+PASS XRSubImage interface: attribute viewport
+PASS XRWebGLSubImage interface: existence and properties of interface object
+PASS XRWebGLSubImage interface object length
+PASS XRWebGLSubImage interface object name
+PASS XRWebGLSubImage interface: existence and properties of interface prototype object
+PASS XRWebGLSubImage interface: existence and properties of interface prototype object's "constructor" property
+PASS XRWebGLSubImage interface: existence and properties of interface prototype object's @@unscopables property
+PASS XRWebGLSubImage interface: attribute colorTexture
+PASS XRWebGLSubImage interface: attribute depthStencilTexture
+PASS XRWebGLSubImage interface: attribute motionVectorTexture
+PASS XRWebGLSubImage interface: attribute imageIndex
+PASS XRWebGLSubImage interface: attribute colorTextureWidth
+PASS XRWebGLSubImage interface: attribute colorTextureHeight
+PASS XRWebGLSubImage interface: attribute depthStencilTextureWidth
+PASS XRWebGLSubImage interface: attribute depthStencilTextureHeight
+PASS XRWebGLSubImage interface: attribute motionVectorTextureWidth
+PASS XRWebGLSubImage interface: attribute motionVectorTextureHeight
+PASS XRWebGLBinding interface: existence and properties of interface object
+PASS XRWebGLBinding interface object length
+PASS XRWebGLBinding interface object name
+PASS XRWebGLBinding interface: existence and properties of interface prototype object
+PASS XRWebGLBinding interface: existence and properties of interface prototype object's "constructor" property
+PASS XRWebGLBinding interface: existence and properties of interface prototype object's @@unscopables property
+PASS XRWebGLBinding interface: attribute nativeProjectionScaleFactor
+PASS XRWebGLBinding interface: attribute usesDepthValues
+PASS XRWebGLBinding interface: operation createProjectionLayer(optional XRProjectionLayerInit)
+PASS XRWebGLBinding interface: operation createQuadLayer(optional XRQuadLayerInit)
+PASS XRWebGLBinding interface: operation createCylinderLayer(optional XRCylinderLayerInit)
+PASS XRWebGLBinding interface: operation createEquirectLayer(optional XREquirectLayerInit)
+PASS XRWebGLBinding interface: operation createCubeLayer(optional XRCubeLayerInit)
+PASS XRWebGLBinding interface: operation getSubImage(XRCompositionLayer, XRFrame, optional XREye)
+PASS XRWebGLBinding interface: operation getViewSubImage(XRProjectionLayer, XRView)
+FAIL XRWebGLBinding interface: operation foveateBoundTexture(GLenum, float) assert_own_property: interface prototype object missing non-static operation expected property "foveateBoundTexture" missing
 FAIL XRMediaBinding interface: existence and properties of interface object assert_own_property: self does not have own property "XRMediaBinding" expected property "XRMediaBinding" missing
 FAIL XRMediaBinding interface object length assert_own_property: self does not have own property "XRMediaBinding" expected property "XRMediaBinding" missing
 FAIL XRMediaBinding interface object name assert_own_property: self does not have own property "XRMediaBinding" expected property "XRMediaBinding" missing
@@ -123,12 +123,16 @@ FAIL XRMediaBinding interface: existence and properties of interface prototype o
 FAIL XRMediaBinding interface: operation createQuadLayer(HTMLVideoElement, optional XRMediaQuadLayerInit) assert_own_property: self does not have own property "XRMediaBinding" expected property "XRMediaBinding" missing
 FAIL XRMediaBinding interface: operation createCylinderLayer(HTMLVideoElement, optional XRMediaCylinderLayerInit) assert_own_property: self does not have own property "XRMediaBinding" expected property "XRMediaBinding" missing
 FAIL XRMediaBinding interface: operation createEquirectLayer(HTMLVideoElement, optional XRMediaEquirectLayerInit) assert_own_property: self does not have own property "XRMediaBinding" expected property "XRMediaBinding" missing
-FAIL XRLayerEvent interface: existence and properties of interface object assert_own_property: self does not have own property "XRLayerEvent" expected property "XRLayerEvent" missing
-FAIL XRLayerEvent interface object length assert_own_property: self does not have own property "XRLayerEvent" expected property "XRLayerEvent" missing
-FAIL XRLayerEvent interface object name assert_own_property: self does not have own property "XRLayerEvent" expected property "XRLayerEvent" missing
-FAIL XRLayerEvent interface: existence and properties of interface prototype object assert_own_property: self does not have own property "XRLayerEvent" expected property "XRLayerEvent" missing
-FAIL XRLayerEvent interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "XRLayerEvent" expected property "XRLayerEvent" missing
-FAIL XRLayerEvent interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "XRLayerEvent" expected property "XRLayerEvent" missing
-FAIL XRLayerEvent interface: attribute layer assert_own_property: self does not have own property "XRLayerEvent" expected property "XRLayerEvent" missing
-FAIL XRRenderState interface: attribute layers assert_true: The prototype object must have a property "layers" expected true got false
+FAIL XRLayerEvent interface: existence and properties of interface object assert_equals: prototype of XRLayerEvent is not Event expected function "function Event() {
+    [native code]
+}" but got function "function () {
+    [native code]
+}"
+PASS XRLayerEvent interface object length
+PASS XRLayerEvent interface object name
+FAIL XRLayerEvent interface: existence and properties of interface prototype object assert_equals: prototype of XRLayerEvent.prototype is not Event.prototype expected object "[object Event]" but got object "[object Object]"
+PASS XRLayerEvent interface: existence and properties of interface prototype object's "constructor" property
+PASS XRLayerEvent interface: existence and properties of interface prototype object's @@unscopables property
+PASS XRLayerEvent interface: attribute layer
+PASS XRRenderState interface: attribute layers
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_constructor.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_constructor.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Ensure that XRWebGLBinding's constructor throws appropriate errors using webgl assert_equals: Should get InvalidStateError for creating with inline session. expected "InvalidStateError" but got "ReferenceError"
-FAIL Ensure that XRWebGLBinding's constructor throws appropriate errors using webgl2 assert_equals: Should get InvalidStateError for creating with inline session. expected "InvalidStateError" but got "ReferenceError"
+PASS Ensure that XRWebGLBinding's constructor throws appropriate errors using webgl
+PASS Ensure that XRWebGLBinding's constructor throws appropriate errors using webgl2
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2854,6 +2854,8 @@ imported/w3c/web-platform-tests/webxr/exclusive_requestFrame_nolayer.https.html 
 imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https.html [ Failure ]
 
 imported/w3c/web-platform-tests/webxr/hand-input/ [ Pass ]
+imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_constructor.https.html [ Pass ]
+imported/w3c/web-platform-tests/webxr/layers/idlharness.https.window.html [ Pass ]
 
 imported/w3c/web-platform-tests/webxr/hit-test/idlharness.https.html [ Pass ]
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -9688,10 +9688,13 @@ WebXRLayersAPIEnabled:
   condition: ENABLE(WEBXR_LAYERS)
   defaultValue:
     WebKitLegacy:
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebKit:
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
 WebXRWebGPUBindingsEnabled:

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.h
@@ -78,6 +78,12 @@ public:
 
     ExceptionOr<Ref<XRWebGLSubImage>> getSubImage(const XRCompositionLayer&, const WebXRFrame&, XREye) { RELEASE_ASSERT_NOT_REACHED(); }
     ExceptionOr<Ref<XRWebGLSubImage>> getViewSubImage(const XRProjectionLayer&, const WebXRView&) { RELEASE_ASSERT_NOT_REACHED(); }
+
+private:
+    XRWebGLBinding(Ref<WebXRSession>&&, WebXRWebGLRenderingContext&&);
+
+    RefPtr<WebXRSession> m_session;
+    WebXRWebGLRenderingContext m_context;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 560926efcc3867ba87c1f064a32874b4999ed2ee
<pre>
[WebXR] Implement XRWebGLBinding constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=301102">https://bugs.webkit.org/show_bug.cgi?id=301102</a>

Reviewed by Dan Glastonbury.

Adding the implementation of the constructor of the bindings
object as per the WebXR spec. So far is basically a sequence
of checks.

Replaced subtests expectations from FAIL to PASS and unskipping
the WPT test that verifies the constructor behaviour.

* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/idlharness.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_constructor.https-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/webxr/XRWebGLBinding.cpp:
(WebCore::XRWebGLBinding::create):
(WebCore::XRWebGLBinding::XRWebGLBinding):
* Source/WebCore/Modules/webxr/XRWebGLBinding.h:

Canonical link: <a href="https://commits.webkit.org/301937@main">https://commits.webkit.org/301937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9ecd47381e5dde9f764f1aec2c798961fbc54ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134424 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78915 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96929 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64923 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77423 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32186 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77806 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119397 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136907 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125823 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41627 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105449 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105126 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26835 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50647 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29095 "Found 1 new test failure: http/tests/misc/ftp-eplf-directory.py (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51598 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53956 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60043 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158861 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53189 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39722 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->