### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for GamepadProviderClient

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadManager.h
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.h
@@ -46,6 +46,10 @@ class GamepadManager : public GamepadProviderClient {
 public:
     static GamepadManager& singleton();
 
+    // Do nothing since this is a singleton.
+    void ref() const final { }
+    void deref() const final { }
+
     void platformGamepadConnected(PlatformGamepad&, EventMakesGamepadsVisible) final;
     void platformGamepadDisconnected(PlatformGamepad&) final;
     void platformGamepadInputActivity(EventMakesGamepadsVisible) final;

--- a/Source/WebCore/platform/gamepad/GamepadProvider.cpp
+++ b/Source/WebCore/platform/gamepad/GamepadProvider.cpp
@@ -52,8 +52,8 @@ void GamepadProvider::setSharedProvider(GamepadProvider& newProvider)
 
 void GamepadProvider::dispatchPlatformGamepadInputActivity()
 {
-    for (auto& client : m_clients)
-        client.platformGamepadInputActivity(m_shouldMakeGamepadsVisible ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No);
+    for (Ref client : m_clients)
+        client->platformGamepadInputActivity(m_shouldMakeGamepadsVisible ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No);
 
     m_shouldMakeGamepadsVisible = false;
 }

--- a/Source/WebCore/platform/gamepad/GamepadProviderClient.h
+++ b/Source/WebCore/platform/gamepad/GamepadProviderClient.h
@@ -27,17 +27,8 @@
 
 #if ENABLE(GAMEPAD)
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class GamepadProviderClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::GamepadProviderClient> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -48,7 +39,7 @@ enum class EventMakesGamepadsVisible : bool {
     Yes,
 };
 
-class GamepadProviderClient : public CanMakeWeakPtr<GamepadProviderClient> {
+class GamepadProviderClient : public AbstractRefCountedAndCanMakeWeakPtr<GamepadProviderClient> {
 public:
     virtual ~GamepadProviderClient() = default;
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
@@ -148,8 +148,8 @@ void GameControllerGamepadProvider::controllerDidConnect(GCController *controlle
 
     makeInvisibleGamepadsVisible();
 
-    for (auto& client : m_clients)
-        client.platformGamepadConnected(*m_gamepadVector[index], EventMakesGamepadsVisible::Yes);
+    for (Ref client : m_clients)
+        client->platformGamepadConnected(*m_gamepadVector[index], EventMakesGamepadsVisible::Yes);
 }
 
 void GameControllerGamepadProvider::controllerDidDisconnect(GCController *controller)
@@ -172,8 +172,8 @@ void GameControllerGamepadProvider::controllerDidDisconnect(GCController *contro
 
     m_invisibleGamepads.remove(*removedGamepad.get());
 
-    for (auto& client : m_clients)
-        client.platformGamepadDisconnected(*removedGamepad);
+    for (Ref client : m_clients)
+        client->platformGamepadDisconnected(*removedGamepad);
 }
 
 void GameControllerGamepadProvider::prewarmGameControllerDevicesIfNecessary()
@@ -277,8 +277,8 @@ void GameControllerGamepadProvider::gamepadHadInput(GameControllerGamepad&, bool
 void GameControllerGamepadProvider::makeInvisibleGamepadsVisible()
 {
     for (auto& gamepad : m_invisibleGamepads) {
-        for (auto& client : m_clients)
-            client.platformGamepadConnected(gamepad, EventMakesGamepadsVisible::Yes);
+        for (Ref client : m_clients)
+            client->platformGamepadConnected(gamepad, EventMakesGamepadsVisible::Yes);
     }
 
     m_invisibleGamepads.clear();

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
@@ -257,8 +257,8 @@ void HIDGamepadProvider::deviceAdded(IOHIDDeviceRef device)
     }
 
     auto eventVisibility = m_initialGamepadsConnected ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No;
-    for (auto& client : m_clients)
-        client.platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
+    for (Ref client : m_clients)
+        client->platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
 
     // If we are working together with the GameController provider, let it know
     // that gamepads should now be visible.
@@ -281,8 +281,8 @@ void HIDGamepadProvider::deviceRemoved(IOHIDDeviceRef device)
 
     LOG(Gamepad, "HIDGamepadProvider device %p removed", device);
 
-    for (auto& client : m_clients)
-        client.platformGamepadDisconnected(*removedGamepad);
+    for (Ref client : m_clients)
+        client->platformGamepadDisconnected(*removedGamepad);
 }
 
 void HIDGamepadProvider::valuesChanged(IOHIDValueRef value)

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
@@ -41,6 +41,10 @@ public:
 
     WEBCORE_EXPORT static MultiGamepadProvider& singleton();
 
+    // Do nothing since this is a singleton.
+    void ref() const final { }
+    void deref() const final { }
+
     void setUsesOnlyHIDGamepadProvider(bool hidProviderOnly) { m_usesOnlyHIDProvider = hidProviderOnly; }
 
     // GamepadProvider

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm
@@ -114,8 +114,8 @@ void MultiGamepadProvider::platformGamepadConnected(PlatformGamepad& gamepad, Ev
     ASSERT(addResult.isNewEntry);
     m_gamepadVector[index] = addResult.iterator->value.get();
 
-    for (auto& client : m_clients)
-        client.platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
+    for (Ref client : m_clients)
+        client->platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
 }
 
 void MultiGamepadProvider::platformGamepadDisconnected(PlatformGamepad& gamepad)
@@ -130,8 +130,8 @@ void MultiGamepadProvider::platformGamepadDisconnected(PlatformGamepad& gamepad)
 
     m_gamepadVector[gamepadWrapper->index()] = nullptr;
 
-    for (auto& client : m_clients)
-        client.platformGamepadDisconnected(*gamepadWrapper);
+    for (Ref client : m_clients)
+        client->platformGamepadDisconnected(*gamepadWrapper);
 }
 
 void MultiGamepadProvider::platformGamepadInputActivity(EventMakesGamepadsVisible eventVisibility)
@@ -139,8 +139,8 @@ void MultiGamepadProvider::platformGamepadInputActivity(EventMakesGamepadsVisibl
     if (eventVisibility == EventMakesGamepadsVisible::Yes)
         GameControllerGamepadProvider::singleton().makeInvisibleGamepadsVisible();
 
-    for (auto& client : m_clients)
-        client.platformGamepadInputActivity(eventVisibility);
+    for (Ref client : m_clients)
+        client->platformGamepadInputActivity(eventVisibility);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockGamepadProvider.cpp
+++ b/Source/WebCore/testing/MockGamepadProvider.cpp
@@ -97,12 +97,12 @@ bool MockGamepadProvider::connectMockGamepad(unsigned index)
 
     EventMakesGamepadsVisible eventMakesGamepadsVisible = m_mockGamepadVector[index]->wasConnected() ?
         EventMakesGamepadsVisible::No : EventMakesGamepadsVisible::Yes;
-    for (auto& client : m_clients) {
-        client.platformGamepadConnected(*m_connectedGamepadVector[index], eventMakesGamepadsVisible);
-        auto gamepadsForClient = m_invisibleGamepadsForClient.find(client);
+    for (Ref client : m_clients) {
+        client->platformGamepadConnected(*m_connectedGamepadVector[index], eventMakesGamepadsVisible);
+        auto gamepadsForClient = m_invisibleGamepadsForClient.find(client.get());
         if (gamepadsForClient != m_invisibleGamepadsForClient.end()) {
             for (auto& invisibleGamepad : gamepadsForClient->value)
-                client.platformGamepadConnected(invisibleGamepad, eventMakesGamepadsVisible);
+                client->platformGamepadConnected(invisibleGamepad, eventMakesGamepadsVisible);
             m_invisibleGamepadsForClient.remove(gamepadsForClient);
         }
     }
@@ -124,10 +124,10 @@ bool MockGamepadProvider::disconnectMockGamepad(unsigned index)
     m_connectedGamepadVector[index] = nullptr;
 
     auto gamepadToRemove = m_mockGamepadVector[index].get();
-    for (auto& client : m_clients) {
-        auto gamepadsForClient = m_invisibleGamepadsForClient.find(client);
+    for (Ref client : m_clients) {
+        auto gamepadsForClient = m_invisibleGamepadsForClient.find(client.get());
         if (gamepadsForClient == m_invisibleGamepadsForClient.end() || !gamepadsForClient->value.remove(*gamepadToRemove))
-            client.platformGamepadDisconnected(*m_mockGamepadVector[index]);
+            client->platformGamepadDisconnected(*m_mockGamepadVector[index]);
     }
 
     return true;

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
@@ -86,8 +86,8 @@ void WebGamepadProvider::gamepadConnected(const GamepadData& gamepadData, EventM
     m_gamepads[gamepadData.index()] = makeUnique<WebGamepad>(gamepadData);
     m_rawGamepads[gamepadData.index()] = m_gamepads[gamepadData.index()].get();
 
-    for (auto& client : m_clients)
-        client.platformGamepadConnected(*m_gamepads[gamepadData.index()], eventVisibility);
+    for (Ref client : m_clients)
+        client->platformGamepadConnected(*m_gamepads[gamepadData.index()], eventVisibility);
 }
 
 void WebGamepadProvider::gamepadDisconnected(unsigned index)
@@ -99,8 +99,8 @@ void WebGamepadProvider::gamepadDisconnected(unsigned index)
 
     LOG(Gamepad, "WebGamepadProvider::gamepadDisconnected - Gamepad index %u detached (m_gamepads size %zu, m_rawGamepads size %zu\n", index, m_gamepads.size(), m_rawGamepads.size());
 
-    for (auto& client : m_clients)
-        client.platformGamepadDisconnected(*disconnectedGamepad);
+    for (Ref client : m_clients)
+        client->platformGamepadDisconnected(*disconnectedGamepad);
 }
 
 void WebGamepadProvider::gamepadActivity(const Vector<std::optional<GamepadData>>& gamepadDatas, EventMakesGamepadsVisible eventVisibility)
@@ -114,8 +114,8 @@ void WebGamepadProvider::gamepadActivity(const Vector<std::optional<GamepadData>
             m_gamepads[i]->updateValues(*gamepadDatas[i]);
     }
 
-    for (auto& client : m_clients)
-        client.platformGamepadInputActivity(eventVisibility);
+    for (Ref client : m_clients)
+        client->platformGamepadInputActivity(eventVisibility);
 }
 
 void WebGamepadProvider::startMonitoringGamepads(GamepadProviderClient& client)


### PR DESCRIPTION
#### 9279422a959cfa88cc2041f1fabce1506500c084
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for GamepadProviderClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=301256">https://bugs.webkit.org/show_bug.cgi?id=301256</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/gamepad/GamepadManager.h:
* Source/WebCore/platform/gamepad/GamepadProvider.cpp:
(WebCore::GamepadProvider::dispatchPlatformGamepadInputActivity):
* Source/WebCore/platform/gamepad/GamepadProviderClient.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm:
(WebCore::GameControllerGamepadProvider::controllerDidConnect):
(WebCore::GameControllerGamepadProvider::controllerDidDisconnect):
(WebCore::GameControllerGamepadProvider::makeInvisibleGamepadsVisible):
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm:
(WebCore::HIDGamepadProvider::deviceAdded):
(WebCore::HIDGamepadProvider::deviceRemoved):
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h:
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm:
(WebCore::MultiGamepadProvider::platformGamepadConnected):
(WebCore::MultiGamepadProvider::platformGamepadDisconnected):
(WebCore::MultiGamepadProvider::platformGamepadInputActivity):
* Source/WebCore/testing/MockGamepadProvider.cpp:
(WebCore::MockGamepadProvider::connectMockGamepad):
(WebCore::MockGamepadProvider::disconnectMockGamepad):
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp:
(WebKit::WebGamepadProvider::gamepadConnected):
(WebKit::WebGamepadProvider::gamepadDisconnected):
(WebKit::WebGamepadProvider::gamepadActivity):

Canonical link: <a href="https://commits.webkit.org/301993@main">https://commits.webkit.org/301993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f46bc54706b988a9ee4ed18eed2f75b576e8272

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134659 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79139 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3b6deacc-0c5d-4fd9-b3c3-b0f6585bae5e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97120 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65033 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cd7b7a36-bfed-4c2b-aac3-f05b393fcd31) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77600 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0e9de2d5-f470-4fb9-9917-89d3958f3156) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32366 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78032 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108136 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137143 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105642 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105293 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26876 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50810 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29249 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51829 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54178 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60265 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53412 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56869 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55171 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->