### PR TITLE
The WebContent process is crashing on startup in some cases

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -364,7 +364,7 @@
     (syscall-unix-in-use-after-launch-blocked-in-lockdown-mode))
 
 (with-filter (require-not (webcontent-process-launched))
-    (allow syscall-unix (syscall-unix-only-in-use-during-launch)))
+    (allow-syscall-unix-only-in-use-during-launch))
 
 (allow syscall-unix
     (syscall-unix-rarely-in-use)
@@ -387,9 +387,7 @@
     (allow syscall-unix (syscall-number SYS_map_with_linking_np)))
 
 (with-filter (system-attribute developer-mode)
-    (allow syscall-unix (syscall-unix-developer-mode)))
-(with-filter (require-not (system-attribute developer-mode))
-    (deny syscall-unix (with no-report) (syscall-unix-developer-mode)))
+    (allow-syscall-unix-developer-mode))
 
 (with-filter (lockdown-mode)
     (deny syscall-unix (with telemetry) (with message "Lockdown mode")

--- a/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
@@ -259,26 +259,30 @@
 (define-once (mach-bootstrap-message-numbers-post-launch)
     (message-number 206 207 711 712 800 804 904))
 
-(define (syscall-unix-only-in-use-during-launch)
-    (syscall-number
-        SYS_bsdthread_register
-        SYS_chdir
-        SYS_dup2
-        SYS_fsgetpath
-        SYS_getpid
-        SYS_kdebug_trace_string
-        SYS_kdebug_typefilter
-        SYS_objc_bp_assist_cfg_np
-        SYS_persona
-        SYS_shared_region_check_np
-        SYS_sigaction
-        SYS_workq_open))
+(define (allow-syscall-unix-kdebug)
+    (allow syscall-unix
+        (syscall-number
+            SYS_kdebug_trace_string
+            SYS_kdebug_trace64
+            SYS_kdebug_typefilter)))
 
-(define (syscall-unix-developer-mode)
-    (syscall-number
-        SYS_kdebug_trace_string
-        SYS_kdebug_trace64
-        SYS_kdebug_typefilter))
+(define (allow-syscall-unix-only-in-use-during-launch)
+    (allow-syscall-unix-kdebug)
+    (allow syscall-unix
+        (syscall-number
+            SYS_bsdthread_register
+            SYS_chdir
+            SYS_dup2
+            SYS_fsgetpath
+            SYS_getpid
+            SYS_objc_bp_assist_cfg_np
+            SYS_persona
+            SYS_shared_region_check_np
+            SYS_sigaction
+            SYS_workq_open)))
+
+(define (allow-syscall-unix-developer-mode)
+    (allow-syscall-unix-kdebug))
 
 (define (syscall-unix-in-use-after-launch)
     (syscall-number


### PR DESCRIPTION
#### d05bf0310a95d82651370a7851b257aa05a8977d
<pre>
The WebContent process is crashing on startup in some cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=301289">https://bugs.webkit.org/show_bug.cgi?id=301289</a>
<a href="https://rdar.apple.com/162825256">rdar://162825256</a>

Reviewed by Sihui Liu.

This is due to a kdebug related syscall being blocked during the launch of the WebContent process
in some cases. This issue is resolved by allowing that syscall during launch.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb:

Canonical link: <a href="https://commits.webkit.org/301967@main">https://commits.webkit.org/301967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/709281c146f6da79ee756370177a16845a686500

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134899 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/72594c44-e959-41ea-aae2-ce0ed1628fc2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97153 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/75beac97-ab56-4d63-8ee2-55457499ae99) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77634 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1ec47501-ebd8-4ad8-91c1-11dbd0b8cbce) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78258 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137381 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105674 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105325 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50847 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51881 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19952 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54224 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60400 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53458 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56915 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55217 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->