### PR TITLE
[Mac] Add a pop-up menu for selecting caption style profiles

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -991,6 +991,9 @@
 /* Media Element Source Type */
 "ManagedMediaSource (Media Element Source Type)" = "Managed Media Source";
 
+/* Subtitle Styles Submenu Link to System Preferences */
+"Manage Styles (Caption Style Menu Title)" = "Manage Styles";
+
 /* WKWebExtensionErrorInvalidBackgroundContent description for empty or invalid preferred environment key */
 "Manifest `background` entry has an empty or invalid `preferred_environment` key." = "Manifest `background` entry has an empty or invalid `preferred_environment` key.";
 

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -1008,7 +1008,51 @@ Vector<RefPtr<TextTrack>> CaptionUserPreferencesMediaAF::sortedTrackListForMenu(
 
     return tracksForMenu;
 }
-    
+
+Vector<String> CaptionUserPreferencesMediaAF::platformProfileIDs()
+{
+    if (!canLoad_MediaAccessibility_MACaptionAppearanceCopyProfileIDs())
+        return { };
+    RetainPtr<CFArrayRef> cfProfileIDs = adoptCF(MACaptionAppearanceCopyProfileIDs());
+    return makeVector<String>(cfProfileIDs.get());
+}
+
+String CaptionUserPreferencesMediaAF::platformActiveProfileID()
+{
+    if (!canLoad_MediaAccessibility_MACaptionAppearanceCopyActiveProfileID())
+        return nullString();
+    RetainPtr cfProfileID = adoptCF(MACaptionAppearanceCopyActiveProfileID());
+    return cfProfileID.get();
+}
+
+bool CaptionUserPreferencesMediaAF::canSetActiveProfileID()
+{
+    return canLoad_MediaAccessibility_MACaptionAppearanceSetActiveProfileID();
+}
+
+bool CaptionUserPreferencesMediaAF::setActiveProfileID(const String& profileID)
+{
+    if (!canSetActiveProfileID())
+        return false;
+
+    if (profileID == platformActiveProfileID())
+        return true;
+
+    RetainPtr cfProfileID = profileID.createCFString();
+    MACaptionAppearanceSetActiveProfileID(cfProfileID.get());
+    return true;
+}
+
+String CaptionUserPreferencesMediaAF::nameForProfileID(const String& profileID)
+{
+    if (!canLoad_MediaAccessibility_MACaptionAppearanceCopyProfileName())
+        return nullString();
+
+    RetainPtr cfProfileID = profileID.createCFString();
+    RetainPtr cfProfileName = adoptCF(MACaptionAppearanceCopyProfileName(cfProfileID.get()));
+    return cfProfileName.get();
+}
+
 }
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
@@ -54,6 +54,12 @@ public:
     WEBCORE_EXPORT static void platformSetCaptionDisplayMode(CaptionDisplayMode);
     WEBCORE_EXPORT static void setCachedCaptionDisplayMode(CaptionDisplayMode);
 
+    WEBCORE_EXPORT static Vector<String> platformProfileIDs();
+    WEBCORE_EXPORT static String platformActiveProfileID();
+    WEBCORE_EXPORT static bool canSetActiveProfileID();
+    WEBCORE_EXPORT static bool setActiveProfileID(const String&);
+    WEBCORE_EXPORT static String nameForProfileID(const String&);
+
     bool userPrefersCaptions() const override;
     bool userPrefersSubtitles() const override;
     bool userPrefersTextDescriptions() const final;

--- a/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp
+++ b/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp
@@ -56,4 +56,9 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, 
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MAAudibleMediaPrefCopyPreferDescriptiveVideo, CFBooleanRef, (), (), WEBCORE_EXPORT)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceIsCustomized, bool, (MACaptionAppearanceDomain domain), (domain), WEBCORE_EXPORT);
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceCopyActiveProfileID, CFStringRef, (), (), WEBCORE_EXPORT);
+
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceCopyProfileIDs, CFArrayRef, (), (), WEBCORE_EXPORT)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceSetActiveProfileID, void, (CFStringRef profileID), (profileID), WEBCORE_EXPORT)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceCopyProfileName, CFStringRef, (CFStringRef profileID), (profileID), WEBCORE_EXPORT)
+
 #endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)

--- a/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h
+++ b/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h
@@ -81,6 +81,15 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionApp
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionAppearanceCopyActiveProfileID, CFStringRef, (), ())
 #define MACaptionAppearanceCopyActiveProfileID softLink_MediaAccessibility_MACaptionAppearanceCopyActiveProfileID
 
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionAppearanceCopyProfileIDs, CFArrayRef, (), ())
+#define MACaptionAppearanceCopyProfileIDs softLink_MediaAccessibility_MACaptionAppearanceCopyProfileIDs
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionAppearanceSetActiveProfileID, void, (CFStringRef profileID), (profileID))
+#define MACaptionAppearanceSetActiveProfileID softLink_MediaAccessibility_MACaptionAppearanceSetActiveProfileID
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionAppearanceCopyActiveProfileID, CFStringRef, (), ())
+#define MACaptionAppearanceCopyActiveProfileID softLink_MediaAccessibility_MACaptionAppearanceCopyActiveProfileID
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionAppearanceCopyProfileName, CFStringRef, (CFStringRef profileID), (profileID))
+#define MACaptionAppearanceCopyProfileName softLink_MediaAccessibility_MACaptionAppearanceCopyProfileName
+
 #endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 
 #endif // MediaAccessibilitySoftLink_h

--- a/Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h
+++ b/Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h
@@ -44,6 +44,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKActivatedElementInfo.h>
 #import <WebKit/_WKAttachment.h>
+#import <WebKit/_WKCaptionStyleMenuController.h>
 #import <WebKit/_WKContentWorldConfiguration.h>
 #import <WebKit/_WKElementAction.h>
 #import <WebKit/_WKFocusedElementInfo.h>

--- a/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h
+++ b/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h
@@ -25,40 +25,25 @@
 
 #pragma once
 
-namespace TestWebKitAPI {
+#import <WebKit/WKFoundation.h>
 
-template<typename R, typename... Args>
-class SoftLinkShim {
-public:
-    using Pointer = R(*)(Args...);
-    using CanLoadPtr = bool(*)();
+#if TARGET_OS_OSX
 
-    SoftLinkShim(Pointer* originalFunctor, Pointer replacementFunctor)
-        : m_originalFunctor { originalFunctor }
-        , m_originalFunctorValue { *originalFunctor }
-    {
-        *m_originalFunctor = replacementFunctor;
-    }
+@class NSMenu;
 
-    SoftLinkShim(Pointer* originalFunctor, Pointer replacementFunctor, CanLoadPtr canLoadPtr)
-        : m_originalFunctor { originalFunctor }
-    {
-        if (canLoadPtr)
-            canLoadPtr();
-        m_originalFunctorValue = *originalFunctor;
-        *m_originalFunctor = replacementFunctor;
-    }
+NS_ASSUME_NONNULL_BEGIN
 
-    ~SoftLinkShim()
-    {
-        *m_originalFunctor = m_originalFunctorValue;
-    }
+@protocol WKCaptionStyleMenuControllerDelegate <NSObject>
+- (void)captionStyleMenuWillOpen:(NSMenu *)menu;
+- (void)captionStyleMenuDidClose:(NSMenu *)menu;
+@end
 
-private:
-    Pointer* m_originalFunctor;
-    Pointer m_originalFunctorValue;
-};
+WK_EXTERN
+@interface WKCaptionStyleMenuController : NSObject
+@property (weak, nonatomic) id<WKCaptionStyleMenuControllerDelegate> delegate;
+@property (readonly, nonatomic) NSMenu *captionStyleMenu;
+@end
 
+NS_ASSUME_NONNULL_END
 
-
-}
+#endif

--- a/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "_WKCaptionStyleMenuController.h"
+
+#if PLATFORM(MAC)
+
+#import <WebCore/CaptionUserPreferencesMediaAF.h>
+#import <WebCore/LocalizedStrings.h>
+#import <wtf/Vector.h>
+#import <wtf/text/WTFString.h>
+
+using namespace WebCore;
+using namespace WTF;
+
+@interface WKCaptionStyleMenuController () <NSMenuDelegate> {
+    Vector<String> _profileIDs;
+    String _savedActiveProfileID;
+    RetainPtr<NSMenu> _menu;
+}
+@end
+
+@implementation WKCaptionStyleMenuController
+
+- (instancetype)init
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _menu = adoptNS([[NSMenu alloc] initWithTitle:@""]);
+    [_menu setDelegate:self];
+    _savedActiveProfileID = CaptionUserPreferencesMediaAF::platformActiveProfileID();
+
+    [self rebuildMenu];
+
+    return self;
+}
+
+- (void)rebuildMenu
+{
+    [_menu removeAllItems];
+    auto profileIDs = CaptionUserPreferencesMediaAF::platformProfileIDs();
+
+    // Add Caption Profile items
+    for (const auto& profileID : profileIDs) {
+        auto title = CaptionUserPreferencesMediaAF::nameForProfileID(profileID);
+        RetainPtr item = adoptNS([[NSMenuItem alloc] initWithTitle:title.createNSString().get() action:@selector(profileMenuItemSelected:) keyEquivalent:@""]);
+        [item setTarget:self];
+        [item setRepresentedObject:profileID.createNSString().get()];
+
+        // Add checkmark for currently selected item
+        if (profileID == _savedActiveProfileID)
+            [item setState:NSControlStateValueOn];
+
+        [_menu addItem:item.get()];
+    }
+
+    if (!profileIDs.isEmpty())
+        [_menu addItem:[NSMenuItem separatorItem]];
+
+    // Add Deep-link to System Caption Settings
+    RetainPtr<NSString> systemCaptionSettingsTitle = WEB_UI_NSSTRING_KEY(@"Manage Styles", @"Manage Styles (Caption Style Menu Title)", @"Subtitle Styles Submenu Link to System Preferences");
+    RetainPtr systemCaptionSettingsItem = adoptNS([[NSMenuItem alloc] initWithTitle:systemCaptionSettingsTitle.get() action:@selector(systemCaptionStyleSettingsItemSelected:) keyEquivalent:@""]);
+    [systemCaptionSettingsItem setTarget:self];
+    [systemCaptionSettingsItem setImage:[NSImage imageWithSystemSymbolName:@"gear" accessibilityDescription:nil]];
+    [_menu addItem:systemCaptionSettingsItem.get()];
+}
+
+#pragma mark - Properties
+
+- (NSMenu *)captionStyleMenu
+{
+    return _menu.get();
+}
+
+#pragma mark - Actions
+
+- (void)profileMenuItemSelected:(NSMenuItem *)item
+{
+    if (!item)
+        return;
+
+    NSString *nsProfileID = (NSString *)item.representedObject;
+    if (![nsProfileID isKindOfClass:NSString.class])
+        return;
+
+    _savedActiveProfileID = nsProfileID;
+    CaptionUserPreferencesMediaAF::setActiveProfileID(_savedActiveProfileID);
+    [self rebuildMenu];
+}
+
+- (void)profileMenuItemHighlighted:(NSMenuItem *)item
+{
+    NSString *nsProfileID = (NSString *)item.representedObject;
+    if ([nsProfileID isKindOfClass:NSString.class]) {
+        CaptionUserPreferencesMediaAF::setActiveProfileID(nsProfileID);
+        return;
+    }
+
+    if (!_savedActiveProfileID.isEmpty())
+        CaptionUserPreferencesMediaAF::setActiveProfileID(_savedActiveProfileID);
+}
+
+- (void)systemCaptionStyleSettingsItemSelected:(NSMenuItem *)sender
+{
+    [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:@"x-apple.systempreferences:com.apple.Accessibility?Captions"]];
+}
+
+#pragma mark - NSMenuDelegate
+
+- (void)menuWillOpen:(NSMenu *)menu
+{
+    _savedActiveProfileID = CaptionUserPreferencesMediaAF::platformActiveProfileID();
+
+    if (auto delegate = self.delegate)
+        [delegate captionStyleMenuWillOpen:_menu.get()];
+}
+
+- (void)menu:(NSMenu *)menu willHighlightItem:(NSMenuItem *)item
+{
+    [self profileMenuItemHighlighted:item];
+}
+
+- (void)menuDidClose:(NSMenu *)menu
+{
+    if (!_savedActiveProfileID.isEmpty())
+        CaptionUserPreferencesMediaAF::setActiveProfileID(_savedActiveProfileID);
+    _savedActiveProfileID = nullString();
+
+    if (auto delegate = self.delegate)
+        [delegate captionStyleMenuDidClose:_menu.get()];
+}
+
+@end
+
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2223,6 +2223,8 @@
 		CD78E1151DB7D7ED0014A2DE /* FullscreenClient.h in Headers */ = {isa = PBXBuildFile; fileRef = CD78E1131DB7D7ED0014A2DE /* FullscreenClient.h */; };
 		CD78E1171DB7DC0A0014A2DE /* APIFullscreenClient.h in Headers */ = {isa = PBXBuildFile; fileRef = CD78E1161DB7DC0A0014A2DE /* APIFullscreenClient.h */; };
 		CD78E1191DB7E5AD0014A2DE /* _WKFullscreenDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CD78E1181DB7E5AD0014A2DE /* _WKFullscreenDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CD89ACBC2EA696A300C76423 /* _WKCaptionStyleMenuControllerMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD89ACBB2EA696A300C76423 /* _WKCaptionStyleMenuControllerMac.mm */; };
+		CD89ACBD2EA696A300C76423 /* _WKCaptionStyleMenuController.h in Headers */ = {isa = PBXBuildFile; fileRef = CD89ACBA2EA696A300C76423 /* _WKCaptionStyleMenuController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CDA041F41ACE2105004A13EC /* BackBoardServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = CDA041F31ACE2105004A13EC /* BackBoardServicesSPI.h */; };
 		CDA29A1B1CBDBF4100901CCF /* PlaybackSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CDA29A191CBDBF4100901CCF /* PlaybackSessionManager.h */; };
 		CDA29A201CBEB5FB00901CCF /* PlaybackSessionManagerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = CDA29A1E1CBEB5FB00901CCF /* PlaybackSessionManagerProxy.h */; };
@@ -8117,6 +8119,8 @@
 		CD8252DA25D4915400862FD8 /* RemoteRemoteCommandListenerProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteRemoteCommandListenerProxyMessageReceiver.cpp; sourceTree = "<group>"; };
 		CD8252E025D4918400862FD8 /* RemoteRemoteCommandListenerMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteRemoteCommandListenerMessageReceiver.cpp; sourceTree = "<group>"; };
 		CD8252E125D4918500862FD8 /* RemoteRemoteCommandListenerMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteRemoteCommandListenerMessages.h; sourceTree = "<group>"; };
+		CD89ACBA2EA696A300C76423 /* _WKCaptionStyleMenuController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKCaptionStyleMenuController.h; sourceTree = "<group>"; };
+		CD89ACBB2EA696A300C76423 /* _WKCaptionStyleMenuControllerMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKCaptionStyleMenuControllerMac.mm; sourceTree = "<group>"; };
 		CD95493526159004008372D9 /* libWebKitSwift.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libWebKitSwift.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD9A649F27C8972C003827C0 /* UIProcessLogInitialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIProcessLogInitialization.h; sourceTree = "<group>"; };
 		CD9A64A027C8972C003827C0 /* UIProcessLogInitialization.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UIProcessLogInitialization.cpp; sourceTree = "<group>"; };
@@ -10355,6 +10359,7 @@
 				CDF1B90C266F395E0007EC10 /* GroupActivities */,
 				57FD316B22B3367E008D0E8B /* SOAuthorization */,
 				0753694A2DC589F4006446F8 /* TextExtraction */,
+				CD89ACBA2EA696A300C76423 /* _WKCaptionStyleMenuController.h */,
 				5CA26D80217ABBB600F97A35 /* _WKWarningView.h */,
 				5CA26D7F217ABBB600F97A35 /* _WKWarningView.mm */,
 				EB517B7A2D7BC03B0019E451 /* AboutSchemeHandlerCocoa.mm */,
@@ -16084,6 +16089,7 @@
 		BCCF085C113F3B7500C650C5 /* mac */ = {
 			isa = PBXGroup;
 			children = (
+				CD89ACBB2EA696A300C76423 /* _WKCaptionStyleMenuControllerMac.mm */,
 				B878B613133428DC006888E9 /* CorrectionPanel.h */,
 				B878B614133428DC006888E9 /* CorrectionPanel.mm */,
 				07EF07592745A8160066EA04 /* DisplayCaptureSessionManager.h */,
@@ -17231,6 +17237,7 @@
 				99788ACB1F421DDA00C08000 /* _WKAutomationSessionConfiguration.h in Headers */,
 				990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */,
 				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
+				CD89ACBD2EA696A300C76423 /* _WKCaptionStyleMenuController.h in Headers */,
 				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
 				5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */,
 				9B4CE9512CD99B7C00351173 /* _WKContentWorldConfiguration.h in Headers */,
@@ -21214,6 +21221,7 @@
 				5790A6852567A21E0077C5A7 /* _WKAuthenticatorAttestationResponse.mm in Sources */,
 				5790A6812567A1AC0077C5A7 /* _WKAuthenticatorResponse.mm in Sources */,
 				5790A66725679CEA0077C5A7 /* _WKAuthenticatorSelectionCriteria.mm in Sources */,
+				CD89ACBC2EA696A300C76423 /* _WKCaptionStyleMenuControllerMac.mm in Sources */,
 				5CBD595C2280EDF4002B22AA /* _WKCustomHeaderFields.mm in Sources */,
 				511FD1132C51AF4300BD8163 /* _WKMockUserNotificationCenter.mm in Sources */,
 				5790A67525679F740077C5A7 /* _WKPublicKeyCredentialCreationOptions.mm in Sources */,


### PR DESCRIPTION
#### 6711229d438fbd977d5b1b9b572096382597e08f
<pre>
[Mac] Add a pop-up menu for selecting caption style profiles
<a href="https://rdar.apple.com/163067314">rdar://163067314</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301134">https://bugs.webkit.org/show_bug.cgi?id=301134</a>

Reviewed by Eric Carlson.

Add a default implementation of a pop-up menu that allows the user to choose
between their current caption style profiles. The menu will source profile
names through MediaAccessibility soft-linked methods, allowing the entire
backing for this menu to be stubbed and tested by TestWebKit API.

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm

* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::platformProfileIDs):
(WebCore::CaptionUserPreferencesMediaAF::platformActiveProfileID):
(WebCore::CaptionUserPreferencesMediaAF::canSetActiveProfileID):
(WebCore::CaptionUserPreferencesMediaAF::setActiveProfileID):
(WebCore::CaptionUserPreferencesMediaAF::nameForProfileID):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.h:
* Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp:
* Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h:
* Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h:
* Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuController.h: Copied from Tools/TestWebKitAPI/SoftLinkShim.h.
* Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuController.mm: Added.
(-[WKCaptionStyleMenuController init]):
(-[WKCaptionStyleMenuController rebuildMenu]):
(-[WKCaptionStyleMenuController captionStyleMenu]):
(-[WKCaptionStyleMenuController profileMenuItemSelected:]):
(-[WKCaptionStyleMenuController profileMenuItemHighlighted:]):
(-[WKCaptionStyleMenuController systemCaptionStyleSettingsItemSelected:]):
(-[WKCaptionStyleMenuController menuWillOpen:]):
(-[WKCaptionStyleMenuController menu:willHighlightItem:]):
(-[WKCaptionStyleMenuController menuDidClose:]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/SoftLinkShim.h:
(TestWebKitAPI::SoftLinkShim::SoftLinkShim):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm:
(TestWebKitAPI::MediaAccessibilityShim::shimmedMACaptionAppearanceSetActiveProfileID):
(TestWebKitAPI::MediaAccessibilityShim::shimmedMACaptionAppearanceCopyProfileName):
(TestWebKitAPI::MediaAccessibilityShim::resetToDefaultValues):
(TestWebKitAPI::TEST(CaptionPreferenceTests, CaptionStyleMenu)):
(TestWebKitAPI::TEST(CaptionPreferenceTests, CaptionStyleMenuHighlight)):
(TestWebKitAPI::TEST(CaptionPreferenceTests, CaptionStyleMenuSelect)):

Canonical link: <a href="https://commits.webkit.org/301952@main">https://commits.webkit.org/301952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/671407a0e5a57bd9139fa94a76021ffef7209c4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78997 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2b6bbd28-5361-4c2a-8484-6e7153339872) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97014 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64965 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/95e21234-aac3-43f9-b23c-0f0d73d6fccf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114143 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77494 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d53d349a-1958-45f2-9285-b4619499ab2b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37001 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32248 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77892 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137003 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105534 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110492 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105187 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26847 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29157 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51680 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54038 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60125 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53272 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56729 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55031 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->