### PR TITLE
fast/animation/request-animation-frame-throttling-aggressiveThermalMitigation.html is a flaky failure

### DIFF
--- a/LayoutTests/fast/animation/request-animation-frame-throttling-aggressiveThermalMitigation.html
+++ b/LayoutTests/fast/animation/request-animation-frame-throttling-aggressiveThermalMitigation.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ RespondToThermalPressureAggressively=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ RespondToThermalPressureAggressively=true PreferPageRenderingUpdatesNear60FPSEnabled=true ] -->
 <html>
 <body>
     <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2557,8 +2557,6 @@ webgl/2.0.y/conformance/glsl/bugs/sampler-array-using-loop-index.html [ Pass Fai
 webgl/2.0.y/conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html [ Pass Failure ]
 inspector/timeline/timeline-event-CancelAnimationFrame.html [ Pass Crash ]
 
-webkit.org/b/300994 fast/animation/request-animation-frame-throttling-aggressiveThermalMitigation.html [ Pass Failure ]
-
 webkit.org/b/300997 webrtc/filtering-ice-candidate-after-reload.html [ Pass Failure ]
 
 # https://bugs.webkit.org/show_bug.cgi?id=300996 [ macOS Tahoe ] 4 fast/forms tests (layout-tests) are constant image failures

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2769,7 +2769,7 @@ void Page::handleThermalMitigationChange(bool thermalMitigationEnabled)
 
     m_throttlingReasons.set(ThrottlingReason::ThermalMitigation, thermalMitigationEnabled);
 
-    if (settings().respondToThermalPressureAggressively()) {
+    if (settings().respondToThermalPressureAggressively() && canUpdateThrottlingReason(ThrottlingReason::AggressiveThermalMitigation)) {
         m_throttlingReasons.set(ThrottlingReason::AggressiveThermalMitigation, thermalMitigationEnabled);
         if (CheckedPtr scheduler = existingRenderingUpdateScheduler())
             scheduler->adjustRenderingUpdateFrequency();


### PR DESCRIPTION
#### a110c773559112509626b3e65047a7a951fa9962
<pre>
fast/animation/request-animation-frame-throttling-aggressiveThermalMitigation.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=301438">https://bugs.webkit.org/show_bug.cgi?id=301438</a>
<a href="https://rdar.apple.com/162876219">rdar://162876219</a>

Reviewed by Per Arne Vollan.

Since the test compares the expected animation frame rate to HalfSpeedThrottlingFramesPerSecond (30
FPS), lock the test page&apos;s FPS to FullSpeedFramesPerSecond (60 FPS).

* LayoutTests/fast/animation/request-animation-frame-throttling-aggressiveThermalMitigation.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::handleThermalMitigationChange):

Canonical link: <a href="https://commits.webkit.org/302173@main">https://commits.webkit.org/302173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d479067fb55bfcac03e20d809630c96d8b7ba80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79549 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9bd5737a-a10a-4a6b-9f2e-94476e64afb0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97472 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65368 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c57985c1-5df3-43b2-bd44-cf3d5e366d28) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114698 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78039 "Found 2 new API test failures: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp, WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5e6c32a3-8e79-42b6-9383-2b6b8a6aed5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/135 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32806 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78717 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108504 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137896 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105999 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105735 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26998 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/132 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29599 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52356 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/223 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61686 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/142 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/218 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/183 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->