### PR TITLE
[Model element] Support `autoplay` in GPU process model element

### DIFF
--- a/Source/WebCore/Modules/Model/Implementation/DDMeshImpl.cpp
+++ b/Source/WebCore/Modules/Model/Implementation/DDMeshImpl.cpp
@@ -465,6 +465,10 @@ void DDMeshImpl::setCameraDistance(float distance)
     wgpuDDMeshSetCameraDistance(m_backing.get(), distance);
 }
 
+void DDMeshImpl::play(bool play)
+{
+    wgpuDDMeshPlay(m_backing.get(), play);
+}
 #endif
 
 Vector<MachSendRight> DDMeshImpl::ioSurfaceHandles()

--- a/Source/WebCore/Modules/Model/Implementation/DDMeshImpl.h
+++ b/Source/WebCore/Modules/Model/Implementation/DDMeshImpl.h
@@ -81,6 +81,7 @@ private:
     void setEntityTransform(const DDFloat4x4&) final;
     std::optional<DDFloat4x4> entityTransform() const final;
     void setCameraDistance(float) final;
+    void play(bool) final;
 
     void render() final;
 #endif

--- a/Source/WebCore/Modules/Model/InternalAPI/DDMesh.h
+++ b/Source/WebCore/Modules/Model/InternalAPI/DDMesh.h
@@ -77,6 +77,7 @@ public:
     virtual void setScale(float) { }
     virtual void setCameraDistance(float) = 0;
     virtual void setStageMode(WebCore::StageModeOperation) { }
+    virtual void play(bool) = 0;
 
     virtual void render() = 0;
 #if PLATFORM(COCOA)

--- a/Source/WebCore/Modules/model-element/DDModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/DDModelPlayer.h
@@ -89,6 +89,12 @@ private:
 
     const MachSendRight* displayBuffer() const;
     GraphicsLayerContentsDisplayDelegate* contentsDisplayDelegate();
+
+    void setAutoplay(bool) override;
+    void setPaused(bool, CompletionHandler<void(bool succeeded)>&&) override;
+    bool paused() const override;
+    void play(bool);
+
     void ensureOnMainThreadWithProtectedThis(Function<void(Ref<DDModelPlayer>)>&& task);
     void setStageMode(WebCore::StageModeOperation) final;
     void notifyEntityTransformUpdated();
@@ -105,6 +111,12 @@ private:
     StageModeOperation m_stageMode { StageModeOperation::None };
     float m_currentScale { 1.f };
     bool m_didFinishLoading { false };
+    enum class PauseState {
+        None,
+        Playing,
+        Paused
+    };
+    PauseState m_pauseState { PauseState::None };
 };
 
 }

--- a/Source/WebCore/Modules/model-element/DDModelPlayer.mm
+++ b/Source/WebCore/Modules/model-element/DDModelPlayer.mm
@@ -367,6 +367,34 @@ bool DDModelPlayer::supportsTransform(TransformationMatrix transformationMatrix)
     return false;
 }
 
+void DDModelPlayer::play(bool playing)
+{
+    if (RefPtr model = m_currentModel) {
+        model->play(playing);
+        m_pauseState = playing ? PauseState::Playing : PauseState::Paused;
+    }
+}
+
+void DDModelPlayer::setAutoplay(bool autoplay)
+{
+    if (m_pauseState == PauseState::Paused)
+        return;
+
+    play(autoplay);
+    m_pauseState = autoplay ? PauseState::Playing : PauseState::Paused;
+}
+
+void DDModelPlayer::setPaused(bool paused, CompletionHandler<void(bool succeeded)>&& completion)
+{
+    play(!paused);
+    completion(!!m_currentModel);
+}
+
+bool DDModelPlayer::paused() const
+{
+    return m_pauseState != PauseState::Playing;
+}
+
 std::optional<TransformationMatrix> DDModelPlayer::entityTransform() const
 {
     if (RefPtr model = m_currentModel) {
@@ -391,8 +419,10 @@ void DDModelPlayer::setStageMode(StageModeOperation stageMode)
 
 void DDModelPlayer::setEntityTransform(TransformationMatrix matrix)
 {
-    if (RefPtr model = m_currentModel)
+    if (RefPtr model = m_currentModel) {
         model->setEntityTransform(static_cast<simd_float4x4>(matrix));
+        notifyEntityTransformUpdated();
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebGPU/WebGPU/DDMesh.h
+++ b/Source/WebGPU/WebGPU/DDMesh.h
@@ -63,6 +63,7 @@ public:
     void updateTexture(WGPUDDUpdateTextureDescriptor*);
     void addMaterial(WGPUDDMaterialDescriptor*);
     void updateMaterial(WGPUDDUpdateMaterialDescriptor*);
+    void play(bool);
 
     id<MTLTexture> texture() const;
     void render() const;

--- a/Source/WebGPU/WebGPU/DDMesh.mm
+++ b/Source/WebGPU/WebGPU/DDMesh.mm
@@ -574,6 +574,15 @@ void DDMesh::setCameraDistance(float distance)
 #endif
 }
 
+void DDMesh::play(bool play)
+{
+#if ENABLE(WEBGPU_SWIFT)
+    [m_ddReceiver setPlaying:play];
+#else
+    UNUSED_PARAM(play);
+#endif
+}
+
 }
 
 #pragma mark WGPU Stubs
@@ -631,4 +640,9 @@ WGPU_EXPORT void wgpuDDMaterialAdd(WGPUDDMesh mesh, WGPUDDMaterialDescriptor* de
 WGPU_EXPORT void wgpuDDMeshSetCameraDistance(WGPUDDMesh mesh, float distance)
 {
     WebGPU::protectedFromAPI(mesh)->setCameraDistance(distance);
+}
+
+WGPU_EXPORT void wgpuDDMeshPlay(WGPUDDMesh mesh, bool play)
+{
+    WebGPU::protectedFromAPI(mesh)->play(play);
 }

--- a/Source/WebGPU/WebGPU/DDModelTypes.h
+++ b/Source/WebGPU/WebGPU/DDModelTypes.h
@@ -396,6 +396,7 @@ enum class DDBridgeNodeType {
 - (void)updateMaterial:(DDBridgeUpdateMaterialRequest *)descriptor identifier:(NSUUID*)identifier;
 - (void)setTransform:(simd_float4x4)transform;
 - (void)setCameraDistance:(float)distance;
+- (void)setPlaying:(BOOL)play;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithDevice:(id<MTLDevice>)device NS_DESIGNATED_INITIALIZER;

--- a/Source/WebGPU/WebGPU/UsdModelRenderer.swift
+++ b/Source/WebGPU/WebGPU/UsdModelRenderer.swift
@@ -1558,10 +1558,17 @@ extension DDBridgeReceiver {
         }
     }
 
-    @objc(setCameraDistance:)
+    @objc
     func setCameraDistance(_ distance: Float) {
         #if canImport(DirectDrawBackend)
         context.setCameraDistance(distance)
+        #endif
+    }
+
+    @objc
+    func setPlaying(_ play: Bool) {
+        #if canImport(DirectDrawBackend)
+        context.setEnableModelRotation(play)
         #endif
     }
 }

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -320,6 +320,7 @@ WGPU_EXPORT void wgpuDDMaterialUpdate(WGPUDDMesh mesh, WGPUDDUpdateMaterialDescr
 WGPU_EXPORT void wgpuDDMeshRender(WGPUDDMesh mesh);
 WGPU_EXPORT void wgpuDDMeshSetTransform(WGPUDDMesh mesh, const simd_float4x4& transform);
 WGPU_EXPORT void wgpuDDMeshSetCameraDistance(WGPUDDMesh mesh, float distance);
+WGPU_EXPORT void wgpuDDMeshPlay(WGPUDDMesh mesh, bool autoplay);
 
 WGPU_EXPORT void wgpuRenderBundleSetLabel(WGPURenderBundle renderBundle, char const * label);
 

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.cpp
@@ -129,6 +129,11 @@ void RemoteDDMesh::setCameraDistance(float distance)
     m_backing->setCameraDistance(distance);
 }
 
+void RemoteDDMesh::play(bool playing)
+{
+    m_backing->play(playing);
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.h
@@ -99,6 +99,7 @@ private:
     void updateMaterial(const WebCore::DDModel::DDUpdateMaterialDescriptor&);
     void updateTransform(const WebCore::DDModel::DDFloat4x4& transform);
     void setCameraDistance(float);
+    void play(bool);
 
     void render();
 

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.messages.in
@@ -40,5 +40,6 @@ messages -> RemoteDDMesh Stream {
     void UpdateMaterial(WebCore::DDModel::DDUpdateMaterialDescriptor descriptor)
     void UpdateTransform(WebCore::DDModel::DDFloat4x4 transform)
     void SetCameraDistance(float distance)
+    void Play(bool playing)
 }
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.cpp
@@ -240,6 +240,14 @@ void RemoteDDMeshProxy::setEntityTransform(const WebCore::DDModel::DDFloat4x4& t
 #endif
 }
 
+void RemoteDDMeshProxy::play(bool playing)
+{
+#if ENABLE(GPU_PROCESS_MODEL)
+    auto sendResult = send(Messages::RemoteDDMesh::Play(playing));
+    UNUSED_PARAM(sendResult);
+#endif
+}
+
 std::optional<WebCore::DDModel::DDFloat4x4> RemoteDDMeshProxy::entityTransform() const
 {
     return m_transform;
@@ -311,7 +319,7 @@ void RemoteDDMeshProxy::setScale(float scale)
 void RemoteDDMeshProxy::setStageMode(WebCore::StageModeOperation stageMode)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
-    if (m_stageMode == stageMode || stageMode == WebCore::StageModeOperation::None)
+    if (stageMode == WebCore::StageModeOperation::None)
         return;
 
     m_stageMode = stageMode;

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h
@@ -83,6 +83,7 @@ private:
 #if PLATFORM(COCOA)
     std::pair<simd_float4, simd_float4> getCenterAndExtents() const final;
 #endif
+    void play(bool) final;
 
     void render() final;
     void setLabelInternal(const String&) final;


### PR DESCRIPTION
#### e77e543069bd20a7fd6585ea9c4792c232715b20
<pre>
[Model element] Support `autoplay` in GPU process model element
<a href="https://bugs.webkit.org/show_bug.cgi?id=299473">https://bugs.webkit.org/show_bug.cgi?id=299473</a>
<a href="https://rdar.apple.com/161268071">rdar://161268071</a>

Reviewed by Sam Weinig.

Add autoplay / pause / play support.

Test: model-element/model-element-animations-playback.html passes all cases
except the one which checks if the USD has an animation as we currently
don&apos;t have the framework support to detect that.

* Source/WebCore/Modules/Model/Implementation/DDMeshImpl.cpp:
(WebCore::DDModel::DDMeshImpl::play):
* Source/WebCore/Modules/Model/Implementation/DDMeshImpl.h:
* Source/WebCore/Modules/Model/InternalAPI/DDMesh.h:
* Source/WebCore/Modules/model-element/DDModelPlayer.h:
* Source/WebCore/Modules/model-element/DDModelPlayer.mm:
(WebCore::DDModelPlayer::play):
(WebCore::DDModelPlayer::setAutoplay):
(WebCore::DDModelPlayer::setPaused):
(WebCore::DDModelPlayer::paused const):
* Source/WebGPU/WebGPU/DDMesh.h:
* Source/WebGPU/WebGPU/DDMesh.mm:
(WebGPU::DDMesh::play):
(wgpuDDMeshPlay):
* Source/WebGPU/WebGPU/DDModelTypes.h:
* Source/WebGPU/WebGPU/UsdModelRenderer.swift:
(DDBridgeReceiver.setPlaying(_:)):
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.cpp:
(WebKit::RemoteDDMesh::play):
* Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.cpp:
(WebKit::DDModel::RemoteDDMeshProxy::play):
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h:

Canonical link: <a href="https://commits.webkit.org/302510@main">https://commits.webkit.org/302510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06d70cdf72d29f1b8352bea72e24732ae8292e95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136714 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80734 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5fe50c30-89a2-4667-8f3f-2c10c1e6279c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98503 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66401 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/739d7add-d598-40e7-af6f-4084684757c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132284 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115845 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79153 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/59b68caf-8535-40b8-bbc2-7503b4c6c032) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33974 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79991 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139187 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107029 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112189 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106872 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27208 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30709 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54020 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1455 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64818 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1272 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1308 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1377 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->