### PR TITLE
REGRESSION(302027@main): [WPE] Building for Android with WebXR enabled fails

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -490,7 +490,7 @@ bool WebXROpaqueFramebuffer::setupFramebuffer(GraphicsContextGL& gl, const Platf
 
 const std::array<WebXRExternalAttachments, 2>* WebXROpaqueFramebuffer::reusableDisplayAttachments(const PlatformXR::FrameData::ExternalTextureData& textureData) const
 {
-    if (!textureData.colorTexture.isNull())
+    if (textureData.colorTexture)
         return nullptr;
 
     auto reusableTextureIndex = textureData.reusableTextureIndex;
@@ -527,8 +527,8 @@ void WebXROpaqueFramebuffer::bindCompositorTexturesForDisplay(GraphicsContextGL&
     releaseDisplayAttachmentsAtIndex(m_currentDisplayAttachmentIndex);
 
     for (int layer = 0; layer < layerCount; ++layer) {
-        ASSERT(!layerData.textureData->colorTexture.isNull());
-        if (layerData.textureData->colorTexture.isNull())
+        ASSERT(layerData.textureData->colorTexture);
+        if (!layerData.textureData->colorTexture)
             return;
 
         auto colorTextureSource = makeExternalImageSource(layerData.textureData->colorTexture, framebufferSize);
@@ -537,7 +537,7 @@ void WebXROpaqueFramebuffer::bindCompositorTexturesForDisplay(GraphicsContextGL&
         if (!m_displayAttachmentsSets[m_currentDisplayAttachmentIndex][layer].colorBuffer.image)
             return;
 
-        if (!layerData.textureData->depthStencilBuffer.isNull()) {
+        if (layerData.textureData->depthStencilBuffer) {
             auto depthStencilBufferSource = makeExternalImageSource(layerData.textureData->depthStencilBuffer, framebufferSize);
             createAndBindCompositorBuffer(gl, m_displayAttachmentsSets[m_currentDisplayAttachmentIndex][layer].depthStencilBuffer, GL::DEPTH24_STENCIL8, WTFMove(depthStencilBufferSource), layer);
         }

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -319,18 +319,11 @@ struct FrameData {
     using ExternalTexture = RefPtr<AHardwareBuffer>;
 #else
     struct ExternalTexture {
-        bool isNull() const
-        {
-#if PLATFORM(COCOA)
-            return !handle;
-#else
-            return fds.isEmpty();
-#endif
-        }
-
 #if PLATFORM(COCOA)
         MachSendRight handle;
         bool isSharedTexture { false };
+
+        explicit operator bool() const { return !!handle; }
 #else
         Vector<WTF::UnixFileDescriptor> fds;
         Vector<uint32_t> strides;


### PR DESCRIPTION
#### af9ccb99d5c43b565881a3c2c0eb343594e7f66a
<pre>
REGRESSION(302027@main): [WPE] Building for Android with WebXR enabled fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=297900">https://bugs.webkit.org/show_bug.cgi?id=297900</a>

Reviewed by Fujii Hironori.

Instead of the added ExternalTexture::isNull() method added in 302027@main,
define the boolean conversion operator for Cocoa. On Android this operator
gets picked directly from RefPtr&lt;AHardwareBuffer&gt;, and there was already
an implementation for non-Cocoa platforms.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp: Invert the
logic of checks to use the boolean conversion operator.
(WebCore::WebXROpaqueFramebuffer::reusableDisplayAttachments const):
(WebCore::WebXROpaqueFramebuffer::bindCompositorTexturesForDisplay):
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::FrameData::ExternalTexture::operator bool const): Define the
operator for PLATFORM(COCOA).
(PlatformXR::FrameData::ExternalTexture::isNull const): Deleted, no longer
needed given that the boolean conversion operator is used in all cases.

Canonical link: <a href="https://commits.webkit.org/302109@main">https://commits.webkit.org/302109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8de920552d980483a50bad4b8610078ae97b2a35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135374 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129875 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97441 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65328 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78009 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32770 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78683 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137857 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/131 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105970 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111016 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105706 "Found 1 new API test failure: WebKitGTK/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26953 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/107 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29566 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52303 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/188 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/61652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/108 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/184 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->