### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for RTCSctpTransportBackendClient

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCSctpTransportBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransportBackend.h
@@ -27,22 +27,13 @@
 #if ENABLE(WEB_RTC)
 
 #include "RTCSctpTransportState.h"
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class RTCSctpTransportBackendClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::RTCSctpTransportBackendClient> : std::true_type { };
-}
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
 class RTCDtlsTransportBackend;
 
-class RTCSctpTransportBackendClient : public CanMakeWeakPtr<RTCSctpTransportBackendClient> {
+class RTCSctpTransportBackendClient : public AbstractRefCountedAndCanMakeWeakPtr<RTCSctpTransportBackendClient> {
 public:
     virtual ~RTCSctpTransportBackendClient() = default;
     virtual void onStateChanged(RTCSctpTransportState, std::optional<double>, std::optional<unsigned short>) = 0;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerSctpTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerSctpTransportBackend.cpp
@@ -95,11 +95,9 @@ void GStreamerSctpTransportBackend::stateChanged()
     uint64_t maxMessageSize;
     g_object_get(m_backend.get(), "state", &transportState, "max-message-size", &maxMessageSize, "max-channels", &maxChannels, nullptr);
     GST_DEBUG("Notifying SCTP transport state, max-message-size: %" G_GUINT64_FORMAT " max-channels: %" G_GUINT16_FORMAT, maxMessageSize, maxChannels);
-    callOnMainThread([client = m_client, transportState, maxChannels, maxMessageSize] {
-        if (!client)
-            return;
-
-        client->onStateChanged(toRTCSctpTransportState(transportState), maxMessageSize, maxChannels);
+    callOnMainThread([weakClient = m_client, transportState, maxChannels, maxMessageSize] {
+        if (RefPtr client = weakClient.get())
+            client->onStateChanged(toRTCSctpTransportState(transportState), maxMessageSize, maxChannels);
     });
 }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCSctpTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCSctpTransportBackend.cpp
@@ -77,7 +77,8 @@ LibWebRTCSctpTransportBackendObserver::LibWebRTCSctpTransportBackendObserver(RTC
 
 void LibWebRTCSctpTransportBackendObserver::updateState(webrtc::SctpTransportInformation&& info)
 {
-    if (!m_client)
+    RefPtr client = m_client.get();
+    if (!client)
         return;
 
     std::optional<unsigned short> maxChannels;
@@ -86,7 +87,7 @@ void LibWebRTCSctpTransportBackendObserver::updateState(webrtc::SctpTransportInf
     std::optional<double> maxMessageSize;
     if (info.MaxMessageSize())
         maxMessageSize = *info.MaxMessageSize();
-    m_client->onStateChanged(toRTCSctpTransportState(info.state()), maxMessageSize, maxChannels);
+    client->onStateChanged(toRTCSctpTransportState(info.state()), maxMessageSize, maxChannels);
 }
 
 void LibWebRTCSctpTransportBackendObserver::start()


### PR DESCRIPTION
#### 3457b54f709f180842c6c6060aa52b6a905abe41
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for RTCSctpTransportBackendClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=301268">https://bugs.webkit.org/show_bug.cgi?id=301268</a>

Reviewed by Philippe Normand.

* Source/WebCore/Modules/mediastream/RTCSctpTransportBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerSctpTransportBackend.cpp:
(WebCore::GStreamerSctpTransportBackend::stateChanged):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCSctpTransportBackend.cpp:
(WebCore::LibWebRTCSctpTransportBackendObserver::updateState):

Canonical link: <a href="https://commits.webkit.org/301995@main">https://commits.webkit.org/301995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4fb6bec5330626ee036732b38801a78756638c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134655 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79135 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d5e52bbd-a5b2-4cd4-a451-091ad562698d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97116 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65030 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aefac456-828b-458f-bb80-bdb08d3b6495) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77596 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1d2a6be6-e53f-47db-858a-498f6fb09406) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32362 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78028 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137139 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41799 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105640 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54748 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105291 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26877 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50807 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29245 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51823 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54174 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60261 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53408 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56865 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55167 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->