### PR TITLE
Optimize RenderLayerScrollableArea::updateScrollInfoAfterLayout()

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -279,6 +279,19 @@ static LayoutUnit computeScrollSnapAlignOffset(LayoutUnit minLocation, LayoutUni
     }
 }
 
+bool hasScrollSnappedBoxes(const RenderBox& scrollingElementBox)
+{
+    auto scrollSnapTypeContainer = scrollingElementBox.style().scrollSnapType().tryContainer();
+    if (!scrollSnapTypeContainer)
+        return false;
+
+    auto& boxesWithScrollSnapPositions = scrollingElementBox.view().boxesWithScrollSnapPositions();
+    if (boxesWithScrollSnapPositions.isEmptyIgnoringNullReferences())
+        return false;
+
+    return true;
+}
+
 void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const RenderBox& scrollingElementBox, const RenderStyle& scrollingElementStyle, LayoutRect viewportRectInBorderBoxCoordinates, WritingMode writingMode, Element* focusedElement)
 {
     auto scrollSnapTypeContainer = scrollingElementStyle.scrollSnapType().tryContainer();

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
@@ -103,6 +103,7 @@ WEBCORE_EXPORT std::pair<LayoutUnit, std::optional<unsigned>> LayoutScrollSnapOf
 // Update the snap offsets for this scrollable area, given the RenderBox of the scroll container, the RenderStyle
 // which defines the scroll-snap properties, and the viewport rectangle with the origin at the top left of
 // the scrolling container's border box.
+bool hasScrollSnappedBoxes(const RenderBox& scrollingElementBox);
 void updateSnapOffsetsForScrollableArea(ScrollableArea&, const RenderBox& scrollingElementBox, const RenderStyle& scrollingElementStyle, LayoutRect viewportRectInBorderBoxCoordinates, WritingMode, Element*);
 
 template <typename T> WTF::TextStream& operator<<(WTF::TextStream& ts, SnapOffset<T> offset)

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -240,11 +240,6 @@ public:
 
     void updateAllScrollbarRelatedStyle();
 
-    LayoutUnit overflowTop() const;
-    LayoutUnit overflowBottom() const;
-    LayoutUnit overflowLeft() const;
-    LayoutUnit overflowRight() const;
-
     RenderLayer::OverflowControlRects overflowControlsRects() const;
 
     bool overflowControlsIntersectRect(const IntRect& localRect) const;


### PR DESCRIPTION
#### 2e04d7d6288ed4c152b8cfe3e6f1820fe2449c05
<pre>
Optimize RenderLayerScrollableArea::updateScrollInfoAfterLayout()
<a href="https://bugs.webkit.org/show_bug.cgi?id=301441">https://bugs.webkit.org/show_bug.cgi?id=301441</a>
<a href="https://rdar.apple.com/163357644">rdar://163357644</a>

Reviewed by Alan Baradlay.

Reduces the amount of time in `RenderLayerScrollableArea::updateScrollInfoAfterLayout()` by
about 50% on a Speedo subtest.

Avoid calling `layoutOverflowRect()` twice, and `clientWidth()`/`clientHeight()` multiple
times.

Avoid the call to `clampScrollOffset()` for the most common case of scrollOffset == minimumScrollOffset(),
which is cheap to compute. `maximumScrollOffset()` is more expensive, because it computes `viewSize()`.

Avoid computing all the inputs to `updateSnapOffsetsForScrollableArea()` for the common case of
no snapping.

More CheckedPtr.

* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::hasScrollSnappedBoxes): A helper to quickly know if we need
to do any scroll snapping work.
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::computeScrollDimensions):
(WebCore::RenderLayerScrollableArea::computeScrollOrigin):
(WebCore::RenderLayerScrollableArea::updateScrollbarsAfterLayout):
(WebCore::RenderLayerScrollableArea::updateScrollbarSteps):
(WebCore::RenderLayerScrollableArea::updateScrollInfoAfterLayout):
(WebCore::RenderLayerScrollableArea::updateSnapOffsets):
(WebCore::RenderLayerScrollableArea::overflowTop const): Deleted.
(WebCore::RenderLayerScrollableArea::overflowBottom const): Deleted.
(WebCore::RenderLayerScrollableArea::overflowLeft const): Deleted.
(WebCore::RenderLayerScrollableArea::overflowRight const): Deleted.
* Source/WebCore/rendering/RenderLayerScrollableArea.h:

Canonical link: <a href="https://commits.webkit.org/302124@main">https://commits.webkit.org/302124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2ab195a2abd1b34b24585010e4bd7cf281a9f78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79558 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/42e594dd-49ca-4af3-8b35-264fa33761f0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97482 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65375 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/308344c8-8a41-40b3-9656-ae5289353d15) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78049 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32815 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78727 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137906 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/191 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/187 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/backdrop-filter-animated.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106013 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105750 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26963 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29611 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52366 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/233 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61700 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/154 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/230 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/197 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->