### PR TITLE
WebGPU  GPUQueue.copyExternalImageToTexture Integer Overflow

### DIFF
--- a/LayoutTests/fast/webgpu/repro_301290-expected.txt
+++ b/LayoutTests/fast/webgpu/repro_301290-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: OperationError: GPUQueue.copyExternalImageToTexture: External image state is not valid
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x8
+  RenderBlock {HTML} at (0,0) size 800x8
+    RenderBody {BODY} at (8,8) size 784x0

--- a/LayoutTests/fast/webgpu/repro_301290.html
+++ b/LayoutTests/fast/webgpu/repro_301290.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+
+<body>
+    <script>
+        (async () => {
+            if (!navigator.gpu)
+                throw new Error("WebGPU unavailable");
+
+            const adapter = await navigator.gpu.requestAdapter();
+            const device = await adapter.requestDevice();
+            const queue = device.queue;
+
+            const texture = device.createTexture({
+                size: [1, 1, 1],
+                format: "rgba8unorm",
+                usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+            });
+
+            const pixel = new Uint8ClampedArray([255, 0, 0, 255]);
+            const image = new ImageData(pixel, 1, 1);
+
+            const extent = { width: 1, height: 1, depthOrArrayLayers: 1 };
+            const destination = {
+                texture,
+                mipLevel: 0,
+                origin: { x: 0, y: 0, z: 0 },
+                premultipliedAlpha: false,
+            };
+
+            const exploitOrigin = 0xFFFFFFFF; // wraps when added to any non-zero copySize component
+
+            const source = {
+                source: image,
+                origin: { x: exploitOrigin, y: 0 },
+                flipY: false,
+            };
+
+            try {
+                for (let i = 0; i < 100; ++i)
+                    queue.copyExternalImageToTexture(source, destination, extent);
+            } catch (ex) {
+                console.log(ex);
+            }
+
+            await queue.onSubmittedWorkDone();
+            console.log("Payload sent; watch for crash/corruption.");
+        })();
+
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
#### 7f49e34b9a178a68c34b463731bb8756eeb1fbea
<pre>
WebGPU  GPUQueue.copyExternalImageToTexture Integer Overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=301290">https://bugs.webkit.org/show_bug.cgi?id=301290</a>
<a href="https://rdar.apple.com/163040732">rdar://163040732</a>

Reviewed by Dan Glastonbury.

Check for overflow while checking the origin is within range.

OOB access was within a span&lt;&gt; so crash was safe but we still
don&apos;t want to crash here.

Test: fast/webgpu/repro_301290.html
* LayoutTests/fast/webgpu/repro_301290-expected.txt: Added.
* LayoutTests/fast/webgpu/repro_301290.html: Added.
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::isStateValid):

Canonical link: <a href="https://commits.webkit.org/301984@main">https://commits.webkit.org/301984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2907eee0d5d56d9172220a604586a409d9425d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79213 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d8459b87-7676-4180-8192-12cec362e3e8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97175 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65079 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7a4d56e9-935d-4065-ae34-85ca24cddbd4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114351 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77656 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/523a7108-a13e-44f0-8b19-d8f896009701) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32443 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78286 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137410 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105693 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105345 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26869 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29296 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/51927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60428 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53487 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56943 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55245 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->