### PR TITLE
Import and fix window.orientation tests from wpt

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/window-orientation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/window-orientation-expected.txt
@@ -1,0 +1,13 @@
+
+FAIL window.orientation attribute should be present assert_true: window.orientation should exist expected true got false
+FAIL window.orientation should return a number assert_equals: window.orientation should be a number expected "number" but got "undefined"
+FAIL window.orientation should return a valid orientation angle assert_true: window.orientation should be one of the valid values expected true got false
+FAIL window.onorientationchange attribute should be present assert_true: window.onorientationchange should exist expected true got false
+FAIL window.onorientationchange should be null by default assert_equals: window.onorientationchange should be null initially expected (object) null but got (undefined) undefined
+PASS window.onorientationchange should be settable and gettable
+FAIL orientationchange event should fire when orientation is changed programmatically promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+FAIL window.orientation should correctly map screen.orientation.angle values assert_equals: window.orientation (undefined) should match expected mapping of screen.orientation.angle (0) expected (number) 0 but got (undefined) undefined
+FAIL window.orientation should only return standardized values assert_unreached: Invalid orientation value: undefined Reached unreachable code
+FAIL window.orientation should return correct values for different orientation locks promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+FAIL Multiple orientation changes should fire multiple orientationchange events with valid values promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/window-orientation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/window-orientation.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>window.orientation API</title>
+<link rel="help" href="https://w3c.github.io/screen-orientation/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script type="module">
+import { makeCleanup, getOppositeOrientation } from "./resources/orientation-utils.js";
+
+test(() => {
+  assert_true("orientation" in window, "window.orientation should exist");
+}, "window.orientation attribute should be present");
+
+test(() => {
+  assert_equals(typeof window.orientation, "number", "window.orientation should be a number");
+}, "window.orientation should return a number");
+
+test(() => {
+  const orientation = window.orientation;
+  assert_true(
+    orientation === -90 || orientation === 0 || orientation === 90 || orientation === 180,
+    "window.orientation should be one of the valid values"
+  );
+}, "window.orientation should return a valid orientation angle");
+
+test(() => {
+  assert_true("onorientationchange" in window, "window.onorientationchange should exist");
+}, "window.onorientationchange attribute should be present");
+
+test(() => {
+  assert_equals(window.onorientationchange, null, "window.onorientationchange should be null initially");
+}, "window.onorientationchange should be null by default");
+
+test(() => {
+  const initialHandler = () => {};
+  window.onorientationchange = initialHandler;
+  assert_equals(window.onorientationchange, initialHandler, "window.onorientationchange should be settable");
+
+  window.onorientationchange = null;
+  assert_equals(window.onorientationchange, null, "window.onorientationchange should be resettable to null");
+}, "window.onorientationchange should be settable and gettable");
+
+promise_test(async (t) => {
+  t.add_cleanup(makeCleanup());
+  await test_driver.bless("request full screen");
+  await document.documentElement.requestFullscreen();
+
+  const initialOrientation = window.orientation;
+  const targetOrientation = getOppositeOrientation();
+
+  const eventPromise = new Promise(resolve => {
+    function handleOrientationChange() {
+      window.removeEventListener("orientationchange", handleOrientationChange);
+      resolve();
+    }
+    window.addEventListener("orientationchange", handleOrientationChange);
+  });
+
+  // Lock the orientation
+  await screen.orientation.lock(targetOrientation);
+
+  // Wait for the orientationchange event
+  await eventPromise;
+
+  // Verify the orientation value is still valid
+  const newOrientation = window.orientation;
+  assert_true(
+    newOrientation === -90 || newOrientation === 0 || newOrientation === 90 || newOrientation === 180,
+    "window.orientation should be a valid value after orientation change"
+  );
+}, "orientationchange event should fire when orientation is changed programmatically");
+
+test(() => {
+  // Test that orientation values map correctly to screen orientation angles
+  const orientation = window.orientation;
+  const screenAngle = screen.orientation.angle;
+
+  let expectedOrientation;
+  if (screenAngle < 180) {
+    expectedOrientation = screenAngle;
+  } else if (screenAngle === 180) {
+    // User agents may or may not support 180
+    expectedOrientation = screenAngle; // or 0 if not supported
+  } else if (screenAngle > 180) {
+    expectedOrientation = screenAngle - 360;
+  }
+
+  // Allow for the fact that some user agents might not support 180
+  if (screenAngle === 180 && orientation === 0) {
+    assert_true(true, "User agent correctly maps unsupported 180° to 0°");
+  } else {
+    assert_equals(orientation, expectedOrientation,
+      `window.orientation (${orientation}) should match expected mapping of screen.orientation.angle (${screenAngle})`);
+  }
+}, "window.orientation should correctly map screen.orientation.angle values");
+
+test(() => {
+  // Test the specific constraints from the spec
+  const orientation = window.orientation;
+
+  // Must support -90, 0, 90
+  if (orientation === -90 || orientation === 0 || orientation === 90) {
+    assert_true(true, "Orientation is one of the required supported values");
+  }
+  // May optionally support 180
+  else if (orientation === 180) {
+    assert_true(true, "Orientation is the optional 180° value");
+  }
+  else {
+    assert_unreached(`Invalid orientation value: ${orientation}`);
+  }
+}, "window.orientation should only return standardized values");
+
+promise_test(async (t) => {
+  t.add_cleanup(makeCleanup());
+  await test_driver.bless("request full screen");
+  await document.documentElement.requestFullscreen();
+
+  // Test different orientation locks and verify window.orientation values
+  const testCases = [
+    { lock: "portrait", expectedValues: [0, 180] },
+    { lock: "landscape", expectedValues: [90, -90] },
+    { lock: "natural", expectedValues: [0, 90, -90, 180] },
+    { lock: "any", expectedValues: [0, 90, -90, 180] },
+  ];
+
+  for (const testCase of testCases) {
+    await screen.orientation.lock(testCase.lock);
+    const orientation = window.orientation;
+
+    assert_true(
+      testCase.expectedValues.includes(orientation),
+      `After locking to ${testCase.lock}, window.orientation (${orientation}) should be one of ${testCase.expectedValues}`
+    );
+  }
+}, "window.orientation should return correct values for different orientation locks");
+
+promise_test(async (t) => {
+  t.add_cleanup(makeCleanup());
+  await test_driver.bless("request full screen");
+  await document.documentElement.requestFullscreen();
+
+  let orientationChangeCount = 0;
+  const orientationValues = [];
+
+  function handleOrientationChange() {
+    orientationChangeCount++;
+    orientationValues.push(window.orientation);
+  }
+
+  window.addEventListener("orientationchange", handleOrientationChange);
+  t.add_cleanup(() => {
+    window.removeEventListener("orientationchange", handleOrientationChange);
+  });
+
+  const initialOrientation = screen.orientation.type.startsWith("portrait")
+    ? "portrait"
+    : "landscape";
+
+  const targetOrientation = getOppositeOrientation();
+
+  // Lock to different orientation
+  await screen.orientation.lock(targetOrientation);
+
+  // Lock back to original
+  await screen.orientation.lock(initialOrientation);
+
+  assert_greater_than_equal(orientationChangeCount, 1, "At least one orientationchange event should have fired");
+
+  // Verify all captured orientation values are valid
+  for (const value of orientationValues) {
+    assert_true(
+      value === -90 || value === 0 || value === 90 || value === 180,
+      `All orientation values should be valid, got: ${value}`
+    );
+  }
+}, "Multiple orientation changes should fire multiple orientationchange events with valid values");
+
+</script>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/window-orientation-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/window-orientation-expected.txt
@@ -1,0 +1,13 @@
+
+PASS window.orientation attribute should be present
+PASS window.orientation should return a number
+PASS window.orientation should return a valid orientation angle
+PASS window.onorientationchange attribute should be present
+PASS window.onorientationchange should be null by default
+PASS window.onorientationchange should be settable and gettable
+PASS orientationchange event should fire when orientation is changed programmatically
+PASS window.orientation should correctly map screen.orientation.angle values
+PASS window.orientation should only return standardized values
+PASS window.orientation should return correct values for different orientation locks
+PASS Multiple orientation changes should fire multiple orientationchange events with valid values
+


### PR DESCRIPTION
#### fd68d3b77fccc13b694baa3c4f62451f60c74fbc
<pre>
Import and fix window.orientation tests from wpt
<a href="https://rdar.apple.com/163102280">rdar://163102280</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301183">https://bugs.webkit.org/show_bug.cgi?id=301183</a>

Reviewed by NOBODY (OOPS!).

Imported window.orientation tests from WPT and fixed a bit.

* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/window-orientation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/window-orientation.html: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/window-orientation-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd68d3b77fccc13b694baa3c4f62451f60c74fbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109825 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120740 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85045 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158920 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22940 "1 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101429 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22022 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20164 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12554 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167204 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128861 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128993 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139683 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86563 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23816 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16481 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28529 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28056 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28284 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28180 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->