### PR TITLE
Report OOM error when render/compute pipeline creation fails

### DIFF
--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -243,7 +243,7 @@ void ComputePassEncoder::executePreDispatchCommands(const Buffer* indirectBuffer
                     continue;
 
                 if (!addResourceToActiveResources(usageData.resource, usageData.usage, BindGroupId { bindGroupIndex }, usagesForResource, textureUsagesForResource, protectedParentEncoder())) {
-                    makeInvalid();
+                    makeInvalid(@"GPUComputePassEncoder.executePreDispatchCommands - could not track resource");
                     return;
                 }
             }
@@ -276,7 +276,7 @@ void ComputePassEncoder::dispatch(uint32_t x, uint32_t y, uint32_t z)
     executePreDispatchCommands();
     auto dimensionMax = m_device->limits().maxComputeWorkgroupsPerDimension;
     if (x > dimensionMax || y > dimensionMax || z > dimensionMax) {
-        makeInvalid();
+        makeInvalid([NSString stringWithFormat:@"x(%u) > dimensionMax(%u) || y(%u) > dimensionMax(%u) || z(%u) > dimensionMax(%u)", x, dimensionMax, y, dimensionMax, z, dimensionMax]);
         return;
     }
 
@@ -320,13 +320,13 @@ void ComputePassEncoder::dispatchIndirect(const Buffer& indirectBuffer, uint64_t
 {
     RETURN_IF_FINISHED();
     if (!isValidToUseWith(indirectBuffer, *this)) {
-        makeInvalid();
+        makeInvalid(@"GPUComputePassEncoder.dispatchIndirect: indirectBuffer is not valid to use with this GPUComputePassEncoder");
         return;
     }
 
     auto indirectOffsetSum = checkedSum<uint64_t>(indirectOffset, 3 * sizeof(uint32_t));
     if ((indirectOffset % 4) || !(indirectBuffer.usage() & WGPUBufferUsage_Indirect) || indirectOffsetSum.hasOverflowed() || (indirectOffsetSum.value() > indirectBuffer.initialSize())) {
-        makeInvalid();
+        makeInvalid([NSString stringWithFormat:@"GPUComputePassEncoder.dispatchIndirect: (indirectOffset(%llu) mod 4) || !(indirectBuffer.usage(%u) & WGPUBufferUsage_Indirect(%u)) || indirectOffsetSum.hasOverflowed(%d) || (indirectOffsetSum(%llu) > indirectBuffer.initialSize(%llu))", indirectOffset, indirectBuffer.usage(), WGPUBufferUsage_Indirect, indirectOffsetSum.hasOverflowed(), indirectOffsetSum.hasOverflowed() ? 0 : indirectOffsetSum.value(), indirectBuffer.initialSize()]);
         return;
     }
 
@@ -511,7 +511,7 @@ void ComputePassEncoder::setPipeline(const ComputePipeline& pipeline)
 {
     RETURN_IF_FINISHED();
     if (!isValidToUseWith(pipeline, *this)) {
-        makeInvalid();
+        makeInvalid(@"GPUComputePipeline is invalid to use with this GPUComputePassEncoder");
         return;
     }
 

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1978,6 +1978,9 @@ id<MTLRenderPipelineState> RenderPipeline::renderPipelineState() const
         return m_renderPipelineState;
 
     m_renderPipelineState = [m_device->device() newRenderPipelineStateWithDescriptor:m_renderPipelineDescriptor error:nil];
+    if (!m_renderPipelineState)
+        m_device->generateAnOutOfMemoryError("Render pipeline failed compilation likely due to being too complex, please reduce its size"_s);
+
     return m_renderPipelineState;
 }
 
@@ -1988,6 +1991,9 @@ id<MTLRenderPipelineState> RenderPipeline::icbRenderPipelineState() const
 
     m_renderPipelineDescriptor.supportIndirectCommandBuffers = YES;
     m_renderPipelineState = [m_device->device() newRenderPipelineStateWithDescriptor:m_renderPipelineDescriptor error:nil];
+    if (!m_renderPipelineState)
+        m_device->generateAnOutOfMemoryError("Render pipeline failed compilation likely due to being too complex, please reduce its size"_s);
+
     return m_renderPipelineState;
 }
 


### PR DESCRIPTION
#### 0d495098f89aab66ce72c587eb5fbd48f9bbcc87
<pre>
Report OOM error when render/compute pipeline creation fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=301113">https://bugs.webkit.org/show_bug.cgi?id=301113</a>
<a href="https://rdar.apple.com/163054253">rdar://163054253</a>

Reviewed by Tadeu Zagallo.

Expand upon error messages and generate OOM errors when
the PSO fails to compile and we did not previously detect
any validations errors.

* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
(WebGPU::ComputePassEncoder::dispatch):
(WebGPU::ComputePassEncoder::dispatchIndirect):
(WebGPU::ComputePassEncoder::setPipeline):
* Source/WebGPU/WebGPU/ComputePipeline.mm:
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::renderPipelineState const):
(WebGPU::RenderPipeline::icbRenderPipelineState const):

Canonical link: <a href="https://commits.webkit.org/301879@main">https://commits.webkit.org/301879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c52c7f6f04b1fc044f359db5482c138e579ae25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78734 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/30e54b2c-1b56-4cef-aab6-c0d84709d37f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96787 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64839 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/02cd73fc-e18b-456f-959b-90aa1aee71f6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77291 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/994b1953-bdc3-4859-b7ff-bd6bb4e2b074) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36877 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77623 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107843 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136726 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105306 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104993 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26802 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50517 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28958 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51401 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53775 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59862 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53007 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56340 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54767 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->