### PR TITLE
Allow all ports to have a ModelPlayer be thread-safe refcounted

### DIFF
--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -38,11 +38,8 @@
 #include <wtf/Platform.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
-
-#if ENABLE(GPU_PROCESS_MODEL)
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
-#endif
 
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE)
 #include <WebCore/StageModeOperations.h>
@@ -63,11 +60,7 @@ class ModelPlayerTransformState;
 class SharedBuffer;
 class TransformationMatrix;
 
-#if ENABLE(GPU_PROCESS_MODEL)
 class WEBCORE_EXPORT ModelPlayer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ModelPlayer> {
-#else
-class WEBCORE_EXPORT ModelPlayer : public RefCounted<ModelPlayer> {
-#endif
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ModelPlayer, WEBCORE_EXPORT);
 public:
     virtual ~ModelPlayer();


### PR DESCRIPTION
#### 87b822ff7de89a29e7d7d52b3a558cc6b447a179
<pre>
Allow all ports to have a ModelPlayer be thread-safe refcounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=301199">https://bugs.webkit.org/show_bug.cgi?id=301199</a>

Reviewed by Chris Dumez.

In 301613@main, ModelPlayer was made conditionally thread-safe
refcounted. Having that be conditional is bound to trip someone
up and there is no good reason all ports shouldn&apos;t be aligned.

* Source/WebCore/Modules/model-element/ModelPlayer.h:

Canonical link: <a href="https://commits.webkit.org/301925@main">https://commits.webkit.org/301925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/657668649f4fd1344277cc3bef9f1484ecf9c854

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78953 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55569 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96972 "17 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77452 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32214 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77844 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136945 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41657 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105483 "16 flakes 54 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54568 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105156 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26828 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50674 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29128 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51636 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53994 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60081 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53228 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->