### PR TITLE
[PageLifecycleAPI] add 'freeze' and 'resume' events and 'wasDiscarded' boolean to the document

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/page-lifecycle/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/page-lifecycle/idlharness-expected.txt
@@ -12,10 +12,10 @@ PASS Document includes NonElementParentNode: member names are unique
 PASS Document includes DocumentOrShadowRoot: member names are unique
 PASS Document includes ParentNode: member names are unique
 PASS Document includes XPathEvaluatorBase: member names are unique
-FAIL Document interface: attribute onfreeze assert_true: The prototype object must have a property "onfreeze" expected true got false
-FAIL Document interface: attribute onresume assert_true: The prototype object must have a property "onresume" expected true got false
-FAIL Document interface: attribute wasDiscarded assert_true: The prototype object must have a property "wasDiscarded" expected true got false
-FAIL Document interface: document must inherit property "onfreeze" with the proper type assert_inherits: property "onfreeze" not found in prototype chain
-FAIL Document interface: document must inherit property "onresume" with the proper type assert_inherits: property "onresume" not found in prototype chain
-FAIL Document interface: document must inherit property "wasDiscarded" with the proper type assert_inherits: property "wasDiscarded" not found in prototype chain
+PASS Document interface: attribute onfreeze
+PASS Document interface: attribute onresume
+PASS Document interface: attribute wasDiscarded
+PASS Document interface: document must inherit property "onfreeze" with the proper type
+PASS Document interface: document must inherit property "onresume" with the proper type
+PASS Document interface: document must inherit property "wasDiscarded" with the proper type
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -755,6 +755,10 @@ imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-005.html [ Pass
 
 imported/w3c/web-platform-tests/service-workers/service-worker/fetch-audio-tainting.https.html [ Pass ]
 
+imported/w3c/web-platform-tests/page-lifecycle/child-display-none.tentative.html [ Pass ]
+imported/w3c/web-platform-tests/page-lifecycle/child-out-of-viewport.tentative.html [ Pass ]
+imported/w3c/web-platform-tests/page-lifecycle/worker-dispay-none.tentative.html [ Pass ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of PASSING tests.
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5877,6 +5877,21 @@ PageAtRuleMarginDescriptorsEnabled:
     WebCore:
       default: true
 
+PageLifecycleAPIEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Page Lifecycle API"
+  humanReadableDescription: "Enable the Page Lifecycle API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      "PLATFORM(GTK) || PLATFORM(WPE)" : true
+      default: false
+    WebCore:
+      default: false
+
 PageVisibilityBasedProcessSuppressionEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -12078,6 +12078,20 @@ void Document::processSpeculationRulesHeader(const String& headerValue, const UR
     }
 }
 
+// https://wicg.github.io/page-lifecycle/spec.html#freeze-steps
+void Document::freeze()
+{
+    m_frozen = true;
+    dispatchEvent(Event::create(eventNames().freezeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+}
+
+// https://wicg.github.io/page-lifecycle/spec.html#resume-steps
+void Document::resume()
+{
+    dispatchEvent(Event::create(eventNames().resumeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    m_frozen = false;
+}
+
 } // namespace WebCore
 
 #undef DOCUMENT_RELEASE_LOG

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2049,6 +2049,11 @@ public:
 
     void processSpeculationRulesHeader(const String& headerValue, const URL& baseURL);
 
+    void freeze();
+    void resume();
+    void discard();
+    bool wasDiscarded() const { return m_discarded; }
+
 protected:
     enum class ConstructionFlag : uint8_t {
         Synthesized = 1 << 0,
@@ -2802,6 +2807,9 @@ private:
     const Ref<DocumentSyncData> m_syncData;
 
     Vector<Ref<LoadableSpeculationRules>> m_loadableSpeculationRules;
+
+    bool m_frozen { false };
+    bool m_discarded { false };
 }; // class Document
 
 inline AXObjectCache* Document::existingAXObjectCache() const

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -93,6 +93,10 @@ typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
 
     // Non standard: It has been dropped from Blink already.
     RenderingContext? getCSSCanvasContext(DOMString contextId, DOMString name, long width, long height);
+
+    [EnabledBySetting=PageLifecycleAPIEnabled] attribute EventHandler onfreeze;
+    [EnabledBySetting=PageLifecycleAPIEnabled] attribute EventHandler onresume;
+    [EnabledBySetting=PageLifecycleAPIEnabled] readonly attribute boolean wasDiscarded;
 };
 
 enum DocumentReadyState { "loading", "interactive", "complete" };

--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -111,6 +111,7 @@
     "formdata": { },
     "fullscreenchange": { },
     "fullscreenerror": { },
+    "freeze": { },
     "gamepadconnected": { "categories": ["Gamepad"] },
     "gamepaddisconnected": { "categories": ["Gamepad"] },
     "gatheringstatechange": { },

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -430,7 +430,7 @@ static void setBackForwardCacheState(Page& page, Document::BackForwardCacheState
     });
 }
 
-static void firePageHideEventRecursively(Frame& frame)
+static void firePageHideAndFreezeEventsRecursively(Frame& frame)
 {
     std::optional<UnloadCountIncrementer> unloadCountIncrementer;
     if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame)) {
@@ -445,9 +445,10 @@ static void firePageHideEventRecursively(Frame& frame)
         unloadCountIncrementer.emplace(document.get());
 
         localFrame->loader().stopLoading(UnloadEventPolicy::UnloadAndPageHide);
+        document->freeze();
     }
     for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling())
-        firePageHideEventRecursively(*child);
+        firePageHideAndFreezeEventsRecursively(*child);
 }
 
 std::unique_ptr<CachedPage> BackForwardCache::trySuspendPage(Page& page, ForceSuspension forceSuspension)
@@ -467,8 +468,8 @@ std::unique_ptr<CachedPage> BackForwardCache::trySuspendPage(Page& page, ForceSu
     if (CheckedRef focusController = page.focusController(); focusController->focusedLocalFrame())
         focusController->setFocusedFrame(mainFrame.ptr());
 
-    // Fire the pagehide event in all frames.
-    firePageHideEventRecursively(mainFrame);
+    // Fire the pagehide and freeze events in all frames.
+    firePageHideAndFreezeEventsRecursively(mainFrame);
 
     page.destroyRenderTrees();
 

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -77,7 +77,7 @@ CachedPage::~CachedPage()
         m_cachedMainFrame->destroy();
 }
 
-static void firePageShowEvent(Page& page)
+static void firePageShowAndResumeEvent(Page& page)
 {
     // Dispatching JavaScript events can cause frame destruction.
     Ref mainFrame = page.mainFrame();
@@ -94,6 +94,8 @@ static void firePageShowEvent(Page& page)
         RefPtr document = child->document();
         if (!document)
             continue;
+
+        document->resume();
 
         document->clearRevealForReactivation();
         // This takes care of firing the visibilitychange event and making sure the document is reported as visible.
@@ -176,7 +178,7 @@ void CachedPage::restore(Page& page)
             frameView->updateContentsSize();
     }
 
-    firePageShowEvent(page);
+    firePageShowAndResumeEvent(page);
 
     // Update Navigation API after pageshow events to ensure correct event ordering.
     if (CheckedRef backForwardController = page.backForward(); page.settings().navigationAPIEnabled() && localMainFrame)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -5933,3 +5933,104 @@ void webkit_web_view_leave_immersive_mode(WebKitWebView* webView)
         xrSystem->invalidate(PlatformXRSystem::InvalidationReason::Client);
 #endif
 }
+
+/**
+ * webkit_web_view_freeze:
+ * @web_view: a #WebKitWebView
+ * @cancellable: (nullable): a #GCancellable, or %NULL
+ * @callback: (scope async): a #GAsyncReadyCallback to invoke when the operation finishes
+ * @user_data: (nullable): data to pass to @callback
+ *
+ * Asynchronously freezes the current web page associated with #WebKitWebView.
+ *
+ * Freezing a web view suspends script execution, timers, and other
+ * activities within the page, reducing CPU usage while keeping the
+ * page state intact. You can later call webkit_web_view_resume() to
+ * resume normal operation.
+ *
+ * When the operation finishes, @callback will be invoked. You should then call
+ * webkit_web_view_freeze_finish() to obtain the result of the operation.
+ *
+ * Since: 2.52
+ */
+void webkit_web_view_freeze(WebKitWebView *webView, GCancellable* cancellable, GAsyncReadyCallback callback, gpointer userData)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+    g_return_if_fail(!getPage(webView).isSuspended());
+
+    GRefPtr<GTask> task = adoptGRef(g_task_new(webView, cancellable, callback, userData));
+    getPage(webView).suspend([task = WTFMove(task)](bool success) {
+        if (g_task_return_error_if_cancelled(task.get()))
+            return;
+        g_task_return_boolean(task.get(), success);
+    });
+}
+
+/**
+ * webkit_web_view_freeze_finish:
+ * @web_view: a #WebKitWebView
+ * @result: a #GAsyncResult
+ * @error: return location for a #GError, or %NULL to ignore
+ *
+ * Finishes an asynchronous operation started with webkit_web_view_freeze().
+ *
+ * Returns: %TRUE if the operation completed successfully, or %FALSE if an error occurred.
+ *
+ * Since: 2.52
+ */
+gboolean webkit_web_view_freeze_finish(WebKitWebView* webView, GAsyncResult* result, GError** error)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), FALSE);
+    g_return_val_if_fail(g_task_is_valid(result, webView), FALSE);
+
+    return g_task_propagate_boolean(G_TASK(result), error);
+}
+
+/**
+ * webkit_web_view_resume:
+ * @web_view: a #WebKitWebView
+ * @cancellable: (nullable): a #GCancellable, or %NULL
+ * @callback: (scope async): a #GAsyncReadyCallback to invoke when the operation finishes
+ * @user_data: (nullable): data to pass to @callback
+ *
+ * Asynchronously resumes the current web page associated with #WebKitWebView.
+ * This reverses a previous call to webkit_web_view_freeze() and allows the
+ * page to continue running.
+ *
+ * When the operation finishes, @callback will be invoked. You should then call
+ * webkit_web_view_resume_finish() to obtain the result of the operation.
+ *
+ * Since: 2.52
+ */
+void webkit_web_view_resume(WebKitWebView *webView, GCancellable* cancellable, GAsyncReadyCallback callback, gpointer userData)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+    g_return_if_fail(getPage(webView).isSuspended());
+
+    GRefPtr<GTask> task = adoptGRef(g_task_new(webView, cancellable, callback, userData));
+    getPage(webView).resume([task = WTFMove(task)](bool success) {
+        if (g_task_return_error_if_cancelled(task.get()))
+            return;
+        g_task_return_boolean(task.get(), success);
+    });
+}
+
+/**
+ * webkit_web_view_resume_finish:
+ * @web_view: a #WebKitWebView
+ * @result: a #GAsyncResult
+ * @error: return location for error or %NULL to ignore
+ *
+ * Finishes an asynchronous operation started with webkit_web_view_resume().
+ *
+ * Returns: %TRUE if the operation completed successfully, or %FALSE if an error occurred.
+ *
+ * Since: 2.52
+ */
+gboolean webkit_web_view_resume_finish(WebKitWebView* webView, GAsyncResult* result, GError** error)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), FALSE);
+    g_return_val_if_fail(g_task_is_valid(result, webView), FALSE);
+
+    return g_task_propagate_boolean(G_TASK(result), error);
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -926,6 +926,28 @@ webkit_web_view_is_immersive_mode_enabled            (WebKitWebView             
 WEBKIT_API void
 webkit_web_view_leave_immersive_mode                 (WebKitWebView             *web_view);
 
+WEBKIT_API void
+webkit_web_view_freeze                               (WebKitWebView               *web_view,
+                                                      GCancellable              *cancellable,
+                                                      GAsyncReadyCallback       callback,
+                                                      gpointer                  user_data);
+
+WEBKIT_API gboolean
+webkit_web_view_freeze_finish                        (WebKitWebView             *web_view,
+                                                      GAsyncResult              *result,
+                                                      GError                    **error);
+
+WEBKIT_API void
+webkit_web_view_resume                               (WebKitWebView               *web_view,
+                                                      GCancellable              *cancellable,
+                                                      GAsyncReadyCallback       callback,
+                                                      gpointer                  user_data);
+
+WEBKIT_API gboolean
+webkit_web_view_resume_finish                        (WebKitWebView             *web_view,
+                                                      GAsyncResult              *result,
+                                                      GError                    **error);
+
 #if USE(GI_FINISH_FUNC_ANNOTATION)
 /**
  * webkit_web_view_run_async_javascript_function_in_world: (finish-func webkit_web_view_run_javascript_in_world_finish)


### PR DESCRIPTION
#### 50bea2493d25e42c600dce436edf0a8fa316826d
<pre>
[PageLifecycleAPI] add &apos;freeze&apos; and &apos;resume&apos; events and &apos;wasDiscarded&apos; boolean to the document
<a href="https://bugs.webkit.org/show_bug.cgi?id=296266">https://bugs.webkit.org/show_bug.cgi?id=296266</a>

It introduces initial support for the Page Lifecycle API as defined by
<a href="https://wicg.github.io/page-lifecycle/.">https://wicg.github.io/page-lifecycle/.</a>
The implementation reuses the existing mechanisms for page suspension and
restoration used by the Back/Forward Cache (bfCache). Freezing leverages the
same suspend logic as when a page enters the bfCache, while resuming uses the
restore path.

- Added `PageLifecycleAPIEnabled` preference flag (disabled by default).
- Basic implementation of `Document::discard()` and `Document::wasDiscarded()`.
- Implemented `Document::freeze()` and `Document::resume()` to dispatch
  `freeze` and `resume` events.
- Updated BackForwardCache to trigger `freeze` event when suspending a page and
  `resume` event when restoring.
- Added `onfreeze` and `onresume` event handler attributes to Document.idl.
- Added `wasDiscarded` boolean and readonly attribute to Document.idl.
- Introduced new public API for WebKitGTK and WPE:
    * `webkit_web_view_freeze()`
    * `webkit_web_view_resume()`
  These allow application to explicitly freeze or resume a web view asynchronously.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::freeze):
(WebCore::Document::resume):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Document.idl:
* Source/WebCore/dom/EventNames.json:
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::fireEventsRecursively):
(WebCore::BackForwardCache::trySuspendPage):
(WebCore::firePageHideEventRecursively): Deleted.
* Source/WebCore/history/CachedPage.cpp:
(WebCore::fireEvents):
(WebCore::CachedPage::restore):
(WebCore::firePageShowEvent): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aebcdab411155959309d3600e419ccf371dd6ab7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135895 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79941 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97827 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65822 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33240 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79178 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120517 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108891 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138344 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126963 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106364 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/652 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106258 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/511 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30013 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52946 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/664 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63863 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159985 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/551 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39955 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->