### PR TITLE
The ContentFilter method continueAfterWillSendRequest should use a completion handler

### DIFF
--- a/LayoutTests/contentfiltering/delay-willsendrequest-decision-expected.html
+++ b/LayoutTests/contentfiltering/delay-willsendrequest-decision-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<iframe src="resources/pass.html"></iframe>

--- a/LayoutTests/contentfiltering/delay-willsendrequest-decision.html
+++ b/LayoutTests/contentfiltering/delay-willsendrequest-decision.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script>
+if (window.internals) {
+    var settings = window.internals.mockContentFilterSettings;
+    settings.enabled = true;
+    settings.willSendRequestDecisionDelay = 10;
+    settings.decisionPoint = "afterWillSendRequest";
+    settings.decision = "allow";
+}
+</script>
+<iframe src="resources/pass.html"></iframe>

--- a/Source/WebCore/platform/PlatformContentFilter.h
+++ b/Source/WebCore/platform/PlatformContentFilter.h
@@ -65,9 +65,12 @@ public:
 
     bool needsMoreData() const { return m_state == State::Filtering; }
     bool didBlockData() const { return m_state == State::Blocked; }
+    bool isAllowed() const { return m_state == State::Allowed; }
 
     virtual ~PlatformContentFilter() = default;
+    virtual bool isEnabled() const { return true; }
     virtual void willSendRequest(ResourceRequest&, const ResourceResponse&) = 0;
+    virtual void willSendRequest(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(String&&)>&&) = 0;
     virtual void responseReceived(const ResourceResponse&) = 0;
     virtual void addData(const SharedBuffer&) = 0;
     virtual void finishedAddingData() = 0;

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h
@@ -48,7 +48,9 @@ class NetworkExtensionContentFilter final : public PlatformContentFilter {
 public:
     static Ref<NetworkExtensionContentFilter> create(const PlatformContentFilter::FilterParameters&);
 
+    bool isEnabled() const final { return enabled(); }
     void willSendRequest(ResourceRequest&, const ResourceResponse&) override;
+    void willSendRequest(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(String&&)>&&) final;
     void responseReceived(const ResourceResponse&) override;
     void addData(const SharedBuffer&) override;
     void finishedAddingData() override;

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -44,7 +44,9 @@ class ParentalControlsContentFilter final : public PlatformContentFilter {
 public:
     static Ref<ParentalControlsContentFilter> create(const PlatformContentFilter::FilterParameters&);
 
+    bool isEnabled() const final { return enabled(); }
     void willSendRequest(ResourceRequest&, const ResourceResponse&) override { }
+    void willSendRequest(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(String&&)>&&) final;
     void responseReceived(const ResourceResponse&) override;
     void addData(const SharedBuffer&) override;
     void finishedAddingData() override;

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
@@ -93,6 +93,11 @@ ParentalControlsContentFilter::ParentalControlsContentFilter(const PlatformConte
     UNUSED_PARAM(params);
 }
 
+void ParentalControlsContentFilter::willSendRequest(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(String&&)>&& completionHandler)
+{
+    completionHandler({ });
+}
+
 static inline bool canHandleResponse(const ResourceResponse& response)
 {
 #if HAVE(SYSTEM_HTTP_CONTENT_FILTERING)

--- a/Source/WebCore/testing/MockContentFilter.h
+++ b/Source/WebCore/testing/MockContentFilter.h
@@ -39,7 +39,9 @@ public:
     static void ensureInstalled();
     static Ref<MockContentFilter> create(const PlatformContentFilter::FilterParameters&);
 
+    bool isEnabled() const final { return enabled(); }
     void willSendRequest(ResourceRequest&, const ResourceResponse&) override;
+    void willSendRequest(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(String&&)>&&) final;
     void responseReceived(const ResourceResponse&) override;
     void addData(const SharedBuffer&) override;
     void finishedAddingData() override;

--- a/Source/WebCore/testing/MockContentFilterSettings.cpp
+++ b/Source/WebCore/testing/MockContentFilterSettings.cpp
@@ -92,6 +92,12 @@ const String& MockContentFilterSettings::unblockRequestURL() const
     return unblockRequestURL;
 }
 
+void MockContentFilterSettings::setWillSendRequestDecisionDelay(double willSendRequestDecisionDelay)
+{
+    m_willSendRequestDecisionDelay = Seconds(willSendRequestDecisionDelay);
+    MockContentFilterManager::singleton().notifySettingsChanged(singleton());
+}
+
 }; // namespace WebCore
 
 #endif // ENABLE(CONTENT_FILTERING)

--- a/Source/WebCore/testing/MockContentFilterSettings.h
+++ b/Source/WebCore/testing/MockContentFilterSettings.h
@@ -75,9 +75,13 @@ public:
     const String& modifiedRequestURL() const { return m_modifiedRequestURL; }
     WEBCORE_TESTSUPPORT_EXPORT void setModifiedRequestURL(const String&);
 
+    double willSendRequestDecisionDelay() const { return m_willSendRequestDecisionDelay.value(); }
+    WEBCORE_TESTSUPPORT_EXPORT void setWillSendRequestDecisionDelay(double);
+
     MockContentFilterSettings() = default;
     MockContentFilterSettings(const MockContentFilterSettings&) = default;
     MockContentFilterSettings& operator=(const MockContentFilterSettings&) = default;
+
 private:
     friend struct IPC::ArgumentCoder<MockContentFilterSettings>;
 
@@ -87,6 +91,7 @@ private:
     Decision m_unblockRequestDecision { Decision::Block };
     String m_blockedString;
     String m_modifiedRequestURL;
+    Seconds m_willSendRequestDecisionDelay;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockContentFilterSettings.idl
+++ b/Source/WebCore/testing/MockContentFilterSettings.idl
@@ -51,4 +51,6 @@ enum Decision {
     attribute Decision unblockRequestDecision;
 
     readonly attribute DOMString unblockRequestURL;
+
+    attribute double willSendRequestDecisionDelay;
 };

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -271,7 +271,7 @@ private:
     ResourceLoadInfo resourceLoadInfo();
 
 #if ENABLE(CONTENT_FILTERING)
-    bool startContentFiltering(WebCore::ResourceRequest&);
+    void startContentFiltering(WebCore::ResourceRequest&&, CompletionHandler<void(WebCore::ResourceRequest)>&&);
 #endif
 
     // ReportingClient

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1746,6 +1746,7 @@ enum class WebCore::RotationDirection : bool
     WebCore::MockContentFilterSettings::Decision m_unblockRequestDecision;
     String m_blockedString;
     String m_modifiedRequestURL;
+    Seconds m_willSendRequestDecisionDelay;
 }
 [Nested] enum class WebCore::MockContentFilterSettings::DecisionPoint : uint8_t {
     AfterWillSendRequest,


### PR DESCRIPTION
#### f5665ae82cc3854a847d27d097f30ab01b092137
<pre>
The ContentFilter method continueAfterWillSendRequest should use a completion handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=301189">https://bugs.webkit.org/show_bug.cgi?id=301189</a>
<a href="https://rdar.apple.com/151461666">rdar://151461666</a>

Reviewed by Chris Dumez and Sihui Liu.

The ContentFilter method continueAfterWillSendRequest should use a completion handler to avoid blocking
the main thread waiting for a decision that can take a significant amount of time. In particular, it is
the NetworkExtensionContentFilter that can take a long time. For this reason, it is currently doing the
work on a non-main thread, and we have a binary semaphore that we use to wait synchronously for the
decision. Performing this work on the main thread can block other network requests. To avoid blocking
the main thread waiting for a semaphore, we should instead use a completion handler. This patch adds no
new threads, but is instead introducing a completion handler that is called when the decision is ready.

Before this change, the responsiveness timer in the UI process would terminate the Networking process
if the content filter was blocking the main thread for more than 6s. This issue is resolved with this
patch.

Test: contentfiltering/delay-willsendrequest-decision.html

* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::continueAfterWillSendRequest):
(WebCore::ContentFilter::ContentFilterCallbackAggregator::~ContentFilterCallbackAggregator):
(WebCore::ContentFilter::ContentFilterCallbackAggregator::didReceivePlatformContentFilterDecision):
(WebCore::ContentFilter::ContentFilterCallbackAggregator::ContentFilterCallbackAggregator):
(WebCore::ContentFilter::anyContentFilterIsEnabled const):
* Source/WebCore/loader/ContentFilter.h:
(WebCore::ContentFilter::ContentFilterCallbackAggregator::create):
* Source/WebCore/platform/PlatformContentFilter.h:
(WebCore::PlatformContentFilter::isEnabled const):
* Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h:
* Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm:
(WebCore::NetworkExtensionContentFilter::willSendRequest):
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::ParentalControlsContentFilter::willSendRequest):
* Source/WebCore/testing/MockContentFilter.cpp:
(WebCore::MockContentFilter::willSendRequest):
* Source/WebCore/testing/MockContentFilter.h:
* Source/WebCore/testing/MockContentFilterSettings.cpp:
(WebCore::MockContentFilterSettings::setWillSendRequestDecisionDelay):
* Source/WebCore/testing/MockContentFilterSettings.h:
(WebCore::MockContentFilterSettings::willSendRequestDecisionDelay const):
* Source/WebCore/testing/MockContentFilterSettings.idl:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startContentFiltering):
(WebKit::NetworkResourceLoader::startWithServiceWorker):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/302627@main">https://commits.webkit.org/302627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e343d2ec4cf7633085f2caafce15c099747e9043

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137086 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81159 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/28a7f8d4-ba8c-4a96-9afb-e08ee6fc9d3a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98800 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66628 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a3223afe-69e9-4efe-8314-72009727b143) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116160 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79475 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eb4f4bbb-861d-47f4-b7fd-86747adf59c1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34293 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80359 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139568 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1643 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107310 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107178 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1416 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31007 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54503 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20238 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65195 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1640 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1675 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1747 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->