### PR TITLE
video-track-add-visible.html fails on Tahoe

### DIFF
--- a/LayoutTests/media/track/video-track-add-visible-expected.txt
+++ b/LayoutTests/media/track/video-track-add-visible-expected.txt
@@ -5,6 +5,6 @@ RUN(track = video.addTextTrack("subtitles"))
 RUN(track.mode = "showing")
 RUN(cue = new VTTCue(0, video.duration, "cue text"))
 RUN(track.addCue(cue))
-EXPECTED (internals.shadowRoot(video).querySelector(".media-controls-container").innerText == 'cue text') OK
+EXPECTED (internals.shadowRoot(video).textContent.includes("cue text") == 'true') OK
 END OF TEST
 

--- a/LayoutTests/media/track/video-track-add-visible.html
+++ b/LayoutTests/media/track/video-track-add-visible.html
@@ -12,7 +12,7 @@
         run('track.mode = "showing"');
         run('cue = new VTTCue(0, video.duration, "cue text")');
         run('track.addCue(cue)');
-        await testExpectedEventually('internals.shadowRoot(video).querySelector(".media-controls-container").innerText', 'cue text');
+        await testExpectedEventually('internals.shadowRoot(video).textContent.includes("cue text")', true);
         endTest();
     });
     </script>


### PR DESCRIPTION
#### 1699ab873db6fd4de2338d789b02f60f3643e9cc
<pre>
video-track-add-visible.html fails on Tahoe
<a href="https://bugs.webkit.org/show_bug.cgi?id=301203">https://bugs.webkit.org/show_bug.cgi?id=301203</a>
<a href="https://rdar.apple.com/163122385">rdar://163122385</a>

Reviewed by Jonathan Bedard.

Change from exact innerText match to textContent.includes() check to make
the test less brittle and more reliable across different platforms and
text track implementations.

* LayoutTests/media/track/video-track-add-visible-expected.txt:
* LayoutTests/media/track/video-track-add-visible.html:

Canonical link: <a href="https://commits.webkit.org/301907@main">https://commits.webkit.org/301907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ca50e7589689796dc56e84844d6ac9b705bfbce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78961 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96973 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b84f631a-ed52-4be7-9f7d-6e0832033b27) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114112 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/77465 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/76282272-0908-4cde-a883-b5073bc5cfbc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77852 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136953 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105497 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105161 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50676 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51644 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19929 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54002 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53236 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54995 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->