### PR TITLE
Cannot log-in to Google account with WebAuthn disabled if second factor configured

### DIFF
--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
@@ -26,11 +26,9 @@
 #include "config.h"
 #include "BasicCredential.h"
 
-#if ENABLE(WEB_AUTHN)
-
 #include "AuthenticatorCoordinator.h"
+#include "DocumentPage.h"
 #include "JSDOMPromiseDeferred.h"
-#include "Page.h"
 
 namespace WebCore {
 
@@ -59,12 +57,14 @@ String BasicCredential::type() const
 
 void BasicCredential::isConditionalMediationAvailable(Document& document, DOMPromiseDeferred<IDLBoolean>&& promise)
 {
-    if (RefPtr page = document.page())
+    if (RefPtr page = document.page()) {
+#if ENABLE(WEB_AUTHN)
         page->authenticatorCoordinator().isConditionalMediationAvailable(document, WTFMove(promise));
-    else
+#else
+        promise.resolve(false);
+#endif
+    } else
         promise.reject(Exception { ExceptionCode::InvalidStateError });
 }
 
 } // namespace WebCore
-
-#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.h
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#if ENABLE(WEB_AUTHN)
-
 #include <WebCore/Document.h>
 #include <WebCore/IDLTypes.h>
 #include <WebCore/JSDOMPromiseDeferredForward.h>
@@ -71,5 +69,3 @@ private:
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToClassName) \
     static bool isType(const WebCore::BasicCredential& credential) { return credential.credentialType() == WebCore::Type; } \
 SPECIALIZE_TYPE_TRAITS_END()
-
-#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.idl
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.idl
@@ -25,8 +25,7 @@
 
 [
     InterfaceName=Credential,
-    Conditional=WEB_AUTHN,
-    EnabledBySetting=WebAuthenticationEnabled,
+    EnabledByQuirk=shouldExposeCredentialsContainer,
     Exposed=Window,
     SecureContext
 ] interface BasicCredential {

--- a/Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.h
@@ -26,8 +26,6 @@
 
 #pragma once
 
-#if ENABLE(WEB_AUTHN)
-
 #include "AbortSignal.h"
 #include "MediationRequirement.h"
 #include "PublicKeyCredentialCreationOptions.h"
@@ -43,5 +41,3 @@ struct CredentialCreationOptions {
 };
 
 } // namespace WebCore
-
-#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.idl
@@ -24,9 +24,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-] dictionary CredentialCreationOptions {
+dictionary CredentialCreationOptions {
     CredentialMediationRequirement mediation = "optional";
     AbortSignal signal;
     PublicKeyCredentialCreationOptions publicKey;

--- a/Source/WebCore/Modules/credentialmanagement/CredentialMediationRequirement.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialMediationRequirement.idl
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
- [
-    Conditional=WEB_AUTHN,
+[
     ImplementedAs=MediationRequirement
 ] enum CredentialMediationRequirement {
     "silent",

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
@@ -26,8 +26,6 @@
 
 #pragma once
 
-#if ENABLE(WEB_AUTHN)
-
 #include <WebCore/DigitalCredentialRequestOptions.h>
 #include <WebCore/MediationRequirement.h>
 #include <WebCore/PublicKeyCredentialRequestOptions.h>
@@ -47,5 +45,3 @@ struct CredentialRequestOptions {
 };
 
 } // namespace WebCore
-
-#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl
@@ -24,12 +24,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-] dictionary CredentialRequestOptions {
+dictionary CredentialRequestOptions {
     [ImplementedAs=mediationString] DOMString mediation = "optional";
     AbortSignal signal;
     PublicKeyCredentialRequestOptions publicKey;
     // https://wicg.github.io/digital-identities/#extensions-to-credentialrequestoptions-dictionary
-    [EnabledBySetting=DigitalCredentialsEnabled] DigitalCredentialRequestOptions digital;
+    [Conditional=WEB_AUTHN, EnabledBySetting=DigitalCredentialsEnabled] DigitalCredentialRequestOptions digital;
 };

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -27,14 +27,12 @@
 #include "config.h"
 #include "CredentialsContainer.h"
 
-#if ENABLE(WEB_AUTHN)
-
 #include "CredentialCreationOptions.h"
 #include "CredentialRequestCoordinator.h"
 #include "CredentialRequestOptions.h"
 #include "DigitalCredential.h"
-#include "Document.h"
-#include "JSDOMPromiseDeferred.h"
+#include "DocumentPage.h"
+#include "JSBasicCredential.h"
 #include "JSDigitalCredential.h"
 #include "LocalFrame.h"
 #include "Navigator.h"
@@ -55,12 +53,16 @@ void CredentialsContainer::get(CredentialRequestOptions&& options, CredentialPro
         return;
     }
 
+#if ENABLE(WEB_AUTHN)
     if (options.digital) {
         DigitalCredential::discoverFromExternalSource(*document(), WTFMove(promise), WTFMove(options));
         return;
     }
 
     document()->page()->authenticatorCoordinator().discoverFromExternalSource(*document(), WTFMove(options), WTFMove(promise));
+#else
+    promise.resolve(nullptr);
+#endif
 }
 
 void CredentialsContainer::store(const BasicCredential&, CredentialPromise&& promise)
@@ -79,10 +81,12 @@ void CredentialsContainer::isCreate(CredentialCreationOptions&& options, Credent
         return;
     }
 
+#if ENABLE(WEB_AUTHN)
     if (options.publicKey) {
         document()->page()->authenticatorCoordinator().create(*document(), WTFMove(options), WTFMove(options.signal), WTFMove(promise));
         return;
     }
+#endif
 
     promise.resolve(nullptr);
 }
@@ -137,5 +141,3 @@ bool CredentialsContainer::performCommonChecks(const Options& options, Credentia
 }
 
 } // namespace WebCore
-
-#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
@@ -26,17 +26,12 @@
 
 #pragma once
 
-#if ENABLE(WEB_AUTHN)
-
-#include "AuthenticatorCoordinator.h"
-#include "CredentialRequestCoordinator.h"
-#include "DigitalCredential.h"
+#include <WebCore/BasicCredential.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-template<typename> class DOMPromiseDeferred;
 using CredentialPromise = DOMPromiseDeferred<IDLNullable<IDLInterface<BasicCredential>>>;
 
 class Document;
@@ -73,5 +68,3 @@ protected:
 };
 
 } // namespace WebCore
-
-#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
@@ -25,8 +25,7 @@
  */
 
 [
-    Conditional=WEB_AUTHN,
-    EnabledBySetting=WebAuthenticationEnabled,
+    EnabledByQuirk=shouldExposeCredentialsContainer,
     Exposed=Window,
     SecureContext,
     SkipVTableValidation,

--- a/Source/WebCore/Modules/credentialmanagement/MediationRequirement.h
+++ b/Source/WebCore/Modules/credentialmanagement/MediationRequirement.h
@@ -25,13 +25,8 @@
 
 #pragma once
 
-#if ENABLE(WEB_AUTHN)
-
 namespace WebCore {
 
 enum class MediationRequirement : uint8_t { Silent, Optional, Required, Conditional };
 
 } // namespace WebCore
-
-
-#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/Navigator+Credentials.idl
+++ b/Source/WebCore/Modules/credentialmanagement/Navigator+Credentials.idl
@@ -27,8 +27,7 @@
 // https://w3c.github.io/webappsec-credential-management/#framework-credential-management
 
 [
-    Conditional=WEB_AUTHN,
-    EnabledBySetting=WebAuthenticationEnabled,
+    EnabledByQuirk=shouldExposeCredentialsContainer,
     ImplementedBy=NavigatorCredentials
 ] partial interface Navigator {
     [SecureContext, SameObject] readonly attribute CredentialsContainer credentials;

--- a/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp
@@ -27,8 +27,6 @@
 #include "config.h"
 #include "NavigatorCredentials.h"
 
-#if ENABLE(WEB_AUTHN)
-
 #include "Document.h"
 #include "LocalFrameInlines.h"
 #include "Navigator.h"
@@ -69,5 +67,3 @@ NavigatorCredentials* NavigatorCredentials::from(Navigator* navigator)
 }
 
 } // namespace WebCore
-
-#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h
+++ b/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h
@@ -26,8 +26,6 @@
 
 #pragma once
 
-#if ENABLE(WEB_AUTHN)
-
 #include "CredentialsContainer.h"
 #include "Supplementable.h"
 #include <wtf/TZoneMalloc.h>
@@ -61,5 +59,3 @@ private:
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorCredentials)
     static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorCredentials(); }
 SPECIALIZE_TYPE_TRAITS_END()
-
-#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
@@ -24,20 +24,20 @@
  */
 
 [
-    Conditional=WEB_AUTHN,
+    EnabledByQuirk=shouldExposeCredentialsContainer,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
 ] dictionary PublicKeyCredentialCreationOptions {
-    required PublicKeyCredentialRpEntity rp;
-    required PublicKeyCredentialUserEntity user;
+    [Conditional=WEB_AUTHN] required PublicKeyCredentialRpEntity rp;
+    [Conditional=WEB_AUTHN] required PublicKeyCredentialUserEntity user;
 
-    required [OverrideIDLType=IDLBufferSource] BufferSource challenge;
-    required sequence<PublicKeyCredentialParameters> pubKeyCredParams;
+    [Conditional=WEB_AUTHN] required [OverrideIDLType=IDLBufferSource] BufferSource challenge;
+    [Conditional=WEB_AUTHN] required sequence<PublicKeyCredentialParameters> pubKeyCredParams;
 
-    unsigned long timeout;
-    sequence<PublicKeyCredentialDescriptor> excludeCredentials = [];
-    AuthenticatorSelectionCriteria authenticatorSelection;
-    [ImplementedAs=attestationString] DOMString attestation = "none";
-    AuthenticationExtensionsClientInputs extensions;
+    [Conditional=WEB_AUTHN] unsigned long timeout;
+    [Conditional=WEB_AUTHN] sequence<PublicKeyCredentialDescriptor> excludeCredentials = [];
+    [Conditional=WEB_AUTHN] AuthenticatorSelectionCriteria authenticatorSelection;
+    [Conditional=WEB_AUTHN, ImplementedAs=attestationString] DOMString attestation = "none";
+    [Conditional=WEB_AUTHN] AuthenticationExtensionsClientInputs extensions;
 };
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
@@ -24,14 +24,14 @@
  */
 
 [
-    Conditional=WEB_AUTHN,
+    EnabledByQuirk=shouldExposeCredentialsContainer,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
 ] dictionary PublicKeyCredentialRequestOptions {
-    required [OverrideIDLType=IDLBufferSource] BufferSource challenge;
-    unsigned long timeout;
-    DOMString rpId;
-    sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-    [ImplementedAs=userVerificationString] DOMString userVerification = "preferred";
-    AuthenticationExtensionsClientInputs extensions;
+    [Conditional=WEB_AUTHN] required [OverrideIDLType=IDLBufferSource] BufferSource challenge;
+    [Conditional=WEB_AUTHN] unsigned long timeout;
+    [Conditional=WEB_AUTHN] DOMString rpId;
+    [Conditional=WEB_AUTHN] sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
+    [Conditional=WEB_AUTHN, ImplementedAs=userVerificationString] DOMString userVerification = "preferred";
+    [Conditional=WEB_AUTHN] AuthenticationExtensionsClientInputs extensions;
 };

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2134,6 +2134,15 @@ bool Quirks::shouldDisableDOMAudioSessionQuirk() const
     return needsQuirks() && m_quirksData.shouldDisableDOMAudioSession;
 }
 
+bool Quirks::shouldExposeCredentialsContainerQuirk() const
+{
+#if ENABLE(WEB_AUTHN)
+    if (m_document && m_document->settings().webAuthenticationEnabled())
+        return true;
+#endif
+    return needsQuirks() && m_quirksData.isGoogleAccounts;
+}
+
 URL Quirks::topDocumentURL() const
 {
     if (!m_topDocumentURLForTesting.isEmpty()) [[unlikely]]
@@ -2765,6 +2774,7 @@ static void handleGoogleQuirks(QuirksData& quirksData, const URL& quirksURL, con
 #if ENABLE(MEDIA_STREAM)
     quirksData.shouldEnableEnumerateDeviceQuirk = topDocumentHost == "meet.google.com"_s;
 #endif
+    quirksData.isGoogleAccounts = topDocumentHost == "accounts.google.com"_s;
 }
 
 static void handleHBOMaxQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -298,6 +298,8 @@ public:
 
     bool needsSuppressPostLayoutBoundaryEventsQuirk() const;
 
+    bool shouldExposeCredentialsContainerQuirk() const;
+
     void determineRelevantQuirks();
 
 private:

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -39,6 +39,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool isGoogleDocs : 1 { false };
     bool isGoogleProperty : 1 { false };
     bool isGoogleMaps : 1 { false };
+    bool isGoogleAccounts : 1 { false };
     bool isNetflix : 1 { false };
     bool isOutlook : 1 { false };
     bool isSoundCloud : 1 { false };


### PR DESCRIPTION
#### b08846a9d6c87b160221fb603351a9ab7a95c310
<pre>
Cannot log-in to Google account with WebAuthn disabled if second factor configured
<a href="https://bugs.webkit.org/show_bug.cgi?id=301202">https://bugs.webkit.org/show_bug.cgi?id=301202</a>

Reviewed by Pascoe.

Add a quirk that makes the navigator.credentials API available for
the accounts.google.com domain, which tries to use it unconditionally
without a correct fallback for the TypeError thrown when accessing
the unavailable property.

When WebAuthn support is disabled at build time, the implementation is
stubbed to always resolve the Promise returned by .get() or .create()
with the &quot;null&quot; value, which Google Accounts does handle correctly and
triggers the fallback that prompts for a different second factor method.

* Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp:
(WebCore::BasicCredential::isConditionalMediationAvailable):
* Source/WebCore/Modules/credentialmanagement/BasicCredential.h:
* Source/WebCore/Modules/credentialmanagement/BasicCredential.idl:
* Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.h:
* Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.idl:
* Source/WebCore/Modules/credentialmanagement/CredentialMediationRequirement.idl:
* Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h:
* Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::get):
(WebCore::CredentialsContainer::isCreate):
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl:
* Source/WebCore/Modules/credentialmanagement/MediationRequirement.h:
* Source/WebCore/Modules/credentialmanagement/Navigator+Credentials.idl:
* Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp:
* Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldExposeCredentialsContainerQuirk const):
(WebCore::handleGoogleQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/302791@main">https://commits.webkit.org/302791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/132007ff2af3c271125a1839c8530429eec71dfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137652 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81798 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2396 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/99216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133181 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79906 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34760 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80908 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110313 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140129 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2295 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/2134 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107739 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107627 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27391 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1812 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31425 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55246 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2365 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65752 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2182 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2291 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->