### PR TITLE
[iPad] Unable to scroll using arrow keys in sub-scrollable region after pressing arrow keys in a focused text field

### DIFF
--- a/LayoutTests/fast/scrolling/ios/keyboard-scrolling-subscrollable-with-input-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/keyboard-scrolling-subscrollable-with-input-expected.txt
@@ -1,0 +1,12 @@
+
+2. Tap me and press ⬇️
+Verifies that keyboard scrolling in a child scroller works after pressing arrow keys in a text field
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS scroller.scrollTop is > 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/keyboard-scrolling-subscrollable-with-input.html
+++ b/LayoutTests/fast/scrolling/ios/keyboard-scrolling-subscrollable-with-input.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<meta charset="utf-8">
+<meta name="viewport" content="initial-scale=1, user-scalable=no">
+<style>
+body, html {
+    font-family: system-ui;
+    margin: 0;
+}
+
+.tall {
+    height: 120vh;
+}
+
+#placeholder {
+    width: 300px;
+    height: 150lvh;
+    background: blue;
+}
+
+#scroller {
+    background: green;
+    width: 250px;
+    height: 250px;
+    overflow: scroll;
+    line-height: 2;
+    padding: 1em;
+}
+
+input {
+    font-size: 18px;
+    width: 250px;
+    height: 44px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+async function pressKeyWithShortDelay(key) {
+    await UIHelper.rawKeyDown(key);
+    await UIHelper.delayFor(300);
+    await UIHelper.rawKeyUp(key);
+    await UIHelper.ensurePresentationUpdate();
+}
+
+addEventListener("load", async () => {
+    description("Verifies that keyboard scrolling in a child scroller works after pressing arrow keys in a text field");
+
+    scroller = document.getElementById("scroller");
+    textField = document.querySelector("input");
+    scroller.addEventListener("click", () => textField.blur());
+
+    await UIHelper.activateElementAndWaitForInputSession(textField);
+    await pressKeyWithShortDelay("upArrow");
+
+    await UIHelper.activateElement(scroller);
+    await UIHelper.waitForKeyboardToHide();
+    await pressKeyWithShortDelay("downArrow");
+    await UIHelper.waitForZoomingOrScrollingToEnd();
+
+    shouldBeGreaterThan("scroller.scrollTop", "0");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <input placeholder="1. Focus me and press ⬇️" />
+    <div id="scroller">
+        2. Tap me and press ⬇️
+        <div class="tall"></div>
+    </div>
+    <div id="console"></div>
+</body>
+</html>


### PR DESCRIPTION
#### d7534d72ebb03f112ce4002fd5e2b437ae25d2d8
<pre>
[iPad] Unable to scroll using arrow keys in sub-scrollable region after pressing arrow keys in a focused text field
<a href="https://bugs.webkit.org/show_bug.cgi?id=301240">https://bugs.webkit.org/show_bug.cgi?id=301240</a>
<a href="https://rdar.apple.com/152188882">rdar://152188882</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

Currently, on chatgpt.com, if you:

1. Focus the chat box and press any of the arrow keys
2. Tap the chat transcript
3. Try to use arrow keys to scroll the transcript

...the transcript fails to scroll, despite it being an overflow scrolling container. This happens
because we first set `_scrollView` here in `WKKeyboardScrollViewAnimator` after pressing an arrow
key in the input field, on the line marked by (1):

```
- (BOOL)beginWithEvent:(::WebEvent *)event scrollView:(WKBaseScrollView *)scrollView
{
    if (!_scrollView)
        _scrollView = scrollView;               // &lt;----- (1)

    if (_scrollView != scrollView)
        return NO;                              // &lt;----- (4)

    return [_animator beginWithEvent:event];    // &lt;----- (2)
}
```

However, when we actually try to `-beginWithEvent:` at (2), we fall down the early return (3) below:

```
- (BOOL)beginWithEvent:(::WebEvent *)event
{
    if (event.type != WebEventKeyDown)
        return NO;

    auto scroll = [self keyboardScrollForEvent:event];
    if (!scroll)
        return NO;                              // &lt;----- (3)
    …
}
```

...and don&apos;t actually begin scrolling. This means that we never end up clearing the `_scrollView` in
`-didFinishScrolling`, and `_scrollView` is stuck pointing to `WKScrollView`.

Later, when `-beginWithEvent:scrollView:` is invoked with the child scroller, we end up bailing at
the line marked (4) above, and never begin scrolling. To fix this, we reset `_scrollView` to `nil`
in the case where keyboard scrolling failed to actually begin as a result of the keypress, such that
it will be set to the child scroller the next time the user attempts to trigger keyboard scrolling
again after tapping inside the child scroller.

Test: fast/scrolling/ios/keyboard-scrolling-subscrollable-with-input.html

* LayoutTests/fast/scrolling/ios/keyboard-scrolling-subscrollable-with-input-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/keyboard-scrolling-subscrollable-with-input.html: Added.

Add a layout test to exercise the fix.

* Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm:

Make `-beginWithEvent:` return a more descriptive enum type describing how the request to begin
keyboard scrolling was handled; only clear out `_scrollView` in the case where the key event itself
does not trigger scrolling at all (not because scrolling is already in progress and the triggering
key is still pressed, or because the scroller is not rubber-bandable). See above for more details.

(-[WKKeyboardScrollingAnimator beginWithEvent:]):
(-[WKKeyboardScrollViewAnimator beginWithEvent:scrollView:]):

Canonical link: <a href="https://commits.webkit.org/301929@main">https://commits.webkit.org/301929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca08ba4619e22931e69367896068e50677b44075

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134587 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f9a756e4-6a9d-461e-aa20-23512f0e96d0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97060 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/51d1951b-765d-40a5-91d7-54df7e95eb16) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77541 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2383599c-cd4c-4fc7-b342-a91337e15948) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77961 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137072 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105587 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54681 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110558 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105239 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26833 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50754 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51750 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54107 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60194 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/53341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55100 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->