### PR TITLE
Implement ToggleEvent.source

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -803,12 +803,12 @@ PASS ToggleEvent interface: existence and properties of interface prototype obje
 PASS ToggleEvent interface: existence and properties of interface prototype object's @@unscopables property
 PASS ToggleEvent interface: attribute oldState
 PASS ToggleEvent interface: attribute newState
-FAIL ToggleEvent interface: attribute source assert_true: The prototype object must have a property "source" expected true got false
+PASS ToggleEvent interface: attribute source
 PASS ToggleEvent must be primary interface of new ToggleEvent("beforetoggle")
 PASS Stringification of new ToggleEvent("beforetoggle")
 PASS ToggleEvent interface: new ToggleEvent("beforetoggle") must inherit property "oldState" with the proper type
 PASS ToggleEvent interface: new ToggleEvent("beforetoggle") must inherit property "newState" with the proper type
-FAIL ToggleEvent interface: new ToggleEvent("beforetoggle") must inherit property "source" with the proper type assert_inherits: property "source" not found in prototype chain
+PASS ToggleEvent interface: new ToggleEvent("beforetoggle") must inherit property "source" with the proper type
 PASS CommandEvent interface: existence and properties of interface object
 PASS CommandEvent interface object length
 PASS CommandEvent interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-toggle-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-toggle-source-expected.txt
@@ -1,9 +1,8 @@
 command source
 summary
-details without summary
 
-FAIL ToggleEvent.source on <details> elements: details.open. assert_equals: Opening toggle.source. expected (object) null but got (undefined) undefined
-FAIL ToggleEvent.source on <details> elements: click summary. assert_equals: toggle newstate should be open. expected "open" but got "closed"
-FAIL ToggleEvent.source on <details> elements: click details. assert_equals: Opening toggle.source. expected (object) null but got (undefined) undefined
+PASS ToggleEvent.source on <details> elements: details.open.
+PASS ToggleEvent.source on <details> elements: click summary.
+PASS ToggleEvent.source on <details> elements: click details.
 FAIL ToggleEvent.source on <details> elements: command invokers. assert_true: An opening toggle event should have been fired. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-toggle-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-toggle-source-expected.txt
@@ -1,9 +1,9 @@
 show modal light dismiss dialog  close  request close
 
-FAIL ToggleEvent.source on <dialog> elements: dialog.showModal(). assert_equals: Opening beforetoggle.source. expected (object) null but got (undefined) undefined
-FAIL ToggleEvent.source on <dialog> elements: command button. assert_true: An opening beforetoggle event should have been fired. expected true got false
-FAIL ToggleEvent.source on <dialog> elements: open with showModal, close with button. assert_true: An opening beforetoggle event should have been fired. expected true got false
-FAIL ToggleEvent.soruce on <dialog> elements: open with button, close with dialog.close(). assert_true: An opening beforetoggle event should have been fired. expected true got false
-FAIL ToggleEvent.source on <dialog> elements: open with showModal, close with request-close button. assert_true: An opening beforetoggle event should have been fired. expected true got false
-FAIL ToggleEvent.source on <dialog> elements: open with button, close with light dismiss. promise_test: Unhandled rejection with value: object "Error: element click intercepted error"
+PASS ToggleEvent.source on <dialog> elements: dialog.showModal().
+PASS ToggleEvent.source on <dialog> elements: command button.
+PASS ToggleEvent.source on <dialog> elements: open with showModal, close with button.
+PASS ToggleEvent.soruce on <dialog> elements: open with button, close with dialog.close().
+PASS ToggleEvent.source on <dialog> elements: open with showModal, close with request-close button.
+FAIL ToggleEvent.source on <dialog> elements: open with button, close with light dismiss. assert_true: A closing beforetoggle event should have been fired. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-toggle-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-toggle-source-expected.txt
@@ -1,10 +1,10 @@
 popovertarget source command source
 
-FAIL ToggleEvent.source on popover elements: showPopover() without source. assert_equals: Opening beforetoggle.source. expected (object) null but got (undefined) undefined
-FAIL ToggleEvent.source on popover elements: showPopover() with source. assert_true: An opening beforetoggle event should have been fired. expected true got false
-FAIL ToggleEvent.source on popover elements: Calling click() on a popovertarget button. assert_equals: beforetoggle newState should be open. expected "open" but got "closed"
-FAIL ToggleEvent.source on popover elements: Calling click() on a command button. assert_equals: Opening beforetoggle.source. expected (object) Element node <button id="commandsource" commandfor="popover" command="... but got (undefined) undefined
-FAIL ToggleEvent.source on popover elements: showPopover() then popovertarget button. assert_true: An opening beforetoggle event should have been fired. expected true got false
-FAIL ToggleEvent.source on popover elements: showPopover(invoker) then popovertarget button. assert_true: An opening beforetoggle event should have been fired. expected true got false
-FAIL ToggleEvent.source on popover elements: popovertarget button then hidePopover(). assert_equals: beforetoggle newState should be open. expected "open" but got "closed"
+PASS ToggleEvent.source on popover elements: showPopover() without source.
+PASS ToggleEvent.source on popover elements: showPopover() with source.
+PASS ToggleEvent.source on popover elements: Calling click() on a popovertarget button.
+PASS ToggleEvent.source on popover elements: Calling click() on a command button.
+PASS ToggleEvent.source on popover elements: showPopover() then popovertarget button.
+PASS ToggleEvent.source on popover elements: showPopover(invoker) then popovertarget button.
+PASS ToggleEvent.source on popover elements: popovertarget button then hidePopover().
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative-expected.txt
@@ -1,8 +1,6 @@
 popover 3show popover 3
 
-FAIL CommandEvent.source and ToggleEvent.source should be retargeted during and after event dispatch. assert_equals: beforetoggle.source during capture. expected (object) Element node <div id="host">
-
-</div> but got (undefined) undefined
+PASS CommandEvent.source and ToggleEvent.source should be retargeted during and after event dispatch.
 PASS CommandEvent.source should be retargeted when manually dispatched with composed set to true.
-FAIL CommandEvent.source and ToggleEvent.source should not be set to null after dispatch without ShadowDOM. assert_equals: beforetoggle.source should be the invoker button after dispatch. expected (object) Element node <button id="button3" commandfor="popover3" command="show-... but got (undefined) undefined
+PASS CommandEvent.source and ToggleEvent.source should not be set to null after dispatch without ShadowDOM.
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -803,12 +803,12 @@ PASS ToggleEvent interface: existence and properties of interface prototype obje
 PASS ToggleEvent interface: existence and properties of interface prototype object's @@unscopables property
 PASS ToggleEvent interface: attribute oldState
 PASS ToggleEvent interface: attribute newState
-FAIL ToggleEvent interface: attribute source assert_true: The prototype object must have a property "source" expected true got false
+PASS ToggleEvent interface: attribute source
 PASS ToggleEvent must be primary interface of new ToggleEvent("beforetoggle")
 PASS Stringification of new ToggleEvent("beforetoggle")
 PASS ToggleEvent interface: new ToggleEvent("beforetoggle") must inherit property "oldState" with the proper type
 PASS ToggleEvent interface: new ToggleEvent("beforetoggle") must inherit property "newState" with the proper type
-FAIL ToggleEvent interface: new ToggleEvent("beforetoggle") must inherit property "source" with the proper type assert_inherits: property "source" not found in prototype chain
+PASS ToggleEvent interface: new ToggleEvent("beforetoggle") must inherit property "source" with the proper type
 PASS CommandEvent interface: existence and properties of interface object
 PASS CommandEvent interface object length
 PASS CommandEvent interface object name

--- a/Source/WebCore/dom/CommandEvent.cpp
+++ b/Source/WebCore/dom/CommandEvent.cpp
@@ -66,12 +66,12 @@ RefPtr<Element> CommandEvent::source() const
     if (RefPtr target = dynamicDowncast<Node>(currentTarget())) {
         Ref treeScope = target->treeScope();
         Ref node = treeScope->retargetToScope(*m_source);
-        return &downcast<Element>(node).get();
+        return downcast<Element>(node);
     }
 
     Ref treeScope = m_source->treeScope().documentScope();
     Ref node = treeScope->retargetToScope(*m_source);
-    return &downcast<Element>(node).get();
+    return downcast<Element>(node);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ToggleEvent.cpp
+++ b/Source/WebCore/dom/ToggleEvent.cpp
@@ -26,6 +26,10 @@
 #include "config.h"
 #include "ToggleEvent.h"
 
+#include "Document.h"
+#include "Element.h"
+#include "TreeScope.h"
+
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -41,6 +45,7 @@ ToggleEvent::ToggleEvent(const AtomString& type, const ToggleEvent::Init& initia
     : Event(EventInterfaceType::ToggleEvent, type, Event::CanBubble::No, cancelable, Event::IsComposed::No)
     , m_oldState(initializer.oldState)
     , m_newState(initializer.newState)
+    , m_source(initializer.source)
 {
 }
 
@@ -48,6 +53,7 @@ ToggleEvent::ToggleEvent(const AtomString& type, const ToggleEvent::Init& initia
     : Event(EventInterfaceType::ToggleEvent, type, initializer, IsTrusted::No)
     , m_oldState(initializer.oldState)
     , m_newState(initializer.newState)
+    , m_source(initializer.source)
 {
 }
 
@@ -64,6 +70,22 @@ Ref<ToggleEvent> ToggleEvent::create(const AtomString& eventType, const ToggleEv
 Ref<ToggleEvent> ToggleEvent::createForBindings()
 {
     return adoptRef(*new ToggleEvent);
+}
+
+RefPtr<Element> ToggleEvent::source() const
+{
+    if (!m_source)
+        return nullptr;
+
+    if (RefPtr target = dynamicDowncast<Node>(currentTarget())) {
+        Ref treeScope = target->treeScope();
+        Ref node = treeScope->retargetToScope(*m_source);
+        return downcast<Element>(node);
+    }
+
+    Ref treeScope = m_source->treeScope().documentScope();
+    Ref node = treeScope->retargetToScope(*m_source);
+    return downcast<Element>(node);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ToggleEvent.h
+++ b/Source/WebCore/dom/ToggleEvent.h
@@ -30,12 +30,15 @@
 
 namespace WebCore {
 
+class Element;
+
 class ToggleEvent final : public Event {
     WTF_MAKE_TZONE_ALLOCATED(ToggleEvent);
 public:
     struct Init : EventInit {
         String oldState;
         String newState;
+        RefPtr<Element> source;
     };
 
     static Ref<ToggleEvent> create(const AtomString& type, const Init&, Event::IsCancelable);
@@ -44,6 +47,7 @@ public:
 
     String oldState() const { return m_oldState; }
     String newState() const { return m_newState; }
+    RefPtr<Element> source() const;
 
 private:
     ToggleEvent();
@@ -52,6 +56,7 @@ private:
 
     String m_oldState;
     String m_newState;
+    const RefPtr<Element> m_source;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ToggleEvent.idl
+++ b/Source/WebCore/dom/ToggleEvent.idl
@@ -28,6 +28,7 @@ interface ToggleEvent : Event {
     constructor([AtomString] DOMString type, optional ToggleEventInit eventInitDict = {});
     readonly attribute DOMString oldState;
     readonly attribute DOMString newState;
+    readonly attribute Element? source;
 };
 
 [
@@ -35,4 +36,5 @@ interface ToggleEvent : Event {
 ] dictionary ToggleEventInit : EventInit {
     DOMString oldState = "";
     DOMString newState = "";
+    Element? source = null;
 };

--- a/Source/WebCore/dom/ToggleEventTask.h
+++ b/Source/WebCore/dom/ToggleEventTask.h
@@ -37,13 +37,14 @@ enum class ToggleState : bool {
 struct ToggleEventData {
     ToggleState oldState;
     ToggleState newState;
+    RefPtr<Element> source;
 };
 
 class ToggleEventTask final: public RefCounted<ToggleEventTask> {
 public:
     static Ref<ToggleEventTask> create(Element&);
 
-    void queue(ToggleState oldState, ToggleState newState);
+    void queue(ToggleState oldState, ToggleState newState, Element* source);
 
 private:
     ToggleEventTask(Element& element)

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -154,7 +154,7 @@ void HTMLDetailsElement::queueDetailsToggleEventTask(ToggleState oldState, Toggl
     if (!m_toggleEventTask)
         m_toggleEventTask = ToggleEventTask::create(*this);
 
-    RefPtr { m_toggleEventTask }->queue(oldState, newState);
+    RefPtr { m_toggleEventTask }->queue(oldState, newState, nullptr);
 }
 
 void HTMLDetailsElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -42,9 +42,9 @@ public:
     void setReturnValue(String&& value) { m_returnValue = WTF::move(value); }
 
     ExceptionOr<void> show();
-    ExceptionOr<void> showModal();
-    void close(const String&);
-    void requestClose(const String&);
+    ExceptionOr<void> showModal(Element* = nullptr);
+    void close(const String&, Element* = nullptr);
+    void requestClose(const String&, Element* = nullptr);
 
     bool isModal() const { return m_isModal; };
 
@@ -55,7 +55,7 @@ public:
     bool isValidCommandType(const CommandType) final;
     bool handleCommandInternal(HTMLButtonElement& invoker, const CommandType&) final;
 
-    void queueDialogToggleEventTask(ToggleState oldState, ToggleState newState);
+    void queueDialogToggleEventTask(ToggleState oldState, ToggleState newState, Element* source);
 
 private:
     HTMLDialogElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -151,11 +151,11 @@ public:
         std::optional<bool> force;
     };
 
-    void queuePopoverToggleEventTask(ToggleState oldState, ToggleState newState);
+    void queuePopoverToggleEventTask(ToggleState oldState, ToggleState newState, Element* source);
     ExceptionOr<void> showPopover(const ShowPopoverOptions&);
     ExceptionOr<void> showPopoverInternal(HTMLElement* = nullptr);
     ExceptionOr<void> hidePopover();
-    ExceptionOr<void> hidePopoverInternal(FocusPreviousElement, FireEvents);
+    ExceptionOr<void> hidePopoverInternal(FocusPreviousElement, FireEvents, HTMLElement* = nullptr);
     ExceptionOr<bool> togglePopover(Variant<WebCore::HTMLElement::TogglePopoverOptions, bool>);
 
     const AtomString& popover() const;

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -393,7 +393,7 @@ void HTMLFormControlElement::handlePopoverTargetAction(const EventTarget* eventT
     bool shouldShow = canShow && popover->popoverData()->visibilityState() == PopoverVisibilityState::Hidden;
 
     if (shouldHide)
-        popover->hidePopover();
+        popover->hidePopoverInternal(FocusPreviousElement::Yes, FireEvents::Yes, this);
     else if (shouldShow)
         popover->showPopoverInternal(this);
 }


### PR DESCRIPTION
#### c4ee30d3b1b98692df765d43c8b07dd3f1674de2
<pre>
Implement ToggleEvent.source
<a href="https://bugs.webkit.org/show_bug.cgi?id=293686">https://bugs.webkit.org/show_bug.cgi?id=293686</a>

Reviewed by Tim Nguyen and Anne van Kesteren.

This implements the new source attribute on ToggleEvent, and wires it up from command invokers for dialogs,
and all invokers for popover.

This also tweaks the source property getter on CommandEvent.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-toggle-source-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-toggle-source-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-toggle-source-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* Source/WebCore/dom/CommandEvent.cpp:
(WebCore::CommandEvent::source const):
* Source/WebCore/dom/ToggleEvent.cpp:
(WebCore::ToggleEvent::ToggleEvent):
(WebCore::ToggleEvent::source const):
* Source/WebCore/dom/ToggleEvent.h:
* Source/WebCore/dom/ToggleEvent.idl:
* Source/WebCore/dom/ToggleEventTask.cpp:
(WebCore::ToggleEventTask::queue):
* Source/WebCore/dom/ToggleEventTask.h:
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::queueDetailsToggleEventTask):
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::show):
(WebCore::HTMLDialogElement::showModal):
(WebCore::HTMLDialogElement::close):
(WebCore::HTMLDialogElement::requestClose):
(WebCore::HTMLDialogElement::handleCommandInternal):
(WebCore::HTMLDialogElement::queueDialogToggleEventTask):
* Source/WebCore/html/HTMLDialogElement.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::queuePopoverToggleEventTask):
(WebCore::HTMLElement::showPopoverInternal):
(WebCore::HTMLElement::hidePopoverInternal):
(WebCore::HTMLElement::togglePopover):
(WebCore::HTMLElement::handleCommandInternal):
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::handlePopoverTargetAction):

Canonical link: <a href="https://commits.webkit.org/306152@main">https://commits.webkit.org/306152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/759b9ecddf4140b7c884bfbd5795549d147fe133

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/29585 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->