### PR TITLE
[Mac] [MiniBrowser] Address bar disappears in narrow windows.

### DIFF
--- a/Tools/MiniBrowser/mac/BrowserWindow.xib
+++ b/Tools/MiniBrowser/mac/BrowserWindow.xib
@@ -28,6 +28,7 @@
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="517" y="330" width="776" height="608"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <value key="minSize" type="size" width="204" height="204"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="776" height="608"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -40,7 +41,7 @@
             </view>
             <toolbar key="toolbar" implicitIdentifier="994A0CB1-7575-4F39-A65B-7165AB1E8015" displayMode="iconOnly" sizeMode="regular" id="48">
                 <allowedToolbarItems>
-                    <toolbarItem implicitItemIdentifier="73DE9F4B-73E2-4036-A134-2D9E029DA980" label="Go Back" paletteLabel="Go Back" image="chevron.left" catalog="system" id="56" customClass="MBToolbarItem">
+                    <toolbarItem implicitItemIdentifier="73DE9F4B-73E2-4036-A134-2D9E029DA980" label="Go Back" paletteLabel="Go Back" image="chevron.left" catalog="system" visibilityPriority="1500" id="56" customClass="MBToolbarItem">
                         <nil key="toolTip"/>
                         <size key="minSize" width="32" height="25"/>
                         <size key="maxSize" width="32" height="25"/>
@@ -56,7 +57,7 @@
                             <action selector="goBack:" target="-2" id="61"/>
                         </connections>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="E1A9D32A-59E3-467B-9ABA-A95780416E69" label="Go Forward" paletteLabel="Go Forward" image="chevron.right" catalog="system" id="57" customClass="MBToolbarItem">
+                    <toolbarItem implicitItemIdentifier="E1A9D32A-59E3-467B-9ABA-A95780416E69" label="Go Forward" paletteLabel="Go Forward" image="chevron.right" catalog="system" visibilityPriority="1400" id="57" customClass="MBToolbarItem">
                         <nil key="toolTip"/>
                         <size key="minSize" width="32" height="25"/>
                         <size key="maxSize" width="32" height="27"/>
@@ -72,7 +73,7 @@
                             <action selector="goForward:" target="-2" id="62"/>
                         </connections>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="88C16109-D40F-4682-BCE4-CBEE2EDE32D2" label="Refresh" paletteLabel="Refresh" image="arrow.clockwise" catalog="system" id="58" customClass="MBToolbarItem">
+                    <toolbarItem implicitItemIdentifier="88C16109-D40F-4682-BCE4-CBEE2EDE32D2" label="Refresh" paletteLabel="Refresh" image="arrow.clockwise" catalog="system" visibilityPriority="1000" id="58" customClass="MBToolbarItem">
                         <nil key="toolTip"/>
                         <size key="minSize" width="29" height="25"/>
                         <size key="maxSize" width="29" height="27"/>
@@ -88,7 +89,7 @@
                             </connections>
                         </button>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="F9C3B2C4-B22D-4E12-92BC-EA326711BBC1" label="Lock" paletteLabel="Lock" image="lock.open" catalog="system" id="Ky3-6Y-3U1" userLabel="Lock" customClass="MBToolbarItem">
+                    <toolbarItem implicitItemIdentifier="F9C3B2C4-B22D-4E12-92BC-EA326711BBC1" label="Lock" paletteLabel="Lock" image="lock.open" catalog="system" visibilityPriority="900" id="Ky3-6Y-3U1" userLabel="Lock" customClass="MBToolbarItem">
                         <nil key="toolTip"/>
                         <size key="minSize" width="29" height="25"/>
                         <size key="maxSize" width="29" height="27"/>
@@ -104,7 +105,7 @@
                             </connections>
                         </button>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="76DCF2B0-1DDE-47D2-9212-705E6E310CCE" label="Use Shrink To Fit" paletteLabel="Use Shrink To Fit" image="arrow.up.backward.and.arrow.down.forward" catalog="system" id="81" customClass="MBToolbarItem">
+                    <toolbarItem implicitItemIdentifier="76DCF2B0-1DDE-47D2-9212-705E6E310CCE" label="Use Shrink To Fit" paletteLabel="Use Shrink To Fit" image="arrow.up.backward.and.arrow.down.forward" catalog="system" visibilityPriority="700" id="81" customClass="MBToolbarItem">
                         <nil key="toolTip"/>
                         <size key="minSize" width="29" height="25"/>
                         <size key="maxSize" width="29" height="27"/>
@@ -120,7 +121,7 @@
                             </connections>
                         </button>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="F1738B7F-895C-48F7-955D-0915E150BE1B" label="Share" paletteLabel="Share" image="square.and.arrow.up" catalog="system" id="dJx-dw-gcC" customClass="MBToolbarItem">
+                    <toolbarItem implicitItemIdentifier="F1738B7F-895C-48F7-955D-0915E150BE1B" label="Share" paletteLabel="Share" image="square.and.arrow.up" catalog="system" visibilityPriority="800" id="dJx-dw-gcC" customClass="MBToolbarItem">
                         <nil key="toolTip"/>
                         <size key="minSize" width="29" height="25"/>
                         <size key="maxSize" width="29" height="27"/>
@@ -136,9 +137,9 @@
                             </buttonCell>
                         </button>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="255D29F2-C9AA-4B4B-BB43-B38FCD6A0BBB" label="Location" paletteLabel="Location" id="59">
+                    <toolbarItem implicitItemIdentifier="255D29F2-C9AA-4B4B-BB43-B38FCD6A0BBB" label="Location" paletteLabel="Location" visibilityPriority="10000" id="59">
                         <nil key="toolTip"/>
-                        <size key="minSize" width="200" height="22"/>
+                        <size key="minSize" width="120" height="22"/>
                         <size key="maxSize" width="100000" height="22"/>
                         <textField key="view" verticalHuggingPriority="750" id="10">
                             <rect key="frame" x="0.0" y="14" width="565" height="22"/>
@@ -153,7 +154,7 @@
                             </connections>
                         </textField>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="86912BAA-B8D0-400F-BFEE-71FC166986E6" label="Progress" paletteLabel="Progress" tag="-1" sizingBehavior="auto" id="60">
+                    <toolbarItem implicitItemIdentifier="86912BAA-B8D0-400F-BFEE-71FC166986E6" label="Progress" paletteLabel="Progress" tag="-1" visibilityPriority="600" sizingBehavior="auto" id="60">
                         <nil key="toolTip"/>
                         <progressIndicator key="view" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="1" displayedWhenStopped="NO" bezeled="NO" controlSize="small" style="spinning" id="21">
                             <rect key="frame" x="19" y="14" width="16" height="16"/>


### PR DESCRIPTION
#### 15b8e5ccd4f00771daf6205961bf170cf8232869
<pre>
[Mac] [MiniBrowser] Address bar disappears in narrow windows.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301285">https://bugs.webkit.org/show_bug.cgi?id=301285</a>
<a href="https://rdar.apple.com/155889708">rdar://155889708</a>

Reviewed by Simon Fraser.

Add visual priority to each toolbar items. Make the location bar item the highest.
Also reduce minimum size of it to fit more buttons to be visible. Lastly add min-
size of window itself to ensure location bar is always visible.

* Tools/MiniBrowser/mac/BrowserWindow.xib:

Canonical link: <a href="https://commits.webkit.org/302008@main">https://commits.webkit.org/302008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7f23fea106631abc09efa2991aac71fa1ca3db2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134938 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79224 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6a9558f2-681b-4255-82c6-118e8da9ba36) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97181 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65107 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a388dc6c-6c7d-49e7-ad29-00a38652de18) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77663 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4410e269-cd3b-4472-adac-67748c766ae2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37135 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32454 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78297 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108202 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137421 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41878 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105702 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105353 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26885 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50872 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51940 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54263 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53498 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56954 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55256 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->