### PR TITLE
[Style] Convert the 'paint-order' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3471,6 +3471,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/svg/StyleSVGGlyphOrientationVertical.h
     style/values/svg/StyleSVGMarkerResource.h
     style/values/svg/StyleSVGPaint.h
+    style/values/svg/StyleSVGPaintOrder.h
     style/values/svg/StyleSVGPathData.h
     style/values/svg/StyleSVGRadius.h
     style/values/svg/StyleSVGRadiusComponent.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3315,6 +3315,7 @@ style/values/svg/StyleSVGBaselineShift.cpp
 style/values/svg/StyleSVGGlyphOrientationHorizontal.cpp
 style/values/svg/StyleSVGGlyphOrientationVertical.cpp
 style/values/svg/StyleSVGPaint.cpp
+style/values/svg/StyleSVGPaintOrder.cpp
 style/values/svg/StyleSVGPathData.cpp
 style/values/svg/StyleSVGStrokeDasharray.cpp
 style/values/svg/StyleSVGStrokeDashoffset.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7182,7 +7182,7 @@
                 "markers"
             ],
             "codegen-properties": {
-                "style-converter": "PaintOrder",
+                "style-converter": "StyleType<SVGPaintOrder>",
                 "parser-function": "consumePaintOrder",
                 "parser-grammar-unused": "normal | [ fill || stroke || markers ]",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."

--- a/Source/WebCore/rendering/TextPaintStyle.h
+++ b/Source/WebCore/rendering/TextPaintStyle.h
@@ -28,6 +28,7 @@
 #include "Color.h"
 #include "GraphicsTypes.h"
 #include "RenderStyleConstants.h"
+#include "StyleSVGPaintOrder.h"
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -56,7 +57,7 @@ struct TextPaintStyle {
     float strokeWidth { 0 };
     // This is not set for -webkit-text-fill-color.
     bool hasExplicitlySetFillColor { false };
-    PaintOrder paintOrder { PaintOrder::Normal };
+    Style::SVGPaintOrder paintOrder { CSS::Keyword::Normal { } };
     LineJoin lineJoin { LineJoin::Miter };
     LineCap lineCap { LineCap::Butt };
     float miterLimit { defaultMiterLimit };

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -164,17 +164,16 @@ void TextPainter::paintTextWithShadows(const Style::TextShadows* shadows, const 
 void TextPainter::paintTextAndEmphasisMarksIfNeeded(const TextRun& textRun, const FloatRect& boxRect, const FloatPoint& textOrigin, unsigned startOffset, unsigned endOffset,
     const TextPaintStyle& paintStyle, const Style::TextShadows& shadow, const Style::AppleColorFilter& shadowColorFilter)
 {
-    if (paintStyle.paintOrder == PaintOrder::Normal) {
+    if (paintStyle.paintOrder.isNormal()) {
         // FIXME: Truncate right-to-left text correctly.
         paintTextWithShadows(&shadow, shadowColorFilter, m_font, textRun, boxRect, textOrigin, startOffset, endOffset, nullAtom(), 0, paintStyle.strokeWidth > 0);
     } else {
         auto textDrawingMode = m_context.textDrawingMode();
-        auto paintOrder = RenderStyle::paintTypesForPaintOrder(paintStyle.paintOrder);
         auto shadowToUse = &shadow;
 
-        for (auto order : paintOrder) {
-            switch (order) {
-            case PaintType::Fill: {
+        for (auto paintType : paintStyle.paintOrder) {
+            switch (paintType) {
+            case Style::PaintType::Fill: {
                 auto textDrawingModeWithoutStroke = textDrawingMode;
                 textDrawingModeWithoutStroke.remove(TextDrawingMode::Stroke);
                 m_context.setTextDrawingMode(textDrawingModeWithoutStroke);
@@ -183,7 +182,7 @@ void TextPainter::paintTextAndEmphasisMarksIfNeeded(const TextRun& textRun, cons
                 m_context.setTextDrawingMode(textDrawingMode);
                 break;
             }
-            case PaintType::Stroke: {
+            case Style::PaintType::Stroke: {
                 auto textDrawingModeWithoutFill = textDrawingMode;
                 textDrawingModeWithoutFill.remove(TextDrawingMode::Fill);
                 m_context.setTextDrawingMode(textDrawingModeWithoutFill);
@@ -192,7 +191,7 @@ void TextPainter::paintTextAndEmphasisMarksIfNeeded(const TextRun& textRun, cons
                 m_context.setTextDrawingMode(textDrawingMode);
             }
                 break;
-            case PaintType::Markers:
+            case Style::PaintType::Markers:
                 continue;
             }
         }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3542,33 +3542,6 @@ bool RenderStyle::shouldPlaceVerticalScrollbarOnLeft() const
     return !writingMode().isAnyLeftToRight();
 }
 
-std::span<const PaintType, 3> RenderStyle::paintTypesForPaintOrder(PaintOrder order)
-{
-    static constexpr std::array fill { PaintType::Fill, PaintType::Stroke, PaintType::Markers };
-    static constexpr std::array fillMarkers { PaintType::Fill, PaintType::Markers, PaintType::Stroke };
-    static constexpr std::array stroke { PaintType::Stroke, PaintType::Fill, PaintType::Markers };
-    static constexpr std::array strokeMarkers { PaintType::Stroke, PaintType::Markers, PaintType::Fill };
-    static constexpr std::array markers { PaintType::Markers, PaintType::Fill, PaintType::Stroke };
-    static constexpr std::array markersStroke { PaintType::Markers, PaintType::Stroke, PaintType::Fill };
-    switch (order) {
-    case PaintOrder::Normal:
-    case PaintOrder::Fill:
-        return fill;
-    case PaintOrder::FillMarkers:
-        return fillMarkers;
-    case PaintOrder::Stroke:
-        return stroke;
-    case PaintOrder::StrokeMarkers:
-        return strokeMarkers;
-    case PaintOrder::Markers:
-        return markers;
-    case PaintOrder::MarkersStroke:
-        return markersStroke;
-    };
-    ASSERT_NOT_REACHED();
-    return fill;
-}
-
 float RenderStyle::computedStrokeWidth(const IntSize& viewportSize) const
 {
     // Use the stroke-width and stroke-color value combination only if stroke-color has been explicitly specified.

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -166,8 +166,6 @@ enum class OverflowWrap : uint8_t;
 enum class OverscrollBehavior : uint8_t;
 enum class PaginationMode : uint8_t;
 enum class PaintBehavior : uint32_t;
-enum class PaintOrder : uint8_t;
-enum class PaintType : uint8_t;
 enum class PointerEvents : uint8_t;
 enum class PositionType : uint8_t;
 enum class PositionVisibility : uint8_t;
@@ -331,6 +329,7 @@ struct SVGCenterCoordinateComponent;
 struct SVGCoordinateComponent;
 struct SVGMarkerResource;
 struct SVGPaint;
+struct SVGPaintOrder;
 struct SVGPathData;
 struct SVGRadius;
 struct SVGRadiusComponent;
@@ -1757,11 +1756,9 @@ public:
 
     void addCustomPaintWatchProperty(const AtomString&);
 
-    // Support for paint-order, stroke-linecap, stroke-linejoin, and stroke-miterlimit from https://drafts.fxtf.org/paint/.
-    inline void setPaintOrder(PaintOrder);
-    inline PaintOrder paintOrder() const;
-    static constexpr PaintOrder initialPaintOrder();
-    static std::span<const PaintType, 3> paintTypesForPaintOrder(PaintOrder);
+    inline void setPaintOrder(Style::SVGPaintOrder);
+    inline Style::SVGPaintOrder paintOrder() const;
+    static constexpr Style::SVGPaintOrder initialPaintOrder();
     
     inline void setCapStyle(LineCap);
     inline LineCap capStyle() const;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -913,20 +913,6 @@ TextStream& operator<<(TextStream& ts, OverflowWrap overflowWrap)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, PaintOrder paintOrder)
-{
-    switch (paintOrder) {
-    case PaintOrder::Normal: ts << "normal"_s; break;
-    case PaintOrder::Fill: ts << "fill"_s; break;
-    case PaintOrder::FillMarkers: ts << "fill markers"_s; break;
-    case PaintOrder::Stroke: ts << "stroke"_s; break;
-    case PaintOrder::StrokeMarkers: ts << "stroke markers"_s; break;
-    case PaintOrder::Markers: ts << "markers"_s; break;
-    case PaintOrder::MarkersStroke: ts << "markers stroke"_s; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, PointerEvents pointerEvents)
 {
     switch (pointerEvents) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1049,23 +1049,6 @@ enum class ScrollSnapStop : bool {
     Always,
 };
 
-// These are all minimized combinations of paint-order.
-enum class PaintOrder : uint8_t {
-    Normal,
-    Fill,
-    FillMarkers,
-    Stroke,
-    StrokeMarkers,
-    Markers,
-    MarkersStroke
-};
-
-enum class PaintType : uint8_t {
-    Fill,
-    Stroke,
-    Markers
-};
-
 enum class FontLoadingBehavior : uint8_t {
     Auto,
     Block,
@@ -1351,7 +1334,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, OutlineStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, WebCore::Overflow);
 WTF::TextStream& operator<<(WTF::TextStream&, OverflowAlignment);
 WTF::TextStream& operator<<(WTF::TextStream&, OverflowWrap);
-WTF::TextStream& operator<<(WTF::TextStream&, PaintOrder);
 WTF::TextStream& operator<<(WTF::TextStream&, PointerEvents);
 WTF::TextStream& operator<<(WTF::TextStream&, PositionType);
 WTF::TextStream& operator<<(WTF::TextStream&, PositionVisibility);

--- a/Source/WebCore/rendering/style/RenderStyleDifference.h
+++ b/Source/WebCore/rendering/style/RenderStyleDifference.h
@@ -42,6 +42,9 @@ namespace WebCore {
 #define LOG_IF_DIFFERENT_WITH_CAST(type, name) \
     do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), static_cast<type>(name), static_cast<type>(other.name)); } while (0)
 
+#define LOG_IF_DIFFERENT_WITH_CAST_AND_CONSTRUCTION(castType, constructionType, name) \
+    do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), constructionType(static_cast<castType>(name)), constructionType(static_cast<castType>(other.name))); } while (0)
+
 #define LOG_RAW_OPTIONSET_IF_DIFFERENT(type, name) \
     do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), OptionSet<type>::fromRaw(name), OptionSet<type>::fromRaw(other.name)); } while (0)
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -519,7 +519,7 @@ constexpr OverscrollBehavior RenderStyle::initialOverscrollBehaviorX() { return 
 constexpr OverscrollBehavior RenderStyle::initialOverscrollBehaviorY() { return OverscrollBehavior::Auto; }
 inline Style::PaddingEdge RenderStyle::initialPadding() { return 0_css_px; }
 inline Style::PageSize RenderStyle::initialPageSize() { return CSS::Keyword::Auto { }; }
-constexpr PaintOrder RenderStyle::initialPaintOrder() { return PaintOrder::Normal; }
+constexpr Style::SVGPaintOrder RenderStyle::initialPaintOrder() { return CSS::Keyword::Normal { }; }
 inline Style::Perspective RenderStyle::initialPerspective() { return CSS::Keyword::None { }; }
 inline Style::PerspectiveOrigin RenderStyle::initialPerspectiveOrigin() { return { initialPerspectiveOriginX(), initialPerspectiveOriginY() }; }
 inline Style::PerspectiveOriginX RenderStyle::initialPerspectiveOriginX() { return 50_css_percentage; }
@@ -749,7 +749,7 @@ inline const Style::PaddingEdge& RenderStyle::paddingStart() const { return padd
 inline const Style::PaddingEdge& RenderStyle::paddingStart(const WritingMode writingMode) const { return paddingBox().start(writingMode); }
 inline const Style::PaddingEdge& RenderStyle::paddingTop() const { return paddingBox().top(); }
 inline const Style::PageSize& RenderStyle::pageSize() const { return m_nonInheritedData->rareData->pageSize; }
-inline PaintOrder RenderStyle::paintOrder() const { return static_cast<PaintOrder>(m_rareInheritedData->paintOrder); }
+inline Style::SVGPaintOrder RenderStyle::paintOrder() const { return static_cast<Style::SVGPaintOrder::Type>(m_rareInheritedData->paintOrder); }
 inline const Style::Perspective& RenderStyle::perspective() const { return m_nonInheritedData->rareData->perspective; }
 inline const Style::PerspectiveOrigin& RenderStyle::perspectiveOrigin() const { return m_nonInheritedData->rareData->perspectiveOrigin; }
 inline const Style::PerspectiveOriginX& RenderStyle::perspectiveOriginX() const { return m_nonInheritedData->rareData->perspectiveOrigin.x; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -253,7 +253,7 @@ inline void RenderStyle::setPaddingLeft(Style::PaddingEdge&& edge) { SET_NESTED(
 inline void RenderStyle::setPaddingRight(Style::PaddingEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, padding.right(), WTFMove(edge)); }
 inline void RenderStyle::setPaddingTop(Style::PaddingEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, padding.top(), WTFMove(edge)); }
 inline void RenderStyle::setPageSize(Style::PageSize&& pageSize) { SET_NESTED(m_nonInheritedData, rareData, pageSize, WTFMove(pageSize)); }
-inline void RenderStyle::setPaintOrder(PaintOrder order) { SET(m_rareInheritedData, paintOrder, static_cast<unsigned>(order)); }
+inline void RenderStyle::setPaintOrder(Style::SVGPaintOrder paintOrder) { SET(m_rareInheritedData, paintOrder, static_cast<unsigned>(paintOrder.type())); }
 inline void RenderStyle::setPerspective(Style::Perspective&& perspective) { SET_NESTED(m_nonInheritedData, rareData, perspective, WTFMove(perspective)); }
 inline void RenderStyle::setPerspectiveOrigin(Style::PerspectiveOrigin&& origin) { SET_NESTED(m_nonInheritedData, rareData, perspectiveOrigin, WTFMove(origin)); }
 inline void RenderStyle::setPerspectiveOriginX(Style::PerspectiveOriginX&& originX) { SET_NESTED(m_nonInheritedData, rareData, perspectiveOrigin.x, WTFMove(originX)); }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -137,7 +137,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , webkitTouchCallout(static_cast<unsigned>(RenderStyle::initialTouchCallout()))
 #endif
     , hangingPunctuation(RenderStyle::initialHangingPunctuation().toRaw())
-    , paintOrder(static_cast<unsigned>(RenderStyle::initialPaintOrder()))
+    , paintOrder(static_cast<unsigned>(RenderStyle::initialPaintOrder().type()))
     , capStyle(static_cast<unsigned>(RenderStyle::initialCapStyle()))
     , joinStyle(static_cast<unsigned>(RenderStyle::initialJoinStyle()))
     , hasSetStrokeWidth(false)
@@ -499,7 +499,7 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
 
     LOG_RAW_OPTIONSET_IF_DIFFERENT(HangingPunctuation, hangingPunctuation);
 
-    LOG_IF_DIFFERENT_WITH_CAST(PaintOrder, paintOrder);
+    LOG_IF_DIFFERENT_WITH_CAST_AND_CONSTRUCTION(Style::SVGPaintOrder::Type, Style::SVGPaintOrder, paintOrder);
     LOG_IF_DIFFERENT_WITH_CAST(LineCap, capStyle);
     LOG_IF_DIFFERENT_WITH_CAST(LineJoin, joinStyle);
 

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -43,6 +43,7 @@
 #include <WebCore/StyleMathDepth.h>
 #include <WebCore/StyleOrphans.h>
 #include <WebCore/StyleQuotes.h>
+#include <WebCore/StyleSVGPaintOrder.h>
 #include <WebCore/StyleScrollbarColor.h>
 #include <WebCore/StyleStrokeMiterlimit.h>
 #include <WebCore/StyleStrokeWidth.h>
@@ -182,7 +183,7 @@ public:
     PREFERRED_TYPE(Style::WebkitTouchCallout) unsigned webkitTouchCallout : 1;
 #endif
     PREFERRED_TYPE(OptionSet<HangingPunctuation>) unsigned hangingPunctuation : 4;
-    PREFERRED_TYPE(PaintOrder) unsigned paintOrder : 3;
+    PREFERRED_TYPE(Style::SVGPaintOrder::Type) unsigned paintOrder : 3;
     PREFERRED_TYPE(LineCap) unsigned capStyle : 2;
     PREFERRED_TYPE(LineJoin) unsigned joinStyle : 2;
     PREFERRED_TYPE(bool) unsigned hasSetStrokeWidth : 1;

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -206,15 +206,15 @@ void RenderSVGShape::strokeShape(const RenderStyle& style, GraphicsContext& cont
 
 void RenderSVGShape::fillStrokeMarkers(PaintInfo& childPaintInfo)
 {
-    for (auto type : RenderStyle::paintTypesForPaintOrder(style().paintOrder())) {
+    for (auto type : style().paintOrder()) {
         switch (type) {
-        case PaintType::Fill:
+        case Style::PaintType::Fill:
             fillShape(style(), childPaintInfo.context());
             break;
-        case PaintType::Stroke:
+        case Style::PaintType::Stroke:
             strokeShape(style(), childPaintInfo.context());
             break;
-        case PaintType::Markers:
+        case Style::PaintType::Markers:
             drawMarkers(childPaintInfo);
             break;
         }

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
@@ -226,23 +226,23 @@ void SVGTextBoxPainter<TextBoxPath>::paint()
         if (decorations.hasOverline())
             paintDecoration(Style::TextDecorationLine::Flag::Overline, fragment);
 
-        for (auto type : RenderStyle::paintTypesForPaintOrder(style.paintOrder())) {
+        for (auto type : style.paintOrder()) {
             switch (type) {
-            case PaintType::Fill:
+            case Style::PaintType::Fill:
                 if (!hasFill)
                     continue;
                 m_paintingResourceMode = { RenderSVGResourceMode::ApplyToFill, RenderSVGResourceMode::ApplyToText };
                 ASSERT(selectionStyle);
                 paintText(style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
                 break;
-            case PaintType::Stroke:
+            case Style::PaintType::Stroke:
                 if (!hasVisibleStroke)
                     continue;
                 m_paintingResourceMode = { RenderSVGResourceMode::ApplyToStroke, RenderSVGResourceMode::ApplyToText };
                 ASSERT(selectionStyle);
                 paintText(style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
                 break;
-            case PaintType::Markers:
+            case Style::PaintType::Markers:
                 continue;
             }
         }
@@ -452,21 +452,21 @@ void SVGTextBoxPainter<TextBoxPath>::paintDecoration(Style::TextDecorationLine d
     if (decorationStyle.usedVisibility() == Visibility::Hidden)
         return;
 
-    for (auto type : RenderStyle::paintTypesForPaintOrder(renderer().style().paintOrder())) {
+    for (auto type : renderer().style().paintOrder()) {
         switch (type) {
-        case PaintType::Fill:
+        case Style::PaintType::Fill:
             if (decorationStyle.hasFill()) {
                 m_paintingResourceMode = RenderSVGResourceMode::ApplyToFill;
                 paintDecorationWithStyle(decoration, fragment, *decorationRenderer);
             }
             break;
-        case PaintType::Stroke:
+        case Style::PaintType::Stroke:
             if (decorationStyle.hasStroke() && decorationStyle.strokeWidth().isPossiblyPositive()) {
                 m_paintingResourceMode = RenderSVGResourceMode::ApplyToStroke;
                 paintDecorationWithStyle(decoration, fragment, *decorationRenderer);
             }
             break;
-        case PaintType::Markers:
+        case Style::PaintType::Markers:
             break;
         default:
             ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -249,15 +249,15 @@ void LegacyRenderSVGShape::strokeShape(const RenderStyle& style, GraphicsContext
 
 void LegacyRenderSVGShape::fillStrokeMarkers(PaintInfo& childPaintInfo)
 {
-    for (auto type : RenderStyle::paintTypesForPaintOrder(style().paintOrder())) {
+    for (auto type : style().paintOrder()) {
         switch (type) {
-        case PaintType::Fill:
+        case Style::PaintType::Fill:
             fillShape(style(), childPaintInfo.context());
             break;
-        case PaintType::Stroke:
+        case Style::PaintType::Stroke:
             strokeShape(style(), childPaintInfo.context());
             break;
-        case PaintType::Markers:
+        case Style::PaintType::Markers:
             drawMarkers(childPaintInfo);
             break;
         }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -128,7 +128,6 @@ public:
     static OptionSet<LineBoxContain> convertLineBoxContain(BuilderState&, const CSSValue&);
     static OptionSet<TouchAction> convertTouchAction(BuilderState&, const CSSValue&);
 
-    static PaintOrder convertPaintOrder(BuilderState&, const CSSValue&);
     static StyleSelfAlignmentData convertSelfOrDefaultAlignmentData(BuilderState&, const CSSValue&);
     static StyleContentAlignmentData convertContentAlignmentData(BuilderState&, const CSSValue&);
 
@@ -412,30 +411,6 @@ inline OptionSet<TouchAction> BuilderConverter::convertTouchAction(BuilderState&
     }
 
     return RenderStyle::initialTouchActions();
-}
-
-inline PaintOrder BuilderConverter::convertPaintOrder(BuilderState& builderState, const CSSValue& value)
-{
-    if (is<CSSPrimitiveValue>(value)) {
-        ASSERT(value.valueID() == CSSValueNormal);
-        return PaintOrder::Normal;
-    }
-
-    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
-    if (!list)
-        return { };
-
-    switch (list->item(0).valueID()) {
-    case CSSValueFill:
-        return list->size() > 1 ? PaintOrder::FillMarkers : PaintOrder::Fill;
-    case CSSValueStroke:
-        return list->size() > 1 ? PaintOrder::StrokeMarkers : PaintOrder::Stroke;
-    case CSSValueMarkers:
-        return list->size() > 1 ? PaintOrder::MarkersStroke : PaintOrder::Markers;
-    default:
-        ASSERT_NOT_REACHED();
-        return PaintOrder::Normal;
-    }
 }
 
 // Get the "opposite" ItemPosition to the provided ItemPosition.

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -147,7 +147,6 @@ public:
     static Ref<CSSValue> convertHangingPunctuation(ExtractorState&, OptionSet<HangingPunctuation>);
     static Ref<CSSValue> convertSelfOrDefaultAlignmentData(ExtractorState&, const StyleSelfAlignmentData&);
     static Ref<CSSValue> convertContentAlignmentData(ExtractorState&, const StyleContentAlignmentData&);
-    static Ref<CSSValue> convertPaintOrder(ExtractorState&, PaintOrder);
     static Ref<CSSValue> convertPositionAnchor(ExtractorState&, const std::optional<ScopedName>&);
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const PositionArea&);
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const std::optional<PositionArea>&);
@@ -549,41 +548,6 @@ inline Ref<CSSValue> ExtractorConverter::convertContentAlignmentData(ExtractorSt
     ASSERT(list.size() > 0);
     ASSERT(list.size() <= 3);
     return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertPaintOrder(ExtractorState&, PaintOrder paintOrder)
-{
-    if (paintOrder == PaintOrder::Normal)
-        return CSSPrimitiveValue::create(CSSValueNormal);
-
-    CSSValueListBuilder paintOrderList;
-    switch (paintOrder) {
-    case PaintOrder::Normal:
-        ASSERT_NOT_REACHED();
-        break;
-    case PaintOrder::Fill:
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueFill));
-        break;
-    case PaintOrder::FillMarkers:
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueFill));
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueMarkers));
-        break;
-    case PaintOrder::Stroke:
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueStroke));
-        break;
-    case PaintOrder::StrokeMarkers:
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueStroke));
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueMarkers));
-        break;
-    case PaintOrder::Markers:
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueMarkers));
-        break;
-    case PaintOrder::MarkersStroke:
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueMarkers));
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueStroke));
-        break;
-    }
-    return CSSValueList::createSpaceSeparated(WTFMove(paintOrderList));
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertPositionAnchor(ExtractorState& state, const std::optional<ScopedName>& positionAnchor)

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -83,7 +83,6 @@ public:
     static void serializeHangingPunctuation(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<HangingPunctuation>);
     static void serializeSelfOrDefaultAlignmentData(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const StyleSelfAlignmentData&);
     static void serializeContentAlignmentData(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const StyleContentAlignmentData&);
-    static void serializePaintOrder(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, PaintOrder);
     static void serializePositionAnchor(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<ScopedName>&);
     static void serializePositionArea(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<PositionArea>&);
     static void serializeNameScope(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const NameScope&);
@@ -563,48 +562,6 @@ inline void ExtractorSerializer::serializeContentAlignmentData(ExtractorState& s
     ASSERT(list.size() > 0);
     ASSERT(list.size() <= 3);
     builder.append(CSSValueList::createSpaceSeparated(WTFMove(list))->cssText(context));
-}
-
-inline void ExtractorSerializer::serializePaintOrder(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, PaintOrder paintOrder)
-{
-    if (paintOrder == PaintOrder::Normal) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Normal { });
-        return;
-    }
-
-    auto appendOne = [&](auto a) {
-        builder.append(nameLiteralForSerialization(a));
-    };
-
-    auto appendTwo = [&](auto a, auto b) {
-        builder.append(nameLiteralForSerialization(a), ' ', nameLiteralForSerialization(b));
-    };
-
-    switch (paintOrder) {
-    case PaintOrder::Normal:
-        ASSERT_NOT_REACHED();
-        return;
-    case PaintOrder::Fill:
-        appendOne(CSSValueFill);
-        return;
-    case PaintOrder::FillMarkers:
-        appendTwo(CSSValueFill, CSSValueMarkers);
-        return;
-    case PaintOrder::Stroke:
-        appendOne(CSSValueStroke);
-        return;
-    case PaintOrder::StrokeMarkers:
-        appendTwo(CSSValueStroke, CSSValueMarkers);
-        return;
-    case PaintOrder::Markers:
-        appendOne(CSSValueMarkers);
-        return;
-    case PaintOrder::MarkersStroke:
-        appendTwo(CSSValueMarkers, CSSValueStroke);
-        return;
-    }
-
-    RELEASE_ASSERT_NOT_REACHED();
 }
 
 inline void ExtractorSerializer::serializePositionAnchor(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const std::optional<ScopedName>& positionAnchor)

--- a/Source/WebCore/style/values/svg/StyleSVGPaintOrder.cpp
+++ b/Source/WebCore/style/values/svg/StyleSVGPaintOrder.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleSVGPaintOrder.h"
+
+#include "StyleBuilderChecking.h"
+
+namespace WebCore {
+namespace Style {
+
+std::span<const PaintType, 3> SVGPaintOrder::paintTypes() const
+{
+    static constexpr std::array fillStrokeMarkers { PaintType::Fill, PaintType::Stroke, PaintType::Markers };
+    static constexpr std::array fillMarkersStroke { PaintType::Fill, PaintType::Markers, PaintType::Stroke };
+    static constexpr std::array strokeFillMarkers { PaintType::Stroke, PaintType::Fill, PaintType::Markers };
+    static constexpr std::array strokeMarkersFill { PaintType::Stroke, PaintType::Markers, PaintType::Fill };
+    static constexpr std::array markersFillStroke { PaintType::Markers, PaintType::Fill, PaintType::Stroke };
+    static constexpr std::array markersStrokeFill { PaintType::Markers, PaintType::Stroke, PaintType::Fill };
+
+    switch (m_type) {
+    case Type::Normal:
+    case Type::FillStrokeMarkers:
+        return fillStrokeMarkers;
+    case Type::FillMarkersStroke:
+        return fillMarkersStroke;
+    case Type::StrokeFillMarkers:
+        return strokeFillMarkers;
+    case Type::StrokeMarkersFill:
+        return strokeMarkersFill;
+    case Type::MarkersFillStroke:
+        return markersFillStroke;
+    case Type::MarkersStrokeFill:
+        return markersStrokeFill;
+    };
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+// MARK: - Conversion
+
+auto CSSValueConversion<SVGPaintOrder>::operator()(BuilderState& state, const CSSValue& value) -> SVGPaintOrder
+{
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueNormal:
+            return CSS::Keyword::Normal { };
+        case CSSValueFill:
+            return CSS::Keyword::Fill { };
+        case CSSValueStroke:
+            return CSS::Keyword::Stroke { };
+        case CSSValueMarkers:
+            return CSS::Keyword::Markers { };
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::Normal { };
+        }
+    }
+
+    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue, 1>(state, value);
+    if (!list)
+        return CSS::Keyword::Normal { };
+
+    switch (Ref first = list->item(0); first->valueID()) {
+    case CSSValueFill:
+        if (list->size() > 1) {
+            switch (Ref second = list->item(1); second->valueID()) {
+            case CSSValueMarkers:
+                return { CSS::Keyword::Fill { }, CSS::Keyword::Markers { } };
+            default:
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Normal { };
+            }
+        }
+        return CSS::Keyword::Fill { };
+    case CSSValueStroke:
+        if (list->size() > 1) {
+            switch (Ref second = list->item(1); second->valueID()) {
+            case CSSValueMarkers:
+                return { CSS::Keyword::Stroke { }, CSS::Keyword::Markers { } };
+            default:
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Normal { };
+            }
+        }
+        return CSS::Keyword::Stroke { };
+    case CSSValueMarkers:
+        if (list->size() > 1) {
+            switch (Ref second = list->item(1); second->valueID()) {
+            case CSSValueStroke:
+                return { CSS::Keyword::Markers { }, CSS::Keyword::Stroke { } };
+            default:
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Normal { };
+            }
+        }
+        return CSS::Keyword::Markers { };
+    default:
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return CSS::Keyword::Normal { };
+    }
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/svg/StyleSVGPaintOrder.h
+++ b/Source/WebCore/style/values/svg/StyleSVGPaintOrder.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+enum class PaintType : uint8_t { Fill, Stroke, Markers };
+
+// <'paint-order'> = normal | [ fill || stroke || markers ]
+// https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty
+struct SVGPaintOrder {
+    using value_type = std::span<const PaintType, 3>::value_type;
+    using iterator = std::span<const PaintType, 3>::iterator;
+
+    constexpr SVGPaintOrder(CSS::Keyword::Normal) { }
+    constexpr SVGPaintOrder(CSS::Keyword::Fill) : m_type { Type::FillStrokeMarkers } { }
+    constexpr SVGPaintOrder(CSS::Keyword::Fill, CSS::Keyword::Markers) : m_type { Type::FillMarkersStroke } { }
+    constexpr SVGPaintOrder(CSS::Keyword::Stroke) : m_type { Type::StrokeFillMarkers } { }
+    constexpr SVGPaintOrder(CSS::Keyword::Stroke, CSS::Keyword::Markers) : m_type { Type::StrokeMarkersFill } { }
+    constexpr SVGPaintOrder(CSS::Keyword::Markers) : m_type { Type::MarkersFillStroke } { }
+    constexpr SVGPaintOrder(CSS::Keyword::Markers, CSS::Keyword::Stroke) : m_type { Type::MarkersStrokeFill } { }
+
+    constexpr bool isNormal() const { return m_type == Type::Normal; }
+
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        switch (m_type) {
+        case Type::Normal:
+            return visitor(CSS::Keyword::Normal { });
+        case Type::FillStrokeMarkers:
+            return visitor(CSS::Keyword::Fill { });
+        case Type::FillMarkersStroke:
+            return visitor(SpaceSeparatedTuple { CSS::Keyword::Fill { }, CSS::Keyword::Markers { } });
+        case Type::StrokeFillMarkers:
+            return visitor(CSS::Keyword::Stroke { });
+        case Type::StrokeMarkersFill:
+            return visitor(SpaceSeparatedTuple { CSS::Keyword::Stroke { }, CSS::Keyword::Markers { } });
+        case Type::MarkersFillStroke:
+            return visitor(CSS::Keyword::Markers { });
+        case Type::MarkersStrokeFill:
+            return visitor(SpaceSeparatedTuple { CSS::Keyword::Markers { }, CSS::Keyword::Stroke { } });
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    std::span<const PaintType, 3> paintTypes() const;
+
+    iterator begin() const { return paintTypes().begin(); }
+    iterator end() const { return paintTypes().end(); }
+
+    constexpr bool operator==(const SVGPaintOrder&) const = default;
+
+    // NOTE: The Type is exposed only to allow efficient storage using a bitfield.
+    enum class Type : uint8_t {
+        Normal,
+        FillStrokeMarkers,
+        FillMarkersStroke,
+        StrokeFillMarkers,
+        StrokeMarkersFill,
+        MarkersFillStroke,
+        MarkersStrokeFill,
+    };
+    constexpr SVGPaintOrder(Type type) : m_type { type } { }
+    constexpr Type type() const { return m_type; }
+
+private:
+    Type m_type { Type::Normal };
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<SVGPaintOrder> { auto operator()(BuilderState&, const CSSValue&) -> SVGPaintOrder; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGPaintOrder)


### PR DESCRIPTION
#### 58ef9bb45e0fba24078783593de939a9d5601805
<pre>
[Style] Convert the &apos;paint-order&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=301288">https://bugs.webkit.org/show_bug.cgi?id=301288</a>

Reviewed by Darin Adler and Antti Koivisto.

Converts the &apos;paint-order&apos; property to use strong style types.

Simplifies users by making the type able to be iterated directly.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/TextPaintStyle.h:
* Source/WebCore/rendering/TextPainter.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
* Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/svg/StyleSVGPaintOrder.cpp: Added.
* Source/WebCore/style/values/svg/StyleSVGPaintOrder.h: Added.

Canonical link: <a href="https://commits.webkit.org/302300@main">https://commits.webkit.org/302300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdeff52143646de986696e76605656916dca9452

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128669 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136056 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/810 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115280 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/78572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33390 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79336 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/33869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138511 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/719 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/808 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/111619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/106311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27071 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/30149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53138 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/821 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64075 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->