### PR TITLE
[CSS Zoom] Fix calc(em) for unzoomed properties

### DIFF
--- a/LayoutTests/fast/css/line-height-basics.html
+++ b/LayoutTests/fast/css/line-height-basics.html
@@ -1,5 +1,3 @@
-<!-- webkit-test-runner [ EvaluationTimeZoomEnabled=false ] -->
- <!-- Disabling flag until we fix zoom for font related units http://webkit.org/b/299816-->
 <!DOCTYPE html>
 <script src="../../resources/js-test.js"></script>
 <style>

--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -144,4 +144,10 @@ CheckedPtr<Style::BuilderState> CSSToLengthConversionData::protectedStyleBuilder
     return m_styleBuilderState;
 }
 
+bool CSSToLengthConversionData::evaluationTimeZoomEnabled() const
+{
+    ASSERT(m_style);
+    return CheckedPtr { m_style }->evaluationTimeZoomEnabled();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -69,6 +69,7 @@ public:
     bool computingFontSize() const { return m_propertyToCompute == CSSPropertyFontSize; }
     bool computingLineHeight() const { return m_propertyToCompute == CSSPropertyLineHeight; }
     CSSPropertyID propertyToCompute() const { return m_propertyToCompute.value_or(CSSPropertyInvalid); }
+    bool evaluationTimeZoomEnabled() const;
     const RenderView* renderView() const { return m_renderView; }
     const Element* elementForContainerUnitResolution() const { return m_elementForContainerUnitResolution.get(); }
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -174,7 +174,7 @@ std::optional<CanonicalDimension> canonicalize(NonCanonicalDimension root, const
     auto tryMakeCanonical = [&](double value, CSS::LengthUnit lengthUnit) -> std::optional<CanonicalDimension> {
         if (conversionData) {
             // We are only interested in canonicalizing to `px`, not adjusting for zoom, which will be handled later. When computing font-size, zoom is not applied in the same way, so must be special cased here.
-            if (conversionData->computingFontSize())
+            if (conversionData->computingFontSize() || (conversionData->evaluationTimeZoomEnabled() && conversionData->rangeZoomOption() == CSS::RangeZoomOptions::Unzoomed))
                 return CanonicalDimension { .value = Style::computeNonCalcLengthDouble(value, lengthUnit, *conversionData), .dimension = CanonicalDimension::Dimension::Length };
             return CanonicalDimension { .value = Style::computeNonCalcLengthDouble(value, lengthUnit, *conversionData) / conversionData->style()->usedZoom(), .dimension = CanonicalDimension::Dimension::Length };
         }


### PR DESCRIPTION
#### b999bb0d07e1b0013a76275b5851351af52a2b91
<pre>
[CSS Zoom] Fix calc(em) for unzoomed properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=301351">https://bugs.webkit.org/show_bug.cgi?id=301351</a>
<a href="https://rdar.apple.com/163267333">rdar://163267333</a>

Reviewed by Sammy Gill.

When canonicalizing to &quot;px&quot; we currently try to compensate
the fact that the `computeNonCalcLengthDouble` would use the
compute font size (that has zoom applied to it) by dividing
by the zoom factor here. This should no longer be necessary
for unzoomed properties (when the evaluation flag is on) as
we now resolve it against the unzoomed computed font size.

Once all properties are converted to be unzoomed and the flag
is removed we can remove the counter branch.

* LayoutTests/fast/css/line-height-basics.html:
* Source/WebCore/css/CSSToLengthConversionData.cpp:
(WebCore::CSSToLengthConversionData::evaluationTimeZoomEnabled const):
* Source/WebCore/css/CSSToLengthConversionData.h:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::canonicalize):

Canonical link: <a href="https://commits.webkit.org/302041@main">https://commits.webkit.org/302041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17fedba5af629581ac92d2b1168c209f48d59c05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135183 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79365 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b176da3c-dd3f-44b7-8763-0000f4965ac8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55985 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65199 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7e19cec5-842d-43ec-96dd-151809337ec6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77860 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32590 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78488 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137661 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/42000 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105556 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/26902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50983 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29421 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52104 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54403 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/60886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53639 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/57093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55395 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->