### PR TITLE
[WebGPU] nullptr access opening webgpureport.org

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_301190-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_301190-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: [object GPUTexture]
+CONSOLE MESSAGE: [object GPUTexture]
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_301190.html
+++ b/LayoutTests/fast/webgpu/regression/repro_301190.html
@@ -1,0 +1,58 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return vec4();
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return vec4();
+}
+`;
+    let module = device.createShaderModule({code});
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {
+        module,
+        buffers: [],
+      },
+      fragment: {module, targets: [{format: 'bgra8unorm'}]},
+      primitive: {topology: 'point-list'},
+    });
+
+    let texture = device.createTexture({format: 'bgra8unorm', size: [1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let commandEncoder = device.createCommandEncoder();
+    log(texture);
+    let renderPassEncoder = commandEncoder.beginRenderPass({
+      colorAttachments: [{
+        view: texture,
+        clearValue: [0, 0, 0, 0],
+        loadOp: 'clear', storeOp: 'store',
+      }],
+    });
+    await 0;
+    GCController.collect();
+    renderPassEncoder.setPipeline(pipeline);
+    renderPassEncoder.draw(1);
+    renderPassEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    log(texture);
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundle.h
+++ b/Source/WebGPU/WebGPU/RenderBundle.h
@@ -56,6 +56,7 @@ class Device;
 class RenderBundleEncoder;
 class RenderPassEncoder;
 class RenderPipeline;
+class TextureOrTextureView;
 class TextureView;
 
 // https://gpuweb.github.io/gpuweb/#gpurenderbundle
@@ -84,7 +85,7 @@ public:
 
     void replayCommands(RenderPassEncoder&) const;
     void updateMinMaxDepths(float minDepth, float maxDepth);
-    bool validateRenderPass(bool depthReadOnly, bool stencilReadOnly, const WGPURenderPassDescriptor&, const Vector<RefPtr<TextureView>>&, const RefPtr<TextureView>&) const;
+    bool validateRenderPass(bool depthReadOnly, bool stencilReadOnly, const WGPURenderPassDescriptor&, const Vector<TextureOrTextureView>&, const std::optional<TextureOrTextureView>&) const;
     bool validatePipeline(const RenderPipeline*);
     uint64_t drawCount() const;
     NSString* lastError() const;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -27,6 +27,7 @@
 
 #import "BindableResource.h"
 #import "CommandsMixin.h"
+#import "TextureOrTextureView.h"
 #import <wtf/FastMalloc.h>
 #import <wtf/HashMap.h>
 #import <wtf/HashSet.h>
@@ -52,6 +53,7 @@ class Device;
 class QuerySet;
 class RenderBundle;
 class RenderPipeline;
+class TextureOrTextureView;
 class TextureView;
 
 struct BindableResources;
@@ -122,7 +124,9 @@ private:
     bool runIndexBufferValidation(uint32_t firstInstance, uint32_t instanceCount);
     void runVertexBufferValidation(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
     void addResourceToActiveResources(const TextureView&, OptionSet<BindGroupEntryUsage>);
+    void addResourceToActiveResources(const TextureOrTextureView&, OptionSet<BindGroupEntryUsage>);
     void addResourceToActiveResources(const TextureView&, OptionSet<BindGroupEntryUsage>, WGPUTextureAspect);
+    void addResourceToActiveResources(const TextureOrTextureView&, OptionSet<BindGroupEntryUsage>, WGPUTextureAspect);
     void addResourceToActiveResources(const Texture&, OptionSet<BindGroupEntryUsage>);
     void addTextureToActiveResources(const void*, id<MTLResource>, OptionSet<BindGroupEntryUsage>, uint32_t baseMipLevel, uint32_t baseArrayLayer, WGPUTextureAspect);
     void addResourceToActiveResources(const void*, OptionSet<BindGroupEntryUsage>);
@@ -184,8 +188,8 @@ private:
     WGPURenderPassDescriptor m_descriptor;
     Vector<WGPURenderPassColorAttachment> m_descriptorColorAttachments;
     WGPURenderPassDepthStencilAttachment m_descriptorDepthStencilAttachment;
-    Vector<RefPtr<TextureView>> m_colorAttachmentViews;
-    RefPtr<TextureView> m_depthStencilView;
+    Vector<TextureOrTextureView> m_colorAttachmentViews;
+    std::optional<TextureOrTextureView> m_depthStencilView;
     struct BufferAndOffset {
         id<MTLBuffer> buffer { nil };
         uint64_t offset { 0 };

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -44,6 +44,7 @@ namespace WebGPU {
 class BindGroupLayout;
 class Device;
 class PipelineLayout;
+class TextureOrTextureView;
 class TextureView;
 
 // https://gpuweb.github.io/gpuweb/#gpurenderpipeline
@@ -92,7 +93,7 @@ public:
 
     Device& device() const { return m_device; }
     PipelineLayout& pipelineLayout() const { return m_pipelineLayout; }
-    NSString* errorValidatingColorDepthStencilTargets(const WGPURenderPassDescriptor&, const Vector<RefPtr<TextureView>>&, const RefPtr<TextureView>&) const;
+    NSString* errorValidatingColorDepthStencilTargets(const WGPURenderPassDescriptor&, const Vector<TextureOrTextureView>&, const std::optional<TextureOrTextureView>&) const;
     bool validateRenderBundle(const WGPURenderBundleEncoderDescriptor&) const;
     bool writesDepth() const;
     bool writesStencil() const;

--- a/Source/WebGPU/WebGPU/TextureOrTextureView.h
+++ b/Source/WebGPU/WebGPU/TextureOrTextureView.h
@@ -43,6 +43,14 @@ public:
         : m_view(&view)
     {
     }
+    TextureOrTextureView(Texture* texture)
+        : m_texture(texture)
+    {
+    }
+    TextureOrTextureView(TextureView* view)
+        : m_view(view)
+    {
+    }
 
 #define TEXTURE_OR_VIEW_INVOKE(x) return m_view ? RefPtr { m_view }->x() : RefPtr { m_texture }->x()
 #define TEXTURE_OR_VIEW_HELPER(x) auto x() const { TEXTURE_OR_VIEW_INVOKE(x); }
@@ -87,6 +95,8 @@ public:
 #undef TEXTURE_OR_VIEW_HELPER
 #undef TEXTURE_OR_VIEW_HELPER_REF
 #undef TEXTURE_OR_VIEW_HELPER_NONCONST
+
+    operator bool() const { return m_texture || m_view; }
 
 private:
     RefPtr<Texture> m_texture;


### PR DESCRIPTION
#### 09e61af8045e96e6b6111d8fa8e7760199f77e84
<pre>
[WebGPU] nullptr access opening webgpureport.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=301190">https://bugs.webkit.org/show_bug.cgi?id=301190</a>
<a href="https://rdar.apple.com/162980970">rdar://162980970</a>

Reviewed by Dan Glastonbury and Tadeu Zagallo.

RenderPassEncoder&apos;s constructor, RenderPipeline&apos;s validation,
and RenderBundle&apos;s validation did not expect GPUTexture instances
in place of GPUTextureView ones and would crash.

No impact to Swift backend but bug reproduces while using the Swift
backend as well.

Test: fast/webgpu/regression/repro_301190.html
* LayoutTests/fast/webgpu/regression/repro_301190-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_301190.html: Added.
* Source/WebGPU/WebGPU/RenderBundle.h:
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::validateRenderPass const):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::RenderPassEncoder):
(WebGPU::RenderPassEncoder::addResourceToActiveResources):
* Source/WebGPU/WebGPU/RenderPipeline.h:
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::errorValidatingColorDepthStencilTargets const):
* Source/WebGPU/WebGPU/TextureOrTextureView.h:
(WebGPU::TextureOrTextureView::operator bool const):

Canonical link: <a href="https://commits.webkit.org/301946@main">https://commits.webkit.org/301946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6a1cacef1bb82e04472e26ea44d582a587010fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79095 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97086 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65006 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77566 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32321 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77989 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137100 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105611 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105262 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26840 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29218 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51778 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60222 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53369 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56826 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55128 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->