### PR TITLE
Address some Safer CPP warnings in WebProcess/cocoa

### DIFF
--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -483,6 +483,11 @@ RenderLayer* RenderObject::enclosingLayer() const
     return nullptr;
 }
 
+CheckedPtr<RenderLayer> RenderObject::checkedEnclosingLayer() const
+{
+    return enclosingLayer();
+}
+
 RenderBox& RenderObject::enclosingBox() const
 {
     return *lineageOfType<RenderBox>(const_cast<RenderObject&>(*this)).first();

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -396,6 +396,7 @@ public:
 #endif
 
     WEBCORE_EXPORT RenderLayer* enclosingLayer() const;
+    WEBCORE_EXPORT CheckedPtr<RenderLayer> checkedEnclosingLayer() const;
 
     WEBCORE_EXPORT RenderBox& enclosingBox() const;
     RenderBoxModelObject& enclosingBoxModelObject() const;

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -21,8 +21,6 @@ WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
 WebProcess/WebPage/WebFrame.cpp
 WebProcess/WebPage/WebPage.cpp
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
-WebProcess/cocoa/VideoPresentationManager.mm
-WebProcess/cocoa/WebProcessCocoa.mm
 [ Mac ] Platform/cocoa/_WKWebViewTextInputNotifications.mm
 [ Mac ] WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
 [ Mac ] WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -41,9 +41,6 @@ WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 WebProcess/WebPage/Cocoa/TextAnimationController.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
-WebProcess/cocoa/TextTrackRepresentationCocoa.mm
-WebProcess/cocoa/VideoPresentationManager.mm
-WebProcess/cocoa/WebProcessCocoa.mm
 [ Mac ] WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
 [ Mac ] WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
 [ Mac ] WebProcess/Inspector/WebInspectorUIExtensionController.cpp

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -11,7 +11,6 @@ WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
 WebProcess/WebPage/WebPage.cpp
-WebProcess/cocoa/WebProcessCocoa.mm
 [ Mac ] WebProcess/WebPage/mac/PageBannerMac.mm
 [ Mac ] WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 [ Mac ] WebProcess/WebPage/mac/WebPageMac.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -40,6 +40,5 @@
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
 [ iOS ] WebProcess/WebPage/ios/WebPageIOS.mm
-[ iOS ] WebProcess/cocoa/WebProcessCocoa.mm
 [ iOS ] webpushd/WebClipCache.mm
 [ iOS ] webpushd/WebPushDaemon.mm

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1466,6 +1466,16 @@ bool WebPage::shouldFallbackToWebContentAXObjectForMainFramePlugin() const
 #endif
 }
 
+WKAccessibilityWebPageObject* WebPage::accessibilityRemoteObject()
+{
+    return m_mockAccessibilityElement.get();
+}
+
+RetainPtr<WKAccessibilityWebPageObject> WebPage::protectedAccessibilityRemoteObject()
+{
+    return accessibilityRemoteObject();
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1244,6 +1244,7 @@ public:
     void registerUIProcessAccessibilityTokens(std::span<const uint8_t> elementToken, std::span<const uint8_t> windowToken);
     void registerRemoteFrameAccessibilityTokens(pid_t, std::span<const uint8_t>, WebCore::FrameIdentifier);
     WKAccessibilityWebPageObject* accessibilityRemoteObject();
+    RetainPtr<WKAccessibilityWebPageObject> protectedAccessibilityRemoteObject();
     WebCore::IntPoint accessibilityRemoteFrameOffset();
     void createMockAccessibilityElement(pid_t);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -771,11 +771,6 @@ WebCore::IntPoint WebPage::accessibilityRemoteFrameOffset()
     return [m_mockAccessibilityElement accessibilityRemoteFrameOffset];
 }
 
-WKAccessibilityWebPageObject* WebPage::accessibilityRemoteObject()
-{
-    return m_mockAccessibilityElement.get();
-}
-
 bool WebPage::platformCanHandleRequest(const WebCore::ResourceRequest& request)
 {
     NSURLRequest *nsRequest = request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody);

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -496,11 +496,6 @@ void WebPage::getDataSelectionForPasteboard(const String pasteboardType, Complet
     completionHandler(buffer.releaseNonNull());
 }
 
-WKAccessibilityWebPageObject* WebPage::accessibilityRemoteObject()
-{
-    return m_mockAccessibilityElement.get();
-}
-
 WebCore::IntPoint WebPage::accessibilityRemoteFrameOffset()
 {
     return [m_mockAccessibilityElement accessibilityRemoteFrameOffset];

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
@@ -50,9 +50,10 @@ WebTextTrackRepresentationCocoa::WebTextTrackRepresentationCocoa(WebCore::TextTr
 
 void WebTextTrackRepresentationCocoa::update()
 {
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
-    Ref fullscreenManager = m_page->videoPresentationManager();
+    Ref fullscreenManager = page->videoPresentationManager();
     if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
         return;
     
@@ -77,9 +78,10 @@ void WebTextTrackRepresentationCocoa::update()
 void WebTextTrackRepresentationCocoa::setContentScale(float scale)
 {
     WebCore::TextTrackRepresentationCocoa::setContentScale(scale);
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
-    Ref fullscreenManager = m_page->videoPresentationManager();
+    Ref fullscreenManager = page->videoPresentationManager();
     RefPtr videoElement = dynamicDowncast<WebCore::HTMLVideoElement>(m_mediaElement.get());
     if (!videoElement)
         return;
@@ -89,9 +91,10 @@ void WebTextTrackRepresentationCocoa::setContentScale(float scale)
 void WebTextTrackRepresentationCocoa::setHidden(bool hidden) const
 {
     WebCore::TextTrackRepresentationCocoa::setHidden(hidden);
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
-    Ref fullscreenManager = m_page->videoPresentationManager();
+    Ref fullscreenManager = page->videoPresentationManager();
     RefPtr videoElement = dynamicDowncast<WebCore::HTMLVideoElement>(m_mediaElement.get());
     if (!videoElement)
         return;

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -77,10 +77,10 @@ static FloatRect inlineVideoFrame(HTMLVideoElement& element)
     if (!renderer)
         return { };
 
-    if (renderer->hasLayer() && renderer->enclosingLayer()->isComposited()) {
+    if (renderer->hasLayer() && renderer->checkedEnclosingLayer()->isComposited()) {
         FloatQuad contentsBox = static_cast<FloatRect>(renderer->enclosingLayer()->backing()->contentsBox());
         contentsBox = renderer->localToAbsoluteQuad(contentsBox);
-        return document->view()->contentsToRootView(contentsBox.boundingBox());
+        return document->protectedView()->contentsToRootView(contentsBox.boundingBox());
     }
 
     return renderer->videoBoxInRootView();
@@ -112,8 +112,8 @@ void VideoPresentationInterfaceContext::setRootLayer(RetainPtr<CALayer> layer)
 
 void VideoPresentationInterfaceContext::hasVideoChanged(bool hasVideo)
 {
-    if (m_manager)
-        m_manager->hasVideoChanged(m_contextId, hasVideo);
+    if (RefPtr manager = m_manager.get())
+        manager->hasVideoChanged(m_contextId, hasVideo);
 }
 
 void VideoPresentationInterfaceContext::documentVisibilityChanged(bool isDocumentVisible)
@@ -148,14 +148,14 @@ void VideoPresentationInterfaceContext::hasBeenInteractedWith()
 
 void VideoPresentationInterfaceContext::videoDimensionsChanged(const FloatSize& videoDimensions)
 {
-    if (m_manager)
-        m_manager->videoDimensionsChanged(m_contextId, videoDimensions);
+    if (RefPtr manager = m_manager.get())
+        manager->videoDimensionsChanged(m_contextId, videoDimensions);
 }
 
 void VideoPresentationInterfaceContext::setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier)
 {
-    if (m_manager)
-        m_manager->setPlayerIdentifier(m_contextId, identifier);
+    if (RefPtr manager = m_manager.get())
+        manager->setPlayerIdentifier(m_contextId, identifier);
 }
 
 #pragma mark - VideoPresentationManager
@@ -288,7 +288,7 @@ bool VideoPresentationManager::canEnterVideoFullscreen(HTMLVideoElement& videoEl
     ASSERT(mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
 
 #if ENABLE(FULLSCREEN_API)
-    if (videoElement.protectedDocument()->fullscreen().isAnimatingFullscreen())
+    if (videoElement.protectedDocument()->protectedFullscreen()->isAnimatingFullscreen())
         return false;
 #endif
 


### PR DESCRIPTION
#### d48127591114d78aa2702f45c44f3218e99520be
<pre>
Address some Safer CPP warnings in WebProcess/cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=301251">https://bugs.webkit.org/show_bug.cgi?id=301251</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::checkedEnclosingLayer const):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::accessibilityRemoteObject):
(WebKit::WebPage::protectedAccessibilityRemoteObject):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::accessibilityRemoteObject): Deleted.
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::accessibilityRemoteObject): Deleted.
* Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm:
(WebKit::WebTextTrackRepresentationCocoa::update):
(WebKit::WebTextTrackRepresentationCocoa::setContentScale):
(WebKit::WebTextTrackRepresentationCocoa::setHidden const):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::inlineVideoFrame):
(WebKit::VideoPresentationInterfaceContext::hasVideoChanged):
(WebKit::VideoPresentationInterfaceContext::videoDimensionsChanged):
(WebKit::VideoPresentationInterfaceContext::setPlayerIdentifier):
(WebKit::VideoPresentationManager::canEnterVideoFullscreen const):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
(WebKit::WebProcess::platformInitializeWebProcess):
(WebKit::WebProcess::updateProcessName):
(WebKit::WebProcess::updateActivePages):
(WebKit::WebProcess::updateCPUMonitorState):

Canonical link: <a href="https://commits.webkit.org/301992@main">https://commits.webkit.org/301992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ba0801bea675dc809c3cb382853c5491bf44cfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79092 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/28de3aa7-3355-4a86-9011-a2bdf5daad8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97084 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65004 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/738e168d-89ed-4c29-b302-7cdbed4cfb40) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77564 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b86b3ff7-b639-4bed-bf52-f917b04309f8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37053 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32316 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77986 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137097 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105608 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54706 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105259 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26875 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50774 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29213 "Found 1 new test failure: http/tests/misc/ftp-eplf-directory.py (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51775 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54132 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60219 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53366 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56823 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55125 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->