### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for RealtimeMediaSourceObserver

### DIFF
--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
@@ -24,6 +24,7 @@
 
 #include "config.h"
 #include "MediaStreamTrackDataHolder.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MEDIA_STREAM)
@@ -49,8 +50,9 @@ private:
         });
     }
 
-    class PreventSourceFromEndingObserver final : public RealtimeMediaSourceObserver {
+    class PreventSourceFromEndingObserver final : public RealtimeMediaSourceObserver, public CanMakeCheckedPtr<PreventSourceFromEndingObserver> {
         WTF_MAKE_TZONE_ALLOCATED_INLINE(PreventSourceFromEndingObserver);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PreventSourceFromEndingObserver);
     public:
         explicit PreventSourceFromEndingObserver(Ref<RealtimeMediaSource>&& source)
             : m_source(WTFMove(source))
@@ -62,6 +64,12 @@ private:
         {
             m_source->removeObserver(*this);
         }
+
+        // RealtimeMediaSourceObserver.
+        uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+        uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+        void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+        void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     private:
         bool preventSourceFromEnding() final { return true; }

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -49,15 +49,6 @@
 #endif
 
 namespace WebCore {
-class MediaStreamTrackPrivateSourceObserverSourceProxy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaStreamTrackPrivateSourceObserverSourceProxy> : std::true_type { };
-}
-
-namespace WebCore {
 
 Ref<MediaStreamTrackPrivate> MediaStreamTrackPrivate::create(Ref<const Logger>&& logger, Ref<RealtimeMediaSource>&& source, std::function<void(Function<void()>&&)>&& postTask)
 {
@@ -78,8 +69,9 @@ Ref<MediaStreamTrackPrivate> MediaStreamTrackPrivate::create(Ref<const Logger>&&
     return privateTrack;
 }
 
-class MediaStreamTrackPrivateSourceObserverSourceProxy final : public RealtimeMediaSourceObserver {
+class MediaStreamTrackPrivateSourceObserverSourceProxy final : public RealtimeMediaSourceObserver, public CanMakeCheckedPtr<MediaStreamTrackPrivateSourceObserverSourceProxy> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(MediaStreamTrackPrivateSourceObserverSourceProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaStreamTrackPrivateSourceObserverSourceProxy);
 public:
     MediaStreamTrackPrivateSourceObserverSourceProxy(WeakPtr<MediaStreamTrackPrivate>&& privateTrack, Ref<RealtimeMediaSource>&& source, std::function<void(Function<void()>&&)>&& postTask)
         : m_privateTrack(WTFMove(privateTrack))
@@ -89,6 +81,12 @@ public:
         ASSERT(m_postTask);
         ASSERT(isMainThread());
     }
+
+    // RealtimeMediaSourceObserver.
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     std::function<void(Function<void()>&&)> getPostTask()
     {
@@ -229,7 +227,7 @@ public:
     void initialize(MediaStreamTrackPrivate& privateTrack)
     {
         ensureOnMainThread([this, protectedThis = Ref { *this }, privateTrack = WeakPtr { privateTrack }, postTask = m_postTask, source = m_source, interrupted = privateTrack.interrupted(), muted = privateTrack.muted()] () mutable {
-            m_sourceProxy = makeUnique<MediaStreamTrackPrivateSourceObserverSourceProxy>(WTFMove(privateTrack), WTFMove(source), WTFMove(postTask));
+            lazyInitialize(m_sourceProxy, makeUnique<MediaStreamTrackPrivateSourceObserverSourceProxy>(WTFMove(privateTrack), WTFMove(source), WTFMove(postTask)));
             m_sourceProxy->initialize(interrupted, muted);
         });
     }
@@ -303,7 +301,7 @@ private:
     }
 
     const Ref<RealtimeMediaSource> m_source;
-    std::unique_ptr<MediaStreamTrackPrivateSourceObserverSourceProxy> m_sourceProxy;
+    const std::unique_ptr<MediaStreamTrackPrivateSourceObserverSourceProxy> m_sourceProxy;
     std::function<void(Function<void()>&&)> m_postTask;
     HashMap<uint64_t, ApplyConstraintsHandler> m_applyConstraintsCallbacks;
     uint64_t m_applyConstraintsCallbacksIdentifier { 0 };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -67,17 +67,11 @@
 #endif
 
 namespace WebCore {
-class RealtimeMediaSourceObserver;
 
 #if PLATFORM(COCOA)
 class ImageRotationSessionVT;
 #endif
 
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::RealtimeMediaSourceObserver> : std::true_type { };
 }
 
 namespace WTF {
@@ -101,7 +95,7 @@ struct CaptureSourceError;
 struct CaptureSourceOrError;
 struct VideoFrameAdaptor;
 
-class RealtimeMediaSourceObserver : public CanMakeWeakPtr<RealtimeMediaSourceObserver> {
+class RealtimeMediaSourceObserver : public CanMakeWeakPtr<RealtimeMediaSourceObserver>, public AbstractCanMakeCheckedPtr {
 public:
     WEBCORE_EXPORT RealtimeMediaSourceObserver();
     WEBCORE_EXPORT virtual ~RealtimeMediaSourceObserver();

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
@@ -121,10 +121,17 @@ void SpeechRecognitionServer::handleRequest(UniqueRef<WebCore::SpeechRecognition
 
         protectedThis->sendUpdate(update);
 
-        if (update.type() == WebCore::SpeechRecognitionUpdateType::Error)
-            protectedThis->checkedRecognizer()->abort();
-        else if (update.type() == WebCore::SpeechRecognitionUpdateType::End)
-            protectedThis->checkedRecognizer()->setInactive();
+        if (update.type() == WebCore::SpeechRecognitionUpdateType::Error) {
+            // Do this asynchronously to as synchronous object destruction trips CheckedPtrs.
+            callOnMainRunLoop([protectedThis] {
+                protectedThis->checkedRecognizer()->abort();
+            });
+        } else if (update.type() == WebCore::SpeechRecognitionUpdateType::End) {
+            // Do this asynchronously to as synchronous object destruction trips CheckedPtrs.
+            callOnMainRunLoop([protectedThis] {
+                protectedThis->checkedRecognizer()->setInactive();
+            });
+        }
     }, WTFMove(request));
 
 #if ENABLE(MEDIA_STREAM)


### PR DESCRIPTION
#### b8754bf2198e961a72110dd7184869d40bd17f7a
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for RealtimeMediaSourceObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=301395">https://bugs.webkit.org/show_bug.cgi?id=301395</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp:
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivateSourceObserver::initialize):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebKit/UIProcess/SpeechRecognitionServer.cpp:
(WebKit::SpeechRecognitionServer::handleRequest):

Canonical link: <a href="https://commits.webkit.org/302129@main">https://commits.webkit.org/302129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c55761b9fda093636e9cb13df576a4cad464cd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79598 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/85e7dd7e-59bc-4339-94b1-010aceebce5a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97520 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65405 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/49a31a90-9dbb-47b7-8232-a10189b6f977) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78090 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/750c1348-683d-429d-bcc9-e63878a0d4a1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32863 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78779 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108545 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137959 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106048 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111100 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105787 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26968 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/176 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29654 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52418 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/285 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61767 "Found 3 new failures in WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/194 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/268 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/244 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->