### PR TITLE
[GTK][WPE] Pass-through arguments to install-dependencies

### DIFF
--- a/Tools/gtk/install-dependencies
+++ b/Tools/gtk/install-dependencies
@@ -4,7 +4,7 @@ set -e
 
 # On Linux systems, this script needs to be run with root rights.
 if [ `uname` != "Darwin" ] && [ $UID -ne 0 ]; then
-    sudo $0
+    sudo "$0" "$@"
     exit 0
 fi
 
@@ -49,23 +49,23 @@ function installDependencies {
 
     packageManager=$(guessPackageManager)
     source "$(dirname "$0")/dependencies/$packageManager"
-    installDependenciesWith${packageManager^}
+    installDependenciesWith${packageManager^} "$@"
 }
 
 function installDependenciesWithApt {
-    apt-get install -y --no-install-recommends ${PACKAGES[@]}
+    apt-get install -y --no-install-recommends "$@" ${PACKAGES[@]}
 }
 
 function installDependenciesWithBrew {
-    brew install ${PACKAGES[@]}
+    brew install "$@" ${PACKAGES[@]}
 }
 
 function installDependenciesWithDnf {
-    dnf install ${PACKAGES[@]}
+    dnf install "$@" ${PACKAGES[@]}
 }
 
 function installDependenciesWithPacman {
-    pacman -S --needed ${PACKAGES[@]}
+    pacman -S --needed "$@" ${PACKAGES[@]}
 
     cat <<-EOF
 
@@ -89,4 +89,4 @@ Alternatively, you may use a Python 2.x virtualenv while hacking on WebKitGTK:
 EOF
 }
 
-installDependencies
+installDependencies "$@"

--- a/Tools/wpe/install-dependencies
+++ b/Tools/wpe/install-dependencies
@@ -4,7 +4,7 @@ set -e
 
 # This script needs to be run with root rights.
 if [ $UID -ne 0 ]; then
-    sudo $0
+    sudo "$0" "$@"
     exit $?
 fi
 
@@ -43,19 +43,19 @@ function installDependencies {
 
     packageManager=$(guessPackageManager)
     source "$(dirname "$0")/dependencies/$packageManager"
-    installDependenciesWith${packageManager^}
+    installDependenciesWith${packageManager^} "$@"
 }
 
 function installDependenciesWithApt {
-    apt-get install -y --no-install-recommends ${PACKAGES[@]}
+    apt-get install -y --no-install-recommends "$@" ${PACKAGES[@]}
 }
 
 function installDependenciesWithDnf {
-    dnf install ${PACKAGES[@]}
+    dnf install "$@" ${PACKAGES[@]}
 }
 
 function installDependenciesWithPacman {
-    pacman -S --needed ${PACKAGES[@]}
+    pacman -S --needed "$@" ${PACKAGES[@]}
 
     cat <<-EOF
 
@@ -79,4 +79,4 @@ Alternatively, you may use a Python 2.x virtualenv while hacking on WPE:
 EOF
 }
 
-installDependencies
+installDependencies "$@"


### PR DESCRIPTION
#### 150f88c7a7d2eb89d72c682596eea11b241f8f5c
<pre>
[GTK][WPE] Pass-through arguments to install-dependencies
<a href="https://bugs.webkit.org/show_bug.cgi?id=301348">https://bugs.webkit.org/show_bug.cgi?id=301348</a>

Reviewed by Adrian Perez de Castro.

Allow the user to pass extra arguments to the package manager.

Canonical link: <a href="https://commits.webkit.org/302080@main">https://commits.webkit.org/302080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1a21cc2d1ab05e5426094d702101dfa658647be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135356 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/135 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130933 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/85 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77995 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/91 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32754 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78666 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137840 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/124 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105693 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26934 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/92 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/52276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/169 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/95 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->