### PR TITLE
[visionOS] Entering docked mode from element fullscreen has brief spatial audio hiccup

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm
+++ b/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm
@@ -45,7 +45,7 @@ static CASoundStageSize toCASoundStageSize(MediaPlayerSoundStageSize size)
 RetainPtr<CASpatialAudioExperience> createSpatialAudioExperienceWithOptions(const SpatialAudioExperienceOptions& options)
 {
 #if HAVE(SPATIAL_TRACKING_LABEL)
-    if (options.isVisible && options.hasTarget) {
+    if (options.isVisible && options.hasTarget && !options.spatialTrackingLabel.isEmpty()) {
         // Automatic anchoring does not yet work with remote video targets, so rely on
         // the spatial tracking label, and use that label to create a CAAudioTether. This
         // tether informs the audio rendering subsystem about the connection between the

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -1510,12 +1510,20 @@ void AudioVideoRendererAVFObjC::audioRendererWasAutomaticallyFlushed(AVSampleBuf
 #if HAVE(SPATIAL_TRACKING_LABEL)
 void AudioVideoRendererAVFObjC::setSpatialTrackingInfo(bool prefersSpatialAudioExperience, SoundStageSize soundStage, const String& sceneIdentifier, const String& defaultLabel, const String& label)
 {
+    if (m_prefersSpatialAudioExperience == prefersSpatialAudioExperience
+        && m_soundStage == soundStage
+        && m_sceneIdentifier == sceneIdentifier
+        && m_defaultSpatialTrackingLabel == defaultLabel
+        && m_spatialTrackingLabel == label)
+        return;
+
     m_prefersSpatialAudioExperience = prefersSpatialAudioExperience;
     m_soundStage = soundStage;
     m_sceneIdentifier = sceneIdentifier;
     m_defaultSpatialTrackingLabel = defaultLabel;
     m_spatialTrackingLabel = label;
 
+    ALWAYS_LOG(LOGIDENTIFIER, "prefersSpatialAudioExperience(", prefersSpatialAudioExperience, "), soundStage(", soundStage, "), sceneIdentifier(", sceneIdentifier, "), defaultLabel(", defaultLabel, "), label(", label, ")");
     updateSpatialTrackingLabel();
 }
 
@@ -1535,6 +1543,7 @@ void AudioVideoRendererAVFObjC::updateSpatialTrackingLabel()
             .spatialTrackingLabel = m_spatialTrackingLabel,
 #endif
         });
+        ALWAYS_LOG(LOGIDENTIFIER, "Setting spatialAudioExperience: ", spatialAudioExperienceDescription(experience.get()));
         [m_synchronizer setIntendedSpatialAudioExperience:experience.get()];
         return;
     }


### PR DESCRIPTION
#### 21d177c03645eb589f5d7ae4e66b4b01410415cb
<pre>
[visionOS] Entering docked mode from element fullscreen has brief spatial audio hiccup
<a href="https://rdar.apple.com/160143659">rdar://160143659</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301218">https://bugs.webkit.org/show_bug.cgi?id=301218</a>

Reviewed by Eric Carlson.

It&apos;s possible for the AudioVideoRenderer to get a video target before it receives
a spatial tracking label. In this scenario, the SpatialExperienceHelper will create
a tethered experience with no label, confusing the audio rendering system.

Only create a tethered experience when all of the criteria are met, including that
the label is non-empty.

Drive-by fix: Enable logging for the spatial experience methods so that this behavior
can be seen in logs.

* Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm:
(WebCore::createSpatialAudioExperienceWithOptions):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::setSpatialTrackingInfo):
(WebCore::AudioVideoRendererAVFObjC::updateSpatialTrackingLabel):

Canonical link: <a href="https://commits.webkit.org/301919@main">https://commits.webkit.org/301919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8305d6d394d4b3fd6321953b2f83fc654b222f66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134516 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78995 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1b69f8aa-a9a2-4622-8b8f-24425e6b40de) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97011 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/58d97af5-80e2-4db0-940b-51a569f85202) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77491 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9dd21d24-394b-4eb9-99e0-130c2f31d50e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/36994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32247 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77890 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137001 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105533 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105186 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26827 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50702 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51678 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60123 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53270 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55029 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->