### PR TITLE
[WebXR] WPT WebXR/xrWebGLLayer_opaque_framebuffer_stencil incorrectly uses glReadPixels

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5655,7 +5655,6 @@ webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrSession_input_events
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https.html [ Skip ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_scale.https.html [ Skip ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https.html [ Skip ]
-webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html [ Skip ]
 
 # rdar://79306047
 webkit.org/b/227084 http/wpt/webxr/xrSession_ended_by_system.https.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https-expected.txt
@@ -1,3 +1,4 @@
 
-FAIL Ensure that the framebuffer given by the WebGL layer works with stencil for immersive assert_equals: Should not initially have any errors expected 0 but got 1282
+PASS Ensure that the framebuffer given by the WebGL layer works with stencil for immersive - webgl
+PASS Ensure that the framebuffer given by the WebGL layer works with stencil for immersive - webgl2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html
@@ -183,24 +183,24 @@ let testFunction =
 
     // check that the main color is used correctly (green)
     pixels[0] = pixels[1] = pixels[2] = pixels[3] = 30;
-    gl.readPixels(xrViewport.x + xrViewport.width / 2, xrViewport.y + xrViewport.height/4, 1, 1, gl.RGB, gl.UNSIGNED_BYTE, pixels);
-    if (pixels[0] == 0x0 && pixels[1] == 0xFF && pixels[2] == 0x0) { // green?
+    gl.readPixels(xrViewport.x + xrViewport.width / 2, xrViewport.y + xrViewport.height/4, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+    if (pixels[0] == 0x0 && pixels[1] == 0xFF && pixels[2] == 0x0 && pixels[3] == 0xFF) { // green?
       // PASSED.
-    } else if (pixels[0] == 0xFF && pixels[1] == 0xFF && pixels[2] == 0xFF) { // white?
+    } else if (pixels[0] == 0xFF && pixels[1] == 0xFF && pixels[2] == 0xFF && pixels[3] == 0xFF) { // white?
       reject("Failed, white detected, must be green");
     } else {
-      reject("Failed, readPixels (1) didn't work, gl error = " + gl.getError() + ", pixel = " +pixels[0] + " " +pixels[1] + " " +pixels[2]);
+      reject("Failed, readPixels (1) didn't work, gl error = " + gl.getError() + ", pixel = " +pixels[0] + " " +pixels[1] + " " +pixels[2] + " " +pixels[3]);
     }
 
     // check if stencil worked, i.e. white pixels in the center
     pixels[0] = pixels[1] = pixels[2] = pixels[3] = 20;
-    gl.readPixels(xrViewport.x + xrViewport.width / 2, xrViewport.y + xrViewport.height/2, 1, 1, gl.RGB, gl.UNSIGNED_BYTE, pixels);
-    if (pixels[0] == 0xFF && pixels[1] == 0xFF && pixels[2] == 0xFF) { // white?
+    gl.readPixels(xrViewport.x + xrViewport.width / 2, xrViewport.y + xrViewport.height/2, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+    if (pixels[0] == 0xFF && pixels[1] == 0xFF && pixels[2] == 0xFF && pixels[3] == 0xFF) { // white?
       // PASSED.
-    } else if (pixels[0] == 0x0 && pixels[1] == 0xFF && pixels[2] == 0x0) { // green?
+    } else if (pixels[0] == 0x0 && pixels[1] == 0xFF && pixels[2] == 0x0 && pixels[3] == 0xFF) { // green?
       reject("Failed, green detected, must be white");
     } else {
-      reject("Failed, readPixels (2) didn't work, gl error = " + gl.getError() + ", pixel = " +pixels[0] + " " +pixels[1] + " " +pixels[2]);
+      reject("Failed, readPixels (2) didn't work, gl error = " + gl.getError() + ", pixel = " +pixels[0] + " " +pixels[1] + " " +pixels[2] + " " +pixels[3]);
     }
 
     // Finished.

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -98,6 +98,10 @@ webkit.org/b/254733 inspector/canvas/shaderProgram-add-remove-webgl.html [ Failu
 # Crash on EWS bot.
 webrtc/vp8-then-h264-gpu-process-crash.html [ Skip ]
 
+# WebXR
+webkit.org/b/301494 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html [ Failure ]
+
+
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End of Triaged Expectations
 # Legacy Expectations sections below

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -136,7 +136,6 @@ imported/w3c/web-platform-tests/webxr/webxr_feature_policy.https.html [ Failure 
 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_scale.https.html [ Failure ]
 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https.html [ Failure ]
 imported/w3c/web-platform-tests/webxr/xr_viewport_scale.https.html [ Failure ]
-imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html [ Failure ]
 
 webkit.org/b/274980 imported/w3c/web-platform-tests/webxr/xrViewport_valid.https.html [ Failure ]
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -246,6 +246,7 @@ imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpir
 # WebXR
 
 webkit.org/b/299366 imported/w3c/web-platform-tests/webxr/xrSession_visibilityState_inline.https.html [ Skip ] # Timeout
+webkit.org/b/301493 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html [ Failure ]
 
 # WTR window size handling
 


### PR DESCRIPTION
#### 12fdd3513b715778f22b2fd3a4fc2d4fc4789d20
<pre>
[WebXR] WPT WebXR/xrWebGLLayer_opaque_framebuffer_stencil incorrectly uses glReadPixels
<a href="https://bugs.webkit.org/show_bug.cgi?id=301409">https://bugs.webkit.org/show_bug.cgi?id=301409</a>
<a href="https://rdar.apple.com/163318566">rdar://163318566</a>

Reviewed by Kimmo Kinnunen.

The OpenGL specification says only two combinations of format and type for any
internalformat are accepted in most cases. The first varies depending on the
internalformat of the currently bound rendering surface. For the format and
types used in the test, the combination format RGBA and type UNSIGNED_BYTE is
accepted. The second implementation-chosen format and type for this internalformat
may be determined by calling GetIntegerv with the symbolic constants
IMPLEMENTATION_COLOR_READ_FORMAT and IMPLEMENTATION_COLOR_READ_TYPE, which the
test is not doing.

Changing the format passed to glReadPixels from GL_RGB to GL_RBGA fixes the
test and follows the specification.

Renable and update expectations for xrWebGLLayer_opaque_framebuffer_stencil.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/visionos/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/302321@main">https://commits.webkit.org/302321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15ad8aaca7d712bcaf6a7fb79ede21567cbb5dcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135978 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80002 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9a387dfb-af07-4704-9339-f0f9f3d733bb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97890 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65794 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c5b37df8-3f31-4789-85d9-c307553313ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115210 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78506 "2 api tests failed or timed out") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5dfb9156-18fa-49bd-9f6c-3652a6e539bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33318 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79261 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138430 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/685 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106425 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106245 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27078 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/577 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30080 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53030 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/744 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/616 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/675 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/695 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->