### PR TITLE
Address remaining safer CPP warnings in WebKit/Shared

### DIFF
--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -338,10 +338,10 @@ inline void swap(String& a, String& b) { a.swap(b); }
 #ifdef __OBJC__
 
 // Used in a small number of places where the long standing behavior has been "nil if empty".
-NSString * nsStringNilIfEmpty(const String&);
+RetainPtr<NSString> nsStringNilIfEmpty(const String&);
 
 // Used in a small number of places where null strings should be converted to nil but empty strings should be maintained.
-NSString * nsStringNilIfNull(const String&);
+RetainPtr<NSString> nsStringNilIfNull(const String&);
 
 #endif
 
@@ -515,18 +515,18 @@ inline RetainPtr<NSString> String::createNSString() const
     return @"";
 }
 
-inline NSString * nsStringNilIfEmpty(const String& string)
+inline RetainPtr<NSString> nsStringNilIfEmpty(const String& string)
 {
     if (string.isEmpty())
         return nil;
-    return *string.impl();
+    return string.impl()->createNSString();
 }
 
-inline NSString * nsStringNilIfNull(const String& string)
+inline RetainPtr<NSString> nsStringNilIfNull(const String& string)
 {
     if (string.isNull())
         return nil;
-    return *string.impl();
+    return string.impl()->createNSString();
 }
 
 #endif

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2152,7 +2152,7 @@ id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString 
             RefPtr axRemoteFrame = dynamicDowncast<AXRemoteFrame>(axObject);
             if (page && axRemoteFrame) {
                 auto clientCallback = [callback = makeBlockPtr(callback)] (String result) {
-                    callback(nsStringNilIfEmpty(result));
+                    callback(nsStringNilIfEmpty(result).get());
                 };
 
                 page->chrome().client().resolveAccessibilityHitTestForTesting(*axRemoteFrame->frameID(), IntPoint(point), WTFMove(clientCallback));

--- a/Source/WebCore/platform/cocoa/DragImageCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragImageCocoa.mm
@@ -188,7 +188,7 @@ struct LinkImageLayout {
 
 LinkImageLayout::LinkImageLayout(URL& url, const String& titleString)
 {
-    NSString *title = nsStringNilIfEmpty(titleString);
+    RetainPtr title = nsStringNilIfEmpty(titleString);
     RetainPtr nsURL = url.createNSURL();
     NSString *absoluteURLString = [nsURL absoluteString];
 
@@ -269,7 +269,7 @@ LinkImageLayout::LinkImageLayout(URL& url, const String& titleString)
     };
 
     if (title)
-        buildLines(title, titleColor, titleFont, linkImageTitleMaximumLineCount, kCTLineBreakByTruncatingTail);
+        buildLines(title.get(), titleColor, titleFont, linkImageTitleMaximumLineCount, kCTLineBreakByTruncatingTail);
 
     if (title && domain)
         currentY += linkImageDomainBaselineToTitleBaseline - (domainFont.ascender - domainFont.descender);

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -316,6 +316,13 @@ PlatformPathPtr Path::platformPath() const
     return const_cast<Path&>(*this).ensurePlatformPathImpl().platformPath();
 }
 
+#if USE(CG)
+RetainPtr<CGPathRef> Path::protectedPlatformPath() const
+{
+    return platformPath();
+}
+#endif
+
 const Vector<PathSegment>* Path::segmentsIfExists() const
 {
     if (auto impl = asImpl()) {

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -91,6 +91,9 @@ public:
     bool isEmpty() const;
     bool definitelySingleLine() const;
     WEBCORE_EXPORT PlatformPathPtr platformPath() const;
+#if USE(CG)
+    WEBCORE_EXPORT RetainPtr<CGPathRef> protectedPlatformPath() const;
+#endif
 
     const PathSegment* singleSegmentIfExists() const { return asSingle(); }
     WEBCORE_EXPORT const Vector<PathSegment>* segmentsIfExists() const;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -1025,7 +1025,7 @@ void PlatformCALayerCocoa::setVideoGravity(MediaPlayerVideoGravity gravity)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     if ([m_layer respondsToSelector:@selector(setVideoGravity:)])
-        [(AVPlayerLayer *)m_layer setVideoGravity:convertMediaPlayerToAVLayerVideoGravity(gravity)];
+        [(AVPlayerLayer *)m_layer setVideoGravity:convertMediaPlayerToAVLayerVideoGravity(gravity).get()];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerEnumsCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerEnumsCocoa.h
@@ -31,7 +31,7 @@ OBJC_CLASS NSString;
 
 namespace WebCore {
 
-WEBCORE_EXPORT NSString *convertMediaPlayerToAVLayerVideoGravity(MediaPlayerVideoGravity);
+WEBCORE_EXPORT RetainPtr<NSString> convertMediaPlayerToAVLayerVideoGravity(MediaPlayerVideoGravity);
 WEBCORE_EXPORT MediaPlayerVideoGravity convertAVLayerToMediaPlayerVideoGravity(NSString *);
 
 }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerEnumsCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerEnumsCocoa.mm
@@ -42,7 +42,7 @@ MediaPlayerVideoGravity convertAVLayerToMediaPlayerVideoGravity(NSString *gravit
     return MediaPlayerVideoGravity::ResizeAspect;
 }
 
-NSString *convertMediaPlayerToAVLayerVideoGravity(MediaPlayerVideoGravity gravity)
+RetainPtr<NSString> convertMediaPlayerToAVLayerVideoGravity(MediaPlayerVideoGravity gravity)
 {
     switch (gravity) {
     case MediaPlayerVideoGravity::ResizeAspect:

--- a/Source/WebCore/platform/network/cf/ResourceError.h
+++ b/Source/WebCore/platform/network/cf/ResourceError.h
@@ -50,7 +50,9 @@ public:
     WEBCORE_EXPORT ResourceError(CFErrorRef error);
 
     WEBCORE_EXPORT CFErrorRef cfError() const;
+    WEBCORE_EXPORT RetainPtr<CFErrorRef> protectedCFError() const;
     WEBCORE_EXPORT CFErrorRef cfError(CFErrorRef) const;
+    WEBCORE_EXPORT RetainPtr<CFErrorRef> protectedCFError(CFErrorRef) const;
     WEBCORE_EXPORT operator CFErrorRef() const;
     WEBCORE_EXPORT ResourceError(NSError *);
     WEBCORE_EXPORT NSError *nsError() const;

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -521,7 +521,7 @@ static RetainPtr<NSHTTPCookie> parseDOMCookie(String cookieString, NSURL* cookie
     // cookiesWithResponseHeaderFields doesn't parse cookies without a value
     cookieString = cookieString.contains('=') ? cookieString : makeString(cookieString, '=');
 
-    return adjustScriptWrittenCookie([NSHTTPCookie _cookieForSetCookieString:cookieString.createNSString().get() forURL:cookieURL partition:RetainPtr { nsStringNilIfEmpty(partition) }.get()], cappedLifetime);
+    return adjustScriptWrittenCookie([NSHTTPCookie _cookieForSetCookieString:cookieString.createNSString().get() forURL:cookieURL partition:nsStringNilIfEmpty(partition).get()], cappedLifetime);
 }
 
 void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ApplyTrackingPrevention applyTrackingPrevention, RequiresScriptTrackingPrivacy requiresScriptTrackingPrivacy, const String& cookieString, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker isKnownCrossSiteTracker) const
@@ -548,7 +548,7 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
     if (!cookie)
         return;
 
-    setHTTPCookiesForURL(cookieStorage().get(), @[cookie.get()], cookieURL.get(), firstParty.createNSURL().get(), RetainPtr { nsStringNilIfEmpty(partitionKey) }.get(), sameSiteInfo, thirdPartyCookieBlockingDecision);
+    setHTTPCookiesForURL(cookieStorage().get(), @[cookie.get()], cookieURL.get(), firstParty.createNSURL().get(), nsStringNilIfEmpty(partitionKey).get(), sameSiteInfo, thirdPartyCookieBlockingDecision);
 
     END_BLOCK_OBJC_EXCEPTIONS
 }
@@ -569,12 +569,12 @@ bool NetworkStorageSession::setCookieFromDOM(const URL& firstParty, const SameSi
         return false;
 
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES) && defined(CFN_COOKIE_ACCEPTS_POLICY_PARTITION) && CFN_COOKIE_ACCEPTS_POLICY_PARTITION
-    NSString *partition = isOptInCookiePartitioningEnabled() ? nsStringNilIfEmpty(cookiePartitionIdentifier(firstParty)) : nil;
+    RetainPtr partition = isOptInCookiePartitioningEnabled() ? nsStringNilIfEmpty(cookiePartitionIdentifier(firstParty)) : nil;
 #else
-    NSString *partition = nil;
+    RetainPtr<NSString> partition;
 #endif
 
-    setHTTPCookiesForURL(cookieStorage().get(), @[ nshttpCookie.get() ], url.createNSURL().get(), firstParty.createNSURL().get(), partition, sameSiteInfo, thirdPartyCookieBlockingDecision);
+    setHTTPCookiesForURL(cookieStorage().get(), @[ nshttpCookie.get() ], url.createNSURL().get(), firstParty.createNSURL().get(), partition.get(), sameSiteInfo, thirdPartyCookieBlockingDecision);
     return true;
 
     END_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
@@ -149,7 +149,7 @@ auto ResourceError::ipcData() const -> std::optional<IPCData>
 }
 
 ResourceError::ResourceError(CFErrorRef cfError)
-    : ResourceError { (__bridge NSError *)cfError }
+    : ResourceError { bridge_cast(cfError) }
 {
 }
 
@@ -217,7 +217,7 @@ void ResourceError::mapPlatformError()
     auto domain = [m_platformError domain];
     auto errorCode = [m_platformError code];
 
-    if ([domain isEqualToString:NSURLErrorDomain] || [domain isEqualToString:(__bridge NSString *)kCFErrorDomainCFNetwork])
+    if ([domain isEqualToString:NSURLErrorDomain] || [domain isEqualToString:bridge_cast(kCFErrorDomainCFNetwork)])
         setType((errorCode == NSURLErrorTimedOut) ? Type::Timeout : (errorCode == NSURLErrorCancelled) ? Type::Cancellation : Type::General);
     else
         setType(Type::General);
@@ -292,12 +292,22 @@ ResourceError::operator NSError *() const
 
 CFErrorRef ResourceError::cfError() const
 {
-    return (__bridge CFErrorRef)nsError();
+    return bridge_cast(nsError());
+}
+
+RetainPtr<CFErrorRef> ResourceError::protectedCFError() const
+{
+    return cfError();
 }
 
 CFErrorRef ResourceError::cfError(CFErrorRef underlyingError) const
 {
-    return (__bridge CFErrorRef)nsError((__bridge NSError *)underlyingError);
+    return bridge_cast(nsError(bridge_cast(underlyingError)));
+}
+
+RetainPtr<CFErrorRef> ResourceError::protectedCFError(CFErrorRef underlyingError) const
+{
+    return cfError(underlyingError);
 }
 
 ResourceError::operator CFErrorRef() const

--- a/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
+++ b/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
@@ -130,7 +130,7 @@ inline bool areBuffersEqual(const WebGPU::Buffer& a, const WebGPU::Buffer& b)
 
 inline NSString * convertWTFStringToNSString(const String& input)
 {
-    return nsStringNilIfEmpty(input);
+    return nsStringNilIfEmpty(input).autorelease();
 }
 
 inline ThreadSafeWeakPtr<WebGPU::CommandBuffer> commandBufferThreadSafeWeakPtr(const WebGPU::CommandBuffer* input)

--- a/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
+++ b/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
@@ -124,14 +124,14 @@
 {
     if (!_presenter)
         return nil;
-    return nsStringNilIfEmpty(_presenter->sceneIdentifier());
+    return nsStringNilIfEmpty(_presenter->sceneIdentifier()).autorelease();
 }
 
 - (NSString *)presentationSceneBundleIdentifierForPaymentAuthorizationController:(PKPaymentAuthorizationController *)controller
 {
     if (!_presenter)
         return applicationBundleIdentifier().createNSString().autorelease();
-    return nsStringNilIfEmpty(_presenter->bundleIdentifier());
+    return nsStringNilIfEmpty(_presenter->bundleIdentifier()).autorelease();
 }
 #endif
 

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,6 +1,4 @@
 AutomationProtocolObjects.h
-Shared/API/c/cf/WKStringCF.mm
-Shared/API/c/cf/WKURLCF.mm
 WebDriverBidiProtocolObjects.h
 WebProcess/GPU/graphics/Model/ModelDowncastConvertToBackingContext.cpp
 WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp

--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,4 +1,3 @@
-Shared/API/Cocoa/_WKRemoteObjectInterface.h
 [ Mac ] UIProcess/API/Cocoa/WKView.h
 [ iOS ] Platform/ios/PaymentAuthorizationController.mm
 [ iOS ] UIProcess/API/Cocoa/WKPreviewActionItem.h

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,17 +1,3 @@
-Shared/API/Cocoa/WKRemoteObjectCoder.mm
-Shared/API/Cocoa/_WKRemoteObjectInterface.mm
-Shared/API/c/mac/WKURLRequestNS.mm
-Shared/API/c/mac/WKURLResponseNS.mm
-Shared/Cocoa/ArgumentCodersCocoa.mm
-Shared/Cocoa/CoreIPCContacts.mm
-Shared/Cocoa/CoreIPCPassKit.mm
-Shared/Cocoa/CoreIPCPersonNameComponents.mm
-Shared/Cocoa/RevealItem.mm
-Shared/Cocoa/WKNSError.mm
-Shared/Cocoa/WKNSURLRequest.mm
-Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
-Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
-Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
 WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -26,7 +12,6 @@ WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
 WebProcess/WebPage/WebPage.cpp
 WebProcess/cocoa/WebProcessCocoa.mm
-[ Mac ] Shared/mac/AuxiliaryProcessMac.mm
 [ Mac ] WebProcess/WebPage/mac/PageBannerMac.mm
 [ Mac ] WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 [ Mac ] WebProcess/WebPage/mac/WebPageMac.mm

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -458,7 +458,8 @@ static void encodeObject(WKRemoteObjectEncoder *encoder, id object)
     if (![object conformsToProtocol:@protocol(NSSecureCoding)] && ![object isKindOfClass:[NSInvocation class]])
         [NSException raise:NSInvalidArgumentException format:@"%@ does not conform to NSSecureCoding", object];
 
-    if (class_isMetaClass(object_getClass(object)))
+    // FIXME: This is a safer cpp false positive (rdar://163108778).
+    SUPPRESS_UNRETAINED_ARG if (class_isMetaClass(object_getClass(object)))
         [NSException raise:NSInvalidArgumentException format:@"Class objects may not be encoded"];
 
     RetainPtr<Class> objectClass = [object classForCoder];
@@ -466,8 +467,9 @@ static void encodeObject(WKRemoteObjectEncoder *encoder, id object)
         [NSException raise:NSInvalidArgumentException format:@"-classForCoder returned nil for %@", object];
 
     if (encoder->_objectsBeingEncoded.contains(object)) {
-        RELEASE_LOG_FAULT(IPC, "WKRemoteObjectCode::encodeObject: Object of type '%{private}s' contains a cycle", class_getName(object_getClass(object)));
-        [NSException raise:NSInvalidArgumentException format:@"Object of type '%s' contains a cycle", class_getName(object_getClass(object))];
+        // FIXME: This is a safer cpp false positive (rdar://163108778).
+        SUPPRESS_UNRETAINED_ARG RELEASE_LOG_FAULT(IPC, "WKRemoteObjectCode::encodeObject: Object of type '%{private}s' contains a cycle", class_getName(object_getClass(object)));
+        SUPPRESS_UNRETAINED_ARG [NSException raise:NSInvalidArgumentException format:@"Object of type '%s' contains a cycle", class_getName(object_getClass(object))];
         return;
     }
 

--- a/Source/WebKit/Shared/API/c/mac/WKURLRequestNS.mm
+++ b/Source/WebKit/Shared/API/c/mac/WKURLRequestNS.mm
@@ -39,5 +39,5 @@ WKURLRequestRef WKURLRequestCreateWithNSURLRequest(NSURLRequest *urlRequest)
 
 NSURLRequest *WKURLRequestCopyNSURLRequest(WKURLRequestRef urlRequest)
 {
-    return [WebKit::toImpl(urlRequest)->resourceRequest().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) copy];
+    return [WebKit::toImpl(urlRequest)->resourceRequest().protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) copy];
 }

--- a/Source/WebKit/Shared/API/c/mac/WKURLResponseNS.mm
+++ b/Source/WebKit/Shared/API/c/mac/WKURLResponseNS.mm
@@ -37,5 +37,5 @@ WKURLResponseRef WKURLResponseCreateWithNSURLResponse(NSURLResponse *urlResponse
 
 NSURLResponse *WKURLResponseCopyNSURLResponse(WKURLResponseRef urlResponse)
 {
-    return [WebKit::toImpl(urlResponse)->resourceResponse().nsURLResponse() copy];
+    return [WebKit::toImpl(urlResponse)->resourceResponse().protectedNSURLResponse() copy];
 }

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -383,36 +383,37 @@ NSType typeFromObject(id object)
     if ([object isKindOfClass:[NSURL class]])
         return NSType::URL;
 #if USE(PASSKIT)
-    if ([object isKindOfClass:getClass<PKPaymentMethod>()])
+    // No need to retain Class, it is immortal.
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<PKPaymentMethod>()])
         return NSType::PKPaymentMethod;
-    if ([object isKindOfClass:getClass<PKPaymentMerchantSession>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<PKPaymentMerchantSession>()])
         return NSType::PKPaymentMerchantSession;
-    if ([object isKindOfClass:getClass<PKPaymentSetupFeature>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<PKPaymentSetupFeature>()])
         return NSType::PKPaymentSetupFeature;
-    if ([object isKindOfClass:getClass<PKContact>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<PKContact>()])
         return NSType::PKContact;
-    if ([object isKindOfClass:getClass<PKSecureElementPass>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<PKSecureElementPass>()])
         return NSType::PKSecureElementPass;
-    if ([object isKindOfClass:getClass<PKPayment>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<PKPayment>()])
         return NSType::PKPayment;
-    if ([object isKindOfClass:getClass<PKPaymentToken>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<PKPaymentToken>()])
         return NSType::PKPaymentToken;
-    if ([object isKindOfClass:getClass<PKShippingMethod>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<PKShippingMethod>()])
         return NSType::PKShippingMethod;
-    if ([object isKindOfClass:getClass<PKDateComponentsRange>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<PKDateComponentsRange>()])
         return NSType::PKDateComponentsRange;
-    if ([object isKindOfClass:getClass<CNContact>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<CNContact>()])
         return NSType::CNContact;
-    if ([object isKindOfClass:getClass<CNPhoneNumber>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<CNPhoneNumber>()])
         return NSType::CNPhoneNumber;
-    if ([object isKindOfClass:getClass<CNPostalAddress>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<CNPostalAddress>()])
         return NSType::CNPostalAddress;
 #endif
 #if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
-    if ([object isKindOfClass:getClass<DDScannerResult>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<DDScannerResult>()])
         return NSType::DDScannerResult;
 #if PLATFORM(MAC)
-    if ([object isKindOfClass:getClass<WKDDActionContext>()])
+    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<WKDDActionContext>()])
         return NSType::WKDDActionContext;
 #endif
 #endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm
@@ -64,15 +64,15 @@ RetainPtr<id> CoreIPCCNPostalAddress::toID() const
 {
     RetainPtr<CNMutablePostalAddress> address = adoptNS([[PAL::getCNMutablePostalAddressClassSingleton() alloc] init]);
 
-    address.get().street = nsStringNilIfNull(m_street);
-    address.get().subLocality = nsStringNilIfNull(m_subLocality);
-    address.get().city = nsStringNilIfNull(m_city);
-    address.get().subAdministrativeArea = nsStringNilIfNull(m_subAdministrativeArea);
-    address.get().state = nsStringNilIfNull(m_state);
-    address.get().postalCode = nsStringNilIfNull(m_postalCode);
-    address.get().country = nsStringNilIfNull(m_country);
-    address.get().ISOCountryCode = nsStringNilIfNull(m_isoCountryCode);
-    address.get().formattedAddress = nsStringNilIfNull(m_formattedAddress);
+    address.get().street = nsStringNilIfNull(m_street).get();
+    address.get().subLocality = nsStringNilIfNull(m_subLocality).get();
+    address.get().city = nsStringNilIfNull(m_city).get();
+    address.get().subAdministrativeArea = nsStringNilIfNull(m_subAdministrativeArea).get();
+    address.get().state = nsStringNilIfNull(m_state).get();
+    address.get().postalCode = nsStringNilIfNull(m_postalCode).get();
+    address.get().country = nsStringNilIfNull(m_country).get();
+    address.get().ISOCountryCode = nsStringNilIfNull(m_isoCountryCode).get();
+    address.get().formattedAddress = nsStringNilIfNull(m_formattedAddress).get();
 
     return address;
 }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.mm
@@ -57,9 +57,9 @@ RetainPtr<id> CoreIPCPKContact::toID() const
     if (m_postalAddress)
         contact.get().postalAddress = (CNPostalAddress *)m_postalAddress->toID();
 
-    contact.get().emailAddress = nsStringNilIfNull(m_emailAddress);
+    contact.get().emailAddress = nsStringNilIfNull(m_emailAddress).get();
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    contact.get().supplementarySubLocality = nsStringNilIfNull(m_supplementarySublocality);
+    contact.get().supplementarySubLocality = nsStringNilIfNull(m_supplementarySublocality).get();
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     return contact;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.mm
@@ -49,11 +49,11 @@ CoreIPCPersonNameComponents::CoreIPCPersonNameComponents(NSPersonNameComponents 
 RetainPtr<id> CoreIPCPersonNameComponents::toID() const
 {
     auto components = adoptNS([NSPersonNameComponents new]);
-    components.get().namePrefix = nsStringNilIfNull(m_namePrefix);
-    components.get().givenName = nsStringNilIfNull(m_givenName);
-    components.get().middleName = nsStringNilIfNull(m_middleName);
-    components.get().familyName = nsStringNilIfNull(m_familyName);
-    components.get().nickname = nsStringNilIfNull(m_nickname);
+    components.get().namePrefix = nsStringNilIfNull(m_namePrefix).get();
+    components.get().givenName = nsStringNilIfNull(m_givenName).get();
+    components.get().middleName = nsStringNilIfNull(m_middleName).get();
+    components.get().familyName = nsStringNilIfNull(m_familyName).get();
+    components.get().nickname = nsStringNilIfNull(m_nickname).get();
     if (m_phoneticRepresentation)
         components.get().phoneticRepresentation = m_phoneticRepresentation->toID().get();
 

--- a/Source/WebKit/Shared/Cocoa/RevealItem.h
+++ b/Source/WebKit/Shared/Cocoa/RevealItem.h
@@ -60,6 +60,7 @@ public:
     NSRange highlightRange() const;
 
     RVItem *item() const;
+    RetainPtr<RVItem> protectedItem() const;
 
 private:
     String m_text;

--- a/Source/WebKit/Shared/Cocoa/RevealItem.mm
+++ b/Source/WebKit/Shared/Cocoa/RevealItem.mm
@@ -47,7 +47,7 @@ RevealItem::RevealItem(const String& text, RevealItemRange selectedRange)
 
 NSRange RevealItem::highlightRange() const
 {
-    return item().highlightRange;
+    return protectedItem().get().highlightRange;
 }
 
 RVItem *RevealItem::item() const
@@ -55,6 +55,11 @@ RVItem *RevealItem::item() const
     if (!m_item)
         m_item = adoptNS([PAL::allocRVItemInstance() initWithText:m_text.createNSString().get() selectedRange:NSMakeRange(m_selectedRange.location, m_selectedRange.length)]);
     return m_item.get();
+}
+
+RetainPtr<RVItem> RevealItem::protectedItem() const
+{
+    return item();
 }
 
 #endif // ENABLE(REVEAL)

--- a/Source/WebKit/Shared/Cocoa/WKNSError.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSError.mm
@@ -34,8 +34,8 @@
 {
     RefPtr underlyingError = downcast<API::Error>(&self._apiObject)->underlyingError();
     if (underlyingError)
-        return [(__bridge NSError *)downcast<API::Error>(&self._apiObject)->platformError().cfError((__bridge CFErrorRef)wrapper(*underlyingError)) copy];
-    return [(__bridge NSError *)downcast<API::Error>(&self._apiObject)->platformError().cfError() copy];
+        return [bridge_cast(downcast<API::Error>(&self._apiObject)->platformError().protectedCFError(bridge_cast(protectedWrapper(*underlyingError)).get())) copy];
+    return [bridge_cast(downcast<API::Error>(&self._apiObject)->platformError().protectedCFError()) copy];
 }
 
 #pragma mark NSCopying protocol implementation

--- a/Source/WebKit/Shared/Cocoa/WKNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSURLRequest.mm
@@ -32,7 +32,7 @@
 
 - (NSObject *)_web_createTarget
 {
-    return [downcast<API::URLRequest>(&self._apiObject)->resourceRequest().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) copy];
+    return [downcast<API::URLRequest>(&self._apiObject)->resourceRequest().protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) copy];
 }
 
 - (NSURL *)URL

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
@@ -55,7 +55,7 @@ static CompletionHandler<void(PCM::EncodedMessage&&)> replySender(PCM::MessageTy
     return [request = WTFMove(request)] (PCM::EncodedMessage&& message) {
         auto reply = adoptOSObject(xpc_dictionary_create_reply(request.get()));
         PCM::addVersionAndEncodedMessageToDictionary(WTFMove(message), reply.get());
-        xpc_connection_send_message(xpc_dictionary_get_remote_connection(request.get()), reply.get());
+        xpc_connection_send_message(OSObjectPtr { xpc_dictionary_get_remote_connection(request.get()) }.get(), reply.get());
     };
 }
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -243,7 +243,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
 
             auto reply = adoptOSObject(xpc_dictionary_create_reply(event));
             xpc_dictionary_set_string(reply.get(), "message-name", "process-finished-launching");
-            xpc_connection_send_message(xpc_dictionary_get_remote_connection(event), reply.get());
+            xpc_connection_send_message(OSObjectPtr { xpc_dictionary_get_remote_connection(event) }.get(), reply.get());
 
             int fd = xpc_dictionary_dup_fd(event, "stdout");
             if (fd != -1)

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -164,7 +164,7 @@ void AuxiliaryProcess::launchServicesCheckIn()
 #endif
 
     _LSSetApplicationLaunchServicesServerConnectionStatus(0, 0);
-    RetainPtr<CFDictionaryRef> unused = _LSApplicationCheckIn(kLSDefaultSessionID, CFBundleGetInfoDictionary(CFBundleGetMainBundle()));
+    RetainPtr<CFDictionaryRef> unused = _LSApplicationCheckIn(kLSDefaultSessionID, RetainPtr { CFBundleGetInfoDictionary(RetainPtr { CFBundleGetMainBundle() }.get()) }.get());
 }
 
 static OSStatus enableSandboxStyleFileQuarantine()
@@ -518,7 +518,7 @@ static bool tryApplyCachedSandbox(const SandboxInfo& info)
 }
 #endif // USE(CACHE_COMPILED_SANDBOX)
 
-static inline const NSBundle *webKit2Bundle()
+static inline const NSBundle *webKit2BundleSingleton()
 {
     const static NeverDestroyed<RetainPtr<NSBundle>> bundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
     return bundle.get().get();
@@ -528,7 +528,7 @@ static void getSandboxProfileOrProfilePath(const SandboxInitializationParameters
 {
     switch (parameters.mode()) {
     case SandboxInitializationParameters::ProfileSelectionMode::UseDefaultSandboxProfilePath:
-        profileOrProfilePath = [webKit2Bundle() pathForResource:[[NSBundle mainBundle] bundleIdentifier] ofType:@"sb"];
+        profileOrProfilePath = [webKit2BundleSingleton() pathForResource:[[NSBundle mainBundle] bundleIdentifier] ofType:@"sb"];
         isProfilePath = true;
         return;
     case SandboxInitializationParameters::ProfileSelectionMode::UseOverrideSandboxProfilePath:
@@ -693,9 +693,9 @@ static void populateSandboxInitializationParameters(SandboxInitializationParamet
     }
     setenv("TMPDIR", temporaryDirectory, 1);
 
-    String bundlePath = webKit2Bundle().bundlePath;
+    String bundlePath = webKit2BundleSingleton().bundlePath;
     if (!bundlePath.startsWith("/System/Library/Frameworks"_s))
-        bundlePath = webKit2Bundle().bundlePath.stringByDeletingLastPathComponent;
+        bundlePath = webKit2BundleSingleton().bundlePath.stringByDeletingLastPathComponent;
 
     sandboxParameters.addPathParameter("WEBKIT2_FRAMEWORK_DIR"_s, bundlePath.utf8().data());
     sandboxParameters.addConfDirectoryParameter("DARWIN_USER_TEMP_DIR"_s, _CS_DARWIN_USER_TEMP_DIR);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
@@ -205,39 +205,39 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
 
 - (NSLocale *)defaultLocale
 {
-    if (auto *defaultLocale = nsStringNilIfEmpty(self._protectedWebExtension->defaultLocale()))
-        return [NSLocale localeWithLocaleIdentifier:defaultLocale];
+    if (RetainPtr defaultLocale = nsStringNilIfEmpty(self._protectedWebExtension->defaultLocale()))
+        return [NSLocale localeWithLocaleIdentifier:defaultLocale.get()];
     return nil;
 }
 
 - (NSString *)displayName
 {
-    return nsStringNilIfEmpty(self._protectedWebExtension->displayName());
+    return nsStringNilIfEmpty(self._protectedWebExtension->displayName()).autorelease();
 }
 
 - (NSString *)displayShortName
 {
-    return nsStringNilIfEmpty(self._protectedWebExtension->displayShortName());
+    return nsStringNilIfEmpty(self._protectedWebExtension->displayShortName()).autorelease();
 }
 
 - (NSString *)displayVersion
 {
-    return nsStringNilIfEmpty(self._protectedWebExtension->displayVersion());
+    return nsStringNilIfEmpty(self._protectedWebExtension->displayVersion()).autorelease();
 }
 
 - (NSString *)displayDescription
 {
-    return nsStringNilIfEmpty(self._protectedWebExtension->displayDescription());
+    return nsStringNilIfEmpty(self._protectedWebExtension->displayDescription()).autorelease();
 }
 
 - (NSString *)displayActionLabel
 {
-    return nsStringNilIfEmpty(self._protectedWebExtension->displayActionLabel());
+    return nsStringNilIfEmpty(self._protectedWebExtension->displayActionLabel()).autorelease();
 }
 
 - (NSString *)version
 {
-    return nsStringNilIfEmpty(self._protectedWebExtension->version());
+    return nsStringNilIfEmpty(self._protectedWebExtension->version()).autorelease();
 }
 
 - (CocoaImage *)iconForSize:(CGSize)size

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -5508,7 +5508,7 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
 {
     THROW_IF_SUSPENDED;
     _page->getTextFragmentMatch([completionHandler = makeBlockPtr(completionHandler)](const String& textFragmentMatch) {
-        completionHandler(RetainPtr { nsStringNilIfNull(textFragmentMatch) }.get());
+        completionHandler(nsStringNilIfNull(textFragmentMatch).get());
     });
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -539,12 +539,12 @@ static NSString *defaultApplicationNameForUserAgent()
 
 - (NSString *)_applicationNameForDesktopUserAgent
 {
-    return nsStringNilIfNull(_pageConfiguration->applicationNameForUserAgent().value_or(String()));
+    return nsStringNilIfNull(_pageConfiguration->applicationNameForUserAgent().value_or(String())).autorelease();
 }
 
 - (NSString *)applicationNameForUserAgent
 {
-    return nsStringNilIfNull(_pageConfiguration->applicationNameForUserAgent().value_or(defaultApplicationNameForUserAgent()));
+    return nsStringNilIfNull(_pageConfiguration->applicationNameForUserAgent().value_or(defaultApplicationNameForUserAgent())).autorelease();
 }
 
 - (void)setApplicationNameForUserAgent:(NSString *)applicationNameForUserAgent
@@ -714,7 +714,7 @@ static NSString *defaultApplicationNameForUserAgent()
 
 - (NSString *)_groupIdentifier
 {
-    return nsStringNilIfNull(_pageConfiguration->groupIdentifier());
+    return nsStringNilIfNull(_pageConfiguration->groupIdentifier()).autorelease();
 }
 
 - (void)_setGroupIdentifier:(NSString *)groupIdentifier

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
@@ -60,7 +60,7 @@
 - (NSString *)qrCodePayloadString
 {
     auto& qrCodePayloadString = _contextMenuElementInfoMac->qrCodePayloadString();
-    return nsStringNilIfEmpty(qrCodePayloadString);
+    return nsStringNilIfEmpty(qrCodePayloadString).autorelease();
 }
 
 - (BOOL)hasEntireImage

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -5278,7 +5278,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 @implementation WKWebView(WKPrivateVision)
 - (NSString *)_defaultSTSLabel
 {
-    return nsStringNilIfNull(_page->defaultSpatialTrackingLabel());
+    return nsStringNilIfNull(_page->defaultSpatialTrackingLabel()).autorelease();
 }
 
 - (void)_setDefaultSTSLabel:(NSString *)defaultSTSLabel

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -16055,10 +16055,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 + (WKAutocorrectionContext *)autocorrectionContextWithWebContext:(const WebKit::WebAutocorrectionContext&)webCorrection
 {
     auto correction = adoptNS([[WKAutocorrectionContext alloc] init]);
-    [correction setContextBeforeSelection:nsStringNilIfEmpty(webCorrection.contextBefore)];
-    [correction setSelectedText:nsStringNilIfEmpty(webCorrection.selectedText)];
-    [correction setMarkedText:nsStringNilIfEmpty(webCorrection.markedText)];
-    [correction setContextAfterSelection:nsStringNilIfEmpty(webCorrection.contextAfter)];
+    [correction setContextBeforeSelection:nsStringNilIfEmpty(webCorrection.contextBefore).get()];
+    [correction setSelectedText:nsStringNilIfEmpty(webCorrection.selectedText).get()];
+    [correction setMarkedText:nsStringNilIfEmpty(webCorrection.markedText).get()];
+    [correction setContextAfterSelection:nsStringNilIfEmpty(webCorrection.contextAfter).get()];
     [correction setRangeInMarkedText:webCorrection.selectedRangeInMarkedText];
     return correction.autorelease();
 }

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
@@ -440,7 +440,7 @@ using namespace WebKit;
 
 - (NSString *)_toJSONString
 {
-    return nsStringNilIfEmpty(serializeJSObject(self.context.JSGlobalContextRef, self.JSValueRef, nullptr));
+    return nsStringNilIfEmpty(serializeJSObject(self.context.JSGlobalContextRef, self.JSValueRef, nullptr)).autorelease();
 }
 
 - (NSString *)_toSortedJSONString

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -170,19 +170,19 @@ void WKNotifyHistoryItemChanged()
 // FIXME: Need to decide if this class ever returns URLs and decide on the name of this method
 - (NSString *)URLString
 {
-    return nsStringNilIfEmpty(core(_private)->urlString());
+    return nsStringNilIfEmpty(core(_private)->urlString()).autorelease();
 }
 
 // The first URL we loaded to get to where this history item points.  Includes both client
 // and server redirects.
 - (NSString *)originalURLString
 {
-    return nsStringNilIfEmpty(core(_private)->originalURLString());
+    return nsStringNilIfEmpty(core(_private)->originalURLString()).autorelease();
 }
 
 - (NSString *)title
 {
-    return nsStringNilIfEmpty(core(_private)->title());
+    return nsStringNilIfEmpty(core(_private)->title()).autorelease();
 }
 
 - (void)setAlternateTitle:(NSString *)alternateTitle
@@ -192,7 +192,7 @@ void WKNotifyHistoryItemChanged()
 
 - (NSString *)alternateTitle
 {
-    return nsStringNilIfEmpty(core(_private)->alternateTitle());
+    return nsStringNilIfEmpty(core(_private)->alternateTitle()).autorelease();
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -441,7 +441,7 @@ WebHistoryItem *kit(HistoryItem* item)
 
 - (NSString *)target
 {
-    return nsStringNilIfEmpty(core(_private)->target());
+    return nsStringNilIfEmpty(core(_private)->target()).autorelease();
 }
 
 - (BOOL)isTargetItem
@@ -451,7 +451,7 @@ WebHistoryItem *kit(HistoryItem* item)
 
 - (NSString *)RSSFeedReferrer
 {
-    return nsStringNilIfEmpty(core(_private)->referrer());
+    return nsStringNilIfEmpty(core(_private)->referrer()).autorelease();
 }
 
 - (void)setRSSFeedReferrer:(NSString *)referrer

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
@@ -250,7 +250,7 @@ using JSC::Yarr::RegularExpression;
 
 - (NSString *)title
 {
-    return nsStringNilIfEmpty([_private->dataSource _documentLoader]->title().string);
+    return nsStringNilIfEmpty([_private->dataSource _documentLoader]->title().string).autorelease();
 }
 
 - (DOMDocument *)DOMDocument

--- a/Source/WebKitLegacy/mac/WebView/WebScriptDebugDelegate.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptDebugDelegate.mm
@@ -146,7 +146,7 @@ NSString * const WebScriptErrorLineNumberKey = @"WebScriptErrorLineNumber";
         return nil;
 
     String functionName = _private->functionName;
-    return nsStringNilIfEmpty(functionName);
+    return nsStringNilIfEmpty(functionName).autorelease();
 }
 
 // Returns the pending exception for this frame (nil if none).

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -6110,7 +6110,7 @@ static bool needsWebViewInitThreadWorkaround()
         dataSource = [[self mainFrame] _dataSource];
     if (dataSource == nil)
         return nil;
-    return nsStringNilIfEmpty([dataSource _documentLoader]->overrideEncoding());
+    return nsStringNilIfEmpty([dataSource _documentLoader]->overrideEncoding()).autorelease();
 }
 
 - (NSString *)customTextEncodingName


### PR DESCRIPTION
#### 520ff168966e217ac220e6874bfb46087e6d546d
<pre>
Address remaining safer CPP warnings in WebKit/Shared
<a href="https://bugs.webkit.org/show_bug.cgi?id=301163">https://bugs.webkit.org/show_bug.cgi?id=301163</a>

Reviewed by Timothy Hatcher and Darin Adler.

* Source/WTF/wtf/text/WTFString.h:
(WTF::nsStringNilIfEmpty):
(WTF::nsStringNilIfNull):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper _accessibilityHitTestResolvingRemoteFrame:callback:]):
* Source/WebCore/platform/cocoa/DragImageCocoa.mm:
(WebCore::LinkImageLayout::LinkImageLayout):
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::protectedPlatformPath const):
* Source/WebCore/platform/graphics/Path.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::setVideoGravity):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerEnumsCocoa.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerEnumsCocoa.mm:
(WebCore::convertMediaPlayerToAVLayerVideoGravity):
* Source/WebCore/platform/network/cf/ResourceError.h:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::parseDOMCookie):
(WebCore::NetworkStorageSession::setCookiesFromDOM const):
(WebCore::NetworkStorageSession::setCookieFromDOM const):
* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::ResourceError::ResourceError):
(WebCore::ResourceError::mapPlatformError):
(WebCore::ResourceError::cfError const):
(WebCore::ResourceError::protectedCFError const):
* Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h:
(WebGPU_Internal::convertWTFStringToNSString):
* Source/WebKit/Platform/ios/PaymentAuthorizationController.mm:
(-[WKPaymentAuthorizationControllerDelegate presentationSceneIdentifierForPaymentAuthorizationController:]):
(-[WKPaymentAuthorizationControllerDelegate presentationSceneBundleIdentifierForPaymentAuthorizationController:]):
* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(encodeObject):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm:
(-[_WKRemoteObjectInterface initWithProtocol:identifier:]):
(-[_WKRemoteObjectInterface protocol]):
(-[_WKRemoteObjectInterface debugDescription]):
* Source/WebKit/Shared/API/c/cf/WKStringCF.mm:
(WKStringCreateWithCFString):
(wkNSStringClassSingleton): Deleted.
* Source/WebKit/Shared/API/c/cf/WKURLCF.mm:
(WKURLCreateWithCFURL):
(wkNSURLClassSingleton): Deleted.
* Source/WebKit/Shared/API/c/mac/WKURLRequestNS.mm:
(WKURLRequestCopyNSURLRequest):
* Source/WebKit/Shared/API/c/mac/WKURLResponseNS.mm:
(WKURLResponseCopyNSURLResponse):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::typeFromObject):
* Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm:
(WebKit::CoreIPCCNPostalAddress::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.mm:
(WebKit::CoreIPCPKContact::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.mm:
(WebKit::CoreIPCPersonNameComponents::toID const):
* Source/WebKit/Shared/Cocoa/RevealItem.h:
* Source/WebKit/Shared/Cocoa/RevealItem.mm:
(WebKit::RevealItem::highlightRange const):
(WebKit::RevealItem::protectedItem const):
* Source/WebKit/Shared/Cocoa/WKNSError.mm:
(-[WKNSError _web_createTarget]):
* Source/WebKit/Shared/Cocoa/WKNSURLRequest.mm:
(-[WKNSURLRequest _web_createTarget]):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
(WebKit::CompletionHandler&lt;void):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::toCAFilterType):
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyProperties):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::AuxiliaryProcess::launchServicesCheckIn):
(WebKit::webKit2BundleSingleton):
(WebKit::getSandboxProfileOrProfilePath):
(WebKit::populateSandboxInitializationParameters):
(WebKit::webKit2Bundle): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm:
(-[WKWebExtension defaultLocale]):
(-[WKWebExtension displayName]):
(-[WKWebExtension displayShortName]):
(-[WKWebExtension displayVersion]):
(-[WKWebExtension displayDescription]):
(-[WKWebExtension displayActionLabel]):
(-[WKWebExtension version]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _getTextFragmentMatchWithCompletionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _applicationNameForDesktopUserAgent]):
(-[WKWebViewConfiguration applicationNameForUserAgent]):
(-[WKWebViewConfiguration _groupIdentifier]):
* Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm:
(-[_WKContextMenuElementInfo qrCodePayloadString]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _defaultSTSLabel]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(+[WKAutocorrectionContext autocorrectionContextWithWebContext:]):
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm:
(-[WebHistoryItem URLString]):
(-[WebHistoryItem originalURLString]):
(-[WebHistoryItem title]):
(-[WebHistoryItem alternateTitle]):
* Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm:
(-[WebHTMLRepresentation title]):
* Source/WebKitLegacy/mac/WebView/WebScriptDebugDelegate.mm:
(-[WebScriptCallFrame functionName]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _mainFrameOverrideEncoding]):

Canonical link: <a href="https://commits.webkit.org/301920@main">https://commits.webkit.org/301920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f2a015390d026f738b6e2da7b8c2cc182f66dac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134410 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78901 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96922 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77416 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32178 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77792 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119383 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136893 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125809 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41612 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105440 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105119 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26826 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50639 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29090 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51581 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60029 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158847 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53175 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39720 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56633 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54935 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->