### PR TITLE
Address some Safer CPP warnings in WebPage.cpp

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -11428,6 +11428,11 @@ TextManipulationController& Document::textManipulationController()
     return *m_textManipulationController;
 }
 
+CheckedRef<TextManipulationController> Document::checkedTextManipulationController()
+{
+    return textManipulationController();
+}
+
 LazyLoadImageObserver& Document::lazyLoadImageObserver()
 {
     if (!m_lazyLoadImageObserver)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1911,6 +1911,7 @@ public:
 #endif
 
     WEBCORE_EXPORT TextManipulationController& textManipulationController();
+    WEBCORE_EXPORT CheckedRef<TextManipulationController> checkedTextManipulationController();
     TextManipulationController* textManipulationControllerIfExists() { return m_textManipulationController.get(); }
 
     bool hasHighlight() const;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -362,6 +362,11 @@ EditorClient* Editor::client() const
     return m_client.get();
 }
 
+CheckedPtr<EditorClient> Editor::checkedClient() const
+{
+    return client();
+}
+
 TextCheckerClient* Editor::textChecker() const
 {
     if (EditorClient* owner = client())

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -207,6 +207,7 @@ public:
     };
 
     WEBCORE_EXPORT EditorClient* client() const;
+    WEBCORE_EXPORT CheckedPtr<EditorClient> checkedClient() const;
     WEBCORE_EXPORT TextCheckerClient* textChecker() const;
 
     CompositeEditCommand* lastEditCommand() { return m_lastEditCommand.get(); }

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -847,6 +847,11 @@ RenderView* LocalFrame::contentRenderer() const
     return document() ? document()->renderView() : nullptr;
 }
 
+CheckedPtr<RenderView> LocalFrame::checkedContentRenderer() const
+{
+    return contentRenderer();
+}
+
 LocalFrame* LocalFrame::frameForWidget(const Widget& widget)
 {
     SUPPRESS_UNCOUNTED_LOCAL auto* renderer = RenderWidget::find(widget);

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -176,8 +176,8 @@ public:
     CheckedRef<FrameSelection> checkedSelection() const; // Defined in LocalFrameInlines.h
     ScriptController& script() { return m_script; }
     const ScriptController& script() const { return m_script; }
-    CheckedRef<ScriptController> checkedScript();
-    CheckedRef<const ScriptController> checkedScript() const;
+    WEBCORE_EXPORT CheckedRef<ScriptController> checkedScript();
+    WEBCORE_EXPORT CheckedRef<const ScriptController> checkedScript() const;
     void resetScript();
 
     bool isRootFrame() const final { return m_rootFrame.get() == this; }
@@ -185,6 +185,7 @@ public:
     LocalFrame& rootFrame() { return *m_rootFrame; }
 
     WEBCORE_EXPORT RenderView* contentRenderer() const; // Root of the render tree for the document contained in this frame.
+    WEBCORE_EXPORT CheckedPtr<RenderView> checkedContentRenderer() const;
 
     bool documentIsBeingReplaced() const { return m_documentIsBeingReplaced; }
 

--- a/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -1,6 +1,5 @@
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
 WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
-WebProcess/WebPage/WebPage.cpp
 [ iOS ] UIProcess/API/ios/WKWebViewIOS.mm
 [ iOS ] UIProcess/ViewGestureController.h
 [ iOS ] UIProcess/ios/PageClientImplIOS.mm

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -19,7 +19,6 @@ WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
 WebProcess/WebPage/WebFrame.cpp
-WebProcess/WebPage/WebPage.cpp
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
 [ Mac ] Platform/cocoa/_WKWebViewTextInputNotifications.mm
 [ Mac ] WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -10,7 +10,6 @@ WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
 WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
-WebProcess/WebPage/WebPage.cpp
 [ Mac ] WebProcess/WebPage/mac/PageBannerMac.mm
 [ Mac ] WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 [ Mac ] WebProcess/WebPage/mac/WebPageMac.mm

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -373,7 +373,6 @@
 #include "InsertTextOptions.h"
 #include "PlaybackSessionManager.h"
 #include "RemoteLayerTreeDrawingArea.h"
-#include "RemoteLayerTreeTransaction.h"
 #include "RemoteObjectRegistryMessages.h"
 #include "TextAnimationController.h"
 #include "TextCheckingControllerProxy.h"
@@ -382,8 +381,6 @@
 #include "WebRemoteObjectRegistry.h"
 #include <WebCore/ImageUtilities.h>
 #include <WebCore/LegacyWebArchive.h>
-#include <WebCore/SVGImage.h>
-#include <WebCore/TextPlaceholderElement.h>
 #include <WebCore/VP9UtilitiesCocoa.h>
 #include <pal/spi/cg/ImageIOSPI.h>
 #include <wtf/MachSendRight.h>
@@ -490,10 +487,6 @@
 
 #if ENABLE(WEBXR)
 #include "PlatformXRSystemProxy.h"
-#endif
-
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-#import <WebCore/AcceleratedEffectStackUpdater.h>
 #endif
 
 #if ENABLE(PDF_HUD)
@@ -1640,7 +1633,7 @@ EditorState WebPage::editorState(ShouldPerformLayout shouldPerformLayout) const
     result.isContentRichlyEditable = selection.isContentRichlyEditable();
     result.isInPasswordField = selection.isInPasswordField();
     result.hasComposition = editor->hasComposition();
-    result.shouldIgnoreSelectionChanges = editor->ignoreSelectionChanges() || (editor->client() && !editor->client()->shouldRevealCurrentSelectionAfterInsertion());
+    result.shouldIgnoreSelectionChanges = editor->ignoreSelectionChanges() || (editor->client() && !editor->checkedClient()->shouldRevealCurrentSelectionAfterInsertion());
     result.triggeredByAccessibilitySelectionChange = m_pendingEditorStateUpdateStatus == PendingEditorStateUpdateStatus::ScheduledDuringAccessibilitySelectionChange || m_isChangingSelectionForAccessibility;
 
     Ref<Document> document = *frame->document();
@@ -1894,7 +1887,7 @@ void WebPage::setEditable(bool editable)
         frame->protectedEditor()->applyEditingStyleToBodyElement();
         // If the page is made editable and the selection is empty, set it to something.
         if (frame->selection().isNone())
-            frame->selection().setSelectionFromNone();
+            frame->checkedSelection()->setSelectionFromNone();
     }
 }
 
@@ -3228,7 +3221,7 @@ void WebPage::paintSnapshotAtSize(const IntRect& rect, const IntSize& bitmapSize
     frameView.paintContentsForSnapshot(graphicsContext, snapshotRect, shouldPaintSelection, coordinateSpace);
 
     if (options.contains(SnapshotOption::PaintSelectionRectangle)) {
-        FloatRect selectionRectangle = frame.selection().selectionBounds();
+        FloatRect selectionRectangle = frame.checkedSelection()->selectionBounds();
         graphicsContext.setStrokeColor(Color::red);
         graphicsContext.strokeRect(selectionRectangle, 1);
     }
@@ -3300,7 +3293,7 @@ RefPtr<WebImage> WebPage::snapshotNode(WebCore::Node& node, SnapshotOptions opti
         return nullptr;
 
     LayoutRect topLevelRect;
-    IntRect snapshotRect = snappedIntRect(node.renderer()->paintingRootRect(topLevelRect));
+    IntRect snapshotRect = snappedIntRect(node.checkedRenderer()->paintingRootRect(topLevelRect));
     if (snapshotRect.isEmpty())
         return nullptr;
 
@@ -4056,7 +4049,7 @@ void WebPage::centerSelectionInVisibleArea()
     RefPtr frame = corePage()->focusController().focusedOrMainFrame();
     if (!frame)
         return;
-    frame->selection().revealSelection({ SelectionRevealMode::Reveal, ScrollAlignment::alignCenterAlways });
+    frame->checkedSelection()->revealSelection({ SelectionRevealMode::Reveal, ScrollAlignment::alignCenterAlways });
     findController().showFindIndicatorInSelection();
 }
 
@@ -4119,14 +4112,6 @@ void WebPage::setBackgroundColor(const std::optional<WebCore::Color>& background
     drawingArea->setNeedsDisplay();
 }
 
-#if PLATFORM(COCOA)
-void WebPage::setObscuredContentInsetsFenced(const FloatBoxExtent& obscuredContentInsets, const WTF::MachSendRight& machSendRight)
-{
-    protectedDrawingArea()->addFence(machSendRight);
-    setObscuredContentInsets(obscuredContentInsets);
-}
-#endif
-
 void WebPage::setObscuredContentInsets(const FloatBoxExtent& obscuredContentInsets)
 {
     RefPtr page = m_page;
@@ -4183,7 +4168,7 @@ void WebPage::setInitialFocus(bool forward, bool isKeyboardEventValid, const std
     frame->protectedDocument()->setFocusedElement(nullptr);
 
     if (isKeyboardEventValid && event && event->type() == WebEventType::KeyDown) {
-        PlatformKeyboardEvent platformEvent(platform(*event));
+        PlatformKeyboardEvent platformEvent(platform(CheckedRef { *event }));
         platformEvent.disambiguateKeyDownEvent(PlatformEvent::Type::RawKeyDown);
         focusController->setInitialFocus(forward ? FocusDirection::Forward : FocusDirection::Backward, &KeyboardEvent::create(platformEvent, &frame->windowProxy()).get());
         completionHandler();
@@ -4506,7 +4491,7 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
             return completionHandler(makeUnexpected(std::nullopt));
 
         JSGlobalContextRef context = frame->jsContextForWorld(world.ptr());
-        JSValueRef jsValue = toRef(coreFrame->script().globalObject(Ref { world->coreWorld() }), result.value());
+        JSValueRef jsValue = toRef(coreFrame->checkedScript()->globalObject(Ref { world->coreWorld() }), result.value());
         if (auto result = JavaScriptEvaluationResult::extract(context, jsValue))
             return completionHandler(WTFMove(*result));
         return completionHandler(makeUnexpected(std::nullopt));
@@ -4535,7 +4520,7 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
     };
 
     JSLockHolder lock(commonVM());
-    frame->coreLocalFrame()->script().executeAsynchronousUserAgentScriptInWorld(world->protectedCoreWorld(), WTFMove(coreParameters), WTFMove(resolveFunction));
+    frame->protectedCoreLocalFrame()->checkedScript()->executeAsynchronousUserAgentScriptInWorld(world->protectedCoreWorld(), WTFMove(coreParameters), WTFMove(resolveFunction));
 }
 
 void WebPage::runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&& parameters, std::optional<WebCore::FrameIdentifier> frameID, const ContentWorldData& worldData, bool wantsResult, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>)>&& completionHandler)
@@ -4976,7 +4961,7 @@ void WebPage::removeDataDetectedLinks(CompletionHandler<void(DataDetectionResult
         if (auto* results = localFrame->dataDetectionResultsIfExists()) {
             // FIXME: It seems odd that we're clearing out all data detection results here,
             // instead of only data detectors that correspond to links.
-            results->setDocumentLevelResults({ });
+            results->setDocumentLevelResults(nullptr);
         }
     }
     completionHandler({ });
@@ -5012,106 +4997,6 @@ void WebPage::detectDataInAllFrames(OptionSet<WebCore::DataDetectorType> dataDet
 }
 
 #endif // ENABLE(DATA_DETECTION)
-
-#if PLATFORM(COCOA)
-void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, WebCore::FrameIdentifier rootFrameID)
-{
-    RefPtr rootFrame = WebProcess::singleton().webFrame(rootFrameID);
-    if (!rootFrame)
-        return;
-
-    RefPtr localRootFrame = rootFrame->coreLocalFrame();
-    if (!localRootFrame)
-        return;
-
-    RefPtr frameView = localRootFrame->view();
-    if (!frameView)
-        return;
-
-    Ref page = *corePage();
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    if (RefPtr document = localRootFrame->document()) {
-        if (CheckedPtr timelinesController = document->timelinesController()) {
-            if (auto* acceleratedEffectStackUpdater = timelinesController->existingAcceleratedEffectStackUpdater())
-                layerTransaction.setTimelines(acceleratedEffectStackUpdater->timelines());
-        }
-    }
-#endif
-
-    layerTransaction.setContentsSize(frameView->contentsSize());
-    layerTransaction.setScrollGeometryContentSize(frameView->scrollGeometryContentSize());
-    layerTransaction.setScrollOrigin(frameView->scrollOrigin());
-    layerTransaction.setPageScaleFactor(page->pageScaleFactor());
-    layerTransaction.setRenderTreeSize(page->renderTreeSize());
-    layerTransaction.setThemeColor(page->themeColor());
-    layerTransaction.setPageExtendedBackgroundColor(page->pageExtendedBackgroundColor());
-    layerTransaction.setSampledPageTopColor(page->sampledPageTopColor());
-
-    bool isMainFrameProcess = !!page->localMainFrame();
-    if (isMainFrameProcess && std::exchange(m_needsFixedContainerEdgesUpdate, false)) {
-        page->updateFixedContainerEdges(sidesRequiringFixedContainerEdges());
-        layerTransaction.setFixedContainerEdges(page->fixedContainerEdges());
-    }
-
-    layerTransaction.setBaseLayoutViewportSize(frameView->baseLayoutViewportSize());
-    layerTransaction.setMinStableLayoutViewportOrigin(frameView->minStableLayoutViewportOrigin());
-    layerTransaction.setMaxStableLayoutViewportOrigin(frameView->maxStableLayoutViewportOrigin());
-
-#if PLATFORM(IOS_FAMILY)
-    layerTransaction.setScaleWasSetByUIProcess(scaleWasSetByUIProcess());
-    layerTransaction.setMinimumScaleFactor(m_viewportConfiguration.minimumScale());
-    layerTransaction.setMaximumScaleFactor(m_viewportConfiguration.maximumScale());
-    layerTransaction.setInitialScaleFactor(m_viewportConfiguration.initialScale());
-    layerTransaction.setViewportMetaTagInteractiveWidget(m_viewportConfiguration.viewportArguments().interactiveWidget);
-    layerTransaction.setViewportMetaTagWidth(m_viewportConfiguration.viewportArguments().width);
-    layerTransaction.setViewportMetaTagWidthWasExplicit(m_viewportConfiguration.viewportArguments().widthWasExplicit);
-    layerTransaction.setViewportMetaTagCameFromImageDocument(m_viewportConfiguration.viewportArguments().type == ViewportArguments::Type::ImageDocument);
-    layerTransaction.setAvoidsUnsafeArea(m_viewportConfiguration.avoidsUnsafeArea());
-    layerTransaction.setIsInStableState(m_isInStableState);
-    layerTransaction.setAllowsUserScaling(allowsUserScaling());
-    if (m_pendingDynamicViewportSizeUpdateID) {
-        layerTransaction.setDynamicViewportSizeUpdateID(*m_pendingDynamicViewportSizeUpdateID);
-        m_pendingDynamicViewportSizeUpdateID = std::nullopt;
-    }
-    if (m_lastTransactionPageScaleFactor != layerTransaction.pageScaleFactor()) {
-        m_lastTransactionPageScaleFactor = layerTransaction.pageScaleFactor();
-        m_internals->lastTransactionIDWithScaleChange = layerTransaction.transactionID();
-    }
-#endif
-
-    layerTransaction.setScrollPosition(frameView->scrollPosition());
-
-    m_pendingThemeColorChange = false;
-    m_pendingPageExtendedBackgroundColorChange = false;
-    m_pendingSampledPageTopColorChange = false;
-
-    if (hasPendingEditorStateUpdate() || m_needsEditorStateVisualDataUpdate) {
-        layerTransaction.setEditorState(editorState());
-        m_pendingEditorStateUpdateStatus = PendingEditorStateUpdateStatus::NotScheduled;
-        m_needsEditorStateVisualDataUpdate = false;
-    }
-}
-
-void WebPage::didFlushLayerTreeAtTime(MonotonicTime timestamp, bool flushSucceeded)
-{
-#if PLATFORM(IOS_FAMILY)
-    if (m_oldestNonStableUpdateVisibleContentRectsTimestamp != MonotonicTime()) {
-        Seconds elapsed = timestamp - m_oldestNonStableUpdateVisibleContentRectsTimestamp;
-        m_oldestNonStableUpdateVisibleContentRectsTimestamp = MonotonicTime();
-
-        m_estimatedLatency = m_estimatedLatency * 0.80 + elapsed * 0.20;
-    }
-#else
-    UNUSED_PARAM(timestamp);
-#endif
-#if ENABLE(GPU_PROCESS)
-    if (!flushSucceeded) {
-        if (RefPtr proxy = m_remoteRenderingBackendProxy)
-            proxy->didBecomeUnresponsive();
-    }
-#endif
-}
-#endif
 
 void WebPage::layoutIfNeeded()
 {
@@ -6091,7 +5976,7 @@ void WebPage::unmarkAllMisspellings()
         if (!localFrame)
             continue;
         if (RefPtr document = localFrame->document())
-            document->markers().removeMarkers(DocumentMarkerType::Spelling);
+            document->checkedMarkers()->removeMarkers(DocumentMarkerType::Spelling);
     }
 }
 
@@ -6102,7 +5987,7 @@ void WebPage::unmarkAllBadGrammar()
         if (!localFrame)
             continue;
         if (RefPtr document = localFrame->document())
-            document->markers().removeMarkers(DocumentMarkerType::Grammar);
+            document->checkedMarkers()->removeMarkers(DocumentMarkerType::Grammar);
     }
 }
 
@@ -6184,7 +6069,7 @@ void WebPage::clearSelection()
     if (!frame)
         return;
 
-    frame->selection().clear();
+    frame->checkedSelection()->clear();
 }
 #endif
 
@@ -6471,17 +6356,6 @@ void WebPage::didRemoveBackForwardItem(BackForwardItemIdentifier itemID)
     WebBackForwardListProxy::removeItem(itemID);
 }
 
-#if PLATFORM(COCOA)
-
-bool WebPage::isSpeaking() const
-{
-    auto sendResult = const_cast<WebPage*>(this)->sendSync(Messages::WebPageProxy::GetIsSpeaking());
-    auto [result] = sendResult.takeReplyOr(false);
-    return result;
-}
-
-#endif
-
 #if PLATFORM(MAC)
 void WebPage::setCaretAnimatorType(WebCore::CaretAnimatorType caretType)
 {
@@ -6489,7 +6363,7 @@ void WebPage::setCaretAnimatorType(WebCore::CaretAnimatorType caretType)
     if (!frame)
         return;
 
-    frame->selection().caretAnimatorInvalidated(caretType);
+    frame->checkedSelection()->caretAnimatorInvalidated(caretType);
 }
 
 void WebPage::setCaretBlinkingSuspended(bool suspended)
@@ -6498,20 +6372,9 @@ void WebPage::setCaretBlinkingSuspended(bool suspended)
     if (!frame)
         return;
 
-    frame->selection().setCaretBlinkingSuspended(suspended);
+    frame->checkedSelection()->setCaretBlinkingSuspended(suspended);
 }
 
-#endif
-
-#if PLATFORM(COCOA)
-RetainPtr<PDFDocument> WebPage::pdfDocumentForPrintingFrame(LocalFrame* coreFrame)
-{
-#if ENABLE(PDF_PLUGIN)
-    if (RefPtr pluginView = pluginViewForFrame(coreFrame))
-        return pluginView->pdfDocumentForPrinting();
-#endif
-    return nullptr;
-}
 #endif
 
 void WebPage::setUseColorAppearance(bool useDarkAppearance, bool useElevatedUserInterfaceLevel)
@@ -6794,206 +6657,7 @@ void WebPage::pdfSnapshotAtSize(LocalFrame& localMainFrame, GraphicsContext& con
     }
 }
 
-
-#if PLATFORM(COCOA)
-void WebPage::drawToPDF(const std::optional<FloatRect>& rect, bool allowTransparentBackground, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&& completionHandler)
-{
-    RefPtr localMainFrame = this->localMainFrame();
-    if (!localMainFrame)
-        return;
-
-    Ref frameView = *localMainFrame->view();
-    auto snapshotRect = IntRect { rect.value_or(FloatRect { { }, frameView->contentsSize() }) };
-
-    RefPtr buffer = ImageBuffer::create(snapshotRect.size(), RenderingMode::PDFDocument, RenderingPurpose::Snapshot, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
-    if (!buffer)
-        return;
-
-    drawMainFrameToPDF(*localMainFrame, buffer->context(), snapshotRect, allowTransparentBackground);
-    completionHandler(buffer->sinkIntoPDFDocument());
-}
-
-void WebPage::drawRectToImage(FrameIdentifier frameID, const PrintInfo& printInfo, const IntRect& rect, const WebCore::IntSize& imageSize, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler)
-{
-    PrintContextAccessScope scope { *this };
-    RefPtr frame = WebProcess::singleton().webFrame(frameID);
-    RefPtr coreFrame = frame ? frame->coreLocalFrame() : 0;
-
-    RefPtr<WebImage> image;
-
-#if USE(CG)
-    if (coreFrame) {
-        ASSERT(coreFrame->document()->printing() || pdfDocumentForPrintingFrame(coreFrame.get()));
-        image = WebImage::create(imageSize, ImageOption::Local, DestinationColorSpace::SRGB(), &m_page->chrome().client());
-        if (!image || !image->context()) {
-            ASSERT_NOT_REACHED();
-            return completionHandler({ });
-        }
-
-        auto& graphicsContext = *image->context();
-        float printingScale = static_cast<float>(imageSize.width()) / rect.width();
-        graphicsContext.scale(printingScale);
-
-        if (RetainPtr<PDFDocument> pdfDocument = pdfDocumentForPrintingFrame(coreFrame.get())) {
-            ASSERT(!m_printContext);
-            graphicsContext.scale(FloatSize(1, -1));
-            graphicsContext.translate(0, -rect.height());
-            drawPDFDocument(graphicsContext.platformContext(), pdfDocument.get(), printInfo, rect);
-        } else
-            m_printContext->spoolRect(graphicsContext, rect);
-    }
-#endif
-
-    std::optional<ShareableBitmap::Handle> handle;
-    if (image)
-        handle = image->createHandle(SharedMemory::Protection::ReadOnly);
-
-    completionHandler(WTFMove(handle));
-}
-
-void WebPage::drawPagesToPDF(FrameIdentifier frameID, const PrintInfo& printInfo, uint32_t first, uint32_t count, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&& callback)
-{
-    PrintContextAccessScope scope { *this };
-    RefPtr<SharedBuffer> pdfPageData;
-    drawPagesToPDFImpl(frameID, printInfo, first, count, pdfPageData);
-    callback(WTFMove(pdfPageData));
-}
-
-void WebPage::drawPagesToPDFImpl(FrameIdentifier frameID, const PrintInfo& printInfo, uint32_t first, uint32_t count, RefPtr<SharedBuffer>& pdfPageData)
-{
-    RefPtr frame = WebProcess::singleton().webFrame(frameID);
-    RefPtr coreFrame = frame ? frame->coreLocalFrame() : 0;
-
-#if USE(CG)
-    if (coreFrame) {
-        ASSERT(coreFrame->document()->printing() || pdfDocumentForPrintingFrame(coreFrame.get()));
-
-        FloatRect mediaBox = (m_printContext && m_printContext->pageCount()) ? m_printContext->pageRect(0) : FloatRect { 0, 0, printInfo.availablePaperWidth, printInfo.availablePaperHeight };
-
-        RefPtr buffer = ImageBuffer::create(mediaBox.size(), RenderingMode::PDFDocument, RenderingPurpose::Snapshot, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
-        if (!buffer)
-            return;
-        GraphicsContext& context = buffer->context();
-
-        if (RetainPtr<PDFDocument> pdfDocument = pdfDocumentForPrintingFrame(coreFrame.get())) {
-            ASSERT(!m_printContext);
-            drawPagesToPDFFromPDFDocument(context, pdfDocument.get(), printInfo, mediaBox, first, count);
-        } else {
-            if (!m_printContext)
-                return;
-
-            drawPrintContextPagesToGraphicsContext(context, mediaBox, first, count);
-        }
-        pdfPageData = ImageBuffer::sinkIntoPDFDocument(WTFMove(buffer));
-    }
-#endif
-}
-
-void WebPage::drawPrintContextPagesToGraphicsContext(GraphicsContext& context, const FloatRect& pageRect, uint32_t first, uint32_t count)
-{
-    for (uint32_t page = first; page < first + count; ++page) {
-        if (page >= m_printContext->pageCount())
-            break;
-
-        context.beginPage(pageRect);
-
-        context.scale(FloatSize(1, -1));
-        context.translate(0, -m_printContext->pageRect(page).height());
-        m_printContext->spoolPage(context, page, m_printContext->pageRect(page).width());
-
-        context.endPage();
-    }
-}
-
-void WebPage::drawPrintingRectToSnapshot(RemoteSnapshotIdentifier snapshotIdentifier, WebCore::FrameIdentifier frameID, const PrintInfo& printInfo, const WebCore::IntRect& rect, const WebCore::IntSize& imageSize, CompletionHandler<void(bool)>&& completionHandler)
-{
-    RefPtr frame = WebProcess::singleton().webFrame(frameID);
-    if (!frame) {
-        completionHandler(false);
-        return;
-    }
-
-    RefPtr coreFrame = frame->coreLocalFrame();
-    if (!coreFrame) {
-        completionHandler(false);
-        return;
-    }
-
-    if (pdfDocumentForPrintingFrame(coreFrame.get())) {
-        // Can't do this remotely.
-        completionHandler(false);
-        return;
-    }
-    ASSERT(coreFrame->document()->printing());
-    PrintContextAccessScope scope { *this };
-
-    Ref remoteRenderingBackend = ensureRemoteRenderingBackendProxy();
-    m_remoteSnapshotState = {
-        snapshotIdentifier,
-        remoteRenderingBackend->createSnapshotRecorder(snapshotIdentifier),
-        MainRunLoopSuccessCallbackAggregator::create([completionHandler = WTFMove(completionHandler)] (bool success) mutable {
-            completionHandler(success);
-        })
-    };
-    GraphicsContext& context = m_remoteSnapshotState->recorder.get();
-
-    float printingScale = static_cast<float>(imageSize.width()) / rect.width();
-    context.scale(printingScale);
-
-    m_printContext->spoolRect(context, rect);
-
-    remoteRenderingBackend->sinkSnapshotRecorderIntoSnapshotFrame(WTFMove(m_remoteSnapshotState->recorder), frameID, Ref { m_remoteSnapshotState->callback }->chain());
-    m_remoteSnapshotState = std::nullopt;
-}
-
-void WebPage::drawPrintingPagesToSnapshot(RemoteSnapshotIdentifier snapshotIdentifier, FrameIdentifier frameID, const PrintInfo& printInfo, uint32_t first, uint32_t count, CompletionHandler<void(std::optional<WebCore::FloatSize>)>&& completionHandler)
-{
-    RefPtr frame = WebProcess::singleton().webFrame(frameID);
-    if (!frame) {
-        completionHandler({ });
-        return;
-    }
-
-    RefPtr coreFrame = frame->coreLocalFrame();
-    if (!coreFrame) {
-        completionHandler({ });
-        return;
-    }
-
-    if (pdfDocumentForPrintingFrame(coreFrame.get())) {
-        // Can't do this remotely.
-        completionHandler({ });
-        return;
-    }
-
-    if (!m_printContext) {
-        completionHandler({ });
-        return;
-    }
-
-    PrintContextAccessScope scope { *this };
-    ASSERT(coreFrame->document()->printing());
-
-    FloatRect mediaBox = (m_printContext && m_printContext->pageCount()) ? m_printContext->pageRect(0) : FloatRect { 0, 0, printInfo.availablePaperWidth, printInfo.availablePaperHeight };
-
-    Ref remoteRenderingBackend = ensureRemoteRenderingBackendProxy();
-    m_remoteSnapshotState = {
-        snapshotIdentifier,
-        remoteRenderingBackend->createSnapshotRecorder(snapshotIdentifier),
-        MainRunLoopSuccessCallbackAggregator::create([completionHandler = WTFMove(completionHandler), snapshotSize = mediaBox.size()] (bool success) mutable {
-            completionHandler(success ? std::optional<FloatSize>(snapshotSize) : std::nullopt);
-        })
-    };
-
-    GraphicsContext& context = m_remoteSnapshotState->recorder.get();
-
-    drawPrintContextPagesToGraphicsContext(context, mediaBox, first, count);
-
-    remoteRenderingBackend->sinkSnapshotRecorderIntoSnapshotFrame(WTFMove(m_remoteSnapshotState->recorder), frameID, Ref { m_remoteSnapshotState->callback }->chain());
-    m_remoteSnapshotState = std::nullopt;
-}
-
-#elif PLATFORM(GTK)
+#if PLATFORM(GTK)
 void WebPage::drawPagesForPrinting(FrameIdentifier frameID, const PrintInfo& printInfo, CompletionHandler<void(std::optional<SharedMemory::Handle>&&, WebCore::ResourceError&&)>&& completionHandler)
 {
     beginPrinting(frameID, printInfo);
@@ -7133,17 +6797,6 @@ bool WebPage::canHandleRequest(const WebCore::ResourceRequest& request)
 
     return platformCanHandleRequest(request);
 }
-
-#if PLATFORM(COCOA)
-void WebPage::handleAlternativeTextUIResult(const String& result)
-{
-    RefPtr frame = corePage()->focusController().focusedOrMainFrame();
-    if (!frame)
-        return;
-
-    frame->protectedEditor()->handleAlternativeTextUIResult(result);
-}
-#endif
 
 void WebPage::setCompositionForTesting(const String& compositionString, uint64_t from, uint64_t length, bool suppressUnderline, const Vector<CompositionHighlight>& highlights, const HashMap<String, Vector<WebCore::CharacterRange>>& annotations)
 {
@@ -7293,225 +6946,6 @@ bool WebPage::shouldUseCustomContentProviderForResponse(const ResourceResponse& 
     return m_mimeTypesWithCustomContentProviders.contains(mimeType);
 }
 
-#if PLATFORM(COCOA)
-
-void WebPage::setTextAsync(const String& text)
-{
-    RefPtr frame = corePage()->focusController().focusedOrMainFrame();
-    if (!frame)
-        return;
-
-    if (frame->selection().selection().isContentEditable()) {
-        UserTypingGestureIndicator indicator(*frame);
-        frame->selection().selectAll();
-        if (text.isEmpty())
-            frame->protectedEditor()->deleteSelectionWithSmartDelete(false);
-        else
-            frame->protectedEditor()->insertText(text, nullptr, TextEventInputKeyboard);
-        return;
-    }
-
-    if (RefPtr input = dynamicDowncast<HTMLInputElement>(m_focusedElement)) {
-        input->setValueForUser(text);
-        return;
-    }
-
-    ASSERT_NOT_REACHED();
-}
-
-void WebPage::insertTextAsync(const String& text, const EditingRange& replacementEditingRange, InsertTextOptions&& options)
-{
-    platformWillPerformEditingCommand();
-
-    RefPtr frame = corePage()->focusController().focusedOrMainFrame();
-    if (!frame)
-        return;
-
-    UserGestureIndicator gestureIndicator { options.processingUserGesture ? IsProcessingUserGesture::Yes : IsProcessingUserGesture::No, frame->document() };
-
-    bool replacesText = false;
-    if (replacementEditingRange.location != notFound) {
-        if (auto replacementRange = EditingRange::toRange(*frame, replacementEditingRange, options.editingRangeIsRelativeTo)) {
-            SetForScope isSelectingTextWhileInsertingAsynchronously(m_isSelectingTextWhileInsertingAsynchronously, options.suppressSelectionUpdate);
-            frame->selection().setSelection(VisibleSelection(*replacementRange));
-            replacesText = replacementEditingRange.length;
-        }
-    }
-
-    if (options.registerUndoGroup)
-        send(Messages::WebPageProxy::RegisterInsertionUndoGrouping());
-
-    RefPtr focusedElement = frame->document() ? frame->document()->focusedElement() : nullptr;
-    if (focusedElement && options.shouldSimulateKeyboardInput)
-        focusedElement->dispatchEvent(Event::create(eventNames().keydownEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes));
-
-    Ref editor = frame->editor();
-    if (!editor->hasComposition()) {
-        if (text.isEmpty() && frame->selection().isRange())
-            editor->deleteWithDirection(SelectionDirection::Backward, TextGranularity::CharacterGranularity, false, true);
-        else {
-            // An insertText: might be handled by other responders in the chain if we don't handle it.
-            // One example is space bar that results in scrolling down the page.
-            editor->insertText(text, nullptr, replacesText ? TextEventInputAutocompletion : TextEventInputKeyboard);
-        }
-    } else
-        editor->confirmComposition(text);
-
-    auto baseWritingDirectionFromInputMode = [&] -> std::optional<WritingDirection> {
-        auto direction = options.directionFromCurrentInputMode;
-        if (!direction)
-            return { };
-
-        if (text != "\n"_s)
-            return { };
-
-        auto selection = frame->selection().selection();
-        if (!selection.isCaret() || !selection.isContentEditable())
-            return { };
-
-        auto start = selection.visibleStart();
-        if (!isStartOfLine(start) || !isEndOfLine(start))
-            return { };
-
-        if (direction == directionOfEnclosingBlock(start.deepEquivalent()))
-            return { };
-
-        return { direction == TextDirection::LTR ? WritingDirection::LeftToRight : WritingDirection::RightToLeft };
-    }();
-
-    if (baseWritingDirectionFromInputMode) {
-        editor->setBaseWritingDirection(*baseWritingDirectionFromInputMode);
-        editor->setTextAlignmentForChangedBaseWritingDirection(*baseWritingDirectionFromInputMode);
-    }
-
-    if (focusedElement && options.shouldSimulateKeyboardInput) {
-        focusedElement->dispatchEvent(Event::create(eventNames().keyupEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes));
-        focusedElement->dispatchEvent(Event::create(eventNames().changeEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes));
-    }
-}
-
-void WebPage::hasMarkedText(CompletionHandler<void(bool)>&& completionHandler)
-{
-    RefPtr focusedOrMainFrame = corePage()->focusController().focusedOrMainFrame();
-    if (!focusedOrMainFrame)
-        return completionHandler(false);
-    completionHandler(focusedOrMainFrame->editor().hasComposition());
-}
-
-void WebPage::getMarkedRangeAsync(CompletionHandler<void(const EditingRange&)>&& completionHandler)
-{
-    RefPtr frame = corePage()->focusController().focusedOrMainFrame();
-    if (!frame)
-        return completionHandler({ });
-
-    completionHandler(EditingRange::fromRange(*frame, frame->protectedEditor()->compositionRange()));
-}
-
-void WebPage::getSelectedRangeAsync(CompletionHandler<void(const EditingRange& selectedRange, const EditingRange& compositionRange)>&& completionHandler)
-{
-    RefPtr frame = corePage()->focusController().focusedOrMainFrame();
-    if (!frame)
-        return completionHandler({ }, { });
-
-    completionHandler(EditingRange::fromRange(*frame, frame->selection().selection().toNormalizedRange()),
-        EditingRange::fromRange(*frame, frame->protectedEditor()->compositionRange()));
-}
-
-void WebPage::characterIndexForPointAsync(const WebCore::IntPoint& point, CompletionHandler<void(uint64_t)>&& completionHandler)
-{
-    RefPtr localMainFrame = this->localMainFrame();
-    if (!localMainFrame)
-        return;
-    constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent,  HitTestRequest::Type::AllowChildFrameContent };
-    auto result = localMainFrame->eventHandler().hitTestResultAtPoint(point, hitType);
-    RefPtr frame = result.innerNonSharedNode() ? result.innerNodeFrame() : corePage()->focusController().focusedOrMainFrame();
-    if (!frame)
-        return completionHandler({ });
-    auto range = frame->rangeForPoint(result.roundedPointInInnerNodeFrame());
-    auto editingRange = EditingRange::fromRange(*frame, range);
-    completionHandler(editingRange.location);
-}
-
-void WebPage::firstRectForCharacterRangeAsync(const EditingRange& editingRange, CompletionHandler<void(const WebCore::IntRect&, const EditingRange&)>&& completionHandler)
-{
-    RefPtr frame = corePage()->focusController().focusedOrMainFrame();
-    if (!frame)
-        return completionHandler({ }, { });
-
-    auto range = EditingRange::toRange(*frame, editingRange);
-    if (!range)
-        return completionHandler({ }, editingRange);
-
-    auto rect = RefPtr(frame->view())->contentsToWindow(frame->protectedEditor()->firstRectForRange(*range));
-    auto startPosition = makeContainerOffsetPosition(range->start);
-
-    auto endPosition = endOfLine(startPosition);
-    if (endPosition.isNull())
-        endPosition = startPosition;
-    else if (endPosition.affinity() == Affinity::Downstream && inSameLine(startPosition, endPosition)) {
-        auto nextLineStartPosition = positionOfNextBoundaryOfGranularity(endPosition, TextGranularity::LineGranularity, SelectionDirection::Forward);
-        if (nextLineStartPosition.isNotNull() && endPosition < nextLineStartPosition)
-            endPosition = nextLineStartPosition;
-    }
-
-    auto endBoundary = makeBoundaryPoint(endPosition);
-    if (!endBoundary)
-        return completionHandler({ }, editingRange);
-
-    auto rangeForFirstLine = EditingRange::fromRange(*frame, makeSimpleRange(range->start, WTFMove(endBoundary)));
-
-    rangeForFirstLine.location = std::min(std::max(rangeForFirstLine.location, editingRange.location), editingRange.location + editingRange.length);
-    rangeForFirstLine.length = std::min(rangeForFirstLine.location + rangeForFirstLine.length, editingRange.location + editingRange.length) - rangeForFirstLine.location;
-
-    completionHandler(rect, rangeForFirstLine);
-}
-
-void WebPage::setCompositionAsync(const String& text, const Vector<CompositionUnderline>& underlines, const Vector<CompositionHighlight>& highlights, const HashMap<String, Vector<CharacterRange>>& annotations, const EditingRange& selection, const EditingRange& replacementEditingRange)
-{
-    platformWillPerformEditingCommand();
-
-    RefPtr frame = corePage()->focusController().focusedOrMainFrame();
-    if (!frame)
-        return;
-
-    if (frame->selection().selection().isContentEditable()) {
-        if (replacementEditingRange.location != notFound) {
-            if (auto replacementRange = EditingRange::toRange(*frame, replacementEditingRange))
-                frame->selection().setSelection(VisibleSelection(*replacementRange));
-        }
-        frame->protectedEditor()->setComposition(text, underlines, highlights, annotations, selection.location, selection.location + selection.length);
-    }
-}
-
-void WebPage::setWritingSuggestion(const String& fullTextWithPrediction, const EditingRange& selection)
-{
-#if PLATFORM(COCOA)
-    platformWillPerformEditingCommand();
-
-    RefPtr frame = corePage()->focusController().focusedOrMainFrame();
-    if (!frame)
-        return;
-
-    frame->protectedEditor()->setWritingSuggestion(fullTextWithPrediction, { selection.location, selection.length });
-#else
-    UNUSED_PARAM(fullTextWithPrediction);
-    UNUSED_PARAM(selection);
-#endif
-}
-
-void WebPage::confirmCompositionAsync()
-{
-    platformWillPerformEditingCommand();
-
-    RefPtr frame = corePage()->focusController().focusedOrMainFrame();
-    if (!frame)
-        return;
-
-    frame->protectedEditor()->confirmComposition();
-}
-
-#endif // PLATFORM(COCOA)
-
 #if PLATFORM(GTK) || PLATFORM(WPE)
 
 static RefPtr<LocalFrame> targetFrameForEditing(WebPage& page)
@@ -7563,7 +6997,7 @@ void WebPage::deleteSurrounding(int64_t offset, unsigned characterCount)
     auto selectionRange = resolveCharacterRange(makeRangeSelectingNodeContents(rootNode), characterRange);
 
     targetFrame->editor().setIgnoreSelectionChanges(true);
-    targetFrame->selection().setSelection(VisibleSelection(selectionRange));
+    targetFrame->checkedSelection()->setSelection(VisibleSelection(selectionRange));
     targetFrame->editor().deleteSelectionWithSmartDelete(false);
     targetFrame->editor().setIgnoreSelectionChanges(false);
     sendEditorStateUpdate();
@@ -8399,19 +7833,6 @@ void WebPage::loadAndDecodeImage(WebCore::ResourceRequest&& request, std::option
         completionHandler(bitmap.releaseNonNull());
     });
 }
-
-#if PLATFORM(COCOA)
-void WebPage::getInformationFromImageData(const Vector<uint8_t>& data, CompletionHandler<void(Expected<std::pair<String, Vector<IntSize>>, WebCore::ImageDecodingError>&&)>&& completionHandler)
-{
-    if (m_isClosed)
-        return completionHandler(makeUnexpected(ImageDecodingError::Internal));
-
-    if (SVGImage::isDataDecodable(m_page->settings(), data.span()))
-        return completionHandler(std::make_pair(String { "public.svg-image"_s }, Vector<IntSize> { }));
-
-    completionHandler(utiAndAvailableSizesFromImageData(data.span()));
-}
-#endif
 
 #if PLATFORM(MAC) || PLATFORM(WPE) || PLATFORM(GTK)
 void WebPage::flushPendingThemeColorChange()
@@ -9255,7 +8676,7 @@ void WebPage::startTextManipulationForFrame(WebCore::Frame& frame)
         return;
 
     auto exclusionRules = *m_internals->textManipulationExclusionRules;
-    document->textManipulationController().startObservingParagraphs([webPage = WeakPtr { *this }] (Document& document, const Vector<WebCore::TextManipulationItem>& items) {
+    document->checkedTextManipulationController()->startObservingParagraphs([webPage = WeakPtr { *this }] (Document& document, const Vector<WebCore::TextManipulationItem>& items) {
         RefPtr frame = document.frame();
         if (!webPage || !frame)
             return;
@@ -9969,28 +9390,6 @@ bool WebPage::handlesPageScaleGesture()
 #endif
 }
 
-#if PLATFORM(COCOA)
-void WebPage::insertTextPlaceholder(const IntSize& size, CompletionHandler<void(const std::optional<WebCore::ElementContext>&)>&& completionHandler)
-{
-    // Inserting the placeholder may run JavaScript, which can do anything, including frame destruction.
-    RefPtr frame = corePage()->focusController().focusedOrMainFrame();
-    if (!frame)
-        return completionHandler({ });
-
-    auto placeholder = frame->protectedEditor()->insertTextPlaceholder(size);
-    completionHandler(placeholder ? contextForElement(*placeholder) : std::nullopt);
-}
-
-void WebPage::removeTextPlaceholder(const ElementContext& placeholder, CompletionHandler<void()>&& completionHandler)
-{
-    if (auto element = elementForContext(placeholder)) {
-        if (RefPtr frame = element->document().frame())
-            frame->protectedEditor()->removeTextPlaceholder(downcast<TextPlaceholderElement>(*element));
-    }
-    completionHandler();
-}
-#endif
-
 void WebPage::generateTestReport(String&& message, String&& group)
 {
     if (RefPtr localTopDocument = this->localTopDocument())
@@ -10250,7 +9649,7 @@ void WebPage::layerTreeAsTextForTesting(WebCore::FrameIdentifier frameID, uint64
     }
 
     auto ts = WebCore::createTextStream(*renderer);
-    ts << coreLocalFrame->contentRenderer()->compositor().layerTreeAsText(options, baseIndent);
+    ts << coreLocalFrame->checkedContentRenderer()->checkedCompositor()->layerTreeAsText(options, baseIndent);
     completionHandler(ts.release());
 }
 


### PR DESCRIPTION
#### 80fc05a4c20623d72e1fa626c606c752ef9de1b5
<pre>
Address some Safer CPP warnings in WebPage.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=301262">https://bugs.webkit.org/show_bug.cgi?id=301262</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::checkedTextManipulationController):
* Source/WebCore/dom/Document.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::checkedClient const):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::checkedContentRenderer const):
* Source/WebCore/page/LocalFrame.h:
* Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::pdfDocumentForPrintingFrame):
(WebKit::WebPage::drawToPDF):
(WebKit::WebPage::drawRectToImage):
(WebKit::WebPage::drawPagesToPDF):
(WebKit::WebPage::drawPagesToPDFImpl):
(WebKit::WebPage::drawPrintContextPagesToGraphicsContext):
(WebKit::WebPage::drawPrintingRectToSnapshot):
(WebKit::WebPage::drawPrintingPagesToSnapshot):
(WebKit::WebPage::handleAlternativeTextUIResult):
(WebKit::WebPage::setTextAsync):
(WebKit::WebPage::insertTextAsync):
(WebKit::WebPage::hasMarkedText):
(WebKit::WebPage::getMarkedRangeAsync):
(WebKit::WebPage::getSelectedRangeAsync):
(WebKit::WebPage::characterIndexForPointAsync):
(WebKit::WebPage::firstRectForCharacterRangeAsync):
(WebKit::WebPage::setCompositionAsync):
(WebKit::WebPage::setWritingSuggestion):
(WebKit::WebPage::confirmCompositionAsync):
(WebKit::WebPage::getInformationFromImageData):
(WebKit::WebPage::insertTextPlaceholder):
(WebKit::WebPage::removeTextPlaceholder):
(WebKit::WebPage::setObscuredContentInsetsFenced):
(WebKit::WebPage::willCommitLayerTree):
(WebKit::WebPage::didFlushLayerTreeAtTime):
(WebKit::WebPage::isSpeaking const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::editorState const):
(WebKit::WebPage::setEditable):
(WebKit::WebPage::paintSnapshotAtSize):
(WebKit::WebPage::snapshotNode):
(WebKit::WebPage::centerSelectionInVisibleArea):
(WebKit::WebPage::setInitialFocus):
(WebKit::WebPage::runJavaScript):
(WebKit::WebPage::removeDataDetectedLinks):
(WebKit::WebPage::unmarkAllMisspellings):
(WebKit::WebPage::unmarkAllBadGrammar):
(WebKit::WebPage::clearSelection):
(WebKit::WebPage::setCaretAnimatorType):
(WebKit::WebPage::setCaretBlinkingSuspended):
(WebKit::WebPage::deleteSurrounding):
(WebKit::WebPage::startTextManipulationForFrame):
(WebKit::WebPage::layerTreeAsTextForTesting):
(WebKit::WebPage::setObscuredContentInsetsFenced): Deleted.
(WebKit::WebPage::willCommitLayerTree): Deleted.
(WebKit::WebPage::didFlushLayerTreeAtTime): Deleted.
(WebKit::WebPage::isSpeaking const): Deleted.
(WebKit::WebPage::pdfDocumentForPrintingFrame): Deleted.
(WebKit::WebPage::drawToPDF): Deleted.
(WebKit::WebPage::drawRectToImage):
(WebKit::WebPage::drawPagesToPDF): Deleted.
(WebKit::WebPage::drawPagesToPDFImpl): Deleted.
(WebKit::WebPage::drawPrintContextPagesToGraphicsContext): Deleted.
(WebKit::WebPage::drawPrintingRectToSnapshot): Deleted.
(WebKit::WebPage::drawPrintingPagesToSnapshot): Deleted.
(WebKit::WebPage::handleAlternativeTextUIResult): Deleted.
(WebKit::WebPage::setTextAsync):
(WebKit::WebPage::insertTextAsync):
(WebKit::WebPage::hasMarkedText): Deleted.
(WebKit::WebPage::getMarkedRangeAsync): Deleted.
(WebKit::WebPage::getSelectedRangeAsync): Deleted.
(WebKit::WebPage::characterIndexForPointAsync): Deleted.
(WebKit::WebPage::firstRectForCharacterRangeAsync): Deleted.
(WebKit::WebPage::setCompositionAsync):
(WebKit::WebPage::setWritingSuggestion): Deleted.
(WebKit::WebPage::confirmCompositionAsync): Deleted.
(WebKit::WebPage::getInformationFromImageData): Deleted.
(WebKit::WebPage::insertTextPlaceholder): Deleted.
(WebKit::WebPage::removeTextPlaceholder): Deleted.

Canonical link: <a href="https://commits.webkit.org/302023@main">https://commits.webkit.org/302023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66e86ba8af12a8abd3897b71575cacd598ca7ebb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135013 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79298 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e3c2568c-7d5d-4d05-8680-4df486656036) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97233 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65137 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/726e1ea0-ed98-422b-99f1-e05a71fbff2f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77715 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c05ebd37-5f48-4cf4-b598-bdbf4d9a41fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32524 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78383 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137497 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105756 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105408 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26893 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50927 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29361 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52020 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54337 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60540 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53573 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/57028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55330 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->