### PR TITLE
Migrate more RemoteLayerTreeTransaction members from transaction scope to main frame scope

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -121,8 +121,6 @@ header: "RemoteLayerBackingStore.h"
     Vector<WebCore::PlatformLayerIdentifier> m_videoLayerIDsPendingFullscreen;
     Vector<WebCore::PlatformLayerIdentifier> m_layerIDsWithNewlyUnreachableBackingStore;
 
-    Vector<IPC::AsyncReplyID> m_callbackIDs;
-
     WebCore::IntSize m_contentsSize;
     WebCore::IntSize m_scrollGeometryContentSize;
     WebCore::IntPoint m_scrollOrigin;
@@ -130,16 +128,6 @@ header: "RemoteLayerBackingStore.h"
     WebCore::LayoutPoint m_minStableLayoutViewportOrigin;
     WebCore::LayoutPoint m_maxStableLayoutViewportOrigin;
     WebCore::IntPoint m_scrollPosition;
-    WebCore::Color m_themeColor;
-    WebCore::Color m_pageExtendedBackgroundColor;
-    WebCore::Color m_sampledPageTopColor;
-    std::optional<WebCore::FixedContainerEdges> m_fixedContainerEdges;
-
-#if PLATFORM(MAC)
-    Markable<WebCore::PlatformLayerIdentifier> m_pageScalingLayerID;
-    Markable<WebCore::PlatformLayerIdentifier> m_scrolledContentsLayerID;
-    Markable<WebCore::PlatformLayerIdentifier> m_mainFrameClipLayerID;
-#endif
 
     double m_pageScaleFactor;
     double m_minimumScaleFactor;
@@ -149,15 +137,12 @@ header: "RemoteLayerBackingStore.h"
     WebCore::InteractiveWidget m_viewportMetaTagInteractiveWidget;
     uint64_t m_renderTreeSize;
     WebKit::TransactionID m_transactionID;
-    OptionSet<WebCore::LayoutMilestone> m_newlyReachedPaintingMilestones;
     bool m_scaleWasSetByUIProcess;
     bool m_allowsUserScaling;
     bool m_avoidsUnsafeArea;
     bool m_viewportMetaTagWidthWasExplicit;
     bool m_viewportMetaTagCameFromImageDocument;
-    bool m_isInStableState;
 
-    std::optional<WebKit::EditorState> m_editorState;
 #if PLATFORM(IOS_FAMILY)
     std::optional<uint64_t> m_dynamicViewportSizeUpdateID;
 #endif
@@ -290,14 +275,34 @@ headers: "LayerProperties.h" "PlatformCALayerRemote.h"
 
 using WebKit::LayerHostingContextID = uint32_t;
 
-using WebKit::RemoteLayerTreeCommitBundle::RootFrameData = std::pair<WebKit::RemoteLayerTreeTransaction, WebKit::RemoteScrollingCoordinatorTransaction>;
+header: "RemoteLayerTreeCommitBundle.h"
 
-headers: "RemoteLayerTreeCommitBundle.h"
-struct WebKit::RemoteLayerTreeCommitBundle {
-    Vector<WebKit::RemoteLayerTreeCommitBundle::RootFrameData> transactions;
-    std::optional<WebKit::RemoteLayerTreeCommitBundle::MainFrameData> mainFrameData;
+using WebKit::PageData::TransactionCallbackID = IPC::AsyncReplyID;
+
+[CustomHeader] struct WebKit::PageData {
+    Vector<WebKit::PageData::TransactionCallbackID> callbackIDs;
 };
 
-[Nested] struct WebKit::RemoteLayerTreeCommitBundle::MainFrameData {
+[CustomHeader] struct WebKit::MainFrameData {
     WebKit::ActivityStateChangeID activityStateChangeID;
+    WebCore::Color themeColor;
+    WebCore::Color pageExtendedBackgroundColor;
+    WebCore::Color sampledPageTopColor;
+    std::optional<WebKit::EditorState> editorState;
+    OptionSet<WebCore::LayoutMilestone> newlyReachedPaintingMilestones;
+    std::optional<WebCore::FixedContainerEdges> fixedContainerEdges;
+    bool isInStableState;
+#if PLATFORM(MAC)
+    Markable<WebCore::PlatformLayerIdentifier> pageScalingLayerID;
+    Markable<WebCore::PlatformLayerIdentifier> scrolledContentsLayerID;
+    Markable<WebCore::PlatformLayerIdentifier> mainFrameClipLayerID;
+#endif
+};
+
+using WebKit::RemoteLayerTreeCommitBundle::RootFrameData = std::pair<WebKit::RemoteLayerTreeTransaction, WebKit::RemoteScrollingCoordinatorTransaction>;
+
+struct WebKit::RemoteLayerTreeCommitBundle {
+    Vector<WebKit::RemoteLayerTreeCommitBundle::RootFrameData> transactions;
+    WebKit::PageData pageData;
+    std::optional<WebKit::MainFrameData> mainFrameData;
 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
@@ -25,21 +25,44 @@
 
 #pragma once
 
+#include "Connection.h"
+#include "EditorState.h"
 #include "RemoteLayerTreeTransaction.h"
 #include "RemoteScrollingCoordinatorTransaction.h"
+#include <WebCore/Color.h>
+#include <WebCore/LayoutMilestone.h>
 #include <optional>
 #include <wtf/Vector.h>
 
 namespace WebKit {
 
+struct PageData {
+    using TransactionCallbackID = IPC::AsyncReplyID;
+
+    Vector<TransactionCallbackID> callbackIDs;
+};
+
+struct MainFrameData {
+    ActivityStateChangeID activityStateChangeID { ActivityStateChangeAsynchronous };
+    WebCore::Color themeColor;
+    WebCore::Color pageExtendedBackgroundColor;
+    WebCore::Color sampledPageTopColor;
+    std::optional<EditorState> editorState;
+    OptionSet<WebCore::LayoutMilestone> newlyReachedPaintingMilestones;
+    std::optional<WebCore::FixedContainerEdges> fixedContainerEdges;
+    bool isInStableState { false };
+#if PLATFORM(MAC)
+    Markable<WebCore::PlatformLayerIdentifier> pageScalingLayerID;
+    Markable<WebCore::PlatformLayerIdentifier> scrolledContentsLayerID;
+    Markable<WebCore::PlatformLayerIdentifier> mainFrameClipLayerID;
+#endif
+};
+
 struct RemoteLayerTreeCommitBundle {
     using RootFrameData = std::pair<RemoteLayerTreeTransaction, RemoteScrollingCoordinatorTransaction>;
+
     Vector<RootFrameData> transactions;
-
-    struct MainFrameData {
-        ActivityStateChangeID activityStateChangeID { ActivityStateChangeAsynchronous };
-    };
-
+    PageData pageData;
     std::optional<MainFrameData> mainFrameData;
 };
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -189,15 +189,6 @@ public:
     WebCore::LayoutPoint maxStableLayoutViewportOrigin() const { return m_maxStableLayoutViewportOrigin; }
     void setMaxStableLayoutViewportOrigin(const WebCore::LayoutPoint& point) { m_maxStableLayoutViewportOrigin = point; };
 
-    WebCore::Color themeColor() const { return m_themeColor; }
-    void setThemeColor(WebCore::Color color) { m_themeColor = color; }
-
-    WebCore::Color pageExtendedBackgroundColor() const { return m_pageExtendedBackgroundColor; }
-    void setPageExtendedBackgroundColor(WebCore::Color color) { m_pageExtendedBackgroundColor = color; }
-
-    WebCore::Color sampledPageTopColor() const { return m_sampledPageTopColor; }
-    void setSampledPageTopColor(WebCore::Color color) { m_sampledPageTopColor = color; }
-
     WebCore::IntPoint scrollPosition() const { return m_scrollPosition; }
     void setScrollPosition(WebCore::IntPoint p) { m_scrollPosition = p; }
 
@@ -206,17 +197,6 @@ public:
 
     bool scaleWasSetByUIProcess() const { return m_scaleWasSetByUIProcess; }
     void setScaleWasSetByUIProcess(bool scaleWasSetByUIProcess) { m_scaleWasSetByUIProcess = scaleWasSetByUIProcess; }
-
-#if PLATFORM(MAC)
-    std::optional<WebCore::PlatformLayerIdentifier> pageScalingLayerID() const { return m_pageScalingLayerID.asOptional(); }
-    void setPageScalingLayerID(std::optional<WebCore::PlatformLayerIdentifier> layerID) { m_pageScalingLayerID = layerID; }
-
-    std::optional<WebCore::PlatformLayerIdentifier> scrolledContentsLayerID() const { return m_scrolledContentsLayerID.asOptional(); }
-    void setScrolledContentsLayerID(std::optional<WebCore::PlatformLayerIdentifier> layerID) { m_scrolledContentsLayerID = layerID; }
-
-    std::optional<WebCore::PlatformLayerIdentifier> mainFrameClipLayerID() const { return m_mainFrameClipLayerID.asOptional(); }
-    void setMainFrameClipLayerID(std::optional<WebCore::PlatformLayerIdentifier> layerID) { m_mainFrameClipLayerID = layerID; }
-#endif // PLATFORM(MAC)
 
     uint64_t renderTreeSize() const { return m_renderTreeSize; }
     void setRenderTreeSize(uint64_t renderTreeSize) { m_renderTreeSize = renderTreeSize; }
@@ -242,9 +222,6 @@ public:
     bool viewportMetaTagCameFromImageDocument() const { return m_viewportMetaTagCameFromImageDocument; }
     void setViewportMetaTagCameFromImageDocument(bool cameFromImageDocument) { m_viewportMetaTagCameFromImageDocument = cameFromImageDocument; }
 
-    bool isInStableState() const { return m_isInStableState; }
-    void setIsInStableState(bool isInStableState) { m_isInStableState = isInStableState; }
-
     bool allowsUserScaling() const { return m_allowsUserScaling; }
     void setAllowsUserScaling(bool allowsUserScaling) { m_allowsUserScaling = allowsUserScaling; }
 
@@ -253,24 +230,10 @@ public:
 
     TransactionID transactionID() const { return m_transactionID; }
 
-    using TransactionCallbackID = IPC::AsyncReplyID;
-    const Vector<TransactionCallbackID>& callbackIDs() const { return m_callbackIDs; }
-    void setCallbackIDs(Vector<TransactionCallbackID>&& callbackIDs) { m_callbackIDs = WTFMove(callbackIDs); }
-
-    OptionSet<WebCore::LayoutMilestone> newlyReachedPaintingMilestones() const { return m_newlyReachedPaintingMilestones; }
-    void setNewlyReachedPaintingMilestones(OptionSet<WebCore::LayoutMilestone> milestones) { m_newlyReachedPaintingMilestones = milestones; }
-
-    bool hasEditorState() const { return !!m_editorState; }
-    const EditorState& editorState() const { return m_editorState.value(); }
-    void setEditorState(const EditorState& editorState) { m_editorState = editorState; }
-
 #if PLATFORM(IOS_FAMILY)
     std::optional<DynamicViewportSizeUpdateID> dynamicViewportSizeUpdateID() const { return m_dynamicViewportSizeUpdateID; }
     void setDynamicViewportSizeUpdateID(DynamicViewportSizeUpdateID resizeID) { m_dynamicViewportSizeUpdateID = resizeID; }
 #endif
-
-    const std::optional<WebCore::FixedContainerEdges>& fixedContainerEdges() const { return m_fixedContainerEdges; }
-    void setFixedContainerEdges(const WebCore::FixedContainerEdges& edges) { m_fixedContainerEdges = edges; }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelines() const { return m_timelines; }
@@ -293,8 +256,6 @@ private:
     Vector<WebCore::PlatformLayerIdentifier> m_videoLayerIDsPendingFullscreen;
     Vector<WebCore::PlatformLayerIdentifier> m_layerIDsWithNewlyUnreachableBackingStore;
 
-    Vector<TransactionCallbackID> m_callbackIDs;
-
     WebCore::IntSize m_contentsSize;
     WebCore::IntSize m_scrollGeometryContentSize;
     WebCore::IntPoint m_scrollOrigin;
@@ -302,16 +263,6 @@ private:
     WebCore::LayoutPoint m_minStableLayoutViewportOrigin;
     WebCore::LayoutPoint m_maxStableLayoutViewportOrigin;
     WebCore::IntPoint m_scrollPosition;
-    WebCore::Color m_themeColor;
-    WebCore::Color m_pageExtendedBackgroundColor;
-    WebCore::Color m_sampledPageTopColor;
-    std::optional<WebCore::FixedContainerEdges> m_fixedContainerEdges;
-
-#if PLATFORM(MAC)
-    Markable<WebCore::PlatformLayerIdentifier> m_pageScalingLayerID; // Only used for non-delegated scaling.
-    Markable<WebCore::PlatformLayerIdentifier> m_scrolledContentsLayerID;
-    Markable<WebCore::PlatformLayerIdentifier> m_mainFrameClipLayerID;
-#endif
 
     double m_pageScaleFactor { 1 };
     double m_minimumScaleFactor { 1 };
@@ -320,16 +271,13 @@ private:
     double m_viewportMetaTagWidth { -1 };
     uint64_t m_renderTreeSize { 0 };
     TransactionID m_transactionID;
-    OptionSet<WebCore::LayoutMilestone> m_newlyReachedPaintingMilestones;
     bool m_scaleWasSetByUIProcess { false };
     bool m_allowsUserScaling { false };
     bool m_avoidsUnsafeArea { true };
     bool m_viewportMetaTagWidthWasExplicit { false };
     bool m_viewportMetaTagCameFromImageDocument { false };
-    bool m_isInStableState { false };
     WebCore::InteractiveWidget m_viewportMetaTagInteractiveWidget { WebCore::InteractiveWidget::ResizesVisual };
 
-    std::optional<EditorState> m_editorState;
 #if PLATFORM(IOS_FAMILY)
     std::optional<DynamicViewportSizeUpdateID> m_dynamicViewportSizeUpdateID;
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -282,12 +282,6 @@ String RemoteLayerTreeTransaction::description() const
     if (m_pageScaleFactor != 1)
         ts.dumpProperty("pageScaleFactor"_s, m_pageScaleFactor);
 
-#if PLATFORM(MAC)
-    ts.dumpProperty("pageScalingLayer"_s, m_pageScalingLayerID);
-    ts.dumpProperty("scrolledContentsLayerID"_s, m_scrolledContentsLayerID);
-    ts.dumpProperty("mainFrameClipLayerID"_s, m_mainFrameClipLayerID);
-#endif
-
     ts.dumpProperty("minimumScaleFactor"_s, m_minimumScaleFactor);
     ts.dumpProperty("maximumScaleFactor"_s, m_maximumScaleFactor);
     ts.dumpProperty("initialScaleFactor"_s, m_initialScaleFactor);
@@ -296,7 +290,6 @@ String RemoteLayerTreeTransaction::description() const
     ts.dumpProperty("viewportMetaTagCameFromImageDocument"_s, m_viewportMetaTagCameFromImageDocument);
     ts.dumpProperty("allowsUserScaling"_s, m_allowsUserScaling);
     ts.dumpProperty("avoidsUnsafeArea"_s, m_avoidsUnsafeArea);
-    ts.dumpProperty("isInStableState"_s, m_isInStableState);
     ts.dumpProperty("renderTreeSize"_s, m_renderTreeSize);
     ts.dumpProperty("root-layer"_s, m_rootLayerID);
 
@@ -334,12 +327,6 @@ String RemoteLayerTreeTransaction::description() const
 
     if (!m_destroyedLayerIDs.isEmpty())
         ts.dumpProperty<Vector<WebCore::PlatformLayerIdentifier>>("destroyed-layers", m_destroyedLayerIDs);
-
-    if (m_editorState) {
-        TextStream::GroupScope scope(ts);
-        ts << "EditorState"_s;
-        ts << *m_editorState;
-    }
 
     ts.endGroup();
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -68,7 +68,7 @@ enum class TapHandlingResult : uint8_t;
 - (UIView *)_currentContentView;
 
 - (void)_didCommitLoadForMainFrame;
-- (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction;
+- (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction mainFrameData:(const std::optional<WebKit::MainFrameData>&)mainFrameData;
 - (void)_layerTreeCommitComplete;
 
 - (void)_couldNotRestorePageState;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -102,7 +102,7 @@ public:
     void storeAppHighlight(const WebCore::AppHighlight&) final;
 #endif
 
-    void didCommitLayerTree(const RemoteLayerTreeTransaction&) override;
+    void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&) override;
 
     void microphoneCaptureWillChange() final;
     void cameraCaptureWillChange() final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -27,6 +27,7 @@
 #import "PageClientImplCocoa.h"
 
 #import "APIUIClient.h"
+#import "RemoteLayerTreeCommitBundle.h"
 #import "RemoteLayerTreeTransaction.h"
 #import "WKWebViewInternal.h"
 #import "WebFullScreenManagerProxy.h"
@@ -450,10 +451,10 @@ void PageClientImplCocoa::setFullScreenClientForTesting(std::unique_ptr<WebFullS
 }
 #endif
 
-void PageClientImplCocoa::didCommitLayerTree(const RemoteLayerTreeTransaction& transaction)
+void PageClientImplCocoa::didCommitLayerTree(const RemoteLayerTreeTransaction& transaction, const std::optional<MainFrameData>& mainFrameData)
 {
-    if (auto& edges = transaction.fixedContainerEdges())
-        [webView() _updateFixedContainerEdges:*edges];
+    if (mainFrameData && mainFrameData->fixedContainerEdges)
+        [webView() _updateFixedContainerEdges:*mainFrameData->fixedContainerEdges];
     [webView() _updateScrollGeometryWithContentOffset:transaction.scrollPosition() contentSize:transaction.scrollGeometryContentSize()];
 }
 

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -208,6 +208,7 @@ struct FocusedElementInformation;
 struct FrameInfoData;
 struct InteractionInformationAtPosition;
 struct KeyEventInterpretationContext;
+struct MainFrameData;
 struct WebAutocorrectionContext;
 struct WebHitTestResultData;
 
@@ -539,7 +540,7 @@ public:
 #endif // PLATFORM(MAC)
 
 #if PLATFORM(COCOA)
-    virtual void didCommitLayerTree(const RemoteLayerTreeTransaction&) = 0;
+    virtual void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&) = 0;
     virtual void layerTreeCommitComplete() { }
 
     virtual void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) = 0;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -43,6 +43,7 @@ class RemoteLayerTreeTransaction;
 class RemotePageDrawingAreaProxy;
 class RemoteScrollingCoordinatorProxy;
 class RemoteScrollingCoordinatorTransaction;
+struct MainFrameData;
 struct RemoteLayerTreeCommitBundle;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
@@ -179,8 +180,8 @@ private:
     void willCommitLayerTree(IPC::Connection&, TransactionID);
     void commitLayerTreeNotTriggered(IPC::Connection&, TransactionID);
     void commitLayerTree(IPC::Connection&, const RemoteLayerTreeCommitBundle&, HashMap<ImageBufferSetIdentifier, std::unique_ptr<BufferSetBackendHandle>>&&);
-    void commitLayerTreeTransaction(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&);
-    virtual void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&) { }
+    void commitLayerTreeTransaction(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&);
+    virtual void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&) { }
 
     void asyncSetLayerContents(WebCore::PlatformLayerIdentifier, RemoteLayerBackingStoreProperties&&);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -49,6 +49,7 @@ namespace WebKit {
 
 class RemoteLayerTreeDrawingAreaProxy;
 class WebPageProxy;
+struct MainFrameData;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 class RemoteAnimationTimeline;
@@ -72,7 +73,7 @@ public:
     RemoteLayerTreeDrawingAreaProxy& drawingArea() const;
 
     // Returns true if the root layer changed.
-    bool updateLayerTree(const IPC::Connection&, const RemoteLayerTreeTransaction&, float indicatorScaleFactor  = 1);
+    bool updateLayerTree(const IPC::Connection&, const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&, float indicatorScaleFactor  = 1);
     void asyncSetLayerContents(WebCore::PlatformLayerIdentifier, RemoteLayerBackingStoreProperties&&);
 
     void setIsDebugLayerTreeHost(bool flag) { m_isDebugLayerTreeHost = flag; }
@@ -111,7 +112,7 @@ private:
     void createLayer(const RemoteLayerTreeTransaction::LayerCreationProperties&);
     RefPtr<RemoteLayerTreeNode> makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties&);
 
-    bool updateBannerLayers(const RemoteLayerTreeTransaction&);
+    bool updateBannerLayers(const std::optional<MainFrameData>&);
 
     void layerWillBeRemoved(WebCore::ProcessIdentifier, WebCore::PlatformLayerIdentifier);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -29,6 +29,7 @@
 #import "AuxiliaryProcessProxy.h"
 #import "LayerProperties.h"
 #import "Logging.h"
+#import "RemoteLayerTreeCommitBundle.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteLayerTreePropertyApplier.h"
 #import "RemoteLayerTreeTransaction.h"
@@ -115,9 +116,12 @@ bool RemoteLayerTreeHost::cssUnprefixedBackdropFilterEnabled() const
 }
 
 #if PLATFORM(MAC)
-bool RemoteLayerTreeHost::updateBannerLayers(const RemoteLayerTreeTransaction& transaction)
+bool RemoteLayerTreeHost::updateBannerLayers(const std::optional<MainFrameData>& mainFrameData)
 {
-    RetainPtr scrolledContentsLayer = layerForID(transaction.scrolledContentsLayerID());
+    if (!mainFrameData)
+        return false;
+
+    RetainPtr scrolledContentsLayer = layerForID(mainFrameData->scrolledContentsLayerID);
     if (!scrolledContentsLayer)
         return false;
 
@@ -142,7 +146,7 @@ bool RemoteLayerTreeHost::updateBannerLayers(const RemoteLayerTreeTransaction& t
 }
 #endif
 
-bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, const RemoteLayerTreeTransaction& transaction, float indicatorScaleFactor)
+bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, const RemoteLayerTreeTransaction& transaction, const std::optional<MainFrameData>& mainFrameData, float indicatorScaleFactor)
 {
     if (!m_drawingArea)
         return false;
@@ -248,7 +252,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
     }
 
 #if PLATFORM(MAC)
-    if (updateBannerLayers(transaction))
+    if (updateBannerLayers(mainFrameData))
         rootLayerChanged = true;
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -70,7 +70,7 @@ private:
 
     void layoutBannerLayers(const RemoteLayerTreeTransaction&);
 
-    void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&) override;
+    void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&) override;
 
     void adjustTransientZoom(double, WebCore::FloatPoint originInLayerForPageScale, WebCore::FloatPoint originInVisibleRect) override;
     void commitTransientZoom(double, WebCore::FloatPoint) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -32,6 +32,7 @@
 #import "DrawingArea.h"
 #import "DrawingAreaMessages.h"
 #import "MessageSenderInlines.h"
+#import "RemoteLayerTreeCommitBundle.h"
 #import "RemoteLayerTreeScrollingPerformanceData.h"
 #import "RemoteScrollingCoordinatorProxyMac.h"
 #import "WebPageProxy.h"
@@ -196,17 +197,19 @@ void RemoteLayerTreeDrawingAreaProxyMac::layoutBannerLayers(const RemoteLayerTre
     }
 }
 
-void RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction& transaction, const RemoteScrollingCoordinatorTransaction&)
+void RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction& transaction, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>& mainFrameData)
 {
+    if (mainFrameData) {
+        m_pageScalingLayerID = mainFrameData->pageScalingLayerID;
+        m_pageScrollingLayerID = mainFrameData->scrolledContentsLayerID;
+        m_scrolledContentsLayerID = mainFrameData->scrolledContentsLayerID;
+        m_mainFrameClipLayerID = mainFrameData->mainFrameClipLayerID;
+    }
+
     if (!transaction.isMainFrameProcessTransaction())
         return;
 
     RefPtr page = this->page();
-
-    m_pageScalingLayerID = transaction.pageScalingLayerID();
-    m_pageScrollingLayerID = transaction.scrolledContentsLayerID();
-    m_scrolledContentsLayerID = transaction.scrolledContentsLayerID();
-    m_mainFrameClipLayerID = transaction.mainFrameClipLayerID();
 
     if (m_transientZoomScale)
         applyTransientZoomToLayer();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3706,7 +3706,7 @@ void WebPageProxy::activateMediaStreamCaptureInPage()
 }
 
 #if !PLATFORM(COCOA)
-void WebPageProxy::didCommitLayerTree(const RemoteLayerTreeTransaction&)
+void WebPageProxy::didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&)
 {
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -570,6 +570,7 @@ struct InteractionInformationRequest;
 struct JSHandleInfo;
 struct KeyEventInterpretationContext;
 struct LoadParameters;
+struct MainFrameData;
 struct ModelIdentifier;
 struct NavigationActionData;
 struct NetworkResourceLoadIdentifierType;
@@ -1267,7 +1268,8 @@ public:
     void setDataDetectionResult(DataDetectionResult&&);
     void handleClickForDataDetectionResult(const WebCore::DataDetectorElementInfo&, const WebCore::IntPoint&);
 #endif
-    void didCommitLayerTree(const RemoteLayerTreeTransaction&);
+    void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&);
+    void didCommitMainFrameData(const MainFrameData&);
     void layerTreeCommitComplete();
 
     bool updateLayoutViewportParameters(const RemoteLayerTreeTransaction&);

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -177,7 +177,7 @@ private:
     void commitPotentialTapFailed() override;
     void didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color&, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling) override;
 
-    void didCommitLayerTree(const RemoteLayerTreeTransaction&) final;
+    void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&) final;
     void layerTreeCommitComplete() override;
         
     void didPerformDictionaryLookup(const WebCore::DictionaryPopupInfo&) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -668,11 +668,11 @@ void PageClientImpl::didGetTapHighlightGeometries(WebKit::TapIdentifier requestI
     [contentView() _didGetTapHighlightForRequest:requestID color:color quads:highlightedQuads topLeftRadius:topLeftRadius topRightRadius:topRightRadius bottomLeftRadius:bottomLeftRadius bottomRightRadius:bottomRightRadius nodeHasBuiltInClickHandling:nodeHasBuiltInClickHandling];
 }
 
-void PageClientImpl::didCommitLayerTree(const RemoteLayerTreeTransaction& layerTreeTransaction)
+void PageClientImpl::didCommitLayerTree(const RemoteLayerTreeTransaction& layerTreeTransaction, const std::optional<MainFrameData>& mainFrameData)
 {
-    PageClientImplCocoa::didCommitLayerTree(layerTreeTransaction);
+    PageClientImplCocoa::didCommitLayerTree(layerTreeTransaction, mainFrameData);
 
-    [contentView() _didCommitLayerTree:layerTreeTransaction];
+    [contentView() _didCommitLayerTree:layerTreeTransaction mainFrameData:mainFrameData];
 }
 
 void PageClientImpl::layerTreeCommitComplete()

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -48,6 +48,7 @@ class WebFrameProxy;
 class WebPageProxy;
 class WebProcessProxy;
 class WebProcessPool;
+struct MainFrameData;
 enum class ViewStabilityFlag : uint8_t;
 }
 
@@ -124,7 +125,7 @@ enum class ViewStabilityFlag : uint8_t;
 - (void)_showInspectorHighlight:(const WebCore::InspectorOverlay::Highlight&)highlight;
 - (void)_hideInspectorHighlight;
 
-- (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction;
+- (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction mainFrameData:(const std::optional<WebKit::MainFrameData>&)mainFrameData;
 - (void)_layerTreeCommitComplete;
 
 - (void)_setAccessibilityWebProcessToken:(NSData *)data;

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -993,7 +993,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 #endif // USE(EXTENSIONKIT)
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
-- (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction
+- (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction mainFrameData:(const std::optional<WebKit::MainFrameData>&)mainFrameData
 {
     BOOL transactionMayChangeBounds = layerTreeTransaction.isMainFrameProcessTransaction();
     CGSize contentsSize = layerTreeTransaction.contentsSize();
@@ -1006,7 +1006,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     if (boundsChanged)
         [self setBounds:contentBounds];
 
-    [_webView _didCommitLayerTree:layerTreeTransaction];
+    [_webView _didCommitLayerTree:layerTreeTransaction mainFrameData:mainFrameData];
 
     if (_interactionViewsContainerView) {
         WebCore::FloatPoint scaledOrigin = layerTreeTransaction.scrollOrigin();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -47,6 +47,7 @@ class TiledBacking;
 namespace WebKit {
 
 class RemoteLayerTreeContext;
+struct MainFrameData;
 
 class RemoteLayerTreeDrawingArea : public DrawingArea, public WebCore::GraphicsLayerClient {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeDrawingArea);
@@ -91,7 +92,7 @@ private:
     void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) final;
 
     void dispatchAfterEnsuringDrawing(IPC::AsyncReplyID) final;
-    virtual void willCommitLayerTree(RemoteLayerTreeTransaction&) { }
+    virtual void willCommitLayerTree(MainFrameData&) { }
 
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID) final;
     void setPreferredFramesPerSecond(WebCore::FramesPerSecond);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -376,17 +376,12 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         rootLayer.layer->flushCompositingStateForThisLayerOnly();
 
         RemoteLayerTreeTransaction layerTransaction(transactionID);
-        layerTransaction.setCallbackIDs(WTFMove(m_pendingCallbackIDs));
 
         RefPtr layer = downcast<GraphicsLayerCARemote>(rootLayer.layer.get()).platformCALayer();
         m_remoteLayerTreeContext->buildTransaction(layerTransaction, *layer, rootLayer.frameID);
 
         // FIXME: Investigate whether this needs to be done multiple times in a page with multiple root frames. <rdar://116202678>
         webPage->willCommitLayerTree(layerTransaction, rootLayer.frameID);
-
-        layerTransaction.setNewlyReachedPaintingMilestones(std::exchange(m_pendingNewlyReachedPaintingMilestones, { }));
-
-        willCommitLayerTree(layerTransaction);
 
         m_waitingForBackingStoreSwap = true;
 
@@ -405,9 +400,15 @@ void RemoteLayerTreeDrawingArea::updateRendering()
     for (auto& transaction : transactions)
         backingStoreCollection->willCommitLayerTree(CheckedRef { transaction.first });
 
-    RemoteLayerTreeCommitBundle bundle { WTFMove(transactions) };
-    if (webPage->mainWebFrame().coreLocalFrame())
-        bundle.mainFrameData = { std::exchange(m_activityStateChangeID, ActivityStateChangeAsynchronous) };
+    RemoteLayerTreeCommitBundle bundle { WTFMove(transactions), { WTFMove(m_pendingCallbackIDs) } };
+
+    if (webPage->localMainFrame()) {
+        bundle.mainFrameData = MainFrameData { };
+        bundle.mainFrameData->newlyReachedPaintingMilestones = std::exchange(m_pendingNewlyReachedPaintingMilestones, { });
+        bundle.mainFrameData->activityStateChangeID = std::exchange(m_activityStateChangeID, ActivityStateChangeAsynchronous);
+        webPage->willCommitMainFrameData(*bundle.mainFrameData);
+        willCommitLayerTree(*bundle.mainFrameData);
+    }
 
     auto commitEncoder = makeUniqueRef<IPC::Encoder>(Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree::name(), m_identifier.toUInt64());
     commitEncoder.get() << bundle;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -505,6 +505,7 @@ struct InsertTextOptions;
 struct InteractionInformationAtPosition;
 struct InteractionInformationRequest;
 struct LoadParameters;
+struct MainFrameData;
 struct NodeHitTestResult;
 struct PDFPluginIdentifierType;
 struct PlatformFontInfo;
@@ -635,6 +636,7 @@ public:
 
 #if PLATFORM(COCOA)
     void willCommitLayerTree(RemoteLayerTreeTransaction&, WebCore::FrameIdentifier);
+    void willCommitMainFrameData(MainFrameData&);
     void didFlushLayerTreeAtTime(MonotonicTime, bool flushSucceeded);
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
@@ -62,7 +62,7 @@ private:
 
     void adjustTransientZoom(double scale, WebCore::FloatPoint origin) final;
 
-    void willCommitLayerTree(RemoteLayerTreeTransaction&) final;
+    void willCommitLayerTree(MainFrameData&) final;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "Logging.h"
+#import "RemoteLayerTreeCommitBundle.h"
 #import "WebPage.h"
 #import "WebPageCreationParameters.h"
 #import <WebCore/GraphicsLayer.h>
@@ -83,7 +84,7 @@ void RemoteLayerTreeDrawingAreaMac::adjustTransientZoom(double scale, WebCore::F
     prepopulateRectForZoom(totalScale, origin);
 }
 
-void RemoteLayerTreeDrawingAreaMac::willCommitLayerTree(RemoteLayerTreeTransaction& transaction)
+void RemoteLayerTreeDrawingAreaMac::willCommitLayerTree(MainFrameData& data)
 {
     // FIXME: Probably need something here for PDF.
     RefPtr frameView = protectedWebPage()->localMainFrameView();
@@ -91,13 +92,13 @@ void RemoteLayerTreeDrawingAreaMac::willCommitLayerTree(RemoteLayerTreeTransacti
         return;
 
     if (RefPtr renderViewGraphicsLayer = frameView->graphicsLayerForPageScale())
-        transaction.setPageScalingLayerID(renderViewGraphicsLayer->primaryLayerID());
+        data.pageScalingLayerID = renderViewGraphicsLayer->primaryLayerID();
 
     if (RefPtr scrolledContentsLayer = frameView->graphicsLayerForScrolledContents())
-        transaction.setScrolledContentsLayerID(scrolledContentsLayer->primaryLayerID());
+        data.scrolledContentsLayerID = scrolledContentsLayer->primaryLayerID();
 
     if (RefPtr mainFrameClipLayerID = frameView->clipLayer())
-        transaction.setMainFrameClipLayerID(mainFrameClipLayerID->primaryLayerID());
+        data.mainFrameClipLayerID = mainFrameClipLayerID->primaryLayerID();
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 5f8ac173285d5ec1550606ddc8383c45966e7f94
<pre>
Migrate more RemoteLayerTreeTransaction members from transaction scope to main frame scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=301305">https://bugs.webkit.org/show_bug.cgi?id=301305</a>
<a href="https://rdar.apple.com/163225069">rdar://163225069</a>

Reviewed by Matt Woodrow.

Right now RemoteLayerTreeDrawingAreaProxy::commitLayerTree currently receives a Vector&lt;std::pair&lt;RemoteLayerTreeTransaction,
RemoteScrollingCoordinatorTransaction&gt;&gt;, one pair per root frame. However, some aspects of the transaction are
scoped to the root frame. Some are scoped to the page. And some are scoped to the main frame. We want to accordingly
introduce some separation/organization here to reduce duplication and unnecessary isMainFrameProcessTransaction() checks.

This PR builds on <a href="https://github.com/WebKit/WebKit/pull/52671.">https://github.com/WebKit/WebKit/pull/52671.</a> In this PR, we move more relevant members from transaction
scope to main frame scope and page scope. They get accordingly removed from the isMainFrameProcessTransaction() checks
on UIProcess side and handled separately. Additionally, we introduce a new PageData struct and add a member to it.

Once we get toward the end of the migration and almost all mainframe/page members are moved out of transaction level
code paths, we can introduce more new methods that are only called once for processing PageData/MainFrameData
rather than using existing methods that get called for every transaction. But for now, we leave most of them as part of
the same methods to reduce breakage.

We also add a MESSAGE_CHECK at the start of commitLayerTree() to verify that main frame data is only provided
from the main frame process.

No new functionality is added. This is a simple refactoring. Existing test coverage is enough.
As a result, no new tests are added.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
(WebKit::RemoteLayerTreeTransaction::themeColor const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setThemeColor): Deleted.
(WebKit::RemoteLayerTreeTransaction::pageExtendedBackgroundColor const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setPageExtendedBackgroundColor): Deleted.
(WebKit::RemoteLayerTreeTransaction::sampledPageTopColor const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setSampledPageTopColor): Deleted.
(WebKit::RemoteLayerTreeTransaction::pageScalingLayerID const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setPageScalingLayerID): Deleted.
(WebKit::RemoteLayerTreeTransaction::scrolledContentsLayerID const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setScrolledContentsLayerID): Deleted.
(WebKit::RemoteLayerTreeTransaction::mainFrameClipLayerID const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setMainFrameClipLayerID): Deleted.
(WebKit::RemoteLayerTreeTransaction::isInStableState const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setIsInStableState): Deleted.
(WebKit::RemoteLayerTreeTransaction::callbackIDs const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setCallbackIDs): Deleted.
(WebKit::RemoteLayerTreeTransaction::newlyReachedPaintingMilestones const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setNewlyReachedPaintingMilestones): Deleted.
(WebKit::RemoteLayerTreeTransaction::hasEditorState const): Deleted.
(WebKit::RemoteLayerTreeTransaction::editorState const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setEditorState): Deleted.
(WebKit::RemoteLayerTreeTransaction::fixedContainerEdges const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setFixedContainerEdges): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::description const):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTree:mainFrameData:]):
(-[WKWebView _didCommitLayerTree:]): Deleted.
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::didCommitLayerTree):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::didCommitLayerTree):
(WebKit::WebPageProxy::didCommitMainFrameData):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::didCommitLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateBannerLayers):
(WebKit::RemoteLayerTreeHost::updateLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLayerTree):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didCommitLayerTree):
* Source/WebKit/UIProcess/ios/WKContentView.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _didCommitLayerTree:mainFrameData:]):
(-[WKContentView _didCommitLayerTree:]): Deleted.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::willCommitLayerTree):
(WebKit::WebPage::willCommitMainFrameData):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
(WebKit::RemoteLayerTreeDrawingArea::willCommitLayerTree):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h:
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::willCommitLayerTree):

Canonical link: <a href="https://commits.webkit.org/302408@main">https://commits.webkit.org/302408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08ebc1929159242125f1cd44bc010b3e2e8e7686

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136342 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80321 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9978cb13-395a-45f0-9909-e61c800a96af) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98183 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66098 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7c90cb89-477f-4e99-9549-22395fbf2097) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115524 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78811 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/61f2a827-faea-449a-8efd-471fa1df97ce) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/816 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79623 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109258 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138809 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106761 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106538 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27132 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/846 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53491 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1093 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64486 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/927 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1024 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->