### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for FileReaderLoaderClient

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
@@ -65,6 +65,10 @@ private:
 
         ~ClipboardItemTypeLoader();
 
+        // FileReaderLoaderClient.
+        void ref() const final { RefCounted::ref(); }
+        void deref() const final { RefCounted::deref(); }
+
         void didResolveToString(const String&);
         void didFailToResolve();
         void didResolveToBlob(ScriptExecutionContext&, Ref<Blob>&&);

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.h
@@ -71,8 +71,8 @@ class RefCountedReadableStreamSource
     : public ReadableStreamSource
     , public RefCounted<RefCountedReadableStreamSource> {
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
+    void ref() const override { RefCounted::ref(); }
+    void deref() const override { RefCounted::deref(); }
 };
 
 class SimpleReadableStreamSource

--- a/Source/WebCore/fileapi/BlobLoader.h
+++ b/Source/WebCore/fileapi/BlobLoader.h
@@ -46,6 +46,10 @@ public:
     static Ref<BlobLoader> create(CompleteCallback&& callback) { return adoptRef(*new BlobLoader(WTFMove(callback))); }
     ~BlobLoader();
 
+    // FileReaderLoaderClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void start(Blob&, ScriptExecutionContext*, FileReaderLoader::ReadType);
     void start(const URL&, ScriptExecutionContext*, FileReaderLoader::ReadType);
 

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -191,8 +191,8 @@ void FileReaderLoader::didReceiveResponse(ScriptExecutionContextIdentifier, std:
     if (!processResponse(response))
         return;
 
-    if (m_client)
-        m_client->didStartLoading();
+    if (RefPtr client = m_client.get())
+        client->didStartLoading();
 }
 
 void FileReaderLoader::didReceiveData(const SharedBuffer& buffer)
@@ -204,8 +204,8 @@ void FileReaderLoader::didReceiveData(const SharedBuffer& buffer)
         return;
 
     if (m_readType == ReadType::ReadAsBinaryChunks) {
-        if (m_client)
-            m_client->didReceiveBinaryChunk(buffer);
+        if (RefPtr client = m_client.get())
+            client->didReceiveBinaryChunk(buffer);
         return;
     }
 
@@ -248,8 +248,8 @@ void FileReaderLoader::didReceiveData(const SharedBuffer& buffer)
 
     m_isRawDataConverted = false;
 
-    if (m_client)
-        m_client->didReceiveData();
+    if (RefPtr client = m_client.get())
+        client->didReceiveData();
 }
 
 void FileReaderLoader::didFinishLoading(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const NetworkLoadMetrics&)
@@ -259,8 +259,8 @@ void FileReaderLoader::didFinishLoading(ScriptExecutionContextIdentifier, std::o
         m_totalBytes = m_bytesLoaded;
     }
     cleanup();
-    if (m_client)
-        m_client->didFinishLoading();
+    if (RefPtr client = m_client.get())
+        client->didFinishLoading();
 }
 
 void FileReaderLoader::didFail(std::optional<ScriptExecutionContextIdentifier>, const ResourceError& error)
@@ -276,8 +276,8 @@ void FileReaderLoader::failed(ExceptionCode errorCode)
 {
     m_errorCode = errorCode;
     cleanup();
-    if (m_client)
-        m_client->didFail(errorCode);
+    if (RefPtr client = m_client.get())
+        client->didFail(errorCode);
 }
 
 ExceptionCode FileReaderLoader::toErrorCode(BlobResourceHandle::Error error)

--- a/Source/WebCore/fileapi/FileReaderLoaderClient.h
+++ b/Source/WebCore/fileapi/FileReaderLoaderClient.h
@@ -32,20 +32,11 @@
 
 #include <WebCore/ExceptionCode.h>
 #include <WebCore/SharedBuffer.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class FileReaderLoaderClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::FileReaderLoaderClient> : std::true_type { };
-}
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
-class FileReaderLoaderClient : public CanMakeWeakPtr<FileReaderLoaderClient> {
+class FileReaderLoaderClient : public AbstractRefCountedAndCanMakeWeakPtr<FileReaderLoaderClient> {
 public:
     virtual ~FileReaderLoaderClient() = default;
 

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
@@ -69,6 +69,10 @@ public:
     static Ref<WebSocketChannel> create(Document& document, WebSocketChannelClient& client, SocketProvider& provider) { return adoptRef(*new WebSocketChannel(document, client, provider)); }
     virtual ~WebSocketChannel();
 
+    // FileReaderLoaderClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void send(std::span<const uint8_t> data);
 
     // ThreadableWebSocketChannel functions.
@@ -104,9 +108,6 @@ public:
     bool isConnected() const final { return m_handshake->mode() == WebSocketHandshake::Mode::Connected; }
     ResourceRequest clientHandshakeRequest(const CookieGetter&) const final;
     const ResourceResponse& serverHandshakeResponse() const final;
-
-    using RefCounted<WebSocketChannel>::ref;
-    using RefCounted<WebSocketChannel>::deref;
 
     Document* document();
     


### PR DESCRIPTION
#### a3db1826ddd28837656b79cfa79af3ff916f9e16
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for FileReaderLoaderClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=301168">https://bugs.webkit.org/show_bug.cgi?id=301168</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h:
* Source/WebCore/Modules/streams/ReadableStreamSource.h:
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::stream):
* Source/WebCore/fileapi/BlobLoader.h:
* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::didReceiveResponse):
(WebCore::FileReaderLoader::didReceiveData):
(WebCore::FileReaderLoader::didFinishLoading):
(WebCore::FileReaderLoader::failed):
* Source/WebCore/fileapi/FileReaderLoaderClient.h:
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h:

Canonical link: <a href="https://commits.webkit.org/301872@main">https://commits.webkit.org/301872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf65226d6ebafc6f03237a6fbf88c9955aa9a34c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134375 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78866 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7b30bdbe-dce1-4e8a-af5e-bc7e380e805a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96890 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/272f26c8-61a2-4a35-8bb0-a1c44e955c3c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77385 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a995a9ae-de78-48a0-9992-061b517a277e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77757 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136858 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105407 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105090 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26796 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50608 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51537 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59994 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53139 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54900 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->