### PR TITLE
Add PGM-style allocation stack logging for bmalloc allocations

### DIFF
--- a/Source/JavaScriptCore/API/MARReportCrashPrivate.cpp
+++ b/Source/JavaScriptCore/API/MARReportCrashPrivate.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MARReportCrashPrivate.h"
+
+#ifdef __APPLE__
+
+#if !USE(SYSTEM_MALLOC)
+#include <bmalloc/BPlatform.h>
+#if BENABLE(LIBPAS)
+#include <bmalloc/pas_mar_report_crash.h>
+#endif
+#endif
+
+#if !USE(SYSTEM_MALLOC) && BENABLE(LIBPAS)
+
+ALWAYS_INLINE pas_mar_backtrace* toInternalRepresentation(PASMARCrashReportBacktraceRef backtrace)
+{
+    return reinterpret_cast<pas_mar_backtrace*>(backtrace);
+}
+
+ALWAYS_INLINE pas_mar_crash_report* toInternalRepresentation(PASMARCrashReportRef report)
+{
+    return reinterpret_cast<pas_mar_crash_report*>(report);
+}
+
+#endif /* !USE(SYSTEM_MALLOC) && BENABLE(LIBPAS) */
+
+kern_return_t MARReportCrashExtractResults(vm_address_t faultAddress, mach_vm_address_t marGlobalRegistry, unsigned version, task_t task, PASMARCrashReportRef report, crash_reporter_memory_reader_t crmReader)
+{
+#if !USE(SYSTEM_MALLOC)
+#if BENABLE(LIBPAS)
+    return pas_mar_extract_crash_report(faultAddress, marGlobalRegistry, version, task, toInternalRepresentation(report), crmReader);
+#endif
+#endif
+    UNUSED_PARAM(faultAddress);
+    UNUSED_PARAM(marGlobalRegistry);
+    UNUSED_PARAM(version);
+    UNUSED_PARAM(task);
+    UNUSED_PARAM(report);
+    UNUSED_PARAM(crmReader);
+    return KERN_FAILURE;
+}
+
+#if !USE(SYSTEM_MALLOC) && BENABLE(LIBPAS)
+
+PASMARCrashReportRef MARCrashReportCreate()
+{
+    void* result = fastMalloc(sizeof(pas_mar_crash_report));
+    return reinterpret_cast<PASMARCrashReportRef>(new (result) pas_mar_crash_report);
+}
+
+void MARCrashReportRelease(PASMARCrashReportRef report)
+{
+    fastFree(report);
+}
+
+unsigned MARCrashReportGetVersion(PASMARCrashReportRef report)
+{
+    return toInternalRepresentation(report)->report_version;
+}
+
+const char* MARCrashReportGetErrorType(PASMARCrashReportRef report)
+{
+    return toInternalRepresentation(report)->error_type;
+}
+
+const char* MARCrashReportGetConfidence(PASMARCrashReportRef report)
+{
+    return toInternalRepresentation(report)->confidence;
+}
+
+vm_address_t MARCrashReportGetFaultAddress(PASMARCrashReportRef report)
+{
+    return toInternalRepresentation(report)->fault_address;
+}
+
+size_t MARCrashReportGetAllocationSizeBytes(PASMARCrashReportRef report)
+{
+    return toInternalRepresentation(report)->allocation_size_bytes;
+}
+
+PASMARCrashReportBacktraceRef MARCrashReportGetAllocationBacktrace(PASMARCrashReportRef report)
+{
+    return reinterpret_cast<PASMARCrashReportBacktraceRef>(&toInternalRepresentation(report)->allocation_backtrace);
+}
+
+PASMARCrashReportBacktraceRef MARCrashReportGetDeallocationBacktrace(PASMARCrashReportRef report)
+{
+    return reinterpret_cast<PASMARCrashReportBacktraceRef>(&toInternalRepresentation(report)->deallocation_backtrace);
+}
+
+unsigned MARCrashReportBacktraceGetNumFrames(PASMARCrashReportBacktraceRef backtrace)
+{
+    return toInternalRepresentation(backtrace)->num_frames;
+}
+
+void** MARCrashReportBacktraceGetBacktraceBuffer(PASMARCrashReportBacktraceRef backtrace)
+{
+    return toInternalRepresentation(backtrace)->backtrace_buffer;
+}
+
+#else
+
+PASMARCrashReportRef MARCrashReportCreate()
+{
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+void MARCrashReportRelease(PASMARCrashReportRef)
+{
+    ASSERT_NOT_REACHED();
+}
+
+unsigned MARCrashReportGetVersion(PASMARCrashReportRef)
+{
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
+const char* MARCrashReportGetErrorType(PASMARCrashReportRef)
+{
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+const char* MARCrashReportGetConfidence(PASMARCrashReportRef)
+{
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+vm_address_t MARCrashReportGetFaultAddress(PASMARCrashReportRef)
+{
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
+size_t MARCrashReportGetAllocationSizeBytes(PASMARCrashReportRef)
+{
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
+PASMARCrashReportBacktraceRef MARCrashReportGetAllocationBacktrace(PASMARCrashReportRef)
+{
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+PASMARCrashReportBacktraceRef MARCrashReportGetDeallocationBacktrace(PASMARCrashReportRef)
+{
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+unsigned MARCrashReportBacktraceGetNumFrames(PASMARCrashReportBacktraceRef)
+{
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
+void** MARCrashReportBacktraceGetBacktraceBuffer(PASMARCrashReportBacktraceRef)
+{
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+#endif /* !USE(SYSTEM_MALLOC) && BENABLE(LIBPAS) */
+
+#endif /* __APPLE__ */
+

--- a/Source/JavaScriptCore/API/MARReportCrashPrivate.h
+++ b/Source/JavaScriptCore/API/MARReportCrashPrivate.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/JSBase.h>
+
+#ifdef __APPLE__
+#if OS(DARWIN)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* This needs to stay in sync with pas_mar_crash_reporter_report.h */
+#define PASMARCrashReportBacktraceSize 31
+
+/*
+ * Crash version number: used to keep MAR and ReportCrash in sync
+ * This number should monotonically increase every time the layout
+ * of mar_crash_report or its subfields change
+ * This needs to stay in sync with pas_mar_crash_reporter_report.h
+ */
+static const unsigned PASMARCrashReportVersion = 1;
+
+typedef void *(*crash_reporter_memory_reader_t)(task_t task, vm_address_t address, size_t size);
+
+typedef struct OpaquePASMARCrashReportBacktrace* PASMARCrashReportBacktraceRef;
+typedef struct OpaquePASMARCrashReport* PASMARCrashReportRef;
+
+JS_EXPORT PASMARCrashReportRef MARCrashReportCreate();
+JS_EXPORT void MARCrashReportRelease(PASMARCrashReportRef);
+
+JS_EXPORT kern_return_t MARReportCrashExtractResults(vm_address_t fault_address, mach_vm_address_t mar_global_registry, unsigned version, task_t, PASMARCrashReportRef, crash_reporter_memory_reader_t crm_reader);
+
+JS_EXPORT unsigned MARCrashReportGetVersion(PASMARCrashReportRef);
+JS_EXPORT const char* MARCrashReportGetErrorType(PASMARCrashReportRef);
+JS_EXPORT const char* MARCrashReportGetConfidence(PASMARCrashReportRef);
+JS_EXPORT vm_address_t MARCrashReportGetFaultAddress(PASMARCrashReportRef);
+JS_EXPORT size_t MARCrashReportGetAllocationSizeBytes(PASMARCrashReportRef);
+JS_EXPORT PASMARCrashReportBacktraceRef MARCrashReportGetAllocationBacktrace(PASMARCrashReportRef);
+JS_EXPORT PASMARCrashReportBacktraceRef MARCrashReportGetDeallocationBacktrace(PASMARCrashReportRef);
+
+JS_EXPORT unsigned MARCrashReportBacktraceGetNumFrames(PASMARCrashReportBacktraceRef);
+
+/* 
+ * This buffer is only valid for MARCrashReportBacktraceGetNumFrames(backtrace) entries, and at most
+ * PASMARCrashReportBacktraceSize entries. Accesses beyond these limits are UB.
+ */
+JS_EXPORT void** MARCrashReportBacktraceGetBacktraceBuffer(PASMARCrashReportBacktraceRef);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OS(DARWIN) */
+#endif /* __APPLE__ */
+

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2132,6 +2132,7 @@
 		E3FF75331D9CEA1800C7E16D /* DOMJITGetterSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FF752F1D9CEA1200C7E16D /* DOMJITGetterSetter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E49DC16C12EF294E00184A1F /* SourceProviderCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E49DC15112EF272200184A1F /* SourceProviderCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E49DC16D12EF295300184A1F /* SourceProviderCacheItem.h in Headers */ = {isa = PBXBuildFile; fileRef = E49DC14912EF261A00184A1F /* SourceProviderCacheItem.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F300DBB02E259A8B00430A24 /* MARReportCrashPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F300DBAE2E259A7900430A24 /* MARReportCrashPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F323932D2A43748000421AD2 /* WasmFunctionIPIntMetadataGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = F323932B2A43748000421AD2 /* WasmFunctionIPIntMetadataGenerator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F395BE252A43C5920083DE3A /* InPlaceInterpreter.h in Headers */ = {isa = PBXBuildFile; fileRef = F395BE242A43C58B0083DE3A /* InPlaceInterpreter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F3D9C2392A426CB8006EE152 /* WasmIPIntGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D9C2352A426CB7006EE152 /* WasmIPIntGenerator.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6019,6 +6020,8 @@
 		E49DC14912EF261A00184A1F /* SourceProviderCacheItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SourceProviderCacheItem.h; sourceTree = "<group>"; };
 		E49DC15112EF272200184A1F /* SourceProviderCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SourceProviderCache.h; sourceTree = "<group>"; };
 		E49DC15512EF277200184A1F /* SourceProviderCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SourceProviderCache.cpp; sourceTree = "<group>"; };
+		F300DBAE2E259A7900430A24 /* MARReportCrashPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MARReportCrashPrivate.h; sourceTree = "<group>"; };
+		F300DBAF2E259A7900430A24 /* MARReportCrashPrivate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MARReportCrashPrivate.cpp; sourceTree = "<group>"; };
 		F323932B2A43748000421AD2 /* WasmFunctionIPIntMetadataGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmFunctionIPIntMetadataGenerator.h; sourceTree = "<group>"; };
 		F323932C2A43748000421AD2 /* WasmFunctionIPIntMetadataGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmFunctionIPIntMetadataGenerator.cpp; sourceTree = "<group>"; };
 		F3459D7423973ABD00DCD27A /* InspectorTarget.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorTarget.cpp; sourceTree = "<group>"; };
@@ -7549,6 +7552,8 @@
 				86E3C60B167BAB87006D760A /* JSWrapperMap.mm */,
 				E3D3515E241B89CF008DC16E /* MarkedJSValueRefArray.cpp */,
 				E3D3515D241B89CE008DC16E /* MarkedJSValueRefArray.h */,
+				F300DBAF2E259A7900430A24 /* MARReportCrashPrivate.cpp */,
+				F300DBAE2E259A7900430A24 /* MARReportCrashPrivate.h */,
 				86F3EEB9168CCF750077B92A /* ObjCCallbackFunction.h */,
 				86F3EEBA168CCF750077B92A /* ObjCCallbackFunction.mm */,
 				86F3EEB616855A5B0077B92A /* ObjcRuntimeExtras.h */,
@@ -11834,6 +11839,7 @@
 				0F9DAA091FD1C3CF0079C5B2 /* MarkingConstraintSolver.h in Headers */,
 				142D6F1213539A4100B02E86 /* MarkStack.h in Headers */,
 				0F6453181FD246A7002432A1 /* MarkStackMergingConstraint.h in Headers */,
+				F300DBB02E259A8B00430A24 /* MARReportCrashPrivate.h in Headers */,
 				8612E4CD152389EC00C836BE /* MatchResult.h in Headers */,
 				4340A4851A9051AF00D73CCA /* MathCommon.h in Headers */,
 				BC18C43C0E16F5CD00B34460 /* MathObject.h in Headers */,

--- a/Source/JavaScriptCore/JavaScriptCore_Private.modulemap
+++ b/Source/JavaScriptCore/JavaScriptCore_Private.modulemap
@@ -82,6 +82,11 @@ framework module JavaScriptCore_Private [system] {
         export *
     }
 
+    explicit module MARReportCrashPrivate {
+        header "MARReportCrashPrivate.h"
+        export *
+    }
+
     explicit module PASReportCrashPrivate {
         header "PASReportCrashPrivate.h"
         export *
@@ -114,6 +119,7 @@ framework module JavaScriptCore_Private [system] {
         exclude header "JSVirtualMachinePrivate.h"
         exclude header "JSWeakPrivate.h"
         exclude header "JSWeakObjectMapRefPrivate.h"
+        exclude header "MARReportCrashPrivate.h"
         exclude header "PASReportCrashPrivate.h"
 
         explicit module * {

--- a/Source/JavaScriptCore/SourcesCocoa.txt
+++ b/Source/JavaScriptCore/SourcesCocoa.txt
@@ -34,5 +34,6 @@ API/JSVirtualMachine.mm @nonARC
 API/JSWrapperMap.mm @nonARC
 API/ObjCCallbackFunction.mm @nonARC
 API/PASReportCrashPrivate.cpp
+API/MARReportCrashPrivate.cpp
 
 // Use inspector/remote/SourcesCocoa.txt for Remote Inspector files

--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -148,6 +148,8 @@ set(bmalloc_C_SOURCES
     libpas/src/libpas/pas_lock_free_read_ptr_ptr_hashtable.c
     libpas/src/libpas/pas_log.c
     libpas/src/libpas/pas_malloc_stack_logging.c
+    libpas/src/libpas/pas_mar_registry.c
+    libpas/src/libpas/pas_mar_report_crash.c
     libpas/src/libpas/pas_medium_megapage_cache.c
     libpas/src/libpas/pas_megapage_cache.c
     libpas/src/libpas/pas_monotonic_time.c
@@ -547,6 +549,9 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_lock.h
     libpas/src/libpas/pas_log.h
     libpas/src/libpas/pas_malloc_stack_logging.h
+    libpas/src/libpas/pas_mar_crash_reporter_report.h
+    libpas/src/libpas/pas_mar_registry.h
+    libpas/src/libpas/pas_mar_report_crash.h
     libpas/src/libpas/pas_medium_megapage_cache.h
     libpas/src/libpas/pas_megapage_cache.h
     libpas/src/libpas/pas_min_heap.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		0100000D37BABA0A0A991999 /* pas_zero_memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A991999 /* pas_zero_memory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		079E6EA02E45531700E9AF5F /* pas_backtrace_metadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 079E6E9F2E45531700E9AF5F /* pas_backtrace_metadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F26A7A5205483130090A141 /* PerProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F26A7A42054830D0090A141 /* PerProcess.cpp */; };
 		0F5167741FAD685C008236A8 /* bmalloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5167731FAD6852008236A8 /* bmalloc.cpp */; };
 		0F5414442CFD832E0025EAD0 /* bmalloc_heap_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5414432CFD832E0025EAD0 /* bmalloc_heap_internal.h */; };
@@ -699,6 +701,11 @@
 		EB17D11123BFCD42002093A7 /* HeapConstants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB17D11023BFC8C4002093A7 /* HeapConstants.cpp */; };
 		EB17D11223BFCD7A002093A7 /* HeapConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = EB17D10E23BE691D002093A7 /* HeapConstants.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F15AF5192D791B4B001AE01E /* pas_thread.h in Headers */ = {isa = PBXBuildFile; fileRef = F15AF5182D791B4B001AE01E /* pas_thread.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F34D74B92E71E80200024262 /* pas_mar_report_crash.c in Sources */ = {isa = PBXBuildFile; fileRef = F39CF9AB2E70E40900EB3567 /* pas_mar_report_crash.c */; };
+		F34D74BA2E71E80D00024262 /* pas_mar_registry.c in Sources */ = {isa = PBXBuildFile; fileRef = F39CF9A52E70CA3600EB3567 /* pas_mar_registry.c */; };
+		F39CF9A82E70CA3600EB3567 /* pas_mar_registry.h in Headers */ = {isa = PBXBuildFile; fileRef = F39CF9A42E70CA3600EB3567 /* pas_mar_registry.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F39CF9AD2E70E41400EB3567 /* pas_mar_crash_reporter_report.h in Headers */ = {isa = PBXBuildFile; fileRef = F39CF9AC2E70E40900EB3567 /* pas_mar_crash_reporter_report.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F39CF9AE2E70E41B00EB3567 /* pas_mar_report_crash.h in Headers */ = {isa = PBXBuildFile; fileRef = F39CF9AA2E70E40900EB3567 /* pas_mar_report_crash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE0383202ABC0E9F00A576A2 /* TZoneHeap.h in Headers */ = {isa = PBXBuildFile; fileRef = FE03831E2ABC0E9F00A576A2 /* TZoneHeap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE0383212ABC0E9F00A576A2 /* TZoneHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE03831F2ABC0E9F00A576A2 /* TZoneHeap.cpp */; };
 		FE0383232ABC988C00A576A2 /* TZoneHeapInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FE0383222ABC988C00A576A2 /* TZoneHeapInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -747,6 +754,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0100000B37BABA0A0A991999 /* pas_zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_zero_memory.h; path = libpas/src/libpas/pas_zero_memory.h; sourceTree = "<group>"; };
+		079E6E9F2E45531700E9AF5F /* pas_backtrace_metadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pas_backtrace_metadata.h; path = libpas/src/libpas/pas_backtrace_metadata.h; sourceTree = "<group>"; };
 		0F18F83C25C3467700721C2A /* pas_segregated_exclusive_view_inlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_segregated_exclusive_view_inlines.h; path = libpas/src/libpas/pas_segregated_exclusive_view_inlines.h; sourceTree = "<group>"; };
 		0F18F83D25C3467700721C2A /* minalign32_heap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = minalign32_heap.c; path = libpas/src/libpas/minalign32_heap.c; sourceTree = "<group>"; };
 		0F18F83E25C3467700721C2A /* pagesize64k_heap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pagesize64k_heap.c; path = libpas/src/libpas/pagesize64k_heap.c; sourceTree = "<group>"; };
@@ -1425,6 +1434,11 @@
 		EB17D10E23BE691D002093A7 /* HeapConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HeapConstants.h; path = bmalloc/HeapConstants.h; sourceTree = "<group>"; };
 		EB17D11023BFC8C4002093A7 /* HeapConstants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HeapConstants.cpp; path = bmalloc/HeapConstants.cpp; sourceTree = "<group>"; };
 		F15AF5182D791B4B001AE01E /* pas_thread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pas_thread.h; path = libpas/src/libpas/pas_thread.h; sourceTree = "<group>"; };
+		F39CF9A42E70CA3600EB3567 /* pas_mar_registry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pas_mar_registry.h; path = libpas/src/libpas/pas_mar_registry.h; sourceTree = "<group>"; };
+		F39CF9A52E70CA3600EB3567 /* pas_mar_registry.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pas_mar_registry.c; path = libpas/src/libpas/pas_mar_registry.c; sourceTree = "<group>"; };
+		F39CF9AA2E70E40900EB3567 /* pas_mar_report_crash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pas_mar_report_crash.h; path = libpas/src/libpas/pas_mar_report_crash.h; sourceTree = "<group>"; };
+		F39CF9AB2E70E40900EB3567 /* pas_mar_report_crash.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pas_mar_report_crash.c; path = libpas/src/libpas/pas_mar_report_crash.c; sourceTree = "<group>"; };
+		F39CF9AC2E70E40900EB3567 /* pas_mar_crash_reporter_report.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pas_mar_crash_reporter_report.h; path = libpas/src/libpas/pas_mar_crash_reporter_report.h; sourceTree = "<group>"; };
 		FE03831E2ABC0E9F00A576A2 /* TZoneHeap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TZoneHeap.h; path = bmalloc/TZoneHeap.h; sourceTree = "<group>"; };
 		FE03831F2ABC0E9F00A576A2 /* TZoneHeap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TZoneHeap.cpp; path = bmalloc/TZoneHeap.cpp; sourceTree = "<group>"; };
 		FE0383222ABC988C00A576A2 /* TZoneHeapInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TZoneHeapInlines.h; path = bmalloc/TZoneHeapInlines.h; sourceTree = "<group>"; };
@@ -1867,6 +1881,11 @@
 				0FC40AC12451499000876DA0 /* pas_log.h */,
 				E3696A3A28F6C48B00C2F2D4 /* pas_malloc_stack_logging.c */,
 				E3696A3B28F6C48B00C2F2D4 /* pas_malloc_stack_logging.h */,
+				F39CF9AC2E70E40900EB3567 /* pas_mar_crash_reporter_report.h */,
+				F39CF9A52E70CA3600EB3567 /* pas_mar_registry.c */,
+				F39CF9A42E70CA3600EB3567 /* pas_mar_registry.h */,
+				F39CF9AB2E70E40900EB3567 /* pas_mar_report_crash.c */,
+				F39CF9AA2E70E40900EB3567 /* pas_mar_report_crash.h */,
 				0F87004B25AF8A19000E1ABF /* pas_medium_megapage_cache.c */,
 				0F87004825AF8A19000E1ABF /* pas_medium_megapage_cache.h */,
 				0FC40A812451498B00876DA0 /* pas_megapage_cache.c */,
@@ -2096,6 +2115,7 @@
 				147AAA9C18CE6010002201E4 /* heap: large */,
 				147AAA9A18CE5FD3002201E4 /* heap: small */,
 				0F7EB7FB1F95416900F1ABCB /* iso */,
+				F3D6990D2E1EFCD0006B54BD /* mar */,
 				145F6840179DC45F00D65598 /* Products */,
 				14D9DB4F17F2868900EAAB79 /* stdlib */,
 			);
@@ -2246,6 +2266,13 @@
 				52F47248210BA2F500B730BB /* MemoryStatusSPI.h */,
 			);
 			name = darwin;
+			sourceTree = "<group>";
+		};
+		F3D6990D2E1EFCD0006B54BD /* mar */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = mar;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2613,6 +2640,9 @@
 				DD4BECC929CBA49700398E35 /* pas_lock_free_read_ptr_ptr_hashtable.h in Headers */,
 				DD4BEDFA29CBA49700398E35 /* pas_log.h in Headers */,
 				DD4BED2B29CBA49700398E35 /* pas_malloc_stack_logging.h in Headers */,
+				F39CF9AD2E70E41400EB3567 /* pas_mar_crash_reporter_report.h in Headers */,
+				F39CF9A82E70CA3600EB3567 /* pas_mar_registry.h in Headers */,
+				F39CF9AE2E70E41B00EB3567 /* pas_mar_report_crash.h in Headers */,
 				DD4BED2429CBA49700398E35 /* pas_medium_megapage_cache.h in Headers */,
 				DD4BED4229CBA49700398E35 /* pas_megapage_cache.h in Headers */,
 				DD4BECFF29CBA49700398E35 /* pas_min_heap.h in Headers */,
@@ -3037,6 +3067,8 @@
 				DD4BECF229CBA49700398E35 /* pas_lock_free_read_ptr_ptr_hashtable.c in Sources */,
 				DD4BECD429CBA49700398E35 /* pas_log.c in Sources */,
 				DD4BEC4629CBA49700398E35 /* pas_malloc_stack_logging.c in Sources */,
+				F34D74BA2E71E80D00024262 /* pas_mar_registry.c in Sources */,
+				F34D74B92E71E80200024262 /* pas_mar_report_crash.c in Sources */,
 				DD4BEC2729CBA49700398E35 /* pas_medium_megapage_cache.c in Sources */,
 				DD4BED2829CBA49700398E35 /* pas_megapage_cache.c in Sources */,
 				DD4BECBC29CBA49700398E35 /* pas_monotonic_time.c in Sources */,

--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -604,6 +604,12 @@
 		A4203F4C2DEF5E8600F67514 /* pas_thread.c in Sources */ = {isa = PBXBuildFile; fileRef = A4203F4B2DEF5E8600F67514 /* pas_thread.c */; };
 		E3096D4C2A82357800BC4CA0 /* pas_allocation_result.c in Sources */ = {isa = PBXBuildFile; fileRef = E3096D4B2A82357800BC4CA0 /* pas_allocation_result.c */; };
 		E3AA9B8328C724D8005DF9D6 /* pas_darwin_spi.h in Headers */ = {isa = PBXBuildFile; fileRef = E3AA9B8228C724D8005DF9D6 /* pas_darwin_spi.h */; };
+		F30C5BE42E8F33E4006CA1E9 /* MARTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F30C5BE32E8F33E4006CA1E9 /* MARTests.cpp */; };
+		F3EFAABC2E90316400A1EDE0 /* pas_mar_registry.c in Sources */ = {isa = PBXBuildFile; fileRef = F3EFAAB92E90316400A1EDE0 /* pas_mar_registry.c */; };
+		F3EFAABD2E90316400A1EDE0 /* pas_mar_report_crash.c in Sources */ = {isa = PBXBuildFile; fileRef = F3EFAABB2E90316400A1EDE0 /* pas_mar_report_crash.c */; };
+		F3EFAABE2E90316400A1EDE0 /* pas_mar_crash_reporter_report.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EFAAB72E90316400A1EDE0 /* pas_mar_crash_reporter_report.h */; };
+		F3EFAABF2E90316400A1EDE0 /* pas_mar_report_crash.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EFAABA2E90316400A1EDE0 /* pas_mar_report_crash.h */; };
+		F3EFAAC02E90316400A1EDE0 /* pas_mar_registry.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EFAAB82E90316400A1EDE0 /* pas_mar_registry.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -972,6 +978,7 @@
 		0F8A810025F6A79500790B4A /* hotbit_heap_inlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hotbit_heap_inlines.h; sourceTree = "<group>"; };
 		0F97E62D22A9A85F00C355F8 /* pas_segregated_page_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_segregated_page_config.h; sourceTree = "<group>"; };
 		0F97E62F22A9AAC100C355F8 /* pas_segregated_page_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_segregated_page_config.c; sourceTree = "<group>"; };
+		0F99999B26AAAA0000111111 /* pas_zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_zero_memory.h; sourceTree = "<group>"; };
 		0F9A1C992559961100C8D11B /* pas_fast_path_allocation_result_kind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_fast_path_allocation_result_kind.h; sourceTree = "<group>"; };
 		0F9A1C9A2559961100C8D11B /* pas_bitfit_page_config_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_bitfit_page_config_utils.h; sourceTree = "<group>"; };
 		0F9A1C9B2559961100C8D11B /* pas_bitfit_max_free.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_bitfit_max_free.h; sourceTree = "<group>"; };
@@ -1329,6 +1336,12 @@
 		A4203F4B2DEF5E8600F67514 /* pas_thread.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pas_thread.c; sourceTree = "<group>"; };
 		E3096D4B2A82357800BC4CA0 /* pas_allocation_result.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_allocation_result.c; sourceTree = "<group>"; };
 		E3AA9B8228C724D8005DF9D6 /* pas_darwin_spi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_darwin_spi.h; sourceTree = "<group>"; };
+		F30C5BE32E8F33E4006CA1E9 /* MARTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MARTests.cpp; sourceTree = "<group>"; };
+		F3EFAAB72E90316400A1EDE0 /* pas_mar_crash_reporter_report.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pas_mar_crash_reporter_report.h; sourceTree = "<group>"; };
+		F3EFAAB82E90316400A1EDE0 /* pas_mar_registry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pas_mar_registry.h; sourceTree = "<group>"; };
+		F3EFAAB92E90316400A1EDE0 /* pas_mar_registry.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pas_mar_registry.c; sourceTree = "<group>"; };
+		F3EFAABA2E90316400A1EDE0 /* pas_mar_report_crash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pas_mar_report_crash.h; sourceTree = "<group>"; };
+		F3EFAABB2E90316400A1EDE0 /* pas_mar_report_crash.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pas_mar_report_crash.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1444,6 +1457,7 @@
 				0FEB6669231DA86F009C001B /* LargeSharingPoolTests.cpp */,
 				0FEA45BE236CDAED00B5A375 /* LockFreeReadPtrPtrHashtableTests.cpp */,
 				2CB9B15C278F861B003A8C1B /* LotsOfHeapsAndThreads.cpp */,
+				F30C5BE32E8F33E4006CA1E9 /* MARTests.cpp */,
 				2C734C8F277680EF0017BFFE /* MemalignTests.cpp */,
 				0FD22D0722CD8A7500B21841 /* MinHeapTests.cpp */,
 				2B2A589B2742D815005EE07C /* PGMTests.cpp */,
@@ -1790,6 +1804,11 @@
 				0F9E945723452262009FAFDD /* pas_log.h */,
 				2B2E2FCF2949A41100F85C38 /* pas_malloc_stack_logging.c */,
 				2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */,
+				F3EFAAB72E90316400A1EDE0 /* pas_mar_crash_reporter_report.h */,
+				F3EFAAB92E90316400A1EDE0 /* pas_mar_registry.c */,
+				F3EFAAB82E90316400A1EDE0 /* pas_mar_registry.h */,
+				F3EFAABB2E90316400A1EDE0 /* pas_mar_report_crash.c */,
+				F3EFAABA2E90316400A1EDE0 /* pas_mar_report_crash.h */,
 				0F037AF125AEA9190079B582 /* pas_medium_megapage_cache.c */,
 				0F037AF225AEA91A0079B582 /* pas_medium_megapage_cache.h */,
 				0FC6820021210B19003C6A13 /* pas_megapage_cache.c */,
@@ -2310,6 +2329,9 @@
 				0FEA45BD236CD5AC00B5A375 /* pas_lock_free_read_ptr_ptr_hashtable.h in Headers */,
 				0F9E945923452262009FAFDD /* pas_log.h in Headers */,
 				2B2E2FD22949A41100F85C38 /* pas_malloc_stack_logging.h in Headers */,
+				F3EFAABE2E90316400A1EDE0 /* pas_mar_crash_reporter_report.h in Headers */,
+				F3EFAAC02E90316400A1EDE0 /* pas_mar_registry.h in Headers */,
+				F3EFAABF2E90316400A1EDE0 /* pas_mar_report_crash.h in Headers */,
 				0F037AF425AEA91A0079B582 /* pas_medium_megapage_cache.h in Headers */,
 				0FE7EE2222960142004F4166 /* pas_megapage_cache.h in Headers */,
 				0FD22CFC22CAF16400B21841 /* pas_min_heap.h in Headers */,
@@ -2444,7 +2466,6 @@
 				0F68127022BD419E0036A02B /* pas_versioned_field.h in Headers */,
 				0F78088422FA22D200F37451 /* pas_virtual_range.h in Headers */,
 				0F78088E22FA534100F37451 /* pas_virtual_range_min_heap.h in Headers */,
-				0F99999D26AAAA0000111111 /* pas_zero_memory.h in Headers */,
 				0FE7EE3B22960142004F4166 /* pas_zero_mode.h in Headers */,
 				0F8700A825B0A8C2000E1ABF /* thingy_heap.h in Headers */,
 				0F8700AA25B0A8C3000E1ABF /* thingy_heap_config.h in Headers */,
@@ -2727,6 +2748,7 @@
 				0FEB666A231DA86F009C001B /* LargeSharingPoolTests.cpp in Sources */,
 				0FEA45BF236CDAED00B5A375 /* LockFreeReadPtrPtrHashtableTests.cpp in Sources */,
 				2CB9B15D278F861B003A8C1B /* LotsOfHeapsAndThreads.cpp in Sources */,
+				F30C5BE42E8F33E4006CA1E9 /* MARTests.cpp in Sources */,
 				2C734C90277680EF0017BFFE /* MemalignTests.cpp in Sources */,
 				0FD22D0822CD8A7500B21841 /* MinHeapTests.cpp in Sources */,
 				2B2A589C2742D815005EE07C /* PGMTests.cpp in Sources */,
@@ -2841,6 +2863,8 @@
 				0FEA45BC236CD5AC00B5A375 /* pas_lock_free_read_ptr_ptr_hashtable.c in Sources */,
 				0F9E945823452262009FAFDD /* pas_log.c in Sources */,
 				2B2E2FD12949A41100F85C38 /* pas_malloc_stack_logging.c in Sources */,
+				F3EFAABC2E90316400A1EDE0 /* pas_mar_registry.c in Sources */,
+				F3EFAABD2E90316400A1EDE0 /* pas_mar_report_crash.c in Sources */,
 				0F037AF325AEA91A0079B582 /* pas_medium_megapage_cache.c in Sources */,
 				0FE7EDC822960142004F4166 /* pas_megapage_cache.c in Sources */,
 				0FD48B4B23A9ABB30026C46D /* pas_monotonic_time.c in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
@@ -34,6 +34,7 @@ PAS_IGNORE_WARNINGS_BEGIN("missing-field-initializers")
 #include "bmalloc_heap_config.h"
 #include "bmalloc_heap_innards.h"
 #include "pas_deallocate.h"
+#include "pas_mar_registry.h"
 #include "pas_try_allocate.h"
 #include "pas_try_allocate_array.h"
 #include "pas_try_allocate_intrinsic.h"
@@ -63,14 +64,27 @@ PAS_API void* bmalloc_try_allocate_auxiliary_with_alignment_casual(
 PAS_API void* bmalloc_allocate_auxiliary_with_alignment_casual(
     pas_primitive_heap_ref* heap_ref, size_t size, size_t alignment, pas_allocation_mode allocation_mode);
 
+#if PAS_OS(DARWIN)
+#define PAS_MAR_SHOULD_LOG(allocation_mode, address) (pas_mar_enabled && allocation_mode == pas_non_compact_allocation_mode && pas_mar_is_address_in_qualifying_page(address))
+#define PAS_MAR_TRACK_ALLOCATION(address, size) pas_mar_did_allocate(&pas_mar_global_registry, address, size)
+#define PAS_MAR_TRACK_ALLOCATION_AND_ZERO(address, size) pas_mar_did_allocate_and_zero(&pas_mar_global_registry, address, size)
+#else
+#define PAS_MAR_SHOULD_LOG(allocation_mode, address) false
+#define PAS_MAR_TRACK_ALLOCATION(address, size) address
+#define PAS_MAR_TRACK_ALLOCATION_AND_ZERO(result, size) ((void*) result.begin)
+#endif
+
 static PAS_ALWAYS_INLINE void* bmalloc_try_allocate_auxiliary_inline(pas_primitive_heap_ref* heap_ref,
                                                                      size_t size,
                                                                      pas_allocation_mode allocation_mode)
 {
     pas_allocation_result result;
     result = bmalloc_try_allocate_auxiliary_impl_inline_only(heap_ref, size, 1, allocation_mode);
-    if (PAS_LIKELY(result.did_succeed))
+    if (PAS_LIKELY(result.did_succeed)) {
+        if (PAS_MAR_SHOULD_LOG(allocation_mode, (void*) result.begin))
+            return PAS_MAR_TRACK_ALLOCATION((void*)result.begin, size);
         return (void*)result.begin;
+    }
     return bmalloc_try_allocate_auxiliary_with_alignment_casual(heap_ref, size, 1, allocation_mode);
 }
 
@@ -80,8 +94,11 @@ static PAS_ALWAYS_INLINE void* bmalloc_allocate_auxiliary_inline(pas_primitive_h
 {
     pas_allocation_result result;
     result = bmalloc_allocate_auxiliary_impl_inline_only(heap_ref, size, 1, allocation_mode);
-    if (PAS_LIKELY(result.did_succeed))
+    if (PAS_LIKELY(result.did_succeed)) {
+        if (PAS_MAR_SHOULD_LOG(allocation_mode, (void*) result.begin))
+            return PAS_MAR_TRACK_ALLOCATION((void*) result.begin, size);
         return (void*)result.begin;
+    }
     return bmalloc_allocate_auxiliary_with_alignment_casual(heap_ref, size, 1, allocation_mode);
 }
 
@@ -90,18 +107,22 @@ static PAS_ALWAYS_INLINE void* bmalloc_try_allocate_auxiliary_zeroed_inline(
     size_t size,
     pas_allocation_mode allocation_mode)
 {
-    return (void*)pas_allocation_result_zero(
-        bmalloc_try_allocate_auxiliary_impl(heap_ref, size, 1, allocation_mode),
-        size).begin;
+    pas_allocation_result result;
+    result = bmalloc_try_allocate_auxiliary_impl(heap_ref, size, 1, allocation_mode);
+    if (PAS_MAR_SHOULD_LOG(allocation_mode, (void*) result.begin))
+        return PAS_MAR_TRACK_ALLOCATION_AND_ZERO(result, size);
+    return (void*)pas_allocation_result_zero(result, size).begin;
 }
 
 static PAS_ALWAYS_INLINE void* bmalloc_allocate_auxiliary_zeroed_inline(pas_primitive_heap_ref* heap_ref,
                                                                         size_t size,
                                                                         pas_allocation_mode allocation_mode)
 {
-    return (void*)pas_allocation_result_zero(
-        bmalloc_allocate_auxiliary_impl(heap_ref, size, 1, allocation_mode),
-        size).begin;
+    pas_allocation_result result;
+    result = bmalloc_allocate_auxiliary_impl(heap_ref, size, 1, allocation_mode);
+    if (PAS_MAR_SHOULD_LOG(allocation_mode, (void*) result.begin))
+        return PAS_MAR_TRACK_ALLOCATION_AND_ZERO(result, size);
+    return (void*)pas_allocation_result_zero(result, size).begin;
 }
 
 static PAS_ALWAYS_INLINE void*
@@ -248,8 +269,11 @@ static PAS_ALWAYS_INLINE void* bmalloc_try_allocate_inline(size_t size, pas_allo
         return (void*)bmalloc_try_allocate_auxiliary_inline(&bmalloc_compact_primitive_heap_ref, size, allocation_mode);
     pas_allocation_result result;
     result = bmalloc_try_allocate_impl_inline_only(size, 1, allocation_mode);
-    if (PAS_LIKELY(result.did_succeed))
+    if (PAS_LIKELY(result.did_succeed)) {
+        if (PAS_MAR_SHOULD_LOG(allocation_mode, (void*) result.begin))
+            return PAS_MAR_TRACK_ALLOCATION((void*) result.begin, size);
         return (void*)result.begin;
+    }
     return bmalloc_try_allocate_casual(size, allocation_mode);
 }
 
@@ -273,18 +297,22 @@ bmalloc_try_allocate_zeroed_with_alignment_inline(size_t size, size_t alignment,
 
 static PAS_ALWAYS_INLINE void* bmalloc_try_allocate_zeroed_inline(size_t size, pas_allocation_mode allocation_mode)
 {
+    pas_allocation_result result;
     if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
         return (void*)bmalloc_try_allocate_auxiliary_zeroed_inline(&bmalloc_compact_primitive_heap_ref, size, allocation_mode);
-    return (void*)pas_allocation_result_zero(
-        bmalloc_try_allocate_impl(size, 1, allocation_mode),
-        size).begin;
+
+    result = bmalloc_try_allocate_impl(size, 1, allocation_mode);
+    if (PAS_MAR_SHOULD_LOG(allocation_mode, (void*) result.begin))
+        return PAS_MAR_TRACK_ALLOCATION((void*)result.begin, size);
+    return (void*)pas_allocation_result_zero(result, size).begin;
 }
 
 static PAS_ALWAYS_INLINE void* bmalloc_allocate_inline(size_t size, pas_allocation_mode allocation_mode)
 {
+    pas_allocation_result result;
     if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
         return (void*)bmalloc_allocate_auxiliary_inline(&bmalloc_compact_primitive_heap_ref, size, allocation_mode);
-    pas_allocation_result result;
+
     result = bmalloc_allocate_impl_inline_only(size, 1, allocation_mode);
     if (PAS_LIKELY(result.did_succeed))
         return (void*)result.begin;

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.c
@@ -36,6 +36,7 @@
 #include "pas_heap_table.h"
 #include "pas_immortal_heap.h"
 #include "pas_log.h"
+#include "pas_mar_registry.h"
 #include "pas_monotonic_time.h"
 #include "pas_primitive_heap_ref.h"
 #include "pas_probabilistic_guard_malloc_allocator.h"
@@ -83,6 +84,11 @@ pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
     // PGM being enabled in the config does not guarantee it will be called during runtime.
     if (config->pgm_enabled)
         pas_probabilistic_guard_malloc_initialize_pgm();
+
+#if PAS_OS(DARWIN)
+    static pthread_once_t mar_control = PTHREAD_ONCE_INIT;
+    pthread_once(&mar_control, pas_mar_initialize);
+#endif /* PAS_OS(DARWIN) */
     
     pas_all_heaps_add_heap(heap);
     

--- a/Source/bmalloc/libpas/src/libpas/pas_mar_crash_reporter_report.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mar_crash_reporter_report.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef MAR_CRASH_REPORTER_REPORT_H
+#define MAR_CRASH_REPORTER_REPORT_H
+
+#include <stddef.h>
+
+#ifdef __APPLE__
+
+#include <mach/mach_types.h>
+#include <mach/vm_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PAS_MAR_BACKTRACE_MAX_SIZE 31
+
+/* Read memory from crashed process. */
+typedef void *(*crash_reporter_memory_reader_t)(task_t task, vm_address_t address, size_t size);
+
+// Crash version number: used to keep MAR and ReportCrash in sync
+// This number should monotonically increase every time the layout
+// of mar_crash_report or its subfields change
+static const unsigned pas_mar_crash_report_version = 1;
+
+typedef struct pas_mar_backtrace pas_mar_backtrace;
+struct pas_mar_backtrace {
+    unsigned num_frames;
+    void* backtrace_buffer[PAS_MAR_BACKTRACE_MAX_SIZE];
+};
+
+typedef struct pas_mar_crash_report pas_mar_crash_report;
+struct pas_mar_crash_report {
+    unsigned report_version;
+    const char* error_type;
+    const char* confidence;
+    vm_address_t fault_address;
+    size_t allocation_size_bytes;
+    pas_mar_backtrace allocation_backtrace;
+    pas_mar_backtrace deallocation_backtrace;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __APPLE__ */
+
+#endif /* MAR_CRASH_REPORTER_REPORT_H */
+

--- a/Source/bmalloc/libpas/src/libpas/pas_mar_registry.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mar_registry.c
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "pas_config.h"
+
+#if LIBPAS_ENABLED
+
+#include "pas_mar_registry.h"
+
+#include "pas_random.h"
+
+#if PAS_OS(DARWIN)
+
+#include <assert.h>
+#include <execinfo.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+bool pas_mar_enabled = false;
+unsigned pas_mar_qualifying_page_index = 0;
+
+struct pas_mar_registry pas_mar_global_registry = {
+    { },
+    { },
+    0,
+    0,
+    { },
+};
+
+struct pas_mar_registry* pas_mar_registry_for_crash_reporter_enumeration = NULL;
+
+// Backtrace hashing
+
+#if PAS_CPU(ADDRESS64)
+
+static uint32_t hash_backtrace(unsigned num_stack_frames, void** backtrace)
+{
+    // This implements Murmur hash on the low 32b of each backtrace
+    const uint32_t c1 = 0xcc9e2d51;
+    const uint32_t c2 = 0x1b873593;
+    const uint32_t r1 = 15;
+    const uint32_t r2 = 13;
+    const uint32_t m = 5;
+    const uint32_t n = 0xe6546b64;
+
+    uint32_t result = 0;
+
+    for (unsigned i = 0; i < num_stack_frames; ++i) {
+        uint32_t k = ((uintptr_t)backtrace[i]) & ((1ull << 32) - 1);
+        k *= c1;
+        k = (k << r1) | (k >> (32 - r1));
+        k *= c2;
+
+        result ^= k;
+        result = (result << r2) | (result >> (32 - r2));
+        result = result * m + n;
+    }
+
+    result ^= (num_stack_frames * 4);
+    result = result ^ (result >> 16);
+    result *= 0x85ebca6b;
+    result = result ^ (result >> 13);
+    result *= 0xc2b2ae35;
+    result = result ^ (result >> 16);
+
+    return result;
+}
+
+unsigned pas_mar_insert_backtrace(pas_mar_registry*, unsigned num_stack_frames, void** backtrace, uint32_t hash);
+unsigned pas_mar_insert_backtrace(pas_mar_registry* registry, unsigned num_stack_frames, void** backtrace, uint32_t hash)
+{
+    unsigned index = hash % PAS_MAR_TRACKED_BACKTRACES;
+    if (hash == registry->backtrace_registry[index].hash)
+        return index;
+
+    registry->backtrace_registry[index].num_frames = num_stack_frames;
+    registry->backtrace_registry[index].hash = hash;
+    memcpy(registry->backtrace_registry[index].backtrace_buffer, backtrace, num_stack_frames* sizeof(void*));
+    return index;
+}
+
+#endif /* PAS_CPU(ADDRESS64) */
+
+// MAR Registry
+
+void pas_mar_initialize(void)
+{
+    if (!pas_mar_registry_for_crash_reporter_enumeration)
+        pas_mar_registry_for_crash_reporter_enumeration = &pas_mar_global_registry;
+
+    pas_lock_construct(&pas_mar_global_registry.lock);
+
+    if (PAS_UNLIKELY(getenv("SanitizersAllocationTraces"))) {
+        pas_mar_enabled = true;
+        pas_mar_qualifying_page_index = pas_get_fast_random(PAS_MAR_PROBABILITY);
+        return;
+    }
+    if (PAS_LIKELY(pas_get_fast_random(1000) >= 1))
+        pas_mar_enabled = false;
+    else {
+        pas_mar_enabled = true;
+        pas_mar_qualifying_page_index = pas_get_fast_random(PAS_MAR_PROBABILITY);
+    }
+}
+
+void* pas_mar_did_allocate(pas_mar_registry* registry, void* address, size_t allocation_size)
+{
+    void* stacktrace[PAS_MAR_BACKTRACE_MAX_SIZE];
+    unsigned num_stack_frames = (unsigned) backtrace(stacktrace, PAS_MAR_BACKTRACE_MAX_SIZE);
+
+    return pas_mar_record_allocation(registry, address, allocation_size, num_stack_frames, stacktrace);
+}
+
+void* pas_mar_did_allocate_and_zero(pas_mar_registry* registry, pas_allocation_result result, size_t allocation_size)
+{
+    void* stacktrace[PAS_MAR_BACKTRACE_MAX_SIZE];
+    unsigned num_stack_frames = (unsigned) backtrace(stacktrace, PAS_MAR_BACKTRACE_MAX_SIZE);
+
+    pas_mar_record_allocation(registry, (void*)result.begin, allocation_size, num_stack_frames, stacktrace);
+    return (void*)pas_allocation_result_zero(result, allocation_size).begin;
+}
+
+void* pas_mar_did_deallocate(pas_mar_registry* registry, void* address)
+{
+    void* stacktrace[PAS_MAR_BACKTRACE_MAX_SIZE];
+    unsigned num_stack_frames = (unsigned) backtrace(stacktrace, PAS_MAR_BACKTRACE_MAX_SIZE);
+
+    return pas_mar_record_deallocation(registry, address, num_stack_frames, stacktrace);
+}
+
+void* pas_mar_record_allocation(pas_mar_registry* registry, void* address, size_t allocation_size_bytes, unsigned num_stack_frames, void** backtrace)
+{
+    pas_lock_lock(&registry->lock);
+    PAS_ASSERT(num_stack_frames <= PAS_MAR_BACKTRACE_MAX_SIZE);
+
+    if (pas_mar_is_allocation_table_full(registry))
+        pas_mar_increment_allocation_record_table_head(registry);
+
+    unsigned allocation_table_index = pas_mar_allocation_table_tail_index(registry);
+    pas_mar_increment_allocation_record_table_tail(registry);
+
+    uint32_t backtrace_hash = hash_backtrace(num_stack_frames, backtrace);
+    unsigned backtrace_registry_index = pas_mar_insert_backtrace(registry, num_stack_frames, backtrace, backtrace_hash);
+    struct pas_mar_memory_action_record new_record = {
+        address,
+        allocation_size_bytes,
+        backtrace_registry_index,
+        backtrace_hash,
+        true
+    };
+    registry->allocation_record_table[allocation_table_index] = new_record;
+    pas_lock_unlock(&registry->lock);
+    return address;
+}
+
+void* pas_mar_record_deallocation(pas_mar_registry* registry, void* address, unsigned num_stack_frames, void** backtrace)
+{
+    pas_lock_lock(&registry->lock);
+    PAS_ASSERT(num_stack_frames <= PAS_MAR_BACKTRACE_MAX_SIZE);
+
+    if (pas_mar_is_allocation_table_full(registry))
+        pas_mar_increment_allocation_record_table_head(registry);
+
+    unsigned allocation_table_index = pas_mar_allocation_table_tail_index(registry);
+    pas_mar_increment_allocation_record_table_tail(registry);
+
+    uint32_t backtrace_hash = hash_backtrace(num_stack_frames, backtrace);
+    unsigned backtrace_registry_index = pas_mar_insert_backtrace(registry, num_stack_frames, backtrace, backtrace_hash);
+    struct pas_mar_memory_action_record new_record = {
+        address,
+        0,
+        backtrace_registry_index,
+        backtrace_hash,
+        false
+    };
+    registry->allocation_record_table[allocation_table_index] = new_record;
+    pas_lock_unlock(&registry->lock);
+    return address;
+}
+
+struct pas_mar_exported_allocation_record pas_mar_get_allocation_record(pas_mar_registry* registry, void* address)
+{
+    struct pas_mar_exported_allocation_record result;
+    result.is_valid = false;
+
+    address = pas_mar_canonicalize_address(address);
+
+    void* base_object_address = NULL;
+    for (unsigned i = 0; i < PAS_MAR_TRACKED_ALLOCATIONS; ++i) {
+        unsigned index = (pas_mar_allocation_table_head_index(registry) + i) % PAS_MAR_TRACKED_ALLOCATIONS;
+        if ((registry->allocation_record_table_head + i) % MAR_ALLOCATION_RECORD_TABLE_FIFO_MODULUS == registry->allocation_record_table_tail)
+            break;
+        struct pas_mar_memory_action_record* art_entry = &registry->allocation_record_table[index];
+        if (art_entry->is_allocation) {
+            // Check if the allocation was within the range
+            if ((uintptr_t) address >= (uintptr_t) pas_mar_canonicalize_address(art_entry->address) && (uintptr_t) address < ((uintptr_t) pas_mar_canonicalize_address(art_entry->address)) + art_entry->allocation_size_bytes) {
+                // Check that we have a valid backtrace
+                unsigned registry_index = art_entry->backtrace_registry_index;
+                if (registry->backtrace_registry[registry_index].hash != art_entry->backtrace_hash)
+                    continue;
+
+                pas_mar_backtrace_record* backtrace = &registry->backtrace_registry[registry_index];
+
+                result.allocation_size_bytes = art_entry->allocation_size_bytes;
+                result.is_valid = true;
+                result.allocation_trace.num_frames= backtrace->num_frames;
+                memcpy(result.allocation_trace.backtrace_buffer, backtrace->backtrace_buffer, backtrace->num_frames * sizeof(void*));
+
+                base_object_address = art_entry->address;
+            }
+        }
+        if (result.is_valid && !art_entry->is_allocation && art_entry->address == base_object_address) {
+            // Check that we have a valid backtrace
+            unsigned registry_index = art_entry->backtrace_registry_index;
+            if (registry->backtrace_registry[registry_index].hash != art_entry->backtrace_hash)
+                continue;
+
+            pas_mar_backtrace_record* backtrace = &registry->backtrace_registry[registry_index];
+
+            result.deallocation_trace.num_frames= backtrace->num_frames;
+            memcpy(result.deallocation_trace.backtrace_buffer, backtrace->backtrace_buffer, backtrace->num_frames * sizeof(void*));
+
+            base_object_address = NULL;
+        }
+    }
+    return result;
+}
+
+#endif /* PAS_OS(DARWIN) */
+
+#endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/pas_mar_registry.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mar_registry.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+MAR: Malloc Audit Records
+
+MAR provides a new way to audit bmalloc/libpas memory allocations
+without resorting to PGM's guard pages. MAR maintains the address
+of each allocation, but instead tracks what allocations were made
+within pages of interest through the stack trace when `malloc` is
+invoked.
+*/
+
+#ifndef MAR_REGISTRY_H
+#define MAR_REGISTRY_H
+
+#include "pas_platform.h"
+
+#if PAS_OS(DARWIN)
+
+#include "pas_allocation_result.h"
+#include "pas_lock.h"
+#include "pas_mar_crash_reporter_report.h"
+#include "pas_utils.h"
+
+#include <assert.h>
+#include <execinfo.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#define PAS_MAR_PROBABILITY 8192
+#define PAS_MAR_TRACKED_BACKTRACES 16384
+#define PAS_MAR_TRACKED_ALLOCATIONS 16384
+
+/*
+We'll use an approach similar to hardware FIFO; the queue is empty if head == tail
+and full if head ^ tail == size
+*/
+
+#define MAR_ALLOCATION_RECORD_TABLE_FIFO_MODULUS (2 * PAS_MAR_TRACKED_ALLOCATIONS)
+
+#define PAS_MAR_PAGE_SHIFT 14
+
+typedef struct pas_mar_backtrace_record pas_mar_backtrace_record;
+struct pas_mar_backtrace_record {
+    unsigned num_frames;
+    uint32_t hash;
+    void* backtrace_buffer[PAS_MAR_BACKTRACE_MAX_SIZE];
+};
+
+typedef struct pas_mar_memory_action_record pas_mar_memory_action_record;
+struct pas_mar_memory_action_record {
+    void* address;
+    size_t allocation_size_bytes;
+    unsigned backtrace_registry_index;
+    uint32_t backtrace_hash;
+    bool is_allocation;
+};
+
+typedef struct pas_mar_registry pas_mar_registry;
+struct pas_mar_registry {
+    struct pas_mar_backtrace_record backtrace_registry[PAS_MAR_TRACKED_BACKTRACES];
+    struct pas_mar_memory_action_record allocation_record_table[PAS_MAR_TRACKED_ALLOCATIONS];
+    /* push to the tail of the FIFO, evict from head */
+    unsigned allocation_record_table_head;
+    unsigned allocation_record_table_tail;
+    pas_lock lock;
+};
+
+struct pas_mar_exported_allocation_record {
+    struct pas_mar_backtrace allocation_trace;
+    struct pas_mar_backtrace deallocation_trace;
+    size_t allocation_size_bytes;
+    bool is_valid;
+};
+
+/* Paging helpers */
+
+PAS_ALWAYS_INLINE static void* pas_mar_canonicalize_address(void* address)
+{
+    return (void*)((uintptr_t)(address) & ((1ull << 48) - 1));
+}
+
+PAS_ALWAYS_INLINE static uintptr_t pas_mar_address_to_virtual_page_number(void* address)
+{
+    return (uintptr_t)(pas_mar_canonicalize_address(address)) >> PAS_MAR_PAGE_SHIFT;
+}
+
+// FIFO helpers
+
+PAS_ALWAYS_INLINE static unsigned pas_mar_allocation_table_head_index(pas_mar_registry* registry)
+{
+    return registry->allocation_record_table_head % PAS_MAR_TRACKED_ALLOCATIONS;
+}
+
+PAS_ALWAYS_INLINE static unsigned pas_mar_allocation_table_tail_index(pas_mar_registry* registry)
+{
+    return registry->allocation_record_table_tail % PAS_MAR_TRACKED_ALLOCATIONS;
+}
+
+PAS_ALWAYS_INLINE static bool pas_mar_is_allocation_table_full(pas_mar_registry* registry)
+{
+    return (registry->allocation_record_table_head ^ registry->allocation_record_table_tail) == PAS_MAR_TRACKED_ALLOCATIONS;
+}
+
+PAS_ALWAYS_INLINE static void pas_mar_increment_allocation_record_table_head(pas_mar_registry* registry)
+{
+    registry->allocation_record_table_head = registry->allocation_record_table_head + 1;
+    registry->allocation_record_table_head %= MAR_ALLOCATION_RECORD_TABLE_FIFO_MODULUS;
+}
+
+PAS_ALWAYS_INLINE static void pas_mar_increment_allocation_record_table_tail(pas_mar_registry* registry)
+{
+    registry->allocation_record_table_tail = registry->allocation_record_table_tail + 1;
+    registry->allocation_record_table_tail %= MAR_ALLOCATION_RECORD_TABLE_FIFO_MODULUS;
+}
+
+PAS_BEGIN_EXTERN_C;
+
+void* pas_mar_record_allocation(pas_mar_registry*, void* address, size_t allocation_size_bytes, unsigned num_stack_frames, void** backtrace);
+void* pas_mar_record_deallocation(pas_mar_registry*, void* address, unsigned num_stack_frames, void** backtrace);
+
+struct pas_mar_exported_allocation_record pas_mar_get_allocation_record(pas_mar_registry*, void* address);
+
+void pas_mar_initialize(void);
+void* pas_mar_did_allocate(pas_mar_registry*, void* address, size_t allocation_size);
+void* pas_mar_did_allocate_and_zero(pas_mar_registry*, pas_allocation_result, size_t allocation_size);
+void* pas_mar_did_deallocate(pas_mar_registry*, void* address);
+
+extern bool pas_mar_enabled;
+extern unsigned pas_mar_qualifying_page_index;
+extern struct pas_mar_registry pas_mar_global_registry;
+extern struct pas_mar_registry* pas_mar_registry_for_crash_reporter_enumeration;
+
+PAS_END_EXTERN_C;
+
+PAS_ALWAYS_INLINE bool pas_mar_is_address_in_qualifying_page(void* address)
+{
+    return pas_mar_address_to_virtual_page_number(address) % PAS_MAR_PROBABILITY == pas_mar_qualifying_page_index;
+}
+
+#endif /* PAS_OS(DARWIN) */
+
+#endif

--- a/Source/bmalloc/libpas/src/libpas/pas_mar_report_crash.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mar_report_crash.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "pas_config.h"
+
+#if LIBPAS_ENABLED
+
+#include "pas_mar_report_crash.h"
+
+#include "pas_mar_crash_reporter_report.h"
+
+#if PAS_OS(DARWIN)
+
+#include <malloc/malloc.h>
+
+PAS_BEGIN_EXTERN_C;
+
+kern_return_t pas_mar_populate_crash_report(pas_mar_crash_report* report, const char* error_type, const char* confidence,
+        vm_address_t fault_address, size_t allocation_size_bytes,
+        pas_mar_backtrace* allocation_backtrace, pas_mar_backtrace* deallocation_backtrace)
+{
+    report->report_version = pas_mar_crash_report_version;
+    report->error_type = error_type;
+    report->confidence = confidence;
+    report->fault_address = fault_address;
+    report->allocation_size_bytes = allocation_size_bytes;
+
+    report->allocation_backtrace.num_frames = allocation_backtrace->num_frames;
+    memcpy(&report->allocation_backtrace.backtrace_buffer, &allocation_backtrace->backtrace_buffer, sizeof(report->allocation_backtrace.backtrace_buffer));
+
+    report->deallocation_backtrace.num_frames = deallocation_backtrace->num_frames;
+    memcpy(&report->deallocation_backtrace.backtrace_buffer, &deallocation_backtrace->backtrace_buffer, sizeof(report->deallocation_backtrace.backtrace_buffer));
+    return KERN_SUCCESS;
+}
+
+// Note that local_memory will be invalidated by future calls to the reader.
+// FIXME: improve this interface (rdar://161831626)
+
+static crash_reporter_memory_reader_t memory_reader;
+
+static kern_return_t memory_reader_adapter(task_t task, vm_address_t address, vm_size_t size, void** local_memory)
+{
+    if (!local_memory)
+        return KERN_FAILURE;
+
+    void* ptr = memory_reader(task, address, size);
+    *local_memory = ptr;
+    return ptr ? KERN_SUCCESS : KERN_FAILURE;
+}
+
+static memory_reader_t* setup_memory_reader(crash_reporter_memory_reader_t crm_reader)
+{
+    memory_reader = crm_reader;
+    return memory_reader_adapter;
+}
+
+kern_return_t pas_mar_extract_crash_report(vm_address_t fault_address, mach_vm_address_t mar_global_registry, unsigned version, task_t task, pas_mar_crash_report* report, crash_reporter_memory_reader_t crm_reader)
+{
+    if (version != pas_mar_crash_report_version)
+        return KERN_FAILURE;
+
+    pas_mar_registry* dead_registry = NULL;
+    memory_reader_t* reader = setup_memory_reader(crm_reader);
+    kern_return_t kr = reader(task, mar_global_registry, sizeof(pas_mar_registry), (void**)&dead_registry);
+    if (kr != KERN_SUCCESS)
+        return KERN_FAILURE;
+
+    struct pas_mar_exported_allocation_record result = pas_mar_get_allocation_record((pas_mar_registry*)dead_registry, (void*)fault_address);
+
+    if (!result.is_valid)
+        return KERN_NOT_FOUND;
+
+    if (!result.deallocation_trace.num_frames)
+        return pas_mar_populate_crash_report(report, "UAF", "high", fault_address, result.allocation_size_bytes, &result.allocation_trace, &result.deallocation_trace);
+    return pas_mar_populate_crash_report(report, "bad access", "high", fault_address, result.allocation_size_bytes, &result.allocation_trace, &result.deallocation_trace);
+}
+
+PAS_END_EXTERN_C;
+
+#endif /* PAS_OS(DARWIN) */
+
+#endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/pas_mar_report_crash.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mar_report_crash.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "pas_mar_crash_reporter_report.h"
+#include "pas_mar_registry.h"
+#include "pas_platform.h"
+
+#include <stddef.h>
+
+#if PAS_OS(DARWIN)
+
+PAS_BEGIN_EXTERN_C;
+
+extern PAS_API kern_return_t pas_mar_populate_crash_report(pas_mar_crash_report*, const char* error_type, const char* confidence,
+        vm_address_t fault_address, size_t allocation_size_bytes,
+        pas_mar_backtrace* allocation_backtrace, pas_mar_backtrace* deallocation_backtrace);
+
+extern PAS_API kern_return_t pas_mar_extract_crash_report(vm_address_t fault_address, mach_vm_address_t mar_global_registry, unsigned version, task_t, pas_mar_crash_report*, crash_reporter_memory_reader_t crm_reader);
+
+PAS_END_EXTERN_C;
+
+#endif /* PAS_OS(DARWIN) */

--- a/Source/bmalloc/libpas/src/test/MARTests.cpp
+++ b/Source/bmalloc/libpas/src/test/MARTests.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <bit>
+#include <mach/arm/kern_return.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "TestHarness.h"
+
+#include "pas_mar_registry.h"
+
+using namespace std;
+
+namespace {
+
+void testRetrieval()
+{
+    struct pas_mar_registry registry = {
+        { },
+        { },
+        0,
+        0,
+        { },
+    };
+    void* backtrace[8] = { (void*)0x1111, (void*)0x2222, (void*)0x3333, (void*)0x4444, (void*)0x5555, (void*)0x6666, (void*)0x7777, (void*)0x8888 };
+
+    void* address = (void*)0x11223344;
+
+    pas_mar_record_allocation(&registry, address, 32, 8, backtrace);
+
+    auto result = pas_mar_get_allocation_record(&registry, address);
+    CHECK(result.is_valid);
+    CHECK_EQUAL(result.allocation_size, 32);
+    CHECK_EQUAL(result.allocation_trace.num_frames, 8);
+    CHECK_EQUAL(result.allocation_trace.backtrace_buffer[0], backtrace[0]);
+}
+
+void testRetrievalAfterCycling()
+{
+    struct pas_mar_registry registry = {
+        { },
+        { },
+        0,
+        0,
+        { },
+    };
+    void* backtrace[8] = { (void*)0x1111, (void*)0x2222, (void*)0x3333, (void*)0x4444, (void*)0x5555, (void*)0x6666, (void*)0x7777, (void*)0x8888 };
+
+    void* address = (void*)0x11223344;
+
+    for (unsigned long i = 0; i < 1000; ++i)
+        pas_mar_record_allocation(&registry, (void*)i, 32, 8, backtrace);
+
+    pas_mar_record_allocation(&registry, address, 32, 8, backtrace);
+
+    for (unsigned long i = 1; i < MARTrackedAllocations; ++i)
+        pas_mar_record_allocation(&registry, (void*)i, 32, 8, backtrace);
+
+    auto result = pas_mar_get_allocation_record(&registry, address);
+    CHECK(result.is_valid);
+    CHECK_EQUAL(result.allocation_size, 32);
+    CHECK_EQUAL(result.allocation_trace.num_frames, 8);
+    CHECK_EQUAL(result.allocation_trace.backtrace_buffer[0], backtrace[0]);
+}
+
+void testRetrievalAfterMultipleCycles()
+{
+    struct pas_mar_registry registry = {
+        { },
+        { },
+        0,
+        0,
+        { },
+    };
+    void* backtrace[8] = { (void*)0x1111, (void*)0x2222, (void*)0x3333, (void*)0x4444, (void*)0x5555, (void*)0x6666, (void*)0x7777, (void*)0x8888 };
+
+    void* address = (void*)0x11223344;
+
+    for (unsigned long i = 0; i < 3 * MARTrackedAllocations; ++i)
+        pas_mar_record_allocation(&registry, (void*)i, 32, 8, backtrace);
+
+    pas_mar_record_allocation(&registry, address, 32, 8, backtrace);
+
+    for (unsigned long i = 1; i < MARTrackedAllocations; ++i)
+        pas_mar_record_allocation(&registry, (void*)i, 32, 8, backtrace);
+
+    auto result = pas_mar_get_allocation_record(&registry, address);
+    CHECK(result.is_valid);
+    CHECK_EQUAL(result.allocation_size, 32);
+    CHECK_EQUAL(result.allocation_trace.num_frames, 8);
+    CHECK_EQUAL(result.allocation_trace.backtrace_buffer[0], backtrace[0]);
+}
+
+} // anonymous namespace
+
+void addMARTests()
+{
+    ADD_TEST(testRetrieval());
+    ADD_TEST(testRetrievalAfterCycling());
+    ADD_TEST(testRetrievalAfterMultipleCycles());
+}

--- a/Source/bmalloc/libpas/src/test/TestHarness.cpp
+++ b/Source/bmalloc/libpas/src/test/TestHarness.cpp
@@ -369,6 +369,7 @@ void addLargeFreeHeapTests();
 void addLargeSharingPoolTests();
 void addLockFreeReadPtrPtrHashtableTests();
 void addLotsOfHeapsAndThreadsTests();
+void addMARTests();
 void addMemalignTests();
 void addMinHeapTests();
 void addPGMTests();
@@ -740,6 +741,7 @@ int main(int argc, char** argv)
     ADD_SUITE(LargeSharingPool);
     ADD_SUITE(LockFreeReadPtrPtrHashtable);
     ADD_SUITE(LotsOfHeapsAndThreads);
+    ADD_SUITE(MAR);
     ADD_SUITE(Memalign);
     ADD_SUITE(MinHeap);
     ADD_SUITE(PGM);


### PR DESCRIPTION
#### 5acbecd77f1bd514e2aab9a716c9cbbafd264b52
<pre>
Add PGM-style allocation stack logging for bmalloc allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=299621">https://bugs.webkit.org/show_bug.cgi?id=299621</a>
<a href="https://rdar.apple.com/153737681">rdar://153737681</a>

Reviewed by Yusuke Suzuki.

As another useful diagnostic tool, we want to add in allocation stack logging for
bmalloc&apos;s allocations. Memory Allocation Records (MAR) track metadata about where
allocations were made, enabling the analysis of these records if we crash. We aim
to utilize this to help debug bugs involving misuse of allocated memory, likely a
crash caught by features such as MIE. MAR ensures that the memory access patterns
are not disrupted, but we are still able to log some metadata to diagnose bugs at
crash time.

This patch was previously landed, but caused internal builds to fail. The updated
patch here fixes some module-related issues, which should fix these build issues.

Canonical link: <a href="https://commits.webkit.org/301955@main">https://commits.webkit.org/301955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26713e6ab44498afc7b539bdccf37c3c5ff6726d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127435 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78990 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cbfb9be3-7458-46ad-90d0-6bc6e476a749) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97012 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64962 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/79bd4584-9185-4e51-b129-26853645fc2d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77492 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/03bf767b-671e-4cef-abd1-ccfea900758f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36995 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32243 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77885 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119472 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136996 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125898 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41684 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105536 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105189 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26848 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50698 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29152 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51673 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54031 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60118 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158936 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53265 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39732 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56722 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55024 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->