### PR TITLE
Address post-landing review comments on recent safer CPP fixes

### DIFF
--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -41,11 +41,17 @@
 #import <wtf/MainThread.h>
 
 @interface WKObservablePageState : NSObject <_WKObservablePageState> {
+    @package
     RefPtr<WebKit::WebPageProxy> _page;
     RefPtr<WebKit::PageLoadStateObserver> _observer;
 }
 
 @end
+
+static Ref<WebKit::WebPageProxy> protectedPage(WKObservablePageState *state)
+{
+    return *state->_page;
+}
 
 @implementation WKObservablePageState
 
@@ -57,14 +63,9 @@
     _page = WTFMove(page);
     Ref observer = WebKit::PageLoadStateObserver::create(self, @"URL");
     _observer = observer.get();
-    self._protectedPage->protectedPageLoadState()->addObserver(observer.get());
+    protectedPage(self)->protectedPageLoadState()->addObserver(observer.get());
 
     return self;
-}
-
-- (Ref<WebKit::WebPageProxy>)_protectedPage
-{
-    return *_page;
 }
 
 - (void)dealloc
@@ -80,42 +81,42 @@
 
 - (BOOL)isLoading
 {
-    return self._protectedPage->protectedPageLoadState()->isLoading();
+    return protectedPage(self)->protectedPageLoadState()->isLoading();
 }
 
 - (NSString *)title
 {
-    return self._protectedPage->protectedPageLoadState()->title().createNSString().autorelease();
+    return protectedPage(self)->protectedPageLoadState()->title().createNSString().autorelease();
 }
 
 - (NSURL *)URL
 {
-    return [NSURL _web_URLWithWTFString:self._protectedPage->protectedPageLoadState()->activeURL()];
+    return [NSURL _web_URLWithWTFString:protectedPage(self)->protectedPageLoadState()->activeURL()];
 }
 
 - (BOOL)hasOnlySecureContent
 {
-    return self._protectedPage->protectedPageLoadState()->hasOnlySecureContent();
+    return protectedPage(self)->protectedPageLoadState()->hasOnlySecureContent();
 }
 
 - (BOOL)_webProcessIsResponsive
 {
-    return self._protectedPage->protectedLegacyMainFrameProcess()->isResponsive();
+    return protectedPage(self)->protectedLegacyMainFrameProcess()->isResponsive();
 }
 
 - (double)estimatedProgress
 {
-    return self._protectedPage->estimatedProgress();
+    return protectedPage(self)->estimatedProgress();
 }
 
 - (NSURL *)unreachableURL
 {
-    return [NSURL _web_URLWithWTFString:self._protectedPage->pageLoadState().unreachableURL()];
+    return [NSURL _web_URLWithWTFString:protectedPage(self)->pageLoadState().unreachableURL()];
 }
 
 - (SecTrustRef)serverTrust
 {
-    return self._protectedPage->pageLoadState().certificateInfo().trust().get();
+    return protectedPage(self)->pageLoadState().certificateInfo().trust().get();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -38,9 +38,9 @@
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
-- (Ref<API::FrameInfo>)_protectedFrameInfo
+static Ref<API::FrameInfo> protectedFrameInfo(WKFrameInfo *frameInfo)
 {
-    return *_frameInfo;
+    return *frameInfo->_frameInfo;
 }
 
 - (void)dealloc
@@ -48,7 +48,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKFrameInfo.class, self))
         return;
 
-    SUPPRESS_UNCOUNTED_ARG self._protectedFrameInfo->~FrameInfo();
+    SUPPRESS_UNCOUNTED_ARG protectedFrameInfo(self)->~FrameInfo();
 
     [super dealloc];
 }
@@ -77,7 +77,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKWebView *)webView
 {
-    RefPtr page = self._protectedFrameInfo->page();
+    RefPtr page = protectedFrameInfo(self)->page();
     return page ? page->cocoaView().autorelease() : nil;
 }
 
@@ -99,12 +99,12 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (_WKFrameHandle *)_handle
 {
-    return wrapper(self._protectedFrameInfo->handle()).autorelease();
+    return wrapper(protectedFrameInfo(self)->handle()).autorelease();
 }
 
 - (_WKFrameHandle *)_parentFrameHandle
 {
-    return wrapper(self._protectedFrameInfo->parentFrameHandle()).autorelease();
+    return wrapper(protectedFrameInfo(self)->parentFrameHandle()).autorelease();
 }
 
 - (NSUUID *)_documentIdentifier
@@ -134,7 +134,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSString *)_title
 {
-    return self._protectedFrameInfo->title().createNSString().autorelease();
+    return protectedFrameInfo(self)->title().createNSString().autorelease();
 }
 
 - (BOOL)_isScrollable


### PR DESCRIPTION
#### 48810d0c2a9f672262b51ad68c998423cb2a661d
<pre>
Address post-landing review comments on recent safer CPP fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=301182">https://bugs.webkit.org/show_bug.cgi?id=301182</a>

Reviewed by Darin Adler.

Darin suggested that instead of ObjC++ methods we should use
static C++ functions for protected getters, where it makes
sense. Fix a few of instances from my recent commits to follow this.

* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(protectedPage):
(-[WKObservablePageState initWithPage:]):
(-[WKObservablePageState isLoading]):
(-[WKObservablePageState title]):
(-[WKObservablePageState URL]):
(-[WKObservablePageState hasOnlySecureContent]):
(-[WKObservablePageState _webProcessIsResponsive]):
(-[WKObservablePageState estimatedProgress]):
(-[WKObservablePageState unreachableURL]):
(-[WKObservablePageState serverTrust]):
(-[WKObservablePageState _protectedPage]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(protectedFrameInfo):
(-[WKFrameInfo dealloc]):
(-[WKFrameInfo webView]):
(-[WKFrameInfo _handle]):
(-[WKFrameInfo _parentFrameHandle]):
(-[WKFrameInfo _title]):
(-[WKFrameInfo _protectedFrameInfo]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeTask.mm:
(protectedURLSchemeTask):
(-[WKURLSchemeTaskImpl request]):
(-[WKURLSchemeTaskImpl _requestOnlyIfCached]):
(-[WKURLSchemeTaskImpl _willPerformRedirection:newRequest:completionHandler:]):
(-[WKURLSchemeTaskImpl didReceiveResponse:]):
(-[WKURLSchemeTaskImpl didReceiveData:]):
(-[WKURLSchemeTaskImpl didFinish]):
(-[WKURLSchemeTaskImpl didFailWithError:]):
(-[WKURLSchemeTaskImpl _didPerformRedirection:newRequest:]):
(-[WKURLSchemeTaskImpl _protectedURLSchemeTask]): Deleted.

Canonical link: <a href="https://commits.webkit.org/301871@main">https://commits.webkit.org/301871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d1b8c0054d527e2e33ba4ed626dbf42b061a385

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78887 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96908 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77402 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77778 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136879 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41596 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105423 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54502 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105105 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26795 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50628 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51560 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53928 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60015 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/53161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54921 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->