### PR TITLE
Remove JSValue extras

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -280,10 +280,10 @@ NSString *encodeJSONString(id object, JSONOptionSet options, NSError **error)
 {
 #if JSC_OBJC_API_ENABLED
     if (JSValue *value = dynamic_objc_cast<JSValue>(object)) {
-        if (!options.contains(JSONOptions::FragmentsAllowed) && !value._isDictionary)
+        if (!options.contains(JSONOptions::FragmentsAllowed) && !isDictionary(value.context.JSGlobalContextRef, value.JSValueRef))
             return nil;
 
-        return value._toJSONString;
+        return nsStringNilIfEmpty(toJSONString(value.context.JSGlobalContextRef, value.JSValueRef)).autorelease();
     }
 #endif
 
@@ -300,10 +300,10 @@ NSData *encodeJSONData(id object, JSONOptionSet options, NSError **error)
 
 #if JSC_OBJC_API_ENABLED
     if (JSValue *value = dynamic_objc_cast<JSValue>(object)) {
-        if (!options.contains(JSONOptions::FragmentsAllowed) && !value._isDictionary)
+        if (!options.contains(JSONOptions::FragmentsAllowed) && !isDictionary(value.context.JSGlobalContextRef, value.JSValueRef))
             return nil;
 
-        return [value._toJSONString dataUsingEncoding:NSUTF8StringEncoding];
+        return [nsStringNilIfEmpty(toJSONString(value.context.JSGlobalContextRef, value.JSValueRef)).autorelease() dataUsingEncoding:NSUTF8StringEncoding];
     }
 #endif
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -100,13 +100,13 @@ static NSString *valueToTypeString(NSObject *value, bool plural = false)
         if (scriptValue.isUndefined)
             return plural ? @"undefined values" : @"undefined";
 
-        if (scriptValue._isRegularExpression)
+        if (isRegularExpression(scriptValue.context.JSGlobalContextRef, scriptValue.JSValueRef))
             return plural ? @"regular expressions" : @"a regular expression";
 
-        if (scriptValue._isThenable)
+        if (isThenable(scriptValue.context.JSGlobalContextRef, scriptValue.JSValueRef))
             return plural ? @"promises" : @"a promise";
 
-        if (scriptValue._isFunction)
+        if (isFunction(scriptValue.context.JSGlobalContextRef, scriptValue.JSValueRef))
             return plural ? @"functions" : @"a function";
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -248,12 +248,12 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
     }
 
     if (JSValue *clickCallback = properties[onclickKey]) {
-        if (!clickCallback._isFunction) {
+        if (!isFunction(clickCallback.context.JSGlobalContextRef, clickCallback.JSValueRef)) {
             *outExceptionString = toErrorString(nullString(), onclickKey, @"it must be a function").createNSString().autorelease();
             return false;
         }
 
-        outClickCallback = WebExtensionCallbackHandler::create(clickCallback);
+        outClickCallback = WebExtensionCallbackHandler::create(clickCallback.context.JSGlobalContextRef, JSValueToObject(clickCallback.context.JSGlobalContextRef, clickCallback.JSValueRef, nullptr), runtime());
     }
 
     NSDictionary *iconDictionary;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
@@ -479,7 +479,7 @@ bool WebExtensionAPIScripting::parseScriptInjectionOptions(NSDictionary *script,
         parameters.world = worldType.value();
 
     if (JSValue *function = script[usedFunctionKey]) {
-        if (!function._isFunction) {
+        if (!isFunction(function.context.JSGlobalContextRef, function.JSValueRef)) {
             *outExceptionString = toErrorString(nullString(), usedFunctionKey, @"it is not a function").createNSString().autorelease();
             return false;
         }

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -35,22 +35,6 @@
 #endif
 #include <wtf/WeakPtr.h>
 
-#if JSC_OBJC_API_ENABLED && defined(__OBJC__)
-
-@interface JSValue (WebKitExtras)
-- (NSString *)_toJSONString;
-- (NSString *)_toSortedJSONString;
-
-@property (nonatomic, readonly, getter=_isFunction) BOOL _function;
-@property (nonatomic, readonly, getter=_isDictionary) BOOL _dictionary;
-@property (nonatomic, readonly, getter=_isRegularExpression) BOOL _regularExpression;
-@property (nonatomic, readonly, getter=_isThenable) BOOL _thenable;
-
-- (void)_awaitThenableResolutionWithCompletionHandler:(void (^)(JSValue *result, JSValue *error))completionHandler;
-@end
-
-#endif // JSC_OBJC_API_ENABLED && defined(__OBJC__)
-
 namespace WebKit {
 
 class WebFrame;
@@ -92,9 +76,6 @@ public:
 #endif
 
 private:
-#ifdef __OBJC__
-    WebExtensionCallbackHandler(JSValue *callbackFunction);
-#endif
     WebExtensionCallbackHandler(JSContextRef, JSObjectRef resolveFunction, JSObjectRef rejectFunction);
     WebExtensionCallbackHandler(JSContextRef, JSObjectRef callbackFunction, WebExtensionAPIRuntimeBase&);
     WebExtensionCallbackHandler(JSContextRef, WebExtensionAPIRuntimeBase&);
@@ -171,6 +152,13 @@ JSRetainPtr<JSStringRef> toJSString(const String&);
 JSValueRef deserializeJSONString(JSContextRef, const String& jsonString);
 String serializeJSObject(JSContextRef, JSValueRef, JSValueRef* exception);
 
+String toJSONString(JSContextRef, JSValueRef);
+String toSortedJSONString(JSContextRef, JSValueRef);
+bool isFunction(JSContextRef, JSValueRef);
+bool isDictionary(JSContextRef, JSValueRef);
+bool isRegularExpression(JSContextRef, JSValueRef);
+bool isThenable(JSContextRef, JSValueRef);
+
 #ifdef __OBJC__
 
 id toNSObject(JSContextRef, JSValueRef, Class containingObjectsOfClass = Nil, NullValuePolicy = NullValuePolicy::NotAllowed, ValuePolicy = ValuePolicy::Recursive);
@@ -190,8 +178,6 @@ JSValueRef toJSValueRef(JSContextRef, const String&, NullOrEmptyString = NullOrE
 JSValueRef toJSValueRef(JSContextRef, NSURL *, NullOrEmptyString = NullOrEmptyString::NullStringAsEmptyString);
 
 JSValueRef toJSValueRefOrJSNull(JSContextRef, id);
-
-inline bool isDictionary(JSContextRef context, JSValueRef value) { return toJSValue(context, value)._isDictionary; }
 
 #endif // __OBJC__
 


### PR DESCRIPTION
#### e7856fb3079a6882ac86d485a8763f86d7cf4b63
<pre>
Remove JSValue extras
<a href="https://bugs.webkit.org/show_bug.cgi?id=301432">https://bugs.webkit.org/show_bug.cgi?id=301432</a>

Reviewed by Timothy Hatcher.

We can’t use these on C++, and these should instead be written using
the JSContextRef and JSValueRef combination, for cross-platform support.

* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::encodeJSONString):
(WebKit::encodeJSONData):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::valueToTypeString):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::parseCreateAndUpdateProperties):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::WebExtensionAPIScripting::parseScriptInjectionOptions):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::sendMessage):
(WebKit::debugString):
(WebKit::WebExtensionAPITest::assertRejects):
(WebKit::WebExtensionAPITest::assertResolves):
(WebKit::WebExtensionAPITest::assertThrows):
(WebKit::WebExtensionAPITest::assertSafeResolve):
(WebKit::WebExtensionAPITest::startNextTest):
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::toNSObject):
(WebKit::toNSDictionary):
(WebKit::toSortedJSONString):
(-[JSValue _toSortedJSONString]): Deleted.
(-[JSValue _isFunction]): Deleted.
(-[JSValue _isDictionary]): Deleted.
(-[JSValue _isRegularExpression]): Deleted.
(-[JSValue _isThenable]): Deleted.
(-[JSValue _awaitThenableResolutionWithCompletionHandler:]): Deleted.
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::toJSONString):
(WebKit::isFunction):
(WebKit::isDictionary):
(WebKit::isRegularExpression):
(WebKit::isThenable):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
(WebKit::isDictionary): Deleted.

Canonical link: <a href="https://commits.webkit.org/302144@main">https://commits.webkit.org/302144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8eb0e2f7e78a57baaed218a48384f03e95bc9430

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135420 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79560 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97480 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65374 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78047 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/143 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78729 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137908 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/186 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106010 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105746 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/138 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29612 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/52368 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20023 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/235 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61703 "Found 6 new failures in WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp, WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/156 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/232 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->