### PR TITLE
[Site Isolation] Navigation to about:blank inherits navigator's origin

### DIFF
--- a/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page-expected.txt
@@ -1,0 +1,8 @@
+This test passes if the main page can modify it's child iframe's DOM (once the child iframe has navigated away from a cross-origin site to about:blank).
+
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+Hello from the main page

--- a/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page.html
+++ b/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page.html
@@ -1,0 +1,44 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+// Have the main frame navigate a cross-origin child iframe
+// to about:blank.
+// The about:blank iframe should inherit the origin of it's parent,
+// or it's opener if the parent doesn't exist.
+// https://dev.w3.org/html5/spec-LC/origin-0.html
+// https://dev.w3.org/html5/spec-LC/browsers.html#about-blank-origin
+
+if (window.testRunner) {
+    testRunner.dumpChildFramesAsText();
+    testRunner.waitUntilDone();
+}
+
+
+// Once we get back to about:blank, check that we can modify DOM
+loadedAboutBlank = function() {
+  let child = document.getElementById("child");
+  child.onload = null;
+
+  child.contentWindow.document.body.appendChild(
+      child.contentWindow.document.createTextNode('Hello from the main page')
+  );
+
+  if (window.testRunner)
+      testRunner.notifyDone();
+}
+
+loadedCrossOrigin = function() {
+    let child = document.getElementById("child");
+    child.onload = loadedAboutBlank;
+    child.src = 'about:blank';
+};
+
+</script>
+
+<p>This test passes if the main page can modify it's child iframe's DOM (once the child iframe has navigated away from a cross-origin site to about:blank).</p>
+<!-- Navigate to a cross origin url (where 127.0.0.1 is cross origin from localhost)-->
+<iframe id="child" onload="loadedCrossOrigin()" src="http://127.0.0.1:8000/site-isolation/resources/green-background.html"></iframe> 
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe-expected.txt
@@ -1,0 +1,15 @@
+This test passes if the child frame can modify the grandchild iframe's DOM (once the grandchild iframe has navigated away from a cross-origin site to about:blank).
+
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+Child iframe
+
+
+
+--------
+Frame: '<!--frame2-->'
+--------
+Hello from your parent

--- a/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html
@@ -1,0 +1,22 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<script>
+// Have the main frame navigate a cross-origin child iframe
+// to about:blank.
+// The about:blank iframe should inherit the origin of it's parent,
+// or it's opener if the parent doesn't exist.
+// https://dev.w3.org/html5/spec-LC/origin-0.html
+// https://dev.w3.org/html5/spec-LC/browsers.html#about-blank-origin
+
+if (window.testRunner) {
+    testRunner.dumpChildFramesAsText();
+    testRunner.waitUntilDone();
+}
+
+</script>
+<body>
+<p>This test passes if the child frame can modify the grandchild iframe's DOM (once the grandchild iframe has navigated away from a cross-origin site to about:blank).</p>
+<iframe src="http://localhost:8000/site-isolation/resources/frame-child-navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html" style="border:5px solid red;"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/frame-child-navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/frame-child-navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<head>
+<script>
+
+function loadedAboutBlank() {
+    let grandchild = document.getElementById("grandchild");
+    grandchild.contentWindow.document.body.appendChild(
+        grandchild.contentWindow.document.createTextNode('Hello from your parent')
+    );
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+function loadedCrossOrigin()
+{
+    // Once this frame's child loads to a cross site 
+    // origin, then we can attempt to navigate this frame's 
+    // child to about:blank which should make it change origin to
+    // whatever this current frame's origin is. Then, once we share 
+    // origins, we should be able to modify the frame's DOM.
+    let grandchild = document.getElementById("grandchild");
+    grandchild.onload = loadedAboutBlank;
+    grandchild.src = "about:blank";
+}
+</script>
+</head>
+<body>
+<p>Child iframe</p>
+
+<!-- Navigate to a cross origin url (where 127.0.0.1 is cross origin from localhost)-->
+<iframe id="grandchild" onload="loadedCrossOrigin()" src="http://127.0.0.1:8000/site-isolation/resources/green-background.html" style="border:5px solid blue;"></iframe>
+</body>
+</html>

--- a/Source/WebKit/Shared/ProvisionalFrameCreationParameters.h
+++ b/Source/WebKit/Shared/ProvisionalFrameCreationParameters.h
@@ -38,6 +38,11 @@ using SandboxFlags = OptionSet<SandboxFlag>;
 
 namespace WebKit {
 
+enum class CommitTiming : bool {
+    WaitForLoad,
+    Immediately,
+};
+
 struct ProvisionalFrameCreationParameters {
     WebCore::FrameIdentifier frameID;
     std::optional<WebCore::FrameIdentifier> frameIDBeforeProvisionalNavigation;
@@ -46,6 +51,7 @@ struct ProvisionalFrameCreationParameters {
     WebCore::ReferrerPolicy effectiveReferrerPolicy { WebCore::ReferrerPolicy::EmptyString };
     WebCore::ScrollbarMode scrollingMode;
     std::optional<WebCore::IntSize> initialSize;
+    CommitTiming commitTiming { CommitTiming::WaitForLoad };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ProvisionalFrameCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/ProvisionalFrameCreationParameters.serialization.in
@@ -28,4 +28,5 @@ struct WebKit::ProvisionalFrameCreationParameters {
     WebCore::ReferrerPolicy effectiveReferrerPolicy;
     WebCore::ScrollbarMode scrollingMode;
     std::optional<WebCore::IntSize> initialSize;
+    WebKit::CommitTiming commitTiming;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9045,3 +9045,5 @@ struct WebCore::FocusOptions {
     bool preventScroll;
     std::optional<bool> focusVisible;
 };
+
+enum class WebKit::CommitTiming : bool;

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -39,22 +39,15 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProvisionalFrameProxy);
 
-ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProcess>&& frameProcess)
+ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProcess>&& frameProcess, CommitTiming commitTiming)
     : m_frame(frame)
     , m_frameProcess(WTFMove(frameProcess))
     , m_visitedLinkStore(frame.page()->visitedLinkStore())
 {
     Ref process = this->process();
     process->markProcessAsRecentlyUsed();
-    process->send(Messages::WebFrame::CreateProvisionalFrame(ProvisionalFrameCreationParameters {
-        frame.frameID(),
-        std::nullopt,
-        frame.layerHostingContextIdentifier(),
-        frame.effectiveSandboxFlags(),
-        frame.effectiveReferrerPolicy(),
-        frame.scrollingMode(),
-        frame.remoteFrameSize()
-    }), frame.frameID());
+    auto parameters = frame.provisionalFrameCreationParameters(std::nullopt, commitTiming);
+    process->send(Messages::WebFrame::CreateProvisionalFrame(parameters), frame.frameID());
 }
 
 ProvisionalFrameProxy::~ProvisionalFrameProxy()

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -37,11 +37,12 @@ class FrameProcess;
 class VisitedLinkStore;
 class WebFrameProxy;
 class WebProcessProxy;
+enum class CommitTiming : bool;
 
 class ProvisionalFrameProxy : public RefCountedAndCanMakeWeakPtr<ProvisionalFrameProxy> {
     WTF_MAKE_TZONE_ALLOCATED(ProvisionalFrameProxy);
 public:
-    explicit ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&);
+    explicit ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&, CommitTiming);
 
     ~ProvisionalFrameProxy();
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -295,15 +295,10 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
             mainFrame->frameTreeCreationParameters(),
             websitePolicies ? std::optional(websitePolicies->dataForProcess(process)) : std::nullopt
         };
-        creationParameters.provisionalFrameCreationParameters = ProvisionalFrameCreationParameters {
-            m_mainFrame->frameID(),
+        creationParameters.provisionalFrameCreationParameters = mainFrame->provisionalFrameCreationParameters(
             page->mainFrame() && !m_isProcessSwappingForNewWindow ? std::optional(page->mainFrame()->frameID()) : std::nullopt,
-            std::nullopt,
-            mainFrame->effectiveSandboxFlags(),
-            mainFrame->effectiveReferrerPolicy(),
-            mainFrame->scrollingMode(),
-            mainFrame->remoteFrameSize()
-        };
+            CommitTiming::WaitForLoad
+        );
     }
     process->send(Messages::WebProcess::CreateWebPage(m_webPageID, WTFMove(creationParameters)), 0);
     if (!preferences->siteIsolationEnabled())

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -28,6 +28,7 @@
 #include "APIObject.h"
 #include "FrameLoadState.h"
 #include "MessageReceiver.h"
+#include "ProvisionalFrameCreationParameters.h"
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/IntSize.h>
@@ -199,7 +200,7 @@ public:
     bool isConnected() const;
     void didCreateSubframe(WebCore::FrameIdentifier, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
     ProcessID processID() const;
-    void prepareForProvisionalLoadInProcess(WebProcessProxy&, API::Navigation&, BrowsingContextGroup&, CompletionHandler<void(WebCore::PageIdentifier)>&&);
+    void prepareForProvisionalLoadInProcess(WebProcessProxy&, API::Navigation&, BrowsingContextGroup&, std::optional<WebCore::SecurityOriginData>, CompletionHandler<void(WebCore::PageIdentifier)>&&);
 
     void commitProvisionalFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, String&& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool privateRelayed, String&& proxyName, WebCore::ResourceResponseSource, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, const UserData&);
 
@@ -274,6 +275,8 @@ public:
     template<typename M> void send(M&&);
 
     void sendMessageToInspectorFrontend(const String& targetId, const String& message);
+
+    ProvisionalFrameCreationParameters provisionalFrameCreationParameters(std::optional<WebCore::FrameIdentifier>, CommitTiming);
 
 private:
     WebFrameProxy(WebPageProxy&, FrameProcess&, WebCore::FrameIdentifier, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode, WebFrameProxy*, IsMainFrame);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5447,7 +5447,10 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         if (navigation.isInitialFrameSrcLoad())
             frame.setIsPendingInitialHistoryItem(true);
 
-        frame.prepareForProvisionalLoadInProcess(newProcess, navigation, browsingContextGroup, [
+        // about:blank frames should be in the same process as the frame which originated navigation
+        std::optional<SecurityOriginData> originator = navigation.currentRequest().url().isAboutBlank() && navigation.originatingFrameInfo() ? std::make_optional(navigation.originatingFrameInfo()->securityOrigin) : std::nullopt;
+
+        frame.prepareForProvisionalLoadInProcess(newProcess, navigation, browsingContextGroup, originator, [
             loadParameters = WTFMove(loadParameters),
             newProcess = newProcess.copyRef(),
             preventProcessShutdownScope = newProcess->shutdownPreventingScope()

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2271,6 +2271,12 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
         return { WTFMove(sourceProcess), nullptr, "Process has not yet committed any provisional loads"_s };
     }
 
+    if (siteIsolationEnabled && navigation.currentRequest().url().isAboutBlank()) {
+        RefPtr navigationOriginatorFrame = navigation.originatingFrameInfo() ? WebFrameProxy::webFrame(navigation.originatingFrameInfo()->frameID) : nullptr;
+        if (navigationOriginatorFrame)
+            return { navigationOriginatorFrame->process(), nullptr, "Frame is navigating to about:blank from a cross site origin. Switching to process that originated navigation."_s };
+    }
+
     // FIXME: We should support process swap when a window has been opened via window.open() without 'noopener'.
     // The issue is that the opener has a handle to the WindowProxy.
     //

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -472,6 +472,9 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
         setLayerHostingContextIdentifier(*parameters.layerHostingContextIdentifier);
     if (parameters.initialSize)
         updateLocalFrameSize(localFrame, *parameters.initialSize);
+
+    if (parameters.commitTiming == CommitTiming::Immediately)
+        commitProvisionalFrame();
 }
 
 void WebFrame::destroyProvisionalFrame()


### PR DESCRIPTION
#### 84738405475ef105f150ad3d56be0e0c268902a2
<pre>
[Site Isolation] Navigation to about:blank inherits navigator&apos;s origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=302102">https://bugs.webkit.org/show_bug.cgi?id=302102</a>
<a href="https://rdar.apple.com/160706600">rdar://160706600</a>

Reviewed by Alex Christensen.

If an iframe is navigated to about:blank, it should inherit the origin
of whoever initiated the navigation.

With site isolation, this means that the about:blank iframe needs to
be in the same process as the navigator. If the iframe was previously
in a different origin than the navigator, this might require a process
swap.

This patch also attempts to perform these loads to about:blank &quot;immediately&quot;
by committing a provisional frame right after creating one since about:blank
iframes don&apos;t have any network resources to load.

Tests: http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page.html
       http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html

* LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page.html: Added.
* LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/frame-child-navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html: Added.
* Source/WebKit/Shared/ProvisionalFrameCreationParameters.h:
* Source/WebKit/Shared/ProvisionalFrameCreationParameters.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::initializeWebPage):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
(WebKit::WebFrameProxy::provisionalFrameCreationParameters):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigationInternal):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createProvisionalFrame):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, MainPageNavigatesCrossOriginIframeToAboutBlank)):
(TestWebKitAPI::(SiteIsolation, ChildIframeNavigatesCrossOriginGrandchildIframeToAboutBlank)):

Canonical link: <a href="https://commits.webkit.org/303299@main">https://commits.webkit.org/303299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c05ee53dd6f8281a26d2e7e442d31420aa16c0cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/131695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139204 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83558 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b376962d-9c99-4a43-862f-0755f7d6dae7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100674 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68111 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/43fd7279-dabd-4a0d-a9fb-3db401584a27) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/134641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117967 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81445 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/27a93207-a603-4feb-b5a5-f186a7cbb72f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2859 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/821 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82426 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/141850 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/3856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36663 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109038 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/3937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109195 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2946 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114240 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57066 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20518 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/3909 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32658 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/3741 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4001 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/3870 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->