### PR TITLE
Adopt safer CPP in WebArchiveDumpSupport.mm

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -117,4 +117,3 @@ svg/properties/SVGAnimatedPropertyPairAccessorImpl.h
 svg/properties/SVGAnimatedValueProperty.h
 testing/InternalSettings.cpp
 testing/Internals.cpp
-testing/cocoa/WebArchiveDumpSupport.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -141,4 +141,3 @@ platform/text/cocoa/LocalizedDateCache.mm
 rendering/AttachmentLayout.mm
 [ iOS ] rendering/ios/RenderThemeIOS.mm
 [ Mac ] testing/ServiceWorkerInternals.mm
-testing/cocoa/WebArchiveDumpSupport.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -74,7 +74,6 @@ platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
 platform/text/cocoa/LocaleCocoa.mm
 rendering/AttachmentLayout.mm
 testing/Internals.mm
-testing/cocoa/WebArchiveDumpSupport.mm
 testing/cocoa/WebViewVisualIdentificationOverlay.mm
 [ iOS ] Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
 [ iOS ] Modules/system-preview/ARKitBadgeSystemImage.mm


### PR DESCRIPTION
#### 3a9054be513602cb8a3720bcf86fa6ce9c099a82
<pre>
Adopt safer CPP in WebArchiveDumpSupport.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=301403">https://bugs.webkit.org/show_bug.cgi?id=301403</a>
<a href="https://rdar.apple.com/163316734">rdar://163316734</a>

Reviewed by Ryosuke Niwa.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.</a>

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/testing/cocoa/WebArchiveDumpSupport.mm:
(WebCoreTestSupport::createCFURLResponseFromResponseData):
(WebCoreTestSupport::convertWebResourceDataToString):
(WebCoreTestSupport::convertWebResourceResponseToDictionary):
(WebCoreTestSupport::compareResourceURLs):
(WebCoreTestSupport::createXMLStringFromWebArchiveData):

Canonical link: <a href="https://commits.webkit.org/302280@main">https://commits.webkit.org/302280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fc0909636a200b3938ac76bff7e0c9f612c8921

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79993 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1f069ba8-603b-4ab2-98ee-a19a1a97221c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97873 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65789 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fb0ceb46-4b11-4ffa-8b91-281f4560e324) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78489 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c32935dc-d221-4def-939c-bcf8fa05feee) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33302 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79248 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138414 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106409 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106226 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/565 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30064 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53009 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20083 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/730 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63951 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/605 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/665 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/682 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->