### PR TITLE
[macOS 26] TestWebKitAPI.FontManagerTests.ChangeAttributesWithFontEffectsBox fails due to changes in NSFontPanel

### DIFF
--- a/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
+++ b/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
@@ -150,4 +150,8 @@ NSString * const NSInspectorBarTextAlignmentItemIdentifier = @"NSInspectorBarTex
 - (void)_chooseFace:(id)sender;
 @end
 
+@interface NSFontEffectsBox: NSBox
+- (void)_openEffectsButton:(id)sender;
+@end
+
 #endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/mac/NSFontPanelTesting.h
+++ b/Tools/TestWebKitAPI/mac/NSFontPanelTesting.h
@@ -29,6 +29,13 @@
 
 @interface NSFontPanel (TestWebKitAPI)
 
+- (void)setUnderlineStyle:(NSUnderlineStyle)style;
+- (void)setStrikethroughStyle:(NSUnderlineStyle)style;
+- (void)setTextShadow:(NSShadow *)shadow;
+- (void)commitAttributeChanges;
+
+// FIXME: The following properties below no longer work on macOS 26,
+// as they depend on the state of UI that no longer exists.
 @property (nonatomic) double shadowOpacity;
 @property (nonatomic) double shadowBlur;
 @property (nonatomic) double shadowLength;
@@ -37,10 +44,6 @@
 @property (nonatomic, readonly) BOOL hasUnderline;
 @property (nonatomic, readonly) BOOL hasStrikeThrough;
 @property (nonatomic, readonly) NSColor *foregroundColor;
-
-- (void)toggleShadow;
-- (void)chooseUnderlineMenuItemWithTitle:(NSString *)itemTitle;
-- (void)chooseStrikeThroughMenuItemWithTitle:(NSString *)itemTitle;
 
 @end
 


### PR DESCRIPTION
#### 114e809bdd0e97118a0efd2a24f9f727aff5f8bc
<pre>
[macOS 26] TestWebKitAPI.FontManagerTests.ChangeAttributesWithFontEffectsBox fails due to changes in NSFontPanel
<a href="https://bugs.webkit.org/show_bug.cgi?id=301352">https://bugs.webkit.org/show_bug.cgi?id=301352</a>
<a href="https://rdar.apple.com/163133860">rdar://163133860</a>

Reviewed by Aditya Keerthi.

Since macOS 26, parts of the `NSFontPanel` UI have been reimplemented in Swift, or otherwise changed
so that styling options are now behind popovers and menus. As a result, all of the popup buttons
previously found by looking for `NSFontPanel*ToolbarItem` no longer exist.

This test currently tries (and fails) to interact with these nonexistent controls. Fix this by
changing how these tests work, such that they directly change the `_attributesToAdd` and
`_attributesToRemove` ivars that determine which text styles should be applied when calling into
`-changeAttributes:`.

* Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h:
* Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm:
(TestWebKitAPI::TEST(FontManagerTests, ChangeAttributesWithFontEffectsBox)):
* Tools/TestWebKitAPI/mac/NSFontPanelTesting.h:
* Tools/TestWebKitAPI/mac/NSFontPanelTesting.mm:
(-[NSBox _addAttribute:value:]):
(-[NSBox _removeAttribute:]):
(-[NSBox _clearAttributes]):

Add helpers to directly add or remove text styling attributes.

(-[NSFontPanel fontEffectsBox]):
(-[NSFontPanel setUnderlineStyle:]):
(-[NSFontPanel setStrikethroughStyle:]):
(-[NSFontPanel setTextShadow:]):
(-[NSFontPanel commitAttributeChanges]):
(findMenuItemWithTitle): Deleted.
(-[NSFontPanel chooseUnderlineMenuItemWithTitle:]): Deleted.
(-[NSFontPanel chooseStrikeThroughMenuItemWithTitle:]): Deleted.
(-[NSFontPanel toggleShadow]): Deleted.

Canonical link: <a href="https://commits.webkit.org/302033@main">https://commits.webkit.org/302033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb2286e047d008dc4d4f7b9b48427ba56255c954

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79350 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/716b0399-bc92-444d-8a6c-a50f82fc06ba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97281 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65184 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aa9958bd-d5fb-479d-9a15-fa985e06326a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114473 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77850 "Found 2 new API test failures: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak, WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9cefd2f9-a268-42be-bd16-b824fc5a675a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/37232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32576 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78473 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108322 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137646 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105811 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105544 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26900 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50971 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29408 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52089 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54388 "Built successfully") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53624 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/57078 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55380 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->