### PR TITLE
[blocks-in-inline] Add a setting to stop RenderTreeBuilder from generating continuations

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-layout-expected.html
@@ -1,0 +1,2 @@
+<span>span start<div style="border:2px solid blue">div line 1<br>div line 2</div>span end</span>
+

--- a/LayoutTests/fast/inline/blocks-in-inline-layout.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-layout.html
@@ -1,0 +1,3 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<span>span start<div style="border:2px solid blue">div line 1<br>div line 2</div>span end</span>
+

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -942,6 +942,19 @@ BlockWebInspectorInWebContentSandbox:
     WebKit:
       default: false
 
+BlocksInInlineLayoutEnabled:
+  type: bool
+  status: unstable
+  humanReadableName: "Blocks in inline layout (disable continuations)"
+  humanReadableDescription: "Enable blocks in inline layout (disable continuations)"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # We would have to partition BroadcastChannel based on PageGroups if we wanted to enable this for WebKitLegacy.
 BroadcastChannelEnabled:
   type: bool

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
@@ -917,7 +917,7 @@ void InlineContentBreaker::ContinuousContent::resetTrailingTrimmableContent()
 
 void InlineContentBreaker::ContinuousContent::append(const InlineItem& inlineItem, const RenderStyle& style, InlineLayoutUnit logicalWidth, InlineLayoutUnit textSpacingAdjustment)
 {
-    ASSERT(inlineItem.isAtomicInlineBox() || inlineItem.isInlineBoxStartOrEnd() || inlineItem.isOpaque());
+    ASSERT(inlineItem.isAtomicInlineBox() || inlineItem.isInlineBoxStartOrEnd() || inlineItem.isOpaque() || inlineItem.isBlock());
     m_isTextOnlyContent = false;
     m_hasTrailingWordSeparator = m_hasTrailingWordSeparator && !inlineItem.isAtomicInlineBox();
     appendToRunList(inlineItem, style, { }, logicalWidth, textSpacingAdjustment);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItem.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItem.h
@@ -45,6 +45,7 @@ public:
         InlineBoxStart,
         InlineBoxEnd,
         Float,
+        Block,
         Opaque
     };
     InlineItem(const Box& layoutBox, Type, UBiDiLevel = UBIDI_DEFAULT_LTR);
@@ -67,6 +68,7 @@ public:
     bool isInlineBoxEnd() const { return type() == Type::InlineBoxEnd; }
     bool isInlineBoxStartOrEnd() const { return isInlineBoxStart() || isInlineBoxEnd(); }
     bool isOpaque() const { return type() == Type::Opaque; }
+    bool isBlock() const { return type() == Type::Block; }
 
 private:
     friend class InlineItemsBuilder;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -28,7 +28,9 @@
 
 #include "FontCascade.h"
 #include "InlineSoftLineBreakItem.h"
+#include "RenderObjectInlines.h"
 #include "RenderStyleInlines.h"
+#include "Settings.h"
 #include "StyleResolver.h"
 #include "TextBreakingPositionCache.h"
 #include "TextUtil.h"
@@ -325,7 +327,10 @@ void InlineItemsBuilder::collectInlineItems(InlineItemList& inlineItemList, Inli
                 handleInlineBoxEnd(layoutBox, inlineItemList);
             else if (layoutBox->isFloatingPositioned())
                 inlineItemList.append({ layoutBox, InlineItem::Type::Float });
-            else
+            else if (layoutBox->isBlockLevelBox()) {
+                ASSERT(m_root.rendererForIntegration()->settings().blocksInInlineLayoutEnabled());
+                inlineItemList.append({ layoutBox, InlineItem::Type::Block });
+            } else
                 ASSERT_NOT_REACHED();
 
             if (auto* nextSibling = layoutBox->nextSibling()) {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -354,7 +354,7 @@ void Line::appendText(const InlineTextItem& inlineTextItem, const RenderStyle& s
             // provided both spaces are within the same inline formatting context—is collapsed to have zero advance width.
             if (run.isText())
                 return run.hasCollapsibleTrailingWhitespace();
-            ASSERT(run.isListMarker() || run.isLineSpanningInlineBoxStart() || run.isInlineBoxStart() || run.isInlineBoxEnd() || run.isWordBreakOpportunity() || run.isOpaque());
+            ASSERT(run.isListMarker() || run.isLineSpanningInlineBoxStart() || run.isInlineBoxStart() || run.isInlineBoxEnd() || run.isWordBreakOpportunity() || run.isOpaque() || run.isBlock());
         }
         // Leading whitespace.
         return true;
@@ -762,6 +762,8 @@ inline static Line::Run::Type toLineRunType(const InlineItem& inlineItem)
         return Line::Run::Type::InlineBoxEnd;
     case InlineItem::Type::Opaque:
         return Line::Run::Type::Opaque;
+    case InlineItem::Type::Block:
+        return Line::Run::Type::Block;
     default:
         ASSERT_NOT_REACHED();
         return { };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
@@ -100,7 +100,8 @@ public:
             InlineBoxStart,
             InlineBoxEnd,
             LineSpanningInlineBoxStart,
-            Opaque
+            Opaque,
+            Block
         };
 
         bool isText() const { return m_type == Type::Text || isWordSeparator() || isNonBreakingSpace(); }
@@ -119,8 +120,9 @@ public:
         bool isLineSpanningInlineBoxStart() const { return m_type == Type::LineSpanningInlineBoxStart; }
         bool isInlineBoxEnd() const { return m_type == Type::InlineBoxEnd; }
         bool isOpaque() const { return m_type == Type::Opaque; }
+        bool isBlock() const { return m_type == Type::Block; }
 
-        bool isContentful() const { return (isText() && textContent()->length) || isAtomicInlineBox() || isLineBreak() || isListMarker(); }
+        bool isContentful() const { return (isText() && textContent()->length) || isAtomicInlineBox() || isLineBreak() || isListMarker() || isBlock(); }
         bool isGenerated() const { return isListMarker(); }
         static bool isContentfulOrHasDecoration(const Run&, const InlineFormattingContext&);
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp
@@ -100,7 +100,8 @@ InlineLayoutUnit LineBox::inlineLevelBoxAbsoluteTop(const InlineLevelBox& inline
 
 InlineRect LineBox::logicalRectForInlineLevelBox(const Box& layoutBox) const
 {
-    ASSERT(layoutBox.isInlineLevelBox() || layoutBox.isLineBreakBox());
+    // FIXME: Blocks in inline. Refactor and remove the block test.
+    ASSERT(layoutBox.isInlineLevelBox() || layoutBox.isLineBreakBox() || (layoutBox.isBlockLevelBox() && layoutBox.isInFlow()));
     auto* inlineBox = inlineLevelBoxFor(layoutBox);
     if (!inlineBox) {
         ASSERT_NOT_REACHED();
@@ -112,7 +113,8 @@ InlineRect LineBox::logicalRectForInlineLevelBox(const Box& layoutBox) const
 
 InlineRect LineBox::logicalBorderBoxForAtomicInlineBox(const Box& layoutBox, const BoxGeometry& boxGeometry) const
 {
-    ASSERT(layoutBox.isAtomicInlineBox());
+    // FIXME: Blocks in inline. Refactor and remove the block test.
+    ASSERT(layoutBox.isAtomicInlineBox() || (layoutBox.isBlockLevelBox() && layoutBox.isInFlow()));
     auto logicalRect = logicalRectForInlineLevelBox(layoutBox);
     // Inline level boxes use their margin box for vertical alignment. Let's covert them to border boxes.
     logicalRect.moveVertically(boxGeometry.marginBefore());

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -504,6 +504,14 @@ void LineBoxBuilder::constructInlineLevelBoxes(LineBox& lineBox)
             lineBox.addInlineLevelBox(InlineLevelBox::createGenericInlineLevelBox(layoutBox, style, logicalLeft));
             continue;
         }
+        if (run.isBlock()) {
+            auto& inlineLevelBoxGeometry = formattingContext.geometryForBox(layoutBox);
+            logicalLeft += inlineLevelBoxGeometry.marginStart();
+            auto atomicInlineBox = InlineLevelBox::createAtomicInlineBox(layoutBox, style, logicalLeft, inlineLevelBoxGeometry.borderBoxWidth());
+            setVerticalPropertiesForInlineLevelBox(lineBox, atomicInlineBox);
+            lineBox.addInlineLevelBox(WTFMove(atomicInlineBox));
+            continue;
+        }
         ASSERT(run.isOpaque());
     }
     lineBox.setHasContent(lineHasContent);

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -299,7 +299,8 @@ void InlineDisplayContentBuilder::appendHardLineBreakDisplayBox(const Line::Run&
 
 void InlineDisplayContentBuilder::appendAtomicInlineLevelDisplayBox(const Line::Run& lineRun, const InlineRect& borderBoxRect, InlineDisplay::Boxes& boxes)
 {
-    ASSERT(lineRun.layoutBox().isAtomicInlineBox());
+    // FIXME: Blocks in inline. Refactor and remove the block test.
+    ASSERT(lineRun.layoutBox().isAtomicInlineBox() || lineRun.isBlock());
     auto& layoutBox = lineRun.layoutBox();
 
     auto isContentful = true;
@@ -485,6 +486,10 @@ void InlineDisplayContentBuilder::processNonBidiContent(const LineLayoutResult& 
             }
             if (lineRun.isLineSpanningInlineBoxStart())
                 return lineBox.logicalBorderBoxForInlineBox(layoutBox, boxGeometry);
+            if (lineRun.isBlock()) {
+                // FIXME: Blocks in inline.
+                return lineBox.logicalBorderBoxForAtomicInlineBox(layoutBox, boxGeometry);
+            }
             ASSERT_NOT_REACHED();
             return { };
         }();
@@ -504,7 +509,10 @@ void InlineDisplayContentBuilder::processNonBidiContent(const LineLayoutResult& 
                 appendHardLineBreakDisplayBox(lineRun, visualRectRelativeToRoot, boxes);
             else if (lineRun.isAtomicInlineBox() || lineRun.isListMarker())
                 appendAtomicInlineLevelDisplayBox(lineRun, visualRectRelativeToRoot, boxes);
-            else if (lineRun.isInlineBoxStart() || lineRun.isLineSpanningInlineBoxStart()) {
+            else if (lineRun.isBlock()) {
+                // FIXME: Blocks in inline.
+                appendAtomicInlineLevelDisplayBox(lineRun, visualRectRelativeToRoot, boxes);
+            } else if (lineRun.isInlineBoxStart() || lineRun.isLineSpanningInlineBoxStart()) {
                 // Do not generate display boxes for inline boxes on non-contentful lines (e.g. <span></span>)
                 if (lineBox.hasContent())
                     appendInlineBoxDisplayBox(lineRun, lineBox.inlineLevelBoxFor(lineRun), visualRectRelativeToRoot, boxes);

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -120,7 +120,7 @@ void InlineContentPainter::paintDisplayBox(const InlineDisplay::Box& box)
         return;
     }
 
-    if (auto* renderer = dynamicDowncast<RenderBox>(box.layoutBox().rendererForIntegration()); renderer && renderer->isBlockLevelReplacedOrAtomicInline()) {
+    if (auto* renderer = dynamicDowncast<RenderBox>(box.layoutBox().rendererForIntegration()); renderer) {
         if (m_paintInfo.shouldPaintWithinRoot(*renderer)) {
             // FIXME: Painting should not require a non-const renderer.
             const_cast<RenderBox*>(renderer)->paintAsInlineBlock(m_paintInfo, flippedContentOffsetIfNeeded(*renderer));

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -585,10 +585,18 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
                 continue;
 
             auto& layoutBox = box.layoutBox();
+
+            if (layoutBox.isBlockLevelBox() && layoutBox.isInFlow()) {
+                auto& renderer = downcast<RenderBox>(*box.layoutBox().rendererForIntegration());
+                renderer.setLocation(Layout::toLayoutPoint(box.visualRectIgnoringBlockDirection().location()));
+                continue;
+            }
+
             if (!layoutBox.isAtomicInlineBox())
                 continue;
 
             auto& renderer = downcast<RenderBox>(*box.layoutBox().rendererForIntegration());
+
             if (auto* layer = renderer.layer())
                 layer->setIsHiddenByOverflowTruncation(box.isFullyTruncated());
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -42,6 +42,8 @@ public:
     // FIXME: Remove.
     static RenderTreeBuilder* current() { return s_current; }
 
+    const RenderView& view() const { return m_view; }
+
     static bool isRebuildRootForChildren(const RenderElement&);
 
     void attach(RenderElement& parent, RenderPtr<RenderObject>, RenderObject* beforeChild = nullptr);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.h
@@ -50,6 +50,7 @@ private:
     void splitFlow(RenderInline& parent, RenderObject* beforeChild, RenderPtr<RenderBlock> newBlockBox, RenderPtr<RenderObject> child, RenderBoxModelObject* oldCont);
 
     RenderTreeBuilder& m_builder;
+    const bool m_buildsContinuations;
 };
 
 }


### PR DESCRIPTION
#### 0444196ff2515c520b37e5c69d4a38dcc8e8d257
<pre>
[blocks-in-inline] Add a setting to stop RenderTreeBuilder from generating continuations
<a href="https://bugs.webkit.org/show_bug.cgi?id=301355">https://bugs.webkit.org/show_bug.cgi?id=301355</a>
<a href="https://rdar.apple.com/163271827">rdar://163271827</a>

Reviewed by Alan Baradlay.

Add a setting that stops generation of continuation renderers in cases like

&lt;span&gt;span&lt;div&gt;div&lt;/div&gt;&lt;/span&gt;

The setting is not enabled even for testing yet.

Also add basic IFC support for having blocks in inline context that can handle some simple cases.

Test: fast/inline/blocks-in-inline-layout.html
* LayoutTests/fast/inline/blocks-in-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-layout.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp:
(WebCore::Layout::InlineContentBreaker::ContinuousContent::append):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::inlineItemWidth const):
(WebCore::Layout::InlineFormattingUtils::nextWrapOpportunity const):
* Source/WebCore/layout/formattingContexts/inline/InlineItem.h:
(WebCore::Layout::InlineItem::isBlock const):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::collectInlineItems):
* Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp:
(WebCore::Layout::Line::appendText):
(WebCore::Layout::toLineRunType):
* Source/WebCore/layout/formattingContexts/inline/InlineLine.h:
(WebCore::Layout::Line::Run::isBlock const):
(WebCore::Layout::Line::Run::isContentful const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp:
(WebCore::Layout::LineBox::logicalRectForInlineLevelBox const):
(WebCore::Layout::LineBox::logicalBorderBoxForAtomicInlineBox const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
(WebCore::Layout::LineBoxBuilder::constructInlineLevelBoxes):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::hasTrailingSoftWrapOpportunity):
(WebCore::Layout::LineCandidate::InlineContent::appendInlineItem):
(WebCore::Layout::LineBuilder::collectShapeRanges const):
(WebCore::Layout::LineBuilder::candidateContentForLine):
(WebCore::Layout::LineBuilder::commitCandidateContent):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::appendAtomicInlineLevelDisplayBox):
(WebCore::Layout::InlineDisplayContentBuilder::processNonBidiContent):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::paintDisplayBox):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):
* Source/WebCore/rendering/updating/RenderTreeBuilder.h:
(WebCore::RenderTreeBuilder::view const):
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::RenderTreeBuilder::Inline::Inline):
(WebCore::RenderTreeBuilder::Inline::insertChildToContinuation):
(WebCore::RenderTreeBuilder::Inline::attachIgnoringContinuation):
(WebCore::RenderTreeBuilder::Inline::splitFlow):
(WebCore::RenderTreeBuilder::Inline::splitInlines):
(WebCore::RenderTreeBuilder::Inline::childBecameNonInline):
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.h:

Canonical link: <a href="https://commits.webkit.org/302427@main">https://commits.webkit.org/302427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7173b6f42589e9115802b22ec84eb2d921a30ce9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135690 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79768 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a96b10a2-7628-49da-bb63-9ff031620bd9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130171 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97655 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65559 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/45185daa-c676-4daf-9c41-d1430ea88459) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114938 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78246 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4b205485-6af7-472a-b0fb-92885001e2ef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/325 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33044 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78979 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120320 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138146 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126759 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106194 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/127730 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105994 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27145 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29829 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52718 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63534 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159783 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/370 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39911 "Found 16 new JSC stress test failures: wasm.yaml/wasm/stress/osr-entry-live-fpr.js.default-wasm, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-bbq, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-collect-continuously, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-eager, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-eager-jettison, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-no-cjit, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-slow-memory, wasm.yaml/wasm/stress/osr-entry-live-stack.js.default-wasm, wasm.yaml/wasm/stress/osr-entry-live-stack.js.wasm-bbq ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/439 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/435 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->