### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for ScreenCaptureSessionSourceObserver

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -31,6 +31,7 @@
 #include <WebCore/DisplayCaptureSourceCocoa.h>
 #include <WebCore/ScreenCaptureKitSharingSessionManager.h>
 #include <wtf/BlockPtr.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/OSObjectPtr.h>
@@ -54,7 +55,10 @@ class ImageTransferSessionVT;
 
 class ScreenCaptureKitCaptureSource final
     : public DisplayCaptureSourceCocoa::Capturer
-    , public ScreenCaptureSessionSourceObserver {
+    , public ScreenCaptureSessionSourceObserver
+    , public CanMakeCheckedPtr<ScreenCaptureKitCaptureSource> {
+    WTF_MAKE_TZONE_ALLOCATED(ScreenCaptureKitCaptureSource);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScreenCaptureKitCaptureSource);
 public:
     static Expected<uint32_t, CaptureSourceError> computeDeviceID(const CaptureDevice&);
 
@@ -71,6 +75,12 @@ public:
     void sessionFailedWithError(RetainPtr<NSError>&&, const String&);
     void outputVideoEffectDidStartForStream() { m_isVideoEffectEnabled = true; }
     void outputVideoEffectDidStopForStream() { m_isVideoEffectEnabled = false; }
+
+    // ScreenCaptureSessionSourceObserver.
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
 private:
     // DisplayCaptureSourceCocoa::Capturer

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -41,6 +41,7 @@
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/StringToIntegerConversion.h>
@@ -164,6 +165,8 @@ using namespace WebCore;
 #pragma clang diagnostic pop
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScreenCaptureKitCaptureSource);
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
 

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
@@ -27,6 +27,7 @@
 #if HAVE(SCREEN_CAPTURE_KIT)
 
 #include <WebCore/DisplayCapturePromptType.h>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
@@ -42,20 +43,11 @@ OBJC_CLASS SCStreamDelegate;
 OBJC_CLASS WebDisplayMediaPromptHelper;
 
 namespace WebCore {
-class ScreenCaptureSessionSourceObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ScreenCaptureSessionSourceObserver> : std::true_type { };
-}
-
-namespace WebCore {
 
 class CaptureDevice;
 class ScreenCaptureKitSharingSessionManager;
 
-class ScreenCaptureSessionSourceObserver : public CanMakeWeakPtr<ScreenCaptureSessionSourceObserver> {
+class ScreenCaptureSessionSourceObserver : public CanMakeWeakPtr<ScreenCaptureSessionSourceObserver>, public AbstractCanMakeCheckedPtr {
 public:
     virtual ~ScreenCaptureSessionSourceObserver() = default;
 
@@ -75,7 +67,8 @@ public:
     SCStream* stream() const { return m_stream.get(); }
     SCContentFilter* contentFilter() const { return m_contentFilter.get(); }
     SCContentSharingSession* sharingSession() const { return m_sharingSession.get(); }
-    WeakPtr<ScreenCaptureSessionSourceObserver> observer() const { return m_observer; }
+    ScreenCaptureSessionSourceObserver* observer() const { return m_observer.get(); }
+    CheckedPtr<ScreenCaptureSessionSourceObserver> checkedObserver() const { return m_observer.get(); }
 
     void updateContentFilter(SCContentFilter*);
     void streamDidEnd();

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -353,7 +353,7 @@ void ScreenCaptureKitSharingSessionManager::sharingSessionDidChangeContent(SCCon
     }
 
     activeSource->updateContentFilter(sharingSession.content);
-    activeSource->observer()->sessionFilterDidChange(sharingSession.content);
+    activeSource->checkedObserver()->sessionFilterDidChange(sharingSession.content);
 }
 
 void ScreenCaptureKitSharingSessionManager::contentSharingPickerSelectedFilterForStream(SCContentFilter* contentFilter, SCStream*)
@@ -642,13 +642,13 @@ void ScreenCaptureSessionSource::updateContentFilter(SCContentFilter* contentFil
 {
     ASSERT(m_observer);
     m_contentFilter = contentFilter;
-    m_observer->sessionFilterDidChange(contentFilter);
+    CheckedRef { *m_observer }->sessionFilterDidChange(contentFilter);
 }
 
 void ScreenCaptureSessionSource::streamDidEnd()
 {
     ASSERT(m_observer);
-    m_observer->sessionStreamDidEnd(m_stream.get());
+    CheckedRef { *m_observer }->sessionStreamDidEnd(m_stream.get());
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 46315ee6449928f2678206b9510594312244e28a
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for ScreenCaptureSessionSourceObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=301254">https://bugs.webkit.org/show_bug.cgi?id=301254</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h:
(WebCore::ScreenCaptureSessionSource::observer const):
(WebCore::ScreenCaptureSessionSource::checkedObserver const):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(WebCore::ScreenCaptureKitSharingSessionManager::sharingSessionDidChangeContent):
(WebCore::ScreenCaptureSessionSource::updateContentFilter):
(WebCore::ScreenCaptureSessionSource::streamDidEnd):

Canonical link: <a href="https://commits.webkit.org/301991@main">https://commits.webkit.org/301991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ba1a5f1035417c4c30a88b65bcd0127d57e31a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134634 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79114 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/17119fd4-cdab-4a14-b3ab-9cc74f317bd9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97098 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65015 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/557ccb9e-8843-4d8d-8d29-21c26d9ba718) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77578 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6e8c431e-d855-4ba5-8905-0f43849b8b3a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32337 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78007 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137118 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105621 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105272 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26873 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50787 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29232 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51801 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54153 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60240 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53387 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55146 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->