### PR TITLE
[Style] Apply zoom to lengths within calc when evaluating.

### DIFF
--- a/LayoutTests/fast/css/line-height-calc-zoomed-expected.html
+++ b/LayoutTests/fast/css/line-height-calc-zoomed-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<style>
+</style>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>
+

--- a/LayoutTests/fast/css/line-height-calc-zoomed.html
+++ b/LayoutTests/fast/css/line-height-calc-zoomed.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<style>
+.container {
+  zoom: 5;
+  font: 10px/1 Ahem;
+  width: 20px;
+  background-color: green;
+  color: green;
+  line-height: max(20px, 50%);
+}
+</style>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="container">x</div>
+</body>
+</html>
+

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -206,7 +206,7 @@ inline InlineLayoutUnit InlineLevelBox::preferredLineHeight() const
             return WebCore::Style::evaluate<LayoutUnit>(percentage, LayoutUnit { fontSize() });
         },
         [&](const WebCore::Style::LineHeight::Calc& calc) -> InlineLayoutUnit {
-            return WebCore::Style::evaluate<LayoutUnit>(calc, LayoutUnit { fontSize() });
+            return WebCore::Style::evaluate<LayoutUnit>(calc, LayoutUnit { fontSize() }, m_style.zoomFactor);
         }
     );
 }

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3799,7 +3799,7 @@ template<typename SizeType> std::optional<LayoutUnit> RenderBox::computePercenta
 
 
     auto result = [&] {
-        if constexpr (Style::IsPercentageOrCalc<SizeType>)
+        if constexpr (Style::IsPercentage<SizeType>)
             return Style::evaluate<LayoutUnit>(logicalHeight, *availableHeight - rootMarginBorderPaddingHeight + (isRenderTable() && isOutOfFlowPositioned() ? containingBlock->paddingBefore() + containingBlock->paddingAfter() : 0_lu));
         else
             return Style::evaluate<LayoutUnit>(logicalHeight, *availableHeight - rootMarginBorderPaddingHeight + (isRenderTable() && isOutOfFlowPositioned() ? containingBlock->paddingBefore() + containingBlock->paddingAfter() : 0_lu), Style::ZoomNeeded { });
@@ -4179,7 +4179,7 @@ template<typename SizeType> LayoutUnit RenderBox::computeOutOfFlowPositionedLogi
             return adjustContentBoxLogicalWidthForBoxSizing(Style::evaluate<LayoutUnit>(percentageLogicalWidth, inlineConstraints.containingSize()));
         },
         [&](const typename SizeType::Calc& calculatedLogicalWidth) -> LayoutUnit {
-            return adjustContentBoxLogicalWidthForBoxSizing(Style::evaluate<LayoutUnit>(calculatedLogicalWidth, inlineConstraints.containingSize()));
+            return adjustContentBoxLogicalWidthForBoxSizing(Style::evaluate<LayoutUnit>(calculatedLogicalWidth, inlineConstraints.containingSize(), Style::ZoomNeeded { }));
         },
         [&](const CSS::Keyword::FitContent& keyword) -> LayoutUnit {
             return intrinsic(keyword);

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1162,7 +1162,7 @@ template<typename SizeType> LayoutUnit RenderFlexibleBox::computeMainSizeFromAsp
         [&](const SizeType::Calc& calcCrossSizeLength) -> std::optional<LayoutUnit> {
             return mainAxisIsFlexItemInlineAxis(flexItem)
                 ? flexItem.computePercentageLogicalHeight(calcCrossSizeLength)
-                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate<LayoutUnit>(calcCrossSizeLength, contentBoxWidth()));
+                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate<LayoutUnit>(calcCrossSizeLength, contentBoxWidth(), Style::ZoomNeeded { }));
         },
         [&](const CSS::Keyword::Auto&) -> std::optional<LayoutUnit> {
             ASSERT(flexItemCrossSizeShouldUseContainerCrossSize(flexItem));

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -909,7 +909,7 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
                     : adjustContentBoxLogicalHeightForBoxSizing(maxSizeValue);
             },
             [&](const Style::MaximumSize::Calc& calcMaxSize) -> std::optional<LayoutUnit> {
-                auto maxSizeValue = Style::evaluate<LayoutUnit>(calcMaxSize, containingBlockAvailableSize());
+                auto maxSizeValue = Style::evaluate<LayoutUnit>(calcMaxSize, containingBlockAvailableSize(), Style::ZoomNeeded { });
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(maxSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(maxSizeValue);
@@ -941,7 +941,7 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
                     : adjustContentBoxLogicalHeightForBoxSizing(minSizeValue);
             },
             [&](const Style::MinimumSize::Calc& calcMinSize) -> std::optional<LayoutUnit> {
-                auto minSizeValue = Style::evaluate<LayoutUnit>(calcMinSize, containingBlockAvailableSize());
+                auto minSizeValue = Style::evaluate<LayoutUnit>(calcMinSize, containingBlockAvailableSize(), Style::ZoomNeeded { });
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(minSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(minSizeValue);

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2599,7 +2599,7 @@ float RenderStyle::computeLineHeight(const Style::LineHeight& lineHeight) const
             return Style::evaluate<LayoutUnit>(percentage, LayoutUnit { computedFontSize() }).toFloat();
         },
         [&](const Style::LineHeight::Calc& calc) -> float {
-            return Style::evaluate<LayoutUnit>(calc, LayoutUnit { computedFontSize() }).toFloat();
+            return Style::evaluate<LayoutUnit>(calc, LayoutUnit { computedFontSize() }, usedZoomForLength()).toFloat();
         }
     );
 }
@@ -3593,7 +3593,7 @@ float RenderStyle::computedStrokeWidth(const IntSize& viewportSize) const
         },
         [&](const Style::StrokeWidth::Calc& calcStrokeWidth) -> float {
             // FIXME: It is almost certainly wrong that calc and percentage are being handled differently - https://bugs.webkit.org/show_bug.cgi?id=296482
-            return Style::evaluate<float>(calcStrokeWidth, viewportSize.width());
+            return Style::evaluate<float>(calcStrokeWidth, viewportSize.width(), Style::ZoomNeeded { });
         }
     );
 }

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1269,7 +1269,7 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
         else if (primitiveValue->isPercentage())
             size = (primitiveValue->resolveAsPercentage<float>(conversionData) * parentSize) / 100.0f;
         else if (primitiveValue->isCalculatedPercentageWithLength())
-            size = primitiveValue->cssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(parentSize);
+            size = primitiveValue->cssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(parentSize, Style::ZoomNeeded { });
         else
             return;
     }

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -283,7 +283,9 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyLineHeight> {
                 return functor(Length<CSS::Nonnegative> { percentage.value * state.style.fontDescription().computedSize() / 100 });
             },
             [&](const LineHeight::Calc& calc) {
-                return functor(Length<CSS::Nonnegative> { evaluate<float>(calc, 0.0f) });
+                // FIXME: We pass 1.0f here to get the unzoomed value but it really is not clear why we are even
+                // evaluating calc here. We should probably revisit this and figure out another way to do this.
+                return functor(Length<CSS::Nonnegative> { evaluate<float>(calc, 0.0f, Style::ZoomFactor { 1.0f, 1.0f }) });
             }
         );
     }

--- a/Source/WebCore/style/calc/StyleCalculationTree+Evaluation.h
+++ b/Source/WebCore/style/calc/StyleCalculationTree+Evaluation.h
@@ -26,13 +26,18 @@
 
 namespace WebCore {
 namespace Style {
+
+struct ZoomFactor;
+struct ZoomNeeded;
+
 namespace Calculation {
 
 struct Tree;
 
 // MARK: Evaluation.
 
-double evaluate(const Tree&, double percentResolutionLength);
+double evaluate(const Tree&, double percentResolutionLength, const ZoomFactor&);
+double evaluate(const Tree&, double percentResolutionLength, const ZoomNeeded&);
 
 } // namespace Calculation
 } // namespace Style

--- a/Source/WebCore/style/calc/StyleCalculationValue.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationValue.cpp
@@ -34,6 +34,7 @@
 
 #include "StyleCalculationTree+Copy.h"
 #include "StyleCalculationTree+Evaluation.h"
+#include "StyleZoomPrimitives.h"
 #include <cmath>
 #include <wtf/text/TextStream.h>
 
@@ -55,9 +56,17 @@ Value::Value(CSS::Category category, CSS::Range range, Tree&& tree)
 
 Value::~Value() = default;
 
-double Value::evaluate(double percentResolutionLength) const
+double Value::evaluate(double percentResolutionLength, const ZoomFactor& usedZoom) const
 {
-    auto result = Calculation::evaluate(m_tree, percentResolutionLength);
+    auto result = Calculation::evaluate(m_tree, percentResolutionLength, usedZoom);
+    if (std::isnan(result))
+        return 0;
+    return std::clamp(result, m_range.min, m_range.max);
+}
+
+double Value::evaluate(double percentResolutionLength, const ZoomNeeded& zoomNeeded) const
+{
+    auto result = Calculation::evaluate(m_tree, percentResolutionLength, zoomNeeded);
     if (std::isnan(result))
         return 0;
     return std::clamp(result, m_range.min, m_range.max);

--- a/Source/WebCore/style/calc/StyleCalculationValue.h
+++ b/Source/WebCore/style/calc/StyleCalculationValue.h
@@ -43,6 +43,10 @@ enum class Category : uint8_t;
 }
 
 namespace Style {
+
+struct ZoomFactor;
+struct ZoomNeeded;
+
 namespace Calculation {
 
 class Value : public RefCounted<Value> {
@@ -51,7 +55,8 @@ public:
     WEBCORE_EXPORT static Ref<Value> create(CSS::Category, CSS::Range, Tree&&);
     WEBCORE_EXPORT ~Value();
 
-    double evaluate(double percentResolutionLength) const;
+    double evaluate(double percentResolutionLength, const ZoomFactor& usedZoom) const;
+    double evaluate(double percentResolutionLength, const ZoomNeeded&) const;
 
     CSS::Category category() const { return m_category; }
     CSS::Range range() const { return m_range; }

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -137,7 +137,7 @@ static std::optional<float> resolveColorStopPosition(const GradientLinearColorSt
         [&](const typename LengthPercentage<>::Calc& calc) -> std::optional<float> {
             if (gradientLength <= 0)
                 return 0;
-            return calc.protectedCalculation()->evaluate(gradientLength) / gradientLength;
+            return Style::evaluate<float>(calc, gradientLength, Style::ZoomNeeded { }) / gradientLength;
         }
     );
 }
@@ -155,7 +155,7 @@ static std::optional<float> resolveColorStopPosition(const GradientAngularColorS
             return percentage.value / 100.0;
         },
         [&](const typename AnglePercentage<>::Calc& calc) -> std::optional<float> {
-            return calc.protectedCalculation()->evaluate(100) / 100.0;
+            return Style::evaluate<float>(calc, 100, Style::ZoomNeeded { });
         }
     );
 }

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -55,12 +55,23 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSPr
         .cssToLengthConversionData()
         .copyForLineHeight(zoomWithTextZoomFactor(state));
 
+    // If EvaluationTimeZoom is not enabled then we will scale the lengths in the
+    // calc values when we create the CalculationValue below by using the zoom from conversionData.
+    // To avoid double zooming when we evaluate the calc expression we need to make sure
+    // we have a ZoomFactor of 1.0. Otherwise, we defer to whatever is on the conversionData
+    // since EvaluationTimeZoom will set the appropriate value.
+    auto zoomFactor = [&] {
+        if (!state.style().evaluationTimeZoomEnabled())
+            return Style::ZoomFactor { 1.0f, state.style().deviceScaleFactor() };
+        return Style::ZoomFactor { conversionData.zoom(), state.style().deviceScaleFactor() };
+    };
+
     if (primitiveValue.isLength() || primitiveValue.isCalculatedPercentageWithLength()) {
         double fixedValue = 0;
         if (primitiveValue.isLength())
             fixedValue = primitiveValue.resolveAsLength(conversionData);
         else
-            fixedValue = primitiveValue.protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(state.style().fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption()));
+            fixedValue = primitiveValue.protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(state.style().fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption()), zoomFactor());
 
         if (multiplier != 1.0f)
             fixedValue *= multiplier;

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp
@@ -81,10 +81,19 @@ auto LengthWrapperData::ipcData() const -> IPCData
     };
 }
 
-float LengthWrapperData::nonNanCalculatedValue(float maxValue) const
+float LengthWrapperData::nonNanCalculatedValue(float maxValue, const ZoomFactor& usedZoom) const
 {
     ASSERT(m_kind == LengthWrapperDataKind::Calculation);
-    float result = protectedCalculationValue()->evaluate(maxValue);
+    float result = protectedCalculationValue()->evaluate(maxValue, usedZoom);
+    if (std::isnan(result))
+        return 0;
+    return result;
+}
+
+float LengthWrapperData::nonNanCalculatedValue(float maxValue, const ZoomNeeded& token) const
+{
+    ASSERT(m_kind == LengthWrapperDataKind::Calculation);
+    float result = protectedCalculationValue()->evaluate(maxValue, token);
     if (std::isnan(result))
         return 0;
     return result;

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
@@ -96,7 +96,8 @@ struct LengthWrapperData {
     ReturnType valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomFactor) const;
 
 private:
-    WEBCORE_EXPORT float nonNanCalculatedValue(float maxValue) const;
+    WEBCORE_EXPORT float nonNanCalculatedValue(float maxValue, const ZoomFactor& usedZoom) const;
+    WEBCORE_EXPORT float nonNanCalculatedValue(float maxValue, const ZoomNeeded&) const;
     bool isCalculatedEqual(const LengthWrapperData&) const;
 
     void initialize(const LengthWrapperData&);
@@ -273,7 +274,7 @@ inline bool LengthWrapperData::isPossiblyNegative(LengthWrapperDataEvaluationKin
 }
 
 template<typename ReturnType, typename MaximumType>
-ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomNeeded) const
+ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomNeeded token) const
 {
     switch (evaluationKind) {
     case LengthWrapperDataEvaluationKind::Fixed:
@@ -284,7 +285,7 @@ ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(Le
         return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * m_floatValue / 100.0f));
     case LengthWrapperDataEvaluationKind::Calculation:
         ASSERT(m_kind == LengthWrapperDataKind::Calculation);
-        return ReturnType(nonNanCalculatedValue(lazyMaximumValueFunctor()));
+        return ReturnType(nonNanCalculatedValue(lazyMaximumValueFunctor(), token));
     case LengthWrapperDataEvaluationKind::Flag:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
         return ReturnType(0);
@@ -305,7 +306,7 @@ ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(Le
         return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * m_floatValue / 100.0f));
     case LengthWrapperDataEvaluationKind::Calculation:
         ASSERT(m_kind == LengthWrapperDataKind::Calculation);
-        return ReturnType(nonNanCalculatedValue(lazyMaximumValueFunctor()));
+        return ReturnType(nonNanCalculatedValue(lazyMaximumValueFunctor(), zoom));
     case LengthWrapperDataEvaluationKind::Flag:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
         return ReturnType(0);
@@ -315,7 +316,7 @@ ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(Le
 }
 
 template<typename ReturnType, typename MaximumType>
-ReturnType LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomNeeded) const
+ReturnType LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomNeeded token) const
 {
     switch (evaluationKind) {
     case LengthWrapperDataEvaluationKind::Fixed:
@@ -326,7 +327,7 @@ ReturnType LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum(LengthWra
         return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * m_floatValue / 100.0f));
     case LengthWrapperDataEvaluationKind::Calculation:
         ASSERT(m_kind == LengthWrapperDataKind::Calculation);
-        return ReturnType(nonNanCalculatedValue(lazyMaximumValueFunctor()));
+        return ReturnType(nonNanCalculatedValue(lazyMaximumValueFunctor(), token));
     case LengthWrapperDataEvaluationKind::Flag:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
         return ReturnType(lazyMaximumValueFunctor());
@@ -347,7 +348,7 @@ ReturnType LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum(LengthWra
         return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * m_floatValue / 100.0f));
     case LengthWrapperDataEvaluationKind::Calculation:
         ASSERT(m_kind == LengthWrapperDataKind::Calculation);
-        return ReturnType(nonNanCalculatedValue(lazyMaximumValueFunctor()));
+        return ReturnType(nonNanCalculatedValue(lazyMaximumValueFunctor(), zoom));
     case LengthWrapperDataEvaluationKind::Flag:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
         return ReturnType(lazyMaximumValueFunctor());

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
@@ -382,9 +382,10 @@ template<Numeric T> struct ToCSSMapping<T> {
 
 // MARK: Utility Concepts
 
-template<typename T> concept IsPercentageOrCalc =
-       std::same_as<T, Percentage<T::range, typename T::ResolvedValueType>>
-    || std::same_as<T, UnevaluatedCalculation<typename T::CSS>>;
+template<typename T> concept IsPercentage = std::same_as<T, Percentage<T::range, typename T::ResolvedValueType>>;
+template<typename T> concept IsCalc = std::same_as<T, UnevaluatedCalculation<typename T::CSS>>;
+
+template<typename T> concept IsPercentageOrCalc = IsPercentage<T> || IsCalc<T>;
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
@@ -43,7 +43,7 @@ auto Evaluation<ScrollPaddingEdge, LayoutUnit>::operator()(const ScrollPaddingEd
             return evaluate<LayoutUnit>(percentage, referenceLength);
         },
         [&](const ScrollPaddingEdge::Calc& calculated) {
-            return evaluate<LayoutUnit>(calculated, referenceLength);
+            return evaluate<LayoutUnit>(calculated, referenceLength, token);
         },
         [&](const CSS::Keyword::Auto&) {
             return 0_lu;
@@ -61,7 +61,7 @@ auto Evaluation<ScrollPaddingEdge, float>::operator()(const ScrollPaddingEdge& e
             return evaluate<float>(percentage, referenceLength);
         },
         [&](const ScrollPaddingEdge::Calc& calculated) {
-            return evaluate<float>(calculated, referenceLength);
+            return evaluate<float>(calculated, referenceLength, token);
         },
         [&](const CSS::Keyword::Auto&) {
             return 0.0f;

--- a/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp
@@ -42,7 +42,10 @@ float TextUnderlineOffset::resolve(const RenderStyle& style, float autoValue) co
         [&](const Fixed& fixed) -> float {
             return Style::evaluate<float>(fixed, style.usedZoomForLength());
         },
-        [&](const auto& percentage) -> float {
+        [&](const Calc& calc) -> float {
+            return Style::evaluate<float>(calc, style.computedFontSize(), style.usedZoomForLength());
+        },
+        [&](const Percentage& percentage) -> float {
             return Style::evaluate<float>(percentage, style.computedFontSize());
         }
     );

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -126,7 +126,7 @@ template<typename SizeType> float SVGLengthContext::valueForSizeType(const SizeT
         },
         [&](const typename SizeType::Calc& calc) -> float {
             auto viewportSize = this->viewportSize().value_or(FloatSize { });
-            return Style::evaluate<float>(calc, dimensionForLengthMode(lengthMode, viewportSize));
+            return Style::evaluate<float>(calc, dimensionForLengthMode(lengthMode, viewportSize), Style::ZoomNeeded { });
         },
         [&](const auto&) -> float {
             return 0;


### PR DESCRIPTION
#### 761924a0502321e047299221e9ef26096458dc8b
<pre>
[Style] Apply zoom to lengths within calc when evaluating.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301219">https://bugs.webkit.org/show_bug.cgi?id=301219</a>
<a href="https://rdar.apple.com/problem/163141549">rdar://problem/163141549</a>

Reviewed by Sam Weinig.

Before we can start evaluting Preferred, Minimum, and Maximum Sizes at
use time with zoom we need to be able to support evaluating calc
expressions with zoom since any length values within the expression
should be affected by zoom. For example, something like
width: calc(50% + 100px) will need to have the used zoom multiplied into
the 100px.

We can do this in a similar manner to how we force callers to pass in a
ZoomFactor to various Length types when evaluating their values. The
Style Evaluation code will then call into the Calculation&apos;s evaluate API
with the passed in zoom factor. This requires us to plumb the ZoomFactor
through this codepath when evaluating different Calc nodes and using it
when applicable. The other half of this patch is then mostly applying
Style::ZoomNeeded { } at different call sites to mark which types still
need to become Unzoomed and have an actual ZoomFactor passed in.

* LayoutTests/fast/css/line-height-calc-zoomed-expected.html: Added.
* LayoutTests/fast/css/line-height-calc-zoomed.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
(WebCore::Layout::InlineLevelBox::preferredLineHeight const):
Here we can actually pass in the usedZoom since line-height is already
Unzoomed.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computePercentageLogicalHeightGeneric const):
Note here we separate out the percent and calc logic since we need to
now treat these differently. Percentages still do not have zoom applied
to them but calc expressions will now have the used zoom applied to
their lengths. This is done in a few different area of the code but I am
only going to note it here.

(WebCore::RenderBox::computeOutOfFlowPositionedLogicalWidthUsing const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::computeMainSizeFromAspectRatioUsing const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::computeAutoRepeatTracksCount const):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::computeLineHeight const):
(WebCore::RenderStyle::computedStrokeWidth const):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueFontSize):
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::PropertyExtractorAdaptor&lt;CSSPropertyLineHeight&gt;::computedValue const):

* Source/WebCore/style/calc/StyleCalculationTree+Evaluation.cpp:
(WebCore::Style::Calculation::evaluate):
* Source/WebCore/style/calc/StyleCalculationTree+Evaluation.h:
* Source/WebCore/style/calc/StyleCalculationValue.cpp:
(WebCore::Style::Calculation::Value::evaluate const):
* Source/WebCore/style/calc/StyleCalculationValue.h:
Plumbing for the zoom factor through all the different evaluate
implementations. This should only get applied to lengths so in many
cases we do not need to use it.

* Source/WebCore/style/values/primitives/StyleLengthWrapperData.h:
(WebCore::Style::LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum const):
(WebCore::Style::LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum const):
* Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
When called on a type that is Unzoomed we will pass in the ZoomFactor
that they gave us, but in the other case we will just use a
Style::ZoomFactor { 1.0f, 1.0f, } so that the calc value is unaffected.
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp:
(WebCore::Style::LayoutUnit&gt;::operator):
(WebCore::Style::float&gt;::operator):
* Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp:
(WebCore::Style::TextUnderlineOffset::resolve const):
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::valueForSizeType):

Canonical link: <a href="https://commits.webkit.org/301968@main">https://commits.webkit.org/301968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2628c9ee487674a34d85029f3a023cc4422f93eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134897 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aed576a0-4dfd-47cb-9743-2130abaafee1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97155 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/45ced037-295e-406d-bec4-d96dc4884da4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114327 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77636 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8c03458c-7f5e-4ad8-85c7-7ac630e912a8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32416 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78256 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137379 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41842 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105675 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105326 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26860 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50845 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51879 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54222 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60398 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53456 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55215 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->