### PR TITLE
[css-anchor-position-1] Style resolution repeats indefinitely when position-try box is in a display: none tree

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-display-none-hang-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-display-none-hang-crash.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+
+<html class="test-wait">
+
+<title>Browser doesn't hang when a child using position-try has an ancestor with display: none</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position/#fallback">
+
+<style>
+  .inner {
+    position: absolute;
+    position-try: top right;
+  }
+</style>
+
+<!-- not nested -->
+<div class="outer inner"></div>
+
+<!-- 1 level nest -->
+<div class="outer">
+  <div class="inner"></div>
+</div>
+
+<!-- 2 level nest -->
+<div class="outer">
+  <div>
+    <div class="inner"></div>
+  </div>
+</div>
+
+<!-- 3 level nest -->
+<div class="outer">
+  <div>
+    <div>
+      <div class="inner"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+  let html = document.documentElement;
+  html.addEventListener("TestRendered", () => {
+    const outers = document.getElementsByClassName("outer");
+    for (let i = 0; i < outers.length; ++i)
+      outers[i].style.display = "none";
+
+    html.classList.remove("test-wait");
+  });
+</script>
+
+</html>

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -107,6 +107,8 @@ private:
     std::optional<ResolvedStyle> resolveAncestorFirstLinePseudoElement(Element&, const ElementUpdate&);
     std::optional<ResolvedStyle> resolveAncestorFirstLetterPseudoElement(Element&, const ElementUpdate&, ResolutionContext&);
 
+    void resetStyleForNonRenderedDescendants(Element&);
+
     struct Scope : RefCounted<Scope> {
         WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(TreeResolverScope, TreeResolverScope);
         Ref<Resolver> resolver;


### PR DESCRIPTION
#### 2826fcdebc5b310c60ec04f17010a42a0a2d8599
<pre>
[css-anchor-position-1] Style resolution repeats indefinitely when position-try box is in a display: none tree
<a href="https://rdar.apple.com/161570947">rdar://161570947</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299742">https://bugs.webkit.org/show_bug.cgi?id=299742</a>

Reviewed by Antti Koivisto.

If a position-try box is in a display: none tree (one of its ancestors is display: none):
* On the first style resolution, a PositionOption is generated for the box
* After resolution, the box is invalidated because a position hasn&apos;t been chosen
* On the second resolution, when the display: none ancestor is visited, it&apos;ll skip
visiting its descendants because of display: none. Hence style resolution never visits
the position-try box.
* Because there&apos;s still a PositionOption for the box, after the second resolution,
the box is still invalidated, even though style resolution will never visit it.

The result is style resolution repeats ad infinitum. Fix this by adding logic in
TreeResolver::resetStyleForNonRenderedDescendants to remove generated PositionOptions
of non-rendered elements.

Test: imported/w3c/web-platform-tests/css/css-anchor-position/position-try-display-none-hang-crash.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-display-none-hang-crash.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resetStyleForNonRenderedDescendants):
    - Remove PositionOptions of non-rendered descendants.

(WebCore::Style::resetStyleForNonRenderedDescendants):
    - Move into TreeResolver so it can access the position options map.

* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/302254@main">https://commits.webkit.org/302254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6be4d9dda5a7103508592a7fef7b492d8ca27b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79900 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bc544d28-3284-4965-be3a-a5146c08aad8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97784 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65691 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/509da0e0-deea-409b-9600-f48f649ea8cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115088 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78395 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33195 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79131 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138298 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/532 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106326 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106136 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27049 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/468 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29970 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52894 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/617 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63810 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/508 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/571 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/575 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->