### PR TITLE
REGRESSION (300909@main): Closing a transitioned popover with "position-try" can crash the browser window

### DIFF
--- a/LayoutTests/fast/css/css-anchor-position/position-try-popover-transition-display-none-crash-expected.txt
+++ b/LayoutTests/fast/css/css-anchor-position/position-try-popover-transition-display-none-crash-expected.txt
@@ -1,0 +1,4 @@
+This test passes if it does not crash
+
+Toggle popover
+

--- a/LayoutTests/fast/css/css-anchor-position/position-try-popover-transition-display-none-crash.html
+++ b/LayoutTests/fast/css/css-anchor-position/position-try-popover-transition-display-none-crash.html
@@ -1,0 +1,50 @@
+<style>
+#anchor {
+  width: 100px;
+  height: 100px;
+  background: cyan;
+  anchor-name: --anchor;
+}
+
+#anchored {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  position-anchor: --anchor;
+  position-area: top right;
+  position-try-fallbacks: bottom right;
+  background: green;
+  transition: display 0.1s allow-discrete;
+}
+</style>
+
+<body onload="onLoad()">
+  <p>This test passes if it does not crash</p>
+
+  <button id="toggle" popovertarget="anchored">Toggle popover</button>
+  <div id="anchor"></div>
+  <div id="anchored" popover></div>
+
+  <script>
+    function onLoad() {
+      testRunner.dumpAsText();
+      testRunner.waitUntilDone();
+
+      // Simulates clicking the toggle button. toggle.click() and anchored.show/hidePopover()
+      // doesn't trigger the bug otherwise.
+
+      const toggleButtonBoundingRect = toggle.getBoundingClientRect();
+
+      eventSender.mouseMoveTo(toggleButtonBoundingRect.x, toggleButtonBoundingRect.y);
+
+      eventSender.mouseDown();
+      eventSender.mouseUp();
+
+      eventSender.mouseDown();
+      setTimeout(() => {
+        eventSender.mouseUp();
+        testRunner.notifyDone();
+      }, 0);
+    }
+  </script>
+</body>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1664,7 +1664,7 @@ void TreeResolver::sortPositionOptionsIfNeeded(PositionOptions& options, const S
 
         // If there's one, move it to the beginning.
         // (if it's at index zero, do nothing since it's already at the beginning)
-        if (lastSuccessfulIndexInOptionStyles > 0) {
+        if (lastSuccessfulIndexInOptionStyles && lastSuccessfulIndexInOptionStyles != notFound) {
             auto lastSuccessfulOption = WTFMove(options.optionStyles[lastSuccessfulIndexInOptionStyles]);
             options.optionStyles.removeAt(lastSuccessfulIndexInOptionStyles);
             options.optionStyles.insert(0, WTFMove(lastSuccessfulOption));


### PR DESCRIPTION
#### 1f488a95e2fce8d54f19c802846829c4334ececf
<pre>
REGRESSION (300909@main): Closing a transitioned popover with &quot;position-try&quot; can crash the browser window
<a href="https://rdar.apple.com/163072798">rdar://163072798</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301057">https://bugs.webkit.org/show_bug.cgi?id=301057</a>

Reviewed by Simon Fraser.

Vector::findIf returns notFound if no element is found. notFound is (size_t)(-1)
or positive 0xffff...ffff, so the &gt; 0 check won&apos;t catch notFound. Fix the check
to explicitly check for non-zero and not notFound.

Test: fast/css/css-anchor-position/position-try-popover-transition-display-none-crash.html

* LayoutTests/fast/css/css-anchor-position/position-try-popover-transition-display-none-crash-expected.txt: Added.
* LayoutTests/fast/css/css-anchor-position/position-try-popover-transition-display-none-crash.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::sortPositionOptionsIfNeeded):

Canonical link: <a href="https://commits.webkit.org/301966@main">https://commits.webkit.org/301966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f39e91b2e8578f9256e46e4a8292db1eacbad81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134627 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79107 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c131df3-f18a-4bb8-918a-4a21ab217f9e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97092 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65009 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a1dd5359-6949-44ff-89ff-f97c491987d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77572 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c4eb292-a8ee-4762-9fd9-8ed36de9b4ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32324 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78000 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137111 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105615 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105266 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26859 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50783 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51789 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60233 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53380 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55139 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->