### PR TITLE
[WebXR Hit Test] XRRay support

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS XRRay constructors work
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS XRRay matrix works
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2858,6 +2858,8 @@ imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_constructor.https.ht
 imported/w3c/web-platform-tests/webxr/layers/idlharness.https.window.html [ Pass ]
 
 imported/w3c/web-platform-tests/webxr/hit-test/idlharness.https.html [ Pass ]
+imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https.html [ Pass ]
+imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https.html [ Pass ]
 
 http/wpt/webxr [ Pass ]
 webxr [ Pass ]

--- a/Source/WebCore/Modules/webxr/WebXRRay.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRRay.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025 Igalia S.L. All rights reserved.
+ * Copyright (C) 2018 The Chromium Authors
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,19 +41,29 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebXRRay);
 
 ExceptionOr<Ref<WebXRRay>> WebXRRay::create(const DOMPointInit& origin, const XRRayDirectionInit& direction)
 {
-    auto exceptionOrTransform = WebXRRigidTransform::create(origin, DOMPointInit { direction.x, direction.y, direction.z, direction.w });
-    if (exceptionOrTransform.hasException())
-        return exceptionOrTransform.releaseException();
-    return adoptRef(*new WebXRRay(exceptionOrTransform.releaseReturnValue()));
+    if (!direction.x && !direction.y && !direction.z)
+        return Exception { ExceptionCode::TypeError };
+    if (direction.w)
+        return Exception { ExceptionCode::TypeError };
+    if (origin.w != 1)
+        return Exception { ExceptionCode::TypeError };
+    double length = std::hypot(direction.x, direction.y, direction.z);
+    FloatPoint3D nomalizedDirection { 0, 0, -1 };
+    if (length)
+        nomalizedDirection = FloatPoint3D(direction.x / length, direction.y / length, direction.z / length);
+    return adoptRef(*new WebXRRay(FloatPoint3D(origin.x, origin.y, origin.z), nomalizedDirection));
 }
 
 Ref<WebXRRay> WebXRRay::create(WebXRRigidTransform& transform)
 {
-    return adoptRef(*new WebXRRay(transform));
+    FloatPoint3D origin = transform.rawTransform().mapPoint({ 0, 0, 0 });
+    FloatPoint3D direction = transform.rawTransform().mapPoint({ 0, 0, -1 });
+    return adoptRef(*new WebXRRay(origin, direction - origin));
 }
 
-WebXRRay::WebXRRay(WebXRRigidTransform& transform)
-    : m_transform(transform)
+WebXRRay::WebXRRay(FloatPoint3D origin, FloatPoint3D direction)
+    : m_origin(origin)
+    , m_direction(direction)
 {
 }
 
@@ -60,17 +71,40 @@ WebXRRay::~WebXRRay() = default;
 
 const DOMPointReadOnly& WebXRRay::origin()
 {
-    return m_transform->position();
+    return DOMPointReadOnly::fromFloatPoint(m_origin);
 }
 
 const DOMPointReadOnly& WebXRRay::direction()
 {
-    return m_transform->orientation();
+    return DOMPointReadOnly::create(m_direction.x(), m_direction.y(), m_direction.z(), 0);
 }
 
 const Float32Array& WebXRRay::matrix()
 {
-    return m_transform->matrix();
+    if (m_matrix && !m_matrix->isDetached())
+        return *m_matrix;
+
+    TransformationMatrix transform;
+    transform.translate3d(m_origin.x(), m_origin.y(), m_origin.z());
+    FloatPoint3D z { 0, 0, -1 };
+    float cosAngle = z.dot(m_direction);
+    if (cosAngle > 0.9999) {
+        // Vectors are co-linear or almost co-linear & face the same direction,
+        // no rotation is needed.
+    } else if (cosAngle < -0.9999) {
+        // Vectors are co-linear or almost co-linear & face the opposite
+        // direction, rotation by 180 degrees is needed & can be around any vector
+        // perpendicular to (0,0,-1) so let's rotate about the x-axis.
+        transform.rotate3d(1, 0, 0, 180);
+    } else {
+        // Rotation needed - create it from axis-angle.
+        FloatPoint3D axis = z.cross(m_direction);
+        transform.rotate3d(axis.x(), axis.y(), axis.z(), rad2deg(std::acos(cosAngle)));
+    }
+
+    auto matrixData = transform.toColumnMajorFloatArray();
+    m_matrix = Float32Array::create(matrixData.data(), matrixData.size());
+    return *m_matrix;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/WebXRRay.h
+++ b/Source/WebCore/Modules/webxr/WebXRRay.h
@@ -28,6 +28,8 @@
 #if ENABLE(WEBXR_HIT_TEST)
 
 #include "ExceptionOr.h"
+#include "FloatPoint3D.h"
+#include "TransformationMatrix.h"
 #include <JavaScriptCore/Float32Array.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -51,9 +53,11 @@ public:
     const Float32Array& matrix();
 
 private:
-    WebXRRay(WebXRRigidTransform&);
+    WebXRRay(FloatPoint3D origin, FloatPoint3D direction);
 
-    Ref<WebXRRigidTransform> m_transform;
+    FloatPoint3D m_origin;
+    FloatPoint3D m_direction;
+    RefPtr<Float32Array> m_matrix;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### b9d52d2f714fb997187caba6026bfa6ddcf17753
<pre>
[WebXR Hit Test] XRRay support
<a href="https://bugs.webkit.org/show_bug.cgi?id=301255">https://bugs.webkit.org/show_bug.cgi?id=301255</a>

Reviewed by Dan Glastonbury.

Added XRRay support based on the Chromium implementations.
&lt;<a href="https://immersive-web.github.io/hit-test/#xrray-interface">https://immersive-web.github.io/hit-test/#xrray-interface</a>&gt;
&lt;<a href="https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/modules/xr/xr_ray.cc">https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/modules/xr/xr_ray.cc</a>&gt;

Tests: imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https.html
       imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https-expected.txt: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/webxr/WebXRRay.cpp:
(WebCore::WebXRRay::create):
(WebCore::WebXRRay::WebXRRay):
(WebCore::WebXRRay::origin):
(WebCore::WebXRRay::direction):
(WebCore::WebXRRay::matrix):
* Source/WebCore/Modules/webxr/WebXRRay.h:

Canonical link: <a href="https://commits.webkit.org/301987@main">https://commits.webkit.org/301987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/754813ca397326648ae0eca89ba922fe1be0ba95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134625 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79105 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97090 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65010 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32333 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77998 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137109 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105616 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105267 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50777 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29227 "Found 1 new test failure: http/tests/misc/ftp-eplf-directory.py (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51787 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19961 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60231 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53378 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->