### PR TITLE
[Safer CPP] Address issues in HTMLBodyElement

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -235,7 +235,6 @@ html/FTPDirectoryDocument.cpp
 html/FormAssociatedCustomElement.cpp
 html/FormAssociatedElement.cpp
 html/HTMLAttachmentElement.cpp
-html/HTMLBodyElement.cpp
 html/HTMLFieldSetElement.cpp
 html/HTMLFormControlElement.cpp
 html/HTMLFormControlsCollection.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -464,7 +464,6 @@ html/FormAssociatedCustomElement.cpp
 html/FormAssociatedElement.cpp
 html/FormListedElement.cpp
 html/HTMLAttachmentElement.cpp
-html/HTMLBodyElement.cpp
 html/HTMLButtonElement.cpp
 html/HTMLCanvasElement.cpp
 html/HTMLFieldSetElement.cpp

--- a/Source/WebCore/html/HTMLBodyElement.cpp
+++ b/Source/WebCore/html/HTMLBodyElement.cpp
@@ -88,7 +88,7 @@ void HTMLBodyElement::collectPresentationalHintsForAttribute(const QualifiedName
     case AttributeNames::backgroundAttr: {
         auto url = value.string().trim(isASCIIWhitespace);
         if (!url.isEmpty())
-            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(url), localName())));
+            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protectedDocument()->completeURL(url), localName())));
         break;
     }
     case AttributeNames::marginwidthAttr:
@@ -127,39 +127,40 @@ const AtomString& HTMLBodyElement::eventNameForWindowEventHandlerAttribute(const
 
 void HTMLBodyElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
+    Ref document = this->document();
     switch (name.nodeName()) {
     case AttributeNames::vlinkAttr:
         if (auto parsedColor = parseLegacyColorValue(newValue))
-            document().setVisitedLinkColor(*parsedColor);
+            document->setVisitedLinkColor(*parsedColor);
         else
-            document().resetVisitedLinkColor();
+            document->resetVisitedLinkColor();
         invalidateStyleForSubtree();
         return;
     case AttributeNames::alinkAttr:
         if (auto parsedColor = parseLegacyColorValue(newValue))
-            document().setActiveLinkColor(*parsedColor);
+            document->setActiveLinkColor(*parsedColor);
         else
-            document().resetActiveLinkColor();
+            document->resetActiveLinkColor();
         invalidateStyleForSubtree();
         return;
     case AttributeNames::linkAttr:
         if (auto parsedColor = parseLegacyColorValue(newValue))
-            document().setLinkColor(*parsedColor);
+            document->setLinkColor(*parsedColor);
         else
-            document().resetLinkColor();
+            document->resetLinkColor();
         invalidateStyleForSubtree();
         return;
     case AttributeNames::onselectionchangeAttr:
         // FIXME: Emit "selectionchange" event at <input> / <textarea> elements and remove this special-case.
         // https://bugs.webkit.org/show_bug.cgi?id=234348
-        document().setAttributeEventListener(eventNames().selectionchangeEvent, name, newValue, mainThreadNormalWorldSingleton());
+        document->setAttributeEventListener(eventNames().selectionchangeEvent, name, newValue, mainThreadNormalWorldSingleton());
         return;
     default:
         break;
     }
 
     if (auto& eventName = eventNameForWindowEventHandlerAttribute(name); !eventName.isNull()) {
-        document().setWindowAttributeEventListener(eventName, name, newValue, mainThreadNormalWorldSingleton());
+        document->setWindowAttributeEventListener(eventName, name, newValue, mainThreadNormalWorldSingleton());
         return;
     }
 
@@ -171,7 +172,7 @@ Node::InsertedIntoAncestorResult HTMLBodyElement::insertedIntoAncestor(Insertion
     HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument)
         return InsertedIntoAncestorResult::Done;
-    if (!is<HTMLFrameElementBase>(document().ownerElement()))
+    if (!is<HTMLFrameElementBase>(protectedDocument()->ownerElement()))
         return InsertedIntoAncestorResult::Done;
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
@@ -180,10 +181,11 @@ void HTMLBodyElement::didFinishInsertingNode()
 {
     // A DOM mutation could have happened in between the call to insertedIntoAncestor() and the
     // call to didFinishInsertingNode().
-    if (!is<HTMLFrameElementBase>(document().ownerElement()))
+    Ref document = this->document();
+    if (!is<HTMLFrameElementBase>(document->ownerElement()))
         return;
 
-    Ref ownerElement = *document().ownerElement();
+    Ref ownerElement = *document->ownerElement();
 
     // FIXME: It's surprising this is web compatible since it means marginwidth and marginheight attributes
     // appear or get overwritten on body elements of a document embedded through <iframe> or <frame>.
@@ -212,7 +214,7 @@ void HTMLBodyElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     HTMLElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, document().completeURL(attributeWithoutSynchronization(backgroundAttr)));
+    addSubresourceURL(urls, protectedDocument()->completeURL(attributeWithoutSynchronization(backgroundAttr)));
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 2f17fe988e76e15fc743f9a26632130c2bd3a678
<pre>
[Safer CPP] Address issues in HTMLBodyElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=301402">https://bugs.webkit.org/show_bug.cgi?id=301402</a>
<a href="https://rdar.apple.com/163316451">rdar://163316451</a>

Reviewed by Chris Dumez.

Address remaining Safer CPP issues in HTMLBodyElement

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/html/HTMLBodyElement.cpp:
(WebCore::HTMLBodyElement::collectPresentationalHintsForAttribute):
(WebCore::HTMLBodyElement::attributeChanged):
(WebCore::HTMLBodyElement::insertedIntoAncestor):
(WebCore::HTMLBodyElement::didFinishInsertingNode):
(WebCore::HTMLBodyElement::addSubresourceAttributeURLs const):

Canonical link: <a href="https://commits.webkit.org/302133@main">https://commits.webkit.org/302133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1acc493885b43f3e84f85459a5a0b32a0ffcd0a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135475 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79604 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ba2ebb51-0396-4624-b140-5abb0c4d01b8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97524 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65416 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3619c470-04dc-40ef-beaf-e06911daad45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78094 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9cddabf4-d9de-47b5-b0e6-b4b35fb9b4e7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32868 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78785 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137965 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106052 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105791 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26971 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29658 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52424 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/291 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61785 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/200 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/274 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/250 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->