### PR TITLE
Fix SaferCPP uncounted call argument for a raw pointer/reference parameter in ContainerNode.cpp and Element.cpp

### DIFF
--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -415,7 +415,7 @@ void ContainerNode::takeAllChildrenFrom(ContainerNode* oldParent)
         if (child->parentNode()) // Previous parserAppendChild may have mutated DOM.
             continue;
         ASSERT(!ensurePreInsertionValidity(child, nullptr).hasException());
-        child->setTreeScopeRecursively(treeScope());
+        child->setTreeScopeRecursively(protectedTreeScope().get());
         parserAppendChild(child);
     }
 }
@@ -580,7 +580,7 @@ ExceptionOr<void> ContainerNode::insertBefore(Node& newChild, RefPtr<Node>&& ref
             break;
 
         executeNodeInsertionWithScriptAssertion(*this, child.get(), next.ptr(), ChildChange::Source::API, ReplacedAllChildren::No, [&] {
-            child->setTreeScopeRecursively(treeScope());
+            child->setTreeScopeRecursively(protectedTreeScope().get());
             insertBeforeCommon(next, child);
         });
     }
@@ -643,7 +643,7 @@ void ContainerNode::parserInsertBefore(Node& newChild, Node& nextChild)
             document().adoptNode(newChild);
 
         insertBeforeCommon(nextChild, newChild);
-        newChild.setTreeScopeRecursively(treeScope());
+        newChild.setTreeScopeRecursively(protectedTreeScope());
         newChild.updateAncestorConnectedSubframeCountForInsertion();
     });
 }
@@ -713,7 +713,7 @@ ExceptionOr<void> ContainerNode::replaceChild(Node& newChild, Node& oldChild)
             break;
 
         executeNodeInsertionWithScriptAssertion(*this, child.get(), refChild.get(), ChildChange::Source::API, ReplacedAllChildren::No, [&] {
-            child->setTreeScopeRecursively(treeScope());
+            child->setTreeScopeRecursively(protectedTreeScope().get());
             if (refChild)
                 insertBeforeCommon(*refChild, child.get());
             else
@@ -823,7 +823,7 @@ void ContainerNode::replaceAll(Node* node)
 
     executeNodeInsertionWithScriptAssertion(*this, *node, nullptr, ChildChange::Source::API, replacedAllChildren, [&] {
         InspectorInstrumentation::willInsertDOMNode(protectedDocument(), *this);
-        node->setTreeScopeRecursively(treeScope());
+        node->setTreeScopeRecursively(protectedTreeScope().get());
         appendChildCommon(*node);
     });
 
@@ -905,7 +905,7 @@ ExceptionOr<void> ContainerNode::appendChildWithoutPreInsertionValidityCheck(Nod
 
         // Append child to the end of the list
         executeNodeInsertionWithScriptAssertion(*this, child.get(), nullptr, ChildChange::Source::API, ReplacedAllChildren::No, [&] {
-            child->setTreeScopeRecursively(treeScope());
+            child->setTreeScopeRecursively(protectedTreeScope().get());
             appendChildCommon(child);
         });
     }
@@ -942,7 +942,7 @@ ExceptionOr<void> ContainerNode::insertChildrenBeforeWithoutPreInsertionValidity
         if (child->parentNode()) // Event listeners inserted this child elsewhere.
             break;
         executeNodeInsertionWithScriptAssertion(*this, child.get(), refChild.get(), ChildChange::Source::API, ReplacedAllChildren::No, [&] {
-            child->setTreeScopeRecursively(treeScope());
+            child->setTreeScopeRecursively(protectedTreeScope().get());
             if (refChild)
                 insertBeforeCommon(*refChild, child.get());
             else
@@ -965,7 +965,7 @@ void ContainerNode::parserAppendChild(Node& newChild)
             document().adoptNode(newChild);
 
         appendChildCommon(newChild);
-        newChild.setTreeScopeRecursively(treeScope());
+        newChild.setTreeScopeRecursively(protectedTreeScope().get());
         newChild.updateAncestorConnectedSubframeCountForInsertion();
     });
 }
@@ -983,7 +983,7 @@ void ContainerNode::parserAppendChildIntoIsolatedTree(Node& newChild)
 
     executeParserNodeInsertionIntoIsolatedTreeWithoutNotifyingParent(*this, newChild, [&] {
         appendChildCommon(newChild);
-        newChild.setTreeScopeRecursively(treeScope());
+        newChild.setTreeScopeRecursively(protectedTreeScope().get());
         newChild.updateAncestorConnectedSubframeCountForInsertion();
     });
 }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5685,7 +5685,7 @@ Ref<Attr> Element::ensureAttr(const QualifiedName& name)
     RefPtr<Attr> attrNode = findAttrNodeInList(attrNodeList, name);
     if (!attrNode) {
         attrNode = Attr::create(*this, name);
-        attrNode->setTreeScopeRecursively(treeScope());
+        attrNode->setTreeScopeRecursively(protectedTreeScope().get());
         attrNodeList.append(attrNode);
     }
     return attrNode.releaseNonNull();


### PR DESCRIPTION
#### eacd194b0e1873b45c33f0e4259ae4ae3daa2f34
<pre>
Fix SaferCPP uncounted call argument for a raw pointer/reference parameter in ContainerNode.cpp and Element.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=301383">https://bugs.webkit.org/show_bug.cgi?id=301383</a>
<a href="https://rdar.apple.com/163300316">rdar://163300316</a>

Reviewed by NOBODY (OOPS!).

treeScope() is called in multiple places as a parameter to setTreeScopeRecursively().
treeScope() returns an uncounted reference. Make a temporary Ref for
treeScope() while setTreeScopeRecursively executes so that treeScope()
is ensured to live for the duration of setTreeScopeRecursively().

No new tests (OOPS!).
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::takeAllChildrenFrom):
(WebCore::ContainerNode::insertBefore):
(WebCore::ContainerNode::parserInsertBefore):
(WebCore::ContainerNode::replaceChild):
(WebCore::ContainerNode::replaceAll):
(WebCore::ContainerNode::appendChildWithoutPreInsertionValidityCheck):
(WebCore::ContainerNode::insertChildrenBeforeWithoutPreInsertionValidityCheck):
(WebCore::ContainerNode::parserAppendChild):
(WebCore::ContainerNode::parserAppendChildIntoIsolatedTree):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::ensureAttr):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eacd194b0e1873b45c33f0e4259ae4ae3daa2f34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/165 "Built successfully") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79438 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9761787-652e-410f-9029-60100c85b349) 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97353 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66470 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/be8a60d0-d501-4e28-a5db-4c6294d15ceb) 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114560 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77919 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | ⏳ 🛠 vision-apple 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32665 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33135 "Passed tests") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105887 "Passed tests") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/67 "Built successfully") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105620 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29483 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52193 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/90 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61542 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/71 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->