### PR TITLE
[JSC] Wasm: Fix loop OSR entry to BBQ with live FPRs

### DIFF
--- a/JSTests/wasm/stress/osr-entry-live-fpr.js
+++ b/JSTests/wasm/stress/osr-entry-live-fpr.js
@@ -1,0 +1,145 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from '../assert.js';
+
+// Verify loop OSR entry with a live FPR, for f32, f64, and v128 types.
+
+function generateWat(type, initialValue) {
+  const constOp = `${type}.const`;
+  const mulOp = `${type}.mul`;
+
+  return `
+(module
+  (global $factor (mut ${type}) (${constOp} 1.0))
+
+  (func (export "test") (param $iterations i32) (result ${type})
+    (local $counter i32)
+
+    (local.set $counter (i32.const 0))
+
+    ;; Push initial ${type} value onto expression stack
+    (${constOp} ${initialValue})
+
+    ;; Loop that keeps the ${type} value on the expression stack
+    (loop $continue (param ${type}) (result ${type})
+      ;; Stack: [${type}_value]
+
+      ;; Multiply by factor to keep it live and prevent constant folding
+      (global.get $factor)
+      (${mulOp})
+      ;; Stack: [${type}_value * 1.0]
+
+      ;; Increment and check counter
+      (local.set $counter (i32.add (local.get $counter) (i32.const 1)))
+      (local.get $counter)
+      (local.get $iterations)
+      (i32.lt_u)
+      ;; Stack: [${type}_value, continue?]
+
+      (if (param ${type}) (result ${type})
+        (then
+          ;; Continue looping - branch back with the ${type} value
+          (br $continue)
+        )
+        (else
+          ;; Exit - return the ${type} value
+        )
+      )
+    )
+  )
+)
+`;
+}
+
+const watF32 = generateWat('f32', '3.14159274101257324');
+const watF64 = generateWat('f64', '2.718281828459045');
+
+// v128 test - uses i32x4.splat and i32x4.add for vector operations
+// Returns the sum of all lanes to verify correctness
+const watV128 = `
+(module
+  (global $factor (mut v128) (v128.const i32x4 1 1 1 1))
+
+  (func (export "test") (param $iterations i32) (result i32)
+    (local $counter i32)
+    (local $result v128)
+
+    ;; Initialize counter
+    (local.set $counter (i32.const 0))
+
+    ;; Push initial v128 value onto expression stack (42, 43, 44, 45)
+    (v128.const i32x4 42 43 44 45)
+
+    ;; Loop that keeps the v128 value on the expression stack
+    (loop $continue (param v128) (result v128)
+      ;; Stack: [v128_value]
+
+      ;; Add factor to keep it live and prevent constant folding
+      (global.get $factor)
+      (i32x4.add)
+      ;; Stack: [v128_value + (1,1,1,1)]
+
+      ;; Increment and check counter
+      (local.set $counter (i32.add (local.get $counter) (i32.const 1)))
+      (local.get $counter)
+      (local.get $iterations)
+      (i32.lt_u)
+      ;; Stack: [v128_value, continue?]
+
+      (if (param v128) (result v128)
+        (then
+          ;; Continue looping - branch back with the v128 value
+          (br $continue)
+        )
+        (else
+          ;; Exit - return the v128 value
+        )
+      )
+    )
+
+    ;; Store result for lane extraction
+    (local.set $result)
+
+    ;; Return sum of all 4 lanes: (42 + n) + (43 + n) + (44 + n) + (45 + n)
+    ;; where n = iterations
+    (i32.add
+      (i32.add
+        (i32x4.extract_lane 0 (local.get $result))
+        (i32x4.extract_lane 1 (local.get $result))
+      )
+      (i32.add
+        (i32x4.extract_lane 2 (local.get $result))
+        (i32x4.extract_lane 3 (local.get $result))
+      )
+    )
+  )
+)
+`;
+
+async function testFloatType(wat, expected, typeName, tolerance) {
+    const instance = await instantiate(wat, {});
+    const { test } = instance.exports;
+
+    const result = test(wasmTestLoopCount);
+
+    assert.truthy(!isNaN(result), `${typeName} result should not be NaN`);
+    assert.truthy(isFinite(result), `${typeName} result should be finite`);
+    assert.truthy(Math.abs(result - expected) < tolerance,
+                  `${typeName} result should be approximately ${expected}, got ${result}`);
+}
+
+async function testV128Type(wat, expected, typeName) {
+    const instance = await instantiate(wat, {});
+    const { test } = instance.exports;
+
+    const result = test(wasmTestLoopCount);
+
+    // Result is the sum of all 4 lanes
+    assert.eq(result, expected,
+              `${typeName} sum should be ${expected}, got ${result}`);
+}
+
+await assert.asyncTest(testFloatType(watF32, 3.1415927410125732, "f32", 0.0001));
+await assert.asyncTest(testFloatType(watF64, 2.718281828459045, "f64", 0.0000001));
+// Expected: sum of (42 + n, 43 + n, 44 + n, 45 + n) where n = wasmTestLoopCount
+// = (42 + 43 + 44 + 45) + 4 * wasmTestLoopCount = 174 + 4 * wasmTestLoopCount
+await assert.asyncTest(testV128Type(watV128, 174 + 4 * wasmTestLoopCount, "v128"));

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1178,12 +1178,12 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmLoopOSREnterBBQJIT, void, (Probe:
         } else if (value.isFPR()) {
             if (type.isVector()) {
 #if CPU(X86_64) || CPU(ARM64)
-                *std::bit_cast<v128_t*>(&context.vector(value.fpr())) = *std::bit_cast<v128_t*>(bufferSlot);
+                context.vector(value.fpr()) = *std::bit_cast<v128_t*>(bufferSlot);
 #else
                 UNREACHABLE_FOR_PLATFORM();
 #endif
             } else
-                context.fpr(value.fpr()) = *bufferSlot;
+                context.fpr(value.fpr()) = *std::bit_cast<double*>(bufferSlot);
         } else if (value.isStack()) {
             auto* baseStore = std::bit_cast<uint8_t*>(context.fp()) + value.offsetFromFP();
             switch (type.kind()) {


### PR DESCRIPTION
#### 5c9ea3c73f316b62cd56eb12d4599bb6e2a6e89f
<pre>
[JSC] Wasm: Fix loop OSR entry to BBQ with live FPRs
<a href="https://bugs.webkit.org/show_bug.cgi?id=301435">https://bugs.webkit.org/show_bug.cgi?id=301435</a>
<a href="https://rdar.apple.com/163350385">rdar://163350385</a>

Reviewed by Yusuke Suzuki.

The operationWasmLoopOSREnterBBQJIT code for loading FPRs is incorrect.
It interprets the bytes holding the register value as an integer and
then implicitly converts that to double, which will be some &quot;random&quot; value.

Instead, we should interpret the bytes as a double and load that value
into the FPR.

Added a test that demonstrates this correctness issue and verifies
the v128 case as well (which was not buggy but had extraneous casting).

Test: JSTests/wasm/stress/osr-entry-live-fpr.js
* JSTests/wasm/stress/osr-entry-live-fpr.js: Added.
(generateWat):
(async testFloatType):
(async testV128Type):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/302112@main">https://commits.webkit.org/302112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c20b2886df9fe4c94ae9cef76ce7920821cc7d21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79537 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3e0f1561-13c8-4753-96a7-28bd4f077f52) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/180 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97463 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65359 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aef2fa20-10d4-469c-a319-6caa8c4ac45f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/121 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114692 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/78031 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests (cancelled)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4d6ca0b2-c667-4e72-8e60-9c73dc3ffa90) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32801 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78705 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120070 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108482 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137879 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126486 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105992 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105728 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/125 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29594 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52336 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20009 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/210 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/61667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159507 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/129 "Built successfully") | | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39819 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Found 8 jsc stress test failures: wasm.yaml/wasm/stress/osr-entry-live-fpr.js.default-wasm, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-bbq, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-collect-continuously, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-eager ...; Compiled JSC; jscore-tests (cancelled)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/206 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/170 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->