### PR TITLE
[JSC] Fix `Error` Typos

### DIFF
--- a/JSTests/stress/arrowfunction-lexical-bind-supercall-2.js
+++ b/JSTests/stress/arrowfunction-lexical-bind-supercall-2.js
@@ -59,7 +59,7 @@ var C = class C extends A {
       var arrow = () => {
           let __proto__ = 'some-text';
           var arr = () => {
-              testCase(typeof  __proto__, 'string', "Erorr: __proto__ variable has wrong type");
+              testCase(typeof  __proto__, 'string', "Error: __proto__ variable has wrong type");
               super();
               testCase(this.idValue, testValue, "Error: super() should create this and put value into idValue property");
            };

--- a/JSTests/stress/throw-from-next-in-for-of-header.js
+++ b/JSTests/stress/throw-from-next-in-for-of-header.js
@@ -13,7 +13,7 @@ for (let i = 0; i <= testLoopCount; ++i) {
     noInline(iterable.next);
     try {
         for (_ of iterable)
-            throw new Erorr();
+            throw new Error();
     } catch (e) {
         if (e !== error)
             throw e;


### PR DESCRIPTION
#### 7561bac832802d49d9d83825b39d8a05977becc1
<pre>
[JSC] Fix `Error` Typos
<a href="https://bugs.webkit.org/show_bug.cgi?id=301220">https://bugs.webkit.org/show_bug.cgi?id=301220</a>

Reviewed by Yusuke Suzuki.

This patch fixes typos related to `error` in JavaScript.

* JSTests/stress/arrowfunction-lexical-bind-supercall-2.js:
(C):
* JSTests/stress/throw-from-next-in-for-of-header.js:

Canonical link: <a href="https://commits.webkit.org/301938@main">https://commits.webkit.org/301938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec5641dd5b94a401c9a26bbb2d9b4ea96e099471

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79001 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97015 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77495 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37010 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77896 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119483 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137007 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125909 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105539 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105192 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26836 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29161 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51684 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54042 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/158947 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53276 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39737 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56733 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55035 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->