### PR TITLE
Address Safer CPP casting warnings in WebGPUDowncastConvertToBackingContext.cpp

### DIFF
--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
@@ -117,6 +117,8 @@ public:
     virtual bool isValid(const XRProjectionLayer&) const = 0;
     virtual bool isValid(const XRView&) const = 0;
 
+    virtual bool isRemoteGPUProxy() const { return false; }
+
 protected:
     GPU() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUAdapter.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUAdapter.h
@@ -48,6 +48,7 @@ public:
     SupportedLimits& limits() const { return m_limits; }
     bool isFallbackAdapter() const { return m_isFallbackAdapter; }
     virtual bool xrCompatible() = 0;
+    virtual bool isRemoteAdapterProxy() const { return false; }
 
     virtual void requestDevice(const DeviceDescriptor&, CompletionHandler<void(RefPtr<Device>&&)>&&) = 0;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroup.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroup.h
@@ -47,6 +47,8 @@ public:
         setLabelInternal(m_label);
     }
 
+    virtual bool isRemoteBindGroupProxy() const { return false; }
+
 protected:
     BindGroup() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupLayout.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupLayout.h
@@ -45,6 +45,8 @@ public:
         setLabelInternal(m_label);
     }
 
+    virtual bool isRemoteBindGroupLayoutProxy() const { return false; }
+
 protected:
     BindGroupLayout() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
@@ -56,6 +56,9 @@ public:
     virtual void destroy() = 0;
     virtual std::span<uint8_t> getBufferContents() = 0;
     virtual void copyFrom(std::span<const uint8_t>, size_t offset) = 0;
+
+    virtual bool isRemoteBufferProxy() const { return false; }
+
 protected:
     Buffer() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandBuffer.h
@@ -44,6 +44,8 @@ public:
         setLabelInternal(m_label);
     }
 
+    virtual bool isRemoteCommandBufferProxy() const { return false; }
+
 protected:
     CommandBuffer() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandEncoder.h
@@ -102,6 +102,7 @@ public:
         Size64 destinationOffset) = 0;
 
     virtual RefPtr<CommandBuffer> finish(const CommandBufferDescriptor&) = 0;
+    virtual bool isRemoteCommandEncoderProxy() const { return false; }
 
 protected:
     CommandEncoder() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h
@@ -65,6 +65,7 @@ public:
     virtual void withDisplayBufferAsNativeImage(uint32_t bufferIndex, Function<void(WebCore::NativeImage*)>) = 0;
     virtual void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t bufferIndex) = 0;
     virtual void updateContentsHeadroom(float) = 0;
+    virtual bool isRemoteCompositorIntegrationProxy() const { return false; }
 
 protected:
     CompositorIntegration() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassEncoder.h
@@ -70,6 +70,7 @@ public:
     virtual void pushDebugGroup(String&& groupLabel) = 0;
     virtual void popDebugGroup() = 0;
     virtual void insertDebugMarker(String&& markerLabel) = 0;
+    virtual bool isRemoteComputePassEncoderProxy() const { return false; }
 
 protected:
     ComputePassEncoder() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePipeline.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePipeline.h
@@ -49,6 +49,7 @@ public:
 
     // "A new GPUBindGroupLayout wrapper is returned each time"
     virtual Ref<BindGroupLayout> getBindGroupLayout(uint32_t index) = 0;
+    virtual bool isRemoteComputePipelineProxy() const { return false; }
 
 protected:
     ComputePipeline() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTexture.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTexture.h
@@ -53,6 +53,7 @@ public:
 #if PLATFORM(COCOA)
     virtual void updateExternalTexture(CVPixelBufferRef) = 0;
 #endif
+    virtual bool isRemoteExternalTextureProxy() const { return false; }
 
 protected:
     ExternalTexture() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineLayout.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineLayout.h
@@ -44,6 +44,8 @@ public:
         setLabelInternal(m_label);
     }
 
+    virtual bool isRemotePipelineLayoutProxy() const { return false; }
+
 protected:
     PipelineLayout() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h
@@ -55,6 +55,8 @@ public:
     virtual RefPtr<Texture> getCurrentTexture(uint32_t) = 0;
     virtual RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat) = 0;
 
+    virtual bool isRemotePresentationContextProxy() const { return false; }
+
 protected:
     PresentationContext() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQuerySet.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQuerySet.h
@@ -45,6 +45,7 @@ public:
     }
 
     virtual void destroy() = 0;
+    virtual bool isRemoteQuerySetProxy() const { return false; }
 
 protected:
     QuerySet() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
@@ -99,6 +99,8 @@ public:
         const Extent3D& copySize) = 0;
 
     virtual RefPtr<WebCore::NativeImage> getNativeImage(WebCore::VideoFrame&) = 0;
+    virtual bool isRemoteQueueProxy() const { return false; }
+
 protected:
     Queue() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundle.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundle.h
@@ -44,6 +44,8 @@ public:
         setLabelInternal(m_label);
     }
 
+    virtual bool isRemoteRenderBundleProxy() const { return false; }
+
 protected:
     RenderBundle() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundleEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundleEncoder.h
@@ -83,6 +83,7 @@ public:
     virtual void insertDebugMarker(String&& markerLabel) = 0;
 
     virtual RefPtr<RenderBundle> finish(const RenderBundleDescriptor&) = 0;
+    virtual bool isRemoteRenderBundleEncoderProxy() const { return false; }
 
 protected:
     RenderBundleEncoder() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassEncoder.h
@@ -100,6 +100,8 @@ public:
     virtual void executeBundles(Vector<Ref<RenderBundle>>&&) = 0;
     virtual void end() = 0;
 
+    virtual bool isRemoteRenderPassEncoderProxy() const { return false; }
+
 protected:
     RenderPassEncoder() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPipeline.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPipeline.h
@@ -49,6 +49,7 @@ public:
 
     // "A new GPUBindGroupLayout wrapper is returned each time"
     virtual Ref<BindGroupLayout> getBindGroupLayout(uint32_t index) = 0;
+    virtual bool isRemoteRenderPipelineProxy() const { return false; }
 
 protected:
     RenderPipeline() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUSampler.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUSampler.h
@@ -44,6 +44,8 @@ public:
         setLabelInternal(m_label);
     }
 
+    virtual bool isRemoteSamplerProxy() const { return false; }
+
 protected:
     Sampler() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModule.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModule.h
@@ -49,6 +49,7 @@ public:
     }
 
     virtual void compilationInfo(CompletionHandler<void(Ref<CompilationInfo>&&)>&&) = 0;
+    virtual bool isRemoteShaderModuleProxy() const { return false; }
 
 protected:
     ShaderModule() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h
@@ -53,6 +53,8 @@ public:
     virtual void destroy() = 0;
     virtual void undestroy() = 0;
 
+    virtual bool isRemoteTextureProxy() const { return false; }
+
 protected:
     Texture() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureView.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureView.h
@@ -44,6 +44,8 @@ public:
         setLabelInternal(m_label);
     }
 
+    virtual bool isRemoteTextureViewProxy() const { return false; }
+
 protected:
     TextureView() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRBinding.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRBinding.h
@@ -52,6 +52,7 @@ public:
     virtual RefPtr<XRSubImage> getSubImage(XRProjectionLayer&, WebCore::WebXRFrame&, std::optional<XREye>/* = "none"*/) = 0;
     virtual RefPtr<XRSubImage> getViewSubImage(XRProjectionLayer&) = 0;
     virtual TextureFormat getPreferredColorFormat() = 0;
+    virtual bool isRemoteXRBindingProxy() const { return false; }
 
 protected:
     XRBinding() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRSubImage.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRSubImage.h
@@ -41,6 +41,7 @@ public:
     virtual RefPtr<Texture> colorTexture() = 0;
     virtual RefPtr<Texture> depthStencilTexture() = 0;
     virtual RefPtr<Texture> motionVectorTexture() = 0;
+    virtual bool isRemoteXRSubImageProxy() const { return false; }
 
 protected:
     XRSubImage() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRView.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRView.h
@@ -38,6 +38,8 @@ class XRView : public RefCountedAndCanMakeWeakPtr<XRView> {
 public:
     virtual ~XRView() = default;
 
+    virtual bool isRemoteXRViewProxy() const { return false; }
+
 protected:
     XRView() = default;
 

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,7 +1,6 @@
 AutomationProtocolObjects.h
 WebDriverBidiProtocolObjects.h
 WebProcess/GPU/graphics/Model/ModelDowncastConvertToBackingContext.cpp
-WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
 [ iOS ] NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
 [ iOS ] Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
 [ iOS ] UIProcess/API/ios/WKWebViewIOS.mm

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
@@ -63,6 +63,8 @@ private:
     RemoteAdapterProxy& operator=(const RemoteAdapterProxy&) = delete;
     RemoteAdapterProxy& operator=(RemoteAdapterProxy&&) = delete;
 
+    bool isRemoteAdapterProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     bool xrCompatible() final;
     
@@ -86,5 +88,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteAdapterProxy)
+    static bool isType(const WebCore::WebGPU::Adapter& adapter) { return adapter.isRemoteAdapterProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
@@ -59,6 +59,8 @@ private:
     RemoteBindGroupLayoutProxy& operator=(const RemoteBindGroupLayoutProxy&) = delete;
     RemoteBindGroupLayoutProxy& operator=(RemoteBindGroupLayoutProxy&&) = delete;
 
+    bool isRemoteBindGroupLayoutProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -75,5 +77,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteBindGroupLayoutProxy)
+    static bool isType(const WebCore::WebGPU::BindGroupLayout& layout) { return layout.isRemoteBindGroupLayoutProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
@@ -63,6 +63,8 @@ private:
     RemoteBindGroupProxy& operator=(const RemoteBindGroupProxy&) = delete;
     RemoteBindGroupProxy& operator=(RemoteBindGroupProxy&&) = delete;
 
+    bool isRemoteBindGroupProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -85,5 +87,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteBindGroupProxy)
+    static bool isType(const WebCore::WebGPU::BindGroup& group) { return group.isRemoteBindGroupProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -60,6 +60,8 @@ private:
     RemoteBufferProxy& operator=(const RemoteBufferProxy&) = delete;
     RemoteBufferProxy& operator=(RemoteBufferProxy&&) = delete;
 
+    bool isRemoteBufferProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -95,5 +97,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteBufferProxy)
+    static bool isType(const WebCore::WebGPU::Buffer& buffer) { return buffer.isRemoteBufferProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
@@ -58,6 +58,8 @@ private:
     RemoteCommandBufferProxy& operator=(const RemoteCommandBufferProxy&) = delete;
     RemoteCommandBufferProxy& operator=(RemoteCommandBufferProxy&&) = delete;
 
+    bool isRemoteCommandBufferProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -74,5 +76,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteCommandBufferProxy)
+    static bool isType(const WebCore::WebGPU::CommandBuffer& buffer) { return buffer.isRemoteCommandBufferProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
@@ -58,6 +58,8 @@ private:
     RemoteCommandEncoderProxy& operator=(const RemoteCommandEncoderProxy&) = delete;
     RemoteCommandEncoderProxy& operator=(RemoteCommandEncoderProxy&&) = delete;
 
+    bool isRemoteCommandEncoderProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -124,5 +126,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteCommandEncoderProxy)
+    static bool isType(const WebCore::WebGPU::CommandEncoder& encoder) { return encoder.isRemoteCommandEncoderProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -77,6 +77,8 @@ private:
     RemoteCompositorIntegrationProxy& operator=(const RemoteCompositorIntegrationProxy&) = delete;
     RemoteCompositorIntegrationProxy& operator=(RemoteCompositorIntegrationProxy&&) = delete;
 
+    bool isRemoteCompositorIntegrationProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -104,5 +106,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteCompositorIntegrationProxy)
+    static bool isType(const WebCore::WebGPU::CompositorIntegration& integration) { return integration.isRemoteCompositorIntegrationProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
@@ -58,6 +58,8 @@ private:
     RemoteComputePassEncoderProxy& operator=(const RemoteComputePassEncoderProxy&) = delete;
     RemoteComputePassEncoderProxy& operator=(RemoteComputePassEncoderProxy&&) = delete;
 
+    bool isRemoteComputePassEncoderProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -92,5 +94,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteComputePassEncoderProxy)
+    static bool isType(const WebCore::WebGPU::ComputePassEncoder& encoder) { return encoder.isRemoteComputePassEncoderProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
@@ -61,6 +61,8 @@ private:
     RemoteComputePipelineProxy& operator=(const RemoteComputePipelineProxy&) = delete;
     RemoteComputePipelineProxy& operator=(RemoteComputePipelineProxy&&) = delete;
 
+    bool isRemoteComputePipelineProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -79,5 +81,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteComputePipelineProxy)
+    static bool isType(const WebCore::WebGPU::ComputePipeline& pipeline) { return pipeline.isRemoteComputePipelineProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
@@ -59,6 +59,8 @@ private:
     RemoteExternalTextureProxy& operator=(const RemoteExternalTextureProxy&) = delete;
     RemoteExternalTextureProxy& operator=(RemoteExternalTextureProxy&&) = delete;
 
+    bool isRemoteExternalTextureProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -80,5 +82,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteExternalTextureProxy)
+    static bool isType(const WebCore::WebGPU::ExternalTexture& texture) { return texture.isRemoteExternalTextureProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -90,6 +90,8 @@ private:
     RemoteGPUProxy& operator=(const RemoteGPUProxy&) = delete;
     RemoteGPUProxy& operator=(RemoteGPUProxy&&) = delete;
 
+    bool isRemoteGPUProxy() const final { return true; }
+
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     void didClose(IPC::Connection&) final;
@@ -170,5 +172,9 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::RemoteGPUProxy)
+    static bool isType(const WebCore::WebGPU::GPU& gpu) { return gpu.isRemoteGPUProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
@@ -59,6 +59,8 @@ private:
     RemotePipelineLayoutProxy& operator=(const RemotePipelineLayoutProxy&) = delete;
     RemotePipelineLayoutProxy& operator=(RemotePipelineLayoutProxy&&) = delete;
 
+    bool isRemotePipelineLayoutProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -75,5 +77,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemotePipelineLayoutProxy)
+    static bool isType(const WebCore::WebGPU::PipelineLayout& layout) { return layout.isRemotePipelineLayoutProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -69,6 +69,8 @@ private:
     RemotePresentationContextProxy& operator=(const RemotePresentationContextProxy&) = delete;
     RemotePresentationContextProxy& operator=(RemotePresentationContextProxy&&) = delete;
 
+    bool isRemotePresentationContextProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
 
     RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t, bool& isIOSurfaceSupportedFormat) final;
@@ -92,5 +94,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemotePresentationContextProxy)
+    static bool isType(const WebCore::WebGPU::PresentationContext& context) { return context.isRemotePresentationContextProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
@@ -59,6 +59,8 @@ private:
     RemoteQuerySetProxy& operator=(const RemoteQuerySetProxy&) = delete;
     RemoteQuerySetProxy& operator=(RemoteQuerySetProxy&&) = delete;
 
+    bool isRemoteQuerySetProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -77,5 +79,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteQuerySetProxy)
+    static bool isType(const WebCore::WebGPU::QuerySet& set) { return set.isRemoteQuerySetProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -61,6 +61,8 @@ private:
     RemoteQueueProxy& operator=(const RemoteQueueProxy&) = delete;
     RemoteQueueProxy& operator=(RemoteQueueProxy&&) = delete;
 
+    bool isRemoteQueueProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
 
     template<typename T>
@@ -122,5 +124,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteQueueProxy)
+    static bool isType(const WebCore::WebGPU::Queue& queue) { return queue.isRemoteQueueProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
@@ -59,6 +59,8 @@ private:
     RemoteRenderBundleEncoderProxy& operator=(const RemoteRenderBundleEncoderProxy&) = delete;
     RemoteRenderBundleEncoderProxy& operator=(RemoteRenderBundleEncoderProxy&&) = delete;
 
+    bool isRemoteRenderBundleEncoderProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
 
     template<typename T>
@@ -104,5 +106,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteRenderBundleEncoderProxy)
+    static bool isType(const WebCore::WebGPU::RenderBundleEncoder& encoder) { return encoder.isRemoteRenderBundleEncoderProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
@@ -59,6 +59,8 @@ private:
     RemoteRenderBundleProxy& operator=(const RemoteRenderBundleProxy&) = delete;
     RemoteRenderBundleProxy& operator=(RemoteRenderBundleProxy&&) = delete;
 
+    bool isRemoteRenderBundleProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -75,5 +77,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteRenderBundleProxy)
+    static bool isType(const WebCore::WebGPU::RenderBundle& bundle) { return bundle.isRemoteRenderBundleProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -58,6 +58,8 @@ private:
     RemoteRenderPassEncoderProxy& operator=(const RemoteRenderPassEncoderProxy&) = delete;
     RemoteRenderPassEncoderProxy& operator=(RemoteRenderPassEncoderProxy&&) = delete;
 
+    bool isRemoteRenderPassEncoderProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -117,5 +119,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteRenderPassEncoderProxy)
+    static bool isType(const WebCore::WebGPU::RenderPassEncoder& encoder) { return encoder.isRemoteRenderPassEncoderProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
@@ -61,6 +61,8 @@ private:
     RemoteRenderPipelineProxy& operator=(const RemoteRenderPipelineProxy&) = delete;
     RemoteRenderPipelineProxy& operator=(RemoteRenderPipelineProxy&&) = delete;
 
+    bool isRemoteRenderPipelineProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -79,5 +81,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteRenderPipelineProxy)
+    static bool isType(const WebCore::WebGPU::RenderPipeline& pipeline) { return pipeline.isRemoteRenderPipelineProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
@@ -59,6 +59,8 @@ private:
     RemoteSamplerProxy& operator=(const RemoteSamplerProxy&) = delete;
     RemoteSamplerProxy& operator=(RemoteSamplerProxy&&) = delete;
 
+    bool isRemoteSamplerProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -75,5 +77,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteSamplerProxy)
+    static bool isType(const WebCore::WebGPU::Sampler& sampler) { return sampler.isRemoteSamplerProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
@@ -59,6 +59,8 @@ private:
     RemoteShaderModuleProxy& operator=(const RemoteShaderModuleProxy&) = delete;
     RemoteShaderModuleProxy& operator=(RemoteShaderModuleProxy&&) = delete;
 
+    bool isRemoteShaderModuleProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -82,5 +84,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteShaderModuleProxy)
+    static bool isType(const WebCore::WebGPU::ShaderModule& module) { return module.isRemoteShaderModuleProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -63,6 +63,8 @@ private:
     RemoteTextureProxy& operator=(const RemoteTextureProxy&) = delete;
     RemoteTextureProxy& operator=(RemoteTextureProxy&&) = delete;
 
+    bool isRemoteTextureProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -86,5 +88,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteTextureProxy)
+    static bool isType(const WebCore::WebGPU::Texture& texture) { return texture.isRemoteTextureProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
@@ -58,6 +58,8 @@ private:
     RemoteTextureViewProxy& operator=(const RemoteTextureViewProxy&) = delete;
     RemoteTextureViewProxy& operator=(RemoteTextureViewProxy&&) = delete;
 
+    bool isRemoteTextureViewProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
@@ -74,5 +76,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteTextureViewProxy)
+    static bool isType(const WebCore::WebGPU::TextureView& view) { return view.isRemoteTextureViewProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.h
@@ -72,6 +72,8 @@ private:
     RemoteXRBindingProxy& operator=(const RemoteXRBindingProxy&) = delete;
     RemoteXRBindingProxy& operator=(RemoteXRBindingProxy&&) = delete;
 
+    bool isRemoteXRBindingProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
 
     RefPtr<WebCore::WebGPU::XRProjectionLayer> createProjectionLayer(const WebCore::WebGPU::XRProjectionLayerInit&) final;
@@ -96,5 +98,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteXRBindingProxy)
+    static bool isType(const WebCore::WebGPU::XRBinding& binding) { return binding.isRemoteXRBindingProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.h
@@ -68,6 +68,8 @@ private:
     RemoteXRSubImageProxy& operator=(const RemoteXRSubImageProxy&) = delete;
     RemoteXRSubImageProxy& operator=(RemoteXRSubImageProxy&&) = delete;
 
+    bool isRemoteXRSubImageProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
     RefPtr<WebCore::WebGPU::Texture> colorTexture() final;
     RefPtr<WebCore::WebGPU::Texture> depthStencilTexture() final;
@@ -93,5 +95,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteXRSubImageProxy)
+    static bool isType(const WebCore::WebGPU::XRSubImage& image) { return image.isRemoteXRSubImageProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRViewProxy.h
@@ -71,6 +71,8 @@ private:
     RemoteXRViewProxy& operator=(const RemoteXRViewProxy&) = delete;
     RemoteXRViewProxy& operator=(RemoteXRViewProxy&&) = delete;
 
+    bool isRemoteXRViewProxy() const final { return true; }
+
     WebGPUIdentifier backing() const { return m_backing; }
 
     template<typename T>
@@ -90,5 +92,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteXRViewProxy)
+    static bool isType(const WebCore::WebGPU::XRView& view) { return view.isRemoteXRViewProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
@@ -64,147 +64,147 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(DowncastConvertToBackingContext);
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::Adapter& adapter)
 {
-    return static_cast<const RemoteAdapterProxy&>(adapter).backing();
+    return downcast<RemoteAdapterProxy>(adapter).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::BindGroup& bindGroup)
 {
-    return static_cast<const RemoteBindGroupProxy&>(bindGroup).backing();
+    return downcast<RemoteBindGroupProxy>(bindGroup).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::BindGroupLayout& bindGroupLayout)
 {
-    return static_cast<const RemoteBindGroupLayoutProxy&>(bindGroupLayout).backing();
+    return downcast<RemoteBindGroupLayoutProxy>(bindGroupLayout).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::Buffer& buffer)
 {
-    return static_cast<const RemoteBufferProxy&>(buffer).backing();
+    return downcast<RemoteBufferProxy>(buffer).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::CommandBuffer& commandBuffer)
 {
-    return static_cast<const RemoteCommandBufferProxy&>(commandBuffer).backing();
+    return downcast<RemoteCommandBufferProxy>(commandBuffer).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::CommandEncoder& commandEncoder)
 {
-    return static_cast<const RemoteCommandEncoderProxy&>(commandEncoder).backing();
+    return downcast<RemoteCommandEncoderProxy>(commandEncoder).backing();
 }
 
 const RemoteCompositorIntegrationProxy& DowncastConvertToBackingContext::convertToRawBacking(const WebCore::WebGPU::CompositorIntegration& compositorIntegration)
 {
-    return static_cast<const RemoteCompositorIntegrationProxy&>(compositorIntegration);
+    return downcast<RemoteCompositorIntegrationProxy>(compositorIntegration);
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::CompositorIntegration& compositorIntegration)
 {
-    return static_cast<const RemoteCompositorIntegrationProxy&>(compositorIntegration).backing();
+    return downcast<RemoteCompositorIntegrationProxy>(compositorIntegration).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ComputePassEncoder& computePassEncoder)
 {
-    return static_cast<const RemoteComputePassEncoderProxy&>(computePassEncoder).backing();
+    return downcast<RemoteComputePassEncoderProxy>(computePassEncoder).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ComputePipeline& computePipeline)
 {
-    return static_cast<const RemoteComputePipelineProxy&>(computePipeline).backing();
+    return downcast<RemoteComputePipelineProxy>(computePipeline).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::Device& device)
 {
-    return static_cast<const RemoteDeviceProxy&>(device).backing();
+    return downcast<RemoteDeviceProxy>(device).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ExternalTexture& externalTexture)
 {
-    return static_cast<const RemoteExternalTextureProxy&>(externalTexture).backing();
+    return downcast<RemoteExternalTextureProxy>(externalTexture).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::GPU& gpu)
 {
-    return static_cast<const RemoteGPUProxy&>(gpu).backing();
+    return downcast<RemoteGPUProxy>(gpu).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::PipelineLayout& pipelineLayout)
 {
-    return static_cast<const RemotePipelineLayoutProxy&>(pipelineLayout).backing();
+    return downcast<RemotePipelineLayoutProxy>(pipelineLayout).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::PresentationContext& presentationContext)
 {
-    return static_cast<const RemotePresentationContextProxy&>(presentationContext).backing();
+    return downcast<RemotePresentationContextProxy>(presentationContext).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::QuerySet& querySet)
 {
-    return static_cast<const RemoteQuerySetProxy&>(querySet).backing();
+    return downcast<RemoteQuerySetProxy>(querySet).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::Queue& queue)
 {
-    return static_cast<const RemoteQueueProxy&>(queue).backing();
+    return downcast<RemoteQueueProxy>(queue).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::RenderBundleEncoder& renderBundleEncoder)
 {
-    return static_cast<const RemoteRenderBundleEncoderProxy&>(renderBundleEncoder).backing();
+    return downcast<RemoteRenderBundleEncoderProxy>(renderBundleEncoder).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::RenderBundle& renderBundle)
 {
-    return static_cast<const RemoteRenderBundleProxy&>(renderBundle).backing();
+    return downcast<RemoteRenderBundleProxy>(renderBundle).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::RenderPassEncoder& renderPassEncoder)
 {
-    return static_cast<const RemoteRenderPassEncoderProxy&>(renderPassEncoder).backing();
+    return downcast<RemoteRenderPassEncoderProxy>(renderPassEncoder).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::RenderPipeline& renderPipeline)
 {
-    return static_cast<const RemoteRenderPipelineProxy&>(renderPipeline).backing();
+    return downcast<RemoteRenderPipelineProxy>(renderPipeline).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::Sampler& sampler)
 {
-    return static_cast<const RemoteSamplerProxy&>(sampler).backing();
+    return downcast<RemoteSamplerProxy>(sampler).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ShaderModule& shaderModule)
 {
-    return static_cast<const RemoteShaderModuleProxy&>(shaderModule).backing();
+    return downcast<RemoteShaderModuleProxy>(shaderModule).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::Texture& texture)
 {
-    return static_cast<const RemoteTextureProxy&>(texture).backing();
+    return downcast<RemoteTextureProxy>(texture).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::TextureView& textureView)
 {
-    return static_cast<const RemoteTextureViewProxy&>(textureView).backing();
+    return downcast<RemoteTextureViewProxy>(textureView).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::XRBinding& xrBinding)
 {
-    return static_cast<const RemoteXRBindingProxy&>(xrBinding).backing();
+    return downcast<RemoteXRBindingProxy>(xrBinding).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::XRProjectionLayer& layer)
 {
-    return static_cast<const RemoteXRProjectionLayerProxy&>(layer).backing();
+    return downcast<RemoteXRProjectionLayerProxy>(layer).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::XRSubImage& subImage)
 {
-    return static_cast<const RemoteXRSubImageProxy&>(subImage).backing();
+    return downcast<RemoteXRSubImageProxy>(subImage).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::XRView& view)
 {
-    return static_cast<const RemoteXRViewProxy&>(view).backing();
+    return downcast<RemoteXRViewProxy>(view).backing();
 }
 
 } // namespace WebKit::WebGPU


### PR DESCRIPTION
#### 74f36b25384f0d2a8ecd7e0b467a47532103e5c5
<pre>
Address Safer CPP casting warnings in WebGPUDowncastConvertToBackingContext.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=301248">https://bugs.webkit.org/show_bug.cgi?id=301248</a>

Reviewed by Mike Wyrzykowski.

* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h:
(WebCore::WebGPU::GPU::isRemoteGPUProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUAdapter.h:
(WebCore::WebGPU::Adapter::isRemoteAdapterProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroup.h:
(WebCore::WebGPU::BindGroup::isRemoteBindGroupProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupLayout.h:
(WebCore::WebGPU::BindGroupLayout::isRemoteBindGroupLayoutProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h:
(WebCore::WebGPU::Buffer::isRemoteBufferProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandBuffer.h:
(WebCore::WebGPU::CommandBuffer::isRemoteCommandBufferProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandEncoder.h:
(WebCore::WebGPU::CommandEncoder::isRemoteCommandEncoderProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h:
(WebCore::WebGPU::CompositorIntegration::isRemoteCompositorIntegrationProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassEncoder.h:
(WebCore::WebGPU::ComputePassEncoder::isRemoteComputePassEncoderProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePipeline.h:
(WebCore::WebGPU::ComputePipeline::isRemoteComputePipelineProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTexture.h:
(WebCore::WebGPU::ExternalTexture::isRemoteExternalTextureProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineLayout.h:
(WebCore::WebGPU::PipelineLayout::isRemotePipelineLayoutProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h:
(WebCore::WebGPU::PresentationContext::isRemotePresentationContextProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQuerySet.h:
(WebCore::WebGPU::QuerySet::isRemoteQuerySetProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h:
(WebCore::WebGPU::Queue::isRemoteQueueProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundle.h:
(WebCore::WebGPU::RenderBundle::isRemoteRenderBundleProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundleEncoder.h:
(WebCore::WebGPU::RenderBundleEncoder::isRemoteRenderBundleEncoderProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassEncoder.h:
(WebCore::WebGPU::RenderPassEncoder::isRemoteRenderPassEncoderProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPipeline.h:
(WebCore::WebGPU::RenderPipeline::isRemoteRenderPipelineProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUSampler.h:
(WebCore::WebGPU::Sampler::isRemoteSamplerProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModule.h:
(WebCore::WebGPU::ShaderModule::isRemoteShaderModuleProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h:
(WebCore::WebGPU::Texture::isRemoteTextureProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureView.h:
(WebCore::WebGPU::TextureView::isRemoteTextureViewProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRBinding.h:
(WebCore::WebGPU::XRBinding::isRemoteXRBindingProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRSubImage.h:
(WebCore::WebGPU::XRSubImage::isRemoteXRSubImageProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRView.h:
(WebCore::WebGPU::XRView::isRemoteXRViewProxy const):
* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRViewProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp:
(WebKit::WebGPU::DowncastConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::DowncastConvertToBackingContext::convertToRawBacking):

Canonical link: <a href="https://commits.webkit.org/302009@main">https://commits.webkit.org/302009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63a5a665e16ca12af0acbb9d4635194b0bd4b88b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134650 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79130 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0795c880-2812-4830-971e-f5291aad8d9b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97111 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65027 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/42aa7874-d702-4191-b18c-b7bcd48606b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77591 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c9a15c5c-a1b0-4f4c-a26c-462d4e1f2384) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32356 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78023 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108128 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137134 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105638 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105289 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26886 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50803 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29243 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51818 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54169 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60256 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53403 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56860 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55162 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->