### PR TITLE
UnifiedPDF: content is drawn over page boundaries with DCS

### DIFF
--- a/LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html
+++ b/LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true PDFPluginHUDEnabled=false ] -->
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-50">
+    <meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-634" />
     <script src="/js-test-resources/ui-helper.js"></script>
     <style>
         iframe {

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -555,7 +555,7 @@ TileRenderInfo AsyncPDFRenderer::renderInfoForTile(const TiledBacking& tiledBack
 
     auto pageCoverage = presentationController->pageCoverageAndScalesForContentsRect(paintingClipRect, layoutRow, tilingScaleFactor);
 
-    return TileRenderInfo { tileRect, renderRect, WTFMove(background), pageCoverage, m_showDebugBorders };
+    return TileRenderInfo { tileRect, encloseRectToDevicePixels(renderRect, pageCoverage.deviceScaleFactor), WTFMove(background), pageCoverage, m_showDebugBorders };
 }
 
 static void renderPDFTile(PDFDocument *pdfDocument, const TileRenderInfo& renderInfo, GraphicsContext& context)
@@ -563,9 +563,6 @@ static void renderPDFTile(PDFDocument *pdfDocument, const TileRenderInfo& render
     context.translate(-renderInfo.tileRect.location());
     if (renderInfo.tileRect != renderInfo.renderRect)
         context.clip(renderInfo.renderRect);
-    context.fillRect(renderInfo.renderRect, Color::white);
-    if (renderInfo.showDebugIndicators)
-        context.fillRect(renderInfo.renderRect, Color::green.colorWithAlphaByte(32));
 
     context.scale(renderInfo.pageCoverage.tilingScaleFactor);
     context.translate(-renderInfo.pageCoverage.contentsOffset);
@@ -578,6 +575,9 @@ static void renderPDFTile(PDFDocument *pdfDocument, const TileRenderInfo& render
         auto destinationRect = pageInfo.pageBounds;
         auto pageStateSaver = GraphicsContextStateSaver(context);
         context.clip(destinationRect);
+        context.fillRect(destinationRect, Color::white);
+        if (renderInfo.showDebugIndicators)
+            context.fillRect(destinationRect, Color::green.colorWithAlphaByte(32));
 
         // Translate the context to the bottom of pageBounds and flip, so that PDFKit operates
         // from this page's drawing origin.


### PR DESCRIPTION
#### f23f581a778e2452d70d5eff545aeb2e5edcb4c8
<pre>
UnifiedPDF: content is drawn over page boundaries with DCS
<a href="https://bugs.webkit.org/show_bug.cgi?id=301426">https://bugs.webkit.org/show_bug.cgi?id=301426</a>
<a href="https://rdar.apple.com/162536174">rdar://162536174</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

The composited layer for the PDF content overlaps the &quot;PDF document
chrome&quot;, e.g. the depiction of pages with gray margin and black page
border. The idea is that the PDF content contains solid pixels and other
parts of the layer bitmap contains transparent pixels.

The actual &quot;AsyncPDFRenderer&quot; PDF content tiles are bitmaps the size of
the composited layer tiles, but they are distinct bitmaps, not related
to the layer backing store. The pdf tiles were filled with white and pdf
content was drawn on top of the white.

The DCS content is drawn with the same logic as AsyncPDFRenderer PDF
content tiles and used in full. Thus the full-tile white fill rect would
be present in the DCS display list and it would occlude the PDF document
chrome the below gray margin and black page border.

Fix by filling white to only where the page contents actually are.

The bug was not visible with normal layer drawing. When AsyncPDFRenderer
tiles were drawn to PDF content composited layer tiles, only the areas
inside page borders were sourced from and draw to, rest of the
composited layer tiles were left transparent. Thus the gray margin and
black page border were showing through.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::renderPDFTile):

Canonical link: <a href="https://commits.webkit.org/302635@main">https://commits.webkit.org/302635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40959ba53e31e982e342a3a5ff7faaf37f02032b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81010 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b78036fe-06cd-420c-aed1-9c4f88a00167) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98700 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66554 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/91977f3f-dd81-4a66-8170-dcedf4982cce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79350 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/337f8f57-92ce-415e-a58d-e7a47aeff5c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1282 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34187 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80232 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139431 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1620 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1549 "9 flakes 6 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107221 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107066 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1322 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30910 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54338 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20243 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1691 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65054 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1511 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1545 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1613 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->