### PR TITLE
Address some Safer CPP warnings in WTF

### DIFF
--- a/Source/WTF/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,5 +1,2 @@
 usr/local/include/wtf/text/cf/StringConcatenateCF.h
-wtf/RetainPtr.h
-wtf/SchedulePair.h
 wtf/cf/RunLoopCF.cpp
-[ Mac ] wtf/unicode/icu/CollatorICU.cpp

--- a/Source/WTF/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,4 +1,1 @@
-wtf/cf/LanguageCF.cpp
-wtf/cf/SchedulePairCF.cpp
-wtf/darwin/LibraryPathDiagnostics.mm
 wtf/text/cf/StringImplCF.cpp

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -194,14 +194,14 @@ template<typename T> inline RetainPtr<T>::RetainPtr(PtrType ptr)
     : m_ptr(ptr)
 {
     if (m_ptr)
-        retainFoundationPtr(m_ptr);
+        SUPPRESS_UNRETAINED_ARG retainFoundationPtr(m_ptr);
 }
 
 template<typename T> inline RetainPtr<T>::RetainPtr(const RetainPtr& o)
     : m_ptr(o.m_ptr)
 {
     if (m_ptr)
-        retainFoundationPtr(m_ptr);
+        SUPPRESS_UNRETAINED_ARG retainFoundationPtr(m_ptr);
 }
 
 template<typename T> template<typename U> inline RetainPtr<T>::RetainPtr(const RetainPtr<U>& o)

--- a/Source/WTF/wtf/SchedulePair.h
+++ b/Source/WTF/wtf/SchedulePair.h
@@ -74,7 +74,9 @@ private:
 inline void add(Hasher& hasher, const SchedulePair& pair)
 {
     // FIXME: Hashing a CFHash here is unfortunate.
-    add(hasher, pair.runLoop(), pair.mode() ? CFHash(pair.mode()) : 0);
+    // FIXME: Static analysis wants us to retain pair.mode() but this doesn't seem necessary given that
+    // SchedulePair::m_mode is const (rdar://163245052).
+    SUPPRESS_UNRETAINED_ARG add(hasher, pair.runLoop(), pair.mode() ? CFHash(pair.mode()) : 0);
 }
 
 struct SchedulePairHash {

--- a/Source/WTF/wtf/cf/LanguageCF.cpp
+++ b/Source/WTF/wtf/cf/LanguageCF.cpp
@@ -33,6 +33,7 @@
 #include <wtf/Logging.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/cf/NotificationCenterCF.h>
+#include <wtf/cf/TypeCastsCF.h>
 #include <wtf/spi/cf/CFBundleSPI.h>
 #include <wtf/text/TextStream.h>
 #include <wtf/text/WTFString.h>
@@ -103,8 +104,8 @@ Vector<String> platformUserPreferredLanguages(ShouldMinimizeLanguages shouldMini
         return { "en"_s };
 
     Vector<String> languages(platformLanguagesCount, [&](size_t i) {
-        auto platformLanguage = static_cast<CFStringRef>(CFArrayGetValueAtIndex(platformLanguages.get(), i));
-        return httpStyleLanguageCode(platformLanguage, shouldMinimizeLanguages);
+        RetainPtr platformLanguage = checked_cf_cast<CFStringRef>(CFArrayGetValueAtIndex(platformLanguages.get(), i));
+        return httpStyleLanguageCode(platformLanguage.get(), shouldMinimizeLanguages);
     });
 
     LOG_WITH_STREAM(Language, stream << "After passing through httpStyleLanguageCode: "_s << languages);

--- a/Source/WTF/wtf/cf/SchedulePairCF.cpp
+++ b/Source/WTF/wtf/cf/SchedulePairCF.cpp
@@ -35,11 +35,9 @@ bool SchedulePair::operator==(const SchedulePair& other) const
 {
     if (runLoop() != other.runLoop())
         return false;
-    CFStringRef thisMode = mode();
-    CFStringRef otherMode = other.mode();
-    if (!thisMode || !otherMode)
-        return thisMode == otherMode;
-    return CFEqual(thisMode, otherMode);
+    if (!m_mode || !other.m_mode)
+        return m_mode == other.m_mode;
+    return CFEqual(m_mode.get(), other.m_mode.get());
 }
 
 } // namespace

--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -215,18 +215,18 @@ void LibraryPathDiagnosticsLogger::logDynamicLibraryInfo(void)
 
 void LibraryPathDiagnosticsLogger::logBundleInfo(const String& bundleIdentifier)
 {
-    auto bundle = CFBundleGetBundleWithIdentifier(bundleIdentifier.createCFString().get());
+    RetainPtr bundle = CFBundleGetBundleWithIdentifier(bundleIdentifier.createCFString().get());
     if (!bundle)
         return;
 
     auto bundleInfo = JSON::Object::create();
 
-    auto bundleCFURL = adoptCF(CFBundleCopyBundleURL(bundle));
+    auto bundleCFURL = adoptCF(CFBundleCopyBundleURL(bundle.get()));
     auto bundleURL = URL(bundleCFURL.get());
     bundleInfo->setString("Path"_s, FileSystem::realPath(bundleURL.fileSystemPath()));
 
-    if (auto version = dynamic_cf_cast<CFStringRef>(CFBundleGetValueForInfoDictionaryKey(bundle, kCFBundleVersionKey)))
-        bundleInfo->setString("Version"_s, String(version));
+    if (RetainPtr version = dynamic_cf_cast<CFStringRef>(CFBundleGetValueForInfoDictionaryKey(bundle.get(), kCFBundleVersionKey)))
+        bundleInfo->setString("Version"_s, String(version.get()));
     else
         bundleInfo->setValue("Version"_s, JSON::Value::null());
 

--- a/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
+++ b/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
@@ -42,6 +42,7 @@
 #if OS(DARWIN) && USE(CF)
 #include <CoreFoundation/CoreFoundation.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/cf/TypeCastsCF.h>
 #endif
 
 namespace WTF {
@@ -75,10 +76,11 @@ static inline CString copyShortASCIIString(CFStringRef string)
 static CString copyDefaultLocale()
 {
 #if !PLATFORM(IOS_FAMILY)
-    return copyShortASCIIString(static_cast<CFStringRef>(CFLocaleGetValue(adoptCF(CFLocaleCopyCurrent()).get(), kCFLocaleCollatorIdentifier)));
+    RetainPtr locale = checked_cf_cast<CFStringRef>(CFLocaleGetValue(adoptCF(CFLocaleCopyCurrent()).get(), kCFLocaleCollatorIdentifier));
+    return copyShortASCIIString(locale.get());
 #else
     // FIXME: Documentation claims the code above would work on iOS 4.0 and later. After test that works, we should remove this and use that instead.
-    return copyShortASCIIString(adoptCF(static_cast<CFStringRef>(CFPreferencesCopyValue(CFSTR("AppleCollationOrder"), kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost))).get());
+    return copyShortASCIIString(adoptCF(checked_cf_cast<CFStringRef>(CFPreferencesCopyValue(CFSTR("AppleCollationOrder"), kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost))).get());
 #endif
 }
 


### PR DESCRIPTION
#### cf5158ff13414086cf278848cd2c881835e69d0c
<pre>
Address some Safer CPP warnings in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=301244">https://bugs.webkit.org/show_bug.cgi?id=301244</a>

Reviewed by Geoffrey Garen.

* Source/WTF/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtr&lt;T&gt;::RetainPtr):
* Source/WTF/wtf/SchedulePair.h:
(WTF::add):
* Source/WTF/wtf/cf/LanguageCF.cpp:
(WTF::platformUserPreferredLanguages):
* Source/WTF/wtf/cf/SchedulePairCF.cpp:
(WTF::SchedulePair::operator== const):
* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
(WTF::LibraryPathDiagnosticsLogger::logBundleInfo):
* Source/WTF/wtf/unicode/icu/CollatorICU.cpp:
(WTF::copyDefaultLocale):

Canonical link: <a href="https://commits.webkit.org/302013@main">https://commits.webkit.org/302013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a965a80279b4a0bfad179ac7e04aa33b158b399b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135015 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c8fb383b-79be-462c-a37e-f9b6005b86fc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55922 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97232 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6cac737d-5233-490f-baf7-9c8906e343b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130691 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/38399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77714 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/578f0a89-9460-4ad1-a5de-31d56ac73cbf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32527 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78385 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119780 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137499 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126207 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41938 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105755 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54913 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26887 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/50930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29364 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/52023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60546 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53575 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/57030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55332 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->