### PR TITLE
Unreviewed, reverting 301987@main (b9d52d2f714f)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https-expected.txt
@@ -1,3 +1,0 @@
-
-PASS XRRay constructors work
-

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https-expected.txt
@@ -1,3 +1,0 @@
-
-PASS XRRay matrix works
-

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2858,8 +2858,6 @@ imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_constructor.https.ht
 imported/w3c/web-platform-tests/webxr/layers/idlharness.https.window.html [ Pass ]
 
 imported/w3c/web-platform-tests/webxr/hit-test/idlharness.https.html [ Pass ]
-imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https.html [ Pass ]
-imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https.html [ Pass ]
 
 http/wpt/webxr [ Pass ]
 webxr [ Pass ]

--- a/Source/WebCore/Modules/webxr/WebXRRay.h
+++ b/Source/WebCore/Modules/webxr/WebXRRay.h
@@ -28,8 +28,6 @@
 #if ENABLE(WEBXR_HIT_TEST)
 
 #include "ExceptionOr.h"
-#include "FloatPoint3D.h"
-#include "TransformationMatrix.h"
 #include <JavaScriptCore/Float32Array.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -53,11 +51,9 @@ public:
     const Float32Array& matrix();
 
 private:
-    WebXRRay(FloatPoint3D origin, FloatPoint3D direction);
+    WebXRRay(WebXRRigidTransform&);
 
-    FloatPoint3D m_origin;
-    FloatPoint3D m_direction;
-    RefPtr<Float32Array> m_matrix;
+    Ref<WebXRRigidTransform> m_transform;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7ef08aba259e0b850519ab5a46db8e814545cb1f
<pre>
Unreviewed, reverting 301987@main (b9d52d2f714f)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301255">https://bugs.webkit.org/show_bug.cgi?id=301255</a>

It broke GTK and WPE clang builds.

Reverted change:

    [WebXR Hit Test] XRRay support
    <a href="https://bugs.webkit.org/show_bug.cgi?id=301255">https://bugs.webkit.org/show_bug.cgi?id=301255</a>
    301987@main (b9d52d2f714f)

Canonical link: <a href="https://commits.webkit.org/302016@main">https://commits.webkit.org/302016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1f8e61761da595af4e8687e92e82bce0297d5bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135022 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55929 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77722 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78392 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137506 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41944 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105761 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110789 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/105413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26890 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50935 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29370 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/52030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54346 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60606 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53582 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/57037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->