### PR TITLE
RemoteLayerTreeDrawingAreaProxy::CommitLayerTree can be processed before WillCommitLayerTree.

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -117,8 +117,8 @@ protected:
 
         CommitLayerTreeMessageState commitLayerTreeMessageState { Idle };
         std::optional<MonotonicTime> transactionStartTime;
-        std::optional<TransactionID> lastLayerTreeTransactionID;
         std::optional<TransactionID> pendingLayerTreeTransactionID;
+        bool receivedCommitLayerTreePendingConfirmation { false };
     };
 
     ProcessState& processStateForConnection(IPC::Connection&);
@@ -177,8 +177,7 @@ private:
     // per-frame.
     virtual void setPreferredFramesPerSecond(IPC::Connection&, WebCore::FramesPerSecond) { }
 
-    void willCommitLayerTree(IPC::Connection&, TransactionID);
-    void commitLayerTreeNotTriggered(IPC::Connection&, TransactionID);
+    void notifyPendingCommitLayerTree(IPC::Connection&, std::optional<TransactionID>);
     void commitLayerTree(IPC::Connection&, const RemoteLayerTreeCommitBundle&, HashMap<ImageBufferSetIdentifier, std::unique_ptr<BufferSetBackendHandle>>&&);
     void commitLayerTreeTransaction(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&);
     virtual void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&) { }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
@@ -27,8 +27,7 @@
 ]
 messages -> RemoteLayerTreeDrawingAreaProxy : DrawingAreaProxy {
     void SetPreferredFramesPerSecond(unsigned preferredFramesPerSecond)
-    void WillCommitLayerTree(WebKit::TransactionID transactionID)
-    void CommitLayerTreeNotTriggered(WebKit::TransactionID nextCommitTransactionID)
+    void NotifyPendingCommitLayerTree(std::optional<WebKit::TransactionID> transactionID) CanDispatchOutOfOrder
     void CommitLayerTree(struct WebKit::RemoteLayerTreeCommitBundle bundle, HashMap<WebKit::ImageBufferSetIdentifier, std::unique_ptr<WebKit::BufferSetBackendHandle>> handlesMap) CanDispatchOutOfOrder
     void AsyncSetLayerContents(WebCore::PlatformLayerIdentifier layer, WebKit::RemoteLayerBackingStoreProperties properties)
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -371,6 +371,8 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 
     // FIXME: Minimize these transactions if nothing changed.
     auto transactionID = takeNextTransactionID();
+    send(Messages::RemoteLayerTreeDrawingAreaProxy::NotifyPendingCommitLayerTree(transactionID));
+
     auto transactions = WTF::map(m_rootLayers, [&](RootLayerInfo& rootLayer) -> RemoteLayerTreeCommitBundle::RootFrameData {
         backingStoreCollection->willBuildTransaction();
         rootLayer.layer->flushCompositingStateForThisLayerOnly();
@@ -384,8 +386,6 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         webPage->willCommitLayerTree(layerTransaction, rootLayer.frameID);
 
         m_waitingForBackingStoreSwap = true;
-
-        send(Messages::RemoteLayerTreeDrawingAreaProxy::WillCommitLayerTree(layerTransaction.transactionID()));
 
         RemoteScrollingCoordinatorTransaction scrollingTransaction;
 #if ENABLE(ASYNC_SCROLLING)
@@ -465,7 +465,7 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh()
     } else if (wasWaitingForBackingStoreSwap && m_updateRenderingTimer.isActive())
         m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = true;
     else
-        send(Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTreeNotTriggered(nextTransactionID()));
+        send(Messages::RemoteLayerTreeDrawingAreaProxy::NotifyPendingCommitLayerTree(std::nullopt));
 }
 
 auto RemoteLayerTreeDrawingArea::rootLayerInfoWithFrameIdentifier(WebCore::FrameIdentifier frameID) -> RootLayerInfo*


### PR DESCRIPTION
#### be985750e45c1fc613c9129570ab23d1896ee983
<pre>
RemoteLayerTreeDrawingAreaProxy::CommitLayerTree can be processed before WillCommitLayerTree.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301392">https://bugs.webkit.org/show_bug.cgi?id=301392</a>
&lt;<a href="https://rdar.apple.com/problem/163307734">rdar://problem/163307734</a>&gt;

Reviewed by Gerald Squelart.

This happens because we use waitForAndDispatchImmediately which caused that
message to be processed synchronously, before others in the queue.

We workaround this by trying to detect willCommitLayerTree messages that have
been superseded, but it&apos;s hard to reason about.

This combines the WillCommitLayerTree and CommitLayerTreeNotTriggered messages
into a single message, and then has waitForDidUpdateActivityState wait on
whichever message is expected next to avoid reordering.

This reverts 266421@main, and replaces it with MESSAGE_CHECK assertions about
the state of commitLayerTreeMessageState and pendingLayerTreeTransactionID.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::waitForMessage):
(IPC::Connection::processIncomingMessage):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::waitForAndDispatchImmediately):
(IPC::Connection::WaitForMessageState::WaitForMessageState):
(IPC::Connection::waitForAsyncReplyAndDispatchImmediately):
(IPC::Connection::waitForMessageForTesting):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered):
(WebKit::RemoteLayerTreeDrawingAreaProxy::willCommitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
(WebKit::RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh):

Canonical link: <a href="https://commits.webkit.org/302461@main">https://commits.webkit.org/302461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55bc73979ae6a07caac477027f8b56cd56444d34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136531 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80541 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/22cfd3ef-b870-46f6-a80f-200d6083dc8e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98343 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66218 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aa420728-8c1e-4eaa-89aa-7829f145af21) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78991 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4fd280af-8e34-48f7-bdb5-d5279185bea2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/968 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79812 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109416 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139005 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106877 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106712 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27166 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/990 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30553 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53781 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1277 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64630 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1103 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1148 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1201 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->