### PR TITLE
REGRESSION(301753@main): IndexedDB database cannot be opened after name upgrade

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -722,7 +722,7 @@ static IDBError migrateIDBDatabaseInfoTableIfNecessary(SQLiteDatabase& database,
     SQLiteTransaction transaction(database);
     transaction.begin();
 
-    if (existingDatabaseName != databaseName) {
+    {
         auto sql = database.prepareStatement("REPLACE INTO IDBDatabaseInfo VALUES ('DatabaseName', ?);"_s);
         if (!sql
             || CheckedRef { *sql }->bindBlob(1, databaseName) != SQLITE_OK

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm
@@ -270,3 +270,50 @@ TEST(IndexedDB, IndexedDBFileHashCollision)
     RetainPtr<NSString> string = (NSString *)[lastScriptMessage body];
     EXPECT_WK_STREQ(@"Error", string.get());
 }
+
+TEST(IndexedDB, OpenDatabaseAfterDatabaseNameUpgrade)
+{
+    RetainPtr handler = adoptNS([[IndexedDBFileNameMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+
+    RetainPtr originURL = [NSURL URLWithString:@"file://"];
+    __block RetainPtr<NSString> indexedDBDirectoryString;
+    __block bool done = false;
+    [configuration.get().websiteDataStore _originDirectoryForTesting:originURL.get() topOrigin:originURL.get() type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
+        indexedDBDirectoryString = result;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    RetainPtr indexedDBDirectory = [NSURL fileURLWithPath:indexedDBDirectoryString.get() isDirectory:YES];
+    String databaseHash = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBTest"_s);
+    RetainPtr indexedDBDatabaseDirectory = [indexedDBDirectory URLByAppendingPathComponent:databaseHash.createNSString().get()];
+    RetainPtr indexedDBDatabaseFile = [indexedDBDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
+    RetainPtr resourceDatabaseFileURL = [NSBundle.test_resourcesBundle URLForResource:@"IndexedDB" withExtension:@"sqlite3"];
+    RetainPtr fileManager = [NSFileManager defaultManager];
+    // Remove existing database files.
+    [fileManager removeItemAtURL:indexedDBDatabaseDirectory.get() error:nil];
+    [fileManager createDirectoryAtURL:indexedDBDatabaseDirectory.get() withIntermediateDirectories:YES attributes:nil error:nil];
+    // Create database file with old version.
+    [fileManager copyItemAtURL:resourceDatabaseFileURL.get() toURL:indexedDBDatabaseFile.get() error:nil];
+    EXPECT_TRUE([fileManager fileExistsAtPath:resourceDatabaseFileURL.get().path]);
+
+    // Upgrade an existing database.
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBFileName-2" withExtension:@"html"]];
+    receivedScriptMessage = false;
+    [webView loadRequest:request.get()];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    RetainPtr string = (NSString *)[lastScriptMessage body];
+    EXPECT_WK_STREQ(@"Success", string.get());
+
+    // Force re-opening database.
+    [configuration.get().websiteDataStore _terminateNetworkProcess];
+
+    // Ensure the upgraded database can be opened.
+    receivedScriptMessage = false;
+    [webView reload];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    string = (NSString *)[lastScriptMessage body];
+    EXPECT_WK_STREQ(@"Success", string.get());
+}


### PR DESCRIPTION
#### c3cb68d16a4d4d35f17c2d46f784f8675bb141f1
<pre>
REGRESSION(301753@main): IndexedDB database cannot be opened after name upgrade
<a href="https://bugs.webkit.org/show_bug.cgi?id=301327">https://bugs.webkit.org/show_bug.cgi?id=301327</a>
<a href="https://rdar.apple.com/163219457">rdar://163219457</a>

Reviewed by Per Arne Vollan.

The current implementation does not correctly upgrade database name in database due to a wrong condition check --
migrateIDBDatabaseInfoTableIfNecessary already performs database name equality check at L710, so it should not check
again and skip record update at L725. Otherwise, the database might end up having mismatched metadata versions and
database name format.

New test: IndexedDB.OpenDatabaseAfterDatabaseNameUpgrade

* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::migrateIDBDatabaseInfoTableIfNecessary):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm:
(TEST(IndexedDB, OpenDatabaseAfterDatabaseNameUpgrade)):

Canonical link: <a href="https://commits.webkit.org/302055@main">https://commits.webkit.org/302055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f17a51db6f37ad301d3b3d73698a674502a48c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135194 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79376 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d3f576e6-ae8d-4aa1-a513-f33c06881a23) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97301 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65207 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a7949436-bf17-4e5e-b40f-d34a1e951720) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114498 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77871 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c34f9d2a-ce4f-43aa-b2b0-af1d7ea40eb4) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37253 "Build is being retried. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 4 new passes 2 failures; Uploaded test results") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32603 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78499 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137672 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/42011 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105831 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105564 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26913 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50994 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29432 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52115 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54414 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60907 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53650 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55406 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->