### PR TITLE
Scroll to text fragment highlight style can create unreadable text, especially in dark mode

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/highlighted-text-contrast-expected.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/highlighted-text-contrast-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to Text Fragment - Highlighted text contrast</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<style>
+div { 
+    color: transparent;
+    font-size: 48pt;
+}
+
+div span { 
+    color: black;
+}
+</style>
+
+<p>The test passes if the following word is legible when highlighted.</p>
+<div>This <span>word</span> should be visible</div>
+
+<script>
+    location.href = "#:~:text=This-,word,-should";
+</script>
+</html>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/highlighted-text-contrast-targettext-expected-mismatch.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/highlighted-text-contrast-targettext-expected-mismatch.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to Text Fragment - Highlighted text contrast with ::target-text</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<style>
+div { 
+    color: black;
+    font-size: 48pt;
+}
+
+::target-text {
+    background-color: black;
+}
+
+span {
+    color: white;
+}
+</style>
+
+<p>The test passes if the following word is NOT legible when highlighted.</p>
+<div>This <span>word</span> should not be visible</div>
+
+<script>
+    location.href = "#:~:text=This-,word,-should";
+</script>
+</html>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/highlighted-text-contrast-targettext.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/highlighted-text-contrast-targettext.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to Text Fragment - Highlighted text contrast with ::target-text</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<style>
+div { 
+    color: black;
+    font-size: 48pt;
+}
+
+::target-text {
+    background-color: black;
+}
+</style>
+
+<p>The test passes if the following word is NOT legible when highlighted.</p>
+<div>This <span>word</span> should not be visible</div>
+
+<script>
+    location.href = "#:~:text=This-,word,-should";
+</script>
+</html>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/highlighted-text-contrast.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/highlighted-text-contrast.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to Text Fragment - Highlighted text contrast</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<style>
+div { 
+    color: transparent;
+    font-size: 48pt;
+}
+</style>
+
+<p>The test passes if the following word is legible when highlighted.</p>
+<div>This <span>word</span> should be visible</div>
+
+<script>
+    location.href = "#:~:text=This-,word,-should";
+</script>
+</html>

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -209,7 +209,7 @@ Color RenderReplaced::calculateHighlightColor() const
                         continue;
 
                     OptionSet<StyleColorOptions> styleColorOptions = { StyleColorOptions::UseSystemAppearance };
-                    return theme().annotationHighlightColor(styleColorOptions);
+                    return theme().annotationHighlightBackgroundColor(styleColorOptions);
                 }
             }
         }
@@ -243,7 +243,7 @@ Color RenderReplaced::calculateHighlightColor() const
                         continue;
 
                     OptionSet<StyleColorOptions> styleColorOptions = { StyleColorOptions::UseSystemAppearance };
-                    return theme().annotationHighlightColor(styleColorOptions);
+                    return theme().annotationHighlightBackgroundColor(styleColorOptions);
                 }
             }
         }

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -24,6 +24,7 @@
 
 #include "BorderShape.h"
 #include "ButtonPart.h"
+#include "CSSContrastColorResolver.h"
 #include "CSSPropertyNames.h"
 #include "CSSValueKeywords.h"
 #include "ColorBlending.h"
@@ -2032,17 +2033,25 @@ Color RenderTheme::platformTextSearchHighlightColor(OptionSet<StyleColorOptions>
     return Color::yellow;
 }
 
-Color RenderTheme::annotationHighlightColor(OptionSet<StyleColorOptions> options) const
+Color RenderTheme::annotationHighlightBackgroundColor(OptionSet<StyleColorOptions> options) const
 {
     auto& cache = colorCache(options);
-    if (!cache.annotationHighlightColor.isValid())
-        cache.annotationHighlightColor = transformSelectionBackgroundColor(platformAnnotationHighlightColor(options), options);
-    return cache.annotationHighlightColor;
+    if (!cache.annotationHighlightBackgroundColor.isValid())
+        cache.annotationHighlightBackgroundColor = transformSelectionBackgroundColor(platformAnnotationHighlightBackgroundColor(options), options);
+    return cache.annotationHighlightBackgroundColor;
 }
 
-Color RenderTheme::platformAnnotationHighlightColor(OptionSet<StyleColorOptions>) const
+Color RenderTheme::platformAnnotationHighlightBackgroundColor(OptionSet<StyleColorOptions>) const
 {
     return Color::yellow;
+}
+
+Color RenderTheme::annotationHighlightForegroundColor(OptionSet<StyleColorOptions> options) const
+{
+    auto& cache = colorCache(options);
+    if (!cache.annotationHighlightForegroundColor.isValid())
+        cache.annotationHighlightForegroundColor = resolve(CSS::ContrastColorResolver { annotationHighlightBackgroundColor(options) });
+    return cache.annotationHighlightForegroundColor;
 }
 
 Color RenderTheme::defaultButtonTextColor(OptionSet<StyleColorOptions> options) const

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -168,7 +168,8 @@ public:
     Color textSearchHighlightColor(OptionSet<StyleColorOptions>) const;
 
     // Default highlighting color for app highlights.
-    Color annotationHighlightColor(OptionSet<StyleColorOptions>) const;
+    Color annotationHighlightBackgroundColor(OptionSet<StyleColorOptions>) const;
+    Color annotationHighlightForegroundColor(OptionSet<StyleColorOptions>) const;
 
     Color defaultButtonTextColor(OptionSet<StyleColorOptions>) const;
 
@@ -287,7 +288,7 @@ protected:
     virtual Color platformInactiveListBoxSelectionForegroundColor(OptionSet<StyleColorOptions>) const;
 
     virtual Color platformTextSearchHighlightColor(OptionSet<StyleColorOptions>) const;
-    virtual Color platformAnnotationHighlightColor(OptionSet<StyleColorOptions>) const;
+    virtual Color platformAnnotationHighlightBackgroundColor(OptionSet<StyleColorOptions>) const;
 
     virtual Color platformDefaultButtonTextColor(OptionSet<StyleColorOptions>) const;
 
@@ -448,7 +449,8 @@ protected:
         Color inactiveListBoxSelectionForegroundColor;
 
         Color textSearchHighlightColor;
-        Color annotationHighlightColor;
+        Color annotationHighlightBackgroundColor;
+        Color annotationHighlightForegroundColor;
 
         Color defaultButtonTextColor;
         Color defaultSubmitButtonTextColor;

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -100,13 +100,15 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
         }
 
         OptionSet<StyleColorOptions> styleColorOptions = { StyleColorOptions::UseSystemAppearance };
-        style.backgroundColor = renderer.theme().annotationHighlightColor(styleColorOptions);
+        style.backgroundColor = renderer.theme().annotationHighlightBackgroundColor(styleColorOptions);
+        style.textStyles.fillColor = renderer.theme().annotationHighlightForegroundColor(styleColorOptions);
         break;
     }
 #if ENABLE(APP_HIGHLIGHTS)
     case MarkedText::Type::AppHighlight: {
         OptionSet<StyleColorOptions> styleColorOptions = { StyleColorOptions::UseSystemAppearance };
-        style.backgroundColor = renderer.theme().annotationHighlightColor(styleColorOptions);
+        style.backgroundColor = renderer.theme().annotationHighlightBackgroundColor(styleColorOptions);
+        style.textStyles.fillColor = renderer.theme().annotationHighlightForegroundColor(styleColorOptions);
         break;
     }
 #endif

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -150,7 +150,7 @@ private:
     Color platformInactiveSelectionBackgroundColor(OptionSet<StyleColorOptions>) const override;
     Color platformFocusRingColor(OptionSet<StyleColorOptions>) const final;
 
-    Color platformAnnotationHighlightColor(OptionSet<StyleColorOptions>) const final;
+    Color platformAnnotationHighlightBackgroundColor(OptionSet<StyleColorOptions>) const final;
 
 #if ENABLE(TOUCH_EVENTS)
     Color platformTapHighlightColor() const override { return SRGBA<uint8_t> { 26, 26, 26, 77 } ; }

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -1041,7 +1041,7 @@ Color RenderThemeIOS::autocorrectionReplacementMarkerColor(const RenderText& ren
     return caretColor.colorWithAlpha(0.3);
 }
 
-Color RenderThemeIOS::platformAnnotationHighlightColor(OptionSet<StyleColorOptions>) const
+Color RenderThemeIOS::platformAnnotationHighlightBackgroundColor(OptionSet<StyleColorOptions>) const
 {
     // FIXME: expose the real value from UIKit.
     return SRGBA<uint8_t> { 255, 238, 190 };

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -63,7 +63,7 @@ public:
     Color platformInactiveListBoxSelectionForegroundColor(OptionSet<StyleColorOptions>) const final;
     Color platformFocusRingColor(OptionSet<StyleColorOptions>) const final;
     Color platformTextSearchHighlightColor(OptionSet<StyleColorOptions>) const final;
-    Color platformAnnotationHighlightColor(OptionSet<StyleColorOptions>) const final;
+    Color platformAnnotationHighlightBackgroundColor(OptionSet<StyleColorOptions>) const final;
     Color platformDefaultButtonTextColor(OptionSet<StyleColorOptions>) const final;
     Color platformAutocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions>) const final;
 

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -390,7 +390,7 @@ Color RenderThemeMac::platformTextSearchHighlightColor(OptionSet<StyleColorOptio
     return colorFromCocoaColor([NSColor findHighlightColor]);
 }
 
-Color RenderThemeMac::platformAnnotationHighlightColor(OptionSet<StyleColorOptions>) const
+Color RenderThemeMac::platformAnnotationHighlightBackgroundColor(OptionSet<StyleColorOptions>) const
 {
     // FIXME: expose the real value from AppKit.
     return SRGBA<uint8_t> { 255, 238, 190 };


### PR DESCRIPTION
#### 32caf7b3a6b7d33bf91842653832615081325b90
<pre>
Scroll to text fragment highlight style can create unreadable text, especially in dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=272583">https://bugs.webkit.org/show_bug.cgi?id=272583</a>
<a href="https://rdar.apple.com/126539910">rdar://126539910</a>

Reviewed by Abrar Rahman Protyasha.

Scroll-to-Text-Fragment highlights (and App Highlights) dramatically change
the surrounding color of the highlighted text. In many cases, this is fine, but
on dark pages with light or mid-tone text, the default highlight background
color (yellow) makes it hard to read the text.

Align ourselves with Chrome&apos;s behavior: pick a contrasting color, but only
if using the default highlight color; if the author uses ::target-text to style
the background, we leave it alone, assuming they knew what they were doing.

Test: http/tests/scroll-to-text-fragment/highlighted-text-contrast.html,
      http/tests/scroll-to-text-fragment/highlighted-text-contrast-targettext.html

* LayoutTests/http/tests/scroll-to-text-fragment/highlighted-text-contrast-expected.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/highlighted-text-contrast.html: Added.
Add a test that ensures that we contrastify highlighted text colors.

* LayoutTests/http/tests/scroll-to-text-fragment/highlighted-text-contrast-targettext-expected-mismatch.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/highlighted-text-contrast-targettext.html: Added.
Add a test that ensures that we do NOT contrastify text colors when the author overrides the default style.

* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::calculateHighlightColor const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::annotationHighlightBackgroundColor const):
(WebCore::RenderTheme::platformAnnotationHighlightBackgroundColor const):
Rename annotationHighlightColor to annotationHighlightBackgroundColor, to allow
space for our &quot;Foreground&quot; variant.

(WebCore::RenderTheme::annotationHighlightForegroundColor const):
Add annotationHighlightForegroundColor, which is computed by using the CSS
contrast-color() algorithm on the background color.

(WebCore::RenderTheme::annotationHighlightColor const): Deleted.
(WebCore::RenderTheme::platformAnnotationHighlightColor const): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):
Adopt annotationHighlightForegroundColor for STTF and app highlights, only if ::target-text is not used.

Canonical link: <a href="https://commits.webkit.org/301930@main">https://commits.webkit.org/301930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9166da173703470362db887397a73c6b64b68379

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134582 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5331973b-c1f4-429e-8b42-d22a7e516b56) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97057 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b0c0ee20-53ba-4b44-823c-f5c1166850f7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77538 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9ff33c6b-ba6a-451e-9a4c-564744a70ba0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32295 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77956 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137067 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54165 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/41738 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105582 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105234 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26832 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50751 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51745 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54102 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60189 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53336 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55095 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->