### PR TITLE
Partially revert 301345@main.

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8251,7 +8251,7 @@ webkit.org/b/298042 [ Release ] http/tests/security/clipboard/copy-paste-html-cr
 
 imported/w3c/web-platform-tests/css/css-break/block-in-inline-012.html [ ImageOnlyFailure ]
 
-webkit.org/b/298244 imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html [ Pass Failure ]
+webkit.org/b/300905 imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html [ Pass Failure ]
 
 webkit.org/b/298256 [ Debug ] fast/dom/document-all.html [ Timeout ]
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -78,7 +78,6 @@ private:
     // ScrollingCoordinator
     bool coordinatesScrollingForFrameView(const WebCore::LocalFrameView&) const override;
     void scheduleTreeStateCommit() override;
-    void applyScrollUpdate(WebCore::ScrollUpdate&&, WebCore::ScrollType = WebCore::ScrollType::User) override;
 
     bool isRubberBandInProgress(std::optional<WebCore::ScrollingNodeID>) const final;
     bool isUserScrollInProgress(std::optional<WebCore::ScrollingNodeID>) const final;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -76,14 +76,6 @@ void RemoteScrollingCoordinator::scheduleTreeStateCommit()
         webPage->protectedDrawingArea()->triggerRenderingUpdate();
 }
 
-void RemoteScrollingCoordinator::applyScrollUpdate(ScrollUpdate&& update, ScrollType scrollType)
-{
-    if (RefPtr webPage = m_webPage.get())
-        webPage->markPendingLocalScrollPositionChange();
-
-    AsyncScrollingCoordinator::applyScrollUpdate(WTFMove(update), scrollType);
-}
-
 bool RemoteScrollingCoordinator::coordinatesScrollingForFrameView(const LocalFrameView& frameView) const
 {
     CheckedPtr renderView = frameView.renderView();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5077,8 +5077,6 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
         m_lastTransactionPageScaleFactor = layerTransaction.pageScaleFactor();
         m_internals->lastTransactionIDWithScaleChange = layerTransaction.transactionID();
     }
-
-    m_pendingLocalChangeTransactionID = std::nullopt;
 #endif
 
     layerTransaction.setScrollPosition(frameView->scrollPosition());
@@ -10881,17 +10879,6 @@ std::unique_ptr<FrameInfoData> WebPage::takeMainFrameNavigationInitiator()
 bool WebPage::hasAccessoryMousePointingDevice() const
 {
     return true;
-}
-#endif
-
-#if ENABLE(ASYNC_SCROLLING) && !PLATFORM(IOS_FAMILY)
-bool WebPage::shouldIgnoreScrollPositionUpdate(TransactionID) const
-{
-    return false;
-}
-
-void WebPage::markPendingLocalScrollPositionChange()
-{
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -137,10 +137,6 @@ OBJC_CLASS PDFSelection;
 OBJC_CLASS WKAccessibilityWebPageObject;
 #endif
 
-#if ENABLE(ASYNC_SCROLLING)
-#include "MonotonicObjectIdentifier.h"
-#endif
-
 #define ENABLE_VIEWPORT_RESIZING PLATFORM(IOS_FAMILY)
 
 namespace WTF {
@@ -603,8 +599,6 @@ public:
 
 #if ENABLE(ASYNC_SCROLLING)
     WebCore::ScrollingCoordinator* scrollingCoordinator() const;
-    bool shouldIgnoreScrollPositionUpdate(TransactionID) const;
-    void markPendingLocalScrollPositionChange();
 #endif
 
     WebPageGroupProxy* pageGroup() const { return m_pageGroup.get(); }
@@ -3197,10 +3191,6 @@ private:
 
 #if ENABLE(WRITING_TOOLS)
     const UniqueRef<TextAnimationController> m_textAnimationController;
-#endif
-
-#if ENABLE(ASYNC_SCROLLING)
-    std::optional<TransactionID> m_pendingLocalChangeTransactionID;
 #endif
 
     std::unique_ptr<WebCore::NowPlayingMetadataObserver> m_nowPlayingMetadataObserver;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5059,23 +5059,6 @@ static bool selectionIsInsideFixedPositionContainer(LocalFrame& frame)
     return isInsideFixedPosition;
 }
 
-void WebPage::markPendingLocalScrollPositionChange()
-{
-    if (m_pendingLocalChangeTransactionID)
-        return;
-
-    if (auto* drawingArea = dynamicDowncast<RemoteLayerTreeDrawingArea>(this->drawingArea()))
-        m_pendingLocalChangeTransactionID = drawingArea->nextTransactionID();
-}
-
-bool WebPage::shouldIgnoreScrollPositionUpdate(TransactionID receivedTransactionID) const
-{
-    if (m_pendingLocalChangeTransactionID)
-        return receivedTransactionID.lessThanSameProcess(*m_pendingLocalChangeTransactionID);
-
-    return false;
-}
-
 void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visibleContentRectUpdateInfo, MonotonicTime oldestTimestamp)
 {
     LOG_WITH_STREAM(VisibleRects, stream << "\nWebPage " << m_identifier << " updateVisibleContentRects " << visibleContentRectUpdateInfo);
@@ -5121,7 +5104,7 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
 
     auto layoutViewportRect = visibleContentRectUpdateInfo.layoutViewportRect();
     auto unobscuredContentRect = visibleContentRectUpdateInfo.unobscuredContentRect();
-    auto scrollPosition = shouldIgnoreScrollPositionUpdate(visibleContentRectUpdateInfo.lastLayerTreeTransactionID()) ? frameView.scrollPosition() : roundedIntPoint(unobscuredContentRect.location());
+    auto scrollPosition = roundedIntPoint(unobscuredContentRect.location());
 
     // Computation of layoutViewportRect is done in LayoutUnits which loses some precision, so test with an epsilon.
     // FIXME: The loss of precision when converting floating point values to LayoutUnit does not, by itself, explain


### PR DESCRIPTION
#### e92da50558ef3c1ce64353fc0aa263115429f596
<pre>
Partially revert 301345@main.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300905">https://bugs.webkit.org/show_bug.cgi?id=300905</a>
<a href="https://rdar.apple.com/163143829">rdar://163143829</a>

Reviewed by Simon Fraser.

In 301345@main, the changes to remote layer rendering caused many regressions. Reverting
those changes.

* LayoutTests/platform/ios/TestExpectations:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::applyScrollUpdate): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willCommitLayerTree):
(WebKit::WebPage::shouldIgnoreScrollPositionUpdate const): Deleted.
(WebKit::WebPage::markPendingLocalScrollPositionChange): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):
(WebKit::WebPage::markPendingLocalScrollPositionChange): Deleted.
(WebKit::WebPage::shouldIgnoreScrollPositionUpdate const):

Canonical link: <a href="https://commits.webkit.org/301950@main">https://commits.webkit.org/301950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ba9c6c429fb9d1d5256fe49da37ec4bf5702b6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79041 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7e5355b3-4b3c-43db-bfbf-4f154e664a94) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97039 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64982 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/00f57ba1-318e-48f5-9511-a523028068bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77520 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d42e8e34-3a55-4c0b-9072-e3f0cda002eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32282 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77935 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119522 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137046 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105566 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105217 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26845 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50734 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29187 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51723 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54081 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60168 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158986 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53315 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/158986 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56772 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55074 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->