### PR TITLE
Introduce WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_NONNULL

### DIFF
--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -644,8 +644,8 @@ using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
 // delete(T*, std::destroying_delete_t, size_t) is preferred over delete(void*)
 // in overload resolution, so we can use it to interpose before calling delete(void*).
 // Note: WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR must be declared in every subclass.
-#define WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(T) \
-void operator delete(T* object, std::destroying_delete_t, size_t size) { \
+#define WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(T, _Nonnullmacro) \
+void operator delete(T* _Nonnullmacro object, std::destroying_delete_t, size_t size) { \
     ASSERT_UNUSED(size, sizeof(T) == size); \
     object->T::~T(); \
     if (object->checkedPtrCountWithoutThreadCheck()) [[unlikely]] { \
@@ -656,15 +656,26 @@ void operator delete(T* object, std::destroying_delete_t, size_t size) { \
 } \
 using WTFDidOverrideDeleteForCheckedPtr = int;
 
+#define WTF_CHECKEDPTR_NO_NONNULL
+
 // Note: WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR must be declared in the most derived subclass.
 #define WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ClassName) \
 public: \
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(ClassName) \
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(ClassName, WTF_CHECKEDPTR_NO_NONNULL) \
+private: \
+using __thisIsHereToForceASemicolonAfterWTFOverrideDelete UNUSED_TYPE_ALIAS = int
+
+#define WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_NONNULL(ClassName) \
+public: \
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(ClassName, _Nonnull) \
 private: \
 using __thisIsHereToForceASemicolonAfterWTFOverrideDelete UNUSED_TYPE_ALIAS = int
 
 #define WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(ClassName) \
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(ClassName) \
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(ClassName, WTF_CHECKEDPTR_NO_NONNULL) \
+using __thisIsHereToForceASemicolonAfterWTFOverrideDelete UNUSED_TYPE_ALIAS = int
+#define WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR_NONNULL(ClassName) \
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(ClassName, _Nonnull) \
 using __thisIsHereToForceASemicolonAfterWTFOverrideDelete UNUSED_TYPE_ALIAS = int
 
 #if HAVE(36BIT_ADDRESS)


### PR DESCRIPTION
#### 0db051238b3676e807908f7f6b59b9fd37852eb3
<pre>
Introduce WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_NONNULL
<a href="https://bugs.webkit.org/show_bug.cgi?id=301349">https://bugs.webkit.org/show_bug.cgi?id=301349</a>
<a href="https://rdar.apple.com/163263301">rdar://163263301</a>

Reviewed by NOBODY (OOPS!).

Swift requires C++ raw pointer function arguments and return values to be
annotated with _Nonnull or _Nullable. This is analysed on a file-by-file
granularity. For the upcoming CoreIPC work, we will need to annotate
Source/WebKit/UIProcess/WebProcessProxy.h. This class uses a macro
WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR which expands to create an `operator
delete` which needs to be duly annotated. Unfortunately, we can&apos;t just change
WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR always to use _Nonnull, since that would
require us to fully annotate all files in which that macro is expanded.
Instead, we need to create a new version of this macro which expands to NONNULL
only in those header files which we have converted.

Subsequent commits will start to use this new version of the macro in
WebProcessProxy.h.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0db051238b3676e807908f7f6b59b9fd37852eb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127783 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79342 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d33879b8-162c-4853-b4f0-7f808f2e6061) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97275 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65244 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c3d4a22c-be96-46d7-a5cf-539e03e7b2db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38434 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77768 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/88156959-9918-4af6-aa21-ad0fce43dee7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32569 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78465 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119820 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108314 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137583 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126247 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105804 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105488 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50966 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29401 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52077 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54380 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60782 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53616 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/57070 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55372 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->