### PR TITLE
Add support for visionOS in Tools/Scripts

### DIFF
--- a/Tools/Scripts/run-webkit-app
+++ b/Tools/Scripts/run-webkit-app
@@ -51,6 +51,9 @@ die "Did not specify an application to open (e.g. run-webkit-app AppName).\n" un
 checkBuild();
 
 my $appPath = shift(@ARGV);
+if (isVisionOSWebKit()) {
+    exit exitStatus(runVisionOSWebKitApp($appPath));
+}
 if (isIOSWebKit()) {
     exit exitStatus(runIOSWebKitApp($appPath));
 }

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -130,6 +130,8 @@ BEGIN {
        &isGenerateProjectOnly
        &isGtk
        &isIOSWebKit
+       &isVisionOSWebKit
+       &runVisionOSWebKitApp
        &isInspectorFrontend
        &isJSCOnly
        &isLinux
@@ -1602,7 +1604,7 @@ sub builtDylibPathForName
 
         return "";
     }
-    if (isIOSWebKit()) {
+    if (isIOSWebKit() || isVisionOSWebKit()) {
         return "$configurationProductDir/$libraryName.framework/$libraryName";
     }
     if (isAppleCocoaWebKit()) {
@@ -1988,7 +1990,7 @@ sub isVisionOSWebKit()
 
 sub isEmbeddedWebKit()
 {
-    return isIOSWebKit() || isTVOSWebKit() || isWatchOSWebKit() || isVisionOSWebKit;
+    return isIOSWebKit() || isTVOSWebKit() || isWatchOSWebKit() || isVisionOSWebKit();
 }
 
 sub isAppleWebKit()
@@ -2049,6 +2051,25 @@ sub iOSSimulatorDevices
     return @devices;
 }
 
+sub visionOSSimulatorDevices
+{
+    my $output = `xcrun simctl list devices --json`;
+    my $runtimes = decode_json($output)->{devices};
+    if (!$runtimes) {
+        die "No simulator devices found";
+    }
+
+    my @devices = ();
+    while ((my $runtime, my $devicesForRuntime) = each %$runtimes) {
+        foreach my $jsonDevice (@$devicesForRuntime) {
+            next if $jsonDevice->{availabilityError};
+            push @devices, simulatorDeviceFromJSON($runtime, $jsonDevice);
+        }
+    }
+
+    return @devices;
+}
+
 sub createiOSSimulatorDevice
 {
     my $name = shift;
@@ -2059,6 +2080,23 @@ sub createiOSSimulatorDevice
     die "Couldn't create simulator device: $name $deviceTypeId $runtimeId" if not $created;
 
     my @devices = iOSSimulatorDevices();
+    foreach my $device (@devices) {
+        return $device if $device->{name} eq $name and $device->{deviceType} eq $deviceTypeId and $device->{runtime} eq $runtimeId;
+    }
+
+    die "Device $name $deviceTypeId $runtimeId wasn't found";
+}
+
+sub createVisionOSSimulatorDevice
+{
+    my $name = shift;
+    my $deviceTypeId = shift;
+    my $runtimeId = shift;
+
+    my $created = system("xcrun", "--sdk", "xrsimulator", "simctl", "create", $name, $deviceTypeId, $runtimeId) == 0;
+    die "Couldn't create visionOS simulator device: $name $deviceTypeId $runtimeId" if not $created;
+
+    my @devices = visionOSSimulatorDevices();
     foreach my $device (@devices) {
         return $device if $device->{name} eq $name and $device->{deviceType} eq $deviceTypeId and $device->{runtime} eq $runtimeId;
     }
@@ -3192,6 +3230,33 @@ sub iosSimulatorApplicationsPath()
     return File::Spec->catdir($runtimePath, "Applications");
 }
 
+sub visionosSimulatorApplicationsPath()
+{
+    my $output = `xcrun simctl list runtimes xrOS --json`;
+    my $runtimes = decode_json($output)->{runtimes};
+    if (!$runtimes) {
+        die "No visionOS simulator runtimes found";
+    }
+    my $runtimePath = @$runtimes[0]->{runtimeRoot};
+    return File::Spec->catdir($runtimePath, "Applications");
+}
+
+sub visionSimulatorApplicationsPath()
+{
+    my $output = `xcrun simctl list runtimes visionOS --json`;
+    my $runtimes = decode_json($output)->{runtimes};
+    if (!$runtimes) {
+        die "No iOS simulator runtimes found";
+    }
+    my $runtimePath = @$runtimes[0]->{runtimeRoot};
+    return File::Spec->catdir($runtimePath, "Applications");
+}
+
+sub installedVisionSafariBundle()
+{
+    return File::Spec->catfile(visionSimulatorApplicationsPath(), "MobileSafari.app");
+}
+
 sub installedMobileSafariBundle()
 {
     return File::Spec->catfile(iosSimulatorApplicationsPath(), "MobileSafari.app");
@@ -3200,6 +3265,11 @@ sub installedMobileSafariBundle()
 sub installedMobileMiniBrowserBundle()
 {
     return File::Spec->catfile(iosSimulatorApplicationsPath(), "MobileMiniBrowser.app");
+}
+
+sub installedVisionMobileMiniBrowserBundle()
+{
+    return File::Spec->catfile(visionosSimulatorApplicationsPath(), "MobileMiniBrowser.app");
 }
 
 sub mobileSafariBundle()
@@ -3211,6 +3281,17 @@ sub mobileSafariBundle()
         return "$configurationProductDir/MobileSafari.app";
     }
     return installedMobileSafariBundle();
+}
+
+sub visionSafariBundle()
+{
+    determineConfigurationProductDir();
+
+    # Use MobileSafari.app in product directory if present.
+    if (isVisionOSWebKit() && -d "$configurationProductDir/MobileSafari.app") {
+        return "$configurationProductDir/MobileSafari.app";
+    }
+    return installedVisionSafariBundle();
 }
 
 sub mobileMiniBrowserBundle()
@@ -3326,6 +3407,24 @@ sub iosSimulatorDeviceByName($)
     return undef;
 }
 
+sub visionosSimulatorRuntime
+{
+    return simulatorRuntime(visionOS);
+}
+
+sub visionosSimulatorDeviceByName($)
+{
+    my ($simulatorName) = @_;
+    my $simulatorRuntime = visionosSimulatorRuntime();
+    my @devices = visionOSSimulatorDevices();
+    for my $device (@devices) {
+        if ($device->{name} eq $simulatorName && $device->{runtime} eq $simulatorRuntime) {
+            return $device;
+        }
+    }
+    return undef;
+}
+
 sub iosSimulatorDeviceByUDID($)
 {
     my ($simulatedDeviceUDID) = @_;
@@ -3377,10 +3476,29 @@ sub findOrCreateSimulatorForIOSDevice($)
     return createiOSSimulatorDevice($simulatorName, $simulatorDeviceType, iosSimulatorRuntime());
 }
 
+sub findOrCreateSimulatorForVisionOSDevice($)
+{
+    my ($simulatorNameSuffix) = @_;
+    my $simulatorName = "Apple Vision Pro";
+    my $simulatorDeviceType = "com.apple.CoreSimulator.SimRuntime.xrOS-2-5";
+
+    my $simulatedDevice = visionosSimulatorDeviceByName($simulatorName);
+    return $simulatedDevice if $simulatedDevice;
+
+    return createVisionOSSimulatorDevice($simulatorName, $simulatorDeviceType, iosSimulatorRuntime());
+}
+
 sub isIOSSimulatorSystemInstalledApp($)
 {
     my ($appBundle) = @_;
     my $simulatorApplicationsPath = realpath(iosSimulatorApplicationsPath());
+    return substr(realpath($appBundle), 0, length($simulatorApplicationsPath)) eq $simulatorApplicationsPath;
+}
+
+sub isVisionOSSimulatorSystemInstalledApp($)
+{
+    my ($appBundle) = @_;
+    my $simulatorApplicationsPath = realpath(visionosSimulatorApplicationsPath());
     return substr(realpath($appBundle), 0, length($simulatorApplicationsPath)) eq $simulatorApplicationsPath;
 }
 
@@ -3482,6 +3600,66 @@ sub runIOSWebKitAppInSimulator($;$)
     return exitStatus(system("xcrun", "--sdk", "iphonesimulator", "simctl", "launch", $simulatedDeviceUDID, $appIdentifier, @$applicationArguments));
 }
 
+sub runVisionOSWebKitAppInSimulator($;$)
+{
+    my ($appBundle, $simulatorOptions) = @_;
+    my $productDir = productDir();
+    my $appDisplayName = appDisplayNameFromBundle($appBundle);
+    my $appIdentifier = appIdentifierFromBundle($appBundle);
+    my $simulatedDevice = findOrCreateSimulatorForVisionOSDevice(SIMULATOR_DEVICE_SUFFIX_FOR_WEBKIT_DEVELOPMENT);
+    my $simulatedDeviceUDID = $simulatedDevice->{UDID};
+
+    my $willUseSystemInstalledApp = isVisionOSSimulatorSystemInstalledApp($appBundle);
+    if ($willUseSystemInstalledApp) {
+        if (hasUserInstalledAppInSimulatorDevice($appIdentifier, $simulatedDeviceUDID)) {
+            # Restore the system-installed app in the simulator device corresponding to $appBundle as it
+            # was previously overwritten with a custom built version of the app.
+            # FIXME: Only restore the system-installed version of the app instead of erasing all contents and settings.
+            print "Quitting visionOS Simulator...\n";
+            shutDownIOSSimulatorDevice($simulatedDevice);
+            print "Erasing contents and settings for simulator device \"$simulatedDevice->{name}\".\n";
+            exitStatus(system("xcrun", "--sdk", "xrsimulator", "simctl", "erase", $simulatedDeviceUDID)) == 0 or die;
+        }
+        # FIXME: We assume that if $simulatedDeviceUDID is not booted then iOS Simulator is not open. However
+        #        $simulatedDeviceUDID may have been booted using the simctl command line tool. If $simulatedDeviceUDID
+        #        was booted using simctl then we should shutdown the device and launch iOS Simulator to boot it again.
+        if (!isSimulatorDeviceBooted($simulatedDeviceUDID)) {
+            print "Launching visionOS Simulator...\n";
+            relaunchIOSSimulator($simulatedDevice);
+        }
+    } else {
+        # FIXME: We should killall(1) any running instances of $appBundle before installing it to ensure
+        #        that simctl launch opens the latest installed version of the app. For now we quit and
+        #        launch the iOS Simulator again to ensure there are no running instances of $appBundle.
+        print "Quitting and launching visionOS Simulator...\n";
+        relaunchIOSSimulator($simulatedDevice);
+
+        print "Installing $appBundle.\n";
+        # Install custom built app, overwriting an app with the same app identifier if one exists.
+        exitStatus(system("xcrun", "--sdk", "xrsimulator", "simctl", "install", $simulatedDeviceUDID, $appBundle)) == 0 or die;
+
+    }
+
+    $simulatorOptions = {} unless $simulatorOptions;
+
+    my %simulatorENV;
+    %simulatorENV = %{$simulatorOptions->{applicationEnvironment}} if $simulatorOptions->{applicationEnvironment};
+    {
+        local %ENV; # Shadow global-scope %ENV so that changes to it will not be seen outside of this scope.
+        setupIOSWebKitEnvironment($productDir);
+        %simulatorENV = %ENV;
+    }
+    my $applicationArguments = \@ARGV;
+    $applicationArguments = $simulatorOptions->{applicationArguments} if $simulatorOptions && $simulatorOptions->{applicationArguments};
+
+    # Prefix the environment variables with SIMCTL_CHILD_ per `xcrun simctl help launch`.
+    foreach my $key (keys %simulatorENV) {
+        $ENV{"SIMCTL_CHILD_$key"} = $simulatorENV{$key};
+    }
+
+    return exitStatus(system("xcrun", "--sdk", "xrsimulator", "simctl", "launch", $simulatedDeviceUDID, $appIdentifier, @$applicationArguments));
+}
+
 sub runIOSWebKitApp($)
 {
     my ($appBundle) = @_;
@@ -3492,6 +3670,18 @@ sub runIOSWebKitApp($)
         return runIOSWebKitAppInSimulator($appBundle);
     }
     die "Not using an iOS SDK."
+}
+
+sub runVisionOSWebKitApp($)
+{
+    my ($appBundle) = @_;
+    if (willUseVisionDeviceSDK()) {
+        die "Only running Safari in visionOS Simulator is supported now.";
+    }
+    if (willUseVisionSimulatorSDK()) {
+        return runVisionOSWebKitAppInSimulator($appBundle);
+    }
+    die "Not using an visionOS SDK."
 }
 
 sub commandLineArgumentsForRestrictedEnvironmentVariables($)
@@ -3586,7 +3776,12 @@ sub runSafari
         return runMacWebKitApp(safariPath());
     }
 
-    return 1; # Unsupported platform; can't run Safari on this platform.
+    if (isVisionOSWebKit()) {
+        my $bundlePath = visionSafariBundle();
+        return runVisionOSWebKitApp($bundlePath);
+    }
+
+    die "Unsupported platform; can't run Safari on this platform.\n";
 }
 
 sub runMiniBrowser
@@ -3597,7 +3792,16 @@ sub runMiniBrowser
     if (isIOSWebKit()) {
         return runIOSWebKitApp(mobileMiniBrowserBundle());
     }
-    return 1;
+
+    if (isVisionOSWebKit()) {
+        # /Users/ldavid/Documents/GitHub/WebKit/WebKitBuild/Debug-xrsimulator/MobileMiniBrowser.app
+        # Does not work, you need to drag and drop the .app into vision os simulator for now
+        my $bundlePath = File::Spec->catfile(productDir(), "MobileMiniBrowser.app", "MobileMiniBrowser");
+        print "try to run mini browser in visionOS with $bundlePath\n";
+        return runVisionOSWebKitApp($bundlePath);
+    }
+
+    die "Unsupported platform; can't run MiniBrowser on this platform.\n";
 }
 
 sub debugMiniBrowser
@@ -3617,7 +3821,12 @@ sub runSwiftBrowser
     if (isIOSWebKit()) {
         return runIOSWebKitApp(swiftBrowserBundle());
     }
-    return 1;
+    if (isVisionOSWebKit()) {
+        my $bundlePath = swiftBrowserBundle();
+        return runVisionOSWebKitApp($bundlePath);
+    }
+
+    die "Unsupported platform; can't run SwiftBrowser on this platform.\n";
 }
 
 sub debugSwiftBrowser


### PR DESCRIPTION
#### a0f23f20706898ce01fbe28651972c27401aedb0
<pre>
Add support for visionOS in Tools/Scripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=296931">https://bugs.webkit.org/show_bug.cgi?id=296931</a>

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/run-webkit-app:
* Tools/Scripts/webkitdirs.pm:
(builtDylibPathForName):
(isEmbeddedWebKit):
(visionOSSimulatorDevices):
(createVisionOSSimulatorDevice):
(visionosSimulatorApplicationsPath):
(visionSimulatorApplicationsPath):
(installedVisionSafariBundle):
(installedVisionMobileMiniBrowserBundle):
(visionSafariBundle):
(visionosSimulatorRuntime):
(visionosSimulatorDeviceByName):
(findOrCreateSimulatorForVisionOSDevice):
(isVisionOSSimulatorSystemInstalledApp):
(runVisionOSWebKitAppInSimulator):
(runVisionOSWebKitApp):
(runSafari):
(runMiniBrowser):
(runSwiftBrowser):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0f23f20706898ce01fbe28651972c27401aedb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78904 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96920 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64921 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77414 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32177 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77795 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119386 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136896 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125812 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105438 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105117 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50638 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29089 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51584 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53945 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158850 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53178 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39721 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->