### PR TITLE
Skip API Test TestWebKitAPI.WebKit.DidRemoveFrameFromHiearchyInBackForwardCache in site isolation

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp
@@ -30,6 +30,7 @@
 #include "PlatformUtilities.h"
 #include "PlatformWebView.h"
 #include "Test.h"
+#include "Tests/WebKitCocoa/SiteIsolationUtilities.h"
 #include <WebKit/WKString.h>
 
 namespace TestWebKitAPI {
@@ -76,6 +77,12 @@ TEST(WebKit, DidRemoveFrameFromHiearchyInBackForwardCache)
     WKContextSetCacheModel(context.get(), kWKCacheModelPrimaryWebBrowser);
 
     PlatformWebView webView(context.get());
+
+    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
+    // In site isolation, persisted: false. PageShow events are not being restored from the back-forward cache.
+    if (isSiteIsolationEnabled(static_cast<WKWebView*>(webView.platformView())))
+        return;
+
     setPageLoaderClient(webView.page());
     setInjectedBundleClient(webView.page());
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolationUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolationUtilities.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#ifdef __OBJC__
 @class WKWebView;
+#else
+class WKWebView;
+#endif
 
 bool isSiteIsolationEnabled(WKWebView*);


### PR DESCRIPTION
#### 4a812f367956844f0001c97aca10902dff21413b
<pre>
Skip API Test TestWebKitAPI.WebKit.DidRemoveFrameFromHiearchyInBackForwardCache in site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=301381">https://bugs.webkit.org/show_bug.cgi?id=301381</a>
<a href="https://rdar.apple.com/163298426">rdar://163298426</a>

Reviewed by Sihui Liu.

TestWebKitAPI.WebKit.DidRemoveFrameFromHiearchyInBackForwardCache relies on page cache, which is not
enabled in site isolation. This patch skips the test when site isolation is on. Once it is enabled,
the early return should be removed.

* Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp:
(TestWebKitAPI::TEST(WebKit, DidRemoveFrameFromHiearchyInBackForwardCache)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolationUtilities.h:

Canonical link: <a href="https://commits.webkit.org/302127@main">https://commits.webkit.org/302127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ff303f7d1daf67dc37ce995023c55ca74808d94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79561 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7d1b52bf-deb0-4056-b494-cf4308acd102) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97487 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65377 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a56657cc-d267-4b56-87bc-645f706277a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78053 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1925f4d7-fa56-4a32-86ad-3a44faeab5e8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/141 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32821 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78731 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137910 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106011 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105747 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26966 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/149 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29613 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52369 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/238 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/157 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/233 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/200 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->