### PR TITLE
Fix some issues with bmalloc header inclusions.

### DIFF
--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -60,18 +60,22 @@
 #include <WebKitAdditions/WTFConfigAdditions.h>
 #endif
 #if !USE(SYSTEM_MALLOC)
+#if BUSE(LIBPAS)
 #include "bmalloc/pas_mte_config.h"
+#endif
 #endif
 
 #include <mutex>
 
 #if OS(DARWIN) && !USE(SYSTEM_MALLOC)
 
+#if BUSE(LIBPAS)
 #if HAVE(36BIT_ADDRESS) && !PAS_HAVE(36BIT_ADDRESS)
 #error HAVE(36BIT_ADDRESS) is true, but PAS_HAVE(36BIT_ADDRESS) is false. They should match.
 #elif !HAVE(36BIT_ADDRESS) && PAS_HAVE(36BIT_ADDRESS)
 #error HAVE(36BIT_ADDRESS) is false, but PAS_HAVE(36BIT_ADDRESS) is true. They should match.
 #endif
+#endif // BUSE(LIBPAS)
 
 #endif // OS(DARWIN)
 

--- a/Source/bmalloc/bmalloc/VMAllocate.h
+++ b/Source/bmalloc/bmalloc/VMAllocate.h
@@ -27,7 +27,7 @@
 
 #include "AllocationCounts.h"
 #include "BAssert.h"
-#include "BCompiler.h"
+#include "BPlatform.h"
 #include "BSyscall.h"
 #include "BVMTags.h"
 #include "Logging.h"


### PR DESCRIPTION
#### f353ac71e5b8d83462e7dcd4b8c816b429d0579f
<pre>
Fix some issues with bmalloc header inclusions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301390">https://bugs.webkit.org/show_bug.cgi?id=301390</a>
<a href="https://rdar.apple.com/163306584">rdar://163306584</a>

Reviewed by Dan Hecht.

1. In WTFConfig.cpp, we should only include bmalloc/pas_mte_config.h if BUSE(LIBPAS).  This is
   condition for its inclusion elsewhere (see malloc&apos;s Gigacage.cpp and VMAllocate.cpp), but is
   neglected here.

2. VMAllocate.h should include BPlatform.h instead of BCompiler.h.  BPlatform.h defines the
   BOS(), BCPU(), and BENABLE() macros that VMAllocate.h relies on below this.  BCompiler.h
   does not.  BPlatform.h also includes BCompiler.h.  The only reason that this hasn&apos;t caused a
   problem so far is because VMAllocate.h also includes BAssert.h, which happens to include
   BPlatform.h.  Regardless, we should fix this so that the includes truly reflect what is
   needed.

No new tests because these issues turn out to be benign, and have no observable impact other
than consuming some unnecessary build time, and failing to express the #include dependencies
that are actually needed.

* Source/WTF/wtf/WTFConfig.cpp:
* Source/bmalloc/bmalloc/VMAllocate.h:

Canonical link: <a href="https://commits.webkit.org/302094@main">https://commits.webkit.org/302094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ec81d895bc0b9ff0f5df62a31cae8f0a3501ba4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135312 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79475 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/90 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97397 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65294 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/54 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77963 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/58 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32713 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78621 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/119970 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108416 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137796 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126400 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/90 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/77 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105925 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110956 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105661 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/54 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29527 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52234 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20000 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/132 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/61579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159421 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/66 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39807 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/142 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/109 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->