### PR TITLE
[JSC] Profile polymorphic callees in Wasm

### DIFF
--- a/JSTests/wasm/stress/wasm-call-indirect-megamorphic.js
+++ b/JSTests/wasm/stress/wasm-call-indirect-megamorphic.js
@@ -1,0 +1,135 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (type $sig (func (param i32) (result i32)))
+    (table 8 funcref)
+
+    ;; Function 0: multiply by 2
+    (func $mul2 (param i32) (result i32)
+        local.get 0
+        i32.const 2
+        i32.mul
+    )
+
+    ;; Function 1: add 10
+    (func $add10 (param i32) (result i32)
+        local.get 0
+        i32.const 10
+        i32.add
+    )
+
+    ;; Function 2: subtract 5
+    (func $sub5 (param i32) (result i32)
+        local.get 0
+        i32.const 5
+        i32.sub
+    )
+
+    ;; Function 3: multiply by 3
+    (func $mul3 (param i32) (result i32)
+        local.get 0
+        i32.const 3
+        i32.mul
+    )
+
+    ;; Function 4: add 20
+    (func $add20 (param i32) (result i32)
+        local.get 0
+        i32.const 20
+        i32.add
+    )
+
+    ;; Function 5: divide by 2
+    (func $div2 (param i32) (result i32)
+        local.get 0
+        i32.const 2
+        i32.div_s
+    )
+
+    ;; Function 6: negate
+    (func $neg (param i32) (result i32)
+        i32.const 0
+        local.get 0
+        i32.sub
+    )
+
+    ;; Function 7: add 100
+    (func $add100 (param i32) (result i32)
+        local.get 0
+        i32.const 100
+        i32.add
+    )
+
+    ;; Test function: takes an index and a value, calls function at index via call_indirect
+    (func (export "test") (param i32 i32) (result i32)
+        local.get 1    ;; value parameter
+        local.get 0    ;; index parameter
+        call_indirect (type $sig)
+    )
+
+    ;; Initialize table with the eight functions
+    (elem (i32.const 0) $mul2 $add10 $sub5 $mul3 $add20 $div2 $neg $add100)
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const { test } = instance.exports;
+
+    // Helper function to compute expected result
+    function computeExpected(idx, value) {
+        switch(idx) {
+            case 0: return value * 2;
+            case 1: return value + 10;
+            case 2: return value - 5;
+            case 3: return value * 3;
+            case 4: return value + 20;
+            case 5: return Math.trunc(value / 2);
+            case 6: return -value;
+            case 7: return value + 100;
+            default: throw new Error("Invalid index");
+        }
+    }
+
+    // Test each function individually first
+    for (let idx = 0; idx < 8; idx++) {
+        for (let i = 0; i < 100; i++) {
+            const value = 20;
+            const expected = computeExpected(idx, value);
+            assert.eq(test(idx, value), expected);
+        }
+    }
+
+    // Now test megamorphic behavior: call all eight functions in a pattern
+    // This should exercise megamorphic call_indirect profiling
+    for (let i = 0; i < 1000; i++) {
+        const idx = i % 8;
+        const value = 24;
+        const expected = computeExpected(idx, value);
+        assert.eq(test(idx, value), expected);
+    }
+
+    for (let outer = 0; outer < testLoopCount; ++outer) {
+        // Test with different patterns to ensure megamorphic profiling works correctly
+        const patterns = [
+            [0, 1, 2, 3, 4, 5, 6, 7],
+            [7, 6, 5, 4, 3, 2, 1, 0],
+            [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7],
+            [1, 3, 5, 7, 0, 2, 4, 6],
+            [7, 3, 1, 5, 2, 6, 0, 4]
+        ];
+
+        for (const pattern of patterns) {
+            for (let i = 0; i < 100; i++) {
+                const idx = pattern[i % pattern.length];
+                const value = 30;
+                const expected = computeExpected(idx, value);
+                assert.eq(test(idx, value), expected);
+            }
+        }
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/wasm-call-indirect-polymorphic.js
+++ b/JSTests/wasm/stress/wasm-call-indirect-polymorphic.js
@@ -1,0 +1,110 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (type $sig (func (param i32) (result i32)))
+    (table 3 funcref)
+
+    ;; Function 0: multiply by 2
+    (func $mul2 (param i32) (result i32)
+        local.get 0
+        i32.const 2
+        i32.mul
+    )
+
+    ;; Function 1: add 10
+    (func $add10 (param i32) (result i32)
+        local.get 0
+        i32.const 10
+        i32.add
+    )
+
+    ;; Function 2: subtract 5
+    (func $sub5 (param i32) (result i32)
+        local.get 0
+        i32.const 5
+        i32.sub
+    )
+
+    ;; Test function: takes an index and a value, calls function at index via call_indirect
+    (func (export "test") (param i32 i32) (result i32)
+        local.get 1    ;; value parameter
+        local.get 0    ;; index parameter
+        call_indirect (type $sig)
+    )
+
+    ;; Initialize table with the three functions
+    (elem (i32.const 0) $mul2 $add10 $sub5)
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const { test } = instance.exports;
+
+    // Test function 0: multiply by 2
+    for (let i = 0; i < 100; i++) {
+        assert.eq(test(0, 5), 10);
+    }
+
+    // Test function 1: add 10
+    for (let i = 0; i < 100; i++) {
+        assert.eq(test(1, 5), 15);
+    }
+
+    // Test function 2: subtract 5
+    for (let i = 0; i < 100; i++) {
+        assert.eq(test(2, 5), 0);
+    }
+
+    // Now test polymorphic behavior: call all three functions in a pattern
+    // This should exercise polymorphic call_indirect profiling
+    for (let i = 0; i < 1000; i++) {
+        const idx = i % 3;
+        const value = 20;
+        const result = test(idx, value);
+
+        let expected;
+        if (idx === 0) {
+            expected = value * 2;  // 40
+        } else if (idx === 1) {
+            expected = value + 10; // 30
+        } else {
+            expected = value - 5;  // 15
+        }
+
+        assert.eq(result, expected);
+    }
+
+    for (let outer = 0; outer < testLoopCount; ++outer) {
+        // Test with different patterns to ensure polymorphic profiling works correctly
+        const patterns = [
+            [0, 1, 2],
+            [2, 1, 0],
+            [0, 0, 1, 1, 2, 2],
+            [1, 2, 0],
+            [2, 0, 1]
+        ];
+
+        for (const pattern of patterns) {
+            for (let i = 0; i < 100; i++) {
+                const idx = pattern[i % pattern.length];
+                const value = 15;
+
+                let expected;
+                if (idx === 0) {
+                    expected = value * 2;  // 30
+                } else if (idx === 1) {
+                    expected = value + 10; // 25
+                } else {
+                    expected = value - 5;  // 10
+                }
+
+                assert.eq(test(idx, value), expected);
+            }
+        }
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/wasm-call-ref-megamorphic.js
+++ b/JSTests/wasm/stress/wasm-call-ref-megamorphic.js
@@ -1,0 +1,375 @@
+import * as assert from "../assert.js"
+
+/*
+Original WAT format (not supported by wabt due to WasmGC features):
+
+(module
+    (type $sig (func (param i32) (result i32)))
+
+    ;; Function 0: multiply by 2
+    (func $mul2 (type $sig) (param i32) (result i32)
+        local.get 0
+        i32.const 2
+        i32.mul
+    )
+
+    ;; Function 1: add 10
+    (func $add10 (type $sig) (param i32) (result i32)
+        local.get 0
+        i32.const 10
+        i32.add
+    )
+
+    ;; Function 2: subtract 5
+    (func $sub5 (type $sig) (param i32) (result i32)
+        local.get 0
+        i32.const 5
+        i32.sub
+    )
+
+    ;; Function 3: multiply by 3
+    (func $mul3 (type $sig) (param i32) (result i32)
+        local.get 0
+        i32.const 3
+        i32.mul
+    )
+
+    ;; Function 4: add 20
+    (func $add20 (type $sig) (param i32) (result i32)
+        local.get 0
+        i32.const 20
+        i32.add
+    )
+
+    ;; Function 5: divide by 2
+    (func $div2 (type $sig) (param i32) (result i32)
+        local.get 0
+        i32.const 2
+        i32.div_s
+    )
+
+    ;; Function 6: negate
+    (func $neg (type $sig) (param i32) (result i32)
+        i32.const 0
+        local.get 0
+        i32.sub
+    )
+
+    ;; Function 7: add 100
+    (func $add100 (type $sig) (param i32) (result i32)
+        local.get 0
+        i32.const 100
+        i32.add
+    )
+
+    ;; Test function: takes an index and a value, calls function via call_ref
+    ;; Uses index to select which function reference to call
+    (func (export "test") (param $idx i32) (param $val i32) (result i32)
+        local.get $val
+
+        ;; Select function reference based on index (using nested if-else)
+        local.get $idx
+        i32.const 0
+        i32.eq
+        if (result (ref null $sig))
+            ref.func $mul2
+        else
+            local.get $idx
+            i32.const 1
+            i32.eq
+            if (result (ref null $sig))
+                ref.func $add10
+            else
+                local.get $idx
+                i32.const 2
+                i32.eq
+                if (result (ref null $sig))
+                    ref.func $sub5
+                else
+                    local.get $idx
+                    i32.const 3
+                    i32.eq
+                    if (result (ref null $sig))
+                        ref.func $mul3
+                    else
+                        local.get $idx
+                        i32.const 4
+                        i32.eq
+                        if (result (ref null $sig))
+                            ref.func $add20
+                        else
+                            local.get $idx
+                            i32.const 5
+                            i32.eq
+                            if (result (ref null $sig))
+                                ref.func $div2
+                            else
+                                local.get $idx
+                                i32.const 6
+                                i32.eq
+                                if (result (ref null $sig))
+                                    ref.func $neg
+                                else
+                                    ref.func $add100
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+
+        ;; Call the selected function reference
+        call_ref $sig
+    )
+)
+*/
+
+let bytes = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // Type section
+    0x01, // section code
+    0x0c, // section length (12 bytes)
+    0x02, // 2 types
+    // Type 0: (i32) -> i32
+    0x60, // func type
+    0x01, 0x7f, // 1 param: i32
+    0x01, 0x7f, // 1 result: i32
+    // Type 1: (i32, i32) -> i32
+    0x60, // func type
+    0x02, 0x7f, 0x7f, // 2 params: i32, i32
+    0x01, 0x7f, // 1 result: i32
+
+    // Function section
+    0x03, // section code
+    0x0a, // section length (10 bytes)
+    0x09, // 9 functions
+    0x00, // func 0: type 0
+    0x00, // func 1: type 0
+    0x00, // func 2: type 0
+    0x00, // func 3: type 0
+    0x00, // func 4: type 0
+    0x00, // func 5: type 0
+    0x00, // func 6: type 0
+    0x00, // func 7: type 0
+    0x01, // func 8: type 1 (test function)
+
+    // Export section
+    0x07, // section code
+    0x08, // section length (8 bytes)
+    0x01, // 1 export
+    0x04, 0x74, 0x65, 0x73, 0x74, // "test" (4 bytes length + "test")
+    0x00, 0x08, // export func 8
+
+    // Element section (declare functions for ref.func)
+    0x09, // section code
+    0x1c, // section length (28 bytes: 1 count + 1 mode + 1 type + 1 count + 8*3 bytes)
+    0x01, // 1 element segment
+    0x07, // declarative mode with element kind and expressions
+    0x70, // element type: funcref (0x70)
+    0x08, // 8 elements
+    0xd2, 0x00, 0x0b, // ref.func 0, end
+    0xd2, 0x01, 0x0b, // ref.func 1, end
+    0xd2, 0x02, 0x0b, // ref.func 2, end
+    0xd2, 0x03, 0x0b, // ref.func 3, end
+    0xd2, 0x04, 0x0b, // ref.func 4, end
+    0xd2, 0x05, 0x0b, // ref.func 5, end
+    0xd2, 0x06, 0x0b, // ref.func 6, end
+    0xd2, 0x07, 0x0b, // ref.func 7, end
+
+    // Code section
+    0x0a, // section code
+    0x9f, 0x01, // section length (159 bytes using LEB128: 1 + 8*8 + 1 + 93)
+    0x09, // 9 functions
+
+    // Function 0: mul2
+    0x07, // body size (7 bytes)
+    0x00, // 0 locals
+    0x20, 0x00, // local.get 0
+    0x41, 0x02, // i32.const 2
+    0x6c, // i32.mul
+    0x0b, // end
+
+    // Function 1: add10
+    0x07, // body size (7 bytes)
+    0x00, // 0 locals
+    0x20, 0x00, // local.get 0
+    0x41, 0x0a, // i32.const 10
+    0x6a, // i32.add
+    0x0b, // end
+
+    // Function 2: sub5
+    0x07, // body size (7 bytes)
+    0x00, // 0 locals
+    0x20, 0x00, // local.get 0
+    0x41, 0x05, // i32.const 5
+    0x6b, // i32.sub
+    0x0b, // end
+
+    // Function 3: mul3
+    0x07, // body size (7 bytes)
+    0x00, // 0 locals
+    0x20, 0x00, // local.get 0
+    0x41, 0x03, // i32.const 3
+    0x6c, // i32.mul
+    0x0b, // end
+
+    // Function 4: add20
+    0x07, // body size (7 bytes)
+    0x00, // 0 locals
+    0x20, 0x00, // local.get 0
+    0x41, 0x14, // i32.const 20
+    0x6a, // i32.add
+    0x0b, // end
+
+    // Function 5: div2
+    0x07, // body size (7 bytes)
+    0x00, // 0 locals
+    0x20, 0x00, // local.get 0
+    0x41, 0x02, // i32.const 2
+    0x6d, // i32.div_s
+    0x0b, // end
+
+    // Function 6: neg
+    0x07, // body size (7 bytes)
+    0x00, // 0 locals
+    0x41, 0x00, // i32.const 0
+    0x20, 0x00, // local.get 0
+    0x6b, // i32.sub
+    0x0b, // end
+
+    // Function 7: add100
+    0x08, // body size (8 bytes)
+    0x00, // 0 locals
+    0x20, 0x00, // local.get 0
+    0x41, 0xe4, 0x00, // i32.const 100 (LEB128)
+    0x6a, // i32.add
+    0x0b, // end
+
+    // Function 8: test (with nested if-else for 8 functions)
+    0x5c, // body size (92 bytes)
+    0x00, // 0 locals
+    0x20, 0x01, // local.get 1 (val)
+    // idx == 0?
+    0x20, 0x00, // local.get 0 (idx)
+    0x41, 0x00, // i32.const 0
+    0x46, // i32.eq
+    0x04, 0x64, 0x00, // if (result (ref null 0))
+    0xd2, 0x00, // ref.func 0
+    0x05, // else
+    // idx == 1?
+    0x20, 0x00, // local.get 0 (idx)
+    0x41, 0x01, // i32.const 1
+    0x46, // i32.eq
+    0x04, 0x64, 0x00, // if (result (ref null 0))
+    0xd2, 0x01, // ref.func 1
+    0x05, // else
+    // idx == 2?
+    0x20, 0x00, // local.get 0 (idx)
+    0x41, 0x02, // i32.const 2
+    0x46, // i32.eq
+    0x04, 0x64, 0x00, // if (result (ref null 0))
+    0xd2, 0x02, // ref.func 2
+    0x05, // else
+    // idx == 3?
+    0x20, 0x00, // local.get 0 (idx)
+    0x41, 0x03, // i32.const 3
+    0x46, // i32.eq
+    0x04, 0x64, 0x00, // if (result (ref null 0))
+    0xd2, 0x03, // ref.func 3
+    0x05, // else
+    // idx == 4?
+    0x20, 0x00, // local.get 0 (idx)
+    0x41, 0x04, // i32.const 4
+    0x46, // i32.eq
+    0x04, 0x64, 0x00, // if (result (ref null 0))
+    0xd2, 0x04, // ref.func 4
+    0x05, // else
+    // idx == 5?
+    0x20, 0x00, // local.get 0 (idx)
+    0x41, 0x05, // i32.const 5
+    0x46, // i32.eq
+    0x04, 0x64, 0x00, // if (result (ref null 0))
+    0xd2, 0x05, // ref.func 5
+    0x05, // else
+    // idx == 6?
+    0x20, 0x00, // local.get 0 (idx)
+    0x41, 0x06, // i32.const 6
+    0x46, // i32.eq
+    0x04, 0x64, 0x00, // if (result (ref null 0))
+    0xd2, 0x06, // ref.func 6
+    0x05, // else
+    0xd2, 0x07, // ref.func 7
+    0x0b, // end
+    0x0b, // end
+    0x0b, // end
+    0x0b, // end
+    0x0b, // end
+    0x0b, // end
+    0x0b, // end
+    0x14, 0x00, // call_ref 0
+    0x0b, // end
+]);
+
+async function test() {
+    const module = new WebAssembly.Module(bytes);
+    const instance = new WebAssembly.Instance(module, {});
+    const { test } = instance.exports;
+
+    // Helper function to compute expected result
+    function computeExpected(idx, value) {
+        switch(idx) {
+            case 0: return value * 2;
+            case 1: return value + 10;
+            case 2: return value - 5;
+            case 3: return value * 3;
+            case 4: return value + 20;
+            case 5: return Math.trunc(value / 2);
+            case 6: return -value;
+            case 7: return value + 100;
+            default: throw new Error("Invalid index");
+        }
+    }
+
+    // Test each function individually first
+    for (let idx = 0; idx < 8; idx++) {
+        for (let i = 0; i < 100; i++) {
+            const value = 20;
+            const expected = computeExpected(idx, value);
+            assert.eq(test(idx, value), expected);
+        }
+    }
+
+    // Now test megamorphic behavior: call all eight functions in a pattern
+    // This should exercise megamorphic call_ref profiling
+    for (let i = 0; i < 1000; i++) {
+        const idx = i % 8;
+        const value = 24;
+        const expected = computeExpected(idx, value);
+        assert.eq(test(idx, value), expected);
+    }
+
+    for (let outer = 0; outer < testLoopCount; ++outer) {
+        // Test with different patterns to ensure megamorphic profiling works correctly
+        const patterns = [
+            [0, 1, 2, 3, 4, 5, 6, 7],
+            [7, 6, 5, 4, 3, 2, 1, 0],
+            [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7],
+            [1, 3, 5, 7, 0, 2, 4, 6],
+            [7, 3, 1, 5, 2, 6, 0, 4]
+        ];
+
+        for (const pattern of patterns) {
+            for (let i = 0; i < 100; i++) {
+                const idx = pattern[i % pattern.length];
+                const value = 30;
+                const expected = computeExpected(idx, value);
+                assert.eq(test(idx, value), expected);
+            }
+        }
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/wasm-call-ref-polymorphic.js
+++ b/JSTests/wasm/stress/wasm-call-ref-polymorphic.js
@@ -1,0 +1,223 @@
+import * as assert from "../assert.js"
+
+/*
+Original WAT format (not supported by wabt due to WasmGC features):
+
+(module
+    (type $sig (func (param i32) (result i32)))
+
+    ;; Function 0: multiply by 2
+    (func $mul2 (type $sig) (param i32) (result i32)
+        local.get 0
+        i32.const 2
+        i32.mul
+    )
+
+    ;; Function 1: add 10
+    (func $add10 (type $sig) (param i32) (result i32)
+        local.get 0
+        i32.const 10
+        i32.add
+    )
+
+    ;; Function 2: subtract 5
+    (func $sub5 (type $sig) (param i32) (result i32)
+        local.get 0
+        i32.const 5
+        i32.sub
+    )
+
+    ;; Test function: takes an index and a value, calls function via call_ref
+    ;; Uses index to select which function reference to call
+    (func (export "test") (param $idx i32) (param $val i32) (result i32)
+        local.get $val
+
+        ;; Select function reference based on index
+        local.get $idx
+        i32.const 0
+        i32.eq
+        if (result (ref null $sig))
+            ref.func $mul2
+        else
+            local.get $idx
+            i32.const 1
+            i32.eq
+            if (result (ref null $sig))
+                ref.func $add10
+            else
+                ref.func $sub5
+            end
+        end
+
+        ;; Call the selected function reference
+        call_ref $sig
+    )
+)
+*/
+
+let bytes = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // Type section
+    0x01, // section code
+    0x0c, // section length (12 bytes)
+    0x02, // 2 types
+    // Type 0: (i32) -> i32
+    0x60, // func type
+    0x01, 0x7f, // 1 param: i32
+    0x01, 0x7f, // 1 result: i32
+    // Type 1: (i32, i32) -> i32
+    0x60, // func type
+    0x02, 0x7f, 0x7f, // 2 params: i32, i32
+    0x01, 0x7f, // 1 result: i32
+
+    // Function section
+    0x03, // section code
+    0x05, // section length (5 bytes)
+    0x04, // 4 functions
+    0x00, // func 0: type 0
+    0x00, // func 1: type 0
+    0x00, // func 2: type 0
+    0x01, // func 3: type 1
+
+    // Export section
+    0x07, // section code
+    0x08, // section length (8 bytes)
+    0x01, // 1 export
+    0x04, 0x74, 0x65, 0x73, 0x74, // "test" (4 bytes length + "test")
+    0x00, 0x03, // export func 3
+
+    // Element section (declare functions for ref.func)
+    0x09, // section code
+    0x0d, // section length (13 bytes)
+    0x01, // 1 element segment
+    0x07, // declarative mode with element kind and expressions
+    0x70, // element type: funcref (0x70)
+    0x03, // 3 elements
+    0xd2, 0x00, 0x0b, // ref.func 0, end
+    0xd2, 0x01, 0x0b, // ref.func 1, end
+    0xd2, 0x02, 0x0b, // ref.func 2, end
+
+    // Code section
+    0x0a, // section code
+    0x3a, // section length (58 bytes: 1 count + 4*(1 size + body))
+    0x04, // 4 functions
+
+    // Function 0: mul2
+    0x07, // body size (7 bytes)
+    0x00, // 0 locals
+    0x20, 0x00, // local.get 0
+    0x41, 0x02, // i32.const 2
+    0x6c, // i32.mul
+    0x0b, // end
+
+    // Function 1: add10
+    0x07, // body size (7 bytes)
+    0x00, // 0 locals
+    0x20, 0x00, // local.get 0
+    0x41, 0x0a, // i32.const 10
+    0x6a, // i32.add
+    0x0b, // end
+
+    // Function 2: sub5
+    0x07, // body size (7 bytes)
+    0x00, // 0 locals
+    0x20, 0x00, // local.get 0
+    0x41, 0x05, // i32.const 5
+    0x6b, // i32.sub
+    0x0b, // end
+
+    // Function 3: test
+    0x20, // body size (32 bytes)
+    0x00, // 0 locals
+    0x20, 0x01, // local.get 1 (val)
+    0x20, 0x00, // local.get 0 (idx)
+    0x41, 0x00, // i32.const 0
+    0x46, // i32.eq
+    0x04, 0x64, 0x00, // if (result (ref null 0))
+    0xd2, 0x00, // ref.func 0
+    0x05, // else
+    0x20, 0x00, // local.get 0 (idx)
+    0x41, 0x01, // i32.const 1
+    0x46, // i32.eq
+    0x04, 0x64, 0x00, // if (result (ref null 0))
+    0xd2, 0x01, // ref.func 1
+    0x05, // else
+    0xd2, 0x02, // ref.func 2
+    0x0b, // end
+    0x0b, // end
+    0x14, 0x00, // call_ref 0
+    0x0b, // end
+]);
+
+async function test() {
+    const module = new WebAssembly.Module(bytes);
+    const instance = new WebAssembly.Instance(module, {});
+    const { test } = instance.exports;
+
+    // Test function 0: multiply by 2
+    for (let i = 0; i < 100; i++) {
+        assert.eq(test(0, 5), 10);
+    }
+
+    // Test function 1: add 10
+    for (let i = 0; i < 100; i++) {
+        assert.eq(test(1, 5), 15);
+    }
+
+    // Test function 2: subtract 5
+    for (let i = 0; i < 100; i++) {
+        assert.eq(test(2, 5), 0);
+    }
+
+    // Now test polymorphic behavior: call all three functions in a pattern
+    // This should exercise polymorphic call_ref profiling
+    for (let i = 0; i < 1000; i++) {
+        const idx = i % 3;
+        const value = 20;
+        const result = test(idx, value);
+
+        let expected;
+        if (idx === 0) {
+            expected = value * 2;  // 40
+        } else if (idx === 1) {
+            expected = value + 10; // 30
+        } else {
+            expected = value - 5;  // 15
+        }
+
+        assert.eq(result, expected);
+    }
+
+    for (let outer = 0; outer < testLoopCount; ++outer) {
+        // Test with different patterns to ensure polymorphic profiling works correctly
+        const patterns = [
+            [0, 1, 2],
+            [2, 1, 0],
+            [0, 0, 1, 1, 2, 2],
+            [1, 2, 0],
+            [2, 0, 1]
+        ];
+
+        for (const pattern of patterns) {
+            for (let i = 0; i < 100; i++) {
+                const idx = pattern[i % pattern.length];
+                const value = 15;
+
+                let expected;
+                if (idx === 0) {
+                    expected = value * 2;  // 30
+                } else if (idx === 1) {
+                    expected = value + 10; // 25
+                } else {
+                    expected = value - 5;  // 10
+                }
+
+                assert.eq(test(idx, value), expected);
+            }
+        }
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -5888,6 +5888,7 @@
 		E3893A1C2203A7C600E79A74 /* AsyncFromSyncIteratorPrototype.lut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AsyncFromSyncIteratorPrototype.lut.h; sourceTree = "<group>"; };
 		E389D851291226BC0085C3DC /* PageCount.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PageCount.cpp; sourceTree = "<group>"; };
 		E389D852291226BC0085C3DC /* PageCount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageCount.h; sourceTree = "<group>"; };
+		E38C72C32EA05F84009CD28C /* WasmCallProfile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmCallProfile.cpp; sourceTree = "<group>"; };
 		E38CA06E2E614C0C00041A0C /* WasmCallProfile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmCallProfile.h; sourceTree = "<group>"; };
 		E38D060B1F8E814100649CF2 /* JSScriptFetchParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSScriptFetchParameters.h; sourceTree = "<group>"; };
 		E38D060C1F8E814100649CF2 /* ScriptFetchParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScriptFetchParameters.h; sourceTree = "<group>"; };
@@ -8039,6 +8040,7 @@
 				526AC4B51E977C5D003500E1 /* WasmCalleeGroup.h */,
 				53FD04D11D7AB187003287D3 /* WasmCallingConvention.cpp */,
 				53FD04D21D7AB187003287D3 /* WasmCallingConvention.h */,
+				E38C72C32EA05F84009CD28C /* WasmCallProfile.cpp */,
 				E38CA06E2E614C0C00041A0C /* WasmCallProfile.h */,
 				E337B966224324E50093A820 /* WasmCapabilities.h */,
 				E32D51A52C6D0FD600B013D1 /* WasmCompilationContext.h */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1144,6 +1144,7 @@ wasm/WasmBBQJIT64.cpp @no-unify
 wasm/WasmBBQPlan.cpp
 wasm/WasmBinding.cpp
 wasm/WasmBranchHintsSectionParser.cpp
+wasm/WasmCallProfile.cpp
 wasm/WasmCallee.cpp
 wasm/WasmCalleeGroup.cpp
 wasm/WasmCallingConvention.cpp

--- a/Source/JavaScriptCore/runtime/NativeCallee.h
+++ b/Source/JavaScriptCore/runtime/NativeCallee.h
@@ -35,7 +35,7 @@ namespace JSC {
 
 class LLIntOffsetsExtractor;
 
-class NativeCallee : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<NativeCallee> {
+class alignas(16) NativeCallee : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<NativeCallee> {
     WTF_MAKE_COMPACT_TZONE_ALLOCATED(NativeCallee);
 public:
     enum class Category : uint8_t {

--- a/Source/JavaScriptCore/wasm/WasmCallProfile.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallProfile.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WasmCallProfile.h"
+
+#include "WasmMergedProfile.h"
+#include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
+
+#if ENABLE(WEBASSEMBLY)
+
+namespace JSC::Wasm {
+
+CallProfile::~CallProfile()
+{
+    // Do not use ::polymorphic as it does not extract a callee when it is already megamorphic.
+    if (m_boxedCallee & Polymorphic) {
+        if (auto* poly = std::bit_cast<PolymorphicCallee*>(static_cast<uintptr_t>(m_boxedCallee & ~calleeMask)))
+            delete poly;
+    }
+}
+
+auto CallProfile::makePolymorphic() -> PolymorphicCallee*
+{
+    ASSERT(monomorphic(m_boxedCallee));
+    auto* poly = PolymorphicCallee::create(maxPolymorphicCallees, this).release();
+    poly->at(0).m_count = m_count - 1; // The current ongoing count should not be included.
+    poly->at(0).m_boxedCallee = m_boxedCallee;
+    EncodedJSValue boxedCallee = (std::bit_cast<uintptr_t>(poly) | Polymorphic);
+    WTF::storeStoreFence();
+    m_boxedCallee = boxedCallee;
+    return poly;
+}
+
+} // namespace JSC::Wasm
+
+#endif

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -160,11 +160,7 @@ std::unique_ptr<MergedProfile> Module::createMergedProfile(IPIntCallee& callee)
         }
         if (!data)
             continue;
-
-        auto span = result->mutableSpan();
-        RELEASE_ASSERT(data->size() == result->mutableSpan().size());
-        for (unsigned i = 0; i < data->size(); ++i)
-            span[i].merge(data->at(i));
+        result->merge(*data);
     }
     return result;
 }

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -6386,7 +6386,9 @@ auto OMGIRGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIn
 
     ValueResults fastValues;
     if (m_profile->isCalled(callProfileIndex)) {
-        if (auto* callee = m_profile->callee(callProfileIndex)) {
+        auto candidates = m_profile->candidates(callProfileIndex);
+        if (!candidates.isEmpty()) {
+            auto* callee = std::get<0>(candidates.callees()[0]);
             if (callee->compilationMode() == Wasm::CompilationMode::IPIntMode) {
                 BasicBlock* slowCase = m_proc.addBlock();
                 BasicBlock* directCall = m_proc.addBlock();
@@ -6546,7 +6548,9 @@ auto OMGIRGenerator::addCallRef(unsigned callProfileIndex, const TypeDefinition&
 
     ValueResults fastValues;
     if (m_profile->isCalled(callProfileIndex)) {
-        if (auto* callee = m_profile->callee(callProfileIndex)) {
+        auto candidates = m_profile->candidates(callProfileIndex);
+        if (!candidates.isEmpty()) {
+            auto* callee = std::get<0>(candidates.callees()[0]);
             if (callee->compilationMode() == Wasm::CompilationMode::IPIntMode) {
                 BasicBlock* slowCase = m_proc.addBlock();
                 BasicBlock* directCall = m_proc.addBlock();

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -6622,7 +6622,9 @@ auto OMGIRGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIn
 
     ValueResults fastValues;
     if (m_profile->isCalled(callProfileIndex)) {
-        if (auto* callee = m_profile->callee(callProfileIndex)) {
+        auto candidates = m_profile->candidates(callProfileIndex);
+        if (!candidates.isEmpty()) {
+            auto* callee = std::get<0>(candidates.callees()[0]);
             if (callee->compilationMode() == Wasm::CompilationMode::IPIntMode) {
                 BasicBlock* slowCase = m_proc.addBlock();
                 BasicBlock* directCall = m_proc.addBlock();
@@ -6782,7 +6784,9 @@ auto OMGIRGenerator::addCallRef(unsigned callProfileIndex, const TypeDefinition&
 
     ValueResults fastValues;
     if (m_profile->isCalled(callProfileIndex)) {
-        if (auto* callee = m_profile->callee(callProfileIndex)) {
+        auto candidates = m_profile->candidates(callProfileIndex);
+        if (!candidates.isEmpty()) {
+            auto* callee = std::get<0>(candidates.callees()[0]);
             if (callee->compilationMode() == Wasm::CompilationMode::IPIntMode) {
                 BasicBlock* slowCase = m_proc.addBlock();
                 BasicBlock* directCall = m_proc.addBlock();

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1270,6 +1270,12 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMaterializeBaselineData, void, (C
     FunctionCodeIndex functionIndex = calleeGroup.toCodeIndex(functionIndexInSpace);
     instance->ensureBaselineData(functionIndex);
 }
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMaterializePolymorphicCallee, WasmOrJSImportableFunction*, (CallProfile* callProfile, WasmOrJSImportableFunction* importableFunction))
+{
+    callProfile->observeCallIndirect(importableFunction->boxedCallee.encodedBits());
+    return importableFunction;
+}
 #endif
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmUnwind, void*, (JSWebAssemblyInstance* instance))

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -50,6 +50,7 @@ namespace Wasm {
 enum class UseDefaultValue : bool { No, Yes };
 enum class ArrayGetKind : unsigned { New, NewDefault, NewFixed };
 
+class CallProfile;
 class TypeDefinition;
 class JSToWasmCallee;
 
@@ -73,6 +74,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmLoopOSREnterBBQJIT, void, (Probe
 #endif
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMaterializeBaselineData, void, (CallFrame*, JSWebAssemblyInstance*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMaterializePolymorphicCallee, WasmOrJSImportableFunction*, (CallProfile*, WasmOrJSImportableFunction*));
 #endif
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmUnwind, void*, (JSWebAssemblyInstance*));
 

--- a/Source/JavaScriptCore/wasm/WasmThunks.h
+++ b/Source/JavaScriptCore/wasm/WasmThunks.h
@@ -44,6 +44,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> crashDueToBBQStackOverflowGenerator(const 
 MacroAssemblerCodeRef<JITThunkPtrTag> crashDueToOMGStackOverflowGenerator(const AbstractLocker&);
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 MacroAssemblerCodeRef<JITThunkPtrTag> materializeBaselineDataGenerator(const AbstractLocker&);
+MacroAssemblerCodeRef<JITThunkPtrTag> callPolymorphicCalleeGenerator(const AbstractLocker&);
 #endif
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 MacroAssemblerCodeRef<JITThunkPtrTag> triggerOMGEntryTierUpThunkGeneratorImpl(const AbstractLocker&, bool isSIMDContext);


### PR DESCRIPTION
#### 2db0579187cb8667dbc63e3e9b33480d340b512d
<pre>
[JSC] Profile polymorphic callees in Wasm
<a href="https://bugs.webkit.org/show_bug.cgi?id=301236">https://bugs.webkit.org/show_bug.cgi?id=301236</a>
<a href="https://rdar.apple.com/163153817">rdar://163153817</a>

Reviewed by Keith Miller.

This patch adds a mechanism collecting polymorphic callees in wasm
CallProfile. Previously, whenever we observe multiple callees, we mark
it as megamorphic. But this patch extends a mechanism to collect up to 3
callees. This is a preparation for more sophisticated inlining mechanism
for OMG which prioritizes frequently called one first for inlining.

1. We extend IPInt and BBQ to collect polymoprhic calles. For
   polymorphic callee cases, we use a shared thunk and this thunk counts
   which callee is called. And if we observe more than 3 callees, we
   mark it as megamorphic and stop using polymorphic callees.
   From collecting some information, we found 1, 2, or many callees are
   pretty common pattern. We are picking &quot;3&quot;, which is not wasting so
   much for unuseful cases, but still covering what we can see in many
   wasm code.
2. Collected callees &amp; call counts are stored in CallProfile::PolymorphicCallee.
   And MergedProfile read this concurrently to offer profiled
   information to OMG compiler.
3. In this patch, OMG is not leveraging this information so much yet. Only
   use of this information is sorting all call frequency and selecting the
   most frequently called one as an inlining target. In a subsequent patch,
   we will construct global InliningDecision data structure which views all
   call frequencies and decides which one should be inlined, and inlines
   multiple callees in one callsite when it is polymorphic callees and
   it has enough call counts for each case.

* JSTests/wasm/stress/wasm-call-indirect-megamorphic.js: Added.
(Initialize.table.with.the.eight.functions.async test.computeExpected):
(Initialize.table.with.the.eight.functions.async test):
* JSTests/wasm/stress/wasm-call-indirect-polymorphic.js: Added.
(Initialize.table.with.the.three.functions.async test):
* JSTests/wasm/stress/wasm-call-ref-megamorphic.js: Added.
(async test.computeExpected):
(async test):
* JSTests/wasm/stress/wasm-call-ref-polymorphic.js: Added.
(async test):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/NativeCallee.h:
(JSC::NativeCallee::category const): Deleted.
(JSC::NativeCallee::implementationVisibility const): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitIndirectCall):
* Source/JavaScriptCore/wasm/WasmCallProfile.cpp: Copied from Source/JavaScriptCore/wasm/WasmMergedProfile.cpp.
(JSC::Wasm::CallProfile::~CallProfile):
(JSC::Wasm::CallProfile::makePolymorphic):
* Source/JavaScriptCore/wasm/WasmCallProfile.h:
(JSC::Wasm::CallProfile::observeCrossInstanceCall):
(JSC::Wasm::CallProfile::observeCallIndirect):
(JSC::Wasm::CallProfile::isMegamorphic):
(JSC::Wasm::CallProfile::monomorphic):
(JSC::Wasm::CallProfile::polymorphic):
(JSC::Wasm::CallProfile::makeMegamorphic):
* Source/JavaScriptCore/wasm/WasmMergedProfile.cpp:
(JSC::Wasm::MergedProfile::Candidates::markAsMegamorphic):
(JSC::Wasm::MergedProfile::Candidates::add):
(JSC::Wasm::MergedProfile::Candidates::merge):
(JSC::Wasm::MergedProfile::Candidates::finalize const):
(JSC::Wasm::MergedProfile::merge):
(JSC::Wasm::MergedProfile::CallSite::merge): Deleted.
* Source/JavaScriptCore/wasm/WasmMergedProfile.h:
(JSC::Wasm::MergedProfile::Candidates::isCalled const):
(JSC::Wasm::MergedProfile::Candidates::isEmpty const):
(JSC::Wasm::MergedProfile::Candidates::isMegamorphic const):
(JSC::Wasm::MergedProfile::Candidates::totalCount const):
(JSC::Wasm::MergedProfile::isCalled const):
(JSC::Wasm::MergedProfile::candidates const):
(JSC::Wasm::MergedProfile::CallSite::count const): Deleted.
(JSC::Wasm::MergedProfile::CallSite::callee const): Deleted.
(JSC::Wasm::MergedProfile::CallSite::isMegamorphic const): Deleted.
(JSC::Wasm::MergedProfile::callee const): Deleted.
(JSC::Wasm::MergedProfile::mutableSpan): Deleted.
(JSC::Wasm::MergedProfile::span const): Deleted.
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::Module::createMergedProfile):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
(JSC::Wasm::OMGIRGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
(JSC::Wasm::OMGIRGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmThunks.cpp:
(JSC::Wasm::callPolymorphicCalleeGenerator):
* Source/JavaScriptCore/wasm/WasmThunks.h:

Canonical link: <a href="https://commits.webkit.org/301972@main">https://commits.webkit.org/301972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67ee472698f77d38d4cb1628e1e3122be3a04396

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134888 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79174 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3e675ece-4c35-4037-bdc3-8653607688b3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97146 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65059 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/14b09e63-c914-44f9-9ad1-244a5de58271) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77627 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3b67d5c4-77f6-45cc-b6bd-14b3a445c63f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32406 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78247 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119654 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137369 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126080 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54276 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105668 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105319 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50839 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29271 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51870 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19953 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54213 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60384 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159118 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53447 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39772 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56904 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55206 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->