### PR TITLE
[WebXR] XRLayerEvent must be an Event instance

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/idlharness.https.window-expected.txt
@@ -123,14 +123,10 @@ FAIL XRMediaBinding interface: existence and properties of interface prototype o
 FAIL XRMediaBinding interface: operation createQuadLayer(HTMLVideoElement, optional XRMediaQuadLayerInit) assert_own_property: self does not have own property "XRMediaBinding" expected property "XRMediaBinding" missing
 FAIL XRMediaBinding interface: operation createCylinderLayer(HTMLVideoElement, optional XRMediaCylinderLayerInit) assert_own_property: self does not have own property "XRMediaBinding" expected property "XRMediaBinding" missing
 FAIL XRMediaBinding interface: operation createEquirectLayer(HTMLVideoElement, optional XRMediaEquirectLayerInit) assert_own_property: self does not have own property "XRMediaBinding" expected property "XRMediaBinding" missing
-FAIL XRLayerEvent interface: existence and properties of interface object assert_equals: prototype of XRLayerEvent is not Event expected function "function Event() {
-    [native code]
-}" but got function "function () {
-    [native code]
-}"
+PASS XRLayerEvent interface: existence and properties of interface object
 PASS XRLayerEvent interface object length
 PASS XRLayerEvent interface object name
-FAIL XRLayerEvent interface: existence and properties of interface prototype object assert_equals: prototype of XRLayerEvent.prototype is not Event.prototype expected object "[object Event]" but got object "[object Object]"
+PASS XRLayerEvent interface: existence and properties of interface prototype object
 PASS XRLayerEvent interface: existence and properties of interface prototype object's "constructor" property
 PASS XRLayerEvent interface: existence and properties of interface prototype object's @@unscopables property
 PASS XRLayerEvent interface: attribute layer

--- a/Source/WebCore/Modules/webxr/XRLayerEvent.idl
+++ b/Source/WebCore/Modules/webxr/XRLayerEvent.idl
@@ -36,7 +36,7 @@
     ExportMacro=WEBCORE_EXPORT,
     SecureContext,
     Exposed=Window,
-] interface XRLayerEvent {
+] interface XRLayerEvent : Event {
     constructor([AtomString] DOMString type, XRLayerEventInit eventInitDict);
     [SameObject] readonly attribute WebXRLayer layer;
 };


### PR DESCRIPTION
#### a8c3019954762182a45f30f89f687acf6f608c25
<pre>
[WebXR] XRLayerEvent must be an Event instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=301264">https://bugs.webkit.org/show_bug.cgi?id=301264</a>

Reviewed by Fujii Hironori.

It was simply not inheriting from the Event object in the
IDL definition.

Fixed a couple of subtests in the IDL harness test for layers.

* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/idlharness.https.window-expected.txt:
* Source/WebCore/Modules/webxr/XRLayerEvent.idl:

Canonical link: <a href="https://commits.webkit.org/301941@main">https://commits.webkit.org/301941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6a69ec83b5a8e611034b80fd521d006140aa90a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134643 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97106 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114252 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77586 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78016 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108124 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137127 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54225 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41785 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105281 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26837 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50796 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51810 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54162 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60249 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/53396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55155 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->