### PR TITLE
Web Inspector: Support the frame target in protocol tests

### DIFF
--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -63,7 +63,7 @@ FrameInspectorController::FrameInspectorController(LocalFrame& frame)
     , m_instrumentingAgents(InstrumentingAgents::create(*this, frame.protectedPage()->protectedInspectorController()->instrumentingAgents()))
     , m_injectedScriptManager(makeUniqueRef<WebInjectedScriptManager>(*this, WebInjectedScriptHost::create()))
     , m_frontendRouter(FrontendRouter::create())
-    , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
+    , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef(), &frame.protectedPage()->protectedInspectorController()->backendDispatcher()))
     , m_executionStopwatch(Stopwatch::create())
 {
 }

--- a/Source/WebCore/inspector/InspectorController.h
+++ b/Source/WebCore/inspector/InspectorController.h
@@ -119,6 +119,7 @@ public:
     InspectorFrontendClient* inspectorFrontendClient() const { return m_inspectorFrontendClient; }
 
     InstrumentingAgents& instrumentingAgents() const { return m_instrumentingAgents.get(); }
+    Inspector::BackendDispatcher& backendDispatcher() const { return m_backendDispatcher.get(); }
 
     Inspector::InspectorAgent& ensureInspectorAgent();
     InspectorDOMAgent& ensureDOMAgent();

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -63,7 +63,9 @@ public:
         virtual void deleteProperty(const String& name);
     };
 
-    WEBCORE_EXPORT InspectorFrontendClientLocal(InspectorController* inspectedPageController, Page* frontendPage, std::unique_ptr<Settings>);
+    enum class DispatchBackendTarget { Page, MainFrame };
+
+    WEBCORE_EXPORT InspectorFrontendClientLocal(InspectorController* inspectedPageController, Page* frontendPage, std::unique_ptr<Settings>, DispatchBackendTarget = DispatchBackendTarget::Page);
     WEBCORE_EXPORT ~InspectorFrontendClientLocal() override;
 
     WEBCORE_EXPORT void resetState() override;


### PR DESCRIPTION
#### fba6f421140273037c3094577e69a60a85b3326a
<pre>
Web Inspector: Support the frame target in protocol tests
<a href="https://rdar.apple.com/163222919">rdar://163222919</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301304">https://bugs.webkit.org/show_bug.cgi?id=301304</a>

Reviewed by Devin Rousso.

Our current inspector protocol testing infrastructure uses the InspectorStubFrontend
that sends protocol commands directly into the WebCore Page and its InspectorController.
As we start moving inspector domains and agents from page/InspectorController
to frame/FrameInspectorController, protocol tests will break due to
commands being still sent to the page and not the frame where they&apos;ll
be handled.

Make InspectorStubFrontend send commands to the main frame&apos;s FrameInspectorController
instead. As the frame currently still has no domains or agents, add a
fallback mechanism for BackendDispatcher to let frame forward commands
to its page for missing domains. This allows us to begin moving agents
from page to frame while easily maintaining protocol testing coverage.

InspectorStubFrontend still needs to connect with the page plus its InspectorController
because that&apos;s when lazy agent creation and agent registration happens.
So, it connects to both the page and the main frame.

One caveat of this &quot;connect to page and main frame&quot; solution is that it
still won&apos;t work when a protocol test involves more than one frame
(has iframes), as there&apos;s no way for the InspectorStubFrontend or InspectorProtocol
to specify a destination for commands. There exists 8 protocol tests
involving iframes that we may need to rework while re-architecting their
corresponding domains:
   1. inspector/console/x-frame-options-message.html
   2. inspector/dom/dom-search-caseSensitive.html
   3. inspector/dom/dom-search-crash.html
   4. inspector/dom/dom-search-with-context.html
   5. inspector/dom/dom-search.html
   6. inspector/runtime/execution-context-in-scriptless-page.html
   7. inspector/runtime/executionContextCreated-isolated-world.html
   8. inspector/runtime/executionContextCreated-onEnable.html
Given the small number, it should be worthwhile to include this patch
anyway and address these tests later.

No expected perceived behavior change. Existing protocol tests verify
this change.

* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp:
(Inspector::BackendDispatcher::BackendDispatcher):
(Inspector::BackendDispatcher::create):
(Inspector::BackendDispatcher::dispatch):
* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h:
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::FrameInspectorController):
* Source/WebCore/inspector/InspectorController.h:
   Add fallback mechanism for BackendDispatcher so that the frame can
   forward commands from unknown domains to its page.

* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorBackendDispatchTask::create):
(WebCore::InspectorBackendDispatchTask::InspectorBackendDispatchTask):
(WebCore::InspectorBackendDispatchTask::dispatchOneMessage):
(WebCore::InspectorFrontendClientLocal::InspectorFrontendClientLocal):
   Add a way for InspectorBackendDispatchTask to be able to send to the
   main frame instead of the page.

* Source/WebCore/inspector/InspectorFrontendClientLocal.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::InspectorStubFrontend::InspectorStubFrontend):
(WebCore::InspectorStubFrontend::closeWindow):
(WebCore::Internals::openDummyInspectorFrontend):
   Make InspectorStubFrontend, the frontend channel used in protocol
   tests, connect with and send commands to the main frame instead.

Canonical link: <a href="https://commits.webkit.org/302178@main">https://commits.webkit.org/302178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eee839eb29726602e338d3eaec0777227e33d37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79738 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/84e08305-5d2b-43de-b05e-2ebc9b9e835c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97626 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65532 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dd75cdb2-47d6-4d70-b97d-9391113644bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78216 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/84889477-ef24-4ff8-b8b2-ca09a760a6d5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33004 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78937 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120284 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108674 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138103 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126717 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/363 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106163 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105968 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27002 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/304 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52676 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/433 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63329 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159743 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/340 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39896 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/409 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/398 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->