### PR TITLE
ModelPlayerClient cannot be `ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr`

### DIFF
--- a/Source/WebCore/Modules/model-element/DDModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/DDModelPlayer.h
@@ -86,7 +86,7 @@ private:
     GraphicsLayerContentsDisplayDelegate* contentsDisplayDelegate() override;
     void ensureOnMainThreadWithProtectedThis(Function<void(Ref<DDModelPlayer>)>&& task);
 
-    ThreadSafeWeakPtr<ModelPlayerClient> m_client;
+    WeakPtr<ModelPlayerClient> m_client;
 
     WebCore::ModelPlayerIdentifier m_id;
     RetainPtr<WebUSDModelLoader> m_modelLoader;

--- a/Source/WebCore/Modules/model-element/ModelPlayerClient.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerClient.h
@@ -39,11 +39,7 @@ class HTMLModelElement;
 class ModelPlayer;
 class ResourceError;
 
-#if ENABLE(GPU_PROCESS_MODEL)
-class WEBCORE_EXPORT ModelPlayerClient : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ModelPlayerClient> {
-#else
 class WEBCORE_EXPORT ModelPlayerClient : public AbstractRefCountedAndCanMakeWeakPtr<ModelPlayerClient> {
-#endif
 public:
     virtual ~ModelPlayerClient();
 

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
@@ -72,11 +72,7 @@ private:
     GraphicsLayerContentsDisplayDelegate* contentsDisplayDelegate() override;
 #endif
 
-#if ENABLE(GPU_PROCESS_MODEL)
-    ThreadSafeWeakPtr<ModelPlayerClient> m_client;
-#else
     WeakPtr<ModelPlayerClient> m_client;
-#endif
     ModelPlayerIdentifier m_id;
 };
 


### PR DESCRIPTION
#### 7d9a3479678bf4c544537f9d3fb33805fd672a8a
<pre>
ModelPlayerClient cannot be `ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr`
<a href="https://bugs.webkit.org/show_bug.cgi?id=301200">https://bugs.webkit.org/show_bug.cgi?id=301200</a>
<a href="https://rdar.apple.com/163130598">rdar://163130598</a>

Reviewed by Sam Weinig.

All accesses of m_client occur on the main thread, see
DDModelPlayer::ensureOnMainThreadWithProtectedThis

So this doesn&apos;t need to be a ThreadSafeWeakPtr, it can be
a WeakPtr

* Source/WebCore/Modules/model-element/DDModelPlayer.h:
* Source/WebCore/Modules/model-element/ModelPlayerClient.h:
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h:

Canonical link: <a href="https://commits.webkit.org/301904@main">https://commits.webkit.org/301904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ffe17ef9f92f71a5954dc22bddbecaf48b5e2aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134472 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78963 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/38642678-6683-465a-9481-a13f6603730b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47672 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55579 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96975 "11 flakes 16 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/94c4ac90-9168-4ba6-b2f1-e6a6b275e2e8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77463 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6f5bc007-e31a-4edf-8675-e48ab99b0451) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77854 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136955 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41664 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105491 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110457 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/105170 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26817 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50679 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51646 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54004 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60091 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53238 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54997 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->