### PR TITLE
[Safer CPP] Address issues in XMLDocumentParser

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -763,5 +763,4 @@ xml/XPathFunctions.cpp
 xml/XSLImportRule.cpp
 xml/XSLStyleSheetLibxslt.cpp
 xml/XSLTProcessorLibxslt.cpp
-xml/parser/XMLDocumentParser.cpp
 xml/parser/XMLDocumentParserLibxml2.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1024,5 +1024,4 @@ xml/XPathFunctions.cpp
 xml/XSLImportRule.cpp
 xml/XSLStyleSheetLibxslt.cpp
 xml/XSLTProcessorLibxslt.cpp
-xml/parser/XMLDocumentParser.cpp
 xml/parser/XMLDocumentParserLibxml2.cpp

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -153,6 +153,8 @@ private:
     void doWrite(const String&);
     void doEnd();
 
+    RefPtr<Text> protectedLeafTextNode() const { return m_leafTextNode; }
+
     xmlParserCtxtPtr context() const { return m_context ? m_context->context() : nullptr; };
 
     IsInFrameView m_isInFrameView { IsInFrameView::No };


### PR DESCRIPTION
#### b12cb0a1aea24605a9b550fe0275f9999d251bc4
<pre>
[Safer CPP] Address issues in XMLDocumentParser
<a href="https://bugs.webkit.org/show_bug.cgi?id=301408">https://bugs.webkit.org/show_bug.cgi?id=301408</a>
<a href="https://rdar.apple.com/163317843">rdar://163317843</a>

Reviewed by Ryosuke Niwa.

Address remaining Safer CPP issues in XMLDocumentParser

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::XMLDocumentParser::handleError):
(WebCore::XMLDocumentParser::createLeafTextNode):
(WebCore::XMLDocumentParser::updateLeafTextNode):
(WebCore::XMLDocumentParser::end):
(WebCore::XMLDocumentParser::parseDocumentFragment):
* Source/WebCore/xml/parser/XMLDocumentParser.h:

Canonical link: <a href="https://commits.webkit.org/302160@main">https://commits.webkit.org/302160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/242e91f1b261fb0b617b2da4d075fca130e8059b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79663 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/76a7d917-45cf-4a53-89fc-d291c1617619) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97569 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65464 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/361161f7-f12c-465e-8014-25b0e2e29a3b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114823 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78140 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fae67d02-c880-4e8c-bcce-f70c27e97c07) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32931 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78847 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108608 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138026 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106098 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105879 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26990 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/237 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29719 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52554 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/356 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/62446 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/263 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/337 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->