### PR TITLE
Slotted Text Nodes get hidden when elements next to the slot change display

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-text-with-flex-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-text-with-flex-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+    .content {
+        border: 2px solid blue;
+        display: flex;
+    }
+</style>
+<div id="test">
+    <div class="content">
+        This should be visible.
+        <div>This too.</div>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-text-with-flex-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-text-with-flex-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+    .content {
+        border: 2px solid blue;
+        display: flex;
+    }
+</style>
+<div id="test">
+    <div class="content">
+        This should be visible.
+        <div>This too.</div>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-text-with-flex.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-text-with-flex.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>Test dynamic updates with text slotted into flexbox</title>
+<link rel="help" href="https://drafts.csswg.org/css-scoping/">
+<div id="test">
+    <template shadowrootmode=open>
+        <style>
+            .content {
+                border: 2px solid blue;
+                display: flex;
+            }
+        </style>
+        <div class="content">
+            <slot></slot>
+            <div id="toggle">This too.</div>
+        </div>
+    </template>
+    This should be visible.
+</div>
+
+<script>
+document.body.offsetLeft;
+const toggle = test.shadowRoot.querySelector("#toggle");
+toggle.style.display = "none";
+document.body.offsetLeft;
+toggle.style.display = "block";
+</script>

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -175,12 +175,13 @@ void RenderTreeUpdater::updateRebuildRoots()
             return true;
         }
 
-        if (!element.renderer())
-            return element.hasDisplayContents();
+        CheckedPtr existingStyle = element.renderOrDisplayContentsStyle();
+        if (!existingStyle)
+            return false;
 
         auto* parent = composedTreeAncestors(element).first();
         m_styleUpdate->addElement(element, parent, Style::ElementUpdate {
-            makeUnique<RenderStyle>(RenderStyle::cloneIncludingPseudoElements(element.renderer()->style())),
+            makeUnique<RenderStyle>(RenderStyle::cloneIncludingPseudoElements(*existingStyle)),
             Style::Change::Renderer
         });
         return true;


### PR DESCRIPTION
#### 0ad2da25310e43238bf638d2e6533b13c20f33d7
<pre>
Slotted Text Nodes get hidden when elements next to the slot change display
<a href="https://bugs.webkit.org/show_bug.cgi?id=299951">https://bugs.webkit.org/show_bug.cgi?id=299951</a>
<a href="https://rdar.apple.com/162193811">rdar://162193811</a>

Reviewed by Ryosuke Niwa.

During render tree update flex triggers a change to the rebuild root to make a larger update but then
fails to update a display:contents &lt;slot&gt;.

Tests: imported/w3c/web-platform-tests/css/css-scoping/slotted-text-with-flex-ref.html
       imported/w3c/web-platform-tests/css/css-scoping/slotted-text-with-flex.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-text-with-flex-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-text-with-flex-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-text-with-flex.html: Added.
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateRebuildRoots):

If we change the rebuild root we should include styles for &apos;display:contents&apos; elements too.

Canonical link: <a href="https://commits.webkit.org/302082@main">https://commits.webkit.org/302082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24f1173e8cfb7003164f468482f6f42adf0c0243

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135348 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/160315c5-4863-4f47-b016-cdeba7134e33) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97422 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130923 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/79 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77989 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0c709596-274a-4941-ac83-ef273db84e71) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/80 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32743 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78656 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137832 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105950 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105686 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26935 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/83 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52265 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/162 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/61617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/90 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->