### PR TITLE
[ Tahoe ] TestWebKitAPI.FontAttributes.FontAttributesAfterChangingSelection is a constant failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
+++ b/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
@@ -150,8 +150,7 @@ NSString * const NSInspectorBarTextAlignmentItemIdentifier = @"NSInspectorBarTex
 - (void)_chooseFace:(id)sender;
 @end
 
-@interface NSFontEffectsBox: NSBox
-- (void)_openEffectsButton:(id)sender;
+@interface NSFontEffectsBox : NSBox
 @end
 
 #endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FontAttributes.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FontAttributes.mm
@@ -237,14 +237,14 @@ TEST(FontAttributes, FontAttributesAfterChangingSelection)
 
     auto expectFontManagerState = [] (FontExpectation expectedFont, ColorExpectation expectedColor, std::optional<ShadowExpectation> expectedShadow, BOOL underline, BOOL strikeThrough, BOOL expectMultipleFonts) {
 #if PLATFORM(MAC)
-        NSFontManager *fontManager = NSFontManager.sharedFontManager;
         NSFontPanel *fontPanel = NSFontPanel.sharedFontPanel;
+        NSFontManager *fontManager = NSFontManager.sharedFontManager;
+        RetainPtr shadow = [fontPanel lastTextShadow];
+        EXPECT_EQ(!!shadow, !!expectedShadow);
         if (expectedShadow) {
-            EXPECT_TRUE(fontPanel.hasShadow);
-            EXPECT_LT(std::abs(expectedShadow->opacity - fontPanel.shadowOpacity), 0.0001);
-            EXPECT_EQ(expectedShadow->blurRadius, fontPanel.shadowBlur);
-        } else
-            EXPECT_FALSE(fontPanel.hasShadow);
+            EXPECT_LT(std::abs(expectedShadow->opacity - [shadow shadowColor].alphaComponent), 0.0001);
+            EXPECT_EQ(expectedShadow->blurRadius, [shadow shadowBlurRadius]);
+        }
         EXPECT_EQ(underline, fontPanel.hasUnderline);
         EXPECT_EQ(strikeThrough, fontPanel.hasStrikeThrough);
         checkColor([fontPanel.foregroundColor colorUsingColorSpace:NSColorSpace.sRGBColorSpace], { WTFMove(expectedColor) });

--- a/Tools/TestWebKitAPI/mac/NSFontPanelTesting.h
+++ b/Tools/TestWebKitAPI/mac/NSFontPanelTesting.h
@@ -34,13 +34,7 @@
 - (void)setTextShadow:(NSShadow *)shadow;
 - (void)commitAttributeChanges;
 
-// FIXME: The following properties below no longer work on macOS 26,
-// as they depend on the state of UI that no longer exists.
-@property (nonatomic) double shadowOpacity;
-@property (nonatomic) double shadowBlur;
-@property (nonatomic) double shadowLength;
-
-@property (nonatomic, readonly) BOOL hasShadow;
+@property (nonatomic, readonly) NSShadow *lastTextShadow;
 @property (nonatomic, readonly) BOOL hasUnderline;
 @property (nonatomic, readonly) BOOL hasStrikeThrough;
 @property (nonatomic, readonly) NSColor *foregroundColor;


### PR DESCRIPTION
#### 115e0938e581f72db955bb1326f39d4003ba2f6a
<pre>
[ Tahoe ] TestWebKitAPI.FontAttributes.FontAttributesAfterChangingSelection is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=301207">https://bugs.webkit.org/show_bug.cgi?id=301207</a>
<a href="https://rdar.apple.com/163133384">rdar://163133384</a>

Reviewed by Aditya Keerthi.

With changes in macOS 26, `NSFontManager`, `NSFontPanel` and `NSFontEffectsBox` no longer contain
a handful of toolbar items that this test relied on, in order to inspect text shadow, underline,
and strikethrough styles for the current selection. To mitigate this, we refactor our test
infrastructure to directly inspect the `_selection` ivar in `NSFontPanel`.

* Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FontAttributes.mm:
(TestWebKitAPI::TEST(FontAttributes, FontAttributesAfterChangingSelection)):
* Tools/TestWebKitAPI/mac/NSFontPanelTesting.h:
* Tools/TestWebKitAPI/mac/NSFontPanelTesting.mm:
(-[NSFontPanel _selectionAttributeValue:]):
(-[NSFontPanel lastTextShadow]):

Replace helpers that currently return the state of text shadow editing UI with a helper that just
returns the font manager&apos;s last known `NSShadow` at the current selection.

(-[NSFontPanel hasUnderline]):
(-[NSFontPanel hasStrikeThrough]):
(findSubviewOfClass): Deleted.
(-[NSFontPanel underlineToolbarButton]): Deleted.
(-[NSFontPanel strikeThroughToolbarButton]): Deleted.
(-[NSFontPanel shadowBlurSlider]): Deleted.
(-[NSFontPanel shadowOpacitySlider]): Deleted.
(-[NSFontPanel shadowLengthSlider]): Deleted.
(-[NSFontPanel shadowToggleButton]): Deleted.
(-[NSFontPanel hasShadow]): Deleted.
(-[NSFontPanel shadowLength]): Deleted.
(-[NSFontPanel setShadowLength:]): Deleted.
(-[NSFontPanel shadowOpacity]): Deleted.
(-[NSFontPanel setShadowOpacity:]): Deleted.
(-[NSFontPanel shadowBlur]): Deleted.
(-[NSFontPanel setShadowBlur:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/302048@main">https://commits.webkit.org/302048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d891843969cdb27bd17370933ea1e2335f7dee1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79371 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/adb4aea7-0e09-4a5b-abb2-c5c5068c0785) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55991 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97296 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65204 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f2fcaa51-b646-490f-83a5-0a3f13757cde) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130760 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114490 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77866 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ab491496-6935-4edd-a4d3-1f458851b021) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32595 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78494 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137667 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/42006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105829 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105562 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26909 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50987 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29425 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52110 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54409 "Built successfully") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53645 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->