### PR TITLE
REGRESSION (iOS 26): Pasting content cut from Notes into Mail is illegible in dark mode

### DIFF
--- a/LayoutTests/editing/pasteboard/paste-dark-mode-color-filtered-expected.txt
+++ b/LayoutTests/editing/pasteboard/paste-dark-mode-color-filtered-expected.txt
@@ -1,6 +1,6 @@
 This test checks that pasting into a color filtered dark mode document inserts light mode transformed content.
 
-PASS pastedMarkup is '<span style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);">Hello</span>'
+PASS pastedMarkup is '<span style="background-color: rgb(255, 255, 255);">Hello</span>'
 PASS pastedMarkup is '<span style="caret-color: rgb(21, 21, 21); color: rgb(21, 21, 21); background-color: rgb(255, 255, 255);">Hello</span>'
 PASS pastedMarkup is '<span style="caret-color: rgb(21, 21, 21); color: rgb(21, 21, 21); background-color: rgb(213, 213, 213);">Hello</span>'
 PASS pastedMarkup is '<span style="color: rgb(106, 106, 106);">Hello</span><span style="color: rgb(127, 128, 127);">Hello 2</span>'
@@ -8,7 +8,7 @@ PASS pastedMarkup is '<span style="caret-color: rgb(127, 128, 127); color: rgb(1
 PASS pastedMarkup is '<span style="caret-color: rgb(170, 170, 170); color: rgb(170, 170, 170);">Hello</span>'
 PASS pastedMarkup is '<span style="caret-color: rgb(191, 191, 191); color: rgb(191, 191, 191);">Hello</span>'
 PASS pastedMarkup is '<span style="caret-color: rgb(22, 22, 22); color: rgb(22, 22, 22); background-color: rgb(255, 255, 255);">Hello</span>'
-PASS pastedMarkup is '<li>Item 1</li><li><span style="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);">Hello</span></li><li>Item 2</li>'
+PASS pastedMarkup is '<li>Item 1</li><li><span style="background-color: rgb(255, 255, 255);">Hello</span></li><li>Item 2</li>'
 PASS pastedMarkup is '<li>Item 1</li><li style="color: rgb(21, 21, 21); background-color: rgb(213, 213, 213);">Hello 1</li><li>Hello 2</li><li>Item 2</li>'
 PASS pastedMarkup is '<li>Item 1</li><li>Hello 1</li><li style="color: rgb(127, 128, 127);">Hello 2</li><li>Item 2</li>'
 PASS pastedMarkup is '<span style="caret-color: rgb(101, 101, 101); color: rgb(101, 101, 101);">Hello</span>'

--- a/LayoutTests/editing/pasteboard/paste-dark-mode-color-filtered.html
+++ b/LayoutTests/editing/pasteboard/paste-dark-mode-color-filtered.html
@@ -59,7 +59,7 @@
     }
 
     // Transformed on paste
-    testCopyPaste("<span style=\"color: white; background-color: black\">Hello</span>", "<span style=\"caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);\">Hello</span>");
+    testCopyPaste("<span style=\"color: white; background-color: black\">Hello</span>", "<span style=\"background-color: rgb(255, 255, 255);\">Hello</span>");
     testCopyPaste("<span style=\"color: rgb(238, 238, 238); background-color: rgb(51, 51, 51)\">Hello</span>", "<span style=\"caret-color: rgb(21, 21, 21); color: rgb(21, 21, 21); background-color: rgb(255, 255, 255);\">Hello</span>");
     testCopyPaste("<span style=\"color: rgb(238, 238, 238); background-color: rgb(85, 85, 85)\">Hello</span>", "<span style=\"caret-color: rgb(21, 21, 21); color: rgb(21, 21, 21); background-color: rgb(213, 213, 213);\">Hello</span>");
     testCopyPaste("<span style=\"color: rgb(170, 170, 170)\">Hello</span><span style=\"color: rgb(153, 153, 153)\">Hello 2</span>", "<span style=\"color: rgb(106, 106, 106);\">Hello</span><span style=\"color: rgb(127, 128, 127);\">Hello 2</span>");
@@ -69,7 +69,7 @@
     testCopyPaste("<span style=\"color: color(display-p3 0.93 0.93 0.93); background-color: color(display-p3 0.2 0.2 0.2)\">Hello</span>", "<span style=\"caret-color: rgb(22, 22, 22); color: rgb(22, 22, 22); background-color: rgb(255, 255, 255);\">Hello</span>");
 
     // Transformed list items on paste
-    testCopyPaste("<li><span style=\"color: white; background-color: black\">Hello</span></li>", "<li>Item 1</li><li><span style=\"color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);\">Hello</span></li><li>Item 2</li>", true);
+    testCopyPaste("<li><span style=\"color: white; background-color: black\">Hello</span></li>", "<li>Item 1</li><li><span style=\"background-color: rgb(255, 255, 255);\">Hello</span></li><li>Item 2</li>", true);
     testCopyPaste("<li style=\"color: rgb(238, 238, 238); background-color: rgb(85, 85, 85)\">Hello 1</li><li>Hello 2</li>", "<li>Item 1</li><li style=\"color: rgb(21, 21, 21); background-color: rgb(213, 213, 213);\">Hello 1</li><li>Hello 2</li><li>Item 2</li>", true);
     testCopyPaste("<li>Hello 1</li><li style=\"color: rgb(153, 153, 153)\">Hello 2</li>", "<li>Item 1</li><li>Hello 1</li><li style=\"color: rgb(127, 128, 127);\">Hello 2</li><li>Item 2</li>", true);
 

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -310,7 +310,8 @@ void ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::sanitizeDataIfNee
         if (markupToSanitize.isEmpty())
             return;
 
-        m_data = { sanitizeMarkup(markupToSanitize) };
+        RefPtr document = documentFromClipboard(RefPtr { m_writingDestination.get() }.get());
+        m_data = { sanitizeMarkup(markupToSanitize, document.get()) };
     }
 
     if (m_type == "image/png"_s) {

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -283,7 +283,7 @@ void DataTransfer::setDataFromItemList(Document& document, const String& type, c
 
     String sanitizedData;
     if (type == "text/html"_s)
-        sanitizedData = sanitizeMarkup(data);
+        sanitizedData = sanitizeMarkup(data, &document);
     else if (type == "text/uri-list"_s) {
         auto url = URL({ }, data);
         if (url.isValid())

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -198,7 +198,7 @@ ReplacementFragment::ReplacementFragment(RefPtr<DocumentFragment>&& inputFragmen
         return;
     }
 
-    Ref page = createPageForSanitizingWebContent();
+    Ref page = createPageForSanitizingWebContent(&editableRoot->document());
     RefPtr stagingDocument = page->localTopDocument();
     if (!stagingDocument)
         return;
@@ -1427,12 +1427,17 @@ void ReplaceSelectionCommand::doApply()
     if (!insertedNodes.firstNodeInserted()->isConnected())
         return;
 
-    if (needsColorTransformed)
-        inverseTransformColor(insertedNodes);
-
     removeRedundantStylesAndKeepStyleSpanInline(insertedNodes);
     if (insertedNodes.isEmpty())
         return;
+
+    if (needsColorTransformed) {
+        inverseTransformColor(insertedNodes);
+
+        removeRedundantStylesAndKeepStyleSpanInline(insertedNodes);
+        if (insertedNodes.isEmpty())
+            return;
+    }
 
     if (m_sanitizeFragment)
         applyCommandToComposite(SimplifyMarkupCommand::create(document(), insertedNodes.firstNodeInserted(), insertedNodes.pastLastLeaf()));

--- a/Source/WebCore/editing/glib/WebContentReaderGLib.cpp
+++ b/Source/WebCore/editing/glib/WebContentReaderGLib.cpp
@@ -98,7 +98,7 @@ bool WebContentMarkupReader::readHTML(const String& string)
         return false;
 
     if (shouldSanitize()) {
-        m_markup = sanitizeMarkup(string, MSOListQuirks::Disabled, Function<void(DocumentFragment&)> { [](DocumentFragment& fragment) {
+        m_markup = sanitizeMarkup(string, frame().document(), MSOListQuirks::Disabled, Function<void(DocumentFragment&)> { [](DocumentFragment& fragment) {
             removeSubresourceURLAttributes(fragment, [](const URL& url) {
                 return shouldReplaceSubresourceURL(url);
             });

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -59,9 +59,9 @@ template<typename> class ExceptionOr;
 void replaceSubresourceURLs(Ref<DocumentFragment>&&, HashMap<AtomString, AtomString>&&);
 void removeSubresourceURLAttributes(Ref<DocumentFragment>&&, Function<bool(const URL&)> shouldRemoveURL);
 
-Ref<Page> createPageForSanitizingWebContent();
+Ref<Page> createPageForSanitizingWebContent(Document* destinationDocument);
 enum class MSOListQuirks : bool { CheckIfNeeded, Disabled };
-String sanitizeMarkup(const String&, MSOListQuirks = MSOListQuirks::Disabled, std::optional<Function<void(DocumentFragment&)>> fragmentSanitizer = std::nullopt);
+String sanitizeMarkup(const String&, Document* destinationDocument, MSOListQuirks = MSOListQuirks::Disabled, std::optional<Function<void(DocumentFragment&)>> fragmentSanitizer = std::nullopt);
 String sanitizedMarkupForFragmentInDocument(Ref<DocumentFragment>&&, Document&, MSOListQuirks, const String& originalMarkup);
 
 class UserSelectNoneStateCache {


### PR DESCRIPTION
#### 6cae1bfde08c0c5e7e3c8e95af3d09480e85a8e6
<pre>
REGRESSION (iOS 26): Pasting content cut from Notes into Mail is illegible in dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=301300">https://bugs.webkit.org/show_bug.cgi?id=301300</a>
<a href="https://rdar.apple.com/157387343">rdar://157387343</a>

Reviewed by Richard Robinson, Ryosuke Niwa, Wenson Hsieh, and Abrar Rahman Protyasha.

When pasting a web archive, markup is sanitized before it is inserted into the
destination document. Sanitization is performed by inserting the markup into a
new document, and then serializing the contents back into a markup string.
During the sanitization step, styles are re-serialized. This step adds inline
styles to the markup in order to preserve visual appearance.

As a result of the serialization step, markup such as `&lt;span&gt;Content&lt;/span&gt;` is
transformed into `&lt;span style=&quot;color: rgb(0, 0, 0)&quot;&gt;Content&lt;/span&gt;` (note that
other inline styles are omitted in this example for brevity). The black text
color is due to the fact that the document and page used for sanitization are
both in light mode, and the text color is `canvastext`.

In iOS 26, Mail removed their use of `-apple-color-filter: -apple-invert-lightness()`
on documents that explicitly declare dark mode support. This change extends to
new, empty, Mail compose windows, which have `color-scheme: light dark` specified
on `:root`. As a result, the black text color is no longer inverted to white, and
the pasted text is illegible.

To fix, make the page and document used for markup sanitization dark-mode aware.
This ensures that the sanitized content will specify a dark mode color in inline
style. Ultimately, the inline style will be stripped during the pre-existing
style deduplication step.

* LayoutTests/editing/pasteboard/paste-dark-mode-color-filtered-expected.txt:
* LayoutTests/editing/pasteboard/paste-dark-mode-color-filtered.html:

Rebaseline following the change in `ReplaceSelectionCommand::doApply`. The change
is okay, since the visual appearance is still the same (text remains legible in
dark mode).

* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::sanitizeDataIfNeeded):
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::setDataFromItemList):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplacementFragment::ReplacementFragment):
(WebCore::ReplaceSelectionCommand::doApply):

In order to keep `PasteHTML.TransformColorsOfDarkContentButNotSemanticColor`
passing, remove redundant styles *before* performing color inversion. Without
this change, an unnecessary `caret-color: rgb(0, 0, 0)` would be added, since
`caret-color: auto/currentcolor` resolves to a computed color. Following the
rest of this patch, that would be `caret-color: rgb(255, 255, 255)` in dark mode.
However, that value would be inverted (`inverseTransformColorIfNeeded`) upon
insertion, for documents that use `-apple-color-filter: -apple-invert-lightness()`.
As a result, the final markup would be `caret-color: rgb(0, 0, 0)`. Since that
value differs from the document&apos;s default caret-color (white in dark mode), it
would be preserved in inline style.

This change should be safe since color inversion would only be skipped if the
content is already illegible.

Continue to also remove redundant styles after performing color inversion, to
avoid introducing unnecessary markup.

* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::createFragmentInternal):
(WebCore::sanitizeMarkupWithArchive):
(WebCore::WebContentReader::readHTML):
(WebCore::WebContentMarkupReader::readHTML):
* Source/WebCore/editing/glib/WebContentReaderGLib.cpp:
(WebCore::WebContentMarkupReader::readHTML):
* Source/WebCore/editing/markup.cpp:
(WebCore::createPageForSanitizingWebContent):

Declare the document used for sanitization as supporting both light and dark
mode using the meta tag. Set up the appearance on the page used for sanitization
by forwarding values from the destination page.

The page only uses dark mode if the destination document is using dark mode. This
is done to avoid conditionalizing the existence of the meta tag.

(WebCore::sanitizeMarkup):
* Source/WebCore/editing/markup.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteWebArchive.mm:
(TEST(PasteWebArchive, DestinationUsesDarkMode)):

Canonical link: <a href="https://commits.webkit.org/302202@main">https://commits.webkit.org/302202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f171e8fccea18058ffc60b59a4fbc3bd2d531856

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135708 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79786 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f23cdad7-16bf-4269-891b-63fce5ee999e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97670 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65577 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/079b606f-fd79-4f83-89c6-b536dd6db04d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78261 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c00e65c-9abb-4d61-9924-a078363bee53) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33061 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78996 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138163 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106207 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106007 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/350 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29844 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52748 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20044 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/489 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63660 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/388 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/455 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/451 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->