### PR TITLE
Revert 290596@main

### DIFF
--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable-expected.txt
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS w.location.href is "about:blank"
-PASS testRunner.windowCount() is 3
+PASS testRunner.windowCount() is 2
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable.html
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable.html
@@ -16,8 +16,13 @@ onload = function() {
         w = open("/navigation/resources/otherpage.html", "foo"); // Should create a new window.
         shouldBeEqualToString("w.location.href", "about:blank");
         w.onload = function() {
-            if (window.testRunner)
-                shouldBe("testRunner.windowCount()", "3");
+            if (window.testRunner) {
+                if (testRunner.isWebKit2) {
+                    shouldBe("testRunner.windowCount()", "2");
+                } else {
+                    shouldBe("testRunner.windowCount()", "3");
+                }
+            }
             finishJSTest();
         }
     }, 100);

--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable2-expected.txt
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable2-expected.txt
@@ -5,7 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS w is null
 PASS w.location.href is "about:blank"
-PASS testRunner.windowCount() is 3
+PASS testRunner.windowCount() is 2
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable2.html
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable2.html
@@ -16,8 +16,13 @@ onload = function() {
         w = open("/navigation/resources/otherpage.html", "foo"); // Should create a new window.
         shouldBeEqualToString("w.location.href", "about:blank");
         w.onload = function() {
-            if (window.testRunner)
-                shouldBe("testRunner.windowCount()", "3");
+            if (window.testRunner) {
+                if (testRunner.isWebKit2) {
+                    shouldBe("testRunner.windowCount()", "2");
+                } else {
+                    shouldBe("testRunner.windowCount()", "3");
+                }
+            }
             finishJSTest();
         }
     }, 100);

--- a/LayoutTests/http/tests/dom/noreferrer-window-not-targetable-expected.txt
+++ b/LayoutTests/http/tests/dom/noreferrer-window-not-targetable-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS w.location.href is "about:blank"
-PASS testRunner.windowCount() is 3
+PASS testRunner.windowCount() is 2
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/dom/noreferrer-window-not-targetable.html
+++ b/LayoutTests/http/tests/dom/noreferrer-window-not-targetable.html
@@ -16,7 +16,11 @@ onload = function() {
         shouldBeEqualToString("w.location.href", "about:blank");
         w.onload = function() {
             if (window.testRunner) {
-                shouldBe("testRunner.windowCount()", "3");
+                if (testRunner.isWebKit2) {
+                    shouldBe("testRunner.windowCount()", "2");
+                } else {
+                    shouldBe("testRunner.windowCount()", "3");
+                }
             }
             finishJSTest();
         }

--- a/LayoutTests/http/tests/download/sandboxed-iframe-download-not-allowed-expected.txt
+++ b/LayoutTests/http/tests/download/sandboxed-iframe-download-not-allowed-expected.txt
@@ -1,5 +1,7 @@
 CONSOLE MESSAGE: Not allowed to download due to sandboxing
 CONSOLE MESSAGE: Not allowed to download due to sandboxing
+CONSOLE MESSAGE: Not allowed to download due to sandboxing
+CONSOLE MESSAGE: Not allowed to download due to sandboxing
 This test passes if no download is started.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1991,8 +1991,6 @@ webkit.org/b/288011 [ Sonoma+ Release ] tiled-drawing/top-left-content-insets.ht
 
 webkit.org/b/280019 [ Sonoma+ Release ] fast/canvas/offscreen-giant.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/288006 http/tests/dom/noreferrer-window-not-targetable.html [ Failure ]
-
 # webkit.org/b/287679 REGRESSION(289499@main):[macOS Debug ] imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has.html is flaky (failure in EWS)
 imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has.html [ Pass Failure ]
 imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html [ Pass Failure ]

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8941,10 +8941,9 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
     configuration->setInitialReferrerPolicy(effectiveReferrerPolicy);
     configuration->setWindowFeatures(WTFMove(windowFeatures));
     configuration->setOpenedMainFrameName(openedMainFrameName);
-    if (!protectedPreferences()->siteIsolationEnabled())
-        configuration->setRelatedPage(*this);
 
     if (RefPtr openerFrame = WebFrameProxy::webFrame(originatingFrameInfoData.frameID); navigationActionData.hasOpener && openerFrame) {
+        configuration->setRelatedPage(*this);
         configuration->setOpenerInfo({ {
             openerFrame->frameProcess().process(),
             m_browsingContextGroup.copyRef(),
@@ -8956,6 +8955,8 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
     } else {
         configuration->setOpenerInfo(std::nullopt);
         configuration->setOpenedSite(WebCore::Site(request.url()));
+        if (openedBlobURL)
+            configuration->setRelatedPage(*this);
     }
 
 #if PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -1463,7 +1463,7 @@ TEST(ProcessSwap, CrossSiteWindowOpenWithOpener)
 
 enum class ExpectSwap : bool { No, Yes };
 enum class WindowHasName : bool { No, Yes };
-static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName, ExpectSwap expectSwap)
+static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
@@ -1504,10 +1504,7 @@ static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName, Expec
     EXPECT_TRUE(!!pid2);
 
     // Since there is no opener, we process-swap, even though the navigation is same-site.
-    if (expectSwap == ExpectSwap::Yes)
-        EXPECT_NE(pid1, pid2);
-    else
-        EXPECT_EQ(pid1, pid2);
+    EXPECT_NE(pid1, pid2);
 
     done = false;
     request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/popup2.html"]];
@@ -1525,12 +1522,12 @@ static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName, Expec
 TEST(ProcessSwap, SameSiteWindowOpenNoOpener)
 {
     // We process-swap even though the navigation is same-site, because the popup has no opener.
-    runSameSiteWindowOpenNoOpenerTest(WindowHasName::No, ExpectSwap::Yes);
+    runSameSiteWindowOpenNoOpenerTest(WindowHasName::No);
 }
 
 TEST(ProcessSwap, SameSiteWindowOpenWithNameNoOpener)
 {
-    runSameSiteWindowOpenNoOpenerTest(WindowHasName::Yes, ExpectSwap::No);
+    runSameSiteWindowOpenNoOpenerTest(WindowHasName::Yes);
 }
 
 TEST(ProcessSwap, CrossSiteBlankTargetWithOpener)


### PR DESCRIPTION
#### 54a91f28c3b86412cc8024491c852e2cf1ac6118
<pre>
Revert 290596@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=301215">https://bugs.webkit.org/show_bug.cgi?id=301215</a>
<a href="https://rdar.apple.com/163136116">rdar://163136116</a>

Unreviewed.

Safari was reading WKWebViewConfiguration._relatedWebView for something, and now that
that is not the case with the fix for <a href="https://rdar.apple.com/160393997">rdar://160393997</a> we can re-merge the parts of
285310@main that were reverted in 290596@main without issue.

This also reverts some layout test expectation adjustments in 290858@main.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm

* LayoutTests/http/tests/dom/noopener-window-not-targetable-expected.txt:
* LayoutTests/http/tests/dom/noopener-window-not-targetable.html:
* LayoutTests/http/tests/dom/noopener-window-not-targetable2-expected.txt:
* LayoutTests/http/tests/dom/noopener-window-not-targetable2.html:
* LayoutTests/http/tests/dom/noreferrer-window-not-targetable-expected.txt:
* LayoutTests/http/tests/dom/noreferrer-window-not-targetable.html:
* LayoutTests/http/tests/download/sandboxed-iframe-download-not-allowed-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::createNewPage):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, SameSiteWindowOpenNoOpener)):
((ProcessSwap, SameSiteWindowOpenWithNameNoOpener)):

Canonical link: <a href="https://commits.webkit.org/301954@main">https://commits.webkit.org/301954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc795b87e97b5068edc4f4ce0696756f20c3427c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134624 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79104 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1e6f0016-c716-45fb-a746-df632a16b28b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97089 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65008 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a1c6b84d-c2a3-447a-a82f-bda65c2fb25b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77569 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/780d0390-337e-41bd-9095-545ee0a446f3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32331 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77997 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108099 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137108 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41765 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105614 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105265 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50776 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29226 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51786 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19950 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60230 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53377 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56834 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55136 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->