### PR TITLE
Address a safer CPP warning in _WKWebViewTextInputNotifications.mm

### DIFF
--- a/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm
+++ b/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm
@@ -62,11 +62,11 @@
     }
 
     _caretType = WebCore::CaretAnimatorType::Dictation;
-    if (_webView) {
-        if (RetainPtr context = _webView->inputContext())
+    if (CheckedPtr webView = _webView.get()) {
+        if (RetainPtr context = webView->inputContext())
             context.get().showsCursorAccessories = YES;
 
-        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
+        webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
     }
 }
 

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -18,7 +18,6 @@ WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
 WebProcess/WebPage/WebFrame.cpp
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
-[ Mac ] Platform/cocoa/_WKWebViewTextInputNotifications.mm
 [ Mac ] WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 [ iOS ] UIProcess/API/ios/WKWebViewIOS.mm
 [ iOS ] UIProcess/API/ios/WKWebViewTestingIOS.mm


### PR DESCRIPTION
#### 297da64f4dc3cc1755b6038e79159b3e7ab5e5de
<pre>
Address a safer CPP warning in _WKWebViewTextInputNotifications.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=301347">https://bugs.webkit.org/show_bug.cgi?id=301347</a>

Reviewed by Chris Dumez.

Address a safer CPP warning in _WKWebViewTextInputNotifications.mm.

* Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm:
(-[_WKWebViewTextInputNotifications dictationDidStart]):
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/302236@main">https://commits.webkit.org/302236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/680014625091d13451e98a162620e775eaa7ed9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79902 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97786 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65695 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115087 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78397 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79133 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138300 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106328 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106138 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27036 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/470 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29969 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52897 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/619 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63813 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/510 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/573 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->