### PR TITLE
Change fast/css/viewport-units-zoom.html to use setPageZoomFactor

### DIFF
--- a/LayoutTests/fast/css/viewport-units-zoom-expected.html
+++ b/LayoutTests/fast/css/viewport-units-zoom-expected.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-
 <html>
 <head>
     <style>
@@ -8,18 +7,13 @@
         }
         .box {
             background-color: green;
-            margin-top: 10px;
-        }
-        
-        .width {
+            margin-top: 20px;
             width: 50vw;
-            height: 100px;
+            height: 200px;
         }
     </style>
 </head>
 <body>
-<p>Both boxes should be the same width.</p>
-<div class="box width"></div>
-<div class="box width" style="height: 200px; margin-top: 20px"></div>
+<div class="box"></div>
 </body>
 </html>

--- a/LayoutTests/fast/css/viewport-units-zoom.html
+++ b/LayoutTests/fast/css/viewport-units-zoom.html
@@ -1,6 +1,4 @@
-<!-- webkit-test-runner [ EvaluationTimeZoomEnabled=false ] -->
 <!DOCTYPE html>
-
 <html>
 <head>
     <style>
@@ -10,17 +8,16 @@
         .box {
             background-color: green;
             margin-top: 10px;
-        }
-        
-        .width {
             width: 50vw;
             height: 100px;
         }
     </style>
 </head>
 <body>
-<p>Both boxes should be the same width.</p>
-<div class="box width"></div>
-<div class="box width" style="zoom:2"></div>
+<div class="box"></div>
 </body>
+<script>
+  if (window.internals)
+    window.internals.setPageZoomFactor(2);
+</script>
 </html>


### PR DESCRIPTION
#### 4d919a3865cab0225bc073a4c01527cc12135ac5
<pre>
Change fast/css/viewport-units-zoom.html to use setPageZoomFactor
<a href="https://bugs.webkit.org/show_bug.cgi?id=301404">https://bugs.webkit.org/show_bug.cgi?id=301404</a>
<a href="https://rdar.apple.com/163316825">rdar://163316825</a>

Reviewed by Lily Spiniolas.

This test was added in 196138@main in order to address a bug related to
page scale factor and viewport relative units. It seems like viewport
relative units should *not* be affected by page scale factor. However,
the test uses css-zoom to try and replicate this behavior which is
actually supposted to scale viewport units.

To address this we can change the test to use the setPageZoomFactor
in Internals. The test itself has a div with fixed height and width that
uses viewport units and sets the page scale factor. The expected is
basically the same with the height multiplied by 2. When the page scale
factor is applied, the width of the div should remain the same but the
height should get doubled like in the expectation.

* LayoutTests/fast/css/viewport-units-zoom-expected.html:
* LayoutTests/fast/css/viewport-units-zoom.html:

Canonical link: <a href="https://commits.webkit.org/302275@main">https://commits.webkit.org/302275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/717c0d51d8fee01acc9fa6b9b49e0130b03cff76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79984 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/94748ce8-da08-422a-ab7e-2923dc78eeeb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97865 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78481 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/248bf3e0-6d9a-4ed7-9818-38aa62555848) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33291 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79235 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138402 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/627 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106402 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/706 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106219 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27060 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/560 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30054 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52998 "Hash 717c0d51 for PR 52934 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/718 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/595 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/655 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/671 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->