### PR TITLE
[WebXR] Test gardening after 300383@main

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -97,9 +97,6 @@ WebXRSession::WebXRSession(Document& document, WebXRSystem& system, XRSessionMod
 
 WebXRSession::~WebXRSession()
 {
-    if (RefPtr sessionDocument = downcast<Document>(scriptExecutionContext()))
-        sessionDocument->unregisterForVisibilityStateChangedCallbacks(*this);
-
     auto device = m_device.get();
     if (!m_ended && device)
         device->shutDownTrackingAndRendering();


### PR DESCRIPTION
#### c4180b46dd501e5166743900f5726302a52fc0bf
<pre>
[WebXR] Test gardening after 300383@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=301241">https://bugs.webkit.org/show_bug.cgi?id=301241</a>
<a href="https://rdar.apple.com/161189145">rdar://161189145</a>

Reviewed by Mike Wyrzykowski.

The change in 300383@main is trying to be &quot;a good citizen&quot; by
unregistering observing visibility changes from WebXRSession::~WebXRSession.
This is causing an exception due to trying to accessing already
destructed hash map during DOMWindow destruction.

Since the observers are kept in a WeakHashSet there is no need to
unregister during WebXRSession::~WebXRSession.

In addtion, when obtaining permissions for an inline session, the
request is forwarded to PlatformXRCompositor, which only handles
immersiveVR sessions and asserts in Debug builds because the methods
are called in the wrong order.

Instead of forwarding the request to the compositor for inline mode,
all permissions are granted unconditionally.

* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::~WebXRSession):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::requestPermissionOnSessionFeatures):

Canonical link: <a href="https://commits.webkit.org/301975@main">https://commits.webkit.org/301975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/076bc27892c7ba216a63b693fd2e9c512327ba2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79068 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f1d621cb-963d-4618-9d8a-1a3e15d6159d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97061 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64995 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e6a720aa-af07-41ae-bc99-27cce8ac34c3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114193 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77542 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/458b13f6-63c1-46e6-a445-addcfcfd367b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32296 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77962 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137073 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105588 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105240 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26864 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50753 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29202 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51751 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54108 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60195 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53342 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56799 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55101 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->