### PR TITLE
Keyboard closes after typing one character in gif search field on x.com

### DIFF
--- a/LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html
+++ b/LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html
@@ -76,16 +76,18 @@ addEventListener("load", async () => {
     await shouldBecomeEqual("targetContainsCaretSelection()", "true");
 
     console.log("8. Dismissing keyboard");
-    document.body.blur();
+    document.getElementById("editor").blur();
     await UIHelper.waitForKeyboardToHide();
 
     finishJSTest();
 });
 </script>
 </head>
-<body contenteditable>
-    <div id="start"><br></div>
-    <p id="description"></p>
-    <div id="target"><br></div>
+<body>
+    <div id="editor" contenteditable>
+        <div id="start"><br></div>
+        <p id="description"></p>
+        <div id="target"><br></div>
+    </div>
 </body>
 </html>

--- a/LayoutTests/fast/forms/ios/keyboard-restoration-after-element-replacement-expected.txt
+++ b/LayoutTests/fast/forms/ios/keyboard-restoration-after-element-replacement-expected.txt
@@ -1,0 +1,19 @@
+Test keyboard restoration when input elements are replaced during the same presentation update.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS isShowingKeyboard is true
+PASS isShowingKeyboard is true
+PASS isShowingKeyboard is false
+PASS isShowingKeyboard is true
+PASS isShowingKeyboard is false
+PASS isShowingKeyboard is true
+PASS isShowingKeyboard is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+
+

--- a/LayoutTests/fast/forms/ios/keyboard-restoration-after-element-replacement.html
+++ b/LayoutTests/fast/forms/ios/keyboard-restoration-after-element-replacement.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <style>
+        input {
+            display: block;
+            width: 200px;
+            height: 30px;
+            font-size: 16px;
+        }
+
+        .container {
+            margin: 20px;
+        }
+    </style>
+    <script>
+        jsTestIsAsync = true;
+
+        addEventListener("load", async () => {
+            if (!window.testRunner)
+                return;
+
+            description("Test keyboard restoration when input elements are replaced during the same presentation update.");
+
+            await UIHelper.setHardwareKeyboardAttached(false);
+
+            // Test 1: Keyboard should remain visible after element replacement during same presentation update.
+            const container1 = document.getElementById('container1');
+            const input1 = document.getElementById('input1');
+
+            await UIHelper.activateElement(input1);
+            await UIHelper.waitForKeyboardToShow();
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeTrue("isShowingKeyboard");
+
+            container1.innerHTML = '<input type="text" id="input1_replaced">';
+            const input1_replaced = document.getElementById('input1_replaced');
+            input1_replaced.focus();
+            await UIHelper.ensurePresentationUpdate();
+
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeTrue("isShowingKeyboard");
+
+            input1_replaced.blur();
+            await UIHelper.waitForKeyboardToHide();
+
+            // Test 2: Programmatic focus without user interaction should not show keyboard
+            const input2 = document.getElementById('input2');
+
+            input2.focus();
+            await UIHelper.ensurePresentationUpdate();
+
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeFalse("isShowingKeyboard");
+
+            input2.blur();
+
+            // Test 3: Focus after presentation update should not show keyboard
+            const container3 = document.getElementById('container3');
+            const input3 = document.getElementById('input3');
+
+            await UIHelper.activateElement(input3);
+            await UIHelper.waitForKeyboardToShow();
+
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeTrue("isShowingKeyboard");
+
+            container3.innerHTML = '';
+            await UIHelper.waitForKeyboardToHide();
+            await UIHelper.ensurePresentationUpdate();
+
+            container3.innerHTML = '<input type="text" id="input3_delayed">';
+            const input3_delayed = document.getElementById('input3_delayed');
+            input3_delayed.focus();
+
+            await UIHelper.ensurePresentationUpdate();
+
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeFalse("isShowingKeyboard");
+
+            // Test 4: Programmatic focus immediately after keyboard explicitly dismissed should not show keyboard.
+            const container4 = document.getElementById('container4');
+            const input4 = document.getElementById('input4');
+
+            await UIHelper.activateElement(input4);
+            await UIHelper.waitForKeyboardToShow();
+
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeTrue("isShowingKeyboard");
+
+            setInterval(function(){
+                input4.focus();
+            }, 2);
+
+            await UIHelper.dismissFormAccessoryView();
+            await UIHelper.waitForKeyboardToHide();
+            await UIHelper.ensurePresentationUpdate();
+
+            await UIHelper.ensurePresentationUpdate();
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeFalse("isShowingKeyboard");
+
+            finishJSTest();
+        });
+    </script>
+</head>
+
+<body>
+    <div class="container" id="container1">
+        <input type="text" id="input1">
+    </div>
+    <div class="container" id="container2">
+        <input type="text" id="input2">
+    </div>
+    <div class="container" id="container3">
+        <input type="text" id="input3">
+    </div>
+    <div class="container" id="container4">
+        <input type="text" id="input4">
+    </div>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -566,6 +566,8 @@ struct ImageAnalysisContextMenuActionData {
 
     BOOL _keyboardDidRequestDismissal;
     BOOL _isKeyboardScrollingAnimationRunning;
+    BOOL _keyboardDismissedInCurrentPresentationUpdate;
+    BOOL _editingEndedByUser;
 
     BOOL _candidateViewNeedsUpdate;
     BOOL _seenHardwareKeyDownInNonEditableElement;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1524,6 +1524,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     _selectionInteractionType = SelectionInteractionType::None;
 
+    _editingEndedByUser = YES;
+
     _hasSetUpInteractions = YES;
 }
 
@@ -2059,6 +2061,8 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
 
 - (void)endEditingAndUpdateFocusAppearanceWithReason:(EndEditingReason)reason
 {
+    _editingEndedByUser = YES;
+
     if (!self.webView._retainingActiveFocusedState) {
         // We need to complete the editing operation before we blur the element.
         [self _endEditing];
@@ -6158,6 +6162,9 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 #endif
 
     [_textInteractionWrapper reset];
+
+    _keyboardDismissedInCurrentPresentationUpdate = NO;
+    _editingEndedByUser = YES;
 }
 
 - (void)_nextAccessoryTabForWebView:(id)sender
@@ -8168,9 +8175,17 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
     [self reloadInputViews];
 }
 
-- (void)_hideKeyboard
+- (void)_hideKeyboard:(BOOL)editableChanged
 {
     SetForScope isHidingKeyboardScope { _isHidingKeyboard, YES };
+
+    if (editableChanged) {
+        _keyboardDismissedInCurrentPresentationUpdate = YES;
+        _page->callAfterNextPresentationUpdate([weakSelf = WeakObjCPtr<WKContentView>(self)] {
+            if (RetainPtr strongSelf = weakSelf.get())
+                strongSelf->_keyboardDismissedInCurrentPresentationUpdate = NO;
+        });
+    }
 
     self.inputDelegate = nil;
     [self setUpTextSelectionAssistant];
@@ -8369,6 +8384,9 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
             if (userIsInteracting)
                 return YES;
 
+            if (_keyboardDismissedInCurrentPresentationUpdate && !_editingEndedByUser)
+                return YES;
+
             if (self.isFirstResponder || _becomingFirstResponder) {
                 // When the software keyboard is being used to enter an url, only the focus activity state is changing.
                 // In this case, auto focus on the page being navigated to should be disabled, unless a hardware
@@ -8408,6 +8426,9 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
         [self startDeferringInputViewUpdates:WebKit::InputViewUpdateDeferralSource::ChangingFocusedElement];
         [self _elementDidBlur];
     }
+
+    if (shouldShowInputView)
+        _editingEndedByUser = NO;
 
     if (!shouldShowInputView || information.elementType == WebKit::InputType::None) {
         _page->setIsShowingInputViewForFocusedElement(false);
@@ -8639,7 +8660,7 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
     if (editableChanged)
         _seenHardwareKeyDownInNonEditableElement = NO;
 
-    [self _hideKeyboard];
+    [self _hideKeyboard:editableChanged];
 
 #if HAVE(PEPPER_UI_CORE)
     [self dismissAllInputViewControllers:YES];


### PR DESCRIPTION
#### bdad3ac0ce7807eb1ed9fb8923a8ecb7dc58728d
<pre>
Keyboard closes after typing one character in gif search field on x.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=298304">https://bugs.webkit.org/show_bug.cgi?id=298304</a>
<a href="https://rdar.apple.com/162808064">rdar://162808064</a>

Reviewed by Abrar Rahman Protyasha.

If the keyboard is hidden and an element is programatically focused during
the same presentation update, allow the keyboard to show again.

Track explicit user dismissals of the keyboard using `_editingEndedWithReason`,
and only restore the keyboard if `_editingEndedWithReason` is false.

These changes were originally intoduced in 299615@main but broke async image
decoding for first tile paint and were reverted in 301564@main. This is because
`WebPageProxy::callAfterNextPresentationUpdate()` was being called every time
`_hideKeyboard` was called, which forces a synchronous image decode. This time
around, we pass `editableChanged` to `_hideKeyboard` so that we only call
`WebPageProxy::callAfterNextPresentationUpdate()` if the editing state actually
changed. Thanks to Wenson Hsieh for this fix.

With these changes, layout test
tap-to-change-selection-after-accepting-inline-prediction.html began to fail
due to it using `&lt;body contenteditable&gt;` as the focused element. When
the body was blurred, focus was restored to the body again, and the keyboard
remained open as a result. The test has been updated to use `&lt;div contenteditable&gt;`
instead so that the keyboard is correctly dismissed. This issue appears to only
affect the simulator; programmatic keyboard dismissal on a contenteditable body
using `blur()` still works for both software and hardware keyboard.

Test: fast/forms/ios/keyboard-restoration-after-element-replacement.html
* LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html:
* LayoutTests/fast/forms/ios/keyboard-restoration-after-element-replacement-expected.txt: Added.
* LayoutTests/fast/forms/ios/keyboard-restoration-after-element-replacement.html: Added.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setUpInteraction]):
(-[WKContentView endEditingAndUpdateFocusAppearanceWithReason:]):
(-[WKContentView _didCommitLoadForMainFrame]):
(-[WKContentView _hideKeyboard:]):
(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):
(-[WKContentView _elementDidBlur]):
(-[WKContentView _hideKeyboard]): Deleted.

Canonical link: <a href="https://commits.webkit.org/301887@main">https://commits.webkit.org/301887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1c48247914d097eac30df20f4297b4919e51737

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127390 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/47038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38175 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/134454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129262 "Build is in progress. Recent messages:") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/47654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/55561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/134454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130338 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/47654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/114098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/134454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/47654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/77836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/47654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/32619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/136937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/54049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/55561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/136937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/54560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/110447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/136937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19920 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/53986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/60073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/53220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/54979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->