### PR TITLE
Implement navigation rate limiter to prevent recursive navigation crashes

### DIFF
--- a/LayoutTests/navigation-api/navigation-api-rate-limit-exceeded-expected.txt
+++ b/LayoutTests/navigation-api/navigation-api-rate-limit-exceeded-expected.txt
@@ -1,0 +1,17 @@
+Tests that navigation.navigate() is rate-limited after exceeding the configured window threshold
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Successful navigations: 100
+Failed navigations: 10
+QuotaExceededError count: 10
+PASS successfulNavigations >= 95 && successfulNavigations <= 100 is true
+PASS failedNavigations >= 5 && failedNavigations <= 15 is true
+PASS quotaExceededErrors is failedNavigations
+PASS lastError.name is 'QuotaExceededError'
+PASS lastError.message is 'Navigation rate limit exceeded'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-api-rate-limit-exceeded.html
+++ b/LayoutTests/navigation-api/navigation-api-rate-limit-exceeded.html
@@ -1,0 +1,66 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.navigate() is rate-limited after exceeding the configured window threshold");
+
+// Rate limit details (see Source/WebCore/page/Navigation.h RateLimiter):
+// - maxNavigationsPerWindow = 100
+// - windowDuration = 5 seconds
+// This test verifies the limit is enforced by attempting 110 rapid navigations.
+
+jsTestIsAsync = true;
+
+const EXPECTED_LIMIT = 100; // RateLimiter::maxNavigationsPerWindow
+const TEST_ATTEMPTS = EXPECTED_LIMIT + 10;
+
+var successfulNavigations = 0;
+var failedNavigations = 0;
+var quotaExceededErrors = 0;
+var lastError = null;
+
+window.onload = async () => {
+
+    // Try to navigate more than the limit
+    for (let i = 0; i < TEST_ATTEMPTS; i++) {
+        try {
+            const result = navigation.navigate(`#url${i}`);
+            await result.committed;
+            successfulNavigations++;
+        } catch (error) {
+            failedNavigations++;
+            if (error.name === "QuotaExceededError")
+                quotaExceededErrors++;
+        }
+    }
+
+    debug(`Successful navigations: ${successfulNavigations}`);
+    debug(`Failed navigations: ${failedNavigations}`);
+    debug(`QuotaExceededError count: ${quotaExceededErrors}`);
+
+    // Verify that approximately EXPECTED_LIMIT succeeded (allow small margin for timing)
+    shouldBeTrue(`successfulNavigations >= ${EXPECTED_LIMIT - 5} && successfulNavigations <= ${EXPECTED_LIMIT}`);
+
+    // Verify that remaining failed
+    const expectedFailures = TEST_ATTEMPTS - EXPECTED_LIMIT;
+    shouldBeTrue(`failedNavigations >= ${expectedFailures - 5} && failedNavigations <= ${expectedFailures + 5}`);
+
+    // Verify all failures were QuotaExceededError
+    shouldBe("quotaExceededErrors", "failedNavigations");
+
+    // Verify error message
+    try {
+        // Try one more navigation to get the error
+        for (let i = 0; i < 5; i++) {
+            await navigation.navigate(`#extra${i}`).committed;
+        }
+    } catch (error) {
+        lastError = error;
+    }
+
+    shouldBe("lastError.name", "'QuotaExceededError'");
+    shouldBe("lastError.message", "'Navigation rate limit exceeded'");
+
+    finishJSTest();
+};
+</script>

--- a/LayoutTests/navigation-api/navigation-api-rate-limit-readable-stream-no-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-api-rate-limit-readable-stream-no-crash-expected.txt
@@ -1,0 +1,10 @@
+Tests that recursive navigation.navigate() calls with ReadableStream cleanup do not crash after hitting stack overflow
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-api-rate-limit-readable-stream-no-crash.html
+++ b/LayoutTests/navigation-api/navigation-api-rate-limit-readable-stream-no-crash.html
@@ -1,0 +1,33 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that recursive navigation.navigate() calls with ReadableStream cleanup do not crash after hitting stack overflow");
+
+jsTestIsAsync = true;
+
+let navigationAttempts = 0;
+
+// Trigger the recursive navigation pattern from the original crash
+navigation.addEventListener('navigate', event => {
+    navigationAttempts++;
+
+    // Keep trying to navigate - one will eventually be rate limited
+    const result = navigation.navigate('#nav' + navigationAttempts);
+
+    // Check if this navigation was rate limited
+    result.committed.catch((e) => {
+        if (e.name === 'QuotaExceededError') {
+            // Successfully hit the rate limiter without crashing
+            testPassed("Did not crash");
+            finishJSTest();
+        }
+    });
+});
+
+// Create the ReadableStream that was involved in the original crash
+const stream = new Blob().stream();
+
+// Start the navigation cascade with a same-document navigation
+navigation.navigate('#start');
+</script>

--- a/LayoutTests/navigation-api/navigation-api-rate-limit-window-reset-expected.txt
+++ b/LayoutTests/navigation-api/navigation-api-rate-limit-window-reset-expected.txt
@@ -1,0 +1,19 @@
+Tests that the navigation rate limit resets after the time window expires
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Configured rate limiter: 5 navigations per 0.5s
+Phase 1: Hitting the rate limit...
+First phase - Successful: 5, Failed: 3
+PASS firstPhaseSuccess <= 5 is true
+PASS firstPhaseFailures >= 3 is true
+PASS blockedBeforeWait is true
+Phase 2: Waiting 600ms for window to reset...
+Phase 3: Attempting navigation after window reset...
+PASS successAfterReset is true
+PASS postResetNavigations is 3
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-api-rate-limit-window-reset.html
+++ b/LayoutTests/navigation-api/navigation-api-rate-limit-window-reset.html
@@ -1,0 +1,93 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that the navigation rate limit resets after the time window expires");
+
+// Using test parameters for faster execution:
+// - maxNavigations = 5 (instead of 100)
+// - windowDuration = 0.5 seconds (instead of 5 seconds)
+
+jsTestIsAsync = true;
+
+const TEST_LIMIT = 5;
+const TEST_WINDOW_DURATION_S = 0.5;
+const WAIT_BUFFER_MS = 100; // Small buffer to ensure window has reset
+
+var firstPhaseSuccess = 0;
+var firstPhaseFailures = 0;
+var blockedBeforeWait = false;
+var successAfterReset = false;
+var postResetNavigations = 0;
+
+window.onload = async () => {
+
+    // Configure rate limiter for testing
+    if (window.internals) {
+        internals.setNavigationRateLimiterParameters(window, TEST_LIMIT, TEST_WINDOW_DURATION_S);
+        debug(`Configured rate limiter: ${TEST_LIMIT} navigations per ${TEST_WINDOW_DURATION_S}s`);
+    } else {
+        testFailed("window.internals not available - test cannot run");
+        finishJSTest();
+        return;
+    }
+
+    // Phase 1: Hit the rate limit
+    debug("Phase 1: Hitting the rate limit...");
+
+    for (let i = 0; i < TEST_LIMIT + 3; i++) {
+        try {
+            const result = navigation.navigate(`#phase1-${i}`);
+            await result.committed;
+            firstPhaseSuccess++;
+        } catch (error) {
+            if (error.name === "QuotaExceededError")
+                firstPhaseFailures++;
+        }
+    }
+
+    debug(`First phase - Successful: ${firstPhaseSuccess}, Failed: ${firstPhaseFailures}`);
+    shouldBeTrue(`firstPhaseSuccess <= ${TEST_LIMIT}`);
+    shouldBeTrue("firstPhaseFailures >= 3");
+
+    // Verify we're now blocked
+    try {
+        await navigation.navigate("#blocked-test").committed;
+    } catch (error) {
+        if (error.name === "QuotaExceededError")
+            blockedBeforeWait = true;
+    }
+    shouldBeTrue("blockedBeforeWait");
+
+    // Phase 2: Wait for window to reset
+    const waitTimeMs = (TEST_WINDOW_DURATION_S * 1000) + WAIT_BUFFER_MS;
+    debug(`Phase 2: Waiting ${waitTimeMs}ms for window to reset...`);
+    await new Promise(resolve => setTimeout(resolve, waitTimeMs));
+
+    // Phase 3: Verify navigations are allowed again
+    debug("Phase 3: Attempting navigation after window reset...");
+    try {
+        const result = navigation.navigate("#after-reset");
+        await result.committed;
+        successAfterReset = true;
+    } catch (error) {
+        testFailed(`Navigation after reset failed with: ${error.name}: ${error.message}`);
+    }
+
+    shouldBeTrue("successAfterReset");
+
+    // Verify we can do multiple navigations again
+    for (let i = 0; i < 3; i++) {
+        try {
+            await navigation.navigate(`#post-reset-${i}`).committed;
+            postResetNavigations++;
+        } catch (error) {
+            testFailed(`Post-reset navigation ${i} failed: ${error.name}`);
+        }
+    }
+
+    shouldBe("postResetNavigations", "3");
+
+    finishJSTest();
+};
+</script>

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -349,7 +349,7 @@ public:
 #endif
 
     // Navigation API
-    Navigation& navigation();
+    WEBCORE_EXPORT Navigation& navigation();
     Ref<Navigation> protectedNavigation();
 
     void willDetachDocumentFromFrame();

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -980,6 +980,26 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 
     promoteUpcomingAPIMethodTracker(destination->key());
 
+    // Enforce rate limiting to prevent excessive navigation requests.
+    // Only check for script-initiated navigations (those with an API method tracker).
+    if (m_ongoingAPIMethodTracker && !m_rateLimiter.navigationAllowed()) {
+        // Log a warning once per window when the limit is reached.
+        if (!m_rateLimiter.wasReported()) {
+            m_rateLimiter.markReported();
+            if (RefPtr document = protectedWindow()->document())
+                document->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "Excessive navigation attempts blocked."_s);
+        }
+
+        // Reject the promises and clean up.
+        RefPtr tracker = *m_ongoingAPIMethodTracker;
+        auto exception = Exception { ExceptionCode::QuotaExceededError, "Navigation rate limit exceeded"_s };
+        Ref { tracker->committedPromise }->reject(exception);
+        Ref { tracker->finishedPromise }->reject(exception);
+        cleanupAPIMethodTracker(tracker.get());
+
+        return DispatchResult::Completed;
+    }
+
     RefPtr document = protectedWindow()->document();
 
     RefPtr apiMethodTracker = m_ongoingAPIMethodTracker;
@@ -1265,6 +1285,26 @@ Vector<Ref<HistoryItem>> Navigation::filterHistoryItemsForNavigationAPI(Vector<R
     }
 
     return filteredItems;
+}
+
+bool Navigation::RateLimiter::navigationAllowed()
+{
+    auto currentTime = MonotonicTime::now();
+
+    // Check if we've exceeded the time window and need to reset.
+    if (currentTime - m_windowStartTime > m_windowDuration) {
+        m_windowStartTime = currentTime;
+        m_navigationCount = 0;
+        m_limitMessageSent = false;
+    }
+
+    // Allow navigation if we're still under the limit.
+    if (m_navigationCount < m_maxNavigationsPerWindow) {
+        ++m_navigationCount;
+        return true;
+    }
+
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -33,9 +33,10 @@
 #include "NavigationNavigationType.h"
 #include "NavigationTransition.h"
 #include <JavaScriptCore/JSCJSValue.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/Seconds.h>
 #include <wtf/text/StringHash.h>
-
 namespace WebCore {
 
 class DocumentLoader;
@@ -186,6 +187,51 @@ public:
     };
     Ref<AbortHandler> registerAbortHandler();
 
+    // Rate limiter to prevent excessive navigation requests.
+    class RateLimiter {
+        WTF_MAKE_TZONE_ALLOCATED(RateLimiter);
+        WTF_MAKE_NONCOPYABLE(RateLimiter);
+        WTF_MAKE_NONMOVABLE(RateLimiter);
+    public:
+        RateLimiter() = default;
+
+        bool navigationAllowed();
+        bool wasReported() const { return m_limitMessageSent; }
+        void markReported() { m_limitMessageSent = true; }
+
+        // Testing support
+        void setParameters(unsigned maxNavigations, Seconds duration)
+        {
+            m_maxNavigationsPerWindow = maxNavigations;
+            m_windowDuration = duration;
+            reset();
+        }
+
+        void reset()
+        {
+            m_windowStartTime = MonotonicTime::now();
+            m_navigationCount = 0;
+            m_limitMessageSent = false;
+        }
+
+    private:
+        friend class Navigation;
+
+        // Sliding window rate limiter: allows 100 navigations per 5 second window (~20/sec sustained).
+        // Chromium uses 200 navigations per 10 seconds (same ~20/sec rate):
+        // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/navigation_rate_limiter.cc
+        // Both prevent IPC flooding and stack overflow from recursive navigation patterns.
+        unsigned m_maxNavigationsPerWindow { 100 };
+        Seconds m_windowDuration { 5_s };
+
+        MonotonicTime m_windowStartTime { MonotonicTime::now() };
+        unsigned m_navigationCount { 0 };
+        bool m_limitMessageSent { false };
+    };
+
+    // Testing support
+    RateLimiter& rateLimiterForTesting() { return m_rateLimiter; }
+
     NavigateEvent* ongoingNavigateEvent() { return m_ongoingNavigateEvent.get(); } // This may get called on the GC thread.
     RefPtr<NavigateEvent> protectedOngoingNavigateEvent() { return m_ongoingNavigateEvent; }
     bool hasInterceptedOngoingNavigateEvent() const { return m_ongoingNavigateEvent && m_ongoingNavigateEvent->wasIntercepted(); }
@@ -237,6 +283,7 @@ private:
     RefPtr<NavigationAPIMethodTracker> m_upcomingNonTraverseMethodTracker;
     HashMap<String, Ref<NavigationAPIMethodTracker>> m_upcomingTraverseMethodTrackers;
     WeakHashSet<AbortHandler> m_abortHandlers;
+    RateLimiter m_rateLimiter;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -172,6 +172,7 @@
 #include "MockLibWebRTCPeerConnection.h"
 #include "MockPageOverlay.h"
 #include "MockPageOverlayClient.h"
+#include "Navigation.h"
 #include "NavigatorBeacon.h"
 #include "NavigatorMediaDevices.h"
 #include "NetworkLoadInformation.h"
@@ -7293,6 +7294,24 @@ bool Internals::hasSandboxUnixSyscallAccess(const String& process, unsigned sysc
 String Internals::windowLocationHost(DOMWindow& window)
 {
     return window.location().host();
+}
+
+void Internals::setNavigationRateLimiterParameters(DOMWindow& window, unsigned maxNavigations, double windowDurationSeconds)
+{
+    RefPtr localWindow = dynamicDowncast<LocalDOMWindow>(window);
+    if (!localWindow)
+        return;
+
+    localWindow->navigation().rateLimiterForTesting().setParameters(maxNavigations, Seconds(windowDurationSeconds));
+}
+
+void Internals::resetNavigationRateLimiter(DOMWindow& window)
+{
+    RefPtr localWindow = dynamicDowncast<LocalDOMWindow>(window);
+    if (!localWindow)
+        return;
+
+    localWindow->navigation().rateLimiterForTesting().reset();
 }
 
 ExceptionOr<String> Internals::systemColorForCSSValue(const String& cssValue, bool useDarkModeAppearance, bool useElevatedUserInterfaceLevel)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1465,6 +1465,10 @@ public:
 
     String windowLocationHost(DOMWindow&);
 
+    // Navigation API rate limiter testing
+    void setNavigationRateLimiterParameters(DOMWindow&, unsigned maxNavigations, double windowDurationSeconds);
+    void resetNavigationRateLimiter(DOMWindow&);
+
     ExceptionOr<String> systemColorForCSSValue(const String& cssValue, bool useDarkModeAppearance, bool useElevatedUserInterfaceLevel);
 
     bool systemHasBattery() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1476,4 +1476,8 @@ enum ContentsFormat {
     [Conditional=MODEL_ELEMENT] undefined disableModelLoadDelaysForTesting();
     [Conditional=MODEL_ELEMENT] DOMString modelElementState(HTMLModelElement element);
     [Conditional=MODEL_ELEMENT] boolean isModelElementIntersectingViewport(HTMLModelElement element);
+
+    // Navigation API rate limiter testing
+    undefined setNavigationRateLimiterParameters(DOMWindow window, unsigned long maxNavigations, double windowDurationSeconds);
+    undefined resetNavigationRateLimiter(DOMWindow window);
 };


### PR DESCRIPTION
#### b97666dae8c095a857fd0959e3705505963e2ea5
<pre>
Implement navigation rate limiter to prevent recursive navigation crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=301144">https://bugs.webkit.org/show_bug.cgi?id=301144</a>
<a href="https://rdar.apple.com/161094454">rdar://161094454</a>

Reviewed by NOBODY (OOPS!).

Recursive navigation.navigate() calls from event listeners can trigger stack overflow.
During resource cleanup for a ReadableStream, this causes an exception assertion in
ReadableStreamDefaultController. However, clearing the exception locally
simply reveals more downstream assertions, pointing to a need to prevent
stack overflow from occuring instead.

Add a sliding window rate limiter (100 navigations per 5 second window)
to prevent IPC flooding and stack overflow from recursive calls.
This matches Chromium&apos;s sustained rate (~20 navigations/second).

Tests: navigation-api/navigation-api-rate-limit-exceeded.html
       navigation-api/navigation-api-rate-limit-readable-stream-no-crash.html
       navigation-api/navigation-api-rate-limit-window-reset.html

* LayoutTests/navigation-api/navigation-api-rate-limit-exceeded-expected.txt: Added.
* LayoutTests/navigation-api/navigation-api-rate-limit-exceeded.html: Added.
* LayoutTests/navigation-api/navigation-api-rate-limit-readable-stream-no-crash-expected.txt: Added.
* LayoutTests/navigation-api/navigation-api-rate-limit-readable-stream-no-crash.html: Added.
* LayoutTests/navigation-api/navigation-api-rate-limit-window-reset-expected.txt: Added.
* LayoutTests/navigation-api/navigation-api-rate-limit-window-reset.html: Added.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::RateLimiter::navigationAllowed):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setNavigationRateLimiterParameters):
(WebCore::Internals::resetNavigationRateLimiter):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b97666dae8c095a857fd0959e3705505963e2ea5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137548 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81687 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ab163798-23cd-482b-bbea-d1f5fa7a3db5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99148 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66966 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9cb0e238-ec0c-40fd-8a47-4c2b2dc1c28f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116570 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79842 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/31a11826-c061-414c-8be4-662fe73ac9d6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34697 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80818 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140023 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2205 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2061 "Found 1 new test failure: navigation-api/navigation-api-rate-limit-readable-stream-no-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107671 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107549 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1757 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31363 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55118 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2275 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65662 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2092 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2296 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2201 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->