### PR TITLE
[EME/MSE] AudioVideoRendererRemote doesn't support CDMInstance/LegacyCDMSession

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -34,6 +34,8 @@
 #include "MessageReceiver.h"
 #include "RemoteAudioVideoRendererIdentifier.h"
 #include "RemoteAudioVideoRendererState.h"
+#include "RemoteCDMInstanceIdentifier.h"
+#include "RemoteLegacyCDMSessionIdentifier.h"
 #include "RemoteVideoFrameProxy.h"
 #include <WebCore/AudioVideoRenderer.h>
 #include <WebCore/HTMLMediaElementIdentifier.h>
@@ -145,6 +147,15 @@ private:
 #endif
     void setTextTrackRepresentation(RemoteAudioVideoRendererIdentifier, WebCore::TextTrackRepresentation*);
     void syncTextTrackBounds(RemoteAudioVideoRendererIdentifier);
+
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
+    void setLegacyCDMSession(RemoteAudioVideoRendererIdentifier, std::optional<RemoteLegacyCDMSessionIdentifier>);
+#endif
+#if ENABLE(ENCRYPTED_MEDIA)
+    void setCDMInstance(RemoteAudioVideoRendererIdentifier, std::optional<RemoteCDMInstanceIdentifier>);
+    void setInitData(RemoteAudioVideoRendererIdentifier, Ref<WebCore::SharedBuffer>, CompletionHandler<void(Expected<void, WebCore::PlatformMediaError>)>&&);
+    void attemptToDecrypt(RemoteAudioVideoRendererIdentifier);
+#endif
 
     struct RendererContext {
         RefPtr<WebCore::AudioVideoRenderer> renderer;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -92,6 +92,16 @@ messages -> RemoteAudioVideoRendererProxyManager {
 #if PLATFORM(COCOA)
     SetVideoLayerSizeFenced(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::FloatSize size, struct MachSendRightAnnotated sendRightAnnotated)
 #endif
+
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
+    [EnabledBy=LegacyEncryptedMediaAPIEnabled] SetLegacyCDMSession(WebKit::RemoteAudioVideoRendererIdentifier identifier, std::optional<WebKit::RemoteLegacyCDMSessionIdentifier> instanceId)
+#endif
+#if ENABLE(ENCRYPTED_MEDIA)
+    [EnabledBy=EncryptedMediaAPIEnabled] SetCDMInstance(WebKit::RemoteAudioVideoRendererIdentifier identifier, std::optional<WebKit::RemoteCDMInstanceIdentifier> instanceId)
+    [EnabledBy=EncryptedMediaAPIEnabled] SetInitData(WebKit::RemoteAudioVideoRendererIdentifier identifier, Ref<WebCore::SharedBuffer> initData) -> (Expected<void, WebCore::PlatformMediaError> result)
+    [EnabledBy=EncryptedMediaAPIEnabled] AttemptToDecrypt(WebKit::RemoteAudioVideoRendererIdentifier identifier)
+#endif
+
 }
 
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8587,6 +8587,7 @@ enum class WebCore::PlatformMediaError : uint8_t {
     AudioDecodingError,
     VideoDecodingError,
     RequiresFlushToResume,
+    CDMInstanceKeyNeeded,
 };
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -49,6 +49,8 @@ class Decoder;
 namespace WebCore {
 struct HostingContext;
 class VideoLayerManager;
+class CDMInstance;
+class LegacyCDMSession;
 }
 
 namespace WebKit {
@@ -190,6 +192,15 @@ private:
     bool inVideoFullscreenOrPictureInPicture() const final;
     WebCore::FloatSize naturalSize() const final { return m_naturalSize; }
 
+#if ENABLE(ENCRYPTED_MEDIA)
+    void setCDMInstance(WebCore::CDMInstance*) final;
+    Ref<WebCore::MediaPromise> setInitData(Ref<WebCore::SharedBuffer>) final;
+    void attemptToDecrypt() final;
+#endif
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
+    void setCDMSession(WebCore::LegacyCDMSession*) final;
+#endif
+
     // Logger
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
@@ -208,7 +219,7 @@ private:
 
     const ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     const Ref<MessageReceiver> m_receiver;
-    RemoteAudioVideoRendererIdentifier m_identifier;
+    const RemoteAudioVideoRendererIdentifier m_identifier;
 
     bool m_shutdown { false };
 


### PR DESCRIPTION
#### e3a42447693c4cc3d8274e1113d893e06a63e43e
<pre>
[EME/MSE] AudioVideoRendererRemote doesn&apos;t support CDMInstance/LegacyCDMSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=301238">https://bugs.webkit.org/show_bug.cgi?id=301238</a>
<a href="https://rdar.apple.com/163154712">rdar://163154712</a>

Reviewed by Eric Carlson.

Add IPC supports for setCDMInstance/setCDMSession to AudioVideoRendererRemote.

Will be covered by existing FairPlay tests once MediaSourceUseRemoteAudioVideoRenderer
is enabled.
* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::requestHostingContext): Add extra logging.
(WebKit::RemoteAudioVideoRendererProxyManager::setLegacyCDMSession): Added
(WebKit::RemoteAudioVideoRendererProxyManager::setCDMInstance): Added
(WebKit::RemoteAudioVideoRendererProxyManager::setInitData): Added
(WebKit::RemoteAudioVideoRendererProxyManager::attemptToDecrypt): Added
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::setCDMInstance): Added
(WebKit::AudioVideoRendererRemote::setInitData): Added
(WebKit::AudioVideoRendererRemote::attemptToDecrypt): Added
(WebKit::AudioVideoRendererRemote::setCDMSession): Added
(WebKit::AudioVideoRendererRemote::setVideoLayerSizeFenced): Added
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:

Canonical link: <a href="https://commits.webkit.org/301926@main">https://commits.webkit.org/301926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbe4f48dcd6955b60a16bee6692b52b739a6bbc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134579 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aa50d0a3-5924-47dd-8967-b38edecc31c6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97055 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1e052104-b02e-432e-9631-b722342c2672) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77536 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c8374dea-a014-404f-9880-38af51d2381b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77953 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137064 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105581 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105233 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26830 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50748 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51742 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54099 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60186 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/53333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55092 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->