### PR TITLE
Page freezes with many DOM manipulations and complex :has() selectors present

### DIFF
--- a/LayoutTests/fast/selectors/has-scope-breaking-classification-expected.txt
+++ b/LayoutTests/fast/selectors/has-scope-breaking-classification-expected.txt
@@ -51,4 +51,8 @@
 :not(:has(+ foo bar)) is not scope breaking
 :not(:has(+ :not(foo))) is not scope breaking
 :not(:has(+ :not(foo bar))) IS scope breaking
+:has(> :is(.x > .y)) is not scope breaking
+:has(> :is(.x .y)) IS scope breaking
+:has(:is(.x > .y)) IS scope breaking
+ol:has(> :is(.count-and-index-99-children > li:nth-child(10n+1))) is not scope breaking
 

--- a/LayoutTests/fast/selectors/has-scope-breaking-classification.html
+++ b/LayoutTests/fast/selectors/has-scope-breaking-classification.html
@@ -67,4 +67,8 @@ testScopeBreaking(":not(:has(~ :not(foo bar)))");
 testScopeBreaking(":not(:has(+ foo bar))");
 testScopeBreaking(":not(:has(+ :not(foo)))");
 testScopeBreaking(":not(:has(+ :not(foo bar)))");
+testScopeBreaking(":has(> :is(.x > .y))");
+testScopeBreaking(":has(> :is(.x .y))");
+testScopeBreaking(":has(:is(.x > .y))");
+testScopeBreaking("ol:has(> :is(.count-and-index-99-children > li:nth-child(10n+1)))");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-with-is-child-combinator-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-with-is-child-combinator-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Initial color
+PASS add .parent to subject
+PASS add .child to direct_child
+PASS remove .child from direct_child
+PASS add .parent to subject for .descendant test
+PASS add .descendant to direct_child
+PASS remove .descendant from direct_child
+PASS add .deep-child to grandchild
+PASS add .deep-parent to direct_child
+PASS remove .deep-parent from direct_child
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-with-is-child-combinator.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-with-is-child-combinator.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selector Invalidation: :has(> :is()) with child combinator</title>
+<link rel="author" title="Nipun Shukla" href="mailto:nipun_shukla@apple.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://drafts.csswg.org/selectors/#relational">
+<style>
+div, main { color: grey }
+#subject:has(> :is(.parent > .child)) { color: green }
+#subject:has(> :is(.parent .descendant)) { color: blue }
+#subject:has(:is(.deep-parent > .deep-child)) { color: red }
+</style>
+
+<main id=main>
+    <div id=subject>
+        <div id=direct_child>
+            <div id=grandchild></div>
+        </div>
+    </div>
+</main>
+
+<script>
+const grey = 'rgb(128, 128, 128)';
+const green = 'rgb(0, 128, 0)';
+const blue = 'rgb(0, 0, 255)';
+const red = 'rgb(255, 0, 0)';
+
+function testColor(test_name, color) {
+    test(function() {
+        assert_equals(getComputedStyle(subject).color, color);
+    }, test_name);
+}
+
+testColor('Initial color', grey);
+
+// :has(> :is(.parent > .child))
+subject.classList.add('parent');
+testColor('add .parent to subject', grey);
+direct_child.classList.add('child');
+testColor('add .child to direct_child', green);
+direct_child.classList.remove('child');
+testColor('remove .child from direct_child', grey);
+subject.classList.remove('parent');
+
+// :has(> :is(.parent .descendant))
+subject.classList.add('parent');
+testColor('add .parent to subject for .descendant test', grey);
+direct_child.classList.add('descendant');
+testColor('add .descendant to direct_child', blue);
+direct_child.classList.remove('descendant');
+testColor('remove .descendant from direct_child', grey);
+subject.classList.remove('parent');
+
+// :has(:is(.deep-parent > .deep-child))
+grandchild.classList.add('deep-child');
+testColor('add .deep-child to grandchild', grey);
+direct_child.classList.add('deep-parent');
+testColor('add .deep-parent to direct_child', red);
+direct_child.classList.remove('deep-parent');
+testColor('remove .deep-parent from direct_child', grey);
+grandchild.classList.remove('deep-child');
+
+</script>

--- a/PerformanceTests/CSS/HasWithChildCombinatorInIs.html
+++ b/PerformanceTests/CSS/HasWithChildCombinatorInIs.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Performance test for :has(> :is(x > y)) with child combinators</title>
+    <style>
+        ol.group1:has(> :is(.highlight > li:nth-child(odd))) { border-color: red; }
+        ol.group2:has(> :is(.highlight > li:nth-child(even))) { border-color: blue; }
+        ol.group3:has(> :is(.special > li:first-child)) { border-color: green; }
+        ol.group4:has(> :is(.marker > li:last-child)) { border-color: yellow; }
+        ol.group5:has(> :is(.tagged > li)) { border-color: purple; }
+
+        ol:has(> :is(.active > li)) { background-color: rgba(255, 0, 0, 0.1); }
+        ol:has(> :is(.selected > li)) { background-color: rgba(0, 255, 0, 0.1); }
+        ol:has(> :is(.focused > li)) { background-color: rgba(0, 0, 255, 0.1); }
+        ol:has(> :is(.hover > li)) { box-shadow: 0 0 5px rgba(0,0,0,0.2); }
+        ol:has(> :is(.disabled > li)) { opacity: 0.5; }
+
+        ol:has(> :is(.state1 > li:nth-of-type(1))) { margin-left: 1px; }
+        ol:has(> :is(.state2 > li:nth-of-type(2))) { margin-left: 2px; }
+        ol:has(> :is(.state3 > li:nth-of-type(3))) { margin-left: 3px; }
+        ol:has(> :is(.state4 > li:nth-of-type(4))) { margin-left: 4px; }
+        ol:has(> :is(.state5 > li:nth-of-type(5))) { margin-left: 5px; }
+
+        ol:has(> :is(.parent1 > li)) { --color1: red; }
+        ol:has(> :is(.parent2 > li)) { --color2: blue; }
+        ol:has(> :is(.parent3 > li)) { --color3: green; }
+        ol:has(> :is(.parent4 > li)) { --color4: yellow; }
+        ol:has(> :is(.parent5 > li)) { --color5: purple; }
+    </style>
+</head>
+<body>
+<div id="test-container"></div>
+<script src="../resources/runner.js"></script>
+<script>
+
+const container = document.getElementById('test-container');
+
+for (let i = 0; i < 100; i++) {
+    const ol = document.createElement('ol');
+    ol.className = `group${(i % 5) + 1} highlight special marker tagged`;
+
+    for (let j = 0; j < 30; j++) {
+        const li = document.createElement('li');
+        li.textContent = `Item ${j}`;
+        ol.appendChild(li);
+    }
+
+    container.appendChild(ol);
+}
+
+const allListItems = container.querySelectorAll('li');
+const allLists = container.querySelectorAll('ol');
+
+PerfTestRunner.measureRunsPerSecond({
+    description: "Tests DOM manipulation performance with complex :has(> :is()) selectors containing child combinators.",
+    run: function() {
+        for (let i = 0; i < allListItems.length; i += 3) {
+            allListItems[i].classList.add('temp');
+        }
+        getComputedStyle(container).opacity;
+
+        for (let i = 0; i < allLists.length; i += 2) {
+            allLists[i].classList.add('active', 'selected', 'focused');
+        }
+        getComputedStyle(container).opacity;
+
+        for (let i = 0; i < allListItems.length; i += 3) {
+            allListItems[i].classList.remove('temp');
+        }
+        getComputedStyle(container).opacity;
+
+        for (let i = 0; i < allLists.length; i += 2) {
+            allLists[i].classList.remove('active', 'selected', 'focused');
+        }
+        getComputedStyle(container).opacity;
+    }
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -242,8 +242,15 @@ static MatchElement computeNextHasPseudoClassMatchElement(MatchElement matchElem
         return matchElement;
 
     // `:has(:is(foo bar))` can be affected by changes outside the :has scope.
-    if (relation == CSSSelector::Relation::DescendantSpace || relation == CSSSelector::Relation::Child)
+    if (relation == CSSSelector::Relation::DescendantSpace || relation == CSSSelector::Relation::Child) {
+        // However, for `:has(> :is(.x > .y))`, the child combinator (>) inside :is() is still scoped to the direct child's tree.
+        // The parent in the relationship must be the direct child itself, which is within the :has(>) scope.
+        // Only descendant combinators can reach outside this scope (to ancestors of the subject element).
+        if (matchElement == MatchElement::HasChild && relation == CSSSelector::Relation::Child)
+            return matchElement;
+
         return MatchElement::HasScopeBreaking;
+    }
 
     if (relation == CSSSelector::Relation::IndirectAdjacent || relation == CSSSelector::Relation::DirectAdjacent) {
         // `:has(~ :is(.x ~ .y))` must look at previous siblings of the :scope scope too.


### PR DESCRIPTION
#### 4ef19b5fa4c093b11b221c8d8df3b5a3d9dd398d
<pre>
Page freezes with many DOM manipulations and complex :has() selectors present
<a href="https://bugs.webkit.org/show_bug.cgi?id=281920">https://bugs.webkit.org/show_bug.cgi?id=281920</a>
<a href="https://rdar.apple.com/138431700">rdar://138431700</a>

Reviewed by Matthieu Dubet and Antti Koivisto.

When evaluating :has(&gt; :is(.x &gt; .y)), child combinators within :is() are
scoped to the direct child&apos;s tree and don&apos;t require scope-breaking invalidation.
This avoids excessive DOM traversal on pages with many complex :has() selectors,
preventing page freezes during style recalculation.

* LayoutTests/fast/selectors/has-scope-breaking-classification-expected.txt:
* LayoutTests/fast/selectors/has-scope-breaking-classification.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-with-is-child-combinator-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-with-is-child-combinator.html: Added.
* PerformanceTests/CSS/HasWithChildCombinatorInIs.html: Added.
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::computeNextHasPseudoClassMatchElement):

Canonical link: <a href="https://commits.webkit.org/302587@main">https://commits.webkit.org/302587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c42161cde4772e20bb656aff49fa26e66d95d3e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80704 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98482 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66383 "Found 1 new test failure: webgl/2.0.y/conformance2/query/occlusion-query.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79124 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1298 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33944 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79966 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139161 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107009 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1401 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106843 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27264 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1109 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30680 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53991 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1429 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64793 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1247 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1282 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->