### PR TITLE
YouTube full screen transition is broken

### DIFF
--- a/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
@@ -1,10 +1,8 @@
 supportsFullScreen() == true
 enterFullScreenForElement()
 beganEnterFullScreen() - initialRect.size: {300, 150}, finalRect.size: {800, 600}
-beganEnterFullScreen() - initialRect.origin: {-9992, 11282}, finalRect.origin: {9992, -11282}
 exitFullScreenForElement()
 beganExitFullScreen() - initialRect.size: {800, 600}, finalRect.size: {300, 150}
-beganExitFullScreen() - initialRect.origin: {9992, -11282}, finalRect.origin: {-9992, 11282}
 
 Size after entering fullscreen: 600x800
 iframe border style after transition: 0px none rgb(0, 0, 0)

--- a/LayoutTests/http/tests/site-isolation/fullscreen.html
+++ b/LayoutTests/http/tests/site-isolation/fullscreen.html
@@ -4,7 +4,6 @@
         testRunner.waitUntilDone();
         testRunner.dumpAsText()
         testRunner.dumpFullScreenCallbacks();
-        testRunner.dumpFullScreenOrigin();
     }
     addEventListener("message", (event) => {
         document.getElementById("mylog").innerHTML += event.data + "<br>";

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -128,7 +128,7 @@ public:
 private:
     WebFullScreenManagerProxy(WebPageProxy&, WebFullScreenManagerProxyClient&);
 
-    Awaitable<std::optional<WebCore::IntRect>> enterFullScreen(IPC::Connection&, WebCore::FrameIdentifier, bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails, WebCore::FrameIdentifier rootFrameID, WebCore::IntRect initialFrameInRootFrameCoordinates);
+    Awaitable<bool> enterFullScreen(IPC::Connection&, WebCore::FrameIdentifier, bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails);
     void didEnterFullScreen(CompletionHandler<void(bool)>&&);
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(FullScreenMediaDetails&&);

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
@@ -28,7 +28,7 @@
     EnabledBy=FullScreenEnabled || VideoFullscreenRequiresElementFullscreen
 ]
 messages -> WebFullScreenManagerProxy {
-    EnterFullScreen(WebCore::FrameIdentifier frameID, bool blocksReturnToFullscreenFromPictureInPicture, struct WebKit::FullScreenMediaDetails mediaDetails, WebCore::FrameIdentifier rootFrameID, WebCore::IntRect initialFrameInRootFrameCoordinates) -> (std::optional<WebCore::IntRect> transformedInitialFrame)
+    EnterFullScreen(WebCore::FrameIdentifier frameID, bool blocksReturnToFullscreenFromPictureInPicture, struct WebKit::FullScreenMediaDetails mediaDetails) -> (bool success)
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     UpdateImageSource(struct WebKit::FullScreenMediaDetails mediaDetails)
 #endif

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -628,20 +628,6 @@ void TestController::beganEnterFullScreen(WKPageRef page, WKRect initialFrame, W
             "}\n"_s
         ));
     }
-
-    if (m_dumpFullScreenOrigin) {
-        protectedCurrentInvocation()->outputText(makeString(
-            "beganEnterFullScreen() - initialRect.origin: {"_s,
-            (initialFrame.origin.x - finalFrame.origin.x),
-            ", "_s,
-            (initialFrame.origin.y - finalFrame.origin.y),
-            "}, finalRect.origin: {"_s,
-            (finalFrame.origin.x - initialFrame.origin.x),
-            ", "_s,
-            (finalFrame.origin.y - initialFrame.origin.y),
-            "}\n"_s
-        ));
-    }
 }
 
 void TestController::exitFullScreen(WKPageRef page, const void* clientInfo)
@@ -672,20 +658,6 @@ void TestController::beganExitFullScreen(WKPageRef, WKRect initialFrame, WKRect 
         finalFrame.size.width,
         ", "_s,
         finalFrame.size.height,
-        "}\n"_s
-        ));
-    }
-
-    if (m_dumpFullScreenOrigin) {
-        protectedCurrentInvocation()->outputText(makeString(
-        "beganExitFullScreen() - initialRect.origin: {"_s,
-        (initialFrame.origin.x - finalFrame.origin.x),
-        ", "_s,
-        (initialFrame.origin.y - finalFrame.origin.y),
-        "}, finalRect.origin: {"_s,
-        (finalFrame.origin.x - initialFrame.origin.x),
-        ", "_s,
-        (finalFrame.origin.y - initialFrame.origin.y),
         "}\n"_s
         ));
     }
@@ -1630,7 +1602,6 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     m_shouldDownloadContentDispositionAttachments = true;
     m_dumpPolicyDelegateCallbacks = false;
     m_dumpFullScreenCallbacks = false;
-    m_dumpFullScreenOrigin = false;
     m_waitBeforeFinishingFullscreenExit = false;
     m_scrollDuringEnterFullscreen = false;
     if (m_finishExitFullscreenHandler)
@@ -2001,7 +1972,6 @@ if (window.testRunner) {
     testRunner.setBlockAllPlugins = value => post(['SetBlockAllPlugins', value]);
     testRunner.stopLoading = () => post(['StopLoading']);
     testRunner.dumpFullScreenCallbacks = () => post(['DumpFullScreenCallbacks']);
-    testRunner.dumpFullScreenOrigin = () => post(['DumpFullScreenOrigin']);
     testRunner.displayAndTrackRepaints = () => post(['DisplayAndTrackRepaints']);
     testRunner.clearBackForwardList = () => post(['ClearBackForwardList']);
     testRunner.addChromeInputField = async (callback) => { await post(['AddChromeInputField']); callback?.(); }; // NOLINT
@@ -2571,11 +2541,6 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
 
     if (WKStringIsEqualToUTF8CString(command, "DumpFullScreenCallbacks")) {
         dumpFullScreenCallbacks();
-        return completionHandler(nullptr);
-    }
-
-    if (WKStringIsEqualToUTF8CString(command, "DumpFullScreenOrigin")) {
-        dumpFullScreenOrigin();
         return completionHandler(nullptr);
     }
 

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -202,7 +202,6 @@ public:
 
     void dumpPolicyDelegateCallbacks() { m_dumpPolicyDelegateCallbacks = true; }
     void dumpFullScreenCallbacks() { m_dumpFullScreenCallbacks = true; }
-    void dumpFullScreenOrigin() { m_dumpFullScreenOrigin = true; }
     void waitBeforeFinishingFullscreenExit() { m_waitBeforeFinishingFullscreenExit = true; }
     void scrollDuringEnterFullscreen() { m_scrollDuringEnterFullscreen = true; }
     void finishFullscreenExit();
@@ -852,7 +851,6 @@ private:
     bool m_shouldDownloadContentDispositionAttachments { true };
     bool m_dumpPolicyDelegateCallbacks { false };
     bool m_dumpFullScreenCallbacks { false };
-    bool m_dumpFullScreenOrigin { false };
     bool m_waitBeforeFinishingFullscreenExit { false };
     bool m_scrollDuringEnterFullscreen { false };
     bool m_useWorkQueue { false };


### PR DESCRIPTION
#### e77199296e94ffe8675fdb8e9800fd232e5aa36c
<pre>
YouTube full screen transition is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=301322">https://bugs.webkit.org/show_bug.cgi?id=301322</a>
<a href="https://rdar.apple.com/163228181">rdar://163228181</a>

Unreviewed, reverting 301065@main (10bc7cf26356)

Revert &quot;[Site Isolation] Enter fullscreen animation begin needs coordinate transformation with site isolation on&quot;

This reverts commit 10bc7cf26356bbc80c3261052768d5c8ff8d7fc4.

Canonical link: <a href="https://commits.webkit.org/302010@main">https://commits.webkit.org/302010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad2f367e9065c5a421a19071e14f60aa72fc8b2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135004 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79289 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8b1c473a-821e-4eb0-a311-287417210e31) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97226 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/08961611-12de-4dfa-ab0c-6748abf4e4ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77708 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6f434c90-e9e5-45bc-8501-15166ba86d01) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32516 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78362 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108255 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137486 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41926 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105747 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105399 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26884 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50918 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29354 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/52010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54328 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60504 "Found 3 new failures in WebProcess/FullScreen/WebFullScreenManager.cpp") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53564 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/57019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->