### PR TITLE
Move BlobResourceHandleBase class to its own file

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2967,6 +2967,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/network/BlobRegistry.h
     platform/network/BlobRegistryImpl.h
     platform/network/BlobResourceHandle.h
+    platform/network/BlobResourceHandleBase.h
     platform/network/CacheValidation.h
     platform/network/CertificateSummary.h
     platform/network/CookieRequestHeaderFieldProxy.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2734,6 +2734,7 @@ platform/network/BlobDataFileReference.cpp
 platform/network/BlobRegistry.cpp
 platform/network/BlobRegistryImpl.cpp
 platform/network/BlobResourceHandle.cpp
+platform/network/BlobResourceHandleBase.cpp
 platform/network/CacheValidation.cpp
 platform/network/Cookie.cpp
 platform/network/CredentialBase.cpp

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -32,11 +32,7 @@
 #include "config.h"
 
 #include "BlobResourceHandle.h"
-
-#include "AsyncFileStream.h"
 #include "FileStream.h"
-#include "HTTPHeaderNames.h"
-#include "ParsedContentRange.h"
 #include "ResourceError.h"
 #include "ResourceHandleClient.h"
 #include "ResourceRequest.h"
@@ -44,20 +40,11 @@
 #include "SecurityOrigin.h"
 #include "SharedBuffer.h"
 #include <wtf/CompletionHandler.h>
-#include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
-#include <wtf/Ref.h>
-#include <wtf/StdLibExtras.h>
-#include <wtf/URL.h>
 
 namespace WebCore {
 
 static const unsigned bufferSize = 512 * 1024;
-
-static const int httpOK = 200;
-static const int httpPartialContent = 206;
-static constexpr auto httpOKText = "OK"_s;
-static constexpr auto httpPartialContentText = "Partial Content"_s;
 
 static constexpr auto webKitBlobResourceDomain = "WebKitBlobResource"_s;
 
@@ -128,71 +115,6 @@ void BlobResourceSynchronousLoader::didFail(ResourceHandle*, const ResourceError
 
 }
 
-BlobResourceHandleBase::BlobResourceHandleBase(bool async, RefPtr<BlobData>&& blobData)
-    : m_blobData(WTFMove(blobData))
-{
-    if (async)
-        m_stream = makeUnique<AsyncFileStream>(*this);
-    else
-        m_stream = makeUnique<FileStream>();
-}
-
-BlobResourceHandleBase::~BlobResourceHandleBase() = default;
-
-auto BlobResourceHandleBase::adjustAndValidateRangeBounds() -> std::optional<Error>
-{
-    if (!m_range->start) {
-        if (!m_range->end)
-            return Error::RangeError;
-        // m_range->end indicates the last bytes to read.
-        if (*m_range->end > m_totalSize) {
-            m_range->start = 0;
-            m_range->end = m_totalSize ? (m_totalSize - 1) : 0;
-        } else {
-            m_range->start = m_totalSize - *m_range->end;
-            m_range->end = *m_range->start + *m_range->end - 1;
-        }
-    } else {
-        if (*m_range->start >= m_totalSize)
-            return Error::RangeError;
-        if (m_range->end && *m_range->start > *m_range->end)
-            return Error::RangeError;
-        if (!m_range->end || *m_range->end >= m_totalSize)
-            m_range->end = m_totalSize ? (m_totalSize - 1) : 0;
-        else
-            m_range->end = *m_range->end;
-    }
-    return { };
-}
-
-void BlobResourceHandleBase::closeFileIfOpen()
-{
-    if (m_isFileOpen) {
-        m_isFileOpen = false;
-        asyncStream()->close();
-    }
-}
-
-void BlobResourceHandleBase::clearAsyncStream()
-{
-    m_stream = std::unique_ptr<AsyncFileStream>();
-}
-
-BlobData* BlobResourceHandleBase::blobData() const
-{
-    return m_blobData.get();
-}
-
-FileStream* BlobResourceHandleBase::syncStream() const
-{
-    return std::get<std::unique_ptr<FileStream>>(m_stream).get();
-}
-
-AsyncFileStream* BlobResourceHandleBase::asyncStream() const
-{
-    return std::get<std::unique_ptr<AsyncFileStream>>(m_stream).get();
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // BlobResourceHandle
 
@@ -229,159 +151,6 @@ void BlobResourceHandle::cancel()
     m_aborted = true;
 
     ResourceHandle::cancel();
-}
-
-void BlobResourceHandleBase::start()
-{
-    if (!async()) {
-        doStart();
-        return;
-    }
-
-    // Finish this async call quickly and return.
-    callOnMainThread([protectedThis = Ref { *this }]() mutable {
-        protectedThis->doStart();
-    });
-}
-
-void BlobResourceHandleBase::doStart()
-{
-    ASSERT(isMainThread());
-
-    // Do not continue if the request is aborted or an error occurs.
-    if (erroredOrAborted()) {
-        clearStream();
-        return;
-    }
-
-    if (!equalLettersIgnoringASCIICase(firstRequest().httpMethod(), "get"_s)) {
-        didFail(Error::MethodNotAllowed);
-        return;
-    }
-
-    // If the blob data is not found, fail now.
-    if (!m_blobData) {
-        didFail(Error::NotFoundError);
-        return;
-    }
-
-    // Parse the "Range" header we care about.
-    if (String range = firstRequest().httpHeaderField(HTTPHeaderName::Range); !range.isNull()) {
-        m_range = parseRange(range, RangeAllowWhitespace::Yes);
-        if (!m_range) {
-            didFail(Error::RangeError);
-            return;
-        }
-        m_isRangeRequest = true;
-    }
-
-    if (async())
-        getSizeForNext();
-    else {
-        for (size_t i = 0; i < m_blobData->items().size() && !erroredOrAborted(); ++i)
-            getSizeForNext();
-
-        if (auto error = seek()) {
-            didFail(*error);
-            return;
-        }
-        dispatchDidReceiveResponse();
-    }
-}
-
-void BlobResourceHandleBase::getSizeForNext()
-{
-    ASSERT(isMainThread());
-
-    // Do we finish validating and counting size for all items?
-    if (m_sizeItemCount >= m_blobData->items().size()) {
-        if (auto error = seek()) {
-            didFail(*error);
-            return;
-        }
-
-        // Start reading if in asynchronous mode.
-        if (async())
-            dispatchDidReceiveResponse();
-        return;
-    }
-
-    const BlobDataItem& item = m_blobData->items().at(m_sizeItemCount);
-    switch (item.type()) {
-    case BlobDataItem::Type::Data:
-        didGetSize(item.length());
-        break;
-    case BlobDataItem::Type::File: {
-        // Files know their sizes, but asking the stream to verify that the file wasn't modified.
-        RefPtr file = item.file();
-        if (async())
-            asyncStream()->getSize(file->path(), file->expectedModificationTime());
-        else
-            didGetSize(syncStream()->getSize(file->path(), file->expectedModificationTime()));
-        break;
-    }
-    default:
-        ASSERT_NOT_REACHED();
-    }
-}
-
-void BlobResourceHandleBase::didGetSize(long long size)
-{
-    ASSERT(isMainThread());
-
-    if (erroredOrAborted()) {
-        clearStream();
-        return;
-    }
-
-    // If the size is -1, it means the file has been moved or changed. Fail now.
-    if (size == -1) {
-        didFail(Error::NotFoundError);
-        return;
-    }
-
-    // The size passed back is the size of the whole file. If the underlying item is a sliced file, we need to use the slice length.
-    const BlobDataItem& item = m_blobData->items().at(m_sizeItemCount);
-    uint64_t updatedSize = static_cast<uint64_t>(item.length());
-
-    // Cache the size.
-    m_itemLengthList.append(updatedSize);
-
-    // Count the size.
-    m_totalSize += updatedSize;
-    m_totalRemainingSize += updatedSize;
-    ++m_sizeItemCount;
-
-    // Continue with the next item.
-    getSizeForNext();
-}
-
-auto BlobResourceHandleBase::seek() -> std::optional<Error>
-{
-    ASSERT(isMainThread());
-
-    // Bail out if the range is not provided.
-    if (!m_isRangeRequest)
-        return { };
-
-    if (auto error = adjustAndValidateRangeBounds())
-        return error;
-
-    // Skip the initial items that are not in the range.
-    Checked<uint64_t> offset = *m_range->start;
-    for (m_readItemCount = 0; m_readItemCount < m_blobData->items().size() && offset.value() >= lengthOfItemBeingRead(); ++m_readItemCount)
-        offset -= lengthOfItemBeingRead();
-
-    // Set the offset that need to jump to for the first item in the range.
-    m_currentItemReadSize = offset.value();
-
-    // Adjust the total remaining size in order not to go beyond the range.
-    Checked<uint64_t> rangeSize = *m_range->end;
-    rangeSize -= *m_range->start;
-    rangeSize += 1uz;
-    if (m_totalRemainingSize > rangeSize.value())
-        m_totalRemainingSize = rangeSize.value();
-    return { };
 }
 
 int BlobResourceHandle::readSync(std::span<uint8_t> buffer)
@@ -487,123 +256,6 @@ int BlobResourceHandle::readFileSync(const BlobDataItem& item, std::span<uint8_t
     return bytesRead;
 }
 
-void BlobResourceHandleBase::readAsync()
-{
-    ASSERT(RunLoop::isMain());
-
-    if (erroredOrAborted())
-        return;
-
-    while (m_totalRemainingSize && m_readItemCount < m_blobData->items().size()) {
-        const BlobDataItem& item = m_blobData->items().at(m_readItemCount);
-        switch (item.type()) {
-        case BlobDataItem::Type::Data:
-            if (!readDataAsync(item))
-                return; // error occurred
-            break;
-        case BlobDataItem::Type::File:
-            readFileAsync(item);
-            return;
-        }
-    }
-    didFinish();
-}
-
-bool BlobResourceHandleBase::readDataAsync(const BlobDataItem& item)
-{
-    ASSERT(isMainThread());
-    ASSERT(item.data());
-
-    ASSERT(m_currentItemReadSize <= static_cast<uint64_t>(item.length()));
-    uint64_t bytesToRead = static_cast<uint64_t>(item.length()) - m_currentItemReadSize;
-    if (bytesToRead > m_totalRemainingSize)
-        bytesToRead = m_totalRemainingSize;
-
-    auto data = item.protectedData()->span().subspan(item.offset() + m_currentItemReadSize, bytesToRead);
-    m_currentItemReadSize = 0;
-
-    return consumeData(data);
-}
-
-void BlobResourceHandleBase::readFileAsync(const BlobDataItem& item)
-{
-    ASSERT(isMainThread());
-
-    if (m_isFileOpen) {
-        asyncStream()->read(buffer().mutableSpan());
-        return;
-    }
-
-    uint64_t bytesToRead = lengthOfItemBeingRead() - m_currentItemReadSize;
-    if (bytesToRead > m_totalRemainingSize)
-        bytesToRead = static_cast<int>(m_totalRemainingSize);
-    asyncStream()->openForRead(item.protectedFile()->path(), item.offset() + m_currentItemReadSize, bytesToRead);
-    m_isFileOpen = true;
-    m_currentItemReadSize = 0;
-}
-
-void BlobResourceHandleBase::didOpen(bool success)
-{
-    ASSERT(async());
-
-    if (erroredOrAborted()) {
-        clearStream();
-        return;
-    }
-
-    if (!success) {
-        didFail(Error::NotReadableError);
-        return;
-    }
-
-    // Continue the reading.
-    readAsync();
-}
-
-void BlobResourceHandleBase::didRead(int bytesRead)
-{
-    if (erroredOrAborted()) {
-        clearStream();
-        return;
-    }
-
-    if (bytesRead < 0) {
-        didFail(Error::NotReadableError);
-        return;
-    }
-
-    if (consumeData(m_buffer.subspan(0, bytesRead)))
-        readAsync();
-}
-
-bool BlobResourceHandleBase::consumeData(std::span<const uint8_t> data)
-{
-    ASSERT(async());
-
-    m_totalRemainingSize -= data.size();
-
-    // Notify the client.
-    if (!data.empty()) {
-        if (!didReceiveData(data))
-            return false;
-    }
-
-    if (m_isFileOpen) {
-        // When the current item is a file item, the reading is completed only if bytesRead is 0.
-        if (data.empty()) {
-            closeFileIfOpen();
-
-            // Move to the next item.
-            ++m_readItemCount;
-        }
-    } else {
-        // Otherwise, we read the current text item as a whole and move to the next item.
-        ++m_readItemCount;
-    }
-
-    return true;
-}
-
 bool BlobResourceHandle::shouldAbortDispatchDidReceiveResponse()
 {
     if (!client())
@@ -615,32 +267,6 @@ bool BlobResourceHandle::shouldAbortDispatchDidReceiveResponse()
     }
 
     return false;
-}
-
-void BlobResourceHandleBase::dispatchDidReceiveResponse()
-{
-    ASSERT(isMainThread());
-
-    if (shouldAbortDispatchDidReceiveResponse())
-        return;
-
-    ResourceResponse response(URL { firstRequest().url() }, extractMIMETypeFromMediaType(m_blobData->contentType()), m_totalRemainingSize, String());
-    response.setHTTPStatusCode(m_isRangeRequest ? httpPartialContent : httpOK);
-    response.setHTTPStatusText(m_isRangeRequest ? httpPartialContentText : httpOKText);
-
-    response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
-    response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toString());
-    response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
-    addPolicyContainerHeaders(response, m_blobData->policyContainer());
-
-    if (m_isRangeRequest)
-        response.setHTTPHeaderField(HTTPHeaderName::ContentRange, ParsedContentRange(*m_range->start, *m_range->end, m_totalSize).headerValue());
-
-    // FIXME: If a resource identified with a blob: URL is a File object, user agents must use that file's name attribute,
-    // as if the response had a Content-Disposition header with the filename parameter set to the File's name attribute.
-    // Notably, this will affect a name suggested in "File Save As".
-
-    didReceiveResponse(WTFMove(response));
 }
 
 void BlobResourceHandle::didReceiveResponse(ResourceResponse&& response)

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
@@ -1,0 +1,405 @@
+/*
+ * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BlobResourceHandleBase.h"
+
+#include "AsyncFileStream.h"
+#include "FileStream.h"
+#include "HTTPHeaderNames.h"
+#include "ResourceRequest.h"
+#include "ResourceResponse.h"
+#include <wtf/MainThread.h>
+
+namespace WebCore {
+
+static constexpr int httpOK = 200;
+static constexpr int httpPartialContent = 206;
+static constexpr auto httpOKText = "OK"_s;
+static constexpr auto httpPartialContentText = "Partial Content"_s;
+
+BlobResourceHandleBase::BlobResourceHandleBase(bool async, RefPtr<BlobData>&& blobData)
+    : m_blobData(WTFMove(blobData))
+{
+    if (async)
+        m_stream = makeUnique<AsyncFileStream>(*this);
+    else
+        m_stream = makeUnique<FileStream>();
+}
+
+BlobResourceHandleBase::~BlobResourceHandleBase() = default;
+
+auto BlobResourceHandleBase::adjustAndValidateRangeBounds() -> std::optional<Error>
+{
+    if (!m_range->start) {
+        if (!m_range->end)
+            return Error::RangeError;
+        // m_range->end indicates the last bytes to read.
+        if (*m_range->end > m_totalSize) {
+            m_range->start = 0;
+            m_range->end = m_totalSize ? (m_totalSize - 1) : 0;
+        } else {
+            m_range->start = m_totalSize - *m_range->end;
+            m_range->end = *m_range->start + *m_range->end - 1;
+        }
+    } else {
+        if (*m_range->start >= m_totalSize)
+            return Error::RangeError;
+        if (m_range->end && *m_range->start > *m_range->end)
+            return Error::RangeError;
+        if (!m_range->end || *m_range->end >= m_totalSize)
+            m_range->end = m_totalSize ? (m_totalSize - 1) : 0;
+        else
+            m_range->end = *m_range->end;
+    }
+    return { };
+}
+
+void BlobResourceHandleBase::closeFileIfOpen()
+{
+    if (m_isFileOpen) {
+        m_isFileOpen = false;
+        asyncStream()->close();
+    }
+}
+
+void BlobResourceHandleBase::clearAsyncStream()
+{
+    m_stream = std::unique_ptr<AsyncFileStream>();
+}
+
+BlobData* BlobResourceHandleBase::blobData() const
+{
+    return m_blobData.get();
+}
+
+FileStream* BlobResourceHandleBase::syncStream() const
+{
+    return std::get<std::unique_ptr<FileStream>>(m_stream).get();
+}
+
+AsyncFileStream* BlobResourceHandleBase::asyncStream() const
+{
+    return std::get<std::unique_ptr<AsyncFileStream>>(m_stream).get();
+}
+
+void BlobResourceHandleBase::start()
+{
+    if (!async()) {
+        doStart();
+        return;
+    }
+
+    // Finish this async call quickly and return.
+    callOnMainThread([protectedThis = Ref { *this }]() mutable {
+        protectedThis->doStart();
+    });
+}
+
+void BlobResourceHandleBase::doStart()
+{
+    ASSERT(isMainThread());
+
+    // Do not continue if the request is aborted or an error occurs.
+    if (erroredOrAborted()) {
+        clearStream();
+        return;
+    }
+
+    if (!equalLettersIgnoringASCIICase(firstRequest().httpMethod(), "get"_s)) {
+        didFail(Error::MethodNotAllowed);
+        return;
+    }
+
+    // If the blob data is not found, fail now.
+    if (!m_blobData) {
+        didFail(Error::NotFoundError);
+        return;
+    }
+
+    // Parse the "Range" header we care about.
+    if (String range = firstRequest().httpHeaderField(HTTPHeaderName::Range); !range.isNull()) {
+        m_range = parseRange(range, RangeAllowWhitespace::Yes);
+        if (!m_range) {
+            didFail(Error::RangeError);
+            return;
+        }
+        m_isRangeRequest = true;
+    }
+
+    if (async())
+        getSizeForNext();
+    else {
+        for (size_t i = 0; i < m_blobData->items().size() && !erroredOrAborted(); ++i)
+            getSizeForNext();
+
+        if (auto error = seek()) {
+            didFail(*error);
+            return;
+        }
+        dispatchDidReceiveResponse();
+    }
+}
+
+void BlobResourceHandleBase::getSizeForNext()
+{
+    ASSERT(isMainThread());
+
+    // Do we finish validating and counting size for all items?
+    if (m_sizeItemCount >= m_blobData->items().size()) {
+        if (auto error = seek()) {
+            didFail(*error);
+            return;
+        }
+
+        // Start reading if in asynchronous mode.
+        if (async())
+            dispatchDidReceiveResponse();
+        return;
+    }
+
+    const BlobDataItem& item = m_blobData->items().at(m_sizeItemCount);
+    switch (item.type()) {
+    case BlobDataItem::Type::Data:
+        didGetSize(item.length());
+        break;
+    case BlobDataItem::Type::File: {
+        // Files know their sizes, but asking the stream to verify that the file wasn't modified.
+        RefPtr file = item.file();
+        if (async())
+            asyncStream()->getSize(file->path(), file->expectedModificationTime());
+        else
+            didGetSize(syncStream()->getSize(file->path(), file->expectedModificationTime()));
+        break;
+    }
+    default:
+        ASSERT_NOT_REACHED();
+    }
+}
+
+void BlobResourceHandleBase::didGetSize(long long size)
+{
+    ASSERT(isMainThread());
+
+    if (erroredOrAborted()) {
+        clearStream();
+        return;
+    }
+
+    // If the size is -1, it means the file has been moved or changed. Fail now.
+    if (size == -1) {
+        didFail(Error::NotFoundError);
+        return;
+    }
+
+    // The size passed back is the size of the whole file. If the underlying item is a sliced file, we need to use the slice length.
+    const BlobDataItem& item = m_blobData->items().at(m_sizeItemCount);
+    uint64_t updatedSize = static_cast<uint64_t>(item.length());
+
+    // Cache the size.
+    m_itemLengthList.append(updatedSize);
+
+    // Count the size.
+    m_totalSize += updatedSize;
+    m_totalRemainingSize += updatedSize;
+    ++m_sizeItemCount;
+
+    // Continue with the next item.
+    getSizeForNext();
+}
+
+auto BlobResourceHandleBase::seek() -> std::optional<Error>
+{
+    ASSERT(isMainThread());
+
+    // Bail out if the range is not provided.
+    if (!m_isRangeRequest)
+        return { };
+
+    if (auto error = adjustAndValidateRangeBounds())
+        return error;
+
+    // Skip the initial items that are not in the range.
+    Checked<uint64_t> offset = *m_range->start;
+    for (m_readItemCount = 0; m_readItemCount < m_blobData->items().size() && offset.value() >= lengthOfItemBeingRead(); ++m_readItemCount)
+        offset -= lengthOfItemBeingRead();
+
+    // Set the offset that need to jump to for the first item in the range.
+    m_currentItemReadSize = offset.value();
+
+    // Adjust the total remaining size in order not to go beyond the range.
+    Checked<uint64_t> rangeSize = *m_range->end;
+    rangeSize -= *m_range->start;
+    rangeSize += 1uz;
+    if (m_totalRemainingSize > rangeSize.value())
+        m_totalRemainingSize = rangeSize.value();
+    return { };
+}
+
+void BlobResourceHandleBase::readAsync()
+{
+    ASSERT(isMainThread());
+
+    if (erroredOrAborted())
+        return;
+
+    while (m_totalRemainingSize && m_readItemCount < m_blobData->items().size()) {
+        const BlobDataItem& item = m_blobData->items().at(m_readItemCount);
+        switch (item.type()) {
+        case BlobDataItem::Type::Data:
+            if (!readDataAsync(item))
+                return; // error occurred
+            break;
+        case BlobDataItem::Type::File:
+            readFileAsync(item);
+            return;
+        }
+    }
+    didFinish();
+}
+
+bool BlobResourceHandleBase::readDataAsync(const BlobDataItem& item)
+{
+    ASSERT(isMainThread());
+    ASSERT(item.data());
+
+    ASSERT(m_currentItemReadSize <= static_cast<uint64_t>(item.length()));
+    uint64_t bytesToRead = static_cast<uint64_t>(item.length()) - m_currentItemReadSize;
+    if (bytesToRead > m_totalRemainingSize)
+        bytesToRead = m_totalRemainingSize;
+
+    auto data = item.protectedData()->span().subspan(item.offset() + m_currentItemReadSize, bytesToRead);
+    m_currentItemReadSize = 0;
+
+    return consumeData(data);
+}
+
+void BlobResourceHandleBase::readFileAsync(const BlobDataItem& item)
+{
+    ASSERT(isMainThread());
+
+    if (m_isFileOpen) {
+        asyncStream()->read(buffer().mutableSpan());
+        return;
+    }
+
+    uint64_t bytesToRead = lengthOfItemBeingRead() - m_currentItemReadSize;
+    if (bytesToRead > m_totalRemainingSize)
+        bytesToRead = static_cast<int>(m_totalRemainingSize);
+    asyncStream()->openForRead(item.protectedFile()->path(), item.offset() + m_currentItemReadSize, bytesToRead);
+    m_isFileOpen = true;
+    m_currentItemReadSize = 0;
+}
+
+void BlobResourceHandleBase::didOpen(bool success)
+{
+    ASSERT(async());
+
+    if (erroredOrAborted()) {
+        clearStream();
+        return;
+    }
+
+    if (!success) {
+        didFail(Error::NotReadableError);
+        return;
+    }
+
+    // Continue the reading.
+    readAsync();
+}
+
+void BlobResourceHandleBase::didRead(int bytesRead)
+{
+    if (erroredOrAborted()) {
+        clearStream();
+        return;
+    }
+
+    if (bytesRead < 0) {
+        didFail(Error::NotReadableError);
+        return;
+    }
+
+    if (consumeData(m_buffer.subspan(0, bytesRead)))
+        readAsync();
+}
+
+bool BlobResourceHandleBase::consumeData(std::span<const uint8_t> data)
+{
+    ASSERT(async());
+
+    m_totalRemainingSize -= data.size();
+
+    // Notify the client.
+    if (!data.empty()) {
+        if (!didReceiveData(data))
+            return false;
+    }
+
+    if (m_isFileOpen) {
+        // When the current item is a file item, the reading is completed only if bytesRead is 0.
+        if (data.empty()) {
+            closeFileIfOpen();
+
+            // Move to the next item.
+            ++m_readItemCount;
+        }
+    } else {
+        // Otherwise, we read the current text item as a whole and move to the next item.
+        ++m_readItemCount;
+    }
+
+    return true;
+}
+
+void BlobResourceHandleBase::dispatchDidReceiveResponse()
+{
+    ASSERT(isMainThread());
+
+    if (shouldAbortDispatchDidReceiveResponse())
+        return;
+
+    ResourceResponse response(URL { firstRequest().url() }, extractMIMETypeFromMediaType(m_blobData->contentType()), m_totalRemainingSize, String());
+    response.setHTTPStatusCode(m_isRangeRequest ? httpPartialContent : httpOK);
+    response.setHTTPStatusText(m_isRangeRequest ? httpPartialContentText : httpOKText);
+
+    response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
+    response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toString());
+    response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
+    addPolicyContainerHeaders(response, m_blobData->policyContainer());
+
+    if (m_isRangeRequest)
+        response.setHTTPHeaderField(HTTPHeaderName::ContentRange, ParsedContentRange(*m_range->start, *m_range->end, m_totalSize).headerValue());
+
+    // FIXME: If a resource identified with a blob: URL is a File object, user agents must use that file's name attribute,
+    // as if the response had a Content-Disposition header with the filename parameter set to the File's name attribute.
+    // Notably, this will affect a name suggested in "File Save As".
+
+    didReceiveResponse(WTFMove(response));
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.h
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/BlobData.h>
+#include <WebCore/FileStreamClient.h>
+#include <WebCore/HTTPParsers.h>
+#include <wtf/Forward.h>
+#include <wtf/Variant.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class AsyncFileStream;
+class BlobDataItem;
+class FileStream;
+class ResourceRequest;
+
+class BlobResourceHandleBase : public FileStreamClient {
+public:
+    enum class Error {
+        NoError = 0,
+        NotFoundError = 1,
+        SecurityError = 2,
+        RangeError = 3,
+        NotReadableError = 4,
+        MethodNotAllowed = 5
+    };
+
+protected:
+    WEBCORE_EXPORT BlobResourceHandleBase(bool async = true, RefPtr<BlobData>&& = nullptr);
+    WEBCORE_EXPORT virtual ~BlobResourceHandleBase();
+
+    WEBCORE_EXPORT void start();
+    WEBCORE_EXPORT void readAsync();
+    WEBCORE_EXPORT void closeFileIfOpen();
+    bool isFileOpen() const { return m_isFileOpen; }
+    void setIsFileOpen(bool isOpen) { m_isFileOpen = isOpen; }
+    bool async() const { return std::holds_alternative<std::unique_ptr<AsyncFileStream>>(m_stream); }
+    uint64_t totalSize() { return m_totalSize; }
+    uint64_t totalRemainingSize() const { return m_totalRemainingSize; }
+    uint64_t currentItemReadSize() const { return m_currentItemReadSize; }
+    void setCurrentItemReadSize(uint64_t size) { m_currentItemReadSize = size; }
+    void decrementTotalRemainingSizeBy(uint64_t value) { m_totalRemainingSize -= value; }
+    uint64_t readItemCount() const { return m_readItemCount; }
+    void incrementReadItemCount() { ++m_readItemCount; }
+    uint64_t lengthOfItemBeingRead() const { return m_itemLengthList[m_readItemCount]; }
+    WEBCORE_EXPORT void clearAsyncStream();
+    WEBCORE_EXPORT BlobData* blobData() const;
+    FileStream* syncStream() const;
+    AsyncFileStream* asyncStream() const;
+    Vector<uint8_t>& buffer() { return m_buffer; }
+    const Vector<uint8_t>& buffer() const { return m_buffer; }
+
+private:
+    void getSizeForNext();
+    std::optional<Error> seek();
+    std::optional<Error> adjustAndValidateRangeBounds();
+    bool consumeData(std::span<const uint8_t>);
+    bool readDataAsync(const BlobDataItem&);
+    void readFileAsync(const BlobDataItem&);
+    void dispatchDidReceiveResponse();
+    void doStart();
+
+    virtual void didReceiveResponse(ResourceResponse&&) = 0;
+    virtual void didFail(Error) = 0;
+    virtual bool didReceiveData(std::span<const uint8_t>) = 0;
+    virtual void didFinish() = 0;
+    virtual bool erroredOrAborted() const = 0;
+    virtual bool shouldAbortDispatchDidReceiveResponse() { return false; }
+    virtual const ResourceRequest& firstRequest() const = 0;
+    virtual void clearStream() { }
+
+    // FileStreamClient methods.
+    WEBCORE_EXPORT void didOpen(bool) final;
+    WEBCORE_EXPORT void didGetSize(long long) final;
+    WEBCORE_EXPORT void didRead(int) final;
+
+    RefPtr<BlobData> m_blobData;
+    // For Async or Sync loading.
+    Variant<std::unique_ptr<AsyncFileStream>, std::unique_ptr<FileStream>> m_stream;
+    std::optional<HTTPRange> m_range;
+    Vector<uint8_t> m_buffer;
+    Vector<uint64_t> m_itemLengthList;
+    uint64_t m_totalSize { 0 };
+    uint64_t m_totalRemainingSize { 0 };
+    uint64_t m_currentItemReadSize { 0 };
+    unsigned m_readItemCount { 0 };
+    unsigned m_sizeItemCount { 0 };
+    bool m_isFileOpen { false };
+    bool m_isRangeRequest { false };
+};
+
+} // WebCore

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
@@ -33,7 +33,7 @@
 #pragma once
 
 #include "NetworkDataTask.h"
-#include <WebCore/BlobResourceHandle.h>
+#include <WebCore/BlobResourceHandleBase.h>
 #include <WebCore/FileStreamClient.h>
 #include <WebCore/HTTPParsers.h>
 #include <wtf/FileHandle.h>


### PR DESCRIPTION
#### 36f3d1d9f6d61b9a9e603303537200698486fd72
<pre>
Move BlobResourceHandleBase class to its own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=301156">https://bugs.webkit.org/show_bug.cgi?id=301156</a>

Reviewed by Darin Adler.

Move BlobResourceHandleBase class to its own file for clarity. No behavior change.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandleBase::BlobResourceHandleBase): Deleted.
(WebCore::BlobResourceHandleBase::adjustAndValidateRangeBounds): Deleted.
(WebCore::BlobResourceHandleBase::closeFileIfOpen): Deleted.
(WebCore::BlobResourceHandleBase::clearAsyncStream): Deleted.
(WebCore::BlobResourceHandleBase::blobData const): Deleted.
(WebCore::BlobResourceHandleBase::syncStream const): Deleted.
(WebCore::BlobResourceHandleBase::asyncStream const): Deleted.
(WebCore::BlobResourceHandleBase::start): Deleted.
(WebCore::BlobResourceHandleBase::doStart): Deleted.
(WebCore::BlobResourceHandleBase::getSizeForNext): Deleted.
(WebCore::BlobResourceHandleBase::didGetSize): Deleted.
(WebCore::BlobResourceHandleBase::seek): Deleted.
(WebCore::BlobResourceHandleBase::readAsync): Deleted.
(WebCore::BlobResourceHandleBase::readDataAsync): Deleted.
(WebCore::BlobResourceHandleBase::readFileAsync): Deleted.
(WebCore::BlobResourceHandleBase::didOpen): Deleted.
(WebCore::BlobResourceHandleBase::didRead): Deleted.
(WebCore::BlobResourceHandleBase::consumeData): Deleted.
(WebCore::BlobResourceHandleBase::dispatchDidReceiveResponse): Deleted.
* Source/WebCore/platform/network/BlobResourceHandle.h:
(WebCore::BlobResourceHandleBase::isFileOpen const): Deleted.
(WebCore::BlobResourceHandleBase::setIsFileOpen): Deleted.
(WebCore::BlobResourceHandleBase::async const): Deleted.
(WebCore::BlobResourceHandleBase::totalSize): Deleted.
(WebCore::BlobResourceHandleBase::totalRemainingSize const): Deleted.
(WebCore::BlobResourceHandleBase::currentItemReadSize const): Deleted.
(WebCore::BlobResourceHandleBase::setCurrentItemReadSize): Deleted.
(WebCore::BlobResourceHandleBase::decrementTotalRemainingSizeBy): Deleted.
(WebCore::BlobResourceHandleBase::readItemCount const): Deleted.
(WebCore::BlobResourceHandleBase::incrementReadItemCount): Deleted.
(WebCore::BlobResourceHandleBase::lengthOfItemBeingRead const): Deleted.
(WebCore::BlobResourceHandleBase::buffer): Deleted.
(WebCore::BlobResourceHandleBase::buffer const): Deleted.
(WebCore::BlobResourceHandleBase::shouldAbortDispatchDidReceiveResponse): Deleted.
(WebCore::BlobResourceHandleBase::clearStream): Deleted.
* Source/WebCore/platform/network/BlobResourceHandleBase.cpp: Copied from Source/WebCore/platform/network/BlobResourceHandle.cpp.
(WebCore::BlobResourceHandleBase::BlobResourceHandleBase):
(WebCore::BlobResourceHandleBase::adjustAndValidateRangeBounds):
(WebCore::BlobResourceHandleBase::closeFileIfOpen):
(WebCore::BlobResourceHandleBase::clearAsyncStream):
(WebCore::BlobResourceHandleBase::blobData const):
(WebCore::BlobResourceHandleBase::syncStream const):
(WebCore::BlobResourceHandleBase::asyncStream const):
(WebCore::BlobResourceHandleBase::start):
(WebCore::BlobResourceHandleBase::doStart):
(WebCore::BlobResourceHandleBase::getSizeForNext):
(WebCore::BlobResourceHandleBase::didGetSize):
(WebCore::BlobResourceHandleBase::seek):
(WebCore::BlobResourceHandleBase::readAsync):
(WebCore::BlobResourceHandleBase::readDataAsync):
(WebCore::BlobResourceHandleBase::readFileAsync):
(WebCore::BlobResourceHandleBase::didOpen):
(WebCore::BlobResourceHandleBase::didRead):
(WebCore::BlobResourceHandleBase::consumeData):
(WebCore::BlobResourceHandleBase::dispatchDidReceiveResponse):
* Source/WebCore/platform/network/BlobResourceHandleBase.h: Copied from Source/WebCore/platform/network/BlobResourceHandle.h.
(WebCore::BlobResourceHandleBase::isFileOpen const):
(WebCore::BlobResourceHandleBase::setIsFileOpen):
(WebCore::BlobResourceHandleBase::async const):
(WebCore::BlobResourceHandleBase::totalSize):
(WebCore::BlobResourceHandleBase::totalRemainingSize const):
(WebCore::BlobResourceHandleBase::currentItemReadSize const):
(WebCore::BlobResourceHandleBase::setCurrentItemReadSize):
(WebCore::BlobResourceHandleBase::decrementTotalRemainingSizeBy):
(WebCore::BlobResourceHandleBase::readItemCount const):
(WebCore::BlobResourceHandleBase::incrementReadItemCount):
(WebCore::BlobResourceHandleBase::lengthOfItemBeingRead const):
(WebCore::BlobResourceHandleBase::buffer):
(WebCore::BlobResourceHandleBase::buffer const):
(WebCore::BlobResourceHandleBase::shouldAbortDispatchDidReceiveResponse):
(WebCore::BlobResourceHandleBase::clearStream):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h:

Canonical link: <a href="https://commits.webkit.org/301868@main">https://commits.webkit.org/301868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bc6acc2da4dfbd5034d243d6d088a4b4751acc0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134329 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78820 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96856 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4fbe030e-1abc-49ff-b209-d2864d8015ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77353 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bee01763-e24a-4b63-9a61-1be66145c42b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77709 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136812 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105373 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105058 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26791 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50580 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51487 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53861 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59948 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53093 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54854 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->