### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for IdleCallbackController

### DIFF
--- a/Source/WebCore/dom/IdleCallbackController.h
+++ b/Source/WebCore/dom/IdleCallbackController.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "IdleRequestCallback.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Seconds.h>
@@ -33,24 +34,15 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class IdleCallbackController;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::IdleCallbackController> : std::true_type { };
-}
-
-namespace WebCore {
 
 class Document;
 class WeakPtrImplWithEventTargetData;
 
-class IdleCallbackController : public CanMakeWeakPtr<IdleCallbackController> {
+class IdleCallbackController final : public CanMakeWeakPtr<IdleCallbackController>, public CanMakeCheckedPtr<IdleCallbackController> {
     WTF_MAKE_TZONE_ALLOCATED(IdleCallbackController);
-
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IdleCallbackController);
 public:
-    IdleCallbackController(Document&);
+    explicit IdleCallbackController(Document&);
 
     int queueIdleCallback(Ref<IdleRequestCallback>&&, Seconds timeout);
     void removeIdleCallback(int);

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -165,10 +165,8 @@ void WindowEventLoop::opportunisticallyRunIdleCallbacks(std::optional<MonotonicT
         RefPtr document = dynamicDowncast<Document>(context);
         if (!document || !document->hasPendingIdleCallback())
             return;
-        auto* idleCallbackController = document->idleCallbackController();
-        if (!idleCallbackController)
-            return;
-        idleCallbackController->startIdlePeriod();
+        if (CheckedPtr idleCallbackController = document->idleCallbackController())
+            idleCallbackController->startIdlePeriod();
     });
 
     auto duration = MonotonicTime::now() - m_lastIdlePeriodStartTime;


### PR DESCRIPTION
#### 1a78575f427ec2a9cc1b848548aa223ec83c6f33
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for IdleCallbackController
<a href="https://bugs.webkit.org/show_bug.cgi?id=301164">https://bugs.webkit.org/show_bug.cgi?id=301164</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/IdleCallbackController.cpp:
(WebCore::IdleCallbackController::queueIdleCallback):
(WebCore::IdleCallbackController::queueTaskToInvokeIdleCallbacks):
* Source/WebCore/dom/IdleCallbackController.h:
(WebCore::IdleCallbackController::isEmpty const): Deleted.
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::opportunisticallyRunIdleCallbacks):

Canonical link: <a href="https://commits.webkit.org/301869@main">https://commits.webkit.org/301869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07923862bfa59613b52554da9d1f767533665d07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78855 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/822308e1-1476-4bf7-acc8-8edfb355a28e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96883 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/de74b892-bbae-42f4-989b-76a8fe7677e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77379 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a6108627-d595-4613-a641-d5278d74eb3a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77746 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107916 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136847 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41570 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105401 "16 flakes 56 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105084 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26790 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50603 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51526 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53896 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59983 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53128 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54889 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->