### PR TITLE
301207@main Regression - Address PKDateComponentsRange in test ipc/serialized-type-info.html

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKDateComponentsRange.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKDateComponentsRange.mm
@@ -55,21 +55,4 @@ RetainPtr<id> CoreIPCPKDateComponentsRange::toID() const
 
 } // namespace WebKit
 
-namespace IPC {
-
-template<> void encodeObjectDirectly<PKDateComponentsRange>(Encoder& encoder, PKDateComponentsRange *instance)
-{
-    encoder << (instance ? std::optional(WebKit::CoreIPCPKDateComponentsRange(instance)) : std::nullopt);
-}
-
-template<> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClasses<PKDateComponentsRange>(Decoder& decoder)
-{
-    return decoder.decode<std::optional<WebKit::CoreIPCPKDateComponentsRange>>()
-        .and_then([](const std::optional<WebKit::CoreIPCPKDateComponentsRange>& inner) -> std::optional<RetainPtr<id>> {
-            return inner ? inner->toID() : nullptr;
-        });
-}
-
-} // namespace IPC
-
 #endif

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -434,11 +434,8 @@ NSURLRequest wrapped by CoreIPCNSURLRequest
 AVOutputContext wrapped by CoreIPCAVOutputContext
 #endif
 
-#if USE(PASSKIT) && !HAVE(WK_SECURE_CODING_PKDATECOMPONENTSRANGE)
-PKDateComponentsRange wrapped by CoreIPCPKDateComponentsRange
-#endif
-
 #if USE(PASSKIT)
+PKDateComponentsRange wrapped by CoreIPCPKDateComponentsRange
 PKPaymentMethod wrapped by CoreIPCPKPaymentMethod
 PKPaymentMerchantSession wrapped by CoreIPCPKPaymentMerchantSession
 PKPaymentSetupFeature wrapped by CoreIPCPKPaymentSetupFeature


### PR DESCRIPTION
#### 06b79fc332693049365b90e60e117ec6209ddd49
<pre>
301207@main Regression - Address PKDateComponentsRange in test ipc/serialized-type-info.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=301216">https://bugs.webkit.org/show_bug.cgi?id=301216</a>
<a href="https://rdar.apple.com/163138720">rdar://163138720</a>

Reviewed by Abrar Rahman Protyasha.

In 301207@main a &quot;wrapped by&quot; clause was moved behind a build time conditional. This removed the
generation of serialization metadata for the JS Test API.  This change adds it back in and lets
templates be generated to hook up the specific serializers in Source/WebKit/Shared/Cocoa/CoreIPCPKDateComponentsRange.mm

Tested by layout test ipc/serialized-type-info.html

* Source/WebKit/Shared/Cocoa/CoreIPCPKDateComponentsRange.mm:
(IPC::encodeObjectDirectly&lt;PKDateComponentsRange&gt;): Deleted.
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;PKDateComponentsRange&gt;): Deleted.
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:

Canonical link: <a href="https://commits.webkit.org/301947@main">https://commits.webkit.org/301947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07909ca4dcf600ff2b00140144438d0e5afdfe75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78992 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c80d9bd2-ca73-4850-b621-fb9175e1f348) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97005 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64966 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bc36f5c1-cf7d-4ae3-a276-f5b9e1920ac4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77485 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8f5aa78d-aa8f-4820-87a1-f01dbd3141b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36998 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77887 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136998 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105558 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105190 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26843 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50699 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29153 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51675 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54033 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60120 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53267 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56724 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55026 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->