### PR TITLE
Fix safer C++ static analyzer warnings in WebFullScreenManager.cpp

### DIFF
--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -499,8 +499,8 @@ void WebFullScreenManager::willExitFullScreen(CompletionHandler<void()>&& comple
     setPIPStandbyElement(nullptr);
 #endif
 
-    m_finalFrame = screenRectOfContents(*m_element);
-    if (!m_element->protectedDocument()->fullscreen().willExitFullscreen()) {
+    m_finalFrame = screenRectOfContents(*element);
+    if (!element->protectedDocument()->protectedFullscreen()->willExitFullscreen()) {
         close();
         return completionHandler();
     }


### PR DESCRIPTION
#### e6d5de7d65d7a14b1d0345a17c61e837fd8d751f
<pre>
Fix safer C++ static analyzer warnings in WebFullScreenManager.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=301372">https://bugs.webkit.org/show_bug.cgi?id=301372</a>

Reviewed by Jer Noble.

Addressed the static analyzer warnings by deploying more smart pointers.

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::willExitFullScreen):

Canonical link: <a href="https://commits.webkit.org/302062@main">https://commits.webkit.org/302062@main</a>
</pre>
