### PR TITLE
Remove PlatformMediaSessionClient::isActiveNowPlayingSessionChanged

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -713,14 +713,6 @@ void AudioContext::defaultDestinationWillBecomeConnected()
     m_canOverrideBackgroundPlaybackRestriction = true;
 }
 
-void AudioContext::isActiveNowPlayingSessionChanged()
-{
-    if (RefPtr document = this->document()) {
-        if (RefPtr page = document->page())
-            page->hasActiveNowPlayingSessionChanged();
-    }
-}
-
 #if !RELEASE_LOG_DISABLED
 const Logger& AudioContext::logger() const
 {

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -144,7 +144,6 @@ private:
     bool supportsSeeking() const final { return false; }
     bool canProduceAudio() const final { return true; }
     std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const final;
-    void isActiveNowPlayingSessionChanged() final;
     bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSession::InterruptionType) const final;
     bool isSuspended() const final;
     bool isPlaying() const final;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9843,12 +9843,6 @@ bool HTMLMediaElement::isActiveNowPlayingSession() const
     return m_mediaSession && m_mediaSession->isActiveNowPlayingSession();
 }
 
-void HTMLMediaElement::isActiveNowPlayingSessionChanged()
-{
-    if (RefPtr page = protectedDocument()->page())
-        page->hasActiveNowPlayingSessionChanged();
-}
-
 #if HAVE(SPATIAL_TRACKING_LABEL)
 void HTMLMediaElement::updateSpatialTrackingLabel()
 {

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -259,7 +259,6 @@ public:
     std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const final;
 
     WEBCORE_EXPORT bool isActiveNowPlayingSession() const;
-    void isActiveNowPlayingSessionChanged() final;
 
 // DOM API
 // error state

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.cpp
@@ -44,7 +44,6 @@ public:
     bool supportsSeeking() const final { return false; }
     bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSessionInterruptionType) const final { return false; }
     std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const final { return std::nullopt; }
-    void isActiveNowPlayingSessionChanged() final { }
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const { return emptyLogger(); }

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
@@ -105,8 +105,6 @@ public:
     virtual std::optional<NowPlayingInfo> nowPlayingInfo() const { return { }; }
     virtual WeakPtr<PlatformMediaSessionInterface> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>&, PlatformMediaSessionPlaybackControlsPurpose) { return nullptr; }
 
-    virtual void isActiveNowPlayingSessionChanged() = 0;
-
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;
     Ref<const Logger> protectedLogger() const { return logger(); }


### PR DESCRIPTION
#### c12bea1172da8a458a34b52f56fc87f2f96ec685
<pre>
Remove PlatformMediaSessionClient::isActiveNowPlayingSessionChanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=301141">https://bugs.webkit.org/show_bug.cgi?id=301141</a>
<a href="https://rdar.apple.com/163070140">rdar://163070140</a>

Reviewed by Jean-Yves Avenard.

Remove unused code.

* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::isActiveNowPlayingSessionChanged): Deleted.
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::isActiveNowPlayingSessionChanged): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.cpp:
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.h:

Canonical link: <a href="https://commits.webkit.org/301876@main">https://commits.webkit.org/301876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/182a0fd499a6e63c8c7e049c13b19acf20fd2821

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78779 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/73cb5534-370f-4208-8c16-a49e3941275c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96824 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9b8d6b33-332f-42b4-8714-7758b9affbbe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113951 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77326 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/92e20c03-703b-4d79-a0a3-292235dda759) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32105 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77668 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136771 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105343 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110302 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26799 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50554 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29018 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51446 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59907 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53052 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56465 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54813 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->