### PR TITLE
[Back-deployment] Install libswiftCompatibilitySpan.dylib into StagedFrameworks directory

### DIFF
--- a/Source/WebGPU/Configurations/WebGPU.xcconfig
+++ b/Source/WebGPU/Configurations/WebGPU.xcconfig
@@ -143,3 +143,8 @@ EXCLUDED_SOURCE_FILE_NAMES_ = *.swift;
 
 BUILD_LIBRARY_FOR_DISTRIBUTION = YES; // This is required for all frameworks in the OS.
 RUN_SWIFT_ABI_CHECKER_TOOL = NO
+
+// When back-deploying for STP and downlevel builds, force Xcode to embed any
+// compatibility runtimes alongside WebKit.framework.
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = $(WK_USE_OVERRIDE_FRAMEWORKS_DIR);
+SWIFT_STDLIB_TOOL_DESTINATION_DIR = $(DSTROOT)$(WK_OVERRIDE_FRAMEWORKS_DIR);


### PR DESCRIPTION
#### 322c19a3d449ee9ad70a4398165d334afc8affa9
<pre>
[Back-deployment] Install libswiftCompatibilitySpan.dylib into StagedFrameworks directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=301293">https://bugs.webkit.org/show_bug.cgi?id=301293</a>
<a href="https://rdar.apple.com/162905280">rdar://162905280</a>

Reviewed by Mike Wyrzykowski.

When using recent Swift language features and back-deploying to older OS
versions, the compiler will automatically link against a compatibility
dylib for runtime support. Configure Xcode to install this dylib to the
StagedFrameworks directory when building WebKit for downlevels and STP.

The result is a library layout like:
    ./System/Cryptexes/App/System/Library/StagedFrameworks/Safari/WebGPU.framework
    ./System/Cryptexes/App/System/Library/StagedFrameworks/Safari/WebKit.framework
    ./System/Cryptexes/App/System/Library/StagedFrameworks/Safari/libswiftCompatibilitySpan.dylib
    ./System/Cryptexes/App/System/Library/StagedFrameworks/Safari/libwebrtc.dylib
and so on.

By default, Xcode scans application bundles for needed compatibility
libaries and embeds them automatically, but this does not work for our
project layout, where we install frameworks as siblings onto the system,
and Safari.app is in a separate location altogether. Use
ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to force the scanner to run, and
run it from WebGPU, which is currently the one place where we use Span.

* Source/WebGPU/Configurations/WebGPU.xcconfig:

Canonical link: <a href="https://commits.webkit.org/301973@main">https://commits.webkit.org/301973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c374f45255fbc7fb89cfc8a81590eda04741b201

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38481 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/134936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f67137fb-e864-4d2d-af67-d42c7e64934a) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/47938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55844 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/134936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7b68e33c-2cf1-4292-a201-a0f169832b0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130613 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/47938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/114359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/134936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/47938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/78295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/47938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/32906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/137419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/54324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/41875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/137419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54835 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/110716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/137419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/50873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19954 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/54261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/60437 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/53496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/56952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/55254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->