### PR TITLE
[Style] Convert the 'text-autospace' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3476,6 +3476,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/text/StyleHyphenateLimitLines.h
     style/values/text/StyleLetterSpacing.h
     style/values/text/StyleTabSize.h
+    style/values/text/StyleTextAutospace.h
     style/values/text/StyleTextIndent.h
     style/values/text/StyleTextSpacingTrim.h
     style/values/text/StyleWordSpacing.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3321,6 +3321,7 @@ style/values/text-decoration/StyleTextShadow.cpp
 style/values/text-decoration/StyleTextUnderlineOffset.cpp
 style/values/text/StyleLetterSpacing.cpp
 style/values/text/StyleTabSize.cpp
+style/values/text/StyleTextAutospace.cpp
 style/values/text/StyleTextIndent.cpp
 style/values/text/StyleWordSpacing.cpp
 style/values/transforms/functions/StyleMatrix3DTransformFunction.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1416,7 +1416,7 @@
                 "font-property": true,
                 "high-priority": true,
                 "sink-priority": true,
-                "style-converter": "TextAutospace",
+                "style-converter": "StyleType<TextAutospace>",
                 "parser-grammar": "normal | auto | no-autospace | [ ideograph-alpha || ideograph-numeric ]@(no-single-item-opt)",
                 "parser-grammar-comment": "Current spec grammar is 'normal | auto | no-autospace | [ [ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ] ]'"
             },

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -175,7 +175,7 @@ void InlineItemsBuilder::computeInlineBoxBoundaryTextSpacings(const InlineItemLi
         size_t inlineBoxStartOnBoundaryIndex = inlineBoxStartIndexesOnInlineItemsList.size() - 1 - (currentCharacterDepth - boundaryDepth);
         size_t boundaryIndex = inlineBoxStartIndexesOnInlineItemsList[inlineBoxStartOnBoundaryIndex];
         const RenderStyle& boundaryOwnerStyle = inlineItemList[boundaryIndex].layoutBox().parent().style();
-        const TextAutospace& boundaryTextAutospace = boundaryOwnerStyle.textAutospace();
+        auto boundaryTextAutospace = boundaryOwnerStyle.textAutospace();
         if (!boundaryTextAutospace.isNoAutospace() && boundaryTextAutospace.shouldApplySpacing(inlineTextBox.content().characterAt(start), lastCharacterFromPreviousRun))
             spacings.add(boundaryIndex, TextAutospace::textAutospaceSize(boundaryOwnerStyle.fontCascade().primaryFont()));
 
@@ -732,12 +732,12 @@ static inline bool canCacheMeasuredWidthOnInlineTextItem(const InlineTextBox& in
 
 static void handleTextSpacing(TextSpacing::SpacingState& spacingState, TrimmableTextSpacings& trimmableTextSpacings, const InlineTextItem& inlineTextItem, size_t inlineItemIndex)
 {
-    const auto& autospace = inlineTextItem.style().textAutospace();
+    auto autospace = inlineTextItem.style().textAutospace();
     if (!autospace.isNoAutospace()) {
         // We need to store information about spacing added between inline text items since it needs to be trimmed during line breaking if the consecutive items are placed on different lines
         auto characterClass = TextSpacing::characterClass(inlineTextItem.content().characterAt(0));
         if (autospace.shouldApplySpacing(spacingState.lastCharacterClassFromPreviousRun, characterClass))
-            trimmableTextSpacings.add(inlineItemIndex, autospace.textAutospaceSize(inlineTextItem.style().fontCascade().primaryFont()));
+            trimmableTextSpacings.add(inlineItemIndex, TextAutospace::textAutospaceSize(inlineTextItem.style().fontCascade().primaryFont()));
 
         auto lastCharacterFromPreviousRun = TextUtil::lastBaseCharacterFromText(inlineTextItem.content());
         spacingState.lastCharacterClassFromPreviousRun = TextSpacing::characterClass(lastCharacterFromPreviousRun);

--- a/Source/WebCore/platform/text/TextSpacing.h
+++ b/Source/WebCore/platform/text/TextSpacing.h
@@ -117,18 +117,21 @@ public:
 
     using Options = OptionSet<Type>;
 
-    TextAutospace() = default;
-    TextAutospace(Options options)
+    constexpr TextAutospace() = default;
+    constexpr TextAutospace(Options options)
         : m_options(options)
-        { }
+    {
+    }
 
-    bool isAuto() const { return m_options.contains(Type::Auto); }
-    bool isNoAutospace() const { return m_options.isEmpty(); }
-    bool isNormal() const { return m_options.contains(Type::Normal); }
-    bool hasIdeographAlpha() const { return m_options.containsAny({ Type::IdeographAlpha, Type::Normal }); }
-    bool hasIdeographNumeric() const { return m_options.containsAny({ Type::IdeographNumeric, Type::Normal }); }
-    Options options() { return m_options; }
-    friend bool operator==(const TextAutospace&, const TextAutospace&) = default;
+    constexpr bool isAuto() const { return m_options.contains(Type::Auto); }
+    constexpr bool isNoAutospace() const { return m_options.isEmpty(); }
+    constexpr bool isNormal() const { return m_options.contains(Type::Normal); }
+    constexpr bool hasIdeographAlpha() const { return m_options.containsAny({ Type::IdeographAlpha, Type::Normal }); }
+    constexpr bool hasIdeographNumeric() const { return m_options.containsAny({ Type::IdeographNumeric, Type::Normal }); }
+    constexpr Options options() { return m_options; }
+
+    bool operator==(const TextAutospace&) const = default;
+
     bool shouldApplySpacing(TextSpacing::CharacterClass firstCharacterClass, TextSpacing::CharacterClass secondCharacterClass) const;
     bool shouldApplySpacing(char32_t firstCharacter, char32_t secondCharacter) const;
     static float textAutospaceSize(const Font&);

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2517,11 +2517,6 @@ float RenderStyle::computedFontSize() const
     return fontDescription().computedSize();
 }
 
-TextAutospace RenderStyle::textAutospace() const
-{
-    return fontDescription().textAutospace();
-}
-
 void RenderStyle::setFontCascade(FontCascade&& fontCascade)
 {
     if (fontCascade == this->fontCascade())
@@ -2611,10 +2606,10 @@ void RenderStyle::setTextSpacingTrim(Style::TextSpacingTrim value)
     setFontDescription(WTFMove(description));
 }
 
-void RenderStyle::setTextAutospace(TextAutospace value)
+void RenderStyle::setTextAutospace(Style::TextAutospace value)
 {
     auto description = fontDescription();
-    description.setTextAutospace(value);
+    description.setTextAutospace(Style::toPlatform(value));
     setFontDescription(WTFMove(description));
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -73,7 +73,6 @@ class StyleInheritedData;
 class StyleNonInheritedData;
 class StyleRareInheritedData;
 class StyleSelfAlignmentData;
-class TextAutospace;
 class TransformationMatrix;
 class ViewTimeline;
 class WillChangeData;
@@ -352,6 +351,7 @@ struct ShapeOutside;
 struct StrokeMiterlimit;
 struct StrokeWidth;
 struct TabSize;
+struct TextAutospace;
 struct TextBoxEdge;
 struct TextDecorationThickness;
 struct TextEmphasisStyle;
@@ -787,7 +787,7 @@ public:
     inline float usedWordSpacing() const;
 
     inline Style::TextSpacingTrim textSpacingTrim() const;
-    TextAutospace textAutospace() const;
+    inline Style::TextAutospace textAutospace() const;
 
     inline float zoom() const;
     inline float usedZoom() const;
@@ -1987,7 +1987,7 @@ public:
     inline void setMathStyle(const MathStyle&);
 
     void setTextSpacingTrim(Style::TextSpacingTrim);
-    void setTextAutospace(TextAutospace v);
+    void setTextAutospace(Style::TextAutospace);
 
     static constexpr Overflow initialOverflowX();
     static constexpr Overflow initialOverflowY();
@@ -2024,7 +2024,7 @@ public:
     static constexpr Style::FontVariantNumeric initialFontVariantNumeric();
     static constexpr FontVariantPosition initialFontVariantPosition();
     static inline AtomString initialLocale();
-    static constexpr TextAutospace initialTextAutospace();
+    static constexpr Style::TextAutospace initialTextAutospace();
     static constexpr TextRenderingMode initialTextRendering();
     static constexpr Style::TextSpacingTrim initialTextSpacingTrim();
     static constexpr BreakBetween initialBreakBetween();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -67,6 +67,7 @@
 #include <WebCore/StyleRareInheritedData.h>
 #include <WebCore/StyleRareNonInheritedData.h>
 #include <WebCore/StyleSurroundData.h>
+#include <WebCore/StyleTextAutospace.h>
 #include <WebCore/StyleTextSpacingTrim.h>
 #include <WebCore/StyleTransformData.h>
 #include <WebCore/StyleVisitedLinkColorData.h>
@@ -441,7 +442,7 @@ constexpr Style::FontVariantLigatures RenderStyle::initialFontVariantLigatures()
 constexpr Style::FontVariantNumeric RenderStyle::initialFontVariantNumeric() { return CSS::Keyword::Normal { }; }
 constexpr FontVariantPosition RenderStyle::initialFontVariantPosition() { return FontVariantPosition::Normal; }
 inline AtomString RenderStyle::initialLocale() { return nullAtom(); }
-constexpr TextAutospace RenderStyle::initialTextAutospace() { return { }; }
+constexpr Style::TextAutospace RenderStyle::initialTextAutospace() { return CSS::Keyword::NoAutospace { }; }
 constexpr TextRenderingMode RenderStyle::initialTextRendering() { return TextRenderingMode::AutoTextRendering; }
 constexpr Style::TextSpacingTrim RenderStyle::initialTextSpacingTrim() { return CSS::Keyword::SpaceAll { }; }
 inline Style::GridTrackSizes RenderStyle::initialGridAutoColumns() { return CSS::Keyword::Auto { }; }
@@ -805,6 +806,7 @@ inline const AtomString& RenderStyle::pseudoElementNameArgument() const { return
 inline const Style::TabSize& RenderStyle::tabSize() const { return m_rareInheritedData->tabSize; }
 inline TableLayoutType RenderStyle::tableLayout() const { return static_cast<TableLayoutType>(m_nonInheritedData->miscData->tableLayout); }
 inline TextAlignLast RenderStyle::textAlignLast() const { return static_cast<TextAlignLast>(m_rareInheritedData->textAlignLast); }
+inline Style::TextAutospace RenderStyle::textAutospace() const { return fontDescription().textAutospace(); }
 inline TextBoxTrim RenderStyle::textBoxTrim() const { return static_cast<TextBoxTrim>(m_nonInheritedData->rareData->textBoxTrim); }
 inline Style::TextBoxEdge RenderStyle::textBoxEdge() const { return m_rareInheritedData->textBoxEdge; }
 inline Style::LineFitEdge RenderStyle::lineFitEdge() const { return m_rareInheritedData->lineFitEdge; }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -141,9 +141,6 @@ public:
 
     static OptionSet<MarginTrimType> convertMarginTrim(BuilderState&, const CSSValue&);
 
-    static TextSpacingTrim convertTextSpacingTrim(BuilderState&, const CSSValue&);
-    static TextAutospace convertTextAutospace(BuilderState&, const CSSValue&);
-
     static RefPtr<WillChangeData> convertWillChange(BuilderState&, const CSSValue&);
 
     static std::optional<ScopedName> convertPositionAnchor(BuilderState&, const CSSValue&);
@@ -629,39 +626,6 @@ inline OptionSet<MarginTrimType> BuilderConverter::convertMarginTrim(BuilderStat
     }
     ASSERT(list->size() <= 4);
     return marginTrim;
-}
-
-inline TextAutospace BuilderConverter::convertTextAutospace(BuilderState& builderState, const CSSValue& value)
-{
-    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        if (primitiveValue->valueID() == CSSValueNoAutospace)
-            return { };
-        if (primitiveValue->valueID() == CSSValueAuto)
-            return { TextAutospace::Type::Auto };
-        if (primitiveValue->valueID() == CSSValueNormal)
-            return { TextAutospace::Type::Normal };
-    }
-
-    TextAutospace::Options options;
-
-    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
-    if (!list)
-        return { };
-
-    for (auto& value : *list) {
-        switch (value.valueID()) {
-        case CSSValueIdeographAlpha:
-            options.add(TextAutospace::Type::IdeographAlpha);
-            break;
-        case CSSValueIdeographNumeric:
-            options.add(TextAutospace::Type::IdeographNumeric);
-            break;
-        default:
-            ASSERT_NOT_REACHED();
-            break;
-        }
-    }
-    return options;
 }
 
 inline OptionSet<Containment> BuilderConverter::convertContain(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -47,7 +47,6 @@ class FontSelectionValue;
 class RenderStyle;
 class StyleImage;
 class StyleResolver;
-class TextAutospace;
 
 namespace CSSCalc {
 struct RandomCachingKey;
@@ -68,6 +67,7 @@ struct FontVariantNumeric;
 struct FontVariationSettings;
 struct FontWeight;
 struct FontWidth;
+struct TextAutospace;
 struct TextSpacingTrim;
 
 void maybeUpdateFontForLetterSpacingOrWordSpacing(BuilderState&, CSSValue&);

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -214,11 +214,11 @@ inline void BuilderState::setFontDescriptionSpecifiedLocale(const AtomString& sp
 
 inline void BuilderState::setFontDescriptionTextAutospace(TextAutospace textAutospace)
 {
-    if (m_style.fontDescription().textAutospace() == textAutospace)
+    if (m_style.fontDescription().textAutospace() == toPlatform(textAutospace))
         return;
 
     m_fontDirty = true;
-    m_style.mutableFontDescriptionWithoutUpdate().setTextAutospace(textAutospace);
+    m_style.mutableFontDescriptionWithoutUpdate().setTextAutospace(toPlatform(textAutospace));
 }
 
 inline void BuilderState::setFontDescriptionTextRenderingMode(TextRenderingMode textRenderingMode)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -137,7 +137,6 @@ public:
     static Ref<CSSValue> convertMarginTrim(ExtractorState&, OptionSet<MarginTrimType>);
     static Ref<CSSValue> convertImageOrientation(ExtractorState&, ImageOrientation);
     static Ref<CSSValue> convertContain(ExtractorState&, OptionSet<Containment>);
-    static Ref<CSSValue> convertTextAutospace(ExtractorState&, TextAutospace);
     static Ref<CSSValue> convertPositionTryFallbacks(ExtractorState&, const FixedVector<PositionTryFallback>&);
     static Ref<CSSValue> convertWillChange(ExtractorState&, const WillChangeData*);
     static Ref<CSSValue> convertLineBoxContain(ExtractorState&, OptionSet<Style::LineBoxContain>);
@@ -317,25 +316,6 @@ inline Ref<CSSValue> ExtractorConverter::convertContain(ExtractorState&, OptionS
         list.append(CSSPrimitiveValue::create(CSSValuePaint));
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
-
-inline Ref<CSSValue> ExtractorConverter::convertTextAutospace(ExtractorState&, TextAutospace textAutospace)
-{
-    if (textAutospace.isAuto())
-        return CSSPrimitiveValue::create(CSSValueAuto);
-    if (textAutospace.isNoAutospace())
-        return CSSPrimitiveValue::create(CSSValueNoAutospace);
-    if (textAutospace.isNormal())
-        return CSSPrimitiveValue::create(CSSValueNormal);
-
-    CSSValueListBuilder list;
-    if (textAutospace.hasIdeographAlpha())
-        list.append(CSSPrimitiveValue::create(CSSValueIdeographAlpha));
-    if (textAutospace.hasIdeographNumeric())
-        list.append(CSSPrimitiveValue::create(CSSValueIdeographNumeric));
-
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
-
 
 inline Ref<CSSValue> ExtractorConverter::convertPositionTryFallbacks(ExtractorState& state, const FixedVector<PositionTryFallback>& fallbacks)
 {

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -72,7 +72,6 @@ public:
     static void serializeImageOrientation(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, ImageOrientation);
     static void serializeContain(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<Containment>);
     static void serializeSmoothScrolling(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, bool);
-    static void serializeTextAutospace(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, TextAutospace);
     static void serializePositionTryFallbacks(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<PositionTryFallback>&);
     static void serializeWillChange(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const WillChangeData*);
     static void serializeTabSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TabSize&);
@@ -281,41 +280,6 @@ inline void ExtractorSerializer::serializeContain(ExtractorState& state, StringB
     appendOption(Containment::Layout, CSSValueLayout);
     appendOption(Containment::Style, CSSValueStyle);
     appendOption(Containment::Paint, CSSValuePaint);
-}
-
-inline void ExtractorSerializer::serializeTextAutospace(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, TextAutospace textAutospace)
-{
-    if (textAutospace.isAuto()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Auto { });
-        return;
-    }
-
-    if (textAutospace.isNoAutospace()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::NoAutospace { });
-        return;
-    }
-
-    if (textAutospace.isNormal()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Normal { });
-        return;
-    }
-
-    if (textAutospace.hasIdeographAlpha() && textAutospace.hasIdeographNumeric()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::IdeographAlpha { });
-        builder.append(' ');
-        serializationForCSS(builder, context, state.style, CSS::Keyword::IdeographNumeric { });
-        return;
-    }
-
-    if (textAutospace.hasIdeographAlpha()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::IdeographAlpha { });
-        return;
-    }
-
-    if (textAutospace.hasIdeographNumeric()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::IdeographNumeric { });
-        return;
-    }
 }
 
 inline void ExtractorSerializer::serializePositionTryFallbacks(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<PositionTryFallback>& fallbacks)

--- a/Source/WebCore/style/values/text/StyleTextAutospace.cpp
+++ b/Source/WebCore/style/values/text/StyleTextAutospace.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleTextAutospace.h"
+
+#include "StyleBuilderChecking.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto CSSValueConversion<TextAutospace>::operator()(BuilderState& state, const CSSValue& value) -> TextAutospace
+{
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueNormal:
+            return CSS::Keyword::Normal { };
+        case CSSValueAuto:
+            return CSS::Keyword::Auto { };
+        case CSSValueNoAutospace:
+            return CSS::Keyword::NoAutospace { };
+        case CSSValueIdeographAlpha:
+            return CSS::Keyword::IdeographAlpha { };
+        case CSSValueIdeographNumeric:
+            return CSS::Keyword::IdeographNumeric { };
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::NoAutospace { };
+        }
+    }
+
+    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+    if (!list)
+        return CSS::Keyword::NoAutospace { };
+
+    if (list->size() == 1) {
+        switch (Ref first = list->item(0); first->valueID()) {
+        case CSSValueNormal:
+            return CSS::Keyword::Normal { };
+        case CSSValueAuto:
+            return CSS::Keyword::Auto { };
+        case CSSValueNoAutospace:
+            return CSS::Keyword::NoAutospace { };
+        case CSSValueIdeographAlpha:
+            return CSS::Keyword::IdeographAlpha { };
+        case CSSValueIdeographNumeric:
+            return CSS::Keyword::IdeographNumeric { };
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::NoAutospace { };
+        }
+    }
+    if (list->size() == 2) {
+        switch (Ref first = list->item(0); first->valueID()) {
+        case CSSValueIdeographAlpha:
+            if (Ref second = list->item(1); second->valueID() == CSSValueIdeographNumeric)
+                return { CSS::Keyword::IdeographAlpha { }, CSS::Keyword::IdeographNumeric { } };
+            break;
+        case CSSValueIdeographNumeric:
+            if (Ref second = list->item(1); second->valueID() == CSSValueIdeographAlpha)
+                return { CSS::Keyword::IdeographAlpha { }, CSS::Keyword::IdeographNumeric { } };
+            break;
+        default:
+            break;
+        }
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return CSS::Keyword::NoAutospace { };
+    }
+
+    state.setCurrentPropertyInvalidAtComputedValueTime();
+    return CSS::Keyword::NoAutospace { };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/text/StyleTextAutospace.h
+++ b/Source/WebCore/style/values/text/StyleTextAutospace.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+#include <WebCore/TextSpacing.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'text-autospace'> = normal | auto | no-autospace | [ ideograph-alpha || ideograph-numeric ]
+// FIXME: Current spec is `normal | auto | no-autospace | [ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ]`
+// https://drafts.csswg.org/css-text-4/#propdef-text-autospace
+struct TextAutospace {
+    constexpr TextAutospace(CSS::Keyword::Normal) : m_value { WebCore::TextAutospace::Type::Normal } { }
+    constexpr TextAutospace(CSS::Keyword::Auto) : m_value { WebCore::TextAutospace::Type::Auto } { }
+    constexpr TextAutospace(CSS::Keyword::NoAutospace) : m_value { } { }
+    constexpr TextAutospace(CSS::Keyword::IdeographAlpha) : m_value { WebCore::TextAutospace::Type::IdeographAlpha } { }
+    constexpr TextAutospace(CSS::Keyword::IdeographNumeric) : m_value { WebCore::TextAutospace::Type::IdeographNumeric } { }
+    constexpr TextAutospace(CSS::Keyword::IdeographAlpha, CSS::Keyword::IdeographNumeric) : m_value { { WebCore::TextAutospace::Type::IdeographAlpha, WebCore::TextAutospace::Type::IdeographNumeric } } { }
+
+    constexpr TextAutospace(WebCore::TextAutospace value) : m_value { value } { }
+
+    constexpr bool isNormal() const { return m_value.isNormal(); }
+    constexpr bool isAuto() const { return m_value.isAuto(); }
+    constexpr bool isNoAutospace() const { return m_value.isNoAutospace(); }
+    constexpr bool hasIdeographAlpha() const { return m_value.hasIdeographAlpha(); }
+    constexpr bool hasIdeographNumeric() const { return m_value.hasIdeographNumeric(); }
+
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (isNormal())
+            return visitor(CSS::Keyword::Normal { });
+        if (isAuto())
+            return visitor(CSS::Keyword::Auto { });
+        if (isNoAutospace())
+            return visitor(CSS::Keyword::NoAutospace { });
+        if (hasIdeographAlpha()) {
+            if (hasIdeographNumeric())
+                return visitor(SpaceSeparatedTuple { CSS::Keyword::IdeographAlpha { }, CSS::Keyword::IdeographNumeric { } });
+            return visitor(CSS::Keyword::IdeographAlpha { });
+        }
+        if (hasIdeographNumeric())
+            return visitor(CSS::Keyword::IdeographNumeric { });
+
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    bool shouldApplySpacing(WebCore::TextSpacing::CharacterClass firstCharacterClass, WebCore::TextSpacing::CharacterClass secondCharacterClass) const { return m_value.shouldApplySpacing(firstCharacterClass, secondCharacterClass); }
+    bool shouldApplySpacing(char32_t firstCharacter, char32_t secondCharacter) const { return m_value.shouldApplySpacing(firstCharacter, secondCharacter); }
+
+    constexpr bool operator==(const TextAutospace&) const = default;
+
+private:
+    friend struct ToPlatform<TextAutospace>;
+
+    WebCore::TextAutospace m_value;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<TextAutospace> { auto operator()(BuilderState&, const CSSValue&) -> TextAutospace; };
+
+// MARK: - Platform
+
+template<> struct ToPlatform<TextAutospace> {
+    constexpr auto operator()(const TextAutospace& value) -> WebCore::TextAutospace
+    {
+        return value.m_value;
+    }
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextAutospace);


### PR DESCRIPTION
#### 021072880ec132a607f4494e50fa391c11780fc7
<pre>
[Style] Convert the &apos;text-autospace&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=301357">https://bugs.webkit.org/show_bug.cgi?id=301357</a>

Reviewed by Antti Koivisto.

Converts the &apos;text-autospace&apos; property to use strong style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/platform/text/TextSpacing.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleBuilderStateInlines.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/text/StyleTextAutospace.cpp: Added.
* Source/WebCore/style/values/text/StyleTextAutospace.h: Added.

Canonical link: <a href="https://commits.webkit.org/302093@main">https://commits.webkit.org/302093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fbf987433420dd4db0e5a5bc73b1da9ee576889

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127811 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79370 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97297 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65209 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114495 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77867 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37254 "Build is being retried. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Skipped layout-tests; layout-tests (retry)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32600 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78493 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108348 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137666 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/42005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105832 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105566 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26942 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50995 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29430 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52109 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54408 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60897 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53644 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/57098 "Build is being retried. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (retry)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55400 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->