### PR TITLE
IntersectionObserver: Notify observers asynchronously

### DIFF
--- a/LayoutTests/intersection-observer/observations-queue-a-task-to-notify-expected.txt
+++ b/LayoutTests/intersection-observer/observations-queue-a-task-to-notify-expected.txt
@@ -1,0 +1,7 @@
+Intersection observations should queue a task to notify observers.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The IntersectionObserver callback did not run synchronously
+

--- a/LayoutTests/intersection-observer/observations-queue-a-task-to-notify.html
+++ b/LayoutTests/intersection-observer/observations-queue-a-task-to-notify.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<script src="../resources/ui-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+#target {
+    width: 200px;
+    height: 200px;
+    margin: 200px;
+    background-color: green;
+}
+
+#target.intersecting {
+    background-color: red;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+description('Intersection observations should queue a task to notify observers.');
+if (!window.internals)
+    testFailed('Test requires internals.');
+
+var observer;
+function ioCallback(entries)
+{
+    const target = document.getElementById('target');
+    for (const entry of entries) {
+        if (entry.intersectionRatio === 1)
+            target.classList.add('intersecting');
+        else
+            target.classList.remove('intersecting');
+    }
+}
+
+function testIOCallbackDidNotRun()
+{
+    if (target.classList.contains('intersecting'))
+        testFailed("The IntersectionObserver callback ran synchronously.");
+    else
+        testPassed("The IntersectionObserver callback did not run synchronously");
+    window.testRunner.notifyDone();
+}
+
+
+window.addEventListener('load', () => {
+    const target = document.getElementById('target');
+    observer = new IntersectionObserver(ioCallback, { threshold: [ 0, 1 ] });
+    observer.observe(target);
+    /*
+     * This dance deserves some comment.
+     * What we are trying to do is test that an intersection observation queued a task
+     * to run the callback instead of running it during the "update the rendering" step where
+     * the interesection was computed. In order to do that, we need the "update the rendering"
+     * algorithm to have run once and any observation tasks queued during that step to have not run.
+     * The way to accomplish this is earlier in the update the rendering steps we queue a task
+     * that will perform the final check. Since rAF callbacks are run before updating intersection
+     * observations we can queue a task from there which checks that the div has not yet been mutated.
+     * Unfortunately a zero delay timer does not run before the Event Loop's task queue so we can't use
+     * UIHelper.renderingUpdate which does approximately this sequence of steps but with Web APIs.
+     */
+    requestAnimationFrame(() => {
+        window.internals.queueTask('DOMManipulation', testIOCallbackDidNotRun);
+    });
+});
+
+</script>
+<body>
+<div id="target"></div>
+</body>

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -106,7 +106,7 @@ IntersectionObserver* ContentVisibilityDocumentState::intersectionObserver(Docum
         auto callback = ContentVisibilityIntersectionObserverCallback::create(document);
         IntersectionObserver::Init options { &document, { }, { }, { } };
         auto includeObscuredInsets = document.settings().contentInsetBackgroundFillEnabled() ? IncludeObscuredInsets::Yes : IncludeObscuredInsets::No;
-        auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options), includeObscuredInsets);
+        auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options), includeObscuredInsets, IntersectionObserver::NotificationDelivery::Synchronous);
         if (observer.hasException())
             return nullptr;
         m_observer = observer.releaseReturnValue();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10321,23 +10321,48 @@ void Document::updateIntersectionObservations(const Vector<WeakPtr<IntersectionO
         return;
     }
 
-    Vector<WeakPtr<IntersectionObserver>> intersectionObserversWithPendingNotifications;
+    Vector<WeakPtr<IntersectionObserver>> intersectionObserversToNotifyAsynchronously;
+    Vector<RefPtr<IntersectionObserver>> intersectionObserversToNotifySynchronously;
 
     for (auto& weakObserver : intersectionObservers) {
         RefPtr observer = weakObserver.get();
         if (!observer)
             continue;
 
-        auto needNotify = observer->updateObservations(*this);
-        if (needNotify == IntersectionObserver::NeedNotify::Yes)
-            intersectionObserversWithPendingNotifications.append(observer);
+        if (observer->updateObservations(*this)) {
+            switch (observer->notificationDelivery()) {
+            case IntersectionObserver::NotificationDelivery::Asynchronous:
+                intersectionObserversToNotifyAsynchronously.append(observer);
+                break;
+            case IntersectionObserver::NotificationDelivery::Synchronous:
+                intersectionObserversToNotifySynchronously.append(observer);
+                break;
+            }
+        }
     }
 
-    if (intersectionObserversWithPendingNotifications.size())
-        LOG_WITH_STREAM(IntersectionObserver, stream << "Document " << this << " updateIntersectionObservations - notifying observers");
+    if (!m_intersectionObserverUpdateTaskQueued && intersectionObserversToNotifyAsynchronously.size()) {
+        LOG_WITH_STREAM(IntersectionObserver, stream << "Document " << this << " updateIntersectionObservations - queueing task to notify JavaScript observers");
+        m_intersectionObserverUpdateTaskQueued = true;
 
-    for (auto& weakObserver : intersectionObserversWithPendingNotifications) {
-        if (RefPtr observer = weakObserver.get())
+        eventLoop().queueTask(TaskSource::IntersectionObserver, [weakThis = WeakPtr<Document, WeakPtrImplWithEventTargetData> { *this }, weakObservers = WTFMove(intersectionObserversToNotifyAsynchronously)]() mutable {
+            RefPtr protectedDocument = weakThis.get();
+
+            if (!protectedDocument)
+                return;
+
+            for (auto& weakObserver : weakObservers) {
+                if (RefPtr observer = weakObserver.get())
+                    observer->notify();
+            }
+            protectedDocument->m_intersectionObserverUpdateTaskQueued = false;
+        });
+    }
+
+    if (intersectionObserversToNotifySynchronously.size()) {
+        LOG_WITH_STREAM(IntersectionObserver, stream << "Document " << this << " updateIntersectionObservations - notifying internal observers.");
+
+        for (const auto& observer : intersectionObserversToNotifySynchronously)
             observer->notify();
     }
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2769,6 +2769,8 @@ private:
 
     bool m_requiresTrustedTypes { false };
 
+    bool m_intersectionObserverUpdateTaskQueued { false };
+
     static bool hasEverCreatedAnAXObjectCache;
 
     const RefPtr<ResizeObserver> m_resizeObserverForContainIntrinsicSize;

--- a/Source/WebCore/dom/TaskSource.h
+++ b/Source/WebCore/dom/TaskSource.h
@@ -37,6 +37,7 @@ enum class TaskSource : uint8_t {
     IdleTask,
     ImageCapture,
     IndexedDB,
+    IntersectionObserver,
     MediaElement,
     Microtask,
     ModelElement,

--- a/Source/WebCore/html/LazyLoadImageObserver.cpp
+++ b/Source/WebCore/html/LazyLoadImageObserver.cpp
@@ -95,7 +95,7 @@ IntersectionObserver* LazyLoadImageObserver::intersectionObserver(Document& docu
         auto callback = LazyImageLoadIntersectionObserverCallback::create(document);
         static NeverDestroyed<const String> lazyLoadingScrollMarginFallback(MAKE_STATIC_STRING_IMPL("100%"));
         IntersectionObserver::Init options { std::nullopt, { }, lazyLoadingScrollMarginFallback, { } };
-        auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options));
+        auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options), IncludeObscuredInsets::No, IntersectionObserver::NotificationDelivery::Synchronous);
         if (observer.hasException())
             return nullptr;
         m_observer = observer.returnValue().ptr();

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -129,7 +129,7 @@ static ExceptionOr<IntersectionObserverMarginBox> parseMargin(String& margin, co
     return IntersectionObserverMarginBox { edge1.releaseReturnValue(), edge2.releaseReturnValue(), edge3.releaseReturnValue(), edge4.releaseReturnValue() };
 }
 
-ExceptionOr<Ref<IntersectionObserver>> IntersectionObserver::create(Document& document, Ref<IntersectionObserverCallback>&& callback, IntersectionObserver::Init&& init, IncludeObscuredInsets includeObscuredInsets)
+ExceptionOr<Ref<IntersectionObserver>> IntersectionObserver::create(Document& document, Ref<IntersectionObserverCallback>&& callback, IntersectionObserver::Init&& init, IncludeObscuredInsets includeObscuredInsets, IntersectionObserver::NotificationDelivery notificationDelivery)
 {
     RefPtr<ContainerNode> root;
     if (init.root) {
@@ -166,18 +166,19 @@ ExceptionOr<Ref<IntersectionObserver>> IntersectionObserver::create(Document& do
             return Exception { ExceptionCode::RangeError, "Failed to construct 'IntersectionObserver': all thresholds must lie in the range [0.0, 1.0]."_s };
     }
 
-    return adoptRef(*new IntersectionObserver(document, WTFMove(callback), root.get(), rootMarginOrException.releaseReturnValue(), scrollMarginOrException.releaseReturnValue(), WTFMove(thresholds), includeObscuredInsets));
+    return adoptRef(*new IntersectionObserver(document, WTFMove(callback), root.get(), rootMarginOrException.releaseReturnValue(), scrollMarginOrException.releaseReturnValue(), WTFMove(thresholds), includeObscuredInsets, notificationDelivery));
 }
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(IntersectionObserver);
 
-IntersectionObserver::IntersectionObserver(Document& document, Ref<IntersectionObserverCallback>&& callback, ContainerNode* root, IntersectionObserverMarginBox&& parsedRootMargin, IntersectionObserverMarginBox&& parsedScrollMargin, Vector<double>&& thresholds, IncludeObscuredInsets includeObscuredInsets)
+IntersectionObserver::IntersectionObserver(Document& document, Ref<IntersectionObserverCallback>&& callback, ContainerNode* root, IntersectionObserverMarginBox&& parsedRootMargin, IntersectionObserverMarginBox&& parsedScrollMargin, Vector<double>&& thresholds, IncludeObscuredInsets includeObscuredInsets, IntersectionObserver::NotificationDelivery notificationDelivery)
     : m_root(root)
     , m_rootMargin(WTFMove(parsedRootMargin))
     , m_scrollMargin(WTFMove(parsedScrollMargin))
     , m_thresholds(WTFMove(thresholds))
     , m_callback(WTFMove(callback))
     , m_includeObscuredInsets(includeObscuredInsets)
+    , m_notificationDelivery(notificationDelivery)
 {
     if (RefPtr rootDocument = dynamicDowncast<Document>(root)) {
         auto& observerData = rootDocument->ensureIntersectionObserverData();
@@ -548,17 +549,17 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
     return intersectionState;
 }
 
-auto IntersectionObserver::updateObservations(Document& hostDocument) -> NeedNotify
+bool IntersectionObserver::updateObservations(Document& hostDocument)
 {
     RefPtr frameView = hostDocument.view();
     if (!frameView)
-        return NeedNotify::No;
+        return false;
 
     auto timestamp = nowTimestamp();
     if (!timestamp)
-        return NeedNotify::No;
+        return false;
 
-    auto needNotify = NeedNotify::No;
+    bool needNotify = false;
 
     for (auto& target : observationTargets()) {
         auto& targetRegistrations = target->intersectionObserverDataIfExists()->registrations;
@@ -609,7 +610,7 @@ auto IntersectionObserver::updateObservations(Document& hostDocument) -> NeedNot
                 intersectionState.thresholdIndex > 0,
             }));
 
-            needNotify = NeedNotify::Yes;
+            needNotify = true;
             registration.previousThresholdIndex = intersectionState.thresholdIndex;
         }
     }

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -57,8 +57,7 @@ struct IntersectionObserverData {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(IntersectionObserverData);
 
     // IntersectionObservers for which the node that owns this IntersectionObserverData is the root.
-    // An IntersectionObserver is only owned by a JavaScript wrapper. ActiveDOMObject::virtualHasPendingActivity
-    // is overridden to keep this wrapper alive while the observer has ongoing observations.
+    // ActiveDOMObject::virtualHasPendingActivity is overridden to keep this wrapper alive while the observer has ongoing observations.
     Vector<WeakPtr<IntersectionObserver>> observers;
 
     // IntersectionObserverRegistrations for which the node that owns this IntersectionObserverData is the target.
@@ -77,7 +76,11 @@ public:
         Variant<double, Vector<double>> threshold;
     };
 
-    static ExceptionOr<Ref<IntersectionObserver>> create(Document&, Ref<IntersectionObserverCallback>&&, Init&&, IncludeObscuredInsets = IncludeObscuredInsets::No);
+    // Internal users of IntersectionObserver should have their notifications delivered synchronously.
+    // JavaScript will post a task for asynchronous delivery.
+    enum class NotificationDelivery : uint8_t { Asynchronous, Synchronous };
+
+    static ExceptionOr<Ref<IntersectionObserver>> create(Document&, Ref<IntersectionObserverCallback>&&, Init&&, IncludeObscuredInsets = IncludeObscuredInsets::No, NotificationDelivery = NotificationDelivery::Asynchronous);
 
     ~IntersectionObserver();
 
@@ -106,19 +109,20 @@ public:
     void targetDestroyed(Element&);
     void rootDestroyed();
 
-    enum class NeedNotify : bool { No, Yes };
-    NeedNotify updateObservations(Document&);
+    bool updateObservations(Document&);
 
     std::optional<ReducedResolutionSeconds> nowTimestamp() const;
 
     void appendQueuedEntry(Ref<IntersectionObserverEntry>&&);
     void notify();
 
+    NotificationDelivery notificationDelivery() const { return m_notificationDelivery; }
+
     IntersectionObserverCallback* callbackConcurrently() { return m_callback.get(); }
     bool isReachableFromOpaqueRoots(JSC::AbstractSlotVisitor&) const;
 
 private:
-    IntersectionObserver(Document&, Ref<IntersectionObserverCallback>&&, ContainerNode* root, IntersectionObserverMarginBox&& parsedRootMargin, IntersectionObserverMarginBox&& parsedScrollMargin, Vector<double>&& thresholds, IncludeObscuredInsets);
+    IntersectionObserver(Document&, Ref<IntersectionObserverCallback>&&, ContainerNode* root, IntersectionObserverMarginBox&& parsedRootMargin, IntersectionObserverMarginBox&& parsedScrollMargin, Vector<double>&& thresholds, IncludeObscuredInsets, NotificationDelivery);
 
     bool removeTargetRegistration(Element&);
     void removeAllTargets();
@@ -149,6 +153,7 @@ private:
     Vector<Ref<IntersectionObserverEntry>> m_queuedEntries;
     Vector<GCReachableRef<Element>> m_targetsWaitingForFirstObservation;
     IncludeObscuredInsets m_includeObscuredInsets { IncludeObscuredInsets::No };
+    NotificationDelivery m_notificationDelivery;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### c00cd43d423a4cacae971ba9377917c34a99d75c
<pre>
IntersectionObserver: Notify observers asynchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=294096">https://bugs.webkit.org/show_bug.cgi?id=294096</a>
<a href="https://rdar.apple.com/163289305">rdar://163289305</a>

Reviewed by NOBODY (OOPS!).

IntersectionObservers are being notified synchronously once we determine which
observations are relevant. However, the spec says we should queue a task to notify.

Since lazy loading images and CSS Contain&apos;s content-visibility are implemented in terms of
IntersectionObserver internally, we differentiate between an observer from JavaScript and
internal users by allowing one to specify a notification delivery preference as being
either async for JS or synchronous for other internal users.

This is a spec compliance change, but it also results in
~0.2% overall improvement on Speedometer3 on some devices.

Test: intersection-observer/observations-queue-a-task-to-notify.html

* LayoutTests/intersection-observer/observations-queue-a-task-to-notify-expected.txt: Added.
* LayoutTests/intersection-observer/observations-queue-a-task-to-notify.html: Added.
    This test needs to use internals since we need to inject a task into the event loop to check that
    the intersection observer&apos;s callback didn&apos;t mutate state.

* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::intersectionObserver):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateIntersectionObservations):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/TaskSource.h:
* Source/WebCore/html/LazyLoadImageObserver.cpp:
(WebCore::LazyLoadImageObserver::intersectionObserver):
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::create):
(WebCore::IntersectionObserver::IntersectionObserver):
(WebCore::IntersectionObserver::updateObservations):
* Source/WebCore/page/IntersectionObserver.h:
(WebCore::IntersectionObserver::notificationDelivery const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c00cd43d423a4cacae971ba9377917c34a99d75c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135283 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79450 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5278375b-f905-46be-8301-06574f976eaf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/75 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97370 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65268 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8e1e6e44-e1a6-4773-b867-f253411098fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77936 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ae3ea718-a98a-47a8-913e-eabe40a40594) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32686 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78591 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108394 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137767 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/66 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/54 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105903 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/83 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105637 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29503 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52209 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/106 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61594 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/118 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/85 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->