### PR TITLE
Unhandled web process message 'WebPage_Close'

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1845,23 +1845,11 @@ void WebPageProxy::close()
     Ref processPool = m_configuration->processPool();
     processPool->backForwardCache().removeEntriesForPage(*this);
 
-    struct ProcessToClose {
-        const Ref<WebProcessProxy> process;
-        WebCore::PageIdentifier pageID;
-        WebProcessProxy::ShutdownPreventingScopeCounter::Token shutdownPreventingScope;
-    };
-    Vector<ProcessToClose> processesToClose;
-    forEachWebContentProcess([&](auto& process, auto pageID) {
-        processesToClose.append({
-            process,
-            pageID,
-            process.shutdownPreventingScope()
-        });
-    });
     // Delay sending close message to next runloop cycle to avoid white flash.
-    RunLoop::currentSingleton().dispatch([processesToClose = WTFMove(processesToClose)] {
-        for (auto [process, pageID, scope] : processesToClose)
+    RunLoop::currentSingleton().dispatch([protectedThis = Ref { *this }] {
+        protectedThis->forEachWebContentProcess([](auto& process, auto pageID) {
             Ref { process }->send(Messages::WebPage::Close(), pageID);
+        });
     });
 
     process->removeWebPage(*this, WebProcessProxy::EndsUsingDataStore::Yes);


### PR DESCRIPTION
#### 1a31f53019d45f061a451c7685993c6927a91193
<pre>
Unhandled web process message &apos;WebPage_Close&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=301138">https://bugs.webkit.org/show_bug.cgi?id=301138</a>
<a href="https://rdar.apple.com/163070906">rdar://163070906</a>

Reviewed by NOBODY (OOPS!).

Before, there were messages like this: &quot;Unhandled web process message &apos;WebPage_Close&apos;&quot;
caught by `WebProcess::filterUnhandledMessage()`. These messages were coming from
`WebPageProxy::close()`; in which, the processes to be closed were gathered and the
`WebPage::Close` message was being dispatched from the `RunLoop`. Because this was
done in two steps, process could be closed somewhere else before the messages were
sent. This patch makes process deletion one step, which ensures that each web content
process only recieves one `WebPage::Close` message.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::close):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a31f53019d45f061a451c7685993c6927a91193

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46902 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/43193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/139683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/84089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7dc82aeb-e95e-4b8a-ad1d-4ead03018083) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96842 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64881 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6918b1b7-234d-44d9-ae2a-ee8786ca0367) 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/135114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38020 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113994 "Found 1 new API test failure: TestWebKitAPI.WKWebsiteDataStore.FetchPersistentWebStorage (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77341 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4a25595f-4b64-4ee6-a940-7a5ecbe26f33) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36902 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/138/builds/43193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/82903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124231 "Build is in progress. Recent messages:") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107878 "Found 4 new API test failures: TestWebKitAPI.WKWebsiteDataStore.RemoveDataStoreWithIdentifier, TestWebKitAPI.WKWebsiteDataStore.FetchPersistentWebStorage, TestWebKitAPI.SOAuthorizationRedirect.InterceptionFailedWith307PUT, TestWebKitAPI.WKWebsiteDataStore.RemoveSessionWithIdentifierFromNetworkProcess (failure)") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/142330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53913 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105361 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105046 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50567 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110316 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53850 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29031 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53082 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/67830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56555 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54843 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->