### PR TITLE
[WPEPlatform] Silence unused variable warnings with USE_LIBDRM and USE_GBM disabled

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
@@ -84,7 +84,7 @@ static void wpeBufferDMABufDisposeEGLImageIfNeeded(WPEBufferDMABuf* buffer)
 static void wpeBufferDMABufDispose(GObject* object)
 {
     auto* dmabufBuffer = WPE_BUFFER_DMA_BUF(object);
-    wpeBufferDMABufDisposeEGLImageIfNeeded(WPE_BUFFER_DMA_BUF(object));
+    wpeBufferDMABufDisposeEGLImageIfNeeded(dmabufBuffer);
 
 #if USE(GBM)
     auto* priv = dmabufBuffer->priv;

--- a/Source/WebKit/WPEPlatform/wpe/WPEDRMDevice.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDRMDevice.cpp
@@ -103,6 +103,7 @@ GRefPtr<WPEDRMDevice> wpeDRMDeviceCreateForDevice(const char* deviceFilename)
 
     return drmDevice;
 #else
+    UNUSED_PARAM(deviceFilename);
     return nullptr;
 #endif
 }

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
@@ -155,6 +155,8 @@ static void wpeScreenInvalidate(WPEScreen* screen)
 {
 #if USE(LIBDRM)
     screen->priv->syncObserver = nullptr;
+#else
+    UNUSED_PARAM(screen);
 #endif
 }
 

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
@@ -67,9 +67,8 @@ WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(WPEDisplayHeadless, wpe_display_headless, WPE
 
 static void wpeDisplayHeadlessDispose(GObject* object)
 {
-    auto* priv = WPE_DISPLAY_HEADLESS(object)->priv;
-
 #if USE(GBM)
+    auto* priv = WPE_DISPLAY_HEADLESS(object)->priv;
     g_clear_pointer(&priv->gbmDevice, gbm_device_destroy);
     priv->gbmDeviceFD = { };
 #endif
@@ -133,6 +132,8 @@ static gpointer wpeDisplayHeadlessGetEGLDisplay(WPEDisplay* display, GError** er
         g_set_error(error, WPE_EGL_ERROR, WPE_EGL_ERROR_NOT_AVAILABLE, "Can't get EGL display: failed to create GBM EGL display for %s", filename);
         return nullptr;
     }
+#else
+    UNUSED_PARAM(display);
 #endif
 
     if (!epoxy_has_egl_extension(nullptr, "EGL_MESA_platform_surfaceless")) {
@@ -208,6 +209,7 @@ WPEDisplay* wpe_display_headless_new_for_device(const char* name, GError** error
     priv->drmDevice = WTFMove(drmDevice);
     return WPE_DISPLAY(display);
 #else
+    UNUSED_PARAM(name);
     g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_NOT_SUPPORTED, "DRM device not supported");
     return nullptr;
 #endif


### PR DESCRIPTION
#### c22c1733b83cab5debc143918a8a728b5734ae06
<pre>
[WPEPlatform] Silence unused variable warnings with USE_LIBDRM and USE_GBM disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=301422">https://bugs.webkit.org/show_bug.cgi?id=301422</a>

Reviewed by Carlos Garcia Campos.

Move some variable definitions into their corresponding USE(LIBDRM) and
USE(GBM) guards, or mark them with UNUSED_PARAM() where appropriate.

Canonical link: <a href="https://commits.webkit.org/302083@main">https://commits.webkit.org/302083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9356ac5388a61fdec160bd16f2828ea06959ed94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135361 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/141 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130938 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/88 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78001 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/94 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78671 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137845 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/120 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105962 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111002 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/105699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26936 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/96 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52283 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/175 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/61637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->