### PR TITLE
[threaded-animation-resolution] use a process-qualified identifier for timeline lookup in the remote layer tree

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
@@ -39,12 +39,12 @@ static WebCore::WebAnimationTime computeCurrentTime(Seconds originTime, Monotoni
     return now.secondsSinceEpoch() - originTime;
 }
 
-Ref<RemoteAnimationTimeline> RemoteAnimationTimeline::create(const WebCore::AcceleratedTimeline& input, MonotonicTime now)
+Ref<RemoteAnimationTimeline> RemoteAnimationTimeline::create(TimelineID identifier, const WebCore::AcceleratedTimeline& input, MonotonicTime now)
 {
-    return adoptRef(*new RemoteAnimationTimeline(input.identifier(), input.originTime(), computeCurrentTime(input.originTime(), now)));
+    return adoptRef(*new RemoteAnimationTimeline(identifier, input.originTime(), computeCurrentTime(input.originTime(), now)));
 }
 
-RemoteAnimationTimeline::RemoteAnimationTimeline(WebCore::TimelineIdentifier identifier, Seconds originTime, WebCore::WebAnimationTime currentTime)
+RemoteAnimationTimeline::RemoteAnimationTimeline(TimelineID identifier, Seconds originTime, WebCore::WebAnimationTime currentTime)
     : m_identifier(identifier)
     , m_originTime(originTime)
     , m_currentTime(currentTime)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
@@ -28,6 +28,7 @@
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
 #include <WebCore/AcceleratedTimeline.h>
+#include <WebCore/ProcessQualified.h>
 #include <WebCore/TimelineIdentifier.h>
 #include <WebCore/WebAnimationTime.h>
 #include <wtf/Ref.h>
@@ -35,19 +36,21 @@
 
 namespace WebKit {
 
+using TimelineID = WebCore::ProcessQualified<WebCore::TimelineIdentifier>;
+
 class RemoteAnimationTimeline final : public RefCounted<RemoteAnimationTimeline> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteAnimationTimeline);
 public:
-    static Ref<RemoteAnimationTimeline> create(const WebCore::AcceleratedTimeline&, MonotonicTime);
+    static Ref<RemoteAnimationTimeline> create(TimelineID, const WebCore::AcceleratedTimeline&, MonotonicTime);
 
     void updateCurrentTime(MonotonicTime);
     const WebCore::WebAnimationTime& currentTime() const { return m_currentTime; }
-    const WebCore::TimelineIdentifier& identifier() const { return m_identifier; }
+    const TimelineID& identifier() const { return m_identifier; }
 
 private:
-    RemoteAnimationTimeline(WebCore::TimelineIdentifier, Seconds, WebCore::WebAnimationTime);
+    RemoteAnimationTimeline(TimelineID, Seconds, WebCore::WebAnimationTime);
 
-    WebCore::TimelineIdentifier m_identifier;
+    TimelineID m_identifier;
     Seconds m_originTime;
     WebCore::WebAnimationTime m_currentTime;
 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.cpp
@@ -48,24 +48,25 @@ void RemoteAnimationTimelineRegistry::update(WebCore::ProcessIdentifier processI
     // Populate the list of active timelines, creating new timelines as necessary.
     HashSet<Ref<RemoteAnimationTimeline>> activeTimelines;
     for (auto& timelineRepresentation : timelineRepresentations) {
-        if (RefPtr existingTimeline = get(processIdentifier, timelineRepresentation->identifier()))
+        TimelineID timelineID { timelineRepresentation->identifier(), processIdentifier };
+        if (RefPtr existingTimeline = get(timelineID))
             activeTimelines.add(existingTimeline.releaseNonNull());
         else
-            activeTimelines.add(RemoteAnimationTimeline::create(timelineRepresentation, now));
+            activeTimelines.add(RemoteAnimationTimeline::create(timelineID, timelineRepresentation, now));
     }
 
     // Replace the timelines, which will clear any remaining timeline.
     m_timelines.set(processIdentifier, WTFMove(activeTimelines));
 }
 
-RemoteAnimationTimeline* RemoteAnimationTimelineRegistry::get(WebCore::ProcessIdentifier processIdentifier, const WebCore::TimelineIdentifier& timelineIdentifier) const
+RemoteAnimationTimeline* RemoteAnimationTimelineRegistry::get(const TimelineID& timelineID) const
 {
-    auto it = m_timelines.find(processIdentifier);
+    auto it = m_timelines.find(timelineID.processIdentifier());
     if (it == m_timelines.end())
         return nullptr;
 
     for (auto& timeline : it->value) {
-        if (timeline->identifier() == timelineIdentifier)
+        if (timeline->identifier() == timelineID)
             return timeline.ptr();
     }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.h
@@ -38,7 +38,7 @@ public:
 
     bool isEmpty() const { return m_timelines.isEmpty(); }
     void update(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime);
-    RemoteAnimationTimeline* get(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&) const;
+    RemoteAnimationTimeline* get(const TimelineID&) const;
     void advanceCurrentTime(MonotonicTime);
 
 private:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -84,7 +84,7 @@ public:
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
     void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime);
-    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&) const;
+    const RemoteAnimationTimeline* timeline(const TimelineID&) const;
 #endif
 
     // For testing.

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -852,10 +852,10 @@ void RemoteLayerTreeDrawingAreaProxy::updateTimelineRegistration(WebCore::Proces
         page->checkedScrollingCoordinatorProxy()->updateTimelineRegistration(processIdentifier, timelineRepresentations, now);
 }
 
-const RemoteAnimationTimeline* RemoteLayerTreeDrawingAreaProxy::timeline(WebCore::ProcessIdentifier processIdentifier, const WebCore::TimelineIdentifier& timelineIdentifier) const
+const RemoteAnimationTimeline* RemoteLayerTreeDrawingAreaProxy::timeline(const TimelineID& timelineID) const
 {
     if (RefPtr page = this->page())
-        return page->checkedScrollingCoordinatorProxy()->timeline(processIdentifier, timelineIdentifier);
+        return page->checkedScrollingCoordinatorProxy()->timeline(timelineID);
     return nullptr;
 }
 #endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -87,7 +87,7 @@ public:
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
-    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&) const;
+    const RemoteAnimationTimeline* timeline(const TimelineID&) const;
 #endif
 
     void detachFromDrawingArea();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -519,9 +519,9 @@ void RemoteLayerTreeHost::animationsWereRemovedFromNode(RemoteLayerTreeNode& nod
     protectedDrawingArea()->animationsWereRemovedFromNode(node);
 }
 
-const RemoteAnimationTimeline* RemoteLayerTreeHost::timeline(WebCore::ProcessIdentifier processIdentifier, const WebCore::TimelineIdentifier& timelineIdentifier) const
+const RemoteAnimationTimeline* RemoteLayerTreeHost::timeline(const TimelineID& timelineID) const
 {
-    return protectedDrawingArea()->timeline(processIdentifier, timelineIdentifier);
+    return protectedDrawingArea()->timeline(timelineID);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -317,7 +317,8 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
         return;
 
     Ref animationStack = RemoteAnimationStack::create(effects.map([&](const Ref<AcceleratedEffect>& effect) {
-        RefPtr timeline = host.timeline(m_layerID.processIdentifier(), effect->timelineIdentifier());
+        TimelineID timelineID { effect->timelineIdentifier(), m_layerID.processIdentifier() };
+        RefPtr timeline = host.timeline(timelineID);
         ASSERT(timeline);
         return RemoteAnimation::create(Ref { effect }.get(), *timeline);
     }), baseValues.clone(), layer.get().bounds);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -40,6 +40,10 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+#include "RemoteAnimationTimeline.h"
+#endif
+
 OBJC_CLASS UIScrollView;
 
 namespace WebCore {
@@ -56,10 +60,6 @@ class RemoteScrollingCoordinatorTransaction;
 class RemoteScrollingTree;
 class WebPageProxy;
 class WebWheelEvent;
-
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-class RemoteAnimationTimeline;
-#endif
 
 class RemoteScrollingCoordinatorProxy : public CanMakeWeakPtr<RemoteScrollingCoordinatorProxy>, public CanMakeCheckedPtr<RemoteScrollingCoordinatorProxy> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteScrollingCoordinatorProxy);
@@ -146,7 +146,7 @@ public:
     virtual void animationsWereAddedToNode(RemoteLayerTreeNode&) { }
     virtual void animationsWereRemovedFromNode(RemoteLayerTreeNode&) { }
     virtual void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) { }
-    virtual const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&) const { return nullptr; }
+    virtual const RemoteAnimationTimeline* timeline(const TimelineID&) const { return nullptr; }
 #endif
 
     String scrollingTreeAsText() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -76,7 +76,7 @@ public:
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
     void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) override;
-    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&) const override;
+    const RemoteAnimationTimeline* timeline(const TimelineID&) const override;
     void updateAnimations();
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -466,10 +466,10 @@ void RemoteScrollingCoordinatorProxyIOS::updateTimelineRegistration(WebCore::Pro
         m_timelineRegistry = nullptr;
 }
 
-const RemoteAnimationTimeline* RemoteScrollingCoordinatorProxyIOS::timeline(WebCore::ProcessIdentifier processIdentifier, const WebCore::TimelineIdentifier& timelineIdentifier) const
+const RemoteAnimationTimeline* RemoteScrollingCoordinatorProxyIOS::timeline(const TimelineID& timelineID) const
 {
     if (m_timelineRegistry)
-        return m_timelineRegistry->get(processIdentifier, timelineIdentifier);
+        return m_timelineRegistry->get(timelineID);
     return nullptr;
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -112,7 +112,7 @@ public:
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
     void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime);
-    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&);
+    const RemoteAnimationTimeline* timeline(const TimelineID&);
     void updateAnimations();
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -653,11 +653,11 @@ void RemoteLayerTreeEventDispatcher::updateTimelineRegistration(WebCore::Process
         m_timelineRegistry = nullptr;
 }
 
-const RemoteAnimationTimeline* RemoteLayerTreeEventDispatcher::timeline(WebCore::ProcessIdentifier processIdentifier, const WebCore::TimelineIdentifier& timelineIdentifier)
+const RemoteAnimationTimeline* RemoteLayerTreeEventDispatcher::timeline(const TimelineID& timelineID)
 {
     assertIsHeld(m_animationLock);
     if (m_timelineRegistry)
-        return m_timelineRegistry->get(processIdentifier, timelineIdentifier);
+        return m_timelineRegistry->get(timelineID);
     return nullptr;
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -78,7 +78,7 @@ private:
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
     void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) override;
-    const RemoteAnimationTimeline* timeline(WebCore::ProcessIdentifier, const WebCore::TimelineIdentifier&) const override;
+    const RemoteAnimationTimeline* timeline(const TimelineID&) const override;
 #else
     void willCommitLayerAndScrollingTrees() override;
     void didCommitLayerAndScrollingTrees() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -324,9 +324,9 @@ void RemoteScrollingCoordinatorProxyMac::updateTimelineRegistration(WebCore::Pro
     m_eventDispatcher->updateTimelineRegistration(processIdentifier, timelineRepresentations, now);
 }
 
-const RemoteAnimationTimeline* RemoteScrollingCoordinatorProxyMac::timeline(WebCore::ProcessIdentifier processIdentifier, const WebCore::TimelineIdentifier& timelineIdentifier) const
+const RemoteAnimationTimeline* RemoteScrollingCoordinatorProxyMac::timeline(const TimelineID& timelineID) const
 {
-    return m_eventDispatcher->timeline(processIdentifier, timelineIdentifier);
+    return m_eventDispatcher->timeline(timelineID);
 }
 #endif
 


### PR DESCRIPTION
#### d7a68ffb6a0058351c864ae4d89a94bb0b665fbc
<pre>
[threaded-animation-resolution] use a process-qualified identifier for timeline lookup in the remote layer tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=301270">https://bugs.webkit.org/show_bug.cgi?id=301270</a>
<a href="https://rdar.apple.com/problem/163182947">rdar://problem/163182947</a>

Reviewed by Matt Woodrow.

We wrap `TimelineIdenfitifer`, added in 301942@main, in `ProcessQualified` to create
a new `TimelineID` identifier for use in the remote layer tree for timeline lookup.
This allows us to remove the `ProcessIdentifier` parameter from the call chain leading
to `RemoteAnimationTimelineRegistry::get()`.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp:
(WebKit::RemoteAnimationTimeline::create):
(WebKit::RemoteAnimationTimeline::RemoteAnimationTimeline):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.cpp:
(WebKit::RemoteAnimationTimelineRegistry::update):
(WebKit::RemoteAnimationTimelineRegistry::get const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimelineRegistry.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::timeline const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::timeline const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::timeline const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::timeline const):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::timeline):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::timeline const):

Canonical link: <a href="https://commits.webkit.org/302029@main">https://commits.webkit.org/302029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9908bdd232274228d5bfbbdee5630186315d74a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135023 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79308 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1fd52d76-3b29-4663-9c96-f11f6906cb05) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97239 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65163 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f50e6519-f543-45db-b4d5-470da94e8d2a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77721 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f240d07a-a728-4a89-986b-369c2a38cdce) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37197 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78393 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137507 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41943 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105762 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105414 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50939 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29371 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52031 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19973 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54349 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60610 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53583 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/57038 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55340 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->