### PR TITLE
Cache prefixes of previously seen input when setting innerHTML

### DIFF
--- a/LayoutTests/fast/parser/innerHTML-cache-mutation-test-expected.txt
+++ b/LayoutTests/fast/parser/innerHTML-cache-mutation-test-expected.txt
@@ -1,0 +1,110 @@
+CONSOLE MESSAGE: === Basic prefix extension ===
+CONSOLE MESSAGE: Set base then extend with prefix match
+CONSOLE MESSAGE: children.length: 2 (expected: 2)
+CONSOLE MESSAGE: Result: PASS
+
+CONSOLE MESSAGE: === Multiple extensions ===
+CONSOLE MESSAGE: Extend by adding complete lists
+CONSOLE MESSAGE: ul count: 3 (expected: 3)
+CONSOLE MESSAGE: Result: PASS
+
+CONSOLE MESSAGE: === Exact match (cache hit) ===
+CONSOLE MESSAGE: Set same innerHTML twice
+CONSOLE MESSAGE: children.length: 2 (expected: 2)
+CONSOLE MESSAGE: Result: PASS
+
+CONSOLE MESSAGE: ---------- DOM Mutation Tests ----------
+
+CONSOLE MESSAGE: === appendChild invalidates cache ===
+CONSOLE MESSAGE: appendChild to cached element, then extend
+CONSOLE MESSAGE: Result: PASS
+
+CONSOLE MESSAGE: === insertAdjacentHTML invalidates cache ===
+CONSOLE MESSAGE: insertAdjacentHTML then extend
+CONSOLE MESSAGE: Result: PASS
+
+CONSOLE MESSAGE: === outerHTML invalidates cache ===
+CONSOLE MESSAGE: outerHTML replacement then extend
+CONSOLE MESSAGE: outer-test.tagName: DIV (expected: DIV)
+CONSOLE MESSAGE: Result: PASS
+
+CONSOLE MESSAGE: === removeChild invalidates cache ===
+CONSOLE MESSAGE: removeChild then extend
+CONSOLE MESSAGE: remove-test has span: true (expected: true)
+CONSOLE MESSAGE: Result: PASS
+
+CONSOLE MESSAGE: === textContent change invalidates cache ===
+CONSOLE MESSAGE: textContent change then extend
+CONSOLE MESSAGE: text-test.textContent: "original" (expected: "original")
+CONSOLE MESSAGE: Result: PASS
+
+CONSOLE MESSAGE: === Descendant mutation invalidates cache ===
+CONSOLE MESSAGE: Mutated grandchild element then extend
+CONSOLE MESSAGE: inner-nested.textContent: "text" (expected: "text")
+CONSOLE MESSAGE: Result: PASS
+
+CONSOLE MESSAGE: ---------- Attribute Mutation Tests ----------
+
+CONSOLE MESSAGE: === Inline style change invalidates cache ===
+CONSOLE MESSAGE: Changed style.color to blue, then extended
+CONSOLE MESSAGE: Final color:  (expected: empty/default)
+CONSOLE MESSAGE: Result: PASS
+
+CONSOLE MESSAGE: === style.display change invalidates cache ===
+CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'displayContainer.querySelector('#style-color-testb').style')
+Tests innerHTML prefix cache mutations and invalidation.
+
+=== Basic prefix extension ===
+Set base then extend with prefix match
+children.length: 2 (expected: 2)
+Result: PASS
+
+=== Multiple extensions ===
+Extend by adding complete lists
+ul count: 3 (expected: 3)
+Result: PASS
+
+=== Exact match (cache hit) ===
+Set same innerHTML twice
+children.length: 2 (expected: 2)
+Result: PASS
+
+---------- DOM Mutation Tests ----------
+
+=== appendChild invalidates cache ===
+appendChild to cached element, then extend
+Result: PASS
+
+=== insertAdjacentHTML invalidates cache ===
+insertAdjacentHTML then extend
+Result: PASS
+
+=== outerHTML invalidates cache ===
+outerHTML replacement then extend
+outer-test.tagName: DIV (expected: DIV)
+Result: PASS
+
+=== removeChild invalidates cache ===
+removeChild then extend
+remove-test has span: true (expected: true)
+Result: PASS
+
+=== textContent change invalidates cache ===
+textContent change then extend
+text-test.textContent: "original" (expected: "original")
+Result: PASS
+
+=== Descendant mutation invalidates cache ===
+Mutated grandchild element then extend
+inner-nested.textContent: "text" (expected: "text")
+Result: PASS
+
+---------- Attribute Mutation Tests ----------
+
+=== Inline style change invalidates cache ===
+Changed style.color to blue, then extended
+Final color:  (expected: empty/default)
+Result: PASS
+
+=== style.display change invalidates cache ===
+visible

--- a/LayoutTests/fast/parser/innerHTML-cache-mutation-test.html
+++ b/LayoutTests/fast/parser/innerHTML-cache-mutation-test.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>innerHTML Cache Mutation and Invalidation Test</title>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+}
+
+function log(msg) {
+    console.log(msg)
+    document.getElementById('console').appendChild(document.createTextNode(msg + '\n'));
+}
+
+function testPrefixReuse() {
+    log('=== Basic prefix extension ===');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = '<div>base</div>';
+    container.innerHTML = '<div>base</div><span>extended</span>';
+    log('Set base then extend with prefix match');
+    log('children.length: ' + container.children.length + ' (expected: 2)');
+    log('Result: ' + (container.children.length === 2 ? 'PASS' : 'FAIL') + '\n');
+    container.innerHTML = ''; 
+
+    log('=== Multiple extensions ===');
+    const listContainer = document.createElement('div');
+    document.body.appendChild(listContainer);
+    listContainer.innerHTML = '<ul><li>1</li></ul>';
+    listContainer.innerHTML = '<ul><li>1</li></ul><ul><li>2</li></ul>';
+    listContainer.innerHTML = '<ul><li>1</li></ul><ul><li>2</li></ul><ul><li>3</li></ul>';
+    log('Extend by adding complete lists');
+    log('ul count: ' + listContainer.querySelectorAll('ul').length + ' (expected: 3)');
+    log('Result: ' + (listContainer.querySelectorAll('ul').length === 3 ? 'PASS' : 'FAIL') + '\n');
+    listContainer.innerHTML = ''; 
+
+    log('=== Exact match (cache hit) ===');
+    const exactContainer = document.createElement('div');
+    document.body.appendChild(exactContainer);
+    exactContainer.innerHTML = '<div>content</div><span>more</span>';
+    exactContainer.innerHTML = '<div>content</div><span>more</span>';
+    log('Set same innerHTML twice');
+    log('children.length: ' + exactContainer.children.length + ' (expected: 2)');
+    log('Result: ' + (exactContainer.children.length === 2 ? 'PASS' : 'FAIL') + '\n');
+    exactContainer.innerHTML = ''; 
+}
+
+function testDOMMutations() {
+    log('---------- DOM Mutation Tests ----------\n');
+
+    log('=== appendChild invalidates cache ===');
+    const appendContainer = document.createElement('div');
+    document.body.appendChild(appendContainer);
+    appendContainer.innerHTML = '<div id="append-test">original</div>';
+    appendContainer.innerHTML = '<div id="append-test">original</div><span>extension</span>';
+    // Mutate the cached DOM by appending a <b> element
+    const newEl = document.createElement('b');
+    newEl.textContent = 'added';
+    appendContainer.querySelector('#append-test').appendChild(newEl);
+    // Because the cache was invalidated by the appendChild mutation,
+    // this creates fresh nodes from scratch
+    appendContainer.innerHTML = '<div id="append-test">original</div><span>extension</span><p>more</p>';
+    log('appendChild to cached element, then extend');
+    // Check if the mutation carried over
+    // The test PASSES if there's no <b> element in #append-test
+    // This proves the cache was invalidated and fresh nodes were created
+    log('Result: ' + (!appendContainer.querySelector('#append-test b') ? 'PASS' : 'FAIL') + '\n');
+    appendContainer.innerHTML = '';
+
+    log('=== insertAdjacentHTML invalidates cache ===');
+    const adjacentContainer = document.createElement('div');
+    document.body.appendChild(adjacentContainer);
+    adjacentContainer.innerHTML = '<div id="adjacent-test">content</div>';
+    adjacentContainer.innerHTML = '<div id="adjacent-test">content</div><p>extension</p>';
+    // Mutate the cached DOM by inserting HTML into #adjacent-test
+    adjacentContainer.querySelector('#adjacent-test').insertAdjacentHTML('beforeend', '<span class="strong">inserted</span>');
+    // Because the cache was invalidated by insertAdjacentHTML,
+    // this creates fresh nodes from scratch
+    adjacentContainer.innerHTML = '<div id="adjacent-test">content</div><p>extension</p><div>more</div>';
+    log('insertAdjacentHTML then extend');
+    // Check if the inserted content carried over
+    // The test PASSES if there's no .strong element in #adjacent-test
+    log('Result: ' + (!adjacentContainer.querySelector('#adjacent-test .strong') ? 'PASS' : 'FAIL') + '\n');
+    adjacentContainer.innerHTML = ''; 
+
+    log('=== outerHTML invalidates cache ===');
+    const outerContainer = document.createElement('div');
+    document.body.appendChild(outerContainer);
+    outerContainer.innerHTML = '<div id="outer-test">content</div>';
+    outerContainer.innerHTML = '<div id="outer-test">content</div><span>extension</span>';
+    // Replace the cached element entirely with outerHTML (changes it from div to p)
+    outerContainer.querySelector('#outer-test').outerHTML = '<p id="outer-test">replaced</p>';
+    // Because the cache was invalidated by the outerHTML replacement,
+    // this creates fresh nodes from scratch
+    outerContainer.innerHTML = '<div id="outer-test">content</div><span>extension</span><div class="footer">more</div>';
+    log('outerHTML replacement then extend');
+    // Check if the element is back to being a DIV (not a P)
+    // The test PASSES if it's a DIV, proving fresh nodes were created
+    log('outer-test.tagName: ' + outerContainer.querySelector('#outer-test').tagName + ' (expected: DIV)');
+    log('Result: ' + (outerContainer.querySelector('#outer-test').tagName === 'DIV' ? 'PASS' : 'FAIL') + '\n');
+    outerContainer.innerHTML = '';
+
+    log('=== removeChild invalidates cache ===');
+    const removeContainer = document.createElement('div');
+    document.body.appendChild(removeContainer);
+    removeContainer.innerHTML = '<div id="remove-test"><span>child</span></div>';
+    removeContainer.innerHTML = '<div id="remove-test"><span>child</span></div><p>extension</p>';
+    // Remove the span element from the cached DOM
+    const childToRemove = removeContainer.querySelector('#remove-test span');
+    removeContainer.querySelector('#remove-test').removeChild(childToRemove);
+    // Because the cache was invalidated by removeChild,
+    // this creates fresh nodes from scratch
+    removeContainer.innerHTML = '<div id="remove-test"><span>child</span></div><p>extension</p><div class="footer">more</div>';
+    log('removeChild then extend');
+    // Check if the span is back (it should be, proving fresh nodes were created)
+    log('remove-test has span: ' + (removeContainer.querySelector('#remove-test span') !== null) + ' (expected: true)');
+    log('Result: ' + (removeContainer.querySelector('#remove-test span') !== null ? 'PASS' : 'FAIL') + '\n');
+    removeContainer.innerHTML = '';
+
+    log('=== textContent change invalidates cache ===');
+    const textContainer = document.createElement('div');
+    document.body.appendChild(textContainer);
+    textContainer.innerHTML = '<div id="text-test">original</div>';
+    textContainer.innerHTML = '<div id="text-test">original</div><span>extension</span>';
+    textContainer.querySelector('#text-test').textContent = 'changed';
+    textContainer.innerHTML = '<div id="text-test">original</div><span>extension</span><p>more</p>';
+    log('textContent change then extend');
+    log('text-test.textContent: "' + textContainer.querySelector('#text-test').textContent + '" (expected: "original")');
+    log('Result: ' + (textContainer.querySelector('#text-test').textContent === 'original' ? 'PASS' : 'FAIL') + '\n');
+    textContainer.innerHTML = '';
+
+    log('=== Descendant mutation invalidates cache ===');
+    const nestedContainer = document.createElement('div');
+    document.body.appendChild(nestedContainer);
+    nestedContainer.innerHTML = '<div id="outer-nested"><div id="middle"><span id="inner-nested">text</span></div></div>';
+    nestedContainer.innerHTML = '<div id="outer-nested"><div id="middle"><span id="inner-nested">text</span></div></div><p>extension</p>';
+    nestedContainer.querySelector('#inner-nested').textContent = 'changed';
+    nestedContainer.innerHTML = '<div id="outer-nested"><div id="middle"><span id="inner-nested">text</span></div></div><p>extension</p><div class="footer">more</div>';
+    log('Mutated grandchild element then extend');
+    log('inner-nested.textContent: "' + nestedContainer.querySelector('#inner-nested').textContent + '" (expected: "text")');
+    log('Result: ' + (nestedContainer.querySelector('#inner-nested').textContent === 'text' ? 'PASS' : 'FAIL') + '\n');
+    nestedContainer.innerHTML = ''; 
+}
+
+function testAttributeMutations() {
+    log('---------- Attribute Mutation Tests ----------\n');
+
+    log('=== Inline style change invalidates cache ===');
+    const colorContainer = document.createElement('div');
+    document.body.appendChild(colorContainer);
+    // Note: Avoiding inline style attributes in initial content for fast parser compatibility
+    colorContainer.innerHTML = '<div id="style-color-test">text</div>';
+    // Add style programmatically to the element
+    colorContainer.querySelector('#style-color-test').style.color = 'red';
+    colorContainer.innerHTML = '<div id="style-color-test">text</div><span>extension</span>';
+    // Mutate the cached element's style
+    colorContainer.querySelector('#style-color-test').style.color = 'blue';
+    // Because the cache was invalidated by the style mutation,
+    // this creates fresh nodes from scratch
+    colorContainer.innerHTML = '<div id="style-color-test">text</div><span>extension</span><p>more</p>';
+    log('Changed style.color to blue, then extended');
+    // Check if the style carried over
+    // The test PASSES if style.color is empty (no inline style)
+    const finalColor = colorContainer.querySelector('#style-color-test').style.color;
+    log('Final color: ' + finalColor + ' (expected: empty/default)');
+    log('Result: ' + (finalColor === '' ? 'PASS' : 'FAIL') + '\n');
+    colorContainer.innerHTML = ''; 
+
+    log('=== style.display change invalidates cache ===');
+    const displayContainer = document.createElement('div');
+    document.body.appendChild(displayContainer);
+    displayContainer.innerHTML = '<div id="style-display-test">visible</div>';
+    displayContainer.querySelector('#style-color-testb').style.display = 'block';
+    displayContainer.innerHTML = '<div id="style-display-test">visible</div><span>extension</span>';
+    displayContainer.querySelector('#style-color-testb').style.display = 'none';
+    displayContainer.innerHTML = '<div id="style-display-test">visible</div><span>extension</span><p>more</p>';
+    log('Changed style.display to none, then extended');
+    const finalDisplay = displayContainer.querySelector('#style-color-testb').style.display;
+    log('Final display: ' + finalDisplay + ' (expected: empty/default)');
+    log('Result: ' + (finalDisplay === '' ? 'PASS' : 'FAIL') + '\n');
+    displayContainer.innerHTML = ''; 
+
+    log('=== className change invalidates cache ===');
+    const classContainer = document.createElement('div');
+    document.body.appendChild(classContainer);
+    classContainer.innerHTML = '<div id="class-test" class="original">text</div>';
+    classContainer.innerHTML = '<div id="class-test" class="original">text</div><span>extension</span>';
+    classContainer.querySelector('#class-test').className = 'changed';
+    classContainer.innerHTML = '<div id="class-test" class="original">text</div><span>extension</span><p>more</p>';
+    log('Changed className then extended');
+    log('m7.className: "' + classContainer.querySelector('#class-test').className + '" (expected: "original")');
+    log('Result: ' + (classContainer.querySelector('#class-test').className === 'original' ? 'PASS' : 'FAIL') + '\n');
+    classContainer.innerHTML = ''; 
+
+    log('=== setAttribute invalidates cache ===');
+    const attrContainer = document.createElement('div');
+    document.body.appendChild(attrContainer);
+    // Using id attribute which is supported by fast parser
+    attrContainer.innerHTML = '<div id="attr-test">text</div>';
+    attrContainer.innerHTML = '<div id="attr-test">text</div><span>extension</span>';
+    // Add a data attribute to the cached element
+    attrContainer.querySelector('#attr-test').setAttribute('data-value', '999');
+    // Because the cache was invalidated by setAttribute,
+    // this creates fresh nodes from scratch
+    attrContainer.innerHTML = '<div id="attr-test">text</div><span>extension</span><p>more</p>';
+    log('Added attribute then extended');
+    // Check if the data-value attribute carried over
+    // The test PASSES if there's no data-value attribute
+    const hasDataValue = attrContainer.querySelector('#attr-test').hasAttribute('data-value');
+    log('Has data-value attribute: ' + hasDataValue + ' (expected: false)');
+    log('Result: ' + (!hasDataValue ? 'PASS' : 'FAIL') + '\n');
+    attrContainer.innerHTML = ''; 
+
+    log('=== Descendant attribute change invalidates cache ===');
+    const nestedAttrContainer = document.createElement('div');
+    document.body.appendChild(nestedAttrContainer);
+    nestedAttrContainer.innerHTML = '<div id="nested-attr-outer"><ul><li id="nested-attr-item" class="original">item</li></ul></div>';
+    nestedAttrContainer.innerHTML = '<div id="nested-attr-outer"><ul><li id="nested-attr-item" class="original">item</li></ul></div><span>extension</span>';
+    nestedAttrContainer.querySelector('#nested-attr-item').className = 'changed';
+    nestedAttrContainer.innerHTML = '<div id="nested-attr-outer"><ul><li id="nested-attr-item" class="original">item</li></ul></div><span>extension</span><div class="footer">more</div>';
+    log('Changed nested element className then extended');
+    log('nested.className: "' + nestedAttrContainer.querySelector('#nested-attr-item').className + '" (expected: "original")');
+    log('Result: ' + (nestedAttrContainer.querySelector('#nested-attr-item').className === 'original' ? 'PASS' : 'FAIL') + '\n');
+    nestedAttrContainer.innerHTML = ''; 
+}
+
+function testStringLength() {
+    log('---------- String Length Tests ----------\n');
+
+    log('=== Shorter string invalidates cache ===');
+    const shorterContainer = document.createElement('div');
+    document.body.appendChild(shorterContainer);
+    const longHTML = '<div>base</div><span>extra</span>';
+    const shortHTML = '<div>base</div>';
+    // Set long HTML string (caches it)
+    shorterContainer.innerHTML = longHTML;
+    // Set shorter HTML string (should invalidate cache since it's not a prefix extension)
+    shorterContainer.innerHTML = shortHTML;
+    // Set long HTML string again (should create fresh nodes, not reuse old cache)
+    shorterContainer.innerHTML = longHTML;
+    log('Set long -> short -> long');
+    // If cache was properly invalidated, we should have exactly 2 fresh children
+    log('children.length: ' + shorterContainer.children.length + ' (expected: 2)');
+    log('Result: ' + (shorterContainer.children.length === 2 ? 'PASS' : 'FAIL') + '\n');
+    shorterContainer.innerHTML = ''; 
+
+    log('=== Empty string invalidates cache ===');
+    const emptyContainer = document.createElement('div');
+    document.body.appendChild(emptyContainer);
+    emptyContainer.innerHTML = '<div>content</div>';
+    emptyContainer.innerHTML = '';
+    emptyContainer.innerHTML = '<div>content</div>';
+    log('Set content -> empty -> content');
+    log('children.length: ' + emptyContainer.children.length + ' (expected: 1)');
+    log('Result: ' + (emptyContainer.children.length === 1 ? 'PASS' : 'FAIL') + '\n');
+    // No need to reset here since the test already uses empty string
+}
+
+function testShadowDOM() {
+    log('---------- Shadow DOM Tests ----------\n');
+
+    log('=== Shadow DOM innerHTML caching ===');
+    const shadowHost1 = document.createElement('div');
+    document.body.appendChild(shadowHost1);
+    const shadow1 = shadowHost1.attachShadow({mode: 'open'});
+    shadow1.innerHTML = '<div>shadow base</div>';
+    shadow1.innerHTML = '<div>shadow base</div><span>extended</span>';
+    log('Set shadowRoot.innerHTML twice with prefix match');
+    log('shadow children.length: ' + shadow1.children.length + ' (expected: 2)');
+    log('Result: ' + (shadow1.children.length === 2 ? 'PASS' : 'FAIL') + '\n');
+    shadow1.innerHTML = ''; 
+
+    log('=== Shadow DOM mutation invalidates cache ===');
+    const shadowHost2 = document.createElement('div');
+    document.body.appendChild(shadowHost2);
+    const shadow2 = shadowHost2.attachShadow({mode: 'open'});
+    shadow2.innerHTML = '<div id="shadow-test">content</div>';
+    shadow2.innerHTML = '<div id="shadow-test">content</div><span>extension</span>';
+    shadow2.getElementById('shadow-test').appendChild(document.createElement('b'));
+    shadow2.innerHTML = '<div id="shadow-test">content</div><span>extension</span><p>more</p>';
+    log('Mutate shadow content then extend');
+    log('Result: ' + (!shadow2.getElementById('shadow-test').querySelector('b') ? 'PASS' : 'FAIL') + '\n');
+    shadow2.innerHTML = ''; 
+}
+
+function testCrossContainer() {
+    log('---------- Cross-Container Tests ----------\n');
+
+    log('=== Cache can be reused across different containers ===');
+    const container1 = document.createElement('div');
+    const container2 = document.createElement('div');
+    const container3 = document.createElement('div');
+    document.body.appendChild(container1);
+    document.body.appendChild(container2);
+    document.body.appendChild(container3);
+
+    // Set initial content in container1 (this caches it)
+    container1.innerHTML = '<div id="cross-container-test">content</div><span>more</span>';
+
+    // Set same content in container2 (should reuse cache from container1)
+    container2.innerHTML = '<div id="cross-container-test">content</div><span>more</span>';
+
+    // Extend in container3 with prefix match (should reuse cache)
+    container3.innerHTML = '<div id="cross-container-test">content</div><span>more</span><p>extended</p>';
+
+    log('Set same innerHTML across multiple containers');
+    log('container1 has content: ' + (container1.querySelector('#cross-container-test') !== null));
+    log('container2 has content: ' + (container2.querySelector('#cross-container-test') !== null));
+    log('container3 has extended content: ' + (container3.querySelector('p') !== null));
+    log('Result: ' + (container1.querySelector('#cross-container-test') && container2.querySelector('#cross-container-test') && container3.querySelector('p') ? 'PASS' : 'FAIL') + '\n');
+
+    container1.innerHTML = '';
+    container2.innerHTML = '';
+    container3.innerHTML = '';
+
+    log('=== Mutation in one container invalidates cache for all ===');
+    const mutateContainer1 = document.createElement('div');
+    const mutateContainer2 = document.createElement('div');
+    document.body.appendChild(mutateContainer1);
+    document.body.appendChild(mutateContainer2);
+
+    // Set content in first container (caches it)
+    mutateContainer1.innerHTML = '<div id="mutation-cross-test">original</div>';
+    mutateContainer1.innerHTML = '<div id="mutation-cross-test">original</div><span>extended</span>';
+
+    // Mutate the cached DOM
+    mutateContainer1.querySelector('#mutation-cross-test').appendChild(document.createElement('b'));
+
+    // Try to use cache in a different container
+    // Should create fresh nodes (cache was invalidated by mutation)
+    mutateContainer2.innerHTML = '<div id="mutation-cross-test">original</div><span>extended</span>';
+
+    log('Mutated container1, then set innerHTML in container2');
+    log('container2 has no <b> element: ' + (!mutateContainer2.querySelector('#mutation-cross-test b')));
+    log('Result: ' + (!mutateContainer2.querySelector('#mutation-cross-test b') ? 'PASS' : 'FAIL') + '\n');
+
+    mutateContainer1.innerHTML = '';
+    mutateContainer2.innerHTML = '';
+}
+
+function runTest() {
+    testPrefixReuse();
+    testDOMMutations();
+    testAttributeMutations();
+    testStringLength();
+    testShadowDOM();
+    testCrossContainer();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests innerHTML prefix cache mutations and invalidation.</p>
+<pre id="console"></pre>
+</body>
+</html>

--- a/LayoutTests/fast/parser/innerHTML-prefix-cache-boundary-test-expected.txt
+++ b/LayoutTests/fast/parser/innerHTML-prefix-cache-boundary-test-expected.txt
@@ -1,0 +1,30 @@
+Tests safe and unsafe boundaries for innerHTML prefix cache to ensure proper HTML parsing.
+
+---------- Safe Boundary Tests ----------
+
+=== Element boundary (safe to cache) ===
+Extended after closing tag ">"
+children.length: 2 (expected: 2)
+Result: PASS
+
+=== Whitespace boundary (safe to cache) ===
+Extended after whitespace
+children.length: 2 (expected: 2)
+Result: PASS
+
+---------- Unsafe Boundary Tests ----------
+
+=== Text node splitting prevention ===
+Extended text from "hello" to "helloworld"
+Should NOT split text into multiple nodes
+childNodes.length: 1 (expected: 1)
+textContent: "helloworld" (expected: "helloworld")
+Result: PASS
+
+=== Entity splitting prevention ===
+Extended incomplete entity "&apos" to "&apos;"
+Should NOT split entity - should render as apostrophe
+Contains apostrophe: true (expected: true)
+Result: PASS
+
+

--- a/LayoutTests/fast/parser/innerHTML-prefix-cache-boundary-test.html
+++ b/LayoutTests/fast/parser/innerHTML-prefix-cache-boundary-test.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>innerHTML Prefix Cache Boundary Test</title>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+}
+
+function log(msg) {
+    document.getElementById('console').appendChild(document.createTextNode(msg + '\n'));
+}
+
+function testSafeBoundaries() {
+    log('---------- Safe Boundary Tests ----------\n');
+
+    log('=== Element boundary (safe to cache) ===');
+    const elementContainer = document.createElement('div');
+    document.body.appendChild(elementContainer);
+    elementContainer.innerHTML = '<div>first</div>';
+    elementContainer.innerHTML = '<div>first</div><span>second</span>';
+    log('Extended after closing tag ">"');
+    log('children.length: ' + elementContainer.children.length + ' (expected: 2)');
+    log('Result: ' + (elementContainer.children.length === 2 ? 'PASS' : 'FAIL') + '\n');
+    elementContainer.innerHTML = '';
+
+    log('=== Whitespace boundary (safe to cache) ===');
+    const whitespaceContainer = document.createElement('div');
+    document.body.appendChild(whitespaceContainer);
+    whitespaceContainer.innerHTML = '<div>content</div> ';
+    whitespaceContainer.innerHTML = '<div>content</div>        <span>more</span>';
+    log('Extended after whitespace');
+    log('children.length: ' + whitespaceContainer.children.length + ' (expected: 2)');
+    log('Result: ' + (whitespaceContainer.children.length === 2 ? 'PASS' : 'FAIL') + '\n');
+    whitespaceContainer.innerHTML = '';
+}
+
+function testUnsafeBoundaries() {
+    log('---------- Unsafe Boundary Tests ----------\n');
+
+    log('=== Text node splitting prevention ===');
+    const textContainer = document.createElement('div');
+    document.body.appendChild(textContainer);
+    textContainer.innerHTML = 'hello';
+    textContainer.innerHTML = 'helloworld';
+    log('Extended text from "hello" to "helloworld"');
+    log('Should NOT split text into multiple nodes');
+    log('childNodes.length: ' + textContainer.childNodes.length + ' (expected: 1)');
+    log('textContent: "' + textContainer.textContent + '" (expected: "helloworld")');
+    log('Result: ' + (textContainer.childNodes.length === 1 && textContainer.textContent === 'helloworld' ? 'PASS' : 'FAIL') + '\n');
+    textContainer.innerHTML = '';
+
+    log('=== Entity splitting prevention ===');
+    const entityContainer = document.createElement('div');
+    document.body.appendChild(entityContainer);
+    entityContainer.innerHTML = '<br>&apos';
+    entityContainer.innerHTML = '<br>&apos;';
+    log('Extended incomplete entity "&apos" to "&apos;"');
+    log('Should NOT split entity - should render as apostrophe');
+    // The entity should render as apostrophe
+    const hasApostrophe = entityContainer.textContent.includes("'");
+    log('Contains apostrophe: ' + hasApostrophe + ' (expected: true)');
+    log('Result: ' + (hasApostrophe ? 'PASS' : 'FAIL') + '\n');
+    entityContainer.innerHTML = '';
+}
+
+function runTest() {
+    testSafeBoundaries();
+    testUnsafeBoundaries();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests safe and unsafe boundaries for innerHTML prefix cache to ensure proper HTML parsing.</p>
+<pre id="console"></pre>
+</body>
+</html>

--- a/Source/WebCore/css/CSSStyleProperties.cpp
+++ b/Source/WebCore/css/CSSStyleProperties.cpp
@@ -634,6 +634,10 @@ void InlineCSSStyleProperties::didMutate(MutationType type)
     if (!m_parentElement)
         return;
 
+    // Inline style changes from JavaScript (e.g., element.style.color = 'red') need to set
+    // the mutation bit for innerHTML prefix cache invalidation, since they don't go through
+    // the normal attribute change notification path.
+    m_parentElement->setDidMutateSubtreeAfterSetInnerHTMLOnAncestors();
     m_parentElement->invalidateStyleAttribute();
     InspectorInstrumentation::didInvalidateStyleAttr(*m_parentElement);
 }

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -80,6 +80,7 @@ public:
     void takeAllChildrenFrom(ContainerNode*);
 
     void cloneChildNodes(Document&, CustomElementRegistry*, ContainerNode& clone, size_t currentDepth = 0) const;
+    void cloneSubtreeForFastParser(Document&, CustomElementRegistry*, ContainerNode& clone, size_t currentDepth = 0) const;
     Vector<SerializedNode> serializeChildNodes(size_t currentDepth = 0) const;
 
     enum class CanDelayNodeDeletion : uint8_t { No, Yes, Unknown };
@@ -95,6 +96,7 @@ public:
         SUPPRESS_UNCOUNTED_MEMBER Element* nextSiblingElement;
         ChildChange::Source source;
         AffectsElements affectsElements;
+        IsMutationBySetInnerHTML isMutationBySetInnerHTML { IsMutationBySetInnerHTML::No };
 
         bool isInsertion() const
         {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -12126,6 +12126,27 @@ void Document::ariaNotify(const String& announcement, const AriaNotifyOptions& o
         cache->postARIANotifyNotification(*this, announcement, options);
 }
 
+void Document::invalidateCachedSetInnerHTML()
+{
+    auto& cache = cachedSetInnerHTML();
+    if (cache.cachedContainer)
+        cache.cachedContainer->setDidMutateSubtreeAfterSetInnerHTML();
+    cache.source = String();
+}
+
+void Document::updateCachedSetInnerHTML(const String& sourceString, ContainerNode& container, Element& contextElement)
+{
+    auto& cache = cachedSetInnerHTML();
+
+    if (sourceString.length() < cache.source.length() || sourceString.length() > maxCachedSetInnerHTMLStringSize())
+        return;
+
+    cache.source = sourceString;
+    cache.cachedContainer = &container;
+    cache.contextElementName = contextElement.elementName();
+    container.clearDidMutateSubtreeAfterSetInnerHTML();
+}
+
 } // namespace WebCore
 
 #undef DOCUMENT_RELEASE_LOG

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -34,6 +34,7 @@
 #include <WebCore/DocumentClasses.h>
 #include <WebCore/DocumentEnums.h>
 #include <WebCore/DocumentEventTiming.h>
+#include <WebCore/Element.h>
 #include <WebCore/FocusControllerTypes.h>
 #include <WebCore/FontSelectorClient.h>
 #include <WebCore/FrameDestructionObserver.h>
@@ -382,6 +383,12 @@ enum class PageshowEventPersistence : bool { NotPersisted, Persisted };
 
 enum class EventHandlerRemoval : bool { One, All };
 using EventTargetSet = WeakHashCountedSet<Node, WeakPtrImplWithEventTargetData>;
+
+struct CachedSetInnerHTML {
+    String source;
+    WeakPtr<ContainerNode, WeakPtrImplWithEventTargetData> cachedContainer;
+    ElementName contextElementName;
+};
 
 enum class DimensionsCheck : uint8_t {
     Left = 1 << 0,
@@ -2055,6 +2062,9 @@ public:
     WEBCORE_EXPORT void prefetch(const URL&, const Vector<String>&, std::optional<ReferrerPolicy>, bool lowPriority = false);
 
     void processSpeculationRulesHeader(const String& headerValue, const URL& baseURL);
+    CachedSetInnerHTML& cachedSetInnerHTML() { return m_cachedSetInnerHTML; }
+    void updateCachedSetInnerHTML(const String& sourceString, ContainerNode&, Element& contextElement);
+    void invalidateCachedSetInnerHTML();
 
     WEBCORE_EXPORT void ariaNotify(const String&);
     WEBCORE_EXPORT void ariaNotify(const String&, const AriaNotifyOptions&);
@@ -2813,6 +2823,8 @@ private:
     const Ref<DocumentSyncData> m_syncData;
 
     Vector<Ref<LoadableSpeculationRules>> m_loadableSpeculationRules;
+
+    CachedSetInnerHTML m_cachedSetInnerHTML;
 }; // class Document
 
 inline AXObjectCache* Document::existingAXObjectCache() const

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -95,6 +95,7 @@ void DocumentFragment::parseHTML(const String& source, Element& contextElement, 
 {
     Ref document = this->document();
     if (!registry && tryFastParsingHTMLFragment(source, document, *this, contextElement, parserContentPolicy)) {
+        setWasParsedWithFastPath();
 #if ASSERT_ENABLED
         // As a sanity check for the fast-path, create another fragment using the full parser and compare the results.
         auto referenceFragment = DocumentFragment::create(document);
@@ -103,6 +104,7 @@ void DocumentFragment::parseHTML(const String& source, Element& contextElement, 
 #endif
         return;
     }
+    clearWasParsedWithFastPath();
     if (hasChildNodes())
         removeChildren();
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -407,14 +407,14 @@ public:
     // For exposing to DOM only.
     WEBCORE_EXPORT NamedNodeMap& attributesMap() const;
 
-    enum class AttributeModificationReason : uint8_t { Directly, ByCloning, Parser };
+    enum class AttributeModificationReason : uint8_t { Directly, ByCloning, Parser, ParserFastPath };
     // This function is called whenever an attribute is added, changed or removed.
     // Do not call this function directly. notifyAttributeChanged() should be used instead
     // in order to update state dependent on attribute changes.
     virtual void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = AttributeModificationReason::Directly);
 
     // Only called by the parser immediately after element construction.
-    void parserSetAttributes(std::span<const Attribute>);
+    void parserSetAttributes(std::span<const Attribute>, AttributeModificationReason = AttributeModificationReason::Parser);
 
     bool isEventHandlerAttribute(const Attribute&) const;
     virtual FormListedElement* asFormListedElement();

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -238,7 +238,11 @@ ExceptionOr<void> ShadowRoot::replaceChildrenWithMarkup(const String& markup, Op
     auto fragment = createFragmentForInnerOuterHTML(*protectedHost(), markup, policy, customElementRegistry());
     if (fragment.hasException())
         return fragment.releaseException();
-    return replaceChildrenWithFragment(*this, fragment.releaseReturnValue());
+    bool usedFastPath = fragment.returnValue()->hasWasParsedWithFastPath();
+    auto result = replaceChildrenWithFragment(*this, fragment.releaseReturnValue());
+    if (!result.hasException() && usedFastPath)
+        document().updateCachedSetInnerHTML(markup, *this, *protectedHost());
+    return result;
 }
 
 ExceptionOr<void> ShadowRoot::setHTMLUnsafe(Variant<RefPtr<TrustedHTML>, String>&& html)

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -216,6 +216,7 @@ RefPtr<StyleProperties> StyledElement::protectedInlineStyle() const
 
 void StyledElement::inlineStyleChanged()
 {
+    setDidMutateSubtreeAfterSetInnerHTMLOnAncestors();
     invalidateStyleAttribute();
     InspectorInstrumentation::didInvalidateStyleAttr(*this);
 }

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.h
@@ -42,6 +42,7 @@ class Element;
 enum class ParserContentPolicy : uint8_t;
 
 WEBCORE_EXPORT bool tryFastParsingHTMLFragment(StringView source, Document&, ContainerNode&, Element& contextElement, OptionSet<ParserContentPolicy>);
+unsigned maxCachedSetInnerHTMLStringSize();
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### cd3c9890ec057999b7580d14cc738c3b51ab0407
<pre>
Cache prefixes of previously seen input when setting innerHTML
<a href="https://bugs.webkit.org/show_bug.cgi?id=301231">https://bugs.webkit.org/show_bug.cgi?id=301231</a>
<a href="https://rdar.apple.com/162555307">rdar://162555307</a>

Reviewed by Ryosuke Niwa.

When a user sets innerHTML to an element, the next call to
innerHTML can often be just an extension of the previous markup.
Regardless, we reparse the entire input.
We can add a prefix match detection to tell the parser if the current
input to innerHTML is just an extension of a previous input.
If so, avoid jumping into the parser, deep clone the existing
tree, then just parse the unseen markup.
A prefix can also just be considered an exact match of a previous input.

This is 10% win on TODOMVC.Jquery.AddingAllItems.

Combined changes:
Tests: fast/parser/innerHTML-cache-mutation-test.html
       fast/parser/innerHTML-prefix-cache-boundary-test.html
* LayoutTests/fast/parser/innerHTML-cache-mutation-test-expected.txt: Added.
* LayoutTests/fast/parser/innerHTML-cache-mutation-test.html: Added.
* LayoutTests/fast/parser/innerHTML-prefix-cache-boundary-test-expected.txt: Added.
* LayoutTests/fast/parser/innerHTML-prefix-cache-boundary-test.html: Added.
* Source/WebCore/css/CSSStyleProperties.cpp:
(WebCore::InlineCSSStyleProperties::didMutate):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::parserNotifyChildrenChanged):
(WebCore::ContainerNode::childrenChanged):
(WebCore::ContainerNode::cloneSubtreeForFastParser const):
* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::invalidateCachedSetInnerHTML):
(WebCore::Document::updateCachedSetInnerHTML):
* Source/WebCore/dom/Document.h:
(WebCore::Document::cachedSetInnerHTML):
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::parseHTML):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::notifyAttributeChanged):
(WebCore::Element::classAttributeChanged):
(WebCore::Element::parserSetAttributes):
(WebCore::Element::replaceChildrenWithMarkup):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::invalidateNodeListCollectionAndInnerHTMLPrefixCachesInAncestorsForAttribute):
(WebCore::Node::setDidMutateSubtreeAfterSetInnerHTMLOnAncestors):
(WebCore::Node::setTextContent):
(WebCore::Node::invalidateNodeListAndCollectionCachesInAncestorsForAttribute): Deleted.
* Source/WebCore/dom/Node.h:
(WebCore::Node::hasDidMutateSubtreeAfterSetInnerHTML const):
(WebCore::Node::setDidMutateSubtreeAfterSetInnerHTML):
(WebCore::Node::clearDidMutateSubtreeAfterSetInnerHTML):
(WebCore::Node::hasWasParsedWithFastPath const):
(WebCore::Node::setWasParsedWithFastPath):
(WebCore::Node::clearWasParsedWithFastPath):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::replaceChildrenWithMarkup):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::inlineStyleChanged):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::maxCachedSetInnerHTMLStringSize):
(WebCore::isCachedSubtreeValid):
(WebCore::isCachedPrefixMatch):
(WebCore::tryAvoidParsingByCloningExistingSubtree):
(WebCore::cloneCachedPrefixAndParseSuffix):
(WebCore::HTMLFastPathParser::parseAttributes):
(WebCore::tryFastParsingHTMLFragmentImpl):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.h:

Canonical link: <a href="https://commits.webkit.org/303089@main">https://commits.webkit.org/303089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80c717c43a90f03cd0a3bbcf068cce1ab1b9e7c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138675 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82956 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d896fd77-894b-44c7-ba47-4f9591f93700) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99990 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4861b37a-3f1f-41e8-a1b0-ce3e7c714fd9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80690 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c2af1c9b-2919-4ff9-a3a2-ca4cbd32f182) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2475 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/180 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81927 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111071 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141176 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3307 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108506 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108451 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27571 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2488 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113806 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/56408 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3369 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32230 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3191 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66777 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/3391 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3299 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->