### PR TITLE
Rename CDMPrivateMediaSourceAVFObjC into LegacyCDMPrivateAVFObjC

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.cpp
@@ -39,7 +39,7 @@
 #include <wtf/text/WTFString.h>
 
 #if HAVE(AVCONTENTKEYSESSION) && ENABLE(MEDIA_SOURCE)
-#include "CDMPrivateMediaSourceAVFObjC.h"
+#include "LegacyCDMPrivateAVFObjC.h"
 #endif
 
 namespace WebCore {
@@ -58,7 +58,7 @@ static void platformRegisterFactories(Vector<LegacyCDMFactory>& factories)
     // FIXME: initialize specific UA CDMs. http://webkit.org/b/109318, http://webkit.org/b/109320
     factories.append({ [](LegacyCDM& cdm) { return makeUniqueWithoutRefCountedCheck<CDMPrivateMediaPlayer>(cdm); }, CDMPrivateMediaPlayer::supportsKeySystem, CDMPrivateMediaPlayer::supportsKeySystemAndMimeType });
 #if HAVE(AVCONTENTKEYSESSION) && ENABLE(MEDIA_SOURCE)
-    factories.append({ [](LegacyCDM& cdm) { return makeUniqueWithoutRefCountedCheck<CDMPrivateMediaSourceAVFObjC>(cdm); }, CDMPrivateMediaSourceAVFObjC::supportsKeySystem, CDMPrivateMediaSourceAVFObjC::supportsKeySystemAndMimeType });
+    factories.append({ [](LegacyCDM& cdm) { return makeUniqueWithoutRefCountedCheck<LegacyCDMPrivateAVFObjC>(cdm); }, LegacyCDMPrivateAVFObjC::supportsKeySystem, LegacyCDMPrivateAVFObjC::supportsKeySystemAndMimeType });
 #endif
 }
 

--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -242,9 +242,9 @@ list(APPEND WebCore_SOURCES
     platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
     platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
     platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
-    platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm
     platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp
     platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+    platform/graphics/avfoundation/LegacyCDMPrivateAVFObjC.mm
     platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
     platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
     platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -354,11 +354,11 @@ platform/graphics/MediaPlaybackTargetPicker.cpp
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm @nonARC @no-unify
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm @nonARC @no-unify
 platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm @nonARC
-platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm @nonARC
 platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
 platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.cpp
 platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+platform/graphics/avfoundation/LegacyCDMPrivateAVFObjC.mm @nonARC
 platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm @nonARC
 platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
 platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm @nonARC

--- a/Source/WebCore/platform/graphics/avfoundation/LegacyCDMPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/LegacyCDMPrivateAVFObjC.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(MEDIA_SOURCE)
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
 
 #include "LegacyCDMPrivate.h"
 #include <wtf/TZoneMalloc.h>
@@ -37,13 +37,13 @@ namespace WebCore {
 class LegacyCDM;
 class CDMSessionAVContentKeySession;
 
-class CDMPrivateMediaSourceAVFObjC final : public CDMPrivateInterface, public CanMakeWeakPtr<CDMPrivateMediaSourceAVFObjC> {
-    WTF_MAKE_TZONE_ALLOCATED(CDMPrivateMediaSourceAVFObjC);
+class LegacyCDMPrivateAVFObjC final : public CDMPrivateInterface, public CanMakeWeakPtr<LegacyCDMPrivateAVFObjC> {
+    WTF_MAKE_TZONE_ALLOCATED(LegacyCDMPrivateAVFObjC);
 public:
-    explicit CDMPrivateMediaSourceAVFObjC(LegacyCDM& cdm)
+    explicit LegacyCDMPrivateAVFObjC(LegacyCDM& cdm)
         : m_cdm(cdm)
     { }
-    ~CDMPrivateMediaSourceAVFObjC();
+    ~LegacyCDMPrivateAVFObjC();
 
     static bool supportsKeySystem(const String&);
     static bool supportsKeySystemAndMimeType(const String& keySystem, const String& mimeType);
@@ -71,4 +71,4 @@ private:
 
 }
 
-#endif // ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(MEDIA_SOURCE)
+#endif // ENABLE(LEGACY_ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
@@ -32,7 +32,7 @@
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WTFSemaphore.h>
 
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(MEDIA_SOURCE)
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
 
 OBJC_CLASS AVContentKeyRequest;
 OBJC_CLASS AVContentKeySession;
@@ -45,13 +45,13 @@ class WorkQueue;
 namespace WebCore {
 
 class AudioVideoRenderer;
-class CDMPrivateMediaSourceAVFObjC;
+class LegacyCDMPrivateAVFObjC;
 class MediaSampleAVFObjC;
 
 class CDMSessionAVContentKeySession final : public LegacyCDMSession, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CDMSessionAVContentKeySession> {
     WTF_MAKE_TZONE_ALLOCATED(CDMSessionAVContentKeySession);
 public:
-    static Ref<CDMSessionAVContentKeySession> create(Vector<int>&& protocolVersions, int cdmVersion, CDMPrivateMediaSourceAVFObjC& parent, LegacyCDMSessionClient& client)
+    static Ref<CDMSessionAVContentKeySession> create(Vector<int>&& protocolVersions, int cdmVersion, LegacyCDMPrivateAVFObjC& parent, LegacyCDMSessionClient& client)
     {
         return adoptRef(*new CDMSessionAVContentKeySession(WTFMove(protocolVersions), cdmVersion, parent, client));
     }
@@ -91,7 +91,7 @@ public:
     void didProvideContentKeyRequest(AVContentKeyRequest *);
 
 private:
-    CDMSessionAVContentKeySession(Vector<int>&& protocolVersions, int cdmVersion, CDMPrivateMediaSourceAVFObjC&, LegacyCDMSessionClient&);
+    CDMSessionAVContentKeySession(Vector<int>&& protocolVersions, int cdmVersion, LegacyCDMPrivateAVFObjC&, LegacyCDMSessionClient&);
 
     RefPtr<Uint8Array> generateKeyReleaseMessage(unsigned short& errorCode, uint32_t& systemCode);
 
@@ -108,7 +108,7 @@ private:
     bool hasContentKeyRequest() const;
     RetainPtr<AVContentKeyRequest> contentKeyRequest() const;
 
-    WeakPtr<CDMPrivateMediaSourceAVFObjC> m_cdm;
+    WeakPtr<LegacyCDMPrivateAVFObjC> m_cdm;
     const WeakPtr<LegacyCDMSessionClient> m_client;
     const RetainPtr<AVContentKeySession> m_contentKeySession;
     const RetainPtr<WebCDMSessionAVContentKeySessionDelegate> m_contentKeySessionDelegate;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -26,13 +26,13 @@
 #import "config.h"
 #import "CDMSessionAVContentKeySession.h"
 
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(MEDIA_SOURCE)
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
 
 #import "AudioVideoRenderer.h"
 #import "CDMFairPlayStreaming.h"
 #import "CDMInstanceFairPlayStreamingAVFObjC.h"
-#import "CDMPrivateMediaSourceAVFObjC.h"
 #import "LegacyCDM.h"
+#import "LegacyCDMPrivateAVFObjC.h"
 #import "Logging.h"
 #import "MediaPlayer.h"
 #import "MediaSampleAVFObjC.h"
@@ -124,7 +124,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(CDMSessionAVContentKeySession);
 
 constexpr Seconds kDidProvideContentKeyRequestTimeout { 5_s };
 
-CDMSessionAVContentKeySession::CDMSessionAVContentKeySession(Vector<int>&& protocolVersions, int cdmVersion, CDMPrivateMediaSourceAVFObjC& cdm, LegacyCDMSessionClient& client)
+CDMSessionAVContentKeySession::CDMSessionAVContentKeySession(Vector<int>&& protocolVersions, int cdmVersion, LegacyCDMPrivateAVFObjC& cdm, LegacyCDMSessionClient& client)
     : m_cdm(cdm)
     , m_client(client)
     , m_contentKeySessionDelegate(adoptNS([[WebCDMSessionAVContentKeySessionDelegate alloc] initWithParent:this]))


### PR DESCRIPTION
#### d2348d6dad0cc6040d7a12101491b0335a940765
<pre>
Rename CDMPrivateMediaSourceAVFObjC into LegacyCDMPrivateAVFObjC
<a href="https://bugs.webkit.org/show_bug.cgi?id=301075">https://bugs.webkit.org/show_bug.cgi?id=301075</a>
<a href="https://rdar.apple.com/163008540">rdar://163008540</a>

Reviewed by Eric Carlson.

We rename CDMPrivateMediaSourceAVFObjC into LegacyCDMPrivateAVFObjC as it
is no longer used just with MediaSourcePrivateAVFObjC but any MediaPlayerPrivate
using an AudioVideoRendererAVFobjC.

No functional changes
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.cpp:
(WebCore::platformRegisterFactories):
* Source/WebCore/PlatformMac.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/avfoundation/LegacyCDMPrivateAVFObjC.h: Added.
* Source/WebCore/platform/graphics/avfoundation/LegacyCDMPrivateAVFObjC.mm: Added.
(WebCore::LegacyCDMPrivateAVFObjC::parseKeySystem):
(WebCore::LegacyCDMPrivateAVFObjC::~LegacyCDMPrivateAVFObjC):
(WebCore::queryDecoderAvailability):
(WebCore::LegacyCDMPrivateAVFObjC::supportsKeySystem):
(WebCore::LegacyCDMPrivateAVFObjC::supportsKeySystemAndMimeType):
(WebCore::LegacyCDMPrivateAVFObjC::supportsMIMEType const):
(WebCore::LegacyCDMPrivateAVFObjC::createSession):
(WebCore::LegacyCDMPrivateAVFObjC::invalidateSession):
(WebCore::LegacyCDMPrivateAVFObjC::ref const):
(WebCore::LegacyCDMPrivateAVFObjC::deref const):
(WebCore::LegacyCDMPrivateAVFObjC::cdm const):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::CDMSessionAVContentKeySession):

Canonical link: <a href="https://commits.webkit.org/301856@main">https://commits.webkit.org/301856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/295873977bef75fdef781fd8020c5811eb025e06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127282 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134346 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/78837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3031efbb-5c1c-4550-a82e-fe0798a62d20) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96870 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/78837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0f44e567-aab8-40c4-9872-d5ab0768f94d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130230 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/38042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77367 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9e8a45dc-4de2-41df-b537-2148fce4ef9e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77727 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136829 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53941 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/41556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105384 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105068 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26783 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50591 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51504 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59965 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/53110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54871 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->