### PR TITLE
REGRESSION[macOS iOS Debug] ipc/serialized-type-info.html is fails on macOS and iOS after 301864@main

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8312,8 +8312,6 @@ imported/w3c/web-platform-tests/html/user-activation/activation-trigger-pointere
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute.html [ Pass Failure ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-command.html [ Pass Failure ]
 
-webkit.org/b/301225 [ Debug ] ipc/serialized-type-info.html [ Failure ]
-
 # https://bugs.webkit.org/show_bug.cgi?id=301243 [ iOS 26 ] imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html is a flaky text failure
 imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html [ Pass Failure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2576,4 +2576,5 @@ webkit.org/b/300997 webrtc/filtering-ice-candidate-after-reload.html [ Pass Fail
 # https://bugs.webkit.org/show_bug.cgi?id=301013 [ macOS Tahoe ] http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html is a flaky text failure
 [ Tahoe ] http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html [ Pass Failure ]
 
-webkit.org/b/301225 [ Debug ] ipc/serialized-type-info.html [ Failure ]
+# https://bugs.webkit.org/show_bug.cgi?id=301143# [ macOS Tahoe ] fast/html/text-field-input-types.html is a constant text failure 
+[ Tahoe Debug ] fast/html/text-field-input-types.html [ Failure ]

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -417,6 +417,7 @@ def serialized_identifiers():
         'WebCore::MediaKeySystemRequestIdentifier',
         'WebCore::MediaPlayerClientIdentifier',
         'WebCore::MediaPlayerIdentifier',
+        'WebCore::MediaSessionGroupIdentifier',
         'WebCore::MediaSessionIdentifier',
         'WebCore::ModelPlayerIdentifier',
         'WebCore::MediaUniqueIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
@@ -104,7 +104,7 @@ template<typename T> static Vector<RetainPtr<T>> vectorFromArray(NSArray *array)
         return { };
     Vector<RetainPtr<T>> result;
     for (id element in array) {
-        if ([element isKindOfClass:IPC::getClass<T>()])
+        SUPPRESS_UNRETAINED_ARG if ([element isKindOfClass:retainPtr(IPC::getClass<T>()).get()])
             result.append((T *)element);
     }
     return result;
@@ -131,11 +131,11 @@ CoreIPCAVOutputContext::CoreIPCAVOutputContext(AVOutputContext *object)
 {
     auto dictionary = dictionaryForWebKitSecureCodingType(object);
     m_AVOutputContextSerializationKeyContextID = (NSString *)[dictionary objectForKey:@"AVOutputContextSerializationKeyContextID"];
-    if (![m_AVOutputContextSerializationKeyContextID isKindOfClass:IPC::getClass<NSString>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_AVOutputContextSerializationKeyContextID isKindOfClass:IPC::getClass<NSString>()])
         m_AVOutputContextSerializationKeyContextID = nullptr;
 
     m_AVOutputContextSerializationKeyContextType = (NSString *)[dictionary objectForKey:@"AVOutputContextSerializationKeyContextType"];
-    if (![m_AVOutputContextSerializationKeyContextType isKindOfClass:IPC::getClass<NSString>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_AVOutputContextSerializationKeyContextType isKindOfClass:IPC::getClass<NSString>()])
         m_AVOutputContextSerializationKeyContextType = nullptr;
 
 }
@@ -178,31 +178,31 @@ CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType(NSSomeFoundationType *o
 {
     auto dictionary = dictionaryForWebKitSecureCodingType(object);
     m_StringKey = (NSString *)[dictionary objectForKey:@"StringKey"];
-    if (![m_StringKey isKindOfClass:IPC::getClass<NSString>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_StringKey isKindOfClass:IPC::getClass<NSString>()])
         m_StringKey = nullptr;
 
     m_NumberKey = (NSNumber *)[dictionary objectForKey:@"NumberKey"];
-    if (![m_NumberKey isKindOfClass:IPC::getClass<NSNumber>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_NumberKey isKindOfClass:IPC::getClass<NSNumber>()])
         m_NumberKey = nullptr;
 
     m_OptionalNumberKey = (NSNumber *)[dictionary objectForKey:@"OptionalNumberKey"];
-    if (![m_OptionalNumberKey isKindOfClass:IPC::getClass<NSNumber>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_OptionalNumberKey isKindOfClass:IPC::getClass<NSNumber>()])
         m_OptionalNumberKey = nullptr;
 
     m_ArrayKey = (NSArray *)[dictionary objectForKey:@"ArrayKey"];
-    if (![m_ArrayKey isKindOfClass:IPC::getClass<NSArray>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_ArrayKey isKindOfClass:IPC::getClass<NSArray>()])
         m_ArrayKey = nullptr;
 
     m_OptionalArrayKey = (NSArray *)[dictionary objectForKey:@"OptionalArrayKey"];
-    if (![m_OptionalArrayKey isKindOfClass:IPC::getClass<NSArray>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_OptionalArrayKey isKindOfClass:IPC::getClass<NSArray>()])
         m_OptionalArrayKey = nullptr;
 
     m_DictionaryKey = (NSDictionary *)[dictionary objectForKey:@"DictionaryKey"];
-    if (![m_DictionaryKey isKindOfClass:IPC::getClass<NSDictionary>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_DictionaryKey isKindOfClass:IPC::getClass<NSDictionary>()])
         m_DictionaryKey = nullptr;
 
     m_OptionalDictionaryKey = (NSDictionary *)[dictionary objectForKey:@"OptionalDictionaryKey"];
-    if (![m_OptionalDictionaryKey isKindOfClass:IPC::getClass<NSDictionary>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_OptionalDictionaryKey isKindOfClass:IPC::getClass<NSDictionary>()])
         m_OptionalDictionaryKey = nullptr;
 
 }
@@ -243,7 +243,7 @@ CoreIPCclass NSSomeOtherFoundationType::CoreIPCclass NSSomeOtherFoundationType(c
 {
     auto dictionary = dictionaryForWebKitSecureCodingTypeFromWKKeyedCoder(object);
     m_DictionaryKey = (NSDictionary *)[dictionary objectForKey:@"DictionaryKey"];
-    if (![m_DictionaryKey isKindOfClass:IPC::getClass<NSDictionary>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_DictionaryKey isKindOfClass:IPC::getClass<NSDictionary>()])
         m_DictionaryKey = nullptr;
 
 }
@@ -286,23 +286,23 @@ CoreIPCDDScannerResult::CoreIPCDDScannerResult(DDScannerResult *object)
 {
     auto dictionary = dictionaryForWebKitSecureCodingType(object);
     m_StringKey = (NSString *)[dictionary objectForKey:@"StringKey"];
-    if (![m_StringKey isKindOfClass:IPC::getClass<NSString>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_StringKey isKindOfClass:IPC::getClass<NSString>()])
         m_StringKey = nullptr;
 
     m_NumberKey = (NSNumber *)[dictionary objectForKey:@"NumberKey"];
-    if (![m_NumberKey isKindOfClass:IPC::getClass<NSNumber>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_NumberKey isKindOfClass:IPC::getClass<NSNumber>()])
         m_NumberKey = nullptr;
 
     m_OptionalNumberKey = (NSNumber *)[dictionary objectForKey:@"OptionalNumberKey"];
-    if (![m_OptionalNumberKey isKindOfClass:IPC::getClass<NSNumber>()])
+    SUPPRESS_UNRETAINED_ARG if (![m_OptionalNumberKey isKindOfClass:IPC::getClass<NSNumber>()])
         m_OptionalNumberKey = nullptr;
 
-    m_ArrayKey = vectorFromArray<DDScannerResult>((NSArray *)[dictionary objectForKey:@"ArrayKey"]);
-    m_OptionalArrayKey = optionalVectorFromArray<DDScannerResult>((NSArray *)[dictionary objectForKey:@"OptionalArrayKey"]);
-    m_DictionaryKey = vectorFromDictionary<Number>((NSDictionary *)[dictionary objectForKey:@"DictionaryKey"]);
-    m_OptionalDictionaryKey = optionalVectorFromDictionary<DDScannerResult>((NSDictionary *)[dictionary objectForKey:@"OptionalDictionaryKey"]);
-    m_DataArrayKey = vectorFromArray<NSData>((NSArray *)[dictionary objectForKey:@"DataArrayKey"]);
-    m_SecTrustArrayKey = vectorFromArray<SecTrustRef>((NSArray *)[dictionary objectForKey:@"SecTrustArrayKey"]);
+    m_ArrayKey = vectorFromArray<DDScannerResult>((NSArray *)retainPtr([dictionary objectForKey:@"ArrayKey"]).get());
+    m_OptionalArrayKey = optionalVectorFromArray<DDScannerResult>((NSArray *)retainPtr([dictionary objectForKey:@"OptionalArrayKey"]).get());
+    m_DictionaryKey = vectorFromDictionary<Number>((NSDictionary *)retainPtr([dictionary objectForKey:@"DictionaryKey"]).get());
+    m_OptionalDictionaryKey = optionalVectorFromDictionary<DDScannerResult>((NSDictionary *)retainPtr([dictionary objectForKey:@"OptionalDictionaryKey"]).get());
+    m_DataArrayKey = vectorFromArray<NSData>((NSArray *)retainPtr([dictionary objectForKey:@"DataArrayKey"]).get());
+    m_SecTrustArrayKey = vectorFromArray<SecTrustRef>((NSArray *)retainPtr([dictionary objectForKey:@"SecTrustArrayKey"]).get());
 }
 
 RetainPtr<id> CoreIPCDDScannerResult::toID() const

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -459,6 +459,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebCore::MediaKeySystemRequestIdentifier"_s,
         "WebCore::MediaPlayerClientIdentifier"_s,
         "WebCore::MediaPlayerIdentifier"_s,
+        "WebCore::MediaSessionGroupIdentifier"_s,
         "WebCore::MediaSessionIdentifier"_s,
         "WebCore::ModelPlayerIdentifier"_s,
         "WebCore::MediaUniqueIdentifier"_s,


### PR DESCRIPTION
#### 7eef67bbbdcdb6126be3aed99b14baef9a72a815
<pre>
REGRESSION[macOS iOS Debug] ipc/serialized-type-info.html is fails on macOS and iOS after 301864@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=301284">https://bugs.webkit.org/show_bug.cgi?id=301284</a>
<a href="https://rdar.apple.com/163145172">rdar://163145172</a>

Reviewed by Alex Christensen.

301864@main introduced the first instance of `WebCore::MediaSessionGroupIdentifier` being
sent over IPC, so the type needs to be added to `serialized_identifiers` in messages.py.

This wasn&apos;t caught by EWS because the test only runs on iOS and macOS debug, but we don&apos;t
have debug iOS EWS bots and both of the macOS EWS bots failed for unrelated reasons.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
* Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp:
(WebKit::vectorFromArray):
(WebKit::CoreIPCAVOutputContext::CoreIPCAVOutputContext):
(WebKit::CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType):
(WebKit::NSSomeOtherFoundationType):
(WebKit::CoreIPCDDScannerResult::CoreIPCDDScannerResult):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::serializedIdentifiers):

Canonical link: <a href="https://commits.webkit.org/302028@main">https://commits.webkit.org/302028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d63b8a0e2d46288c188923d74c44900827a9ea1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134948 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79233 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/29bd7751-1d18-4065-a3c7-8be0e7bdd426) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97189 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65088 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77671 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7beec4b0-656a-4d47-bb89-09c7e4932c32) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/127027 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32460 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78306 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137430 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105710 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105361 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26896 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50880 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29308 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51949 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54272 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60448 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53507 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56963 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55265 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->