### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for WTF::Observer and MediaSessionObserver

### DIFF
--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <algorithm>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -81,7 +81,10 @@ MediaKeySession::MediaKeySession(Document& document, WeakPtr<MediaKeys>&& keys, 
     , m_sessionType(sessionType)
     , m_implementation(WTFMove(implementation))
     , m_instanceSession(WTFMove(instanceSession))
-    , m_displayChangedObserver([this] (auto displayID) { displayChanged(displayID); })
+    , m_displayChangedObserver(DisplayChangedObserver::create([weakThis = WeakPtr { *this }] (auto displayID) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->displayChanged(displayID);
+    }))
 {
     // https://w3c.github.io/encrypted-media/#dom-mediakeys-createsession
     // W3C Editor's Draft 09 November 2016

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -148,7 +148,7 @@ private:
     Vector<std::pair<Ref<SharedBuffer>, MediaKeyStatus>> m_statuses;
 
     using DisplayChangedObserver = Observer<void(PlatformDisplayID)>;
-    DisplayChangedObserver m_displayChangedObserver;
+    const Ref<DisplayChangedObserver> m_displayChangedObserver;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -62,8 +62,13 @@ public:
     explicit MediaControlsHost(HTMLMediaElement&);
     ~MediaControlsHost();
 
+#if ENABLE(MEDIA_SESSION)
+    void ref() const final;
+    void deref() const final;
+#else
     void ref() const;
     void deref() const;
+#endif
 
     static const AtomString& automaticKeyword();
     static const AtomString& forcedOnlyKeyword();

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -34,22 +34,13 @@
 #include <WebCore/MediaSessionActionHandler.h>
 #include <WebCore/MediaSessionPlaybackState.h>
 #include <WebCore/MediaSessionReadyState.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Logger.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class MediaSessionObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaSessionObserver> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -64,7 +55,7 @@ struct NowPlayingInfo;
 template<typename> class DOMPromiseDeferred;
 template<typename> class ExceptionOr;
 
-class MediaSessionObserver : public CanMakeWeakPtr<MediaSessionObserver> {
+class MediaSessionObserver : public AbstractRefCountedAndCanMakeWeakPtr<MediaSessionObserver> {
 public:
     virtual ~MediaSessionObserver() = default;
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -186,7 +186,7 @@ SourceBuffer::SourceBuffer(Ref<SourceBufferPrivate>&& sourceBufferPrivate, Media
     , m_private(WTFMove(sourceBufferPrivate))
     , m_client(SourceBufferClientImpl::create(*this))
     , m_source(&source)
-    , m_opaqueRootProvider([this] { return opaqueRoot(); })
+    , m_opaqueRootProvider(Observer<WebCoreOpaqueRoot()>::create([opaqueRoot = WebCoreOpaqueRoot { this }] { return opaqueRoot; }))
     , m_appendWindowStart(MediaTime::zeroTime())
     , m_appendWindowEnd(MediaTime::positiveInfiniteTime())
     , m_appendState(WaitingForSegment)

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -236,7 +236,7 @@ private:
     WeakPtr<MediaSource> m_source;
     AppendMode m_mode { AppendMode::Segments };
 
-    WTF::Observer<WebCoreOpaqueRoot()> m_opaqueRootProvider;
+    const Ref<WTF::Observer<WebCoreOpaqueRoot()>> m_opaqueRootProvider;
 
     RefPtr<SharedBuffer> m_pendingAppendData;
 

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -73,7 +73,10 @@ CSSFontSelector::CSSFontSelector(ScriptExecutionContext& context)
     : ActiveDOMObject(&context)
     , m_context(context)
     , m_cssFontFaceSet(CSSFontFaceSet::create(this))
-    , m_fontModifiedObserver([this] { fontModified(); })
+    , m_fontModifiedObserver(CSSFontFaceSet::FontModifiedObserver::create([weakThis = WeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->fontModified();
+    }))
     , m_uniqueId(++fontSelectorId)
     , m_version(0)
 {

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -149,7 +149,7 @@ private:
     HashSet<RefPtr<CSSFontFace>> m_cssConnectionsPossiblyToRemove;
     HashSet<RefPtr<StyleRuleFontFace>> m_cssConnectionsEncounteredDuringBuild;
 
-    CSSFontFaceSet::FontModifiedObserver m_fontModifiedObserver;
+    const Ref<CSSFontFaceSet::FontModifiedObserver> m_fontModifiedObserver;
 
     unsigned m_uniqueId;
     unsigned m_version;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1392,7 +1392,7 @@ private:
     RefPtr<Blob> m_blob;
     URLKeepingBlobAlive m_blobURLForReading;
     MediaProvider m_mediaProvider;
-    WTF::Observer<WebCoreOpaqueRoot()> m_opaqueRootProvider;
+    const Ref<WTF::Observer<WebCoreOpaqueRoot()>> m_opaqueRootProvider;
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     bool m_hasNeedkeyListener { false };
@@ -1462,7 +1462,7 @@ private:
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     using DefaultSpatialTrackingLabelChangedObserver = WTF::Observer<void(String&&)>;
-    DefaultSpatialTrackingLabelChangedObserver m_defaultSpatialTrackingLabelChangedObserver;
+    const Ref<DefaultSpatialTrackingLabelChangedObserver> m_defaultSpatialTrackingLabelChangedObserver;
     String m_spatialTrackingLabel;
 #endif
 

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -255,7 +255,7 @@ private:
     
 #if ENABLE(MEDIA_SESSION)
     bool m_isScrubbing { false };
-    std::unique_ptr<MediaElementSessionObserver> m_observer;
+    RefPtr<MediaElementSessionObserver> m_observer;
 #endif
 };
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -123,7 +123,7 @@ private:
     GPUIntegerCoordinate m_height { 0 };
 #if HAVE(SUPPORT_HDR_DISPLAY)
     using ScreenPropertiesChangedObserver = Observer<void(PlatformDisplayID)>;
-    std::optional<ScreenPropertiesChangedObserver> m_screenPropertiesChangedObserver;
+    RefPtr<ScreenPropertiesChangedObserver> m_screenPropertiesChangedObserver;
     PlatformDynamicRangeLimit m_dynamicRangeLimit { PlatformDynamicRangeLimit::initialValue() };
     float m_currentEDRHeadroom { 1 };
     bool m_suppressEDR { false };

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -172,17 +172,20 @@ GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, Ref<GPUComposit
     , m_width(getCanvasWidth(htmlOrOffscreenCanvas()))
     , m_height(getCanvasHeight(htmlOrOffscreenCanvas()))
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    , m_screenPropertiesChangedObserver([this](PlatformDisplayID displayID) {
+    , m_screenPropertiesChangedObserver(ScreenPropertiesChangedObserver::create([weakThis = WeakPtr { *this }](PlatformDisplayID displayID) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
         if (auto* screenData = WebCore::screenData(displayID))
-            updateScreenHeadroom(screenData->currentEDRHeadroom, screenData->suppressEDR);
-    })
+            protectedThis->updateScreenHeadroom(screenData->currentEDRHeadroom, screenData->suppressEDR);
+    }))
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
     if (document)
         document->addScreenPropertiesChangedObserver(*m_screenPropertiesChangedObserver);
     else
-        m_screenPropertiesChangedObserver = std::nullopt;
+        m_screenPropertiesChangedObserver = nullptr;
 #else
     UNUSED_PARAM(document);
 #endif

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -61,7 +61,8 @@ void TrackListBase::didMoveToNewDocument(Document& newDocument)
 
 WebCoreOpaqueRoot TrackListBase::opaqueRoot()
 {
-    if (auto* rootObserver = m_opaqueRootObserver.get())
+    // Cannot ref the observer as this gets called on the GC thread.
+    SUPPRESS_UNCOUNTED_LOCAL if (auto* rootObserver = m_opaqueRootObserver.get())
         return (*rootObserver)();
     return WebCoreOpaqueRoot { this };
 }

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
@@ -28,15 +28,18 @@
 #pragma once
 
 #include "InspectorTimelineAgent.h"
+#include <wtf/CheckedRef.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class Page;
 class RunLoopObserver;
 
-class PageTimelineAgent final : public InspectorTimelineAgent {
+class PageTimelineAgent final : public InspectorTimelineAgent, public CanMakeWeakPtr<PageTimelineAgent>, public CanMakeCheckedPtr<PageTimelineAgent> {
     WTF_MAKE_NONCOPYABLE(PageTimelineAgent);
     WTF_MAKE_TZONE_ALLOCATED(PageTimelineAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageTimelineAgent);
 public:
     PageTimelineAgent(PageAgentContext&);
     ~PageTimelineAgent();
@@ -83,7 +86,7 @@ private:
     std::unique_ptr<WebCore::RunLoopObserver> m_frameStopObserver;
     int m_runLoopNestingLevel { 0 };
 #elif USE(GLIB_EVENT_LOOP)
-    std::unique_ptr<RunLoop::EventObserver> m_runLoopObserver;
+    RefPtr<RunLoop::EventObserver> m_runLoopObserver;
 #endif
     bool m_startedComposite { false };
     bool m_isCapturingScreenshot { false };

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -60,6 +60,8 @@ public:
     }
     WEBCORE_EXPORT virtual ~PlaybackSessionModelMediaElement();
 
+    USING_CAN_MAKE_WEAKPTR(PlaybackSessionModel);
+
     // CheckedPtr interface
     uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
@@ -168,7 +170,7 @@ private:
     std::optional<SpatialVideoMetadata> m_spatialVideoMetadata;
     std::optional<VideoProjectionMetadata> m_videoProjectionMetadata;
 
-    Observer<void()> m_videoTrackConfigurationObserver;
+    const Ref<Observer<void()>> m_videoTrackConfigurationObserver;
 };
 
 }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -59,7 +59,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PlaybackSessionModelMediaElement);
 PlaybackSessionModelMediaElement::PlaybackSessionModelMediaElement()
     : EventListener(EventListener::CPPEventListenerType)
     , m_soundStageSize { AudioSessionSoundStageSize::Automatic }
-    , m_videoTrackConfigurationObserver { [&] { videoTrackConfigurationChanged(); } }
+    , m_videoTrackConfigurationObserver { Observer<void()>::create([weakThis = WeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->videoTrackConfigurationChanged();
+    }) }
 {
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -353,7 +353,7 @@ private:
 #if HAVE(AVCONTENTKEYSESSION)
 #if ENABLE(ENCRYPTED_MEDIA)
     RefPtr<CDMInstanceFairPlayStreamingAVFObjC> m_cdmInstance;
-    UniqueRef<Observer<void()>> m_keyStatusesChangedObserver;
+    const Ref<Observer<void()>> m_keyStatusesChangedObserver;
     using KeyIDs = Vector<Ref<SharedBuffer>>;
     KeyIDs m_keyIDs;
     using TrackKeyIdsMap = HashMap<TrackIdentifier, KeyIDs>;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -90,7 +90,10 @@ AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC(const Logger& originalLogge
     , m_listener(WebAVSampleBufferListener::create(*this))
     , m_startupTime(MonotonicTime::now())
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    , m_keyStatusesChangedObserver(makeUniqueRef<Observer<void()>>([this] { tryToEnqueueBlockedSamples(); }))
+    , m_keyStatusesChangedObserver(Observer<void()>::create([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->tryToEnqueueBlockedSamples();
+    }))
 #endif
 {
     // addPeriodicTimeObserverForInterval: throws an exception if you pass a non-numeric CMTime, so just use

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
@@ -84,7 +84,7 @@ private:
     const Ref<AVTrackPrivateAVFObjCImpl> m_impl;
 
     using AudioTrackConfigurationObserver = Observer<void()>;
-    AudioTrackConfigurationObserver m_audioTrackConfigurationObserver;
+    const Ref<AudioTrackConfigurationObserver> m_audioTrackConfigurationObserver;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
@@ -52,7 +52,10 @@ AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC(MediaSelectionOptionAVFObjC& 
 
 AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC(Ref<AVTrackPrivateAVFObjCImpl>&& impl)
     : m_impl(WTFMove(impl))
-    , m_audioTrackConfigurationObserver([this] { audioTrackConfigurationChanged(); })
+    , m_audioTrackConfigurationObserver(AudioTrackConfigurationObserver::create([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->audioTrackConfigurationChanged();
+    }))
 {
     m_impl->setAudioTrackConfigurationObserver(m_audioTrackConfigurationObserver);
     resetPropertiesFromTrack();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -518,8 +518,8 @@ private:
     std::optional<VideoFrameMetadata> m_videoFrameMetadata;
     mutable std::optional<NSTimeInterval> m_cachedSeekableTimeRangesLastModifiedTime;
     mutable std::optional<NSTimeInterval> m_cachedLiveUpdateInterval;
-    std::unique_ptr<Observer<void()>> m_currentImageChangedObserver;
-    std::unique_ptr<Observer<void()>> m_waitForVideoOutputMediaDataWillChangeObserver;
+    RefPtr<Observer<void()>> m_currentImageChangedObserver;
+    RefPtr<Observer<void()>> m_waitForVideoOutputMediaDataWillChangeObserver;
     ProcessIdentity m_resourceOwner;
     PlatformTimeRanges m_buffered;
     TrackID m_currentTextTrackID { 0 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
@@ -54,7 +54,10 @@ VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC(MediaSelectionOptionAVFObjC& 
 
 VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC(Ref<AVTrackPrivateAVFObjCImpl>&& impl)
     : m_impl(WTFMove(impl))
-    , m_videoTrackConfigurationObserver([this] { videoTrackConfigurationChanged(); })
+    , m_videoTrackConfigurationObserver(VideoTrackConfigurationObserver::create([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->videoTrackConfigurationChanged();
+    }))
 {
     m_impl->setVideoTrackConfigurationObserver(m_videoTrackConfigurationObserver);
     resetPropertiesFromTrack();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h
@@ -82,7 +82,7 @@ private:
     const Ref<AVTrackPrivateAVFObjCImpl> m_impl;
 
     using VideoTrackConfigurationObserver = Observer<void()>;
-    VideoTrackConfigurationObserver m_videoTrackConfigurationObserver;
+    const Ref<VideoTrackConfigurationObserver> m_videoTrackConfigurationObserver;
 };
 
 }

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -70,7 +70,7 @@ private:
     PlaybackSessionInterfaceAVKit(PlaybackSessionModel&);
 
     RetainPtr<WebAVContentSource> m_contentSource;
-    NowPlayingMetadataObserver m_nowPlayingMetadataObserver;
+    const Ref<NowPlayingMetadataObserver> m_nowPlayingMetadataObserver;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -214,14 +214,14 @@ Ref<PlaybackSessionInterfaceAVKit> PlaybackSessionInterfaceAVKit::create(Playbac
     return interface;
 }
 
-static NowPlayingMetadataObserver nowPlayingMetadataObserver(PlaybackSessionInterfaceAVKit& interface)
+static Ref<NowPlayingMetadataObserver> nowPlayingMetadataObserver(PlaybackSessionInterfaceAVKit& interface)
 {
-    return {
+    return NowPlayingMetadataObserver::create({
         [weakInterface = WeakPtr { interface }](auto& metadata) {
             if (RefPtr interface = weakInterface.get())
                 interface->nowPlayingMetadataChanged(metadata);
         }
-    };
+    });
 }
 
 PlaybackSessionInterfaceAVKit::PlaybackSessionInterfaceAVKit(PlaybackSessionModel& model)

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp
@@ -41,7 +41,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioMediaStreamTrackRendererCocoa);
 
 AudioMediaStreamTrackRendererCocoa::AudioMediaStreamTrackRendererCocoa(Init&& init)
     : AudioMediaStreamTrackRenderer(WTFMove(init))
-    , m_resetObserver([this] { reset(); })
+    , m_resetObserver(ResetObserver::create([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->reset();
+    }))
     , m_deviceID(AudioMediaStreamTrackRenderer::defaultDeviceID())
 {
 }

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h
@@ -68,7 +68,8 @@ private:
     RefPtr<AudioSampleDataSource> m_dataSource; // Used in background thread.
     RefPtr<AudioSampleDataSource> m_registeredDataSource; // Used in main thread.
     bool m_shouldRecreateDataSource { false };
-    WebCore::AudioMediaStreamTrackRendererUnit::ResetObserver m_resetObserver;
+    using ResetObserver = AudioMediaStreamTrackRendererUnit::ResetObserver;
+    const Ref<ResetObserver> m_resetObserver;
     String m_deviceID;
 };
 

--- a/Source/WebDriver/WebDriverService.h
+++ b/Source/WebDriver/WebDriverService.h
@@ -27,9 +27,11 @@
 
 #include "HTTPServer.h"
 #include "Session.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 
 #if ENABLE(WEBDRIVER_BIDI)
@@ -42,11 +44,13 @@ struct Capabilities;
 class CommandResult;
 class Session;
 
-class WebDriverService final : public HTTPRequestHandler
+class WebDriverService final : public HTTPRequestHandler, public CanMakeWeakPtr<WebDriverService>, public CanMakeCheckedPtr<WebDriverService>
 #if ENABLE(WEBDRIVER_BIDI)
     , public WebSocketMessageHandler
 #endif
 {
+    WTF_MAKE_TZONE_ALLOCATED(WebDriverService);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebDriverService);
 public:
     WebDriverService();
     ~WebDriverService();
@@ -176,7 +180,7 @@ private:
     HTTPServer m_server;
 #if ENABLE(WEBDRIVER_BIDI)
     const Ref<WebSocketServer> m_bidiServer;
-    SessionHost::BrowserTerminatedObserver m_browserTerminatedObserver;
+    const Ref<SessionHost::BrowserTerminatedObserver> m_browserTerminatedObserver;
 #endif
     RefPtr<Session> m_session;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -291,7 +291,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
         return;
     }
 
-    auto nowPlayingMetadataObserver = makeUnique<WebCore::NowPlayingMetadataObserver>([observer = makeBlockPtr(observer)](auto& metadata) {
+    auto nowPlayingMetadataObserver = WebCore::NowPlayingMetadataObserver::create([observer = makeBlockPtr(observer)](auto& metadata) {
         RetainPtr nowPlayingMetadata = adoptNS([[_WKNowPlayingMetadata alloc] init]);
         [nowPlayingMetadata setTitle:metadata.title.createNSString().get()];
         [nowPlayingMetadata setArtist:metadata.artist.createNSString().get()];

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.h
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.h
@@ -81,7 +81,7 @@ private:
     std::optional<WebCore::MediaSessionReadyState> m_readyState;
     std::optional<WebCore::MediaSessionPlaybackState> m_playbackState;
 
-    GroupActivitiesSession::StateChangeObserver m_stateChangeObserver;
+    const Ref<GroupActivitiesSession::StateChangeObserver> m_stateChangeObserver;
 };
 
 }

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
@@ -135,7 +135,10 @@ GroupActivitiesCoordinator::GroupActivitiesCoordinator(GroupActivitiesSession& s
     : m_session(session)
     , m_delegate(adoptNS([[WKGroupActivitiesCoordinatorDelegate alloc] initWithParent:*this]))
     , m_playbackCoordinator(adoptNS([PAL::allocAVDelegatingPlaybackCoordinatorInstance() initWithPlaybackControlDelegate:m_delegate.get()]))
-    , m_stateChangeObserver([this] (auto& session, auto state) { sessionStateChanged(session, state); })
+    , m_stateChangeObserver(GroupActivitiesSession::StateChangeObserver::create([weakThis = WeakPtr { *this }] (auto& session, auto state) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->sessionStateChanged(session, state);
+    }))
 {
     [session.protectedGroupSession() coordinateWithCoordinator:m_playbackCoordinator.get()];
     session.addStateChangeObserver(m_stateChangeObserver);

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.h
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.h
@@ -62,7 +62,7 @@ private:
     HashMap<URL, Ref<GroupActivitiesSession>> m_sessions;
     RetainPtr<WKGroupSessionObserver> m_sessionObserver;
     WeakHashSet<WebPageProxy> m_webPages;
-    GroupActivitiesSession::StateChangeObserver m_stateChangeObserver;
+    const Ref<GroupActivitiesSession::StateChangeObserver> m_stateChangeObserver;
 };
 
 }

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
@@ -52,7 +52,10 @@ GroupActivitiesSessionNotifier& GroupActivitiesSessionNotifier::singleton()
 
 GroupActivitiesSessionNotifier::GroupActivitiesSessionNotifier()
     : m_sessionObserver(adoptNS([allocWKGroupSessionObserverInstance() init]))
-    , m_stateChangeObserver([this] (auto& session, auto state) { sessionStateChanged(session, state); })
+    , m_stateChangeObserver(GroupActivitiesSession::StateChangeObserver::create([weakThis = WeakPtr { *this }] (auto& session, auto state) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->sessionStateChanged(session, state);
+    }))
 {
     m_sessionObserver.get().newSessionCallback = [weakThis = WeakPtr { *this }] (WKGroupSession *groupSession) {
         RefPtr protectedThis = weakThis.get();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16898,15 +16898,15 @@ void WebPageProxy::removeNowPlayingMetadataObserver(const NowPlayingMetadataObse
         send(Messages::WebPage::StopObservingNowPlayingMetadata());
 }
 
-void WebPageProxy::setNowPlayingMetadataObserverForTesting(std::unique_ptr<WebCore::NowPlayingMetadataObserver>&& observer)
+void WebPageProxy::setNowPlayingMetadataObserverForTesting(RefPtr<WebCore::NowPlayingMetadataObserver>&& observer)
 {
-    if (auto previousObserver = std::exchange(m_nowPlayingMetadataObserverForTesting, nullptr))
+    if (RefPtr previousObserver = std::exchange(m_nowPlayingMetadataObserverForTesting, nullptr))
         removeNowPlayingMetadataObserver(*previousObserver);
 
     m_nowPlayingMetadataObserverForTesting = WTFMove(observer);
 
-    if (m_nowPlayingMetadataObserverForTesting)
-        addNowPlayingMetadataObserver(*m_nowPlayingMetadataObserverForTesting);
+    if (RefPtr observer = m_nowPlayingMetadataObserverForTesting)
+        addNowPlayingMetadataObserver(*observer);
 }
 
 void WebPageProxy::nowPlayingMetadataChanged(const WebCore::NowPlayingMetadata& metadata)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2748,7 +2748,7 @@ public:
 
     void addNowPlayingMetadataObserver(const WebCore::NowPlayingMetadataObserver&);
     void removeNowPlayingMetadataObserver(const WebCore::NowPlayingMetadataObserver&);
-    void setNowPlayingMetadataObserverForTesting(std::unique_ptr<WebCore::NowPlayingMetadataObserver>&&);
+    void setNowPlayingMetadataObserverForTesting(RefPtr<WebCore::NowPlayingMetadataObserver>&&);
     void nowPlayingMetadataChanged(const WebCore::NowPlayingMetadata&);
 
     void didAdjustVisibilityWithSelectors(Vector<String>&&);
@@ -4000,7 +4000,7 @@ private:
 #endif
 
     WeakHashSet<WebCore::NowPlayingMetadataObserver> m_nowPlayingMetadataObservers;
-    std::unique_ptr<WebCore::NowPlayingMetadataObserver> m_nowPlayingMetadataObserverForTesting;
+    RefPtr<WebCore::NowPlayingMetadataObserver> m_nowPlayingMetadataObserverForTesting;
 
 #if ENABLE(WRITING_TOOLS)
     bool m_isWritingToolsActive { false };

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -780,7 +780,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif // QUICKLOOK_FULLSCREEN
 #endif
 
-    std::unique_ptr<WebKit::VideoPresentationManagerProxy::VideoInPictureInPictureDidChangeObserver> _pipObserver;
+    RefPtr<WebKit::VideoPresentationManagerProxy::VideoInPictureInPictureDidChangeObserver> _pipObserver;
     BOOL _shouldReturnToFullscreenFromPictureInPicture;
     BOOL _enterFullscreenNeedsExitPictureInPicture;
     BOOL _returnToFullscreenFromPictureInPicture;
@@ -1229,11 +1229,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
             if (auto* videoPresentationManager = self._videoPresentationManager) {
                 if (!_pipObserver) {
-                    _pipObserver = WTF::makeUnique<WebKit::VideoPresentationManagerProxy::VideoInPictureInPictureDidChangeObserver>([self] (bool inPiP) {
+                    _pipObserver = WebKit::VideoPresentationManagerProxy::VideoInPictureInPictureDidChangeObserver::create([weakSelf = WeakObjCPtr { self }] (bool inPiP) {
+                        RetainPtr strongSelf = weakSelf.get();
+                        if (!strongSelf)
+                            return;
                         if (inPiP)
-                            [self didEnterPictureInPicture];
+                            [strongSelf didEnterPictureInPicture];
                         else
-                            [self didExitPictureInPicture];
+                            [strongSelf didExitPictureInPicture];
                     });
                     videoPresentationManager->addVideoInPictureInPictureDidChangeObserver(*_pipObserver);
                 }

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -215,7 +215,7 @@ static void makeResponderFirstResponderIfDescendantOfView(NSWindow *window, NSRe
 }
 
 @implementation WKFullScreenWindowController {
-    std::unique_ptr<WebKit::VideoPresentationManagerProxy::VideoInPictureInPictureDidChangeObserver> _pipObserver;
+    RefPtr<WebKit::VideoPresentationManagerProxy::VideoInPictureInPictureDidChangeObserver> _pipObserver;
 
 #if !RELEASE_LOG_DISABLED
     RefPtr<Logger> _logger;
@@ -842,14 +842,14 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     if (_pipObserver)
         return;
 
-    _pipObserver = WTF::makeUnique<WebKit::VideoPresentationManagerProxy::VideoInPictureInPictureDidChangeObserver>([strongSelf = retainPtr(self)] (bool inPiP) {
+    _pipObserver = WebKit::VideoPresentationManagerProxy::VideoInPictureInPictureDidChangeObserver::create([strongSelf = retainPtr(self)] (bool inPiP) {
         if (inPiP)
             [strongSelf didEnterPictureInPicture];
         else
             [strongSelf didExitPictureInPicture];
     });
 
-    videoPresentationManager->addVideoInPictureInPictureDidChangeObserver(*_pipObserver);
+    videoPresentationManager->addVideoInPictureInPictureDidChangeObserver(Ref { *_pipObserver });
 }
 
 - (void)didEnterPictureInPicture

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9897,19 +9897,19 @@ void WebPage::startObservingNowPlayingMetadata()
     if (!sessionManager || m_nowPlayingMetadataObserver)
         return;
 
-    m_nowPlayingMetadataObserver = makeUnique<NowPlayingMetadataObserver>([weakThis = WeakPtr { *this }](auto& metadata) {
+    m_nowPlayingMetadataObserver = NowPlayingMetadataObserver::create([weakThis = WeakPtr { *this }](auto& metadata) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->send(Messages::WebPageProxy::NowPlayingMetadataChanged { metadata });
     });
 
-    sessionManager->addNowPlayingMetadataObserver(*m_nowPlayingMetadataObserver);
+    sessionManager->addNowPlayingMetadataObserver(Ref { *m_nowPlayingMetadataObserver });
 #endif
 }
 
 void WebPage::stopObservingNowPlayingMetadata()
 {
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    auto nowPlayingMetadataObserver = std::exchange(m_nowPlayingMetadataObserver, nullptr);
+    RefPtr nowPlayingMetadataObserver = std::exchange(m_nowPlayingMetadataObserver, nullptr);
     if (!nowPlayingMetadataObserver)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -3193,7 +3193,7 @@ private:
     const UniqueRef<TextAnimationController> m_textAnimationController;
 #endif
 
-    std::unique_ptr<WebCore::NowPlayingMetadataObserver> m_nowPlayingMetadataObserver;
+    RefPtr<WebCore::NowPlayingMetadataObserver> m_nowPlayingMetadataObserver;
     std::unique_ptr<FrameInfoData> m_mainFrameNavigationInitiator;
 
     mutable RefPtr<Logger> m_logger;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2650,7 +2650,7 @@ void WebProcess::enableMediaPlayback()
 #endif
 
 #if ENABLE(ROUTING_ARBITRATION)
-    m_routingArbitrator = makeUnique<AudioSessionRoutingArbitrator>(*this);
+    lazyInitialize(m_routingArbitrator, makeUniqueWithoutRefCountedCheck<AudioSessionRoutingArbitrator>(*this));
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -946,7 +946,7 @@ private:
     const std::unique_ptr<SpeechRecognitionRealtimeMediaSourceManager> m_speechRecognitionRealtimeMediaSourceManager;
 #endif
 #if ENABLE(ROUTING_ARBITRATION)
-    std::unique_ptr<AudioSessionRoutingArbitrator> m_routingArbitrator;
+    const std::unique_ptr<AudioSessionRoutingArbitrator> m_routingArbitrator;
 #endif
     bool m_hadMainFrameMainResourcePrivateRelayed { false };
     bool m_imageAnimationEnabled { true };

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
@@ -43,6 +43,9 @@ public:
     explicit AudioSessionRoutingArbitrator(WebProcess&);
     virtual ~AudioSessionRoutingArbitrator();
 
+    void ref() const;
+    void deref() const;
+
     static ASCIILiteral supplementName();
 
     // AudioSessionRoutingAbritrator
@@ -53,7 +56,7 @@ private:
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     bool canLog() const final;
 
-    WebCore::AudioSession::ChangedObserver m_observer;
+    const Ref<WebCore::AudioSession::ChangedObserver> m_observer;
     const uint64_t m_logIdentifier;
 };
 

--- a/Tools/TestWebKitAPI/Tests/WTF/Observer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Observer.cpp
@@ -32,11 +32,11 @@ TEST(WTF_Observer, Basic)
 {
     bool testValue = false;
 
-    Observer<void(bool)> observer([&] (bool value) {
+    Ref observer = Observer<void(bool)>::create([&] (bool value) {
         testValue = value;
     });
 
-    observer(true);
+    observer.get()(true);
 
     EXPECT_TRUE(testValue);
 }
@@ -45,11 +45,11 @@ TEST(WTF_Observer, Weak)
 {
     bool testValue = false;
 
-    auto uniqueObserver = WTF::makeUnique<Observer<void(bool)>>([&] (bool value) {
+    RefPtr observer = Observer<void(bool)>::create([&] (bool value) {
         testValue = value;
     });
 
-    WeakPtr weakObserver = uniqueObserver.get();
+    WeakPtr weakObserver = observer.get();
 
     ASSERT_TRUE(static_cast<bool>(weakObserver));
 
@@ -57,7 +57,7 @@ TEST(WTF_Observer, Weak)
 
     EXPECT_TRUE(testValue);
 
-    uniqueObserver = nullptr;
+    observer = nullptr;
 
     EXPECT_FALSE(static_cast<bool>(weakObserver));
 }


### PR DESCRIPTION
#### d0b987b3e35ead433676ed09a2de72f5fedef537
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for WTF::Observer and MediaSessionObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=301393">https://bugs.webkit.org/show_bug.cgi?id=301393</a>

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/Observer.h:
(WTF::Observer&lt;Out):
(): Deleted.
* Source/WTF/wtf/WeakHashSet.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::MediaKeySession):
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::SourceBuffer):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::CSSFontSelector):
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::m_opaqueRootProvider):
(WebCore::m_defaultSpatialTrackingLabelChangedObserver):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSessionObserver::create):
(WebCore::MediaElementSessionObserver::MediaElementSessionObserver):
(WebCore::MediaElementSession::ensureIsObservingMediaSession):
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::GPUCanvasContextCocoa):
* Source/WebCore/html/track/TrackListBase.cpp:
(WebCore::TrackListBase::opaqueRoot):
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
(WebCore::PageTimelineAgent::internalStart):
* Source/WebCore/inspector/agents/page/PageTimelineAgent.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC):
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm:
(WebCore::AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::startVideoFrameMetadataGathering):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createVideoOutput):
(WebCore::MediaPlayerPrivateAVFoundationObjC::waitForVideoOutputMediaDataWillChange):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp:
(WebCore::VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm:
(WebCore::nowPlayingMetadataObserver):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp:
(WebCore::AudioMediaStreamTrackRendererCocoa::AudioMediaStreamTrackRendererCocoa):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h:
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::WebDriverService):
* Source/WebDriver/WebDriverService.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _setNowPlayingMetadataObserver:]):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.h:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm:
(WebKit::GroupActivitiesCoordinator::GroupActivitiesCoordinator):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.h:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm:
(WebKit::GroupActivitiesSessionNotifier::GroupActivitiesSessionNotifier):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setNowPlayingMetadataObserverForTesting):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:completionHandler:]):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController setVideoPresentationManagerObserver]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::startObservingNowPlayingMetadata):
(WebKit::WebPage::stopObservingNowPlayingMetadata):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::enableMediaPlayback):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp:
(WebKit::AudioSessionRoutingArbitrator::AudioSessionRoutingArbitrator):
(WebKit::AudioSessionRoutingArbitrator::ref const):
(WebKit::AudioSessionRoutingArbitrator::deref const):
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h:
* Tools/TestWebKitAPI/Tests/WTF/Observer.cpp:
(TestWebKitAPI::TEST(WTF_Observer, Basic)):
(TestWebKitAPI::TEST(WTF_Observer, Weak)):

Canonical link: <a href="https://commits.webkit.org/302140@main">https://commits.webkit.org/302140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/248c8febb61203d42acb0425605710903f4903dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128116 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135482 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79611 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0913734d-5820-4ae0-b94e-a988fcfa76ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97531 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65425 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b766f768-f006-4190-964e-fcd964a64e0d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114769 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78101 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/182 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32876 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78792 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120150 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137972 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126578 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106059 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105798 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26976 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/191 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29666 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52436 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/299 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61903 "") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159598 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/208 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39836 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/281 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/258 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->