### PR TITLE
Simplify CanvasBase::setSize

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8578,7 +8578,7 @@ std::optional<RenderingContext> Document::getCSSCanvasContext(const String& type
     RefPtr element = getCSSCanvasElement(name);
     if (!element)
         return std::nullopt;
-    element->setSize({ width, height });
+    element->setCSSCanvasContextSize({ width, height });
     auto context = element->getContext(type);
     if (!context)
         return std::nullopt;

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -150,7 +150,7 @@ protected:
     RefPtr<ScriptExecutionContext> protectedCanvasBaseScriptExecutionContext() const;
     virtual std::unique_ptr<CSSParserContext> createCSSParserContext() const = 0;
 
-    virtual void setSize(const IntSize&);
+    void setSize(const IntSize&);
 
     RefPtr<ImageBuffer> setImageBuffer(RefPtr<ImageBuffer>&&) const;
     String lastFillText() const { return m_lastFillText; }

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -77,8 +77,7 @@ public:
 
     WEBCORE_EXPORT ExceptionOr<void> setWidth(unsigned);
     WEBCORE_EXPORT ExceptionOr<void> setHeight(unsigned);
-
-    void setSize(const IntSize& newSize) override;
+    void setCSSCanvasContextSize(const IntSize& newSize);
 
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
     ExceptionOr<std::optional<RenderingContext>> getContext(JSC::JSGlobalObject&, const String& contextId, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments);
@@ -175,12 +174,10 @@ private:
     bool canContainRangeEndPoint() const final;
     bool canStartSelection() const final;
 
-    void reset();
+    void didUpdateSizeProperties();
 
     void createImageBuffer() const final;
     void clearImageBuffer() const;
-
-    void setSurfaceSize(const IntSize&);
 
     bool usesContentsAsLayerContents() const;
 
@@ -191,7 +188,7 @@ private:
 
     std::optional<FloatRect> computeDirtyRectangleIfNeeded(const std::optional<FloatRect>&) const;
 
-    bool m_ignoreReset { false };
+    bool m_ignoreDidUpdateSizeProperties { false };
     mutable bool m_didClearImageBuffer { false };
 #if ENABLE(WEBGL)
     bool m_hasRelevantWebGLEventListener { false };

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -164,11 +164,9 @@ private:
     void refEventTarget() final { RefCounted::ref(); }
     void derefEventTarget() final { RefCounted::deref(); }
 
-    void setSize(const IntSize&) final;
-
+    void didUpdateSizeProperties();
     void createImageBuffer() const final;
 
-    void reset();
     void scheduleCommitToPlaceholderCanvas();
 
     std::unique_ptr<CanvasRenderingContext> m_context;


### PR DESCRIPTION
#### 567d1d7beea8fab8107ee44d5d3ba3723db4542a
<pre>
Simplify CanvasBase::setSize
<a href="https://bugs.webkit.org/show_bug.cgi?id=301343">https://bugs.webkit.org/show_bug.cgi?id=301343</a>
<a href="https://rdar.apple.com/163259339">rdar://163259339</a>

Reviewed by Antti Koivisto.

CanvasBase::setSize() is used by OffscreenCanvas, HTMLCanvasElement as
common implementation to store the context size as requested by the
client. It does not really resize anything.

CanvasBase::setSize() was also a virtual function.

HTMLCanvasElement::setSize() overload was used to expose resize
operation to CSSCanvasContext feature (Document::getCSSCanvasContext).
This would resize the canvas.

The virtual function aspect was not used and created very unclear
control flows.

Fix by:
- Rename HTMLCanvasElement::setSize() to
  HTMLCanvasElement::setCSSCanvasContextSize().
- Remove redundant function HTMLCanvasELement::setSurfaceSize()
  &quot;Surface&quot; is not part of vocabularity of the related abstractions of
  the domain.
- Rename opaque HTMLCanvasElement::reset() to more descriptive
  HTMLCanvasELement::didUpdateSizeProperties().

This is work towards being able to move the backbuffer of various
canvas rendering contexts from CanvasBase to the rendering contexts.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::didUpdateSize):
(WebCore::CanvasBase::setSize): Deleted.
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::attributeChanged):
(WebCore::HTMLCanvasElement::setCSSCanvasContextSize):
(WebCore::HTMLCanvasElement::didUpdateSizeProperties):
(WebCore::HTMLCanvasElement::setSize): Deleted.
(WebCore::HTMLCanvasElement::reset): Deleted.
(WebCore::HTMLCanvasElement::setSurfaceSize): Deleted.
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::setWidth):
(WebCore::OffscreenCanvas::setHeight):
(WebCore::OffscreenCanvas::didUpdateSizeProperties):
(WebCore::OffscreenCanvas::setSize): Deleted.
(WebCore::OffscreenCanvas::reset): Deleted.
* Source/WebCore/html/OffscreenCanvas.h:

Canonical link: <a href="https://commits.webkit.org/302177@main">https://commits.webkit.org/302177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d75a37fbead44395358019a15e8883f8066621a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135119 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79336 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/73f2c8be-38b4-4166-9760-b757b43a5856) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97269 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65178 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/615ffa65-57bd-4725-93b0-d6e7faa4cd4f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77762 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a92aa36d-941c-4053-b72a-31423a23c697) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32561 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78460 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137577 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105799 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105482 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27003 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50959 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29395 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52068 "Hash 9d75a37f for PR 52878 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54375 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60756 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53611 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/57065 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55367 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->