### PR TITLE
Address some Safer CPP warnings in WebCore/workers

### DIFF
--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -110,6 +110,8 @@ public:
     JS_EXPORT_PRIVATE void unlockUnderlyingBuffer();
     JS_EXPORT_PRIVATE virtual CodeBlockHash codeBlockHashConcurrently(int startOffset, int endOffset, CodeSpecializationKind);
 
+    virtual bool isScriptBufferSourceProvider() const { return false; }
+
 private:
     JS_EXPORT_PRIVATE virtual void lockUnderlyingBufferImpl();
     JS_EXPORT_PRIVATE virtual void unlockUnderlyingBufferImpl();

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -33,6 +33,13 @@ Modules/webaudio/WaveShaperProcessor.cpp
 Modules/webdriver/NavigatorWebDriver.cpp
 SVGNames.cpp
 TagName.cpp
+[ Mac ] page/mac/EventHandlerMac.mm
+[ Mac ] platform/graphics/mac/controls/ControlMac.mm
+[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
+[ iOS ] platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
+[ iOS ] platform/ios/wak/WAKView.mm
+[ iOS ] platform/ios/wak/WAKWindow.mm
 bindings/js/DOMGCOutputConstraint.cpp
 bindings/js/JSDOMAsyncIterator.h
 bindings/js/JSDOMConvertWebGL.cpp
@@ -86,11 +93,9 @@ layout/layouttree/LayoutTreeBuilder.cpp
 loader/cache/CachedResourceClientWalker.h
 mathml/MathMLRowElement.cpp
 page/NavigatorLoginStatus.cpp
-[ Mac ] page/mac/EventHandlerMac.mm
 platform/graphics/GraphicsLayer.cpp
 platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
-[ Mac ] platform/graphics/mac/controls/ControlMac.mm
 rendering/BidiRun.cpp
 rendering/BidiRun.h
 rendering/RenderAncestorIterator.h
@@ -113,10 +118,3 @@ svg/properties/SVGAnimatedValueProperty.h
 testing/InternalSettings.cpp
 testing/Internals.cpp
 testing/cocoa/WebArchiveDumpSupport.mm
-workers/WorkerGlobalScope.cpp
-workers/WorkerThread.cpp
-[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
-[ iOS ] platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
-[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
-[ iOS ] platform/ios/wak/WAKView.mm
-[ iOS ] platform/ios/wak/WAKWindow.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1022,8 +1022,6 @@ testing/MockPageOverlay.cpp
 testing/MockPageOverlayClient.cpp
 testing/ServiceWorkerInternals.cpp
 testing/js/WebCoreTestSupport.cpp
-workers/Worker.cpp
-workers/WorkerMessagingProxy.cpp
 workers/shared/SharedWorker.cpp
 worklets/PaintWorkletGlobalScope.cpp
 worklets/WorkletGlobalScope.cpp

--- a/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
@@ -90,6 +90,8 @@ private:
     {
     }
 
+    bool isScriptBufferSourceProvider() const final { return true; }
+
     StringView sourceImpl(const AbstractLocker&) const
     {
         if (m_scriptBuffer.isEmpty())
@@ -123,3 +125,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ScriptBufferSourceProvider)
+    static bool isType(const JSC::SourceProvider& provider) { return provider.isScriptBufferSourceProvider(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.h
+++ b/Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.h
@@ -60,9 +60,14 @@ public:
     static ASCIILiteral supplementName() { return WindowOrWorkerGlobalScopeTrustedTypes::workerGlobalSupplementName(); }
 
 private:
+    bool isWorkerGlobalScopeTrustedTypes() const final { return true; }
+
     WeakPtr<WorkerGlobalScope, WeakPtrImplWithEventTargetData> m_scope;
     mutable RefPtr<TrustedTypePolicyFactory> m_trustedTypes;
 };
 
-
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WorkerGlobalScopeTrustedTypes)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isWorkerGlobalScopeTrustedTypes(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -91,6 +91,7 @@ public:
     virtual bool isDocumentMediaElement() const { return false; }
     virtual bool isGeolocationController() const { return false; }
     virtual bool isWorkerGlobalScopeIndexedDatabase() const { return false; }
+    virtual bool isWorkerGlobalScopeTrustedTypes() const { return false; }
     virtual bool isServiceWorkerRegistrationBackgroundFetchAPI() const { return false; }
 };
 

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -289,7 +289,7 @@ void Worker::createRTCRtpScriptTransformer(RTCRtpScriptTransform& transform, Mes
     if (!scriptExecutionContext())
         return;
 
-    m_contextProxy.postTaskToWorkerGlobalScope([transform = Ref { transform }, options = WTFMove(options)](auto& context) mutable {
+    m_contextProxy.postTaskToWorkerGlobalScope([transform = Ref { transform }, options = WTFMove(options)](ScriptExecutionContext& context) mutable {
         if (RefPtr transformer = downcast<DedicatedWorkerGlobalScope>(context).createRTCRtpScriptTransformer(WTFMove(options)))
             transform->setTransformer(*transformer);
     });

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -169,7 +169,7 @@ void WorkerGlobalScope::prepareForDestruction()
 {
     WorkerOrWorkletGlobalScope::prepareForDestruction();
 
-    if (auto* trustedTypes = static_cast<WorkerGlobalScopeTrustedTypes*>(requireSupplement(WorkerGlobalScopeTrustedTypes::supplementName())))
+    if (auto* trustedTypes = downcast<WorkerGlobalScopeTrustedTypes>(requireSupplement(WorkerGlobalScopeTrustedTypes::supplementName())))
         trustedTypes->prepareForDestruction();
 
     if (settingsValues().serviceWorkersEnabled)
@@ -446,7 +446,7 @@ ExceptionOr<void> WorkerGlobalScope::importScripts(const FixedVector<Variant<Ref
         {
             NakedPtr<JSC::Exception> exception;
             ScriptSourceCode sourceCode(scriptLoader->script(), URL(scriptLoader->responseURL()), scriptLoader->isRedirected() ? URL(scriptLoader->url()) : URL());
-            sourceProvider = static_cast<ScriptBufferSourceProvider&>(sourceCode.provider());
+            sourceProvider = downcast<ScriptBufferSourceProvider>(sourceCode.provider());
             script()->evaluate(sourceCode, exception);
             if (exception) {
                 if (mutedErrors)

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -99,6 +99,7 @@ private:
     void setAppBadge(std::optional<uint64_t>) final;
     
     RefPtr<ScriptExecutionContext> m_scriptExecutionContext;
+    Markable<ScriptExecutionContextIdentifier> m_scriptExecutionContextIdentifier;
     ScriptExecutionContextIdentifier m_loaderContextIdentifier;
     const Ref<WorkerInspectorProxy> m_inspectorProxy;
     RefPtr<WorkerUserGestureForwarder> m_userGestureForwarder;

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -159,14 +159,14 @@ void WorkerThread::evaluateScriptIfNecessary(String& exceptionMessage)
     WeakPtr<ScriptBufferSourceProvider> sourceProvider;
     if (m_startupData->params.workerType == WorkerType::Classic) {
         ScriptSourceCode sourceCode(m_startupData->sourceCode, URL(m_startupData->params.scriptURL));
-        sourceProvider = static_cast<ScriptBufferSourceProvider&>(sourceCode.provider());
+        sourceProvider = downcast<ScriptBufferSourceProvider>(sourceCode.provider());
         globalScope->script()->evaluate(sourceCode, &exceptionMessage);
         finishedEvaluatingScript();
     } else {
         auto parameters = ModuleFetchParameters::create(JSC::ScriptFetchParameters::Type::JavaScript, emptyString(), /* isTopLevelModule */ true);
         auto scriptFetcher = WorkerScriptFetcher::create(WTFMove(parameters), globalScope->credentials(), globalScope->destination(), globalScope->referrerPolicy());
         ScriptSourceCode sourceCode(m_startupData->sourceCode, URL(m_startupData->params.scriptURL), { }, { }, JSC::SourceProviderSourceType::Module, scriptFetcher.copyRef());
-        sourceProvider = static_cast<ScriptBufferSourceProvider&>(sourceCode.provider());
+        sourceProvider = downcast<ScriptBufferSourceProvider>(sourceCode.provider());
         bool success = globalScope->script()->loadModuleSynchronously(scriptFetcher.get(), sourceCode);
         if (success) {
             if (auto error = scriptFetcher->error()) {


### PR DESCRIPTION
#### 6bc11e4d855dc9fe8b6d955c502a0283724e6b6b
<pre>
Address some Safer CPP warnings in WebCore/workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=301242">https://bugs.webkit.org/show_bug.cgi?id=301242</a>

Reviewed by Geoffrey Garen.

* Source/JavaScriptCore/parser/SourceProvider.h:
(JSC::SourceProvider::isScriptBufferSourceProvider const):
* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/bindings/js/ScriptBufferSourceProvider.h:
(isType):
* Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.h:
(isType):
* Source/WebCore/platform/Supplementable.h:
(WebCore::SupplementBase::isWorkerGlobalScopeTrustedTypes const):
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::createRTCRtpScriptTransformer):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::prepareForDestruction):
(WebCore::WorkerGlobalScope::importScripts):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::WorkerMessagingProxy):
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
(WebCore::WorkerMessagingProxy::postMessageToWorkerObject):
(WebCore::WorkerMessagingProxy::postTaskToWorkerObject):
(WebCore::WorkerMessagingProxy::postExceptionToWorkerObject):
(WebCore::WorkerMessagingProxy::reportErrorToWorkerObject):
(WebCore::WorkerMessagingProxy::workerObjectDestroyed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeClosed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyedInternal):
(WebCore::WorkerMessagingProxy::terminateWorkerGlobalScope):
* Source/WebCore/workers/WorkerMessagingProxy.h:
* Source/WebCore/workers/WorkerThread.cpp:
(WebCore::WorkerThread::evaluateScriptIfNecessary):

Canonical link: <a href="https://commits.webkit.org/301994@main">https://commits.webkit.org/301994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20dd5a54df2c59940603181342b490d22c1c824f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134598 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79078 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97069 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64998 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ca49b436-a2f6-471a-80e0-bea3fff12bc8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77549 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/85c1984d-d6bc-4305-b7af-7d27a0e4b05e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32307 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77972 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119559 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137083 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/125985 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105596 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105247 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26874 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29209 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51761 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54118 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60205 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159023 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53352 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39750 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56809 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55111 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->