### PR TITLE
[visionOS] Fullscreen button doesn't glow on inline video controls, making it hard to interact with

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
@@ -134,8 +134,6 @@
 
 .media-controls.vision .controls-bar.simple-layout.top-right > .overflow {
     margin: 0 0 0 5px;
-    /* Needs compositing layer for InteractionRegion hit-testing. */
-    will-change: opacity;
 }
 
 .media-controls.vision .volume-container {
@@ -194,6 +192,11 @@
 .media-controls.vision button > picture {
     mix-blend-mode: initial;
     transform: scale(0.9);
+}
+
+.media-controls.vision button.circular {
+    /* Needs compositing layer for InteractionRegion hit-testing. */
+    will-change: opacity;
 }
 
 /* Center button */


### PR DESCRIPTION
#### 9f59450b5e429c2673d732c379fbfcd27b6cb06c
<pre>
[visionOS] Fullscreen button doesn&apos;t glow on inline video controls, making it hard to interact with
<a href="https://bugs.webkit.org/show_bug.cgi?id=301279">https://bugs.webkit.org/show_bug.cgi?id=301279</a>
&lt;<a href="https://rdar.apple.com/154940919">rdar://154940919</a>&gt;

Reviewed by Abrar Rahman Protyasha.

Expand the original fix for the overflow button to apply to all circular
buttons in visionOS media controls.

* Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css:
(.media-controls.vision .controls-bar.simple-layout.top-right &gt; .overflow):
(.media-controls.vision button.circular):

Canonical link: <a href="https://commits.webkit.org/302014@main">https://commits.webkit.org/302014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae87a09b34566dc7bf97768f1757f2affd627c80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134879 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79165 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/992b5779-f8f1-4db3-b25a-4bb189d460c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97137 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65052 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cb07b2bf-7909-47dd-9886-e94eb30fd447) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77618 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32399 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78238 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108161 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137360 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105659 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105310 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26889 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50827 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29266 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51861 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54204 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60354 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53438 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56895 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55197 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->