### PR TITLE
[GTK] Enable MSAA for GPU rendering

### DIFF
--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -39,8 +39,11 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/gl/GrGLInterface.h>
 
 #if USE(LIBEPOXY)
+#include <epoxy/egl.h>
 #include <skia/gpu/ganesh/gl/epoxy/GrGLMakeEpoxyEGLInterface.h>
 #else
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
 #include <skia/gpu/ganesh/gl/egl/GrGLMakeEGLInterface.h>
 #endif
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -49,9 +52,16 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
+#if USE(LIBDRM)
+#include <fcntl.h>
+#include <unistd.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+#include <xf86drm.h>
+#endif
+
 namespace WebCore {
 
-#if PLATFORM(WPE)
+#if PLATFORM(GTK) || PLATFORM(WPE)
 #if CPU(X86) || CPU(X86_64)
 // On x86 ot x86_64 we need at least 8 samples for the antialiasing result to be similar
 // to non MSAA.
@@ -82,7 +92,111 @@ static sk_sp<const GrGLInterface> skiaGLInterface()
 
 static thread_local RefPtr<SkiaGLContext> s_skiaGLContext;
 
-unsigned initializeMSAASampleCount(GrDirectContext* grContext)
+#if USE(LIBDRM)
+static inline bool isNewIntelDevice()
+{
+    auto eglDisplay = eglGetCurrentDisplay();
+    if (eglDisplay == EGL_NO_DISPLAY)
+        return false;
+
+    if (!GLContext::isExtensionSupported(eglQueryString(nullptr, EGL_EXTENSIONS), "EGL_EXT_device_query"))
+        return false;
+
+    EGLDeviceEXT eglDevice;
+    if (!eglQueryDisplayAttribEXT(eglDisplay, EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&eglDevice)))
+        return false;
+
+    if (!GLContext::isExtensionSupported(eglQueryDeviceStringEXT(eglDevice, EGL_EXTENSIONS), "EGL_EXT_device_drm"))
+        return false;
+
+    const char* device = eglQueryDeviceStringEXT(eglDevice, EGL_DRM_DEVICE_FILE_EXT);
+    if (!device || !*device)
+        return false;
+
+    auto fd = UnixFileDescriptor { open(device, O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
+    if (!fd)
+        return false;
+
+    drmDevicePtr drmDevice;
+    if (drmGetDevice2(fd.value(), 0, &drmDevice))
+        return false;
+
+    if (drmDevice->bustype != DRM_BUS_PCI) {
+        drmFreeDevice(&drmDevice);
+        return false;
+    }
+
+    auto vendorID = drmDevice->deviceinfo.pci->vendor_id;
+    auto deviceID = drmDevice->deviceinfo.pci->device_id;
+    drmFreeDevice(&drmDevice);
+
+    static constexpr uint32_t intelVendorID = 0x8086;
+    if (vendorID != intelVendorID)
+        return false;
+
+    // On pre-Ice Lake Intel GPUs MSAA performance is not acceptable.
+    uint32_t maskedDeviceID = deviceID & 0xFF00;
+    switch (maskedDeviceID) {
+    case 0x2900: // Broadwater
+    case 0x2A00: // Broadwater or Eaglelake
+    case 0x2E00: // Eaglelake
+    case 0x0000: // Ironlake
+    case 0x0100: // Ivybridge, Baytrail or Sandybridge
+    case 0x0F00: // Baytrail
+    case 0x0A00: // Apollolake or Haswell
+    case 0x0400: // Haswell
+    case 0x0C00: // Haswell
+    case 0x0D00: // Haswell
+    case 0x2200: // Cherrytrail
+    case 0x1600: // Broadwell
+    case 0x5A00: // Apollolake or Cannonlake
+    case 0x1900: // Skylake
+    case 0x1A00: // Apollolake
+    case 0x3100: // Geminilake
+    case 0x5900: // Amberlake or Kabylake
+    case 0x8700: // Kabylake or Coffeelake
+    case 0x3E00: // Whiskeylake or Coffeelake
+    case 0x9B00: // Cometlake
+        return false;
+    case 0x8A00: // Icelake
+    case 0x4500: // Elkhartlake
+    case 0x4E00: // Jasperlake
+    case 0x9A00: // Tigerlake
+    case 0x4c00: // Rocketlake
+    case 0x4900: // DG1
+    case 0x4600: // Alderlake
+    case 0x4F00: // Alchemist
+    case 0x5600: // Alchemist
+    case 0xA700: // Raptorlake
+    case 0x7D00: // Arrowlake or Meteorlake
+    case 0xB600: // Arrowlake or Meteorlake
+    case 0x6400: // Lunarlake
+    case 0xE200: // Battlemage
+    case 0xB000: // Pantherlake
+        return true;
+    default:
+        break;
+    }
+
+    return false;
+}
+#endif
+
+static bool shouldAllowMSAAOnNewIntel()
+{
+#if USE(LIBDRM)
+    static std::once_flag onceFlag;
+    static bool allowMSAAOnNewIntel;
+    std::call_once(onceFlag, [] {
+        allowMSAAOnNewIntel = isNewIntelDevice();
+    });
+    return allowMSAAOnNewIntel;
+#else
+    return false;
+#endif
+}
+
+static unsigned initializeMSAASampleCount(GrDirectContext* grContext)
 {
     static std::once_flag onceFlag;
     static int sampleCount = s_defaultSampleCount;
@@ -148,7 +262,9 @@ private:
             return;
 
         // FIXME: add GrContextOptions, shader cache, etc.
-        if (auto grContext = GrDirectContexts::MakeGL(skiaGLInterface())) {
+        GrContextOptions options;
+        options.fAllowMSAAOnNewIntel = shouldAllowMSAAOnNewIntel();
+        if (auto grContext = GrDirectContexts::MakeGL(skiaGLInterface(), options)) {
             m_skiaGLContext = WTFMove(glContext);
             m_skiaGrContext = WTFMove(grContext);
             m_sampleCount = initializeMSAASampleCount(m_skiaGrContext.get());


### PR DESCRIPTION
#### cffcd98ff51ded5848128c3062ea2fa5d69984ae
<pre>
[GTK] Enable MSAA for GPU rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=301273">https://bugs.webkit.org/show_bug.cgi?id=301273</a>

Reviewed by Miguel Gomez.

Only keep it disabled for old intel chips where MSAA performance is not
good enough.

Canonical link: <a href="https://commits.webkit.org/302015@main">https://commits.webkit.org/302015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b01f7deee18c1568b28fb738c8531c932a6e0f06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134667 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97124 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65039 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77605 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32375 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78040 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137151 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105647 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105298 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50816 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29254 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51840 "Hash b01f7dee for PR 52812 does not build (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19968 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54186 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60273 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53420 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->