### PR TITLE
Use WKKeyedCoder instead of NSKeyedUnarchiver to send WebFilterEvaluator over IPC

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebCore/Configurations/AllowedSPI-legacy.toml
@@ -240,7 +240,6 @@ selectors = [
     { name = "_setUseEnhancedPrivacyMode:", class = "?" },
     { name = "_standardMarkerAttributesForAttributes:", class = "?" },
     { name = "_storagePartition", class = "?" },
-    { name = "_strictlyUnarchivedObjectOfClasses:fromData:error:", class = "?" },
     { name = "_useEnhancedPrivacyMode", class = "?" },
     { name = "_web_URLWithString:relativeToURL:", class = "?" },
     { name = "_web_createFileAtPath:contents:attributes:", class = "?" },

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -326,6 +326,8 @@
 		F4E0875C266ACA53000F814A /* DataDetectorsSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E0875A266ACA53000F814A /* DataDetectorsSoftLink.mm */; };
 		F4EC01B22A85432D00DA295D /* NetworkSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EC01B12A85432D00DA295D /* NetworkSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F4F0A5502B634D88001A54E5 /* BrowserEngineKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F4F0A54B2B634D88001A54E5 /* BrowserEngineKitSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FA1D016E2EA6C86000F1052E /* WebContentAnalysisSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA1D016D2EA6C86000F1052E /* WebContentAnalysisSoftLink.mm */; };
+		FA1D016F2EA6C86000F1052E /* WebContentAnalysisSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = FA1D016C2EA6C86000F1052E /* WebContentAnalysisSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE62AC3D2CFE2E0300740A18 /* PALTZoneImpls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE62AC3C2CFE2E0300740A18 /* PALTZoneImpls.cpp */; };
 /* End PBXBuildFile section */
 
@@ -777,6 +779,8 @@
 		F4E0875A266ACA53000F814A /* DataDetectorsSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DataDetectorsSoftLink.mm; sourceTree = "<group>"; };
 		F4EC01B12A85432D00DA295D /* NetworkSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NetworkSPI.h; path = pal/spi/cocoa/NetworkSPI.h; sourceTree = SOURCE_ROOT; };
 		F4F0A54B2B634D88001A54E5 /* BrowserEngineKitSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BrowserEngineKitSPI.h; sourceTree = "<group>"; };
+		FA1D016C2EA6C86000F1052E /* WebContentAnalysisSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebContentAnalysisSoftLink.h; sourceTree = "<group>"; };
+		FA1D016D2EA6C86000F1052E /* WebContentAnalysisSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebContentAnalysisSoftLink.mm; sourceTree = "<group>"; };
 		FE62AC3C2CFE2E0300740A18 /* PALTZoneImpls.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PALTZoneImpls.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1157,6 +1161,8 @@
 				F46B8C4C26740918007A6554 /* VisionKitCoreSoftLink.mm */,
 				E57B44B329AB45F4006069DE /* VisionSoftLink.h */,
 				E57B44B429AB45F4006069DE /* VisionSoftLink.mm */,
+				FA1D016C2EA6C86000F1052E /* WebContentAnalysisSoftLink.h */,
+				FA1D016D2EA6C86000F1052E /* WebContentAnalysisSoftLink.mm */,
 				3AA35C4A2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.h */,
 				3AA35C4B2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.mm */,
 				F499BAAA2947FDBA001241D6 /* WebPrivacySoftLink.h */,
@@ -1604,6 +1610,7 @@
 				E57B44B529AB45F4006069DE /* VisionSoftLink.h in Headers */,
 				A1038D332AB12BF100F57BA4 /* WebAVContentKeyGrouping.h in Headers */,
 				A1038D4F2AB21FBB00F57BA4 /* WebAVContentKeyReportGroupExtras.h in Headers */,
+				FA1D016F2EA6C86000F1052E /* WebContentAnalysisSoftLink.h in Headers */,
 				3AA35C4C2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.h in Headers */,
 				3AA35C462D6E7F430078EA17 /* WebContentRestrictionsSPI.h in Headers */,
 				DD20DE0E27BC90D80093D175 /* WebFilterEvaluatorSPI.h in Headers */,
@@ -1837,6 +1844,7 @@
 				41E1F344248A6A000022D5DE /* VideoToolboxSoftLink.cpp in Sources */,
 				F46B8C4D26740918007A6554 /* VisionKitCoreSoftLink.mm in Sources */,
 				E57B44B729AB462E006069DE /* VisionSoftLink.mm in Sources */,
+				FA1D016E2EA6C86000F1052E /* WebContentAnalysisSoftLink.mm in Sources */,
 				3AA35C4D2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.mm in Sources */,
 				A10826FA1F576292004772AC /* WebPanel.mm in Sources */,
 				F499BAAD2947FDBA001241D6 /* WebPrivacySoftLink.mm in Sources */,

--- a/Source/WebCore/PAL/pal/cocoa/WebContentAnalysisSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/WebContentAnalysisSoftLink.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,42 +25,12 @@
 
 #pragma once
 
-DECLARE_SYSTEM_HEADER
+#if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
 
-#if USE(APPLE_INTERNAL_SDK)
+#import <pal/spi/cocoa/WebFilterEvaluatorSPI.h>
+#import <wtf/SoftLinking.h>
 
-#if HAVE(WEBCONTENTANALYSIS_FRAMEWORK)
-#import <WebContentAnalysis/WebFilterEvaluator.h>
-#endif
-
-#else
-
-#import <Foundation/Foundation.h>
-#import <TargetConditionals.h>
-
-enum {
-    kWFEStateAllowed = 0,
-    kWFEStateBlocked = 1,
-    kWFEStateBuffering = 2,
-    kWFEStateEvaluating = 3
-};
-
-@interface WebFilterEvaluator : NSObject
-@end
-
-@interface WebFilterEvaluator ()
-+ (BOOL)isManagedSession;
-- (BOOL)wasBlocked;
-- (NSData *)addData:(NSData *)receivedData;
-- (NSData *)dataComplete;
-- (OSStatus)filterState;
-- (id)initWithResponse:(NSURLResponse *)response;
-#if TARGET_OS_IPHONE
-- (void)unblockWithCompletion:(void (^)(BOOL unblocked, NSError *error))completion;
-#endif
-#if HAVE(WEBFILTEREVALUATOR_AUDIT_TOKEN)
-@property (nonatomic, assign) audit_token_t browserAuditToken;
-#endif
-@end
+SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, WebContentAnalysis);
+SOFT_LINK_CLASS_FOR_HEADER(PAL, WebFilterEvaluator);
 
 #endif

--- a/Source/WebCore/PAL/pal/cocoa/WebContentAnalysisSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/WebContentAnalysisSoftLink.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,44 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import "config.h"
 
-DECLARE_SYSTEM_HEADER
+#if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
 
-#if USE(APPLE_INTERNAL_SDK)
+#import <pal/spi/cocoa/WebFilterEvaluatorSPI.h>
+#import <wtf/SoftLinking.h>
 
-#if HAVE(WEBCONTENTANALYSIS_FRAMEWORK)
-#import <WebContentAnalysis/WebFilterEvaluator.h>
-#endif
+SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, WebContentAnalysis, PAL_EXPORT)
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL_WITH_EXPORT(PAL, WebContentAnalysis, WebFilterEvaluator, PAL_EXPORT)
 
-#else
-
-#import <Foundation/Foundation.h>
-#import <TargetConditionals.h>
-
-enum {
-    kWFEStateAllowed = 0,
-    kWFEStateBlocked = 1,
-    kWFEStateBuffering = 2,
-    kWFEStateEvaluating = 3
-};
-
-@interface WebFilterEvaluator : NSObject
-@end
-
-@interface WebFilterEvaluator ()
-+ (BOOL)isManagedSession;
-- (BOOL)wasBlocked;
-- (NSData *)addData:(NSData *)receivedData;
-- (NSData *)dataComplete;
-- (OSStatus)filterState;
-- (id)initWithResponse:(NSURLResponse *)response;
-#if TARGET_OS_IPHONE
-- (void)unblockWithCompletion:(void (^)(BOOL unblocked, NSError *error))completion;
-#endif
-#if HAVE(WEBFILTEREVALUATOR_AUDIT_TOKEN)
-@property (nonatomic, assign) audit_token_t browserAuditToken;
-#endif
-@end
-
-#endif
+#endif // ENABLE(ADVANCED_PRIVACY_PROTECTIONS)

--- a/Source/WebCore/platform/ContentFilterUnblockHandler.h
+++ b/Source/WebCore/platform/ContentFilterUnblockHandler.h
@@ -68,7 +68,7 @@ public:
         std::optional<URL>&& evaluatedURL,
 #endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
-        Vector<uint8_t>&& webFilterEvaluatorData,
+        RetainPtr<WebFilterEvaluator>&&,
 #endif
         bool unblockedAfterRequest
     );
@@ -93,18 +93,13 @@ public:
     void setConfigurationPath(const String& path) { m_configurationPath = path; }
 #endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
-    WEBCORE_EXPORT Vector<uint8_t> webFilterEvaluatorData() const;
+    RetainPtr<WebFilterEvaluator> webFilterEvaluator() const { return m_webFilterEvaluator; }
 #endif
 
     WEBCORE_EXPORT void setUnblockedAfterRequest(bool);
     bool unblockedAfterRequest() const { return m_unblockedAfterRequest; }
 
 private:
-#if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
-    bool hasWebFilterEvaluator() const;
-    RetainPtr<WebFilterEvaluator> webFilterEvaluator();
-#endif
-
     String m_unblockURLHost;
     URL m_unreachableURL;
     UnblockRequesterFunction m_unblockRequester;
@@ -115,7 +110,6 @@ private:
     String m_configurationPath;
 #endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
-    Vector<uint8_t> m_webFilterEvaluatorData;
     RetainPtr<WebFilterEvaluator> m_webFilterEvaluator;
 #endif
     bool m_unblockedAfterRequest { false };

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -65,6 +65,10 @@ OBJC_CLASS PKPaymentToken;
 OBJC_CLASS PKShippingMethod;
 #endif
 
+#if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
+OBJC_CLASS WebFilterEvaluator;
+#endif
+
 OBJC_CLASS PlatformColor;
 OBJC_CLASS NSShadow;
 
@@ -158,6 +162,9 @@ template<> Class getClass<PKShippingMethod>();
 template<> Class getClass<PKDateComponentsRange>();
 template<> Class getClass<PKPaymentMethod>();
 template<> Class getClass<PKSecureElementPass>();
+#endif
+#if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
+template<> Class getClass<WebFilterEvaluator>();
 #endif
 
 template<> Class getClass<PlatformColor>();

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -74,6 +74,9 @@
 #if USE(PASSKIT)
 #import <pal/cocoa/ContactsSoftLink.h>
 #endif
+#if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
+#import <pal/cocoa/WebContentAnalysisSoftLink.h>
+#endif
 
 #if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
 
@@ -332,6 +335,13 @@ template<> Class getClass<PKPaymentMethod>()
 template<> Class getClass<PKSecureElementPass>()
 {
     return PAL::getPKSecureElementPassClassSingleton();
+}
+#endif
+
+#if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
+template<> Class getClass<WebFilterEvaluator>()
+{
+    return PAL::getWebFilterEvaluatorClassSingleton();
 }
 #endif
 

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -22,6 +22,17 @@
 
 headers: "ArgumentCodersCocoa.h"
 
+# FIXME: Make WebFilterEvaluator no longer use WKKeyedCoder once rdar://163060208 is complete.
+#if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
+secure_coding_header: <pal/cocoa/WebContentAnalysisSoftLink.h>
+[WebKitSecureCodingClass=PAL::getWebFilterEvaluatorClassSingleton()] webkit_secure_coding WebFilterEvaluator {
+    WebContentFilterStateKey: Number
+    WebContentFilterURLKey: URL
+    WebContentFilterPageTitleKey: String
+}
+WebFilterEvaluator wrapped by CoreIPCWebFilterEvaluator
+#endif
+
 #if ENABLE(CONTENT_FILTERING)
 class WebCore::ContentFilterUnblockHandler {
     String unblockURLHost()
@@ -30,7 +41,7 @@ class WebCore::ContentFilterUnblockHandler {
     std::optional<URL> evaluatedURL();
 #endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
-    Vector<uint8_t> webFilterEvaluatorData()
+    RetainPtr<WebFilterEvaluator> webFilterEvaluator()
 #endif
     bool unblockedAfterRequest()
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -293,21 +293,22 @@ void WebPageProxy::beginSafeBrowsingCheck(const URL& url, API::Navigation& navig
 #if ENABLE(CONTENT_FILTERING)
 void WebPageProxy::contentFilterDidBlockLoadForFrame(IPC::Connection& connection, const WebCore::ContentFilterUnblockHandler& unblockHandler, FrameIdentifier frameID)
 {
+    contentFilterDidBlockLoadForFrameShared(connection, unblockHandler, frameID);
+}
+
+void WebPageProxy::contentFilterDidBlockLoadForFrameShared(IPC::Connection& connection, const WebCore::ContentFilterUnblockHandler& unblockHandler, FrameIdentifier frameID)
+{
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
     bool usesWebContentRestrictions = false;
 #if HAVE(WEBCONTENTRESTRICTIONS)
     usesWebContentRestrictions = protectedPreferences()->usesWebContentRestrictionsForFilter();
 #endif
     if (usesWebContentRestrictions)
-        MESSAGE_CHECK(unblockHandler.webFilterEvaluatorData().isEmpty(), connection);
+        MESSAGE_CHECK(!unblockHandler.webFilterEvaluator(), connection);
+#else
+    UNUSED_PARAM(connection);
 #endif
 
-    RefPtr process = dynamicDowncast<WebProcessProxy>(AuxiliaryProcessProxy::fromConnection(connection));
-    contentFilterDidBlockLoadForFrameShared(*process, unblockHandler, frameID);
-}
-
-void WebPageProxy::contentFilterDidBlockLoadForFrameShared(Ref<WebProcessProxy>&& process, const WebCore::ContentFilterUnblockHandler& unblockHandler, FrameIdentifier frameID)
-{
     if (RefPtr frame = WebFrameProxy::webFrame(frameID))
         frame->contentFilterDidBlockLoad(unblockHandler);
 }

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -638,22 +638,13 @@ void ProvisionalPageProxy::bindAccessibilityTree(const String& plugID)
 #endif
 
 #if ENABLE(CONTENT_FILTERING)
-void ProvisionalPageProxy::contentFilterDidBlockLoadForFrame(const WebCore::ContentFilterUnblockHandler& unblockHandler, FrameIdentifier frameID)
+void ProvisionalPageProxy::contentFilterDidBlockLoadForFrame(IPC::Connection& connection, const WebCore::ContentFilterUnblockHandler& unblockHandler, FrameIdentifier frameID)
 {
     RefPtr page = m_page.get();
     if (!page)
         return;
 
-#if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
-    bool usesWebContentRestrictions = false;
-#if HAVE(WEBCONTENTRESTRICTIONS)
-    usesWebContentRestrictions = page->protectedPreferences()->usesWebContentRestrictionsForFilter();
-#endif
-    if (usesWebContentRestrictions)
-        MESSAGE_CHECK(unblockHandler.webFilterEvaluatorData().isEmpty());
-#endif
-
-    page->contentFilterDidBlockLoadForFrameShared(protectedProcess(), unblockHandler, frameID);
+    page->contentFilterDidBlockLoadForFrameShared(connection, unblockHandler, frameID);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -198,7 +198,7 @@ private:
     void bindAccessibilityTree(const String&);
 #endif
 #if ENABLE(CONTENT_FILTERING)
-    void contentFilterDidBlockLoadForFrame(const WebCore::ContentFilterUnblockHandler&, WebCore::FrameIdentifier);
+    void contentFilterDidBlockLoadForFrame(IPC::Connection&, const WebCore::ContentFilterUnblockHandler&, WebCore::FrameIdentifier);
 #endif
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     void didCreateContextInWebProcessForVisibilityPropagation(LayerHostingContextID);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2246,7 +2246,7 @@ public:
     void requestPasswordForQuickLookDocumentInMainFrameShared(const String& fileName, CompletionHandler<void(const String&)>&&);
 #endif
 #if ENABLE(CONTENT_FILTERING)
-    void contentFilterDidBlockLoadForFrameShared(Ref<WebProcessProxy>&&, const WebCore::ContentFilterUnblockHandler&, WebCore::FrameIdentifier);
+    void contentFilterDidBlockLoadForFrameShared(IPC::Connection&, const WebCore::ContentFilterUnblockHandler&, WebCore::FrameIdentifier);
 #endif
 
 #if ENABLE(SPEECH_SYNTHESIS)


### PR DESCRIPTION
#### 3874e70be385d408a128fd020d40efdb46f40723
<pre>
Use WKKeyedCoder instead of NSKeyedUnarchiver to send WebFilterEvaluator over IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=301126">https://bugs.webkit.org/show_bug.cgi?id=301126</a>
<a href="https://rdar.apple.com/162603751">rdar://162603751</a>

Reviewed by Per Arne Vollan.

Using WKKeyedCoder can expose more metadata to the IPC fuzzer.  A WebFilterEvaluator is just
a number, a URL, and a String.  The FIXME comment to replace it was written before we had WKKeyedCoder.

* Source/WebCore/Configurations/AllowedSPI-legacy.toml:
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/cocoa/WebContentAnalysisSoftLink.h: Copied from Source/WebCore/PAL/pal/cocoa/WebPrivacySoftLink.mm.
* Source/WebCore/PAL/pal/cocoa/WebContentAnalysisSoftLink.mm: Copied from Source/WebCore/PAL/pal/cocoa/WebPrivacySoftLink.mm.
* Source/WebCore/PAL/pal/spi/cocoa/WebFilterEvaluatorSPI.h:
* Source/WebCore/platform/ContentFilterUnblockHandler.h:
(WebCore::ContentFilterUnblockHandler::webFilterEvaluator const):
* Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm:
(WebCore::ContentFilterUnblockHandler::ContentFilterUnblockHandler):
(WebCore::ContentFilterUnblockHandler::wrapWithDecisionHandler):
(WebCore::ContentFilterUnblockHandler::needsUIProcess const):
(WebCore::ContentFilterUnblockHandler::canHandleRequest const):
(WebCore::ContentFilterUnblockHandler::webFilterEvaluatorData const): Deleted.
(WebCore::unpackWebFilterEvaluatorData): Deleted.
(WebCore::ContentFilterUnblockHandler::hasWebFilterEvaluator const): Deleted.
(WebCore::ContentFilterUnblockHandler::webFilterEvaluator): Deleted.
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::getClass&lt;WebFilterEvaluator&gt;):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::contentFilterDidBlockLoadForFrame):
(WebKit::WebPageProxy::contentFilterDidBlockLoadForFrameShared):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::contentFilterDidBlockLoadForFrame):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/301882@main">https://commits.webkit.org/301882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc7e335a461f0a064319549b1b89fbad02bf86f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78920 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6726e0be-4abd-4a54-85ac-c7a092fdff74) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55536 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/96935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/93041bfa-bf77-4b47-9ec0-85bad53e9c14) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77429 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4a1b4ccb-02bd-4a2f-bd1d-72011884bc36) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77811 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136912 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41633 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105453 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105130 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50652 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51603 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19917 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53961 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60048 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53194 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54954 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->