### PR TITLE
Add securityRestrictionMode API and User Default for Enhanced Security

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
@@ -58,6 +58,19 @@ typedef NS_ENUM(NSInteger, WKWebpagePreferencesUpgradeToHTTPSPolicy) {
     WKWebpagePreferencesUpgradeToHTTPSPolicyErrorOnFailure
 } NS_SWIFT_NAME(WKWebpagePreferences.UpgradeToHTTPSPolicy) WK_API_AVAILABLE(macos(15.2), ios(18.2), visionos(2.2));
 
+/*!
+ @enum WKSecurityRestrictionMode
+ @abstract Security restriction modes for WebView content.
+ @constant WKSecurityRestrictionModeNone No additional security restrictions beyond WebKit defaults.
+ @constant WKSecurityRestrictionModeMaximizeCompatibility Enhanced security protections optimized for maintaining web compatibility. Disables JIT compilation and enables increased MTE adoption.
+ @constant WKSecurityRestrictionModeLockdown Maximum security restrictions including feature disablement. Applied automatically by the system in Lockdown Mode.
+ */
+typedef NS_ENUM(NSInteger, WKSecurityRestrictionMode) {
+    WKSecurityRestrictionModeNone,
+    WKSecurityRestrictionModeMaximizeCompatibility,
+    WKSecurityRestrictionModeLockdown
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_MAC_TBA), visionos(WK_MAC_TBA));
+
 /*! A WKWebpagePreferences object is a collection of properties that
  determine the preferences to use when loading and rendering a page.
  @discussion Contains properties used to determine webpage preferences.
@@ -102,5 +115,17 @@ WK_CLASS_AVAILABLE(macos(10.15), ios(13.0))
  supercedes this policy for known hosts.
  */
 @property (nonatomic) WKWebpagePreferencesUpgradeToHTTPSPolicy preferredHTTPSNavigationPolicy WK_API_AVAILABLE(macos(15.2), ios(18.2), visionos(2.2));
+
+/*! @abstract Security restriction mode for this navigation.
+ @discussion Security restriction modes provide different levels of security hardening for high-risk browsing contexts.
+ WKSecurityRestrictionModeMaximizeCompatibility provides additional hardening while maintaining full web compatibility:
+ - JavaScript JIT compilation disabled (interpreter-only execution)
+ - Increased Memory Tagging Extension (MTE) coverage across allocations in the WebContent process
+ Setting a security restriction mode creates separate, isolated WebContent processes for the specified protection level.
+ This preference only applies to main frame navigations and will be ignored for subframe navigations. When set for a main frame, all subframe content and opened windows inherit the same security restrictions.
+ When the system has chosen WKSecurityRestrictionModeLockdown (e.g., in Lockdown Mode), attempts to set a less restrictive mode will fail silently.
+ The default value is WKSecurityRestrictionModeNone.
+ */
+@property (nonatomic) WKSecurityRestrictionMode securityRestrictionMode WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_MAC_TBA), visionos(WK_MAC_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -164,6 +164,12 @@ static WebCore::ModalContainerObservationPolicy coreModalContainerObservationPol
 
 } // namespace WebKit
 
+// EnhancedSecurityFeatureEnabled is a temporary NSUserDefault, See: rdar://163369863
+static BOOL isEnhancedSecurityFeatureEnabled()
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"EnhancedSecurityFeatureEnabled"];
+}
+
 static Ref<API::WebsitePolicies> protectedWebsitePolicies(WKWebpagePreferences *preferences)
 {
     return *preferences->_websitePolicies;
@@ -499,15 +505,22 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
     }
 }
 
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)_setEnhancedSecurityEnabled:(BOOL)enhancedSecurityEnabled
 {
+    if (!isEnhancedSecurityFeatureEnabled())
+        return;
+
     _websitePolicies->setEnhancedSecurityEnabled(enhancedSecurityEnabled ? true : false);
 }
 
 - (BOOL)_enhancedSecurityEnabled
 {
+    if (!isEnhancedSecurityFeatureEnabled())
+        return NO;
     return _websitePolicies->enhancedSecurityEnabled();
 }
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)_setCaptivePortalModeEnabled:(BOOL)enabled
 {
@@ -826,6 +839,38 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 - (BOOL)_allowsJSHandleCreationInPageWorld
 {
     return _websitePolicies->allowsJSHandleCreationInPageWorld();
+}
+
+- (void)setSecurityRestrictionMode:(WKSecurityRestrictionMode)mode
+{
+    if (!isEnhancedSecurityFeatureEnabled())
+        return;
+
+    switch (mode) {
+    case WKSecurityRestrictionModeNone:
+        _websitePolicies->setEnhancedSecurityEnabled(false);
+        _websitePolicies->setLockdownModeEnabled(false);
+        break;
+    case WKSecurityRestrictionModeMaximizeCompatibility:
+        _websitePolicies->setEnhancedSecurityEnabled(true);
+        _websitePolicies->setLockdownModeEnabled(false);
+        break;
+    case WKSecurityRestrictionModeLockdown:
+        _websitePolicies->setEnhancedSecurityEnabled(false);
+        _websitePolicies->setLockdownModeEnabled(true);
+        break;
+    }
+}
+
+- (WKSecurityRestrictionMode)securityRestrictionMode
+{
+    if (!isEnhancedSecurityFeatureEnabled())
+        return WKSecurityRestrictionModeNone;
+    if (_websitePolicies->lockdownModeEnabled())
+        return WKSecurityRestrictionModeLockdown;
+    if (_websitePolicies->enhancedSecurityEnabled())
+        return WKSecurityRestrictionModeMaximizeCompatibility;
+    return WKSecurityRestrictionModeNone;
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -135,6 +135,6 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 
 @property (nonatomic, setter=_setAllowsJSHandleCreationInPageWorld:) BOOL _allowsJSHandleCreationInPageWorld WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
-@property (nonatomic, setter=_setEnhancedSecurityEnabled:) BOOL _enhancedSecurityEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setEnhancedSecurityEnabled:) BOOL _enhancedSecurityEnabled WK_API_DEPRECATED_WITH_REPLACEMENT("securityRestrictionMode", macos(WK_MAC_TBA, WK_MAC_TBA), ios(WK_IOS_TBA, WK_IOS_TBA), visionos(WK_XROS_TBA, WK_XROS_TBA));
 
 @end

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -554,7 +554,7 @@ static BOOL areEssentiallyEqual(double a, double b)
     preferences._serviceControlsEnabled = settings.dataDetectorsEnabled;
     preferences._telephoneNumberDetectionIsEnabled = settings.dataDetectorsEnabled;
 
-    _webView.configuration.defaultWebpagePreferences._enhancedSecurityEnabled = settings.enhancedSecurityEnabled;
+    _webView.configuration.defaultWebpagePreferences.securityRestrictionMode = settings.enhancedSecurityEnabled ? WKSecurityRestrictionModeMaximizeCompatibility : WKSecurityRestrictionModeNone;
     _webView.configuration.websiteDataStore._resourceLoadStatisticsEnabled = settings.resourceLoadStatisticsEnabled;
 
     [self setWebViewFillsWindow:settings.webViewFillsWindow];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
@@ -40,6 +40,19 @@ namespace TestWebKitAPI {
 
 #if !PLATFORM(IOS)
 
+class EnhancedSecurityTest : public testing::Test {
+public:
+    virtual void SetUp()
+    {
+        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"EnhancedSecurityFeatureEnabled"];
+    }
+
+    virtual void TearDown()
+    {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"EnhancedSecurityFeatureEnabled"];
+    }
+};
+
 static bool isEnhancedSecurityEnabled(WKWebView *webView)
 {
     __block bool gotResponse = false;
@@ -66,11 +79,10 @@ static bool isJITEnabled(WKWebView *webView)
     return isJITEnabledResult;
 }
 
-
-TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityEnablesTrue)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
-    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
+    webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
@@ -82,10 +94,10 @@ TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)
 #endif
 }
 
-TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityEnableFalse)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
-    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
+    webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
@@ -97,10 +109,10 @@ TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
 #endif
 }
 
-TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityDisablesJIT)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
-    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
+    webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
@@ -108,10 +120,10 @@ TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)
     EXPECT_EQ(false, isJITEnabled(webView.get()));
 }
 
-TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
-    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
+    webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
@@ -134,10 +146,10 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
 }
 
-TEST(EnhancedSecurity, PSONToEnhancedSecurity)
+TEST_F(EnhancedSecurityTest, PSONToEnhancedSecurity)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
-    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
+    webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
@@ -160,8 +172,8 @@ TEST(EnhancedSecurity, PSONToEnhancedSecurity)
     finishedNavigation = false;
 
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
-        EXPECT_FALSE(preferences._enhancedSecurityEnabled);
-        preferences._enhancedSecurityEnabled = YES;
+        EXPECT_EQ(preferences.securityRestrictionMode, WKSecurityRestrictionModeNone);
+        preferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
@@ -176,10 +188,10 @@ TEST(EnhancedSecurity, PSONToEnhancedSecurity)
     EXPECT_NE(pid1, [webView _webProcessIdentifier]);
 }
 
-TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
+TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySamePage)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
-    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
+    webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
@@ -202,8 +214,8 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
     finishedNavigation = false;
 
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
-        EXPECT_FALSE(preferences._enhancedSecurityEnabled);
-        preferences._enhancedSecurityEnabled = YES;
+        EXPECT_EQ(preferences.securityRestrictionMode, WKSecurityRestrictionModeNone);
+        preferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
@@ -228,14 +240,14 @@ static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
     return processPoolConfiguration;
 }
 
-TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
+TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPool)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
+    webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
@@ -262,8 +274,8 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
     [webView2 setNavigationDelegate:delegate.get()];
 
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
-        EXPECT_FALSE(preferences._enhancedSecurityEnabled);
-        preferences._enhancedSecurityEnabled = YES;
+        EXPECT_EQ(preferences.securityRestrictionMode, WKSecurityRestrictionModeNone);
+        preferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
@@ -278,14 +290,14 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
     EXPECT_NE(pid1, [webView2 _webProcessIdentifier]);
 }
 
-TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
+TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPoolReverse)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
+    webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
@@ -312,8 +324,8 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
     [webView2 setNavigationDelegate:delegate.get()];
 
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
-        EXPECT_TRUE(preferences._enhancedSecurityEnabled);
-        preferences._enhancedSecurityEnabled = NO;
+        EXPECT_EQ(preferences.securityRestrictionMode, WKSecurityRestrictionModeMaximizeCompatibility);
+        preferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
@@ -329,14 +341,14 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
 }
 
 #if USE(APPLE_INTERNAL_SDK)
-TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
+TEST_F(EnhancedSecurityTest, ProcessVariantMatchesConfiguration)
 {
     auto webViewConfiguration1 = adoptNS([WKWebViewConfiguration new]);
-    webViewConfiguration1.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
+    webViewConfiguration1.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
     auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration1.get()]);
 
     auto webViewConfiguration2 = adoptNS([WKWebViewConfiguration new]);
-    webViewConfiguration2.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
+    webViewConfiguration2.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
     auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration2.get()]);
 
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -353,12 +365,12 @@ TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
 }
 #endif
 
-TEST(EnhancedSecurity, ProcessCanLaunch)
+TEST_F(EnhancedSecurityTest, ProcessCanLaunch)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
     configuration.get().processPool = adoptNS([[WKProcessPool alloc] init]).get();
-    configuration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
+    configuration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:@"<html><body>test</body></html>" baseURL:nil];
@@ -387,7 +399,7 @@ TEST(EnhancedSecurity, ProcessCanLaunch)
 
 }
 
-TEST(EnhancedSecurity, CaptivePortalProcessCanLaunch)
+TEST_F(EnhancedSecurityTest, CaptivePortalProcessCanLaunch)
 {
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
 

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -746,7 +746,7 @@ void TestController::configureWebpagePreferences(WKWebViewConfiguration *configu
         [webpagePreferences _setNetworkConnectionIntegrityPolicy:_WKWebsiteNetworkConnectionIntegrityPolicyNone];
 
     if (options.enhancedSecurityEnabled())
-        webpagePreferences.get()._enhancedSecurityEnabled = YES;
+        webpagePreferences.get().securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
 
 #if PLATFORM(IOS_FAMILY)
     [webpagePreferences setPreferredContentMode:contentMode(options)];


### PR DESCRIPTION
#### 5d96852ac2b90a5ce465e91e268f6cb9599bfba0
<pre>
Add securityRestrictionMode API and User Default for Enhanced Security
<a href="https://bugs.webkit.org/show_bug.cgi?id=301382">https://bugs.webkit.org/show_bug.cgi?id=301382</a>
<a href="https://rdar.apple.com/163298679">rdar://163298679</a>

Reviewed by Per Arne Vollan.

Introduces public securityRestrictionMode property to replace the deprecated
_enhancedSecurityEnabled SPI. Adds WKSecurityRestrictionMode User Default
to globally enable/disable the feature for testing.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(isEnhancedSecurityFeatureEnabled):
(-[WKWebpagePreferences _setEnhancedSecurityEnabled:]):
(-[WKWebpagePreferences _enhancedSecurityEnabled]):
(-[WKWebpagePreferences setSecurityRestrictionMode:]):
(-[WKWebpagePreferences securityRestrictionMode]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:
(SecurityRestrictionMode.backingSecurityRestrictionMode):
(SecurityRestrictionMode.securityRestrictionMode):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController didChangeSettings]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm:
(TestWebKitAPI::enableEnhancedSecurityForTesting):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterNavigation)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)):
(TestWebKitAPI::TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)):
(TestWebKitAPI::TEST(EnhancedSecurity, ProcessCanLaunch)):
(TestWebKitAPI::TEST(EnhancedSecurity, CaptivePortalProcessCanLaunch)):

Canonical link: <a href="https://commits.webkit.org/302121@main">https://commits.webkit.org/302121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a9a53433490586d18dccf4ce898aaf6136ecf32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135454 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/243 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/25711c33-b1d5-4124-afb5-32d3ba421ce2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131034 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78077 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32845 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78764 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108531 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137943 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/224 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106035 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105773 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26959 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29637 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52402 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/270 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/61742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->