### PR TITLE
[WebXR Hit Test] XRRay support

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS XRRay constructors work
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS XRRay matrix works
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2856,6 +2856,8 @@ imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.htt
 imported/w3c/web-platform-tests/webxr/hand-input/ [ Pass ]
 
 imported/w3c/web-platform-tests/webxr/hit-test/idlharness.https.html [ Pass ]
+imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https.html [ Pass ]
+imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https.html [ Pass ]
 
 http/wpt/webxr [ Pass ]
 webxr [ Pass ]

--- a/Source/WebCore/Modules/webxr/WebXRRay.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRRay.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025 Igalia S.L. All rights reserved.
+ * Copyright (C) 2018 The Chromium Authors
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,21 +39,37 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebXRRay);
 
+// https://immersive-web.github.io/hit-test/#dom-xrray-xrray
 ExceptionOr<Ref<WebXRRay>> WebXRRay::create(const DOMPointInit& origin, const XRRayDirectionInit& direction)
 {
-    auto exceptionOrTransform = WebXRRigidTransform::create(origin, DOMPointInit { direction.x, direction.y, direction.z, direction.w });
-    if (exceptionOrTransform.hasException())
-        return exceptionOrTransform.releaseException();
-    return adoptRef(*new WebXRRay(exceptionOrTransform.releaseReturnValue()));
+    if (!direction.x && !direction.y && !direction.z)
+        return Exception { ExceptionCode::TypeError };
+    if (direction.w)
+        return Exception { ExceptionCode::TypeError };
+    if (origin.w != 1)
+        return Exception { ExceptionCode::TypeError };
+    Ref<DOMPointReadOnly> dpOrigin = DOMPointReadOnly::fromPoint(origin);
+    std::optional<Ref<DOMPointReadOnly>> dpDirection;
+    double length = std::hypot(direction.x, direction.y, direction.z);
+    if (length)
+        dpDirection = DOMPointReadOnly::create(direction.x / length, direction.y / length, direction.z / length, 0);
+    else
+        dpDirection = DOMPointReadOnly::create(0, 0, -1, 0);
+    return adoptRef(*new WebXRRay(WTFMove(dpOrigin), *WTFMove(dpDirection)));
 }
 
 Ref<WebXRRay> WebXRRay::create(WebXRRigidTransform& transform)
 {
-    return adoptRef(*new WebXRRay(transform));
+    FloatPoint3D origin = transform.rawTransform().mapPoint({ 0, 0, 0 });
+    FloatPoint3D z = transform.rawTransform().mapPoint({ 0, 0, -1 });
+    FloatPoint3D direction = z - origin;
+    Ref dpDirection = DOMPointReadOnly::create(direction.x(), direction.y(), direction.z(), 0);
+    return adoptRef(*new WebXRRay(DOMPointReadOnly::fromFloatPoint(origin), WTFMove(dpDirection)));
 }
 
-WebXRRay::WebXRRay(WebXRRigidTransform& transform)
-    : m_transform(transform)
+WebXRRay::WebXRRay(Ref<DOMPointReadOnly>&& origin, Ref<DOMPointReadOnly>&& direction)
+    : m_origin(WTFMove(origin))
+    , m_direction(WTFMove(direction))
 {
 }
 
@@ -60,17 +77,42 @@ WebXRRay::~WebXRRay() = default;
 
 const DOMPointReadOnly& WebXRRay::origin()
 {
-    return m_transform->position();
+    return m_origin;
 }
 
 const DOMPointReadOnly& WebXRRay::direction()
 {
-    return m_transform->orientation();
+    return m_direction;
 }
 
+// https://immersive-web.github.io/hit-test/#dom-xrray-matrix
 const Float32Array& WebXRRay::matrix()
 {
-    return m_transform->matrix();
+    if (m_matrix && !m_matrix->isDetached())
+        return *m_matrix;
+
+    TransformationMatrix transform;
+    transform.translate3d(m_origin->x(), m_origin->y(), m_origin->z());
+    FloatPoint3D z { 0, 0, -1 };
+    FloatPoint3D direction(m_direction->x(), m_direction->y(), m_direction->z());
+    float cosAngle = z.dot(direction);
+    if (cosAngle > 0.9999) {
+        // Vectors are co-linear or almost co-linear & face the same direction,
+        // no rotation is needed.
+    } else if (cosAngle < -0.9999) {
+        // Vectors are co-linear or almost co-linear & face the opposite
+        // direction, rotation by 180 degrees is needed & can be around any vector
+        // perpendicular to (0,0,-1) so let's rotate about the x-axis.
+        transform.rotate3d(1, 0, 0, 180);
+    } else {
+        // Rotation needed - create it from axis-angle.
+        FloatPoint3D axis = z.cross(direction);
+        transform.rotate3d(axis.x(), axis.y(), axis.z(), rad2deg(std::acos(cosAngle)));
+    }
+
+    auto matrixData = transform.toColumnMajorFloatArray();
+    m_matrix = Float32Array::create(matrixData.data(), matrixData.size());
+    return *m_matrix;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/WebXRRay.h
+++ b/Source/WebCore/Modules/webxr/WebXRRay.h
@@ -28,6 +28,8 @@
 #if ENABLE(WEBXR_HIT_TEST)
 
 #include "ExceptionOr.h"
+#include "FloatPoint3D.h"
+#include "TransformationMatrix.h"
 #include <JavaScriptCore/Float32Array.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -51,9 +53,11 @@ public:
     const Float32Array& matrix();
 
 private:
-    WebXRRay(WebXRRigidTransform&);
+    WebXRRay(Ref<DOMPointReadOnly>&& origin, Ref<DOMPointReadOnly>&& direction);
 
-    Ref<WebXRRigidTransform> m_transform;
+    Ref<DOMPointReadOnly> m_origin;
+    Ref<DOMPointReadOnly> m_direction;
+    RefPtr<Float32Array> m_matrix;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 86abaa3fd071c55dc95c18b24dfa7a55a1bf4300
<pre>
[WebXR Hit Test] XRRay support
<a href="https://bugs.webkit.org/show_bug.cgi?id=301255">https://bugs.webkit.org/show_bug.cgi?id=301255</a>

Reviewed by Dan Glastonbury.

Added XRRay support based on the Chromium implementations.
&lt;<a href="https://immersive-web.github.io/hit-test/#xrray-interface">https://immersive-web.github.io/hit-test/#xrray-interface</a>&gt;
&lt;<a href="https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/modules/xr/xr_ray.cc">https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/modules/xr/xr_ray.cc</a>&gt;

Tests: imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https.html
       imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_constructor.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/xrRay_matrix.https-expected.txt: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/webxr/WebXRRay.cpp:
(WebCore::WebXRRay::create):
(WebCore::WebXRRay::WebXRRay):
(WebCore::WebXRRay::origin):
(WebCore::WebXRRay::direction):
(WebCore::WebXRRay::matrix):
* Source/WebCore/Modules/webxr/WebXRRay.h:

Canonical link: <a href="https://commits.webkit.org/302060@main">https://commits.webkit.org/302060@main</a>
</pre>
