### PR TITLE
[MSE] All SourceBufferPrivateParser calls should be made on provided callback

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -354,20 +354,24 @@ void SourceBufferParserAVFObjC::didProvideMediaDataForTrackID(TrackID trackID, C
 void SourceBufferParserAVFObjC::willProvideContentKeyRequestInitializationDataForTrackID(uint64_t trackID)
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, "trackID = ", trackID);
-    m_willProvideContentKeyRequestInitializationDataForTrackIDCallback(trackID);
+    m_callOnClientThreadCallback([protectedThis = Ref { *this }, trackID] {
+        protectedThis->m_willProvideContentKeyRequestInitializationDataForTrackIDCallback(trackID);
+    });
 }
 
 void SourceBufferParserAVFObjC::didProvideContentKeyRequestInitializationDataForTrackID(NSData* nsInitData, uint64_t trackID)
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, "trackID = ", trackID);
-    m_didProvideContentKeyRequestInitializationDataForTrackIDCallback(SharedBuffer::create(nsInitData), trackID);
+    m_callOnClientThreadCallback([protectedThis = Ref { *this }, initData = SharedBuffer::create(nsInitData), trackID]() mutable {
+        protectedThis->m_didProvideContentKeyRequestInitializationDataForTrackIDCallback(WTFMove(initData), trackID);
+    });
 }
 
 void SourceBufferParserAVFObjC::didProvideContentKeyRequestSpecifierForTrackID(NSData* nsInitData, uint64_t trackID)
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, "trackID = ", trackID);
-    m_callOnClientThreadCallback([this, protectedThis = Ref { *this }, nsInitData = retainPtr(nsInitData), trackID] {
-        m_didProvideContentKeyRequestIdentifierForTrackIDCallback(SharedBuffer::create(nsInitData.get()), trackID);
+    m_callOnClientThreadCallback([protectedThis = Ref { *this }, initData = SharedBuffer::create(nsInitData), trackID]() mutable {
+        protectedThis->m_didProvideContentKeyRequestIdentifierForTrackIDCallback(WTFMove(initData), trackID);
     });
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
@@ -64,6 +64,7 @@ public:
         Discontinuity,
     };
 
+    // All callbacks will be called via this function if set.
     using CallOnClientThreadCallback = Function<void(Function<void()>&&)>;
     void setCallOnClientThreadCallback(CallOnClientThreadCallback&&);
 
@@ -78,7 +79,6 @@ public:
     virtual void setLogger(const Logger&, uint64_t logIdentifier) = 0;
 #endif
 
-    // Will be called on the main thread.
     using InitializationSegment = SourceBufferPrivateClient::InitializationSegment;
     using DidParseInitializationDataCallback = Function<void(InitializationSegment&&)>;
     void setDidParseInitializationDataCallback(DidParseInitializationDataCallback&& callback)
@@ -86,35 +86,30 @@ public:
         m_didParseInitializationDataCallback = WTFMove(callback);
     }
 
-    // Will be called on the main thread.
     using DidProvideMediaDataCallback = Function<void(Ref<MediaSampleAVFObjC>&&, uint64_t trackID, const String& mediaType)>;
     void setDidProvideMediaDataCallback(DidProvideMediaDataCallback&& callback)
     {
         m_didProvideMediaDataCallback = WTFMove(callback);
     }
 
-    // Will be called synchronously on the parser thead.
     using WillProvideContentKeyRequestInitializationDataForTrackIDCallback = Function<void(uint64_t trackID)>;
     void setWillProvideContentKeyRequestInitializationDataForTrackIDCallback(WillProvideContentKeyRequestInitializationDataForTrackIDCallback&& callback)
     {
         m_willProvideContentKeyRequestInitializationDataForTrackIDCallback = WTFMove(callback);
     }
 
-    // Will be called synchronously on the parser thead.
     using DidProvideContentKeyRequestInitializationDataForTrackIDCallback = Function<void(Ref<SharedBuffer>&&, uint64_t trackID)>;
     void setDidProvideContentKeyRequestInitializationDataForTrackIDCallback(DidProvideContentKeyRequestInitializationDataForTrackIDCallback&& callback)
     {
         m_didProvideContentKeyRequestInitializationDataForTrackIDCallback = WTFMove(callback);
     }
 
-    // Will be called on the main thread.
     using DidProvideContentKeyRequestIdentifierForTrackIDCallback = Function<void(Ref<SharedBuffer>&&, uint64_t trackID)>;
     void setDidProvideContentKeyRequestIdentifierForTrackIDCallback(DidProvideContentKeyRequestIdentifierForTrackIDCallback&& callback)
     {
         m_didProvideContentKeyRequestIdentifierForTrackIDCallback = WTFMove(callback);
     }
 
-    // Will be called on the main thread.
     using DidUpdateFormatDescriptionForTrackIDCallback = Function<void(Ref<TrackInfo>&&, uint64_t trackID)>;
     void setDidUpdateFormatDescriptionForTrackIDCallback(DidUpdateFormatDescriptionForTrackIDCallback&& callback)
     {

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -1591,35 +1591,37 @@ void SourceBufferParserWebM::returnSamples(MediaSamplesBlock&& block, CMFormatDe
         return;
     }
 
-    m_callOnClientThreadCallback([this, protectedThis = Ref { *this }, trackID = block.info()->trackID, sampleBuffer = WTFMove(expectedBuffer.value())] () mutable {
-        if (!m_didProvideMediaDataCallback)
+    m_callOnClientThreadCallback([protectedThis = Ref { *this }, trackID = block.info()->trackID, sampleBuffer = WTFMove(expectedBuffer.value())] () mutable {
+        if (!protectedThis->m_didProvideMediaDataCallback)
             return;
 
         auto mediaSample = MediaSampleAVFObjC::create(sampleBuffer.get(), trackID);
 
-        m_didProvideMediaDataCallback(WTFMove(mediaSample), trackID, emptyString());
+        protectedThis->m_didProvideMediaDataCallback(WTFMove(mediaSample), trackID, emptyString());
     });
 }
 
 void SourceBufferParserWebM::parsedTrimmingData(uint64_t trackID, const MediaTime& padding)
 {
-    m_callOnClientThreadCallback([this, protectedThis = Ref { *this }, trackID, padding] () {
-        if (m_didParseTrimmingDataCallback)
-            m_didParseTrimmingDataCallback(trackID, padding);
+    m_callOnClientThreadCallback([protectedThis = Ref { *this }, trackID, padding] () {
+        if (protectedThis->m_didParseTrimmingDataCallback)
+            protectedThis->m_didParseTrimmingDataCallback(trackID, padding);
     });
 }
 
 void SourceBufferParserWebM::contentKeyRequestInitializationDataForTrackID(Ref<SharedBuffer>&& keyID, uint64_t trackID)
 {
-    if (m_didProvideContentKeyRequestInitializationDataForTrackIDCallback)
-        m_didProvideContentKeyRequestInitializationDataForTrackIDCallback(WTFMove(keyID), trackID);
+    m_callOnClientThreadCallback([protectedThis = Ref { *this }, keyID = WTFMove(keyID), trackID]() mutable {
+        if (protectedThis->m_didProvideContentKeyRequestInitializationDataForTrackIDCallback)
+            protectedThis->m_didProvideContentKeyRequestInitializationDataForTrackIDCallback(WTFMove(keyID), trackID);
+    });
 }
 
 void SourceBufferParserWebM::formatDescriptionChangedForTrackID(Ref<TrackInfo>&& formatDescription, uint64_t trackID)
 {
-    m_callOnClientThreadCallback([this, protectedThis = Ref { *this }, formatDescription = WTFMove(formatDescription), trackID]() mutable {
-        if (m_didUpdateFormatDescriptionForTrackIDCallback)
-            m_didUpdateFormatDescriptionForTrackIDCallback(WTFMove(formatDescription), trackID);
+    m_callOnClientThreadCallback([protectedThis = Ref { *this }, formatDescription = WTFMove(formatDescription), trackID]() mutable {
+        if (protectedThis->m_didUpdateFormatDescriptionForTrackIDCallback)
+            protectedThis->m_didUpdateFormatDescriptionForTrackIDCallback(WTFMove(formatDescription), trackID);
     });
 }
 


### PR DESCRIPTION
#### a6ebe63cc21847417bc69fb74fcf328360e915b1
<pre>
[MSE] All SourceBufferPrivateParser calls should be made on provided callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=301245">https://bugs.webkit.org/show_bug.cgi?id=301245</a>
<a href="https://rdar.apple.com/163164795">rdar://163164795</a>

Reviewed by Eric Carlson.

Historically, it was necessary to wait for the LegacyCDMSession to process
the init segment on the main thread before the SourceBufferParser could
return. This was achieved by calling some callbacks on the parser queue
while others on the main thread.
This is no longer necessary and all thread synchronisations were removed
in 301380@main.

We now ensure that all callbacks are called through callOnClientThreadCallback.
This is also required to support having SourceBufferPrivate runs in a worker
thread.

Covered by existing tests.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::willProvideContentKeyRequestInitializationDataForTrackID):
(WebCore::SourceBufferParserAVFObjC::didProvideContentKeyRequestInitializationDataForTrackID):
(WebCore::SourceBufferParserAVFObjC::didProvideContentKeyRequestSpecifierForTrackID):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::appendInternal):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::SourceBufferParserWebM::contentKeyRequestInitializationDataForTrackID):

Canonical link: <a href="https://commits.webkit.org/301981@main">https://commits.webkit.org/301981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6b4d2dc41d7bceaed8a41f741440745d88a58c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134935 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/35852c67-dc53-4efd-ab1c-d4e69be44d97) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97180 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bd861f04-b3c9-4598-9893-909c11528882) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77662 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cc10790e-bb91-4864-ac02-9b4457a84105) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32451 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78294 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137418 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105700 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105351 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26867 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50870 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29302 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60436 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53495 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56951 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55253 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->