### PR TITLE
[Style] Convert the 'grid-auto-flow' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3325,6 +3325,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/fonts/StyleFontWeight.h
     style/values/fonts/StyleFontWidth.h
 
+    style/values/grid/StyleGridAutoFlow.h
     style/values/grid/StyleGridNamedAreaMap.h
     style/values/grid/StyleGridNamedLinesMap.h
     style/values/grid/StyleGridOrderedNamedLinesMap.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -887,7 +887,6 @@ style/RuleSet.cpp
 style/RuleSetBuilder.cpp
 style/StyleAdjuster.cpp
 style/StyleBuilder.cpp
-style/StyleBuilderConverter.h
 style/StyleBuilderCustom.h
 style/StyleBuilderState.cpp
 style/StyleExtractor.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3227,6 +3227,7 @@ style/values/fonts/StyleFontVariantNumeric.cpp
 style/values/fonts/StyleFontVariationSettings.cpp
 style/values/fonts/StyleFontWeight.cpp
 style/values/fonts/StyleFontWidth.cpp
+style/values/grid/StyleGridAutoFlow.cpp
 style/values/grid/StyleGridNamedLinesMap.cpp
 style/values/grid/StyleGridPosition.cpp
 style/values/grid/StyleGridPositionsResolver.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10029,7 +10029,7 @@
             "animation-type": "discrete",
             "initial": "row",
             "codegen-properties": {
-                "style-converter": "GridAutoFlow",
+                "style-converter": "StyleType<GridAutoFlow>",
                 "parser-function": "consumeGridAutoFlow",
                 "parser-grammar-unused": "[ row | column ] || dense",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -102,8 +102,8 @@ std::pair<UsedTrackSizes, GridItemRects> GridLayout::layout(GridFormattingContex
 
     // 1. Run the Grid Item Placement Algorithm to resolve the placement of all grid items in the grid.
     GridAutoFlowOptions autoFlowOptions {
-        .strategy = gridContainerStyle->isGridAutoFlowAlgorithmDense() ? PackingStrategy::Dense : PackingStrategy::Sparse,
-        .direction = gridContainerStyle->isGridAutoFlowDirectionRow() ? GridAutoFlowDirection::Row : GridAutoFlowDirection::Column
+        .strategy = gridContainerStyle->gridAutoFlow().isDense() ? PackingStrategy::Dense : PackingStrategy::Sparse,
+        .direction = gridContainerStyle->gridAutoFlow().isRow() ? GridAutoFlowDirection::Row : GridAutoFlowDirection::Column
     };
     auto [ gridAreas, implicitGridColumnsCount, implicitGridRowsCount ] = placeGridItems(unplacedGridItems, gridTemplateColumnsTrackSizes, gridTemplateRowsTrackSizes, autoFlowOptions);
     auto placedGridItems = formattingContext().constructPlacedGridItems(gridAreas);

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -99,7 +99,7 @@ static std::optional<AvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid
     if (!renderGrid.firstInFlowChild())
         return AvoidanceReason::GridIsEmpty;
 
-    if (renderGridStyle->gridAutoFlow() != GridAutoFlow::AutoFlowRow)
+    if (renderGridStyle->gridAutoFlow() != RenderStyle::initialGridAutoFlow())
         return AvoidanceReason::GridHasNonInitialGridAutoFlow;
 
     if (!renderGridStyle->rowGap().isNormal() || !renderGridStyle->columnGap().isNormal())

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1332,7 +1332,7 @@ bool RenderGrid::isPlacedWithinExtrinsicallySizedExplicitTracks(const RenderBox&
 void RenderGrid::placeSpecifiedMajorAxisItemsOnGrid(const Vector<RenderBox*>& autoGridItems)
 {
     bool isForColumns = autoPlacementMajorAxisDirection() == Style::GridTrackSizingDirection::Columns;
-    bool isGridAutoFlowDense = style().isGridAutoFlowAlgorithmDense();
+    bool isGridAutoFlowDense = style().gridAutoFlow().isDense();
 
     // Mapping between the major axis tracks (rows or columns) and the last auto-placed item's position inserted on
     // that track. This is needed to implement "sparse" packing for items locked to a given track.
@@ -1361,7 +1361,7 @@ void RenderGrid::placeSpecifiedMajorAxisItemsOnGrid(const Vector<RenderBox*>& au
 void RenderGrid::placeAutoMajorAxisItemsOnGrid(const Vector<RenderBox*>& autoGridItems)
 {
     AutoPlacementCursor autoPlacementCursor = {0, 0};
-    bool isGridAutoFlowDense = style().isGridAutoFlowAlgorithmDense();
+    bool isGridAutoFlowDense = style().gridAutoFlow().isDense();
 
     for (auto& autoGridItem : autoGridItems) {
         placeAutoMajorAxisItemOnGrid(*autoGridItem, autoPlacementCursor);
@@ -1435,7 +1435,7 @@ Style::GridTrackSizingDirection RenderGrid::autoPlacementMajorAxisDirection() co
     if (areMasonryRows())
         return Style::GridTrackSizingDirection::Rows;
 
-    return style().isGridAutoFlowDirectionColumn() ? Style::GridTrackSizingDirection::Columns : Style::GridTrackSizingDirection::Rows;
+    return style().gridAutoFlow().isColumn() ? Style::GridTrackSizingDirection::Columns : Style::GridTrackSizingDirection::Rows;
 }
 
 Style::GridTrackSizingDirection RenderGrid::autoPlacementMinorAxisDirection() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -79,7 +79,6 @@ class ViewTimeline;
 class WillChangeData;
 
 enum CSSPropertyID : uint16_t;
-enum GridAutoFlow : uint8_t;
 
 enum class AlignmentBaseline : uint8_t;
 enum class ApplePayButtonStyle : uint8_t;
@@ -282,6 +281,7 @@ struct FontVariationSettings;
 struct FontWeight;
 struct FontWidth;
 struct GapGutter;
+struct GridAutoFlow;
 struct GridPosition;
 struct GridTemplateAreas;
 struct GridTemplateList;
@@ -964,11 +964,7 @@ public:
     inline const StyleSelfAlignmentData& justifyItems() const;
     inline const StyleSelfAlignmentData& justifySelf() const;
 
-    inline GridAutoFlow gridAutoFlow() const;
-    inline bool isGridAutoFlowDirectionRow() const;
-    inline bool isGridAutoFlowDirectionColumn() const;
-    inline bool isGridAutoFlowAlgorithmSparse() const;
-    inline bool isGridAutoFlowAlgorithmDense() const;
+    inline Style::GridAutoFlow gridAutoFlow() const;
     inline const Style::GridTrackSizes& gridAutoColumns() const;
     inline const Style::GridTrackSizes& gridAutoRows() const;
     inline const Style::GridTrackSizes& gridAutoList(Style::GridTrackSizingDirection) const;
@@ -1576,7 +1572,7 @@ public:
 
     inline void setBoxDecorationBreak(BoxDecorationBreak);
 
-    inline void setGridAutoFlow(GridAutoFlow);
+    inline void setGridAutoFlow(Style::GridAutoFlow);
     inline void setGridAutoColumns(Style::GridTrackSizes&&);
     inline void setGridAutoRows(Style::GridTrackSizes&&);
     inline void setGridTemplateAreas(Style::GridTemplateAreas&&);
@@ -2263,7 +2259,7 @@ public:
     static constexpr AppleVisualEffect initialAppleVisualEffect();
 #endif
 
-    static constexpr GridAutoFlow initialGridAutoFlow();
+    static constexpr Style::GridAutoFlow initialGridAutoFlow();
     static inline Style::GridTrackSizes initialGridAutoColumns();
     static inline Style::GridTrackSizes initialGridAutoRows();
     static inline Style::GridTemplateAreas initialGridTemplateAreas();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -649,17 +649,6 @@ TextStream& operator<<(TextStream& ts, UsedFloat floating)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, GridAutoFlow gridAutoFlow)
-{
-    switch (gridAutoFlow) {
-    case AutoFlowRow: ts << "row"_s; break;
-    case AutoFlowColumn: ts << "column"_s; break;
-    case AutoFlowRowDense: ts << "row-dense"_s; break;
-    case AutoFlowColumnDense: ts << "column-dense"_s; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, HangingPunctuation punctuation)
 {
     switch (punctuation) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -991,21 +991,6 @@ enum class ColorScheme : uint8_t {
 
 constexpr size_t ColorSchemeBits = 2;
 
-constexpr size_t GridAutoFlowBits = 4;
-enum InternalGridAutoFlow : uint8_t {
-    InternalAutoFlowAlgorithmSparse = 1 << 0,
-    InternalAutoFlowAlgorithmDense  = 1 << 1,
-    InternalAutoFlowDirectionRow    = 1 << 2,
-    InternalAutoFlowDirectionColumn = 1 << 3
-};
-
-enum GridAutoFlow : uint8_t {
-    AutoFlowRow = InternalAutoFlowAlgorithmSparse | InternalAutoFlowDirectionRow,
-    AutoFlowColumn = InternalAutoFlowAlgorithmSparse | InternalAutoFlowDirectionColumn,
-    AutoFlowRowDense = InternalAutoFlowAlgorithmDense | InternalAutoFlowDirectionRow,
-    AutoFlowColumnDense = InternalAutoFlowAlgorithmDense | InternalAutoFlowDirectionColumn
-};
-
 enum class AutoRepeatType : uint8_t {
     None,
     Fill,
@@ -1342,7 +1327,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, FlexDirection);
 WTF::TextStream& operator<<(WTF::TextStream&, FlexWrap);
 WTF::TextStream& operator<<(WTF::TextStream&, Float);
 WTF::TextStream& operator<<(WTF::TextStream&, UsedFloat);
-WTF::TextStream& operator<<(WTF::TextStream&, GridAutoFlow);
 WTF::TextStream& operator<<(WTF::TextStream&, HangingPunctuation);
 WTF::TextStream& operator<<(WTF::TextStream&, Hyphens);
 WTF::TextStream& operator<<(WTF::TextStream&, ImageRendering);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -255,7 +255,7 @@ inline const AtomString& RenderStyle::locale() const { return fontDescription().
 inline TextRenderingMode RenderStyle::textRendering() const { return fontDescription().textRenderingMode(); }
 inline const Style::GapGutter& RenderStyle::gap(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? columnGap() : rowGap(); }
 inline const Style::GridTrackSizes& RenderStyle::gridAutoColumns() const { return m_nonInheritedData->rareData->grid->m_gridAutoColumns; }
-inline GridAutoFlow RenderStyle::gridAutoFlow() const { return static_cast<GridAutoFlow>(m_nonInheritedData->rareData->grid->m_gridAutoFlow); }
+inline Style::GridAutoFlow RenderStyle::gridAutoFlow() const { return m_nonInheritedData->rareData->grid->m_gridAutoFlow; }
 inline const Style::GridTrackSizes& RenderStyle::gridAutoRows() const { return m_nonInheritedData->rareData->grid->m_gridAutoRows; }
 inline const Style::GridTrackSizes& RenderStyle::gridAutoList(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? gridAutoColumns() : gridAutoRows(); }
 inline const Style::GridTemplateList& RenderStyle::gridTemplateColumns() const { return m_nonInheritedData->rareData->grid->m_gridTemplateColumns; }
@@ -445,7 +445,7 @@ constexpr TextAutospace RenderStyle::initialTextAutospace() { return { }; }
 constexpr TextRenderingMode RenderStyle::initialTextRendering() { return TextRenderingMode::AutoTextRendering; }
 constexpr Style::TextSpacingTrim RenderStyle::initialTextSpacingTrim() { return CSS::Keyword::SpaceAll { }; }
 inline Style::GridTrackSizes RenderStyle::initialGridAutoColumns() { return CSS::Keyword::Auto { }; }
-constexpr GridAutoFlow RenderStyle::initialGridAutoFlow() { return AutoFlowRow; }
+constexpr Style::GridAutoFlow RenderStyle::initialGridAutoFlow() { return CSS::Keyword::Row { }; }
 inline Style::GridTrackSizes RenderStyle::initialGridAutoRows() { return CSS::Keyword::Auto { }; }
 inline Style::GridPosition RenderStyle::initialGridItemColumnEnd() { return CSS::Keyword::Auto { }; }
 inline Style::GridPosition RenderStyle::initialGridItemColumnStart() { return CSS::Keyword::Auto { }; }
@@ -641,10 +641,6 @@ constexpr bool RenderStyle::isInternalTableBox() const { return isInternalTableB
 constexpr bool RenderStyle::isRubyContainerOrInternalRubyBox() const { return isRubyContainerOrInternalRubyBox(display()); }
 inline bool RenderStyle::isFixedTableLayout() const { return tableLayout() == TableLayoutType::Fixed && (logicalWidth().isSpecified() || logicalWidth().isFitContent() || logicalWidth().isFillAvailable() || logicalWidth().isMinContent()); }
 inline bool RenderStyle::isFloating() const { return floating() != Float::None; }
-inline bool RenderStyle::isGridAutoFlowAlgorithmDense() const { return m_nonInheritedData->rareData->grid->m_gridAutoFlow & InternalAutoFlowAlgorithmDense; }
-inline bool RenderStyle::isGridAutoFlowAlgorithmSparse() const { return m_nonInheritedData->rareData->grid->m_gridAutoFlow & InternalAutoFlowAlgorithmSparse; }
-inline bool RenderStyle::isGridAutoFlowDirectionColumn() const { return m_nonInheritedData->rareData->grid->m_gridAutoFlow & InternalAutoFlowDirectionColumn; }
-inline bool RenderStyle::isGridAutoFlowDirectionRow() const { return m_nonInheritedData->rareData->grid->m_gridAutoFlow & InternalAutoFlowDirectionRow; }
 constexpr bool RenderStyle::isOriginalDisplayBlockType() const { return isDisplayBlockType(originalDisplay()); }
 constexpr bool RenderStyle::isOriginalDisplayInlineType() const { return isDisplayInlineType(originalDisplay()); }
 constexpr bool RenderStyle::isOriginalDisplayListItemType() const { return isDisplayListItemType(originalDisplay()); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -156,7 +156,7 @@ inline void RenderStyle::setFlexGrow(Style::FlexGrow grow) { SET_DOUBLY_NESTED(m
 inline void RenderStyle::setFlexShrink(Style::FlexShrink shrink) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexShrink, shrink); }
 inline void RenderStyle::setFlexWrap(FlexWrap wrap) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexWrap, static_cast<unsigned>(wrap)); }
 inline void RenderStyle::setGridAutoColumns(Style::GridTrackSizes&& trackSizeList) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, m_gridAutoColumns, WTFMove(trackSizeList)); }
-inline void RenderStyle::setGridAutoFlow(GridAutoFlow flow) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, m_gridAutoFlow, flow); }
+inline void RenderStyle::setGridAutoFlow(Style::GridAutoFlow flow) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, m_gridAutoFlow, flow); }
 inline void RenderStyle::setGridAutoRows(Style::GridTrackSizes&& trackSizeList) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, m_gridAutoRows, WTFMove(trackSizeList)); }
 inline void RenderStyle::setGridItemColumnEnd(Style::GridPosition&& columnEndPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridColumnEnd, WTFMove(columnEndPosition)); }
 inline void RenderStyle::setGridItemColumnStart(Style::GridPosition&& columnStartPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridColumnStart, WTFMove(columnStartPosition)); }

--- a/Source/WebCore/rendering/style/StyleGridData.h
+++ b/Source/WebCore/rendering/style/StyleGridData.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/RenderStyleConstants.h>
+#include <WebCore/StyleGridAutoFlow.h>
 #include <WebCore/StyleGridTemplateAreas.h>
 #include <WebCore/StyleGridTemplateList.h>
 #include <WebCore/StyleGridTrackSizes.h>
@@ -50,7 +51,7 @@ public:
     void dumpDifferences(TextStream&, const StyleGridData&) const;
 #endif
 
-    unsigned gridAutoFlow() const { return m_gridAutoFlow; }
+    Style::GridAutoFlow gridAutoFlow() const { return m_gridAutoFlow; }
     const Style::GridTrackSizes& gridAutoColumns() const { return m_gridAutoColumns; }
     const Style::GridTrackSizes& gridAutoRows() const { return m_gridAutoRows; }
     const Style::GridTemplateAreas& gridTemplateAreas() { return m_gridTemplateAreas; }
@@ -60,7 +61,7 @@ public:
 private:
     friend class RenderStyle;
 
-    unsigned m_gridAutoFlow : GridAutoFlowBits;
+    Style::GridAutoFlow m_gridAutoFlow;
     Style::GridTrackSizes m_gridAutoColumns;
     Style::GridTrackSizes m_gridAutoRows;
     Style::GridTemplateAreas m_gridTemplateAreas;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -127,7 +127,6 @@ public:
     static Resize convertResize(BuilderState&, const CSSValue&);
     static OptionSet<TextUnderlinePosition> convertTextUnderlinePosition(BuilderState&, const CSSValue&);
     static OptionSet<LineBoxContain> convertLineBoxContain(BuilderState&, const CSSValue&);
-    static GridAutoFlow convertGridAutoFlow(BuilderState&, const CSSValue&);
     static OptionSet<TouchAction> convertTouchAction(BuilderState&, const CSSValue&);
 
     static PaintOrder convertPaintOrder(BuilderState&, const CSSValue&);
@@ -395,48 +394,6 @@ inline OptionSet<LineBoxContain> BuilderConverter::convertLineBoxContain(Builder
         }
     }
     return result;
-}
-
-inline GridAutoFlow BuilderConverter::convertGridAutoFlow(BuilderState& builderState, const CSSValue& value)
-{
-    ASSERT(!is<CSSPrimitiveValue>(value) || downcast<CSSPrimitiveValue>(value).isValueID());
-
-    auto* list = dynamicDowncast<CSSValueList>(value);
-    if (list && !list->size())
-        return RenderStyle::initialGridAutoFlow();
-
-    auto* first = requiredDowncast<CSSPrimitiveValue>(builderState, list ? *(list->item(0)) : value);
-    if (!first)
-        return { };
-    auto* second = dynamicDowncast<CSSPrimitiveValue>(list && list->size() == 2 ? list->item(1) : nullptr);
-
-    GridAutoFlow autoFlow;
-    switch (first->valueID()) {
-    case CSSValueRow:
-        if (second && second->valueID() == CSSValueDense)
-            autoFlow = AutoFlowRowDense;
-        else
-            autoFlow = AutoFlowRow;
-        break;
-    case CSSValueColumn:
-        if (second && second->valueID() == CSSValueDense)
-            autoFlow = AutoFlowColumnDense;
-        else
-            autoFlow = AutoFlowColumn;
-        break;
-    case CSSValueDense:
-        if (second && second->valueID() == CSSValueColumn)
-            autoFlow = AutoFlowColumnDense;
-        else
-            autoFlow = AutoFlowRowDense;
-        break;
-    default:
-        ASSERT_NOT_REACHED();
-        autoFlow = RenderStyle::initialGridAutoFlow();
-        break;
-    }
-
-    return autoFlow;
 }
 
 inline float zoomWithTextZoomFactor(BuilderState& builderState)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -172,10 +172,6 @@ public:
     // MARK: Font conversions
 
     static Ref<CSSValue> convertFontFamily(ExtractorState&, const AtomString&);
-
-    // MARK: Grid conversions
-
-    static Ref<CSSValue> convertGridAutoFlow(ExtractorState&, GridAutoFlow);
 };
 
 // MARK: - Strong value conversions
@@ -934,24 +930,6 @@ inline Ref<CSSValue> ExtractorConverter::convertFontFamily(ExtractorState& state
     if (auto familyIdentifier = identifierForFamily(family))
         return CSSPrimitiveValue::create(familyIdentifier);
     return state.pool.createFontFamilyValue(family);
-}
-
-// MARK: - Grid conversions
-
-inline Ref<CSSValue> ExtractorConverter::convertGridAutoFlow(ExtractorState&, GridAutoFlow gridAutoFlow)
-{
-    ASSERT(gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowDirectionRow) || gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowDirectionColumn));
-
-    CSSValueListBuilder list;
-    if (gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowDirectionColumn))
-        list.append(CSSPrimitiveValue::create(CSSValueColumn));
-    else if (!(gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowAlgorithmDense)))
-        list.append(CSSPrimitiveValue::create(CSSValueRow));
-
-    if (gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowAlgorithmDense))
-        list.append(CSSPrimitiveValue::create(CSSValueDense));
-
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -85,7 +85,6 @@ public:
     static Ref<CSSValue> extractTranslate(ExtractorState&);
     static Ref<CSSValue> extractScale(ExtractorState&);
     static Ref<CSSValue> extractRotate(ExtractorState&);
-    static Ref<CSSValue> extractGridAutoFlow(ExtractorState&);
     static Ref<CSSValue> extractGridTemplateColumns(ExtractorState&);
     static Ref<CSSValue> extractGridTemplateRows(ExtractorState&);
     static Ref<CSSValue> extractAnimationDuration(ExtractorState&);
@@ -176,7 +175,6 @@ public:
     static void extractTranslateSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractScaleSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractRotateSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
-    static void extractGridAutoFlowSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractGridTemplateColumnsSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractGridTemplateRowsSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractAnimationDurationSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
@@ -1740,41 +1738,6 @@ inline Ref<CSSValue> ExtractorCustom::extractRotate(ExtractorState& state)
 inline void ExtractorCustom::extractRotateSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     extractSerialization<CSSPropertyRotate>(state, builder, context);
-}
-
-inline Ref<CSSValue> ExtractorCustom::extractGridAutoFlow(ExtractorState& state)
-{
-    CSSValueListBuilder list;
-    ASSERT(state.style.isGridAutoFlowDirectionRow() || state.style.isGridAutoFlowDirectionColumn());
-    if (state.style.isGridAutoFlowDirectionColumn())
-        list.append(CSSPrimitiveValue::create(CSSValueColumn));
-    else if (!state.style.isGridAutoFlowAlgorithmDense())
-        list.append(CSSPrimitiveValue::create(CSSValueRow));
-
-    if (state.style.isGridAutoFlowAlgorithmDense())
-        list.append(CSSPrimitiveValue::create(CSSValueDense));
-
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
-
-inline void ExtractorCustom::extractGridAutoFlowSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
-{
-    ASSERT(state.style.isGridAutoFlowDirectionRow() || state.style.isGridAutoFlowDirectionColumn());
-
-    bool listEmpty = true;
-    if (state.style.isGridAutoFlowDirectionColumn()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Column { });
-        listEmpty = false;
-    } else if (!state.style.isGridAutoFlowAlgorithmDense()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Row { });
-        listEmpty = false;
-    }
-
-    if (state.style.isGridAutoFlowAlgorithmDense()) {
-        if (!listEmpty)
-            builder.append(' ');
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Dense { });
-    }
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractGridTemplateColumns(ExtractorState& state)

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -108,9 +108,6 @@ public:
 
     static void serializeFontFamily(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const AtomString&);
 
-    // MARK: Grid serializations
-
-    static void serializeGridAutoFlow(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, GridAutoFlow);
 };
 
 // MARK: - Strong value serializations
@@ -861,29 +858,6 @@ inline void ExtractorSerializer::serializeFontFamily(ExtractorState&, StringBuil
         builder.append(nameLiteralForSerialization(familyIdentifier));
     else
         builder.append(WebCore::serializeFontFamily(family));
-}
-
-// MARK: - Grid serializations
-
-inline void ExtractorSerializer::serializeGridAutoFlow(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, GridAutoFlow gridAutoFlow)
-{
-    ASSERT(gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowDirectionRow) || gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowDirectionColumn));
-
-    bool needsSpace = false;
-
-    if (gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowDirectionColumn)) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Column { });
-        needsSpace = true;
-    } else if (!(gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowAlgorithmDense))) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Row { });
-        needsSpace = true;
-    }
-
-    if (gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowAlgorithmDense)) {
-        if (needsSpace)
-            builder.append(' ');
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Dense { });
-    }
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/grid/StyleGridAutoFlow.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridAutoFlow.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleGridAutoFlow.h"
+
+#include "StyleBuilderChecking.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto CSSValueConversion<GridAutoFlow>::operator()(BuilderState& state, const CSSValue& value) -> GridAutoFlow
+{
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueRow:
+            return CSS::Keyword::Row { };
+        case CSSValueColumn:
+            return CSS::Keyword::Column { };
+        case CSSValueDense:
+            return CSS::Keyword::Dense { };
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::Row { };
+        }
+    }
+
+    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue, 1>(state, value);
+    if (!list)
+        return CSS::Keyword::Row { };
+
+    Ref first = list->item(0);
+    switch (first->valueID()) {
+    case CSSValueRow:
+        if (list->size() == 2) {
+            Ref second = list->item(1);
+            switch (second->valueID()) {
+            case CSSValueDense:
+                return { CSS::Keyword::Row { }, CSS::Keyword::Dense { } };
+            default:
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Row { };
+            }
+        }
+        return CSS::Keyword::Row { };
+    case CSSValueColumn:
+        if (list->size() == 2) {
+            Ref second = list->item(1);
+            switch (second->valueID()) {
+            case CSSValueDense:
+                return { CSS::Keyword::Column { }, CSS::Keyword::Dense { } };
+            default:
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Column { };
+            }
+        }
+        return CSS::Keyword::Column { };
+    case CSSValueDense:
+        if (list->size() == 2) {
+            Ref second = list->item(1);
+            switch (second->valueID()) {
+            case CSSValueRow:
+                return { CSS::Keyword::Row { }, CSS::Keyword::Dense { } };
+            case CSSValueColumn:
+                return { CSS::Keyword::Column { }, CSS::Keyword::Dense { } };
+            default:
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Dense { };
+            }
+        }
+        return CSS::Keyword::Dense { };
+    default:
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return CSS::Keyword::Row { };
+    }
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/grid/StyleGridAutoFlow.h
+++ b/Source/WebCore/style/values/grid/StyleGridAutoFlow.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'grid-auto-flow'> = [ row | column ] || dense
+// https://drafts.csswg.org/css-grid-1/#grid-auto-flow-property
+struct GridAutoFlow {
+    enum class Direction : bool { Row, Column };
+    enum class Packing : bool { Dense, Sparse };
+
+    constexpr GridAutoFlow(CSS::Keyword::Row) { }
+    constexpr GridAutoFlow(CSS::Keyword::Row, CSS::Keyword::Dense): m_packing { static_cast<uint8_t>(Packing::Dense) } { }
+    constexpr GridAutoFlow(CSS::Keyword::Column) : m_direction { static_cast<uint8_t>(Direction::Column) } { }
+    constexpr GridAutoFlow(CSS::Keyword::Column, CSS::Keyword::Dense) : m_direction { static_cast<uint8_t>(Direction::Column) }, m_packing { static_cast<uint8_t>(Packing::Dense) } { }
+    constexpr GridAutoFlow(CSS::Keyword::Dense) : m_packing { static_cast<uint8_t>(Packing::Dense) } { }
+
+    constexpr Direction direction() const { return static_cast<Direction>(m_direction); }
+    constexpr Packing packing() const { return static_cast<Packing>(m_packing); }
+
+    constexpr bool isRow() const { return direction() == Direction::Row; }
+    constexpr bool isColumn() const { return direction() == Direction::Column; }
+    constexpr bool isDense() const { return packing() == Packing::Dense; }
+    constexpr bool isSparse() const { return packing() == Packing::Sparse; }
+
+    template<typename... F> decltype(auto) switchOn(F&&...) const;
+
+    constexpr bool operator==(const GridAutoFlow&) const = default;
+
+private:
+    PREFERRED_TYPE(Direction) uint8_t m_direction : 1 { static_cast<uint8_t>(Direction::Row) };
+    PREFERRED_TYPE(Packing) uint8_t m_packing : 1 { static_cast<uint8_t>(Packing::Sparse) };
+};
+
+template<typename... F> decltype(auto) GridAutoFlow::switchOn(F&&... f) const
+{
+    auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+    switch (direction()) {
+    case Direction::Column:
+        switch (packing()) {
+        case Packing::Dense:
+            return visitor(SpaceSeparatedTuple { CSS::Keyword::Column { }, CSS::Keyword::Dense { } });
+        case Packing::Sparse:
+            return visitor(CSS::Keyword::Column { });
+        }
+    case Direction::Row:
+        switch (packing()) {
+        case Packing::Dense:
+            return visitor(CSS::Keyword::Dense { });
+        case Packing::Sparse:
+            return visitor(CSS::Keyword::Row { });
+        }
+    }
+}
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<GridAutoFlow> { auto operator()(BuilderState&, const CSSValue&) -> GridAutoFlow; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::GridAutoFlow)


### PR DESCRIPTION
#### 9f9b91a30bd00b8fc960efdf65ca5ce66ca4847c
<pre>
[Style] Convert the &apos;grid-auto-flow&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=301109">https://bugs.webkit.org/show_bug.cgi?id=301109</a>

Reviewed by Darin Adler.

Converts the &apos;grid-auto-flow&apos; property to use strong style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleGridData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/grid/StyleGridAutoFlow.cpp: Added.
* Source/WebCore/style/values/grid/StyleGridAutoFlow.h: Added.

Canonical link: <a href="https://commits.webkit.org/301914@main">https://commits.webkit.org/301914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0207f1799528e095d6bfa80af1ef5c86ec3270e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127391 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134455 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78946 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96977 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77455 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32217 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77837 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136938 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41656 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105498 "19 flakes 53 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105155 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26821 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50673 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51629 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53987 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60074 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53221 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54980 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->