### PR TITLE
[web-animations] use `TZONE_ALLOCATED` for animation classes that aren't DOM objects

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -94,7 +94,7 @@ AcceleratedEffect::Keyframe AcceleratedEffect::Keyframe::clone() const
     };
 }
 
-WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(AcceleratedEffect);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedEffect);
 
 static AcceleratedEffectProperty acceleratedPropertyFromCSSProperty(AnimatableCSSProperty property, const Settings& settings)
 {

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -46,7 +46,7 @@ class IntRect;
 class KeyframeEffect;
 
 class AcceleratedEffect : public RefCountedAndCanMakeWeakPtr<AcceleratedEffect>, public KeyframeInterpolation {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AcceleratedEffect);
+    WTF_MAKE_TZONE_ALLOCATED(AcceleratedEffect);
 public:
 
     class WEBCORE_EXPORT Keyframe final : public KeyframeInterpolation::Keyframe {

--- a/Source/WebCore/platform/animation/AcceleratedEffectStack.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectStack.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(AcceleratedEffectStack);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedEffectStack);
 
 Ref<AcceleratedEffectStack> AcceleratedEffectStack::create()
 {

--- a/Source/WebCore/platform/animation/AcceleratedEffectStack.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectStack.h
@@ -35,7 +35,7 @@ namespace WebCore {
 using AcceleratedEffects = Vector<Ref<AcceleratedEffect>>;
 
 class WEBCORE_EXPORT AcceleratedEffectStack : public RefCounted<AcceleratedEffectStack> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(AcceleratedEffectStack, WEBCORE_EXPORT);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(AcceleratedEffectStack, WEBCORE_EXPORT);
 public:
     static Ref<AcceleratedEffectStack> create();
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RemoteAnimation);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAnimation);
 
 Ref<RemoteAnimation> RemoteAnimation::create(const WebCore::AcceleratedEffect& effect, const RemoteAnimationTimeline& timeline)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h
@@ -36,7 +36,7 @@
 namespace WebKit {
 
 class RemoteAnimation : public RefCounted<RemoteAnimation> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RemoteAnimation);
+    WTF_MAKE_TZONE_ALLOCATED(RemoteAnimation);
 public:
     static Ref<RemoteAnimation> create(const WebCore::AcceleratedEffect&, const RemoteAnimationTimeline&);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
@@ -43,7 +43,7 @@ namespace WebKit {
 using RemoteAnimations = Vector<Ref<RemoteAnimation>>;
 
 class RemoteAnimationStack final : public RefCounted<RemoteAnimationStack> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RemoteAnimationStack);
+    WTF_MAKE_TZONE_ALLOCATED(RemoteAnimationStack);
 public:
     static Ref<RemoteAnimationStack> create(RemoteAnimations&&, WebCore::AcceleratedEffectValues&&, WebCore::FloatRect);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
@@ -33,7 +33,7 @@
 
 namespace WebKit {
 
-WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RemoteAnimationStack);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAnimationStack);
 
 Ref<RemoteAnimationStack> RemoteAnimationStack::create(RemoteAnimations&& animations, WebCore::AcceleratedEffectValues&& baseValues, WebCore::FloatRect bounds)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RemoteAnimationTimeline);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAnimationTimeline);
 
 static WebCore::WebAnimationTime computeCurrentTime(Seconds originTime, MonotonicTime now)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
@@ -36,7 +36,7 @@
 namespace WebKit {
 
 class RemoteAnimationTimeline final : public RefCounted<RemoteAnimationTimeline> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RemoteAnimationTimeline);
+    WTF_MAKE_TZONE_ALLOCATED(RemoteAnimationTimeline);
 public:
     static Ref<RemoteAnimationTimeline> create(const WebCore::AcceleratedTimeline&, MonotonicTime);
 


### PR DESCRIPTION
#### 19b91e6e289dc60f5b5657d15b8c84bb5622b795
<pre>
[web-animations] use `TZONE_ALLOCATED` for animation classes that aren&apos;t DOM objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=301272">https://bugs.webkit.org/show_bug.cgi?id=301272</a>

Reviewed by Matt Woodrow.

The comments in `FastMalloc.h` indicate that `WTF_MAKE_TZONE_OR_ISO_ALLOCATED` should
be used for classes that are a DOM object, but a few animation-related classes that
aren&apos;t exposed to the DOM are decorated as such.

We now use `WTF_MAKE_TZONE_ALLOCATED` for those classes.

* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebCore/platform/animation/AcceleratedEffectStack.cpp:
* Source/WebCore/platform/animation/AcceleratedEffectStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.cpp:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h:

Canonical link: <a href="https://commits.webkit.org/302004@main">https://commits.webkit.org/302004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02784177768ca73bad3f381ed0fdca71346b548a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134664 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79144 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/59f9c8e9-2c05-4416-aaf4-2c8d7a0da36d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97122 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65038 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/94206d0b-04b4-4b10-b08b-f9af38a1b870) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77602 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bc21d30c-5de7-44d5-a733-adf86bf64da8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32371 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78037 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137148 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41807 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105649 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105300 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50815 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51836 "Hash 02784177 for PR 52811 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19964 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54183 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60270 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53417 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56874 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55176 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->