### PR TITLE
[WebXR] Opaque WebGLFramebuffer incorrect behavior

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5654,7 +5654,6 @@ webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrDevice_requestSessio
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrSession_input_events_end.https.html [ Skip ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https.html [ Skip ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_scale.https.html [ Skip ]
-webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https.html [ Skip ]
 
 # rdar://79306047
 webkit.org/b/227084 http/wpt/webxr/xrSession_ended_by_system.https.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Ensure that the framebuffer given by the WebGL layer is opaque for immersive - webgl
-FAIL Ensure that the framebuffer given by the WebGL layer is opaque for immersive - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Ensure that the framebuffer given by the WebGL layer is opaque for immersive - webgl2
 PASS Ensure that the framebuffer given by the WebGL layer is opaque for non-immersive - webgl
-FAIL Ensure that the framebuffer given by the WebGL layer is opaque for non-immersive - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Ensure that the framebuffer given by the WebGL layer is opaque for non-immersive - webgl2
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -99,8 +99,8 @@ webkit.org/b/254733 inspector/canvas/shaderProgram-add-remove-webgl.html [ Failu
 webrtc/vp8-then-h264-gpu-process-crash.html [ Skip ]
 
 # WebXR
+webkit.org/b/301551 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https.html [ Failure ]
 webkit.org/b/301494 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html [ Failure ]
-
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End of Triaged Expectations

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -134,7 +134,6 @@ imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
 imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https.html [ Failure ]
 imported/w3c/web-platform-tests/webxr/webxr_feature_policy.https.html [ Failure ]
 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_scale.https.html [ Failure ]
-imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https.html [ Failure ]
 imported/w3c/web-platform-tests/webxr/xr_viewport_scale.https.html [ Failure ]
 
 webkit.org/b/274980 imported/w3c/web-platform-tests/webxr/xrViewport_valid.https.html [ Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -246,6 +246,7 @@ imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpir
 # WebXR
 
 webkit.org/b/299366 imported/w3c/web-platform-tests/webxr/xrSession_visibilityState_inline.https.html [ Skip ] # Timeout
+webkit.org/b/301551 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https.html [ Failure ]
 webkit.org/b/301493 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html [ Failure ]
 
 # WTR window size handling

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -176,6 +176,7 @@ void WebXROpaqueFramebuffer::startFrame(PlatformXR::FrameData::LayerData& data)
     ScopedWebGLRestoreTexture restoreTexture { m_context, textureTarget };
     ScopedWebGLRestoreRenderbuffer restoreRenderBuffer { m_context };
 
+    m_drawFramebuffer->setInsideWebXRRAF(true);
     gl->bindFramebuffer(GL::FRAMEBUFFER, m_drawFramebuffer->object());
     // https://immersive-web.github.io/webxr/#opaque-framebuffer
     // The buffers attached to an opaque framebuffer MUST be cleared to the values in the provided table when first created,
@@ -228,6 +229,8 @@ void WebXROpaqueFramebuffer::startFrame(PlatformXR::FrameData::LayerData& data)
 
 void WebXROpaqueFramebuffer::endFrame()
 {
+    m_drawFramebuffer->setInsideWebXRRAF(false);
+
     RefPtr gl = m_context->graphicsContextGL();
     if (!gl)
         return;

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -676,6 +676,13 @@ void WebGL2RenderingContext::deleteFramebuffer(WebGLFramebuffer* framebuffer)
 {
     Locker locker { objectGraphLock() };
 
+#if ENABLE(WEBXR)
+    if (framebuffer && framebuffer->isOpaque()) {
+        synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "deleteFramebuffer"_s, "An opaque framebuffer can't be deleted"_s);
+        return;
+    }
+#endif
+
     if (!deleteObject(locker, framebuffer))
         return;
 

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.h
@@ -44,6 +44,10 @@ namespace WebCore {
 
 class WebGLRenderbuffer;
 class WebGLTexture;
+#if ENABLE(WEBXR)
+class WebGLRenderingContextBase;
+class WebXROpaqueFramebuffer;
+#endif
 
 class WebGLFramebuffer final : public WebGLObject {
 public:
@@ -95,6 +99,11 @@ public:
     bool isInitialized() const { return m_hasEverBeenBound; }
 
 private:
+#if ENABLE(WEBXR)
+    friend class WebGLRenderingContextBase;
+    friend class WebXROpaqueFramebuffer;
+#endif
+
     enum class Type : bool {
         Plain,
 #if ENABLE(WEBXR)
@@ -119,12 +128,18 @@ private:
     // null, remove the attached object.
     void removeAttachmentInternal(const AbstractLocker&, GCGLenum attachment);
 
+#if ENABLE(WEBXR)
+    void setInsideWebXRRAF(bool inside) { m_insideWebXRRAF = inside; }
+    bool isInsideWebXRRAF() const { return m_insideWebXRRAF; }
+#endif
+
     HashMap<GCGLenum, AttachmentEntry> m_attachments;
     bool m_hasEverBeenBound { false };
     Vector<GCGLenum> m_drawBuffers;
     Vector<GCGLenum> m_filteredDrawBuffers;
 #if ENABLE(WEBXR)
     const bool m_isOpaque;
+    bool m_insideWebXRRAF { false };
 #endif
 };
 


### PR DESCRIPTION
#### b4d954c0185e8130346ab41ca9180424496f9b29
<pre>
[WebXR] Opaque WebGLFramebuffer incorrect behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=301407">https://bugs.webkit.org/show_bug.cgi?id=301407</a>
<a href="https://rdar.apple.com/163317425">rdar://163317425</a>

Reviewed by Kimmo Kinnunen.

xrWebGLLayer_opaque_framebuffer.https.html fails due to two oversights:
- WebGL2RenderingContext::deleteFramebuffer override is missing the opaque
  check from WebGLRenderingContextBase::deleteFramebuffer.
- WebGLRenderingContextBase::checkFramebufferStatus does not return
  FRAMEBUFFER_UNSUPPORTED when an opaque framebuffer is accessed outside
  a requestAnimationFrame() callback, as required by the WebXR specification.

This change fixes the test by:
1. Adding the opaque framebuffer validation check to
   WebGL2RenderingContext::deleteFramebuffer (matching the base class).
2. Updating WebGLRenderingContextBase::checkFramebufferStatus to return
   FRAMEBUFFER_UNSUPPORTED when an opaque framebuffer is accessed outside
   a WebXR requestAnimationFrame() callback.
3. Tracking WebXR rAF state via WebGLFramebuffer::setInsideWebXRRAF(),
   called from WebXROpaqueFramebuffer::startFrame() and endFrame().

Change expectations and enable xrWebGLLayer_opaque_framebuffer.https.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https-expected.txt:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/visionos/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::endFrame):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::deleteFramebuffer):
* Source/WebCore/html/canvas/WebGLFramebuffer.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::checkFramebufferStatus):
(WebCore::WebGLRenderingContextBase::deleteFramebuffer):

Canonical link: <a href="https://commits.webkit.org/302324@main">https://commits.webkit.org/302324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a09c9d1bbf241e60ded784e606878a4e6727fe4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136146 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ad998ad3-22f2-4f77-bbe6-e355df97dca3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/898 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98024 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e06d6e67-7e34-4c12-98d5-c7d1416a0293) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131711 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78632 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6dc2988e-9cd9-4ace-a0cb-52780f17d964) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/33460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79426 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109093 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/33954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138605 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/838 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106564 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/891 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/111685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/106372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/27079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/30216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53251 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20112 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64195 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/849 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->