### PR TITLE
Web Inspector: Styles added via "add new rule" are not always applied

### DIFF
--- a/LayoutTests/inspector/css/setStyleTextAfterSetStyleSheetText-expected.txt
+++ b/LayoutTests/inspector/css/setStyleTextAfterSetStyleSheetText-expected.txt
@@ -1,0 +1,19 @@
+Testing that calling CSS.setStyleText works immediately after CSS.setStyleSheetText without an intermediate call to CSS.getStyleSheetText.
+
+
+== Running test suite: CSS.setStyleTextRace
+-- Running test case: CSS.setStyleTextAfterSetStylesheetText
+INFO: Get stylesheet text
+body { color: red; }
+
+INFO: Get style for 'body' CSS rule
+ color: red;
+INFO: Set stylesheet text with identical contents
+INFO: 'styleSheetChanged' event fired
+INFO: Update style for 'body' CSS rule
+PASS: CSS rule text was updated
+INFO: Get stylesheet text again
+body {color: green;}
+
+PASS: Stylsheet text reflects change to CSS rule
+

--- a/LayoutTests/inspector/css/setStyleTextAfterSetStyleSheetText.html
+++ b/LayoutTests/inspector/css/setStyleTextAfterSetStyleSheetText.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<link rel="stylesheet" href="resources/external.css">
+<script>
+function test() {
+    let suite = ProtocolTest.createAsyncSuite("CSS.setStyleTextRace");
+
+    suite.addTestCase({
+        name: "CSS.setStyleTextAfterSetStylesheetText",
+        description: "Ensure that editing the style of a CSS rule works after immediately updating the stylesheet text",
+        test: async () => {
+            await InspectorProtocol.awaitCommand({ method: "Page.enable" });
+
+            let { root } = await InspectorProtocol.awaitCommand({ method: "DOM.getDocument" });
+            let body = await InspectorProtocol.awaitCommand({
+                method: "DOM.querySelector",
+                params: { nodeId: root.nodeId, selector: "body" },
+            });
+
+            async function getAuthorStylesheetId() {
+                let { headers } = await InspectorProtocol.awaitCommand({ method: "CSS.getAllStyleSheets" });
+                return headers.find((header) => header.origin === "author")?.styleSheetId;
+            }
+
+            let styleSheetId = await getAuthorStylesheetId();
+            if (!styleSheetId)
+                ProtocolTest.log("FAIL: Missing author style sheet");
+
+            ProtocolTest.log("INFO: Get stylesheet text");
+            let { text } = await InspectorProtocol.awaitCommand({
+                method: "CSS.getStyleSheetText",
+                params: { styleSheetId },
+            });
+            ProtocolTest.log(text);
+
+            async function getAuthorStyleMatchingElementAndSelector(element, selector) {
+                let { matchedCSSRules } = await InspectorProtocol.awaitCommand({
+                    method: "CSS.getMatchedStylesForNode",
+                    params: { nodeId: element.nodeId },
+                });
+
+                let ruleMatchingSelector = matchedCSSRules
+                    .map(({ rule }) => rule)
+                    .find((rule) => {
+                        if (rule.origin !== "author")
+                            return false;
+
+                        return rule.selectorList.selectors.find(cssSelector => cssSelector.text === selector);
+                    })
+
+                return ruleMatchingSelector?.style;
+            };
+
+            ProtocolTest.log("INFO: Get style for 'body' CSS rule");
+            let bodyStyle = await getAuthorStyleMatchingElementAndSelector(body, "body");
+            if (!bodyStyle)
+                ProtocolTest.log("FAIL: Missing 'body' CSS rule");
+
+            ProtocolTest.log(bodyStyle.cssText);
+
+            ProtocolTest.log("INFO: Set stylesheet text with identical contents");
+            InspectorProtocol.sendCommand({
+                method: "CSS.setStyleSheetText",
+                params: { styleSheetId, text },
+            });
+
+            await InspectorProtocol.awaitEvent({event: "CSS.styleSheetChanged"});
+            ProtocolTest.log("INFO: 'styleSheetChanged' event fired");
+
+            ProtocolTest.log("INFO: Update style for 'body' CSS rule");
+            let updatedCSSText = "color: green;"
+            let setStyleTextResult = await InspectorProtocol.awaitCommand({
+                method: "CSS.setStyleText",
+                params: { styleId: bodyStyle.styleId, text: updatedCSSText },
+            });
+
+            ProtocolTest.expectEqual(setStyleTextResult.style.cssText, updatedCSSText, "CSS rule text was updated");
+
+            ProtocolTest.log("INFO: Get stylesheet text again");
+            let getStyleSheetTextResult = await InspectorProtocol.awaitCommand({
+                method: "CSS.getStyleSheetText",
+                params: { styleSheetId },
+            });
+            ProtocolTest.log(getStyleSheetTextResult.text);
+            ProtocolTest.expectNotEqual(text, getStyleSheetTextResult.text, "Stylsheet text reflects change to CSS rule");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Testing that calling CSS.setStyleText works immediately after CSS.setStyleSheetText without an intermediate call to CSS.getStyleSheetText.</p>
+</body>
+</html>

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1543,6 +1543,9 @@ ExceptionOr<void> InspectorStyleSheet::setRuleStyleText(const InspectorCSSId& id
     if (!cssRule)
         return Exception { ExceptionCode::NotFoundError };
 
+    if (!ensureParsedDataReady())
+        return Exception { ExceptionCode::NotFoundError };
+
     RefPtr<CSSRuleSourceData> sourceData = ruleSourceDataFor(cssRule);
     if (!sourceData)
         return Exception { ExceptionCode::NotFoundError };


### PR DESCRIPTION
#### 58742734b4594e5e330d19ce31b1dfda33e675b9
<pre>
Web Inspector: Styles added via &quot;add new rule&quot; are not always applied
<a href="https://bugs.webkit.org/show_bug.cgi?id=301281">https://bugs.webkit.org/show_bug.cgi?id=301281</a>
<a href="https://rdar.apple.com/103548968">rdar://103548968</a>

Reviewed by Devin Rousso.

`InspectorCSSAgent::setStyleText()` fails when attempted after `InspectorCSSAgent::setStyleSheetText()`
without an intermediary request to get the updated style data to Web Inspector frontend.

Setting the whole stylesheet text, `Inspector::ParsedStyleSheet::setText()` will nullify
the rule source data `m_sourceData`, a list of `CSSRuleSourceData` with information
about each CSS rule used by Web Inspector for mapping and mutations.

`InspectorStyleSheet::reparseStyleSheet()` does not rebuild this list.

Instead, this list is rebuilt by `InspectorStyleSheet::ensureParsedDataReady()`
when requesting updated styles data for the frontend. Order or operations or a race condition
can result in a sequence where the rule source data is missing when attempting a rule mutation.

This patch ensures the `m_sourceData` is rebuilt before updating the text of a CSS rule.
It follows precedent for changing the rule header text or deleting a rule.

Test: inspector/css/setStyleTextAfterSetStyleSheetText.html
* LayoutTests/inspector/css/setStyleTextAfterSetStyleSheetText-expected.txt: Added.
* LayoutTests/inspector/css/setStyleTextAfterSetStyleSheetText.html: Added.
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyleSheet::setRuleStyleText):

Canonical link: <a href="https://commits.webkit.org/302301@main">https://commits.webkit.org/302301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ba69423c54eb735599bd9e5b95a10318e3e1482

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128686 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39517 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/136070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/57ce8f2d-7996-423e-9bad-59ad6005aee6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/824 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/136070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c2eb394d-6efa-4b2d-88eb-42f949dc346a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131634 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/136070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ac703844-841b-4b80-942d-0de86904a1e7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/33398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/79350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/33877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138525 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/111627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/106318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27072 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30157 "Build is in progress. Recent messages:") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64090 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->