### PR TITLE
[Navigation API] navigate-replace-same-document.html is flaky on WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-same-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-same-document.html
@@ -2,21 +2,22 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-async_test(t => {
+promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  window.onload = () => t.step_timeout(t.step_func_done(async () => {
-    let start_length = navigation.entries().length;
-    let start_history_length = history.length;
-    let key1 = navigation.currentEntry.key;
-    await navigation.navigate("#1").committed;
-    let key2 = navigation.currentEntry.key;
-    assert_not_equals(key1, key2);
-    await navigation.navigate("#2", { history: "replace" }).committed;
-    let key3 = navigation.currentEntry.key;
-    assert_equals(key2, key3);
-    assert_equals(navigation.entries().length, start_length + 1);
-    assert_equals(history.length, start_history_length + 1);
-  }), 0);
+  await new Promise(resolve => window.onload = resolve);
+  await new Promise(resolve => t.step_timeout(resolve, 0));
+
+  let start_length = navigation.entries().length;
+  let start_history_length = history.length;
+  let key1 = navigation.currentEntry.key;
+  await navigation.navigate("#1").committed;
+  let key2 = navigation.currentEntry.key;
+  assert_not_equals(key1, key2);
+  await navigation.navigate("#2", { history: "replace" }).committed;
+  let key3 = navigation.currentEntry.key;
+  assert_equals(key2, key3);
+  assert_equals(navigation.entries().length, start_length + 1);
+  assert_equals(history.length, start_history_length + 1);
 }, "navigate() with history: 'replace' option");
 </script>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1295,14 +1295,10 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
         // we have already saved away the scroll and doc state for the long slow load,
         // but it's not an obvious case.
 
-        std::optional<WTF::UUID> uuid;
-        if (historyHandling == NavigationHistoryBehavior::Replace) {
-            if (RefPtr currentItem = history().currentItem())
-                uuid = currentItem->uuidIdentifier();
-        }
-        history().updateBackForwardListForFragmentScroll();
-        if (uuid)
-            history().currentItem()->setUUIDIdentifier(*uuid);
+        if (historyHandling == NavigationHistoryBehavior::Replace)
+            history().updateBackForwardListForReplaceState(nullptr, url.string());
+        else
+            history().updateBackForwardListForFragmentScroll();
 
         if (!document->hasRecentUserInteractionForNavigationFromJS() && !documentLoader()->triggeringAction().isRequestFromClientOrUserInput()) {
             if (RefPtr currentItem = history().currentItem())

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -1084,13 +1084,13 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
         document->protectedWindow()->protectedNavigation()->updateForNavigation(*currentItem, NavigationNavigationType::Push);
 }
 
-void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject, const String& urlString)
+void HistoryController::updateBackForwardListForReplaceState(RefPtr<SerializedScriptValue>&& stateObject, const String& urlString)
 {
     RefPtr currentItem = m_currentItem;
     if (!currentItem)
         return;
 
-    LOG(History, "HistoryController %p replaceState: Setting url of current item %p to %s scrollRestoration %s", this, currentItem.get(), urlString.ascii().data(), currentItem->shouldRestoreScrollPosition() ? "auto" : "manual");
+    LOG(History, "HistoryController %p updateBackForwardListForReplaceState: Setting url of current item %p to %s scrollRestoration %s", this, currentItem.get(), urlString.ascii().data(), currentItem->shouldRestoreScrollPosition() ? "auto" : "manual");
 
     if (!urlString.isEmpty())
         currentItem->setURLString(urlString);
@@ -1098,6 +1098,15 @@ void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject
     currentItem->setFormData(nullptr);
     currentItem->setFormContentType(String());
     currentItem->notifyChanged();
+}
+
+void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject, const String& urlString)
+{
+    RefPtr currentItem = m_currentItem;
+    if (!currentItem)
+        return;
+
+    updateBackForwardListForReplaceState(WTFMove(stateObject), urlString);
 
     Ref frame = m_frame.get();
     RefPtr page = frame->page();

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -62,6 +62,7 @@ public:
     WEBCORE_EXPORT void restoreScrollPositionAndViewState();
 
     void updateBackForwardListForFragmentScroll();
+    void updateBackForwardListForReplaceState(RefPtr<SerializedScriptValue>&&, const String&);
 
     void saveDocumentState();
     WEBCORE_EXPORT void saveDocumentAndScrollState();


### PR DESCRIPTION
#### 865a045f39f68e290947ab4a97967e3b381dcab6
<pre>
[Navigation API] navigate-replace-same-document.html is flaky on WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=301416">https://bugs.webkit.org/show_bug.cgi?id=301416</a>
<a href="https://rdar.apple.com/163323288">rdar://163323288</a>

Reviewed by Basuke Suzuki.

At first glance, this test appears to be flaky on WPT even though it passes
all of the time on WKTR. It turns out that both the mismatch in the results
between WKTR and WebDriver and the flakiness on WebDriver are the result of
the test being written in a way that doesn&apos;t catch exceptions.
(Discused here: <a href="https://bugs.webkit.org/show_bug.cgi?id=301415).">https://bugs.webkit.org/show_bug.cgi?id=301415).</a>

So firstly, we rewrite the test in a manner that will catch the exception.
Upstream PR: <a href="https://github.com/web-platform-tests/wpt/pull/55632.">https://github.com/web-platform-tests/wpt/pull/55632.</a>

With the test rewritten, we see that it fails consistently. The failing line:
&quot;assert_equals(history.length, start_history_length + 1);&quot;

Instead of replacing the current item in the UI Process b/f list, a new item
is being added.

The culprit is the call to History::updateBackForwardListForFragmentScroll()
in FrameLoader::loadInSameDocument(). The History function creates a new History
Item and sends an IPC message to have it added to the UI Process b/f list.

Since this is a same-document replace navigation, no actual load is occuring.
So we can fix this by simply not making a new History Item and instead just
replacing the data (url, stateObject, etc) of the current History Item. We
do this the exact same way that HistoryController::replaceState() does when
&quot;history.replaceState()&quot; is called.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-same-document.html:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadInSameDocument):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::updateBackForwardListForReplaceState):
(WebCore::HistoryController::replaceState):
* Source/WebCore/loader/HistoryController.h:

Canonical link: <a href="https://commits.webkit.org/302130@main">https://commits.webkit.org/302130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0a68230e5d47c8a59a7edcd3f32ef61bad65958

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79568 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a2c0a5a7-5a84-4025-a520-71be79b6e209) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97493 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65385 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b465c4d0-61cd-4a5f-99dc-9aa451fe1739) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78059 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8363647a-50ba-49c3-90c6-fdcef5b92045) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32832 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78745 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108520 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137924 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106020 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111068 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105758 "Found 1 new API test failure: WebKitGTK/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/152 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29624 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52381 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20016 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61720 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/166 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/241 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->