### PR TITLE
Prepare Source/WebCore for clang static analyzer update (part 2)

### DIFF
--- a/Source/WebCore/loader/archive/cf/LegacyWebArchiveMac.mm
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchiveMac.mm
@@ -41,7 +41,7 @@ ResourceResponse LegacyWebArchive::createResourceResponseFromMacArchivedData(CFD
     if (!responseData)
         return ResourceResponse();
     
-    NSURLResponse *response = nil;
+    RetainPtr<NSURLResponse> response;
     auto unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:(__bridge NSData *)responseData error:nullptr]);
     unarchiver.get().decodingFailurePolicy = NSDecodingFailurePolicyRaiseException;
     @try {
@@ -52,7 +52,7 @@ ResourceResponse LegacyWebArchive::createResourceResponseFromMacArchivedData(CFD
         response = nil;
     }
 
-    return ResourceResponse(response);
+    return ResourceResponse(response.get());
 }
 
 RetainPtr<CFDataRef> LegacyWebArchive::createPropertyListRepresentation(const ResourceResponse& response)

--- a/Source/WebCore/loader/mac/LoaderNSURLExtras.mm
+++ b/Source/WebCore/loader/mac/LoaderNSURLExtras.mm
@@ -47,8 +47,8 @@ NSString *suggestedFilenameWithMIMEType(NSURL *url, const String& mimeType)
 NSString *suggestedFilenameWithMIMEType(NSURL *url, const String& mimeType, const String& defaultValue)
 {
     // Get the filename from the URL. Try the lastPathComponent first.
-    NSString *lastPathComponent = [[url path] lastPathComponent];
-    RetainPtr filename = filenameByFixingIllegalCharacters(lastPathComponent);
+    RetainPtr<NSString> lastPathComponent = [[url path] lastPathComponent];
+    RetainPtr filename = filenameByFixingIllegalCharacters(lastPathComponent.get());
     RetainPtr<NSString> extension;
 
     if ([filename length] == 0 || [lastPathComponent isEqualToString:@"/"]) {

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -244,7 +244,7 @@ void ResourceUsageOverlay::platformInitialize()
         // FIXME: It shouldn't be necessary to update the bounds on every single thread loop iteration,
         // but something is causing them to become 0x0.
         [CATransaction begin];
-        CALayer *containerLayer = [m_layer superlayer];
+        RetainPtr<CALayer> containerLayer = [m_layer superlayer];
         CGRect rect = CGRectMake(0, 0, ResourceUsageOverlay::normalWidth, ResourceUsageOverlay::normalHeight);
         [m_layer setBounds:rect];
         [containerLayer setBounds:rect];

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -265,7 +265,7 @@ unsigned ScrollingTreeFrameScrollingNodeMac::exposedUnfilledArea() const
         auto sublayers = adoptNS([[layer sublayers] copy]);
 
         // If this layer is the parent of a tile, it is the parent of all of the tiles and nothing else.
-        if ([[[sublayers objectAtIndex:0] valueForKey:@"isTile"] boolValue]) {
+        if ([[retainPtr([sublayers objectAtIndex:0]) valueForKey:@"isTile"] boolValue]) {
             for (CALayer* sublayer in sublayers.get())
                 tiles.append(sublayer);
         } else {

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -107,8 +107,8 @@ static std::optional<ScrollingNodeID> scrollingNodeIDForLayer(CALayer *layer)
 
 static bool isScrolledBy(const ScrollingTree& tree, ScrollingNodeID scrollingNodeID, CALayer *hitLayer)
 {
-    for (CALayer *layer = hitLayer; layer; layer = [layer superlayer]) {
-        auto nodeID = scrollingNodeIDForLayer(layer);
+    for (RetainPtr<CALayer> layer = hitLayer; layer; layer = [layer superlayer]) {
+        auto nodeID = scrollingNodeIDForLayer(layer.get());
         if (nodeID == scrollingNodeID)
             return true;
 

--- a/Source/WebCore/platform/audio/mac/AudioBusMac.mm
+++ b/Source/WebCore/platform/audio/mac/AudioBusMac.mm
@@ -42,9 +42,9 @@ namespace WebCore {
 RefPtr<AudioBus> AudioBus::loadPlatformResource(const char* name, float sampleRate)
 {
     @autoreleasepool {
-        NSBundle *bundle = [NSBundle bundleForClass:[WebCoreAudioBundleClass class]];
-        NSURL *audioFileURL = [bundle URLForResource:[NSString stringWithUTF8String:name] withExtension:@"wav" subdirectory:@"audio"];
-        if (NSData *audioData = [NSData dataWithContentsOfURL:audioFileURL options:NSDataReadingMappedIfSafe error:nil])
+        RetainPtr<NSBundle> bundle = [NSBundle bundleForClass:[WebCoreAudioBundleClass class]];
+        RetainPtr<NSURL> audioFileURL = [bundle URLForResource:[NSString stringWithUTF8String:name] withExtension:@"wav" subdirectory:@"audio"];
+        if (NSData *audioData = [NSData dataWithContentsOfURL:audioFileURL.get() options:NSDataReadingMappedIfSafe error:nil])
             return createBusFromInMemoryAudioFile(span(audioData), false, sampleRate);
     }
 

--- a/Source/WebCore/platform/cocoa/CoreLocationGeolocationProvider.mm
+++ b/Source/WebCore/platform/cocoa/CoreLocationGeolocationProvider.mm
@@ -146,8 +146,8 @@ SOFT_LINK_CONSTANT(CoreLocation, kCLLocationAccuracyHundredMeters, double)
         return;
     }
 
-    NSString *errorMessage = [error localizedDescription];
-    _client->errorOccurred(_websiteIdentifier, errorMessage);
+    RetainPtr<NSString> errorMessage = [error localizedDescription];
+    _client->errorOccurred(_websiteIdentifier, errorMessage.get());
 }
 
 @end

--- a/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
@@ -140,9 +140,9 @@ String MIMETypeRegistry::mimeTypeForExtension(StringView extension)
 {
     auto string = extension.createNSStringWithoutCopying();
 
-    NSString *mimeType = [[NSURLFileTypeMappings sharedMappings] MIMETypeForExtension:string.get()];
-    if (mimeType.length)
-        return mimeType;
+    RetainPtr<NSString> mimeType = [[NSURLFileTypeMappings sharedMappings] MIMETypeForExtension:string.get()];
+    if (mimeType.get().length)
+        return mimeType.get();
 
     auto mapEntry = additionalMimeTypesMap().find<ASCIICaseInsensitiveStringViewHashTranslator>(extension);
     if (mapEntry != additionalMimeTypesMap().end())

--- a/Source/WebCore/platform/cocoa/PasteboardCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PasteboardCocoa.mm
@@ -207,9 +207,9 @@ Vector<String> Pasteboard::typesForLegacyUnsafeBindings()
 #if PLATFORM(MAC)
 static Ref<SharedBuffer> convertTIFFToPNG(FragmentedSharedBuffer& tiffBuffer)
 {
-    auto image = adoptNS([[NSBitmapImageRep alloc] initWithData: tiffBuffer.makeContiguous()->createNSData().get()]);
-    NSData *pngData = [image representationUsingType:bitmapPNGFileType() properties:@{ }];
-    return SharedBuffer::create(pngData);
+    RetainPtr image = adoptNS([[NSBitmapImageRep alloc] initWithData: tiffBuffer.makeContiguous()->createNSData().get()]);
+    RetainPtr<NSData> pngData = [image representationUsingType:bitmapPNGFileType() properties:@{ }];
+    return SharedBuffer::create(pngData.get());
 }
 #endif
 

--- a/Source/WebCore/platform/cocoa/TextRecognitionResultCocoa.mm
+++ b/Source/WebCore/platform/cocoa/TextRecognitionResultCocoa.mm
@@ -44,8 +44,8 @@ namespace WebCore {
 std::optional<WebCore::AttributedString> TextRecognitionResult::extractAttributedString(VKCImageAnalysis *analysis)
 {
     if ([analysis isKindOfClass:PAL::getVKCImageAnalysisClassSingleton()]; [analysis respondsToSelector:@selector(_attributedStringForRange:)]) {
-        if (auto attributedString = [analysis _attributedStringForRange:NSMakeRange(0, NSIntegerMax)])
-            return { AttributedString::fromNSAttributedString(attributedString) };
+        if (RetainPtr attributedString = [analysis _attributedStringForRange:NSMakeRange(0, NSIntegerMax)])
+            return { AttributedString::fromNSAttributedString(attributedString.get()) };
     }
     return std::nullopt;
 }

--- a/Source/WebCore/platform/cocoa/WebCoreNSErrorExtras.mm
+++ b/Source/WebCore/platform/cocoa/WebCoreNSErrorExtras.mm
@@ -27,6 +27,7 @@
 #import "WebCoreNSErrorExtras.h"
 
 #import <AVFoundation/AVError.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebCore {
 
@@ -35,9 +36,9 @@ long mediaKeyErrorSystemCode(NSError *error)
     NSInteger code = [error code];
 
     if (code == AVErrorUnknown) {
-        NSError* underlyingError = [error.userInfo valueForKey:NSUnderlyingErrorKey];
-        if (underlyingError && [underlyingError isKindOfClass:[NSError class]])
-            return [underlyingError code];
+        RetainPtr<id> underlyingError = [retainPtr(error.userInfo) valueForKey:NSUnderlyingErrorKey];
+        if (RetainPtr error = dynamic_objc_cast<NSError>(underlyingError.get()))
+            return [error code];
     }
 
     return code;

--- a/Source/WebCore/platform/cocoa/WebNSAttributedStringExtras.mm
+++ b/Source/WebCore/platform/cocoa/WebNSAttributedStringExtras.mm
@@ -37,7 +37,7 @@ namespace WebCore {
 NSAttributedString *attributedStringByStrippingAttachmentCharacters(NSAttributedString *attributedString)
 {
     NSRange attachmentRange;
-    NSString *originalString = [attributedString string];
+    RetainPtr<NSString> originalString = [attributedString string];
     static NeverDestroyed attachmentCharString = [] {
         unichar chars[2] = { NSAttachmentCharacter, 0 };
         return adoptNS([[NSString alloc] initWithCharacters:chars length:1]);
@@ -49,7 +49,7 @@ NSAttributedString *attributedStringByStrippingAttachmentCharacters(NSAttributed
 
         while (attachmentRange.location != NSNotFound && attachmentRange.length > 0) {
             [newAttributedString replaceCharactersInRange:attachmentRange withString:@""];
-            attachmentRange = [[newAttributedString string] rangeOfString:attachmentCharString.get().get()];
+            attachmentRange = [retainPtr([newAttributedString string]) rangeOfString:attachmentCharString.get().get()];
         }
         return newAttributedString.autorelease();
     }

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
@@ -217,15 +217,17 @@ void GameControllerGamepadProvider::startMonitoringGamepads(GamepadProviderClien
 
     if (canLoad_GameController_GCControllerDidConnectNotification()) {
         m_connectObserver = [[NSNotificationCenter defaultCenter] addObserverForName:get_GameController_GCControllerDidConnectNotificationSingleton() object:nil queue:nil usingBlock:^(NSNotification *notification) {
-            LOG(Gamepad, "GameControllerGamepadProvider notified of new GCController %p", notification.object);
-            GameControllerGamepadProvider::singleton().controllerDidConnect(notification.object, ConnectionVisibility::Visible);
+            RetainPtr<id> object = notification.object;
+            LOG(Gamepad, "GameControllerGamepadProvider notified of new GCController %p", object.get());
+            GameControllerGamepadProvider::singleton().controllerDidConnect(object.get(), ConnectionVisibility::Visible);
         }];
     }
 
     if (canLoad_GameController_GCControllerDidDisconnectNotification()) {
         m_disconnectObserver = [[NSNotificationCenter defaultCenter] addObserverForName:get_GameController_GCControllerDidDisconnectNotificationSingleton() object:nil queue:nil usingBlock:^(NSNotification *notification) {
-            LOG(Gamepad, "GameControllerGamepadProvider notified of disconnected GCController %p", notification.object);
-            GameControllerGamepadProvider::singleton().controllerDidDisconnect(notification.object);
+            RetainPtr<id> object = notification.object;
+            LOG(Gamepad, "GameControllerGamepadProvider notified of disconnected GCController %p", object.get());
+            GameControllerGamepadProvider::singleton().controllerDidDisconnect(object.get());
         }];
     }
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm
@@ -50,10 +50,10 @@ Ref<GameControllerHapticEngines> GameControllerHapticEngines::create(GCControlle
 }
 
 GameControllerHapticEngines::GameControllerHapticEngines(GCController *gamepad)
-    : m_leftHandleEngine([gamepad.haptics createEngineWithLocality:get_GameController_GCHapticsLocalityLeftHandleSingleton()])
-    , m_rightHandleEngine([gamepad.haptics createEngineWithLocality:get_GameController_GCHapticsLocalityRightHandleSingleton()])
-    , m_leftTriggerEngine([gamepad.haptics createEngineWithLocality:get_GameController_GCHapticsLocalityLeftTriggerSingleton()])
-    , m_rightTriggerEngine([gamepad.haptics createEngineWithLocality:get_GameController_GCHapticsLocalityRightTriggerSingleton()])
+    : m_leftHandleEngine([retainPtr(gamepad.haptics) createEngineWithLocality:get_GameController_GCHapticsLocalityLeftHandleSingleton()])
+    , m_rightHandleEngine([retainPtr(gamepad.haptics) createEngineWithLocality:get_GameController_GCHapticsLocalityRightHandleSingleton()])
+    , m_leftTriggerEngine([retainPtr(gamepad.haptics) createEngineWithLocality:get_GameController_GCHapticsLocalityLeftTriggerSingleton()])
+    , m_rightTriggerEngine([retainPtr(gamepad.haptics) createEngineWithLocality:get_GameController_GCHapticsLocalityRightTriggerSingleton()])
 {
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -1253,7 +1253,7 @@ Ref<GenericPromise> AudioVideoRendererAVFObjC::setVideoRenderer(WebSampleBufferV
         if (RefPtr protectedThis = weakThis.get()) {
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
             if ([error code] == 'HDCP') {
-                bool obscured = [[[error userInfo] valueForKey:@"obscured"] boolValue];
+                bool obscured = [[retainPtr([error userInfo]) valueForKey:@"obscured"] boolValue];
                 if (RefPtr cdmInstance = protectedThis->m_cdmInstance)
                     cdmInstance->setHDCPStatus(obscured ? CDMInstance::HDCPStatus::OutputRestricted : CDMInstance::HDCPStatus::Valid);
                 return;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
@@ -56,7 +56,7 @@ String MediaPlaybackTargetContextCocoa::deviceName() const
 
     auto outputDeviceNames = adoptNS([[NSMutableArray alloc] init]);
     for (AVOutputDevice *outputDevice in [m_outputContext outputDevices])
-        [outputDeviceNames addObject:[outputDevice deviceName]];
+        [outputDeviceNames addObject:retainPtr([outputDevice deviceName]).get()];
 
     return [outputDeviceNames componentsJoinedByString:@" + "];
 }

--- a/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
@@ -81,7 +81,7 @@ int MediaSelectionOptionAVFObjC::index() const
         return 0;
 
     RetainPtr avMediaSelectionGroup = m_group->avMediaSelectionGroup();
-    return [[avMediaSelectionGroup options] indexOfObject:m_mediaSelectionOption.get()];
+    return [retainPtr([avMediaSelectionGroup options]) indexOfObject:m_mediaSelectionOption.get()];
 }
 
 AVAssetTrack* MediaSelectionOptionAVFObjC::assetTrack() const
@@ -149,10 +149,10 @@ void MediaSelectionGroupAVFObjC::updateOptions(const Vector<String>& characteris
         m_options.remove((__bridge CFTypeRef)removedAVOption);
     }
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    AVMediaSelectionOption* selectedOption = [m_playerItem selectedMediaOptionInMediaSelectionGroup:m_mediaSelectionGroup.get()];
+    RetainPtr<AVMediaSelectionOption> selectedOption = [m_playerItem selectedMediaOptionInMediaSelectionGroup:m_mediaSelectionGroup.get()];
 ALLOW_DEPRECATED_DECLARATIONS_END
     for (AVMediaSelectionOption* addedAVOption in addedAVOptions.get()) {
-        auto addedOption = MediaSelectionOptionAVFObjC::create(*this, addedAVOption);
+        Ref addedOption = MediaSelectionOptionAVFObjC::create(*this, addedAVOption);
         if (addedAVOption == selectedOption)
             m_selectedOption = addedOption.ptr();
         m_options.set((__bridge CFTypeRef)addedAVOption, WTFMove(addedOption));
@@ -178,12 +178,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (![filteredOptions count])
         return;
 
-    AVMediaSelectionOption* preferredOption = [filteredOptions objectAtIndex:0];
+    RetainPtr preferredOption = [filteredOptions objectAtIndex:0];
     if (m_selectedOption && m_selectedOption->avMediaSelectionOption() == preferredOption)
         return;
 
-    ASSERT(m_options.contains((__bridge CFTypeRef)preferredOption));
-    m_selectedOption = m_options.get((__bridge CFTypeRef)preferredOption);
+    ASSERT(m_options.contains((__bridge CFTypeRef)preferredOption.get()));
+    m_selectedOption = m_options.get((__bridge CFTypeRef)preferredOption.get());
     m_selectionTimer.startOneShot(0_s);
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
@@ -212,7 +212,7 @@ static bool isSampleBufferVideoRenderer(id object)
 - (void)layerFailedToDecode:(NSNotification *)notification
 {
     RetainPtr renderer = WebCore::isSampleBufferVideoRenderer(notification.object) ? (WebSampleBufferVideoRendering *)notification.object : nil;
-    RetainPtr error = dynamic_objc_cast<NSError>([notification.userInfo valueForKey:AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey]);
+    RetainPtr error = dynamic_objc_cast<NSError>([retainPtr(notification.userInfo) valueForKey:AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey]);
 
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), error = WTFMove(error)] {
         if (!_videoRenderers.contains(renderer.get()))
@@ -254,7 +254,7 @@ static bool isSampleBufferVideoRenderer(id object)
 - (void)audioRendererWasAutomaticallyFlushed:(NSNotification *)notification
 {
     RetainPtr renderer = dynamic_objc_cast<AVSampleBufferAudioRenderer>(notification.object);
-    CMTime flushTime = [[notification.userInfo valueForKey:AVSampleBufferAudioRendererFlushTimeKey] CMTimeValue];
+    CMTime flushTime = [[retainPtr(notification.userInfo) valueForKey:AVSampleBufferAudioRendererFlushTimeKey] CMTimeValue];
 
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), flushTime] {
         if (!_audioRenderers.contains(renderer.get()))

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetTrackUtilities.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetTrackUtilities.mm
@@ -86,9 +86,9 @@ bool assetTrackMeetsHardwareDecodeRequirements(AVAssetTrack *track, const Vector
 {
     Vector<FourCC> codecs;
     for (NSUInteger i = 0, count = track.formatDescriptions.count; i < count; ++i) {
-        CMFormatDescriptionRef description = (__bridge CMFormatDescriptionRef)track.formatDescriptions[i];
-        if (PAL::CMFormatDescriptionGetMediaType(description) == kCMMediaType_Video)
-            codecs.append(FourCC(PAL::CMFormatDescriptionGetMediaSubType(description)));
+        RetainPtr description = (__bridge CMFormatDescriptionRef)track.formatDescriptions[i];
+        if (PAL::CMFormatDescriptionGetMediaType(description.get()) == kCMMediaType_Video)
+            codecs.append(FourCC(PAL::CMFormatDescriptionGetMediaSubType(description.get())));
     }
     return codecsMeetHardwareDecodeRequirements(codecs, contentTypesRequiringHardwareDecode);
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm
@@ -38,15 +38,15 @@ namespace WebCore {
 
 Vector<Ref<SharedBuffer>> CDMPrivateFairPlayStreaming::keyIDsForRequest(AVContentKeyRequest *request)
 {
-    if (auto *identiferStr = dynamic_objc_cast<NSString>(request.identifier))
-        return { SharedBuffer::create([identiferStr dataUsingEncoding:NSUTF8StringEncoding]) };
-    if (auto *identifierData = dynamic_objc_cast<NSData>(request.identifier))
-        return { SharedBuffer::create(identifierData) };
+    if (RetainPtr identiferStr = dynamic_objc_cast<NSString>(request.identifier))
+        return { SharedBuffer::create(retainPtr([identiferStr dataUsingEncoding:NSUTF8StringEncoding]).get()) };
+    if (RetainPtr identifierData = dynamic_objc_cast<NSData>(request.identifier))
+        return { SharedBuffer::create(identifierData.get()) };
     if (request.initializationData) {
-        if (auto sinfKeyIDs = CDMPrivateFairPlayStreaming::extractKeyIDsSinf(SharedBuffer::create(request.initializationData)))
+        if (auto sinfKeyIDs = CDMPrivateFairPlayStreaming::extractKeyIDsSinf(SharedBuffer::create(retainPtr(request.initializationData).get())))
             return WTFMove(sinfKeyIDs.value());
 #if HAVE(FAIRPLAYSTREAMING_MTPS_INITDATA)
-        if (auto mptsKeyIDs = CDMPrivateFairPlayStreaming::extractKeyIDsMpts(SharedBuffer::create(request.initializationData)))
+        if (auto mptsKeyIDs = CDMPrivateFairPlayStreaming::extractKeyIDsMpts(SharedBuffer::create(retainPtr(request.initializationData).get())))
             return WTFMove(mptsKeyIDs.value());
 #endif
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
@@ -124,7 +124,7 @@ void CDMSessionAVFoundationObjC::releaseKeys()
 bool CDMSessionAVFoundationObjC::update(Uint8Array* key, RefPtr<Uint8Array>& nextMessage, unsigned short& errorCode, uint32_t& systemCode)
 {
     RetainPtr keyData = toNSData(key->span());
-    [[m_request dataRequest] respondWithData:keyData.get()];
+    [retainPtr([m_request dataRequest]) respondWithData:keyData.get()];
     [m_request finishLoading];
     errorCode = MediaPlayer::NoError;
     systemCode = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm
@@ -148,11 +148,11 @@ AtomString InbandTextTrackPrivateAVFObjC::label() const
     if (!commonMetadata)
         return emptyAtom();
 
-    NSString *title = 0;
-    NSArray *titles = [PAL::getAVMetadataItemClassSingleton() metadataItemsFromArray:commonMetadata withKey:AVMetadataCommonKeyTitle keySpace:AVMetadataKeySpaceCommon];
+    RetainPtr<NSString> title;
+    RetainPtr<NSArray> titles = [PAL::getAVMetadataItemClassSingleton() metadataItemsFromArray:commonMetadata withKey:AVMetadataCommonKeyTitle keySpace:AVMetadataKeySpaceCommon];
     if ([titles count]) {
         // If possible, return a title in one of the user's preferred languages.
-        NSArray *titlesForPreferredLanguages = [PAL::getAVMetadataItemClassSingleton() metadataItemsFromArray:titles filteredAndSortedAccordingToPreferredLanguages:[NSLocale preferredLanguages]];
+        RetainPtr<NSArray> titlesForPreferredLanguages = [PAL::getAVMetadataItemClassSingleton() metadataItemsFromArray:titles.get() filteredAndSortedAccordingToPreferredLanguages:[NSLocale preferredLanguages]];
         if ([titlesForPreferredLanguages count])
             title = [[titlesForPreferredLanguages objectAtIndex:0] stringValue];
 
@@ -160,7 +160,7 @@ AtomString InbandTextTrackPrivateAVFObjC::label() const
             title = [[titles objectAtIndex:0] stringValue];
     }
 
-    return title ? AtomString(title) : emptyAtom();
+    return title ? AtomString(title.get()) : emptyAtom();
 }
 
 AtomString InbandTextTrackPrivateAVFObjC::language() const

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -427,8 +427,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if !RELEASE_LOG_DISABLED
     constexpr size_t frameCountPerLog = 1800; // log every minute at 30 fps
     if (!(m_frameRateMonitor.frameCount() % frameCountPerLog)) {
-        if (auto* metrics = [m_sampleBufferDisplayLayer videoPerformanceMetrics])
-            RELEASE_LOG(WebRTC, "LocalSampleBufferDisplayLayer (%llu) metrics, total=%lu, dropped=%lu, corrupted=%lu, display-composited=%lu, non-display-composited=%lu (pending=%lu)", m_logIdentifier, metrics.totalNumberOfVideoFrames, metrics.numberOfDroppedVideoFrames, metrics.numberOfCorruptedVideoFrames, metrics.numberOfDisplayCompositedVideoFrames, metrics.numberOfNonDisplayCompositedVideoFrames, m_pendingVideoFrameQueue.size());
+        if (RetainPtr metrics = [m_sampleBufferDisplayLayer videoPerformanceMetrics])
+            RELEASE_LOG(WebRTC, "LocalSampleBufferDisplayLayer (%llu) metrics, total=%lu, dropped=%lu, corrupted=%lu, display-composited=%lu, non-display-composited=%lu (pending=%lu)", m_logIdentifier, metrics.get().totalNumberOfVideoFrames, metrics.get().numberOfDroppedVideoFrames, metrics.get().numberOfCorruptedVideoFrames, metrics.get().numberOfDisplayCompositedVideoFrames, metrics.get().numberOfNonDisplayCompositedVideoFrames, m_pendingVideoFrameQueue.size());
     }
     m_frameRateMonitor.update();
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
@@ -103,9 +103,8 @@ SPECIALIZE_TYPE_TRAITS_END()
     if (![keyPath isEqualToString:@"rate"])
         return;
 
-    auto rateValue = (NSNumber*)[change valueForKey:NSKeyValueChangeNewKey];
-    ASSERT([rateValue isKindOfClass:NSNumber.class]);
-    auto rate = rateValue.floatValue;
+    RetainPtr rateValue = checked_objc_cast<NSNumber>([change valueForKey:NSKeyValueChangeNewKey]);
+    auto rate = rateValue.get().floatValue;
 
     ensureOnMainRunLoop([parent = _parent, rate] {
         if (parent)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
@@ -130,7 +130,7 @@ void VideoLayerManagerObjC::setVideoFullscreenLayer(PlatformLayer *videoFullscre
     [CATransaction setDisableActions:YES];
 
     if (m_videoLayer) {
-        CAContext *oldContext = [m_videoLayer context];
+        RetainPtr<CAContext> oldContext = [m_videoLayer context];
 
         if (m_videoInlineLayer && currentImage)
             [m_videoInlineLayer setContents:(__bridge id)currentImage.get()];
@@ -144,11 +144,11 @@ void VideoLayerManagerObjC::setVideoFullscreenLayer(PlatformLayer *videoFullscre
         } else
             [m_videoLayer removeFromSuperlayer];
 
-        CAContext *newContext = [m_videoLayer context];
+        RetainPtr<CAContext> newContext = [m_videoLayer context];
         if (oldContext && newContext && oldContext != newContext) {
 #if PLATFORM(MAC)
-            oldContext.commitPriority = 0;
-            newContext.commitPriority = 1;
+            oldContext.get().commitPriority = 0;
+            newContext.get().commitPriority = 1;
 #endif
             auto fencePort = MachSendRight::adopt([oldContext createFencePort]);
             [newContext setFencePort:fencePort.sendRight()];

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -301,18 +301,18 @@ void WebCoreAVFResourceLoader::startLoading()
     if (m_dataURLMediaLoader || m_resourceMediaLoader || m_platformMediaLoader || !parent)
         return;
 
-    NSURLRequest *nsRequest = [m_avRequest request];
+    RetainPtr<NSURLRequest> nsRequest = [m_avRequest request];
 
-    ResourceRequest request(nsRequest);
+    ResourceRequest request(nsRequest.get());
     request.setPriority(ResourceLoadPriority::Low);
 
-    AVAssetResourceLoadingDataRequest* dataRequest = [m_avRequest dataRequest];
+    RetainPtr<AVAssetResourceLoadingDataRequest> dataRequest = [m_avRequest dataRequest];
     m_currentOffset = m_requestedOffset = dataRequest ? [dataRequest requestedOffset] : -1;
     m_requestedLength = dataRequest ? [dataRequest requestedLength] : -1;
 
     if (dataRequest && m_requestedLength > 0
         && !request.hasHTTPHeaderField(HTTPHeaderName::Range)) {
-        String rangeEnd = dataRequest.requestsAllDataToEndOfResource ? emptyString() : makeString(m_requestedOffset + m_requestedLength - 1);
+        String rangeEnd = dataRequest.get().requestsAllDataToEndOfResource ? emptyString() : makeString(m_requestedOffset + m_requestedLength - 1);
         request.addHTTPHeaderField(HTTPHeaderName::Range, makeString("bytes="_s, m_requestedOffset, '-', rangeEnd));
     }
 
@@ -369,7 +369,7 @@ bool WebCoreAVFResourceLoader::responseReceived(const String& mimeType, int stat
 
     m_responseOffset = contentRange.isValid() ? static_cast<NSUInteger>(contentRange.firstBytePosition()) : 0;
 
-    if (AVAssetResourceLoadingContentInformationRequest* contentInfo = [m_avRequest contentInformationRequest]) {
+    if (RetainPtr<AVAssetResourceLoadingContentInformationRequest> contentInfo = [m_avRequest contentInformationRequest]) {
         String uti = UTIFromMIMEType(mimeType);
 
         [contentInfo setContentType:uti.createNSString().get()];
@@ -423,7 +423,7 @@ bool WebCoreAVFResourceLoader::newDataStoredInSharedBuffer(const FragmentedShare
 {
     assertIsCurrent(m_targetDispatcher.get());
 
-    AVAssetResourceLoadingDataRequest* dataRequest = [m_avRequest dataRequest];
+    RetainPtr<AVAssetResourceLoadingDataRequest> dataRequest = [m_avRequest dataRequest];
     if (!dataRequest)
         return true;
 

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm
@@ -98,9 +98,9 @@
         return NO;
 
     CGPoint pointInMask = [self.mask convertPoint:point fromLayer:self];
-    if (auto *shapeMask = dynamic_objc_cast<CAShapeLayer>(self.mask)) {
-        bool isEvenOddFill = [shapeMask.fillRule isEqualToString:kCAFillRuleEvenOdd];
-        return CGPathContainsPoint(shapeMask.path, nullptr, pointInMask, isEvenOddFill);
+    if (RetainPtr shapeMask = dynamic_objc_cast<CAShapeLayer>(self.mask)) {
+        bool isEvenOddFill = [shapeMask.get().fillRule isEqualToString:kCAFillRuleEvenOdd];
+        return CGPathContainsPoint(shapeMask.get().path, nullptr, pointInMask, isEvenOddFill);
     }
 
     return [self.mask containsPoint:pointInMask];
@@ -112,8 +112,8 @@
         return NO;
 
     CGRect rectInMask = [self.mask convertRect:rect fromLayer:self];
-    if (auto *shapeMask = dynamic_objc_cast<CAShapeLayer>(self.mask)) {
-        CGRect pathBounds = CGPathGetPathBoundingBox(shapeMask.path);
+    if (RetainPtr shapeMask = dynamic_objc_cast<CAShapeLayer>(self.mask)) {
+        CGRect pathBounds = CGPathGetPathBoundingBox(shapeMask.get().path);
         return CGRectIntersectsRect(pathBounds, rectInMask);
     }
 

--- a/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
@@ -159,13 +159,13 @@ bool FEComponentTransferCoreImageApplier::applyGamma(RetainPtr<CIImage> inputIma
         @(m_effect->blueFunction().amplitude),  @(m_effect->blueFunction().exponent),  @(m_effect->blueFunction().offset)
     ];
 
-    CIImage *outputImage = [kernel applyWithExtent:inputImage.get().extent
+    RetainPtr<CIImage> outputImage = [kernel applyWithExtent:inputImage.get().extent
         roiCallback:^CGRect(int, CGRect destRect) {
             return destRect;
         }
         arguments:arguments.get()];
 
-    result.setCIImage(outputImage);
+    result.setCIImage(WTFMove(outputImage));
     return true;
 }
 #endif

--- a/Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.mm
+++ b/Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.mm
@@ -44,7 +44,7 @@ AppKitControlSystemImage::AppKitControlSystemImage(AppKitControlSystemImageType 
     , m_controlType(controlType)
 {
     NSAppearance *appearance = [NSAppearance currentDrawingAppearance];
-    m_tintColor = colorFromCocoaColor(appearance.tintColor);
+    m_tintColor = colorFromCocoaColor(retainPtr(appearance.tintColor).get());
     m_useDarkAppearance = [appearance.name isEqualToString:NSAppearanceNameDarkAqua];
 }
 

--- a/Source/WebCore/platform/graphics/mac/ColorMac.mm
+++ b/Source/WebCore/platform/graphics/mac/ColorMac.mm
@@ -77,7 +77,7 @@ static std::optional<SRGBA<uint8_t>> makeSimpleColorFromNSColor(NSColor *color)
     CGFloat alpha;
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    NSColor *rgbColor = [color colorUsingColorSpace:NSColorSpace.deviceRGBColorSpace];
+    RetainPtr<NSColor> rgbColor = [color colorUsingColorSpace:NSColorSpace.deviceRGBColorSpace];
     if (!rgbColor) {
         // The color space conversion above can fail if the NSColor is in the NSPatternColorSpace.
         // These colors are actually a repeating pattern, not just a solid color. To workaround

--- a/Source/WebCore/platform/graphics/mac/IconMac.mm
+++ b/Source/WebCore/platform/graphics/mac/IconMac.mm
@@ -65,7 +65,7 @@ RefPtr<Icon> Icon::createIconForFiles(const Vector<String>& filenames)
 RefPtr<Icon> Icon::createIconForFileExtension(const String& fileExtension)
 {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    RetainPtr image = [[NSWorkspace sharedWorkspace] iconForFileType:[@"." stringByAppendingString:fileExtension.createNSString().get()]];
+    RetainPtr image = [[NSWorkspace sharedWorkspace] iconForFileType:retainPtr([@"." stringByAppendingString:fileExtension.createNSString().get()]).get()];
 ALLOW_DEPRECATED_DECLARATIONS_END
     if (!image)
         return nullptr;

--- a/Source/WebCore/platform/graphics/mac/PDFDocumentImageMac.mm
+++ b/Source/WebCore/platform/graphics/mac/PDFDocumentImageMac.mm
@@ -53,7 +53,7 @@ void PDFDocumentImage::createPDFDocument()
 
 void PDFDocumentImage::computeBoundsForCurrentPage()
 {
-    PDFPage *pdfPage = [m_document pageAtIndex:0];
+    RetainPtr<PDFPage> pdfPage = [m_document pageAtIndex:0];
 
     m_cropBox = [pdfPage boundsForBox:kPDFDisplayBoxCropBox];
     m_rotationDegrees = [pdfPage rotation];

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
@@ -71,7 +71,7 @@ void SearchFieldCancelButtonMac::updateCellStates(const FloatRect& rect, const C
     bool readOnly = style.states.contains(ControlStyle::State::ReadOnly);
 
     if (!enabled && !readOnly)
-        updatePressedState([m_searchFieldCell cancelButtonCell], style);
+        updatePressedState(retainPtr([m_searchFieldCell cancelButtonCell]).get(), style);
     else if ([[m_searchFieldCell cancelButtonCell] isHighlighted])
         [[m_searchFieldCell cancelButtonCell] setHighlighted:NO];
 
@@ -94,7 +94,7 @@ void SearchFieldCancelButtonMac::draw(GraphicsContext& context, const FloatRound
     auto styleForDrawing = style;
     styleForDrawing.states.remove(ControlStyle::State::Focused);
 
-    drawCell(context, logicalRect, deviceScaleFactor, styleForDrawing, [m_searchFieldCell cancelButtonCell], true);
+    drawCell(context, logicalRect, deviceScaleFactor, styleForDrawing, retainPtr([m_searchFieldCell cancelButtonCell]).get(), true);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldResultsMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldResultsMac.mm
@@ -66,7 +66,7 @@ void SearchFieldResultsMac::draw(GraphicsContext& context, const FloatRoundedRec
         context.scale(style.zoomFactor);
     }
 
-    drawCell(context, logicalRect, deviceScaleFactor, style, [m_searchFieldCell searchButtonCell], true);
+    drawCell(context, logicalRect, deviceScaleFactor, style, retainPtr([m_searchFieldCell searchButtonCell]).get(), true);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/WebControlView.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/WebControlView.mm
@@ -151,7 +151,7 @@ static NSRect _clipBounds;
 {
     // Dark mode controls don't have borders, just a semi-transparent background of shadows.
     // In the dark mode case we can't disable borders, or we will not paint anything for the control.
-    NSAppearanceName appearance = [[NSAppearance currentDrawingAppearance] bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
+    RetainPtr appearance = [[NSAppearance currentDrawingAppearance] bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
     if ([appearance isEqualToString:NSAppearanceNameDarkAqua])
         return defaultOptions;
 

--- a/Source/WebCore/platform/mac/CursorMac.mm
+++ b/Source/WebCore/platform/mac/CursorMac.mm
@@ -227,7 +227,7 @@ static RetainPtr<NSCursor> createCustomCursor(Image* image, const IntPoint& hotS
 
     // Scale the image and its representation to match retina resolution.
     [nsImage setSize:expandedSize];
-    [[[nsImage representations] objectAtIndex:0] setSize:expandedSize];
+    [[retainPtr([nsImage representations]) objectAtIndex:0] setSize:expandedSize];
 #endif
 
     return adoptNS([[NSCursor alloc] initWithImage:nsImage.get() hotSpot:hotSpot]);

--- a/Source/WebCore/platform/mac/LocalDefaultSystemAppearance.mm
+++ b/Source/WebCore/platform/mac/LocalDefaultSystemAppearance.mm
@@ -40,12 +40,12 @@ LocalDefaultSystemAppearance::LocalDefaultSystemAppearance(bool useDarkAppearanc
     m_usingDarkAppearance = useDarkAppearance;
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSAppearance *appearance = [NSAppearance appearanceNamed:m_usingDarkAppearance ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua];
+    RetainPtr appearance = [NSAppearance appearanceNamed:m_usingDarkAppearance ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua];
 
     if (tintColor.isValid())
         appearance = [appearance appearanceByApplyingTintColor:cocoaColor(tintColor).get()];
 
-    [NSAppearance setCurrentAppearance:appearance];
+    [NSAppearance setCurrentAppearance:appearance.get()];
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -268,11 +268,11 @@ static void writeFileWrapperAsRTFDAttachment(NSFileWrapper *wrapper, const Strin
 {
     RetainPtr string = [NSAttributedString attributedStringWithAttachment:adoptNS([[NSTextAttachment alloc] initWithFileWrapper:wrapper]).get()];
 
-    NSData *RTFDData = [string RTFDFromRange:NSMakeRange(0, [string length]) documentAttributes:@{ }];
+    RetainPtr<NSData> RTFDData = [string RTFDFromRange:NSMakeRange(0, [string length]) documentAttributes:@{ }];
     if (!RTFDData)
         return;
 
-    newChangeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(SharedBuffer::create(RTFDData).ptr(), legacyRTFDPasteboardTypeSingleton(), pasteboardName, context);
+    newChangeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(SharedBuffer::create(RTFDData.get()).ptr(), legacyRTFDPasteboardTypeSingleton(), pasteboardName, context);
 }
 
 void Pasteboard::write(const PasteboardImage& pasteboardImage)
@@ -754,9 +754,9 @@ static void setDragImageImpl(NSImage *image, NSPoint offset)
     NSSize imageSize = image.size;
     CGRect imageRect = CGRectMake(0, 0, imageSize.width, imageSize.height);
     NSRect convertedRect = NSRectFromCGRect(imageRect);
-    NSImageRep *imageRep = [image bestRepresentationForRect:convertedRect context:nil hints:nil];
+    RetainPtr<NSImageRep> imageRep = [image bestRepresentationForRect:convertedRect context:nil hints:nil];
     RetainPtr<NSBitmapImageRep> bitmapImage;
-    if (!imageRep || ![imageRep isKindOfClass:[NSBitmapImageRep class]] || !NSEqualSizes(imageRep.size, imageSize)) {
+    if (!imageRep || ![imageRep isKindOfClass:[NSBitmapImageRep class]] || !NSEqualSizes(imageRep.get().size, imageSize)) {
         [image lockFocus];
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         bitmapImage = adoptNS([[NSBitmapImageRep alloc] initWithFocusedViewRect:convertedRect]);
@@ -770,7 +770,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
     } else {
         flipImage = false;
-        bitmapImage = checked_objc_cast<NSBitmapImageRep>(imageRep);
+        bitmapImage = checked_objc_cast<NSBitmapImageRep>(imageRep.get());
     }
     ASSERT(bitmapImage);
 

--- a/Source/WebCore/platform/mac/PasteboardWriter.mm
+++ b/Source/WebCore/platform/mac/PasteboardWriter.mm
@@ -87,15 +87,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [pasteboardItem setPropertyList:paths.get() forType:toUTI(@"WebURLsWithTitlesPboardType").get()];
 
         // NSURLPboardType.
-        if (NSURL *baseCocoaURL = nsURL.get().baseURL)
-            [pasteboardItem setPropertyList:@[ nsURL.get().relativeString, baseCocoaURL.absoluteString ] forType:toUTI(WebCore::legacyURLPasteboardTypeSingleton()).get()];
+        if (RetainPtr<NSURL> baseCocoaURL = nsURL.get().baseURL)
+            [pasteboardItem setPropertyList:@[ nsURL.get().relativeString, baseCocoaURL.get().absoluteString ] forType:toUTI(WebCore::legacyURLPasteboardTypeSingleton()).get()];
         else if (nsURL)
             [pasteboardItem setPropertyList:@[ nsURL.get().absoluteString, @"" ] forType:toUTI(WebCore::legacyURLPasteboardTypeSingleton()).get()];
         else
             [pasteboardItem setPropertyList:@[ @"", @"" ] forType:toUTI(WebCore::legacyURLPasteboardTypeSingleton()).get()];
 
         if (nsURL.get().fileURL)
-            [pasteboardItem setString:nsURL.get().absoluteString forType:UTTypeFileURL.identifier];
+            [pasteboardItem setString:retainPtr(nsURL.get().absoluteString).get() forType:UTTypeFileURL.identifier];
         [pasteboardItem setString:userVisibleString.get() forType:UTTypeURL.identifier];
 
         // WebURLNamePboardType.

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -55,7 +55,7 @@ namespace WebCore {
 PlatformDisplayID displayID(NSScreen *screen)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    return [[screen.deviceDescription objectForKey:@"NSScreenNumber"] intValue];
+    return [[retainPtr(screen.deviceDescription) objectForKey:@"NSScreenNumber"] intValue];
 }
 
 static PlatformDisplayID displayID(Widget* widget)

--- a/Source/WebCore/platform/mac/ScrollViewMac.mm
+++ b/Source/WebCore/platform/mac/ScrollViewMac.mm
@@ -80,7 +80,7 @@ void ScrollView::platformAddChild(Widget* child)
     ASSERT(![parentView isDescendantOf:childView.get()]);
     
     // Suppress the resetting of drag margins since we know we can't affect them.
-    NSWindow *window = [parentView window];
+    RetainPtr<NSWindow> window = [parentView window];
     BOOL resetDragMargins = [window _needsToResetDragMargins];
     [window _setNeedsToResetDragMargins:NO];
     if ([childView superview] != parentView)
@@ -256,7 +256,7 @@ IntRect ScrollView::platformContentsToScreen(const IntRect& rect) const
     if (RetainPtr documentView = this->documentView()) {
         NSRect tempRect = rect;
         tempRect = [documentView convertRect:tempRect toView:nil];
-        tempRect.origin = [[documentView window] convertPointToScreen:tempRect.origin];
+        tempRect.origin = [retainPtr([documentView window]) convertPointToScreen:tempRect.origin];
         return enclosingIntRect(tempRect);
     }
     END_BLOCK_OBJC_EXCEPTIONS
@@ -267,7 +267,7 @@ IntPoint ScrollView::platformScreenToContents(const IntPoint& point) const
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     if (RetainPtr documentView = this->documentView()) {
-        NSPoint windowCoord = [[documentView window] convertPointFromScreen: point];
+        NSPoint windowCoord = [retainPtr([documentView window]) convertPointFromScreen: point];
         return IntPoint([documentView convertPoint:windowCoord fromView:nil]);
     }
     END_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -959,9 +959,9 @@ void ScrollbarsControllerMac::updateScrollerImps()
     if (verticalScrollbar && !verticalScrollbar->isCustomScrollbar()) {
         verticalScrollbar->invalidate();
 
-        NSScrollerImp *oldVerticalPainter = [m_scrollerImpPair verticalScrollerImp];
+        RetainPtr<NSScrollerImp> oldVerticalPainter = [m_scrollerImpPair verticalScrollerImp];
         RefPtr verticalScrollbarMac = dynamicDowncast<ScrollbarMac>(verticalScrollbar);
-        verticalScrollbarMac->createScrollerImp(WTFMove(oldVerticalPainter));
+        verticalScrollbarMac->createScrollerImp(oldVerticalPainter.get());
         [m_scrollerImpPair setVerticalScrollerImp:verticalScrollbarMac->protectedScrollerImp().get()];
     }
 
@@ -969,9 +969,9 @@ void ScrollbarsControllerMac::updateScrollerImps()
     if (horizontalScrollbar && !horizontalScrollbar->isCustomScrollbar()) {
         horizontalScrollbar->invalidate();
 
-        NSScrollerImp *oldHorizontalPainter = [m_scrollerImpPair horizontalScrollerImp];
+        RetainPtr<NSScrollerImp> oldHorizontalPainter = [m_scrollerImpPair horizontalScrollerImp];
         RefPtr horizontalScrollbarMac = dynamicDowncast<ScrollbarMac>(horizontalScrollbar);
-        horizontalScrollbarMac->createScrollerImp(WTFMove(oldHorizontalPainter));
+        horizontalScrollbarMac->createScrollerImp(oldHorizontalPainter.get());
         [m_scrollerImpPair setHorizontalScrollerImp:horizontalScrollbarMac->protectedScrollerImp().get()];
     }
 }

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
@@ -109,7 +109,7 @@ static JSValue *jsValueWithValueInContext(id value, JSContext *context)
         return [JSValue valueWithObject:value inContext:context];
 
     if ([value isKindOfClass:[NSLocale class]])
-        return [JSValue valueWithObject:[value localeIdentifier] inContext:context];
+        return [JSValue valueWithObject:retainPtr([value localeIdentifier]).get() inContext:context];
 
     if ([value isKindOfClass:[NSDictionary class]])
         return jsValueWithDictionaryInContext(value, context);
@@ -146,7 +146,7 @@ static JSValue *jsValueWithArrayInContext(NSArray *array, JSContext *context)
 
     NSUInteger count = [array count];
     for (NSUInteger i = 0; i < count; ++i) {
-        RetainPtr value = jsValueWithValueInContext([array objectAtIndex:i], context);
+        RetainPtr value = jsValueWithValueInContext(retainPtr([array objectAtIndex:i]).get(), context);
         if (!value)
             continue;
 
@@ -170,7 +170,7 @@ static JSValue *jsValueWithDictionaryInContext(NSDictionary *dictionary, JSConte
         if (![key isKindOfClass:[NSString class]])
             continue;
 
-        RetainPtr value = jsValueWithValueInContext([dictionary objectForKey:key], context);
+        RetainPtr value = jsValueWithValueInContext(retainPtr([dictionary objectForKey:key]).get(), context);
         if (!value)
             continue;
 

--- a/Source/WebCore/platform/mac/ThreadCheck.mm
+++ b/Source/WebCore/platform/mac/ThreadCheck.mm
@@ -44,7 +44,7 @@ static void readThreadViolationBehaviorFromUserDefaults()
     didReadThreadViolationBehaviorFromUserDefaults = true;
 
     ThreadViolationBehavior newBehavior = LogOnFirstThreadViolation;
-    NSString *threadCheckLevel = [[NSUserDefaults standardUserDefaults] stringForKey:@"WebCoreThreadCheck"];
+    RetainPtr<NSString> threadCheckLevel = [[NSUserDefaults standardUserDefaults] stringForKey:@"WebCoreThreadCheck"];
     if (!threadCheckLevel)
         return;
 

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -325,19 +325,19 @@ enum class PIPState {
     [_videoViewContainer setAutoresizingMask:(NSViewWidthSizable | NSViewHeightSizable)];
 
     _playerLayer = adoptNS([[WebAVPlayerLayer alloc] init]);
-    [[_videoViewContainer layer] addSublayer:_playerLayer.get()];
+    [retainPtr([_videoViewContainer layer]) addSublayer:_playerLayer.get()];
     [_playerLayer setFrame:[_videoViewContainer layer].bounds];
     [_playerLayer setPresentationModel:model.get()];
     [_playerLayer setVideoSublayer:videoView.layer];
     [_playerLayer setVideoDimensions:_videoDimensions];
     [_playerLayer setAutoresizingMask:(kCALayerWidthSizable | kCALayerHeightSizable)];
 
-    [videoView.layer removeFromSuperlayer];
-    [_playerLayer addSublayer:videoView.layer];
+    [retainPtr(videoView.layer) removeFromSuperlayer];
+    [_playerLayer addSublayer:retainPtr(videoView.layer).get()];
 
     _videoViewContainerController = adoptNS([[NSViewController alloc] init]);
     [_videoViewContainerController setView:_videoViewContainer.get()];
-    [window.contentView addSubview:_videoViewContainer.get() positioned:NSWindowAbove relativeTo:nil];
+    [retainPtr(window.contentView) addSubview:_videoViewContainer.get() positioned:NSWindowAbove relativeTo:nil];
 
 #if HAVE(PIP_SKIP_PREROLL)
     [self updatePrerollAttributes];
@@ -427,7 +427,7 @@ enum class PIPState {
 
     ASSERT(videoViewContainer == _videoViewContainer);
 
-    if (![videoViewContainer isDescendantOf:[_pipViewController view]])
+    if (![videoViewContainer isDescendantOf:retainPtr([_pipViewController view]).get()])
         return;
 
     // Once the view is moved into the pip view, make sure it resizes with the pip view.
@@ -487,7 +487,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
             [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
                 context.allowsImplicitAnimation = NO;
                 [_videoViewContainer setFrame:_returningRect];
-                [[_returningWindow contentView] addSubview:_videoViewContainer.get() positioned:NSWindowAbove relativeTo:nil];
+                [retainPtr([_returningWindow contentView]) addSubview:_videoViewContainer.get() positioned:NSWindowAbove relativeTo:nil];
             } completionHandler:nil];
         }
 

--- a/Source/WebCore/platform/mac/WebCoreFullScreenWindow.mm
+++ b/Source/WebCore/platform/mac/WebCoreFullScreenWindow.mm
@@ -78,26 +78,26 @@
 
 - (void)cancelOperation:(id)sender
 {
-    [[self windowController] cancelOperation:sender];
+    [retainPtr([self windowController]) cancelOperation:sender];
 }
 
 - (void)performClose:(id)sender
 {
-    [[self windowController] performClose:sender];
+    [retainPtr([self windowController]) performClose:sender];
 }
 
 - (void)setStyleMask:(NSUInteger)styleMask
 {
     // Changing the styleMask of a NSWindow can reset the firstResponder if the frame view changes,
     // so save off the existing one, and restore it if necessary after the call to -setStyleMask:.
-    NSResponder* savedFirstResponder = [self firstResponder];
+    RetainPtr<NSResponder> savedFirstResponder = [self firstResponder];
 
     [super setStyleMask:styleMask];
 
     if ([self firstResponder] != savedFirstResponder
         && [savedFirstResponder isKindOfClass:[NSView class]]
-        && [checked_objc_cast<NSView>(savedFirstResponder) isDescendantOf:[self contentView]])
-        [self makeFirstResponder:savedFirstResponder];
+        && [checked_objc_cast<NSView>(savedFirstResponder.get()) isDescendantOf:retainPtr([self contentView]).get()])
+        [self makeFirstResponder:savedFirstResponder.get()];
 }
 @end
 

--- a/Source/WebCore/platform/mac/WebCoreNSFontManagerExtras.mm
+++ b/Source/WebCore/platform/mac/WebCoreNSFontManagerExtras.mm
@@ -60,8 +60,8 @@ static FontChanges computedFontChanges(NSFontManager *fontManager, NSFont *origi
     // between WebKitLegacy and WebKit.
     const double minimumBoldWeight = 7.;
 
-    NSString *convertedFamilyNameA = convertedFontA.familyName;
-    NSString *convertedFamilyNameB = convertedFontB.familyName;
+    RetainPtr<NSString> convertedFamilyNameA = convertedFontA.familyName;
+    RetainPtr<NSString> convertedFamilyNameB = convertedFontB.familyName;
 
     auto convertedPointSizeA = convertedFontA.pointSize;
     auto convertedPointSizeB = convertedFontB.pointSize;
@@ -75,9 +75,9 @@ static FontChanges computedFontChanges(NSFontManager *fontManager, NSFont *origi
     bool convertedFontAIsBold = convertedFontWeightA > minimumBoldWeight;
 
     FontChanges changes;
-    if ([convertedFamilyNameA isEqualToString:convertedFamilyNameB]) {
+    if ([convertedFamilyNameA isEqualToString:convertedFamilyNameB.get()]) {
         changes.setFontName(convertedFontA.fontName);
-        changes.setFontFamily(convertedFamilyNameA);
+        changes.setFontFamily(convertedFamilyNameA.get());
     }
 
     int originalPointSizeA = originalFontA.pointSize;
@@ -100,7 +100,7 @@ static FontChanges computedFontChanges(NSFontManager *fontManager, NSFont *origi
 FontChanges computedFontChanges(NSFontManager *fontManager)
 {
     RetainPtr originalFontA = firstFontConversionSpecimen(fontManager);
-    return computedFontChanges(fontManager, originalFontA.get(), [fontManager convertFont:originalFontA.get()], [fontManager convertFont:RetainPtr { secondFontConversionSpecimen(fontManager) }.get()]);
+    return computedFontChanges(fontManager, originalFontA.get(), retainPtr([fontManager convertFont:originalFontA.get()]).get(), retainPtr([fontManager convertFont:RetainPtr { secondFontConversionSpecimen(fontManager) }.get()]).get());
 }
 
 FontAttributeChanges computedFontAttributeChanges(NSFontManager *fontManager, id attributeConverter)
@@ -122,14 +122,14 @@ FontAttributeChanges computedFontAttributeChanges(NSFontManager *fontManager, id
         NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle)
     };
 
-    NSDictionary *convertedAttributesA = [attributeConverter convertAttributes:originalAttributesA];
-    NSDictionary *convertedAttributesB = [attributeConverter convertAttributes:originalAttributesB];
+    RetainPtr<NSDictionary> convertedAttributesA = [attributeConverter convertAttributes:originalAttributesA];
+    RetainPtr<NSDictionary> convertedAttributesB = [attributeConverter convertAttributes:originalAttributesB];
 
     RetainPtr convertedBackgroundColorA = [convertedAttributesA objectForKey:NSBackgroundColorAttributeName];
     if (convertedBackgroundColorA == [convertedAttributesB objectForKey:NSBackgroundColorAttributeName])
         changes.setBackgroundColor(colorFromCocoaColor(convertedBackgroundColorA ? convertedBackgroundColorA.get() : RetainPtr { NSColor.clearColor }.get()));
 
-    changes.setFontChanges(computedFontChanges(fontManager, originalFontA.get(), [convertedAttributesA objectForKey:NSFontAttributeName], [convertedAttributesB objectForKey: NSFontAttributeName]));
+    changes.setFontChanges(computedFontChanges(fontManager, originalFontA.get(), retainPtr([convertedAttributesA objectForKey:NSFontAttributeName]).get(), retainPtr([convertedAttributesB objectForKey: NSFontAttributeName]).get()));
 
     RetainPtr convertedForegroundColorA = [convertedAttributesA objectForKey:NSForegroundColorAttributeName];
     if (convertedForegroundColorA == [convertedAttributesB objectForKey:NSForegroundColorAttributeName])

--- a/Source/WebCore/platform/mac/WebCoreNSURLExtras.mm
+++ b/Source/WebCore/platform/mac/WebCoreNSURLExtras.mm
@@ -55,7 +55,7 @@ NSURL *URLByCanonicalizingURL(NSURL *URL)
     // make sense to apply both, but when we tried that it caused a performance degradation
     // (see 5315926). It might make sense to apply only the URL concept and not the NSURL
     // concept, but it's too risky to make that change for WebKit 3.0.
-    NSURLRequest *newRequest = [concreteClass canonicalRequestForRequest:request.get()];
+    RetainPtr<NSURLRequest> newRequest = [concreteClass canonicalRequestForRequest:request.get()];
     return retainPtr([newRequest URL]).autorelease();
 }
 

--- a/Source/WebCore/platform/mac/WebCoreView.mm
+++ b/Source/WebCore/platform/mac/WebCoreView.mm
@@ -50,7 +50,7 @@
 
 - (NSView *)_webcore_effectiveFirstResponder
 {
-    NSView *view = [self documentView];
+    RetainPtr<NSView> view = [self documentView];
     return view ? [view _webcore_effectiveFirstResponder] : [super _webcore_effectiveFirstResponder];
 }
 
@@ -60,7 +60,7 @@
 
 - (NSView *)_webcore_effectiveFirstResponder
 {
-    NSView *view = [self contentView];
+    RetainPtr<NSView> view = [self contentView];
     return view ? [view _webcore_effectiveFirstResponder] : [super _webcore_effectiveFirstResponder];
 }
 

--- a/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
+++ b/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
@@ -276,7 +276,7 @@ static RetainPtr<NSArray> mediaSelectionOptions(const Vector<MediaSelectionOptio
     auto webOptions = mediaSelectionOptions(options);
     [self setAudioTouchBarMediaSelectionOptions:webOptions.get()];
     if (selectedIndex < [webOptions count])
-        [self setCurrentAudioTouchBarMediaSelectionOption:[webOptions objectAtIndex:selectedIndex]];
+        [self setCurrentAudioTouchBarMediaSelectionOption:retainPtr([webOptions objectAtIndex:selectedIndex]).get()];
 }
 
 - (void)setLegibleMediaSelectionOptions:(const Vector<MediaSelectionOption>&)options withSelectedIndex:(NSUInteger)selectedIndex
@@ -284,7 +284,7 @@ static RetainPtr<NSArray> mediaSelectionOptions(const Vector<MediaSelectionOptio
     auto webOptions = mediaSelectionOptions(options);
     [self setLegibleTouchBarMediaSelectionOptions:webOptions.get()];
     if (selectedIndex < [webOptions count])
-        [self setCurrentLegibleTouchBarMediaSelectionOption:[webOptions objectAtIndex:selectedIndex]];
+        [self setCurrentLegibleTouchBarMediaSelectionOption:retainPtr([webOptions objectAtIndex:selectedIndex]).get()];
 }
 
 - (void)setAudioMediaSelectionIndex:(NSUInteger)selectedIndex

--- a/Source/WebCore/platform/mac/WidgetMac.mm
+++ b/Source/WebCore/platform/mac/WidgetMac.mm
@@ -64,8 +64,8 @@ static void safeRemoveFromSuperview(NSView *view)
 {
     // If the view is the first responder, then set the window's first responder to nil so
     // we don't leave the window pointing to a view that's no longer in it.
-    NSWindow *window = [view window];
-    auto *firstResponderView = dynamic_objc_cast<NSView>([window firstResponder]);
+    RetainPtr<NSWindow> window = [view window];
+    RetainPtr firstResponderView = dynamic_objc_cast<NSView>([window firstResponder]);
     if ([firstResponderView isDescendantOf:view])
         [window makeFirstResponder:nil];
 
@@ -211,7 +211,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
         // This is the common case of drawing into a window or an inclusive layer, or printing.
         BEGIN_BLOCK_OBJC_EXCEPTIONS
-        [view displayRectIgnoringOpacity:[view convertRect:r fromView:[view superview]]];
+        [view displayRectIgnoringOpacity:[view convertRect:r fromView:retainPtr([view superview]).get()]];
         END_BLOCK_OBJC_EXCEPTIONS
         return;
     }
@@ -249,7 +249,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     {
         NSGraphicsContext *nsContext = [NSGraphicsContext graphicsContextWithCGContext:cgContext.get() flipped:NO];
-        [view displayRectIgnoringOpacity:[view convertRect:r fromView:[view superview]] inContext:nsContext];
+        [view displayRectIgnoringOpacity:[view convertRect:r fromView:retainPtr([view superview]).get()] inContext:nsContext];
     }
     END_BLOCK_OBJC_EXCEPTIONS
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
@@ -70,8 +70,8 @@ void unregisterAudioInputMuteChangeListener(WebCoreAudioInputMuteChangeListener*
 
 - (void)handleMuteStatusChangedNotification:(NSNotification*)notification
 {
-    NSNumber* newMuteState = [notification.userInfo valueForKey:AVAudioApplicationMuteStateKey];
-    WebCore::CoreAudioSharedUnit::singleton().handleMuteStatusChangedNotification(newMuteState.boolValue);
+    RetainPtr<NSNumber> newMuteState = [notification.userInfo valueForKey:AVAudioApplicationMuteStateKey];
+    WebCore::CoreAudioSharedUnit::singleton().handleMuteStatusChangedNotification(newMuteState.get().boolValue);
 }
 
 @end

--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -121,7 +121,7 @@ Cookie::Cookie(NSHTTPCookie *cookie)
     , session { static_cast<bool>(cookie.sessionOnly) }
     , comment { cookie.comment }
     , commentURL { cookie.commentURL }
-    , ports { portVectorFromList(cookie.portList) }
+    , ports { portVectorFromList(retainPtr(cookie.portList).get()) }
 {
     sameSite = coreSameSitePolicy(cookie.sameSitePolicy);
 }

--- a/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
@@ -67,9 +67,9 @@ Credential::Credential(const Credential& original, CredentialPersistence persist
         return;
 
     if (RetainPtr<NSString> user = originalNSURLCredential.get().user)
-        m_nsCredential = adoptNS([[NSURLCredential alloc] initWithUser:user.get() password:originalNSURLCredential.get().password persistence:toNSURLCredentialPersistence(persistence)]);
+        m_nsCredential = adoptNS([[NSURLCredential alloc] initWithUser:user.get() password:retainPtr(originalNSURLCredential.get().password).get() persistence:toNSURLCredentialPersistence(persistence)]);
     else if (RetainPtr<SecIdentityRef> identity = originalNSURLCredential.get().identity)
-        m_nsCredential = adoptNS([[NSURLCredential alloc] initWithIdentity:identity.get() certificates:originalNSURLCredential.get().certificates persistence:toNSURLCredentialPersistence(persistence)]);
+        m_nsCredential = adoptNS([[NSURLCredential alloc] initWithIdentity:identity.get() certificates:retainPtr(originalNSURLCredential.get().certificates).get() persistence:toNSURLCredentialPersistence(persistence)]);
     else {
         // It is not possible to set the persistence of server trust credentials.
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm
@@ -70,17 +70,17 @@ Box<NetworkLoadMetrics> copyTimingData(NSURLSessionTaskMetrics *incompleteMetric
     RetainPtr<NSArray<NSURLSessionTaskTransactionMetrics *>> transactionMetrics = incompleteMetrics.transactionMetrics;
     RetainPtr<NSURLSessionTaskTransactionMetrics> metrics = transactionMetrics.get().lastObject;
     return packageTimingData(
-        dateToMonotonicTime(transactionMetrics.get().firstObject.fetchStartDate),
-        metrics.get().fetchStartDate,
-        metrics.get().domainLookupStartDate,
-        metrics.get().domainLookupEndDate,
-        metrics.get().connectStartDate,
-        metrics.get().secureConnectionStartDate,
-        metrics.get().connectEndDate,
-        metrics.get().requestStartDate,
-        metrics.get().responseStartDate,
+        dateToMonotonicTime(retainPtr(transactionMetrics.get().firstObject.fetchStartDate).get()),
+        retainPtr(metrics.get().fetchStartDate).get(),
+        retainPtr(metrics.get().domainLookupStartDate).get(),
+        retainPtr(metrics.get().domainLookupEndDate).get(),
+        retainPtr(metrics.get().connectStartDate).get(),
+        retainPtr(metrics.get().secureConnectionStartDate).get(),
+        retainPtr(metrics.get().connectEndDate).get(),
+        retainPtr(metrics.get().requestStartDate).get(),
+        retainPtr(metrics.get().responseStartDate).get(),
         metrics.get().reusedConnection,
-        metrics.get().response.URL.scheme,
+        retainPtr(metrics.get().response.URL.scheme).get(),
         incompleteMetrics.redirectCount,
         metricsFromTask.failsTAOCheck,
         metricsFromTask.hasCrossOriginRedirect
@@ -110,7 +110,7 @@ Box<NetworkLoadMetrics> copyTimingData(NSURLConnection *connection, const Resour
         timingValue(@"_kCFNTimingDataRequestStart").get(),
         timingValue(@"_kCFNTimingDataResponseStart").get(),
         timingValue(@"_kCFNTimingDataConnectionReused").get(),
-        connection.currentRequest.URL.scheme,
+        retainPtr(connection.currentRequest.URL.scheme).get(),
         handle.redirectCount(),
         handle.failsTAOCheck(),
         handle.hasCrossOriginRedirect()

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -122,13 +122,13 @@ static Vector<Cookie> nsCookiesToCookieVector(NSArray<NSHTTPCookie *> *nsCookies
 Vector<Cookie> NetworkStorageSession::getAllCookies()
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
-    return nsCookiesToCookieVector([nsCookieStorage() cookies]);
+    return nsCookiesToCookieVector(retainPtr([nsCookieStorage() cookies]).get());
 }
 
 Vector<Cookie> NetworkStorageSession::getCookies(const URL& url)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
-    return nsCookiesToCookieVector([nsCookieStorage() cookiesForURL:url.createNSURL().get()]);
+    return nsCookiesToCookieVector(retainPtr([nsCookieStorage() cookiesForURL:url.createNSURL().get()]).get());
 }
 
 void NetworkStorageSession::hasCookies(const RegistrableDomain& domain, CompletionHandler<void(bool)>&& completionHandler) const
@@ -726,7 +726,7 @@ void NetworkStorageSession::deleteCookiesForHostnames(const Vector<String>& host
         if (!cookie.domain || (includeHttpOnlyCookies == IncludeHttpOnlyCookies::No && cookie.isHTTPOnly))
             return false;
 #if ENABLE(JS_COOKIE_CHECKING)
-        bool setInJS = [[cookie properties] valueForKey:@"SetInJavaScript"];
+        bool setInJS = [retainPtr([cookie properties]) valueForKey:@"SetInJavaScript"];
         if (scriptWrittenCookiesOnly == ScriptWrittenCookiesOnly::Yes && !setInJS)
             return false;
 #else

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -197,7 +197,7 @@ void ResourceRequest::doUpdateResourceRequest()
         m_requestData.m_priority = toResourceLoadPriority(m_nsRequest ? CFURLRequestGetRequestPriority([m_nsRequest _CFURLRequest]) : 0);
 
     m_requestData.m_httpHeaderFields.clear();
-    [[m_nsRequest allHTTPHeaderFields] enumerateKeysAndObjectsUsingBlock: ^(NSString *name, NSString *value, BOOL *) {
+    [retainPtr([m_nsRequest allHTTPHeaderFields]) enumerateKeysAndObjectsUsingBlock: ^(NSString *name, NSString *value, BOOL *) {
         m_requestData.m_httpHeaderFields.set(name, value);
     }];
 
@@ -307,7 +307,7 @@ void ResourceRequest::doUpdatePlatformRequest()
         [nsRequest setHTTPMethod:httpMethod().createNSString().get()];
     [nsRequest setHTTPShouldHandleCookies:allowCookies()];
 
-    [nsRequest _setProperty:RetainPtr { siteForCookies(m_requestData.m_sameSiteDisposition, [nsRequest URL]) }.get() forKey:@"_kCFHTTPCookiePolicyPropertySiteForCookies"];
+    [nsRequest _setProperty:RetainPtr { siteForCookies(m_requestData.m_sameSiteDisposition, retainPtr([nsRequest URL]).get()) }.get() forKey:@"_kCFHTTPCookiePolicyPropertySiteForCookies"];
     // FIXME: This is a safer cpp false positive (rdar://160851489).
     SUPPRESS_UNRETAINED_ARG [nsRequest _setProperty:m_requestData.m_isTopSite ? @YES : @NO forKey:@"_kCFHTTPCookiePolicyPropertyIsTopLevelNavigation"];
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -570,7 +570,7 @@ Vector<String, 2> RenderThemeCocoa::mediaControlsScripts()
     // FIXME: Localized strings are not worth having a script. We should make it JSON data etc. instead.
     if (m_mediaControlsLocalizedStringsScript.isEmpty()) {
         NSBundle *bundle = [NSBundle bundleForClass:[WebCoreRenderThemeBundle class]];
-        m_mediaControlsLocalizedStringsScript = [NSString stringWithContentsOfFile:[bundle pathForResource:@"modern-media-controls-localized-strings" ofType:@"js"] encoding:NSUTF8StringEncoding error:nil];
+        m_mediaControlsLocalizedStringsScript = [NSString stringWithContentsOfFile:retainPtr([bundle pathForResource:@"modern-media-controls-localized-strings" ofType:@"js"]).get() encoding:NSUTF8StringEncoding error:nil];
     }
 
     if (m_mediaControlsScript.isEmpty())
@@ -586,14 +586,14 @@ RefPtr<FragmentedSharedBuffer> RenderThemeCocoa::mediaControlsImageDataForIconNa
 {
     NSString *directory = @"modern-media-controls/images";
     NSBundle *bundle = [NSBundle bundleForClass:[WebCoreRenderThemeBundle class]];
-    return SharedBuffer::create([NSData dataWithContentsOfFile:[bundle pathForResource:iconName.createNSString().get() ofType:iconType.createNSString().get() inDirectory:directory]]);
+    return SharedBuffer::create([NSData dataWithContentsOfFile:retainPtr([bundle pathForResource:iconName.createNSString().get() ofType:iconType.createNSString().get() inDirectory:directory]).get()]);
 }
 
 String RenderThemeCocoa::mediaControlsBase64StringForIconNameAndType(const String& iconName, const String& iconType)
 {
     NSString *directory = @"modern-media-controls/images";
     NSBundle *bundle = [NSBundle bundleForClass:[WebCoreRenderThemeBundle class]];
-    return [[NSData dataWithContentsOfFile:[bundle pathForResource:iconName.createNSString().get() ofType:iconType.createNSString().get() inDirectory:directory]] base64EncodedStringWithOptions:0];
+    return [[NSData dataWithContentsOfFile:retainPtr([bundle pathForResource:iconName.createNSString().get() ofType:iconType.createNSString().get() inDirectory:directory]).get()] base64EncodedStringWithOptions:0];
 }
 
 String RenderThemeCocoa::mediaControlsFormattedStringForDuration(const double durationInSeconds)

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -105,7 +105,7 @@
 
     [[NSNotificationCenter defaultCenter] addObserver:self
         selector:@selector(systemColorsDidChange:) name:systemColorsChangedNotification.get() object:nil];
-    [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self
+    [retainPtr([[NSWorkspace sharedWorkspace] notificationCenter]) addObserver:self
         selector:@selector(accessibilityDisplayOptionsDidChange:) name:accessibilityDisplayOptionsChangedNotification.get() object:nil];
 
     return self;
@@ -720,13 +720,13 @@ Color RenderThemeMac::systemColor(CSSValueID cssValueID, OptionSet<StyleColorOpt
         case CSSValueAppleSystemEvenAlternatingContentBackground: {
             NSArray<NSColor *> *alternateColors = [NSColor alternatingContentBackgroundColors];
             ASSERT(alternateColors.count >= 2);
-            return semanticColorFromNSColor(alternateColors[0]);
+            return semanticColorFromNSColor(retainPtr(alternateColors[0]).get());
         }
 
         case CSSValueAppleSystemOddAlternatingContentBackground: {
             NSArray<NSColor *> *alternateColors = [NSColor alternatingContentBackgroundColors];
             ASSERT(alternateColors.count >= 2);
-            return semanticColorFromNSColor(alternateColors[1]);
+            return semanticColorFromNSColor(retainPtr(alternateColors[1]).get());
         }
 
         // FIXME: Remove this fallback when AppKit without tertiary-fill is not used anymore; see rdar://108340604.
@@ -1801,12 +1801,12 @@ static RefPtr<Icon> iconForAttachment(const String& fileName, const String& atta
     }
 
     RetainPtr nsTitle = title.createNSString();
-    if (auto fileExtension = nsTitle.get().pathExtension; fileExtension.length) {
-        if (auto icon = Icon::createIconForFileExtension(fileExtension)) {
-            LOG_ATTACHMENT("-> Got icon for title file extension '%s'", String(fileExtension).utf8().data());
+    if (RetainPtr<NSString> fileExtension = nsTitle.get().pathExtension; fileExtension.get().length) {
+        if (auto icon = Icon::createIconForFileExtension(fileExtension.get())) {
+            LOG_ATTACHMENT("-> Got icon for title file extension '%s'", String(fileExtension.get()).utf8().data());
             return icon;
         }
-        LOG_ATTACHMENT("-> No icon for title file extension '%s'! Will fallback to public.data icon", String(fileExtension).utf8().data());
+        LOG_ATTACHMENT("-> No icon for title file extension '%s'! Will fallback to public.data icon", String(fileExtension.get()).utf8().data());
     } else
         LOG_ATTACHMENT("-> No file extension in title! Will fallback to public.data icon");
 

--- a/Source/WebCore/testing/cocoa/WebViewVisualIdentificationOverlay.mm
+++ b/Source/WebCore/testing/cocoa/WebViewVisualIdentificationOverlay.mm
@@ -99,16 +99,17 @@ const void* const webViewVisualIdentificationOverlayKey = &webViewVisualIdentifi
     [_layer setZPosition:999];
     [_layer setDelegate:self];
     [_layer web_disableAllActions];
-    [[_view layer] addSublayer:_layer.get()];
+    RetainPtr viewLayer = [_view layer];
+    [viewLayer addSublayer:_layer.get()];
 
-    [[_view layer] addObserver:self forKeyPath:@"bounds" options:0 context:boundsObservationContext];
+    [viewLayer addObserver:self forKeyPath:@"bounds" options:0 context:boundsObservationContext];
 
     return self;
 }
 
 - (void)dealloc
 {
-    [[_view layer] removeObserver:self forKeyPath:@"bounds" context:boundsObservationContext];
+    [retainPtr([_view layer]) removeObserver:self forKeyPath:@"bounds" context:boundsObservationContext];
 
     [super dealloc];
 }


### PR DESCRIPTION
#### bbf9c61c6db8291be05526138b5d283601dd7630
<pre>
Prepare Source/WebCore for clang static analyzer update (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301258">https://bugs.webkit.org/show_bug.cgi?id=301258</a>

Reviewed by Geoffrey Garen.

Add PAL to the list of projects we check static analyzer results.

Note that we need to adjust the path for PAL to be Source/WebCore/PAL instead of Source/PAL.

* Source/WebCore/loader/archive/cf/LegacyWebArchiveMac.mm:
(WebCore::LegacyWebArchive::createResourceResponseFromMacArchivedData):
* Source/WebCore/loader/mac/LoaderNSURLExtras.mm:
(suggestedFilenameWithMIMEType):
* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
(WebCore::ResourceUsageOverlay::platformInitialize):
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
(WebCore::ScrollingTreeFrameScrollingNodeMac::exposedUnfilledArea const):
* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm:
(isScrolledBy):
* Source/WebCore/platform/audio/mac/AudioBusMac.mm:
(WebCore::AudioBus::loadPlatformResource):
* Source/WebCore/platform/cocoa/CoreLocationGeolocationProvider.mm:
(-[WebCLLocationManager locationManager:didFailWithError:]):
* Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm:
(WebCore::MIMETypeRegistry::mimeTypeForExtension):
* Source/WebCore/platform/cocoa/PasteboardCocoa.mm:
(WebCore::convertTIFFToPNG):
* Source/WebCore/platform/cocoa/TextRecognitionResultCocoa.mm:
(WebCore::TextRecognitionResult::extractAttributedString):
* Source/WebCore/platform/cocoa/WebCoreNSErrorExtras.mm:
(WebCore::mediaKeyErrorSystemCode):
* Source/WebCore/platform/cocoa/WebNSAttributedStringExtras.mm:
(WebCore::attributedStringByStrippingAttachmentCharacters):
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm:
(WebCore::GameControllerGamepad::setupElements):
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm:
(WebCore::GameControllerGamepadProvider::startMonitoringGamepads):
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm:
(WebCore::GameControllerHapticEngines::GameControllerHapticEngines):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::setVideoRenderer):
* Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm:
(WebCore::MediaPlaybackTargetContextCocoa::deviceName const):
* Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm:
(WebCore::MediaSelectionOptionAVFObjC::index const):
(WebCore::MediaSelectionGroupAVFObjC::updateOptions):
* Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm:
(-[WebAVSampleBufferListenerPrivate layerFailedToDecode:]):
(-[WebAVSampleBufferListenerPrivate audioRendererWasAutomaticallyFlushed:]):
* Source/WebCore/platform/graphics/avfoundation/objc/AVAssetTrackUtilities.mm:
(WebCore::assetTrackMeetsHardwareDecodeRequirements):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm:
(WebCore::CDMPrivateFairPlayStreaming::keyIDsForRequest):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm:
(WebCore::CDMSessionAVFoundationObjC::update):
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(-[WebCoreSharedBufferResourceLoaderDelegate canFulfillRequest:]):
(-[WebCoreSharedBufferResourceLoaderDelegate fulfillRequest:]):
(WebCore::ImageDecoderAVFObjC::ImageDecoderAVFObjC):
(WebCore::ImageDecoderAVFObjC::createFrameImageAtIndex):
* Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm:
(WebCore::InbandTextTrackPrivateAVFObjC::label const):
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::LocalSampleBufferDisplayLayer::enqueueBufferInternal):
* Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm:
(-[WebQueuedVideoOutputDelegate observeValueForKeyPath:ofObject:change:context:]):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm:
(WebCore::VideoLayerManagerObjC::setVideoFullscreenLayer):
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::WebCoreAVFResourceLoader::startLoading):
(WebCore::WebCoreAVFResourceLoader::responseReceived):
(WebCore::WebCoreAVFResourceLoader::newDataStoredInSharedBuffer):
* Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm:
(-[CALayer _web_maskContainsPoint:]):
(-[CALayer _web_maskMayIntersectRect:]):
* Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm:
* Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.mm:
(WebCore::AppKitControlSystemImage::AppKitControlSystemImage):
* Source/WebCore/platform/graphics/mac/ColorMac.mm:
(WebCore::makeSimpleColorFromNSColor):
* Source/WebCore/platform/graphics/mac/IconMac.mm:
(WebCore::Icon::createIconForFileExtension):
* Source/WebCore/platform/graphics/mac/PDFDocumentImageMac.mm:
(WebCore::PDFDocumentImage::computeBoundsForCurrentPage):
* Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm:
(WebCore::SearchFieldCancelButtonMac::updateCellStates):
(WebCore::SearchFieldCancelButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SearchFieldResultsMac.mm:
(WebCore::SearchFieldResultsMac::draw):
* Source/WebCore/platform/graphics/mac/controls/WebControlView.mm:
(-[WebControlTextFieldCell _adjustedCoreUIDrawOptionsForDrawingBordersOnly:]):
* Source/WebCore/platform/mac/CursorMac.mm:
(WebCore::createCustomCursor):
* Source/WebCore/platform/mac/LocalDefaultSystemAppearance.mm:
(WebCore::LocalDefaultSystemAppearance::LocalDefaultSystemAppearance):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::writeFileWrapperAsRTFDAttachment):
(WebCore::setDragImageImpl):
* Source/WebCore/platform/mac/PasteboardWriter.mm:
(WebCore::createPasteboardWriter):
* Source/WebCore/platform/mac/PlatformEventFactoryMac.mm:
(WebCore::globalPointForEvent):
(WebCore::keyForKeyEvent):
(WebCore::keyIdentifierForKeyEvent):
(WebCore::windowsKeyCodeForKeyEvent):
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::PlatformPasteboard::getTypes const):
(WebCore::PlatformPasteboard::bufferForType const):
(WebCore::PlatformPasteboard::numberOfFiles const):
(WebCore::PlatformPasteboard::stringForType const):
(WebCore::urlStringsFromPasteboard):
(WebCore::PlatformPasteboard::allStringsForType const):
(WebCore::PlatformPasteboard::typesSafeForDOMToReadAndWrite const):
(WebCore::PlatformPasteboard::copy):
(WebCore::PlatformPasteboard::setStringForType):
(WebCore::PlatformPasteboard::readURL const):
(WebCore::PlatformPasteboard::informationForItemAtIndex):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::displayID):
* Source/WebCore/platform/mac/ScrollViewMac.mm:
(WebCore::ScrollView::platformAddChild):
(WebCore::ScrollView::platformContentsToScreen const):
(WebCore::ScrollView::platformScreenToContents const):
* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
(WebCore::ScrollbarsControllerMac::updateScrollerImps):
* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm:
(WebCore::jsValueWithValueInContext):
(WebCore::jsValueWithArrayInContext):
(WebCore::jsValueWithDictionaryInContext):
* Source/WebCore/platform/mac/ThreadCheck.mm:
(WebCore::readThreadViolationBehaviorFromUserDefaults):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(-[WebVideoPresentationInterfaceMacObjC setUpPIPForVideoView:withFrame:inWindow:]):
(-[WebVideoPresentationInterfaceMacObjC superviewDidChangeForVideoViewContainer:]):
(-[WebVideoPresentationInterfaceMacObjC pipDidClose:]):
* Source/WebCore/platform/mac/WebCoreFullScreenWindow.mm:
(-[WebCoreFullScreenWindow cancelOperation:]):
(-[WebCoreFullScreenWindow performClose:]):
(-[WebCoreFullScreenWindow setStyleMask:]):
* Source/WebCore/platform/mac/WebCoreNSFontManagerExtras.mm:
(WebCore::computedFontChanges):
(WebCore::computedFontAttributeChanges):
* Source/WebCore/platform/mac/WebCoreNSURLExtras.mm:
(WebCore::URLByCanonicalizingURL):
* Source/WebCore/platform/mac/WebCoreView.mm:
(-[NSClipView _webcore_effectiveFirstResponder]):
(-[NSScrollView _webcore_effectiveFirstResponder]):
* Source/WebCore/platform/mac/WebPlaybackControlsManager.mm:
(-[WebPlaybackControlsManager setAudioMediaSelectionOptions:withSelectedIndex:]):
(-[WebPlaybackControlsManager setLegibleMediaSelectionOptions:withSelectedIndex:]):
* Source/WebCore/platform/mac/WidgetMac.mm:
(WebCore::safeRemoveFromSuperview):
(WebCore::Widget::paint):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm:
(-[WebCoreAudioInputMuteChangeListener handleMuteStatusChangedNotification:]):
* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
* Source/WebCore/platform/network/cocoa/CredentialCocoa.mm:
(WebCore::Credential::Credential):
* Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm:
(WebCore::copyTimingData):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::getAllCookies):
(WebCore::NetworkStorageSession::getCookies):
(WebCore::NetworkStorageSession::deleteCookiesForHostnames):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdateResourceRequest):
(WebCore::ResourceRequest::doUpdatePlatformRequest):
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(-[WebCoreNSURLSession taskCompleted:]):
(-[WebCoreNSURLSession addDelegateOperation:]):
(-[WebCoreNSURLSessionDataTask resume]):
(-[WebCoreNSURLSessionDataTask resource:receivedResponse:completionHandler:]):
(-[WebCoreNSURLSessionDataTask resource:receivedData:]):
(-[WebCoreNSURLSessionDataTask resource:receivedRedirect:request:completionHandler:]):
* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::ResourceError::mapPlatformError):
(WebCore::ResourceError::platformLazyInit):
(WebCore::ResourceError::blockedTrackerHostName const):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::mediaControlsScripts):
(WebCore::RenderThemeCocoa::mediaControlsImageDataForIconNameAndType):
(WebCore::RenderThemeCocoa::mediaControlsBase64StringForIconNameAndType):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(-[WebCoreRenderThemeNotificationObserver init]):
(WebCore::RenderThemeMac::systemColor const):
(WebCore::iconForAttachment):
* Source/WebCore/testing/cocoa/WebViewVisualIdentificationOverlay.mm:
(-[WebViewVisualIdentificationOverlay initWithWebView:kind:deprecated:]):
(-[WebViewVisualIdentificationOverlay dealloc]):

Canonical link: <a href="https://commits.webkit.org/301980@main">https://commits.webkit.org/301980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07fb525cee54bf3a3a038708763a78fab741506b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38476 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134931 "Build is in progress. Recent messages:") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2ad81494-6cc6-4d77-a27d-28db98f735f2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129532 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55839 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/134931 "Build is in progress. Recent messages:") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/34908bca-b968-4de0-a210-4adf27165dab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114354 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/134931 "Build is in progress. Recent messages:") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7875c963-26aa-4c73-a4d1-8f5c6a70b11d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32447 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78290 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137414 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41873 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105698 "Found 3 new test failures: imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some.https.sub.html imported/w3c/web-platform-tests/service-workers/service-worker/referer.https.html imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addIceCandidate-timing.https.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105349 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29299 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19957 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60432 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53491 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56947 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55249 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->