### PR TITLE
REGRESSION (iOS 26): Dialog backdrop looks weird, as it doesn't extend below address bar

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-modal-dialog-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-modal-dialog-expected.txt
@@ -1,0 +1,16 @@
+PASS edgeColorsBeforeShowingModalDialog.top is null
+PASS edgeColorsBeforeShowingModalDialog.left is null
+PASS edgeColorsBeforeShowingModalDialog.right is null
+PASS edgeColorsBeforeShowingModalDialog.bottom is null
+PASS edgeColorsAfterShowingModalDialog.top is "rgb(229, 229, 229)"
+PASS edgeColorsAfterShowingModalDialog.left is "rgb(229, 229, 229)"
+PASS edgeColorsAfterShowingModalDialog.right is "rgb(229, 229, 229)"
+PASS edgeColorsAfterShowingModalDialog.bottom is "rgb(229, 229, 229)"
+PASS edgeColorsAfterClosingModalDialog.top is null
+PASS edgeColorsAfterClosingModalDialog.left is null
+PASS edgeColorsAfterClosingModalDialog.right is null
+PASS edgeColorsAfterClosingModalDialog.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-modal-dialog.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-modal-dialog.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=50 obscuredInset.left=50 ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            font-family: system-ui;
+        }
+
+        .tall {
+            height: 200vh;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        const dialog = document.querySelector("dialog");
+        await UIHelper.setObscuredInsets(50, 50, 50, 50);
+        await UIHelper.ensurePresentationUpdate();
+
+        edgeColorsBeforeShowingModalDialog = await UIHelper.fixedContainerEdgeColors();
+        shouldBeNull("edgeColorsBeforeShowingModalDialog.top");
+        shouldBeNull("edgeColorsBeforeShowingModalDialog.left");
+        shouldBeNull("edgeColorsBeforeShowingModalDialog.right");
+        shouldBeNull("edgeColorsBeforeShowingModalDialog.bottom");
+
+        dialog.showModal();
+        await UIHelper.ensurePresentationUpdate();
+
+        edgeColorsAfterShowingModalDialog = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("edgeColorsAfterShowingModalDialog.top", "rgb(229, 229, 229)");
+        shouldBeEqualToString("edgeColorsAfterShowingModalDialog.left", "rgb(229, 229, 229)");
+        shouldBeEqualToString("edgeColorsAfterShowingModalDialog.right", "rgb(229, 229, 229)");
+        shouldBeEqualToString("edgeColorsAfterShowingModalDialog.bottom", "rgb(229, 229, 229)");
+
+        dialog.close();
+        await UIHelper.ensurePresentationUpdate();
+
+        edgeColorsAfterClosingModalDialog = await UIHelper.fixedContainerEdgeColors();
+        shouldBeNull("edgeColorsAfterClosingModalDialog.top");
+        shouldBeNull("edgeColorsAfterClosingModalDialog.left");
+        shouldBeNull("edgeColorsAfterClosingModalDialog.right");
+        shouldBeNull("edgeColorsAfterClosingModalDialog.bottom");
+
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <div class="tall"></div>
+    <dialog>
+        <p>Hello world</p>
+    </dialog>
+</body>
+</html>


### PR DESCRIPTION
#### 2ae949b78743c66d99379b8cc76dfe5d3bf642a1
<pre>
REGRESSION (iOS 26): Dialog backdrop looks weird, as it doesn&apos;t extend below address bar
<a href="https://bugs.webkit.org/show_bug.cgi?id=300965">https://bugs.webkit.org/show_bug.cgi?id=300965</a>
<a href="https://rdar.apple.com/162985065">rdar://162985065</a>

Reviewed by Abrar Rahman Protyasha.

Teach fixed container edge sampling to handle backdrops, by extending the backdrop&apos;s background
color (blended against the page background color) into the obscured content inset areas. This avoids
cases where the page behind the backdrop renderer shows up fully around the edges of the full-page
backdrop element.

Note that this covers native dialog elements as well, which use backdrop renderers.

Test: fast/page-color-sampling/color-sampling-modal-dialog.html

* LayoutTests/fast/page-color-sampling/color-sampling-modal-dialog-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-modal-dialog.html: Added.

Add a test to exercise the change, by checking color extensions after opening and after closing a
modal dialog element.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Canonical link: <a href="https://commits.webkit.org/301911@main">https://commits.webkit.org/301911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25dff8575f51f56b55037a643eb9af73afa61be1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78979 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6691ce91-cd3b-4e65-94bf-b1487c5bcbab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96997 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f8f6bf4c-c31c-40c6-b6ce-eb60be98aeb3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114124 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77477 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ccb74423-150d-4647-a381-f8fcce977493) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77874 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136988 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105524 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110472 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105177 "Found 1 new API test failure: WebKitGTK/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26820 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50689 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51662 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54020 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60107 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/53254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->