### PR TITLE
[MiniBrowser] Fix logging channel names being normalized as URLs

### DIFF
--- a/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
+++ b/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
@@ -60,18 +60,28 @@ def main(argv):
     # string, so it needs to be split again.
     browser_args = [decode(s, "utf-8") for s in option_parser.convert_arg_line_to_args(' '.join(args))[0].split()]
     if options.url:
-        # Normalize URL by adding scheme if missing.
-        url = options.url
-        parsed = urlparse(url)
+        # Check if this "URL" is actually the value for -WebCoreLogging
+        url_index = argv.index(options.url)
+        skip_normalization = url_index > 0 and argv[url_index - 1] == '-WebCoreLogging'
 
-        # If no scheme is given, add https://
-        if not parsed.scheme:
-            # Handle localhost and IP addresses specially
-            if url.startswith('localhost') or url.split(':')[0].replace('.', '').isdigit():
-                url = f'http://{url}'
-            else:
-                url = f'https://{url}'
-        browser_args.append(url)
+        if not skip_normalization:
+            # Normalize URL by adding scheme if missing.
+            url = options.url
+            parsed = urlparse(url)
+
+        # Only normalize if it actually looks like a URL (to not accidentally normalize a logging stream):
+        # - starts with localhost
+        # - looks like an IP address
+        # - contains a dot (likely a domain) or slash (path)
+            if not parsed.scheme:
+                if url.startswith('localhost') or url.split(':')[0].replace('.', '').isdigit():
+                    url = f'http://{url}'
+                elif '.' in url or '/' in url:
+                    url = f'https://{url}'
+            browser_args.append(url)
+        else:
+            # It's the logging channel for -WebCoreLogging, pass through unchanged
+            browser_args.append(options.url)
     if options.platform == "mac" and options.site_isolation is not None:
         browser_args.append('--force-site-isolation')
         browser_args.append('YES' if options.site_isolation else 'NO')


### PR DESCRIPTION
#### 92b7489e014afb385a4b51788d4c2adcc678966f
<pre>
[MiniBrowser] Fix logging channel names being normalized as URLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=301227">https://bugs.webkit.org/show_bug.cgi?id=301227</a>
<a href="https://rdar.apple.com/163146056">rdar://163146056</a>

Reviewed by Abrar Rahman Protyasha and Basuke Suzuki.

After commits.webkit.org/301651@main, we treat strings without a scheme as a URL, and
normalize it with the proper scheme before passing it to MIniBrowser.

This caused issues with WebKit logging channels, which do not have schemes, and thus
were being treated as URLs and getting schemes added.

Fix this by only normalizing if it actually looks like a URL (to not accidentally normalize a logging stream):
         - starts with localhost
         - looks like an IP address
         - contains a dot (likely a domain) or slash (path)

* Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py:
(main):

Canonical link: <a href="https://commits.webkit.org/301927@main">https://commits.webkit.org/301927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c98bc027c7cdaae2a05ebb6c8248177f4b4c6847

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134548 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79028 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c2c8d05-4d19-4e80-b05d-7f620c3b535a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97030 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/be6afa10-8b87-4715-a787-943593d191f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77510 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/553d5661-94c6-4a34-b9a6-75be255f96d0) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/126823 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32268 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77922 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137033 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41710 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105555 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110515 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105207 "Found 1 new API test failure: WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26831 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50724 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51710 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54068 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53302 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56759 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55061 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->