### PR TITLE
Add platform support to update-safer-cpp-expectations

### DIFF
--- a/Tools/Scripts/update-safer-cpp-expectations
+++ b/Tools/Scripts/update-safer-cpp-expectations
@@ -22,9 +22,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import re
 import argparse
 
 from webkitpy.safer_cpp.checkers import Checker
+
+EXPECTATION_LINE_RE = r'(\s*\[\s*(?P<platform>\w+)\s*\]\s*)?(?P<path>.+)'
 
 
 def parser():
@@ -58,6 +61,11 @@ def parser():
         dest='unexpected_results_file',
         default=None,
         help='Path to unexpected results file'
+    )
+    parser.add_argument(
+        '--platform',
+        default=None,
+        help='Mac or iOS'
     )
     return parser.parse_args()
 
@@ -108,32 +116,86 @@ def update_expectations_from_file(unexpected_results, project, add=False):
     print(f'Please add any changes to your commit using `git add` and `git commit --amend`.')
 
 
-def modify_expectations_for_checker(checker, unexpected_contents, project, add=False):
+def modify_expectations_for_checker(checker, unexpected_contents, project, add, platform):
+    if platform:
+        platform = platform.lower()
+    if platform != None and platform != 'mac' and platform != 'ios':
+        print(f'Unknown platform: {platform}')
+        return
+
     path_to_expectations = checker.expectations_path(project)
+    expectation_relpath = os.path.relpath(path_to_expectations)
     checker_name = checker.name()
+    expectation_map = {}
     with open(path_to_expectations) as expectations_file:
-        expectations = expectations_file.readlines()
-        prev_len = len(expectations)
-    for line in unexpected_contents:
-        if not add:
-            try:
-                expectations.remove(f'{line}\n')
-            except ValueError:
-                print(f'Error: {line} is not in {os.path.relpath(path_to_expectations)}!')
-        elif line not in expectations:
-            expectations.append(f'{line}\n')
-        else:
-            print(f'Error: {line} is already in {os.path.relpath(path_to_expectations)}!\n')
-    with open(path_to_expectations, 'w') as expectations_file:
-        expectations_file.writelines(sorted(expectations))
-    print(f'Updated expectations for {checker_name}!')
-    if not add:
-        print(f'Removed {prev_len - len(expectations)} fixed files.\n')
+        expectation_line_re = re.compile(EXPECTATION_LINE_RE)
+        comments = []
+        for line in expectations_file.read().splitlines():
+            if line.startswith('//') or line.startswith('#'):
+                comments.append(line)
+                continue
+            match = expectation_line_re.match(line)
+            if not match:
+                print(f'Unexpected line in {expectation_relpath}: {line}')
+                continue
+            expectation_platform = match.group('platform')
+            path = match.group('path')
+            if path in expectation_map:
+                print(f'Conflicting or duplicate line in {expectation_relpath}: {path}')
+                continue
+            expectation_map[match.group('path')] = {'platform': expectation_platform, 'comments': comments}
+            comments = []
+
+    count = 0
+    if add:
+        for path in unexpected_contents:
+            if path in expectation_map:
+                expectation_platform = expectation_map[path]['platform']
+                lowercase_platform = expectation_platform.lower() if expectation_platform else None
+                if lowercase_platform == platform:
+                    print(f'Path is already present in {expectation_relpath}: {path}')
+                    continue
+                if lowercase_platform != 'mac' and lowercase_platform != 'ios':
+                    print(f'Unexpected platform in {expectation_relpath}: {expectation_platform}')
+                    continue
+                expectation_map[path]['platform'] = None
+            count += 1
+        print(f'Added {count} files with issues.\n')
     else:
-        print(f'Added {len(expectations) - prev_len} files with issues.\n')
+        for path in unexpected_contents:
+            if path not in expectation_map:
+                print(f'Path not found in {expectation_relpath}: {path}')
+                continue
+            if platform:
+                expectation_platform = expectation_map[path]['platform']
+                lowercase_platform = expectation_platform.lower() if expectation_platform else None
+                if lowercase_platform != platform:
+                    platform_name = 'Mac' if platform == 'mac' else 'iOS'
+                    print(f'Expectation not found in {expectation_relpath}: {path} for {platform_name}')
+                    continue # Expectation is for another platform. We're done
+                if expectation_platform == None:
+                    expectation_map[path]['platform'] = 'Mac' if platform == 'ios' else 'iOS'
+                else:
+                    del expectation_map[path]
+            else:
+                del expectation_map[path]
+            count += 1
+        print(f'Removed {count} fixed files.\n')
+
+    lines = []
+    for path in sorted(expectation_map.keys()):
+        platform = expectation_map[path]['platform']
+        for comment in expectation_map[path]['comments']:
+            lines.append(f'{comment}\n')
+        lines.append(f'[ {platform} ] {path}\n' if platform else f'{path}\n')
+
+    with open(path_to_expectations, 'w') as expectations_file:
+        expectations_file.writelines(lines)
+
+    print(f'Updated expectations for {checker_name}!')
 
 
-def update_expectations(args, project, add=False):
+def update_expectations(args, project, add, platform):
     if not project:
         print(f'Could not find a project to update. Please pass in the --project argument.')
         return
@@ -141,7 +203,7 @@ def update_expectations(args, project, add=False):
     for checker in Checker.enumerate():
         files_per_checker = args[checker.name()]
         if files_per_checker:
-            modify_expectations_for_checker(checker, files_per_checker, project, add)
+            modify_expectations_for_checker(checker, files_per_checker, project, add, platform)
     print(f'Please add any changes to your commit using `git add` and `git commit --amend`.')
 
 
@@ -182,7 +244,7 @@ def main():
     if args.unexpected_results_file:
         update_expectations_from_file(args.unexpected_results_file, args.project, args.add)
     else:
-        update_expectations(vars(args), args.project, args.add)
+        update_expectations(vars(args), args.project, args.add, args.platform)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### d8e73be4ec47beeb4bb79b1af111f2953c38149f
<pre>
Add platform support to update-safer-cpp-expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=301265">https://bugs.webkit.org/show_bug.cgi?id=301265</a>

Reviewed by Chris Dumez.

Added the support for platform modifier in update-safer-cpp-expectations.

The script now supports --platform option to specify the platform for which
safer C++ expectations need to be updated. When the platform is omitted,
the addition or removal happens for both platforms (Mac and iOS).

When there is a Mac expectation, removal of the same file for iOS does not
have any effect (results in a warning emitted to stdout).

In addition, this PR adds a support for preserving comments in safer C++
expectation files. Each comment is assumed to belong to the file beneath it
for sorting purposes.

For now, all these changes are made for updating individual checker by
enumerating file names, not when -r / --unexpected-results-file is used.

* Tools/Scripts/update-safer-cpp-expectations:
(parser):
(update_expectations_from_file):
(modify_expectations_for_checker):
(update_expectations):
(main):

Canonical link: <a href="https://commits.webkit.org/301953@main">https://commits.webkit.org/301953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aae0ff6a07d2ecb20c5e07ecdc0424e6e0009715

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134645 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79125 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2f8d3bf8-72ea-4822-a114-9615f656ac8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129440 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97107 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65021 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7d37b764-6943-4934-8d95-740df4a564bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77587 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4cd12b24-7602-4517-b19c-7d766a1290f8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32352 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78018 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137129 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105631 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105282 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50798 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51812 "Hash aae0ff6a for PR 52804 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19949 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54164 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53398 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56855 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55157 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->