### PR TITLE
Crash in Style::Scope::createOrFindSharedShadowTreeResolver with content extensions

### DIFF
--- a/LayoutTests/http/tests/contentextensions/css-display-none-font-shadow-tree-expected.html
+++ b/LayoutTests/http/tests/contentextensions/css-display-none-font-shadow-tree-expected.html
@@ -1,0 +1,1 @@
+This should be visible.

--- a/LayoutTests/http/tests/contentextensions/css-display-none-font-shadow-tree.html
+++ b/LayoutTests/http/tests/contentextensions/css-display-none-font-shadow-tree.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<body>
+<div id=host>
+<template shadowrootmode=open>
+<style id="style">
+@font-face { font-family: 'WebFont'; src: url('../resources/Ahem.woff') format('woff');
+#contents { font-family: 'WebFont'; }
+</style>
+<div id="hideme">FAIL</div>
+<div id="contents"></div>
+This should be visible.
+</template>
+</div>

--- a/LayoutTests/http/tests/contentextensions/css-display-none-font-shadow-tree.html.json
+++ b/LayoutTests/http/tests/contentextensions/css-display-none-font-shadow-tree.html.json
@@ -1,0 +1,14 @@
+[
+    {
+        "action": {
+            "type": "css-display-none",
+            "selector": "#hideme"
+        },
+        "trigger": {
+            "url-filter": ".*",
+            "resource-type": [
+                "font"
+            ]
+        }
+    }
+]

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1365,7 +1365,8 @@ void Document::setCompatibilityMode(DocumentCompatibilityMode mode)
         // All user stylesheets have to reparse using the different mode.
         if (auto* extensionStyleSheets = extensionStyleSheetsIfExists()) {
             extensionStyleSheets->clearPageUserSheet();
-            extensionStyleSheets->invalidateInjectedStyleSheetCache();
+            if (extensionStyleSheets->hasCachedInjectedStyleSheets())
+                extensionStyleSheets->invalidateInjectedStyleSheetCache();
         }
     }
 

--- a/Source/WebCore/dom/ExtensionStyleSheets.cpp
+++ b/Source/WebCore/dom/ExtensionStyleSheets.cpp
@@ -101,7 +101,7 @@ void ExtensionStyleSheets::clearPageUserSheet()
 {
     if (m_pageUserSheet) {
         m_pageUserSheet = nullptr;
-        protectedDocument()->styleScope().didChangeStyleSheetEnvironment();
+        protectedDocument()->styleScope().didChangeExtensionStyleSheets();
     }
 }
 
@@ -109,7 +109,7 @@ void ExtensionStyleSheets::updatePageUserSheet()
 {
     clearPageUserSheet();
     if (pageUserSheet())
-        protectedDocument()->styleScope().didChangeStyleSheetEnvironment();
+        protectedDocument()->styleScope().didChangeExtensionStyleSheets();
 }
 
 const Vector<RefPtr<CSSStyleSheet>>& ExtensionStyleSheets::injectedUserStyleSheets() const
@@ -204,24 +204,31 @@ void ExtensionStyleSheets::removePageSpecificUserStyleSheet(const UserStyleSheet
         invalidateInjectedStyleSheetCache();
 }
 
+bool ExtensionStyleSheets::hasCachedInjectedStyleSheets() const
+{
+    return !m_injectedUserStyleSheets.isEmpty()
+        || !m_injectedAuthorStyleSheets.isEmpty()
+        || !m_injectedStyleSheetToSource.isEmpty();
+}
+
 void ExtensionStyleSheets::invalidateInjectedStyleSheetCache()
 {
     m_injectedStyleSheetCacheValid = false;
-    protectedDocument()->styleScope().didChangeStyleSheetEnvironment();
+    protectedDocument()->styleScope().didChangeExtensionStyleSheets();
 }
 
 void ExtensionStyleSheets::addUserStyleSheet(Ref<StyleSheetContents>&& userSheet)
 {
     ASSERT(userSheet.get().isUserStyleSheet());
     m_userStyleSheets.append(CSSStyleSheet::create(WTFMove(userSheet), protectedDocument().get()));
-    protectedDocument()->styleScope().didChangeStyleSheetEnvironment();
+    protectedDocument()->styleScope().didChangeExtensionStyleSheets();
 }
 
 void ExtensionStyleSheets::addAuthorStyleSheetForTesting(Ref<StyleSheetContents>&& authorSheet)
 {
     ASSERT(!authorSheet.get().isUserStyleSheet());
     m_authorStyleSheetsForTesting.append(CSSStyleSheet::create(WTFMove(authorSheet), protectedDocument().get()));
-    protectedDocument()->styleScope().didChangeStyleSheetEnvironment();
+    protectedDocument()->styleScope().didChangeExtensionStyleSheets();
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -234,7 +241,7 @@ void ExtensionStyleSheets::addDisplayNoneSelector(const String& identifier, cons
     }
 
     if (result.iterator->value->addDisplayNoneSelector(selector, selectorID))
-        protectedDocument()->styleScope().didChangeStyleSheetEnvironment();
+        protectedDocument()->styleScope().didChangeExtensionStyleSheets();
 }
 
 void ExtensionStyleSheets::maybeAddContentExtensionSheet(const String& identifier, StyleSheetContents& sheet)
@@ -247,7 +254,7 @@ void ExtensionStyleSheets::maybeAddContentExtensionSheet(const String& identifie
     Ref<CSSStyleSheet> cssSheet = CSSStyleSheet::create(sheet, protectedDocument().get());
     m_contentExtensionSheets.set(identifier, &cssSheet.get());
     m_userStyleSheets.append(adoptRef(cssSheet.leakRef()));
-    protectedDocument()->styleScope().didChangeStyleSheetEnvironment();
+    protectedDocument()->styleScope().didChangeExtensionStyleSheets();
 
 }
 #endif // ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -64,6 +64,8 @@ public:
     const Vector<RefPtr<CSSStyleSheet>>& injectedAuthorStyleSheets() const;
     const Vector<RefPtr<CSSStyleSheet>>& authorStyleSheetsForTesting() const { return m_authorStyleSheetsForTesting; }
 
+    bool hasCachedInjectedStyleSheets() const;
+
     void clearPageUserSheet();
     void updatePageUserSheet();
     void invalidateInjectedStyleSheetCache();

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -122,6 +122,9 @@ public:
     // The change is assumed to potentially affect all author and user stylesheets including shadow roots.
     WEBCORE_EXPORT void didChangeStyleSheetEnvironment();
 
+    // This is called when extension stylesheets change.
+    void didChangeExtensionStyleSheets();
+
     void didChangeViewportSize();
 
     void invalidateMatchedDeclarationsCache();
@@ -186,7 +189,7 @@ private:
 
     void didRemovePendingStylesheet();
 
-    enum class UpdateType : uint8_t { ActiveSet, ContentsOrInterpretation };
+    enum class UpdateType : uint8_t { ActiveSet, FullForExtensionStyleSheets, ContentsOrInterpretation };
     void updateActiveStyleSheets(UpdateType);
     void scheduleUpdate(UpdateType);
 


### PR DESCRIPTION
#### 68e23c662f549777f47c74fa106f1659c89b6cac
<pre>
Crash in Style::Scope::createOrFindSharedShadowTreeResolver with content extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=301100">https://bugs.webkit.org/show_bug.cgi?id=301100</a>
<a href="https://rdar.apple.com/83302107">rdar://83302107</a>

Reviewed by Alan Baradlay.

Test: http/tests/contentextensions/css-display-none-font-shadow-tree.html
* LayoutTests/http/tests/contentextensions/css-display-none-font-shadow-tree-expected.html: Added.
* LayoutTests/http/tests/contentextensions/css-display-none-font-shadow-tree.html: Added.
* LayoutTests/http/tests/contentextensions/css-display-none-font-shadow-tree.html.json: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setCompatibilityMode):

Don&apos;t invalidate unnecessarily when there are no cached extension stylesheets.

* Source/WebCore/dom/ExtensionStyleSheets.cpp:
(WebCore::ExtensionStyleSheets::clearPageUserSheet):
(WebCore::ExtensionStyleSheets::updatePageUserSheet):
(WebCore::ExtensionStyleSheets::hasCachedInjectedStyleSheets const):
(WebCore::ExtensionStyleSheets::invalidateInjectedStyleSheetCache):
(WebCore::ExtensionStyleSheets::addUserStyleSheet):
(WebCore::ExtensionStyleSheets::addAuthorStyleSheetForTesting):
(WebCore::ExtensionStyleSheets::addDisplayNoneSelector):
(WebCore::ExtensionStyleSheets::maybeAddContentExtensionSheet):

Call new didChangeExtensionStyleSheets instead of didChangeStyleSheetEnvironment.

* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::createOrFindSharedShadowTreeResolver):
(WebCore::Style::Scope::clearResolver):
(WebCore::Style::Scope::scheduleUpdate):

Release assert that we are not in style or stylesheet update when clearing the resolver.

(WebCore::Style::Scope::didChangeStyleSheetEnvironment):
(WebCore::Style::Scope::didChangeExtensionStyleSheets):

Trigger asynchronous full stylesheet update.
Extension stylesheet changes do not require wiping out the style resolver synchronously as
they are additive.

* Source/WebCore/style/StyleScope.h:

Canonical link: <a href="https://commits.webkit.org/301878@main">https://commits.webkit.org/301878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cce04e3621a4db4b0253545f03ff02a6daeda5f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134377 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78868 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b3ce15c1-e41d-415e-815b-e5af39307b26) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96894 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f6b3b9e1-b791-4298-a019-ef35290a38f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77388 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/42a55e08-4084-4f9a-89a5-27ebe5b5c752) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77759 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107923 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136860 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105409 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110375 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105092 "") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26801 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50610 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51539 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53909 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59996 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53144 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54902 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->