### PR TITLE
Add frame attach and detach event tests for Web Inspector with various iframe conditions.

### DIFF
--- a/LayoutTests/http/tests/inspector/network/frame-attached-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/frame-attached-expected.txt
@@ -1,0 +1,20 @@
+
+== Running test suite: FrameAttached
+-- Running test case: FrameAttached.SameOriginIFrame
+PASS: Each attaching frame id should be unique
+PASS: Got total of 1 event(s)
+
+-- Running test case: FrameAttached.CrossOriginIFrame
+PASS: Each attaching frame id should be unique
+PASS: Got total of 1 event(s)
+
+-- Running test case: FrameAttached.EmbeddedSameOriginIFrame
+PASS: Each attaching frame id should be unique
+PASS: Each attaching frame id should be unique
+PASS: Got total of 2 event(s)
+
+-- Running test case: FrameAttached.EmbeddedCrossOriginIFrame
+PASS: Each attaching frame id should be unique
+PASS: Each attaching frame id should be unique
+PASS: Got total of 2 event(s)
+

--- a/LayoutTests/http/tests/inspector/network/frame-attached.html
+++ b/LayoutTests/http/tests/inspector/network/frame-attached.html
@@ -1,0 +1,79 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<script src="/inspector/resources/inspector-test.js"></script>
+
+<script>
+    // Utilities for page code.
+    async function addIFrame(url) {
+        return new Promise((resolve, reject) => {
+            const iframe = document.createElement("iframe");
+            iframe.src = url;
+            iframe.onload = () => {
+                console.log("iframe is loaded in " + location.href);
+                resolve(iframe);
+            };
+            iframe.onerror = reject;
+            document.body.appendChild(iframe);
+        });
+    }
+
+    function test() {
+        // The purpose of these tests are to test that Web Inspector should receive frame attached message from various iframe tree correctly.
+
+        const suite = InspectorTest.createAsyncSuite("Network.FrameAttached");
+
+        // Utilities for test code.
+        function runSubTest({resolve, expected}, func) {
+            let frameIds = new Set;
+            new EventCounter(WI.networkManager, WI.NetworkManager.Event.FrameWasAdded, (event, counter) => {
+                let {frame} = event.data;
+
+                InspectorTest.expectFalse(frameIds.has(frame.id), `Each attaching frame id should be unique`);
+                frameIds.add(frame.id);
+
+                if (counter.count === expected) {
+                    InspectorTest.expectEqual(counter.count, expected, `Got total of ${expected} event(s)`);
+                    counter.cleanup();
+                    resolve();
+                }
+            });
+
+            InspectorTest.evaluateInPage(func);
+        }
+
+        suite.addTestCase({
+            name: "Network.FrameAttached.SameOriginIFrame",
+            description: "add iframe with same origin",
+            test: (resolve) => runSubTest({resolve, expected: 1}, `
+                addIFrame("resources/iframe.html")
+            `),
+        });
+
+        suite.addTestCase({
+            name: "Network.FrameAttached.CrossOriginIFrame",
+            description: "add iframe with cross origin",
+            test: (resolve) => runSubTest({resolve, expected: 1}, `
+                addIFrame("http://localhost:8000/inspector/network/resources/iframe.html")
+            `),
+        });
+
+        suite.addTestCase({
+            name: "Network.FrameAttached.EmbeddedSameOriginIFrame",
+            description: "add embedded iframe with same origin",
+            test: (resolve) => runSubTest({resolve, expected: 2}, `
+                addIFrame("resources/iframe-same-origin.html")
+            `),
+        });
+
+        suite.addTestCase({
+            name: "Network.FrameAttached.EmbeddedCrossOriginIFrame",
+            description: "add embedded iframe with cross origin",
+            test: (resolve) => runSubTest({resolve, expected: 2}, `
+                addIFrame("http://localhost:8000/inspector/network/resources/iframe-cross-origin.html")
+            `),
+        });
+
+        suite.runTestCasesAndFinish();
+    }
+</script>
+
+<body onload="runTest()"></body>

--- a/LayoutTests/http/tests/inspector/network/frame-detached-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/frame-detached-expected.txt
@@ -1,0 +1,20 @@
+
+== Running test suite: FrameDetached
+-- Running test case: FrameDetached.SameOriginIFrame
+PASS: Each detaching frame id should be unique
+PASS: Got total of 1 event(s)
+
+-- Running test case: FrameDetached.CrossOriginIFrame
+PASS: Each detaching frame id should be unique
+PASS: Got total of 1 event(s)
+
+-- Running test case: FrameDetached.EmbeddedSameOriginIFrame
+PASS: Each detaching frame id should be unique
+PASS: Each detaching frame id should be unique
+PASS: Got total of 2 event(s)
+
+-- Running test case: FrameDetached.EmbeddedCrossOriginIFrame
+PASS: Each detaching frame id should be unique
+PASS: Each detaching frame id should be unique
+PASS: Got total of 2 event(s)
+

--- a/LayoutTests/http/tests/inspector/network/frame-detached.html
+++ b/LayoutTests/http/tests/inspector/network/frame-detached.html
@@ -1,0 +1,87 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<script src="/inspector/resources/inspector-test.js"></script>
+<script>
+    // Utilities for page code.
+    async function addIFrame(url) {
+        return new Promise((resolve, reject) => {
+            const iframe = document.createElement("iframe");
+            iframe.src = url;
+            iframe.onload = () => {
+                console.log("iframe is loaded in " + location.href);
+                resolve(iframe);
+            };
+            iframe.onerror = reject;
+            document.body.appendChild(iframe);
+        });
+    }
+
+    function removeFrame(iframe) {
+        iframe.remove();
+        console.log(`iframe was detached: src=${iframe.src}`);
+    }
+
+    function test() {
+        // The purpose of these tests are to test that Web Inspector should receive frame detached message from various iframe tree correctly.
+
+        let suite = InspectorTest.createAsyncSuite("Network.FrameDetached");
+
+        // Utilities for test code.
+        function runSubTest({resolve, expected}, func) {
+            let frameIds = new Set;
+            new EventCounter(WI.networkManager, WI.NetworkManager.Event.FrameWasRemoved, (event, counter) => {
+                let {frame} = event.data;
+
+                InspectorTest.expectFalse(frameIds.has(frame.id), `Each detaching frame id should be unique`);
+                frameIds.add(frame.id);
+
+                if (counter.count === expected) {
+                    InspectorTest.expectEqual(counter.count, expected, `Got total of ${expected} event(s)`);
+                    counter.cleanup();
+                    resolve();
+                }
+            });
+
+            InspectorTest.evaluateInPage(func);
+        }
+
+        suite.addTestCase({
+            name: "Network.FrameDetached.SameOriginIFrame",
+            description: "detach iframe with same origin",
+            test: (resolve) => runSubTest({resolve, expected: 1}, `
+                addIFrame("resources/iframe.html")
+                .then((iframe) => removeFrame(iframe));
+            `),
+        });
+
+        suite.addTestCase({
+            name: "Network.FrameDetached.CrossOriginIFrame",
+            description: "detach iframe with cross origin",
+            test: (resolve) => runSubTest({resolve, expected: 1}, `
+                addIFrame("http://localhost:8000/inspector/network/resources/iframe.html")
+                .then((iframe) => removeFrame(iframe));
+            `),
+        });
+
+        suite.addTestCase({
+            name: "Network.FrameDetached.EmbeddedSameOriginIFrame",
+            description: "detach embedded iframe with same origin",
+            test: (resolve) => runSubTest({resolve, expected: 2}, `
+                addIFrame("resources/iframe-same-origin.html")
+                .then((iframe) => removeFrame(iframe));
+            `),
+        });
+
+        suite.addTestCase({
+            name: "Network.FrameDetached.EmbeddedCrossOriginIFrame",
+            description: "detach embedded iframe with cross origin",
+            test: (resolve) => runSubTest({resolve, expected: 2}, `
+                addIFrame("http://localhost:8000/inspector/network/resources/iframe-cross-origin.html")
+                .then((iframe) => removeFrame(iframe));
+            `),
+        });
+
+        suite.runTestCasesAndFinish();
+    }
+</script>
+
+<body onload="runTest()"></body>

--- a/LayoutTests/http/tests/inspector/network/resources/iframe-cross-origin.html
+++ b/LayoutTests/http/tests/inspector/network/resources/iframe-cross-origin.html
@@ -1,0 +1,11 @@
+<p>iframe embedding other cross origin iframe</p>
+
+<script>
+
+const iframe = document.createElement("iframe");
+const crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+iframe.src = `http://${crossOriginHost}:8000/inspector/network/resources/iframe.html`;
+iframe.onload = () => console.log("iframe is loaded in " + location.href);
+document.body.appendChild(iframe);
+
+</script>

--- a/LayoutTests/http/tests/inspector/network/resources/iframe-same-origin.html
+++ b/LayoutTests/http/tests/inspector/network/resources/iframe-same-origin.html
@@ -1,0 +1,3 @@
+<p>iframe embedding other same origin iframe</p>
+
+<iframe src="iframe.html" onload="console.log('iframe is loaded in iframe ' + location.href)"></iframe>

--- a/LayoutTests/http/tests/inspector/network/resources/iframe.html
+++ b/LayoutTests/http/tests/inspector/network/resources/iframe.html
@@ -1,0 +1,7 @@
+<p>iframe</p>
+
+<script type="module">
+    console.log(`Hello from ${location.href}`);
+    console.warn(`Warning from ${location.href}`);
+    throw `Error from ${location.href}`;
+</script>

--- a/Source/WebInspectorUI/UserInterface/Test/TestUtilities.js
+++ b/Source/WebInspectorUI/UserInterface/Test/TestUtilities.js
@@ -56,3 +56,21 @@ function promisify(func) {
 function sanitizeURL(url) {
     return url.replace(/^.*?LayoutTests\//, "");
 }
+
+class EventCounter {
+    constructor(target, eventName, onEvent) {
+        this.count = 0;
+
+        let callback = (event) => {
+            this.count++;
+            onEvent(event, this);
+        };
+
+        target.addEventListener(eventName, callback);
+        this._cleanup = () => target.removeEventListener(eventName, callback);
+    }
+
+    cleanup() {
+        this._cleanup();
+    }
+}


### PR DESCRIPTION
#### 62a580b4fbd608372ce9256b6cd6435f7ec6f60e
<pre>
Add frame attach and detach event tests for Web Inspector with various iframe conditions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301303">https://bugs.webkit.org/show_bug.cgi?id=301303</a>
<a href="https://rdar.apple.com/163219061">rdar://163219061</a>

Reviewed by NOBODY (OOPS!).

Add tests for the event when frame is attached and detached in various situation:
- same/cross origin iframe.
- same origin grand child iframe embedded in same/cross origin iframe.

For consistent result, added utility class EventCounter to count number of event
sent to the target.

* LayoutTests/http/tests/inspector/network/frame-attached-expected.txt: Added.
* LayoutTests/http/tests/inspector/network/frame-attached.html: Added.
* LayoutTests/http/tests/inspector/network/frame-detached-expected.txt: Added.
* LayoutTests/http/tests/inspector/network/frame-detached.html: Added.
* LayoutTests/http/tests/inspector/network/resources/iframe-cross-origin.html: Added.
* LayoutTests/http/tests/inspector/network/resources/iframe-same-origin.html: Added.
* LayoutTests/http/tests/inspector/network/resources/iframe.html: Added.
* Source/WebInspectorUI/UserInterface/Test/TestUtilities.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62a580b4fbd608372ce9256b6cd6435f7ec6f60e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/158 "Built successfully") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79425 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/889b95e3-6b7c-4d88-b1ae-9130c8397faf) 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/101 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65249 "") | ⏳ 🛠 mac-apple 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/52 "Passed tests") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | ⏳ 🛠 vision-apple 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/56 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/security/dangling-markup-mitigation-data-url.tentative.sub.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32658 "Found 2 new test failures: http/tests/inspector/network/frame-attached.html http/tests/inspector/network/frame-detached.html (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108414 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33127 "Found 2 new test failures: http/tests/inspector/network/frame-attached.html http/tests/inspector/network/frame-detached.html (failure)") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22 "Found 2 new test failures: http/tests/inspector/network/frame-attached.html http/tests/inspector/network/frame-detached.html (failure)") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting to run tests") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/26921 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29475 "Found 2 new test failures: http/tests/inspector/network/frame-attached.html http/tests/inspector/network/frame-detached.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52180 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/76 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61534 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/91 "Built successfully") | | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->