### PR TITLE
Handle very large url pattern input

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1116,6 +1116,7 @@ fast/dom/connected-subframe-counter-overflow.html [ Slow ]
 # Slow on debug webkit.org/b/300706
 [ Debug ] fast/dom/DOMURL/url-very-large-password-no-crash.html [ Skip ]
 [ Debug ] fast/dom/DOMURL/url-very-large-username-no-crash.html [ Skip ]
+[ Debug ] fast/url/url-pattern-very-large-string.html [ Skip ]
 
 http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data.html [ Skip ]
 http/wpt/service-workers/basic-fetch-with-contentfilter.https.html [ Skip ]

--- a/LayoutTests/fast/url/url-pattern-very-large-string-expected.txt
+++ b/LayoutTests/fast/url/url-pattern-very-large-string-expected.txt
@@ -1,0 +1,12 @@
+Test that trying to create a URLPattern with a very large input string will not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Attemping to set large string as input to URLPattern...
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+PASS url-pattern-very-large-string
+

--- a/LayoutTests/fast/url/url-pattern-very-large-string.html
+++ b/LayoutTests/fast/url/url-pattern-very-large-string.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+    test(function() {
+        description('Test that trying to create a URLPattern with a very large input string will not crash.');
+        const largeSize = 500_000_000;
+        const largeString = "\u0000".repeat(largeSize);
+
+        assert_throws_js(TypeError, function() {
+            debug("Attemping to set large string as input to URLPattern...");
+            let urlPattern = new URLPattern(largeString);
+        });
+    });
+
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h
@@ -57,6 +57,7 @@ private:
     size_t m_index { 0 };
     size_t m_nextIndex { 0 };
     char32_t m_codepoint;
+    bool m_tokenAppendFailure { false };
 
     void getNextCodePoint();
     void seekNextCodePoint(size_t index);


### PR DESCRIPTION
#### f5e47e092767eeb0b5168de1ba58899a0162222a
<pre>
Handle very large url pattern input
<a href="https://bugs.webkit.org/show_bug.cgi?id=301302">https://bugs.webkit.org/show_bug.cgi?id=301302</a>
<a href="https://rdar.apple.com/163099884">rdar://163099884</a>

Reviewed by Ryosuke Niwa and Matthieu Dubet.

When creating a URLPattern with a string as an input, it is possible to
create it with a string so large that the underlying token list (vector)
will intentionally crash when performing an append operation and the
capacity cannot be increased. Check the result of each token append
operation and throw an exception if an append cannot be performed.

Test: fast/dom/DOMURL/url-pattern-very-large-string.html

* LayoutTests/fast/dom/DOMURL/url-pattern-very-large-string-expected.txt: Added.
* LayoutTests/fast/dom/DOMURL/url-pattern-very-large-string.html: Added.
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp:
(WebCore::URLPatternUtilities::Tokenizer::addToken):
(WebCore::URLPatternUtilities::Tokenizer::tokenize):
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h:

Canonical link: <a href="https://commits.webkit.org/302131@main">https://commits.webkit.org/302131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df19ca36f5e51a664ad25ea9b8a9c36eea6a4cd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79603 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/34cf63a5-b6d2-4356-84fb-28e3ee31beff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97522 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65414 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/186825f0-e056-4d65-bc64-9defb29bdb0d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78092 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9391f5d-7c2d-4eed-bd58-8bbdaebf77e5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32867 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78784 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137964 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106050 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105789 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26970 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/182 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29657 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52423 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/290 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61783 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/199 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/273 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/249 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->