### PR TITLE
Enable safe scrollable overflow of scrollable containing blocks by default

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7476,7 +7476,6 @@ webkit.org/b/282024 fast/text/text-box-edge-with-margin-padding-border-simple.ht
 
 # general failures
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-012.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-with-position.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/transform-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/transform-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/transform-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-overflow-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-overflow-001-expected.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<title>Reference: position-area normal alignment overflow in a scrollable container</title>
+<style>
+  .container {
+    position: relative;
+    overflow: scroll;
+    scrollbar-width: none;
+    width: 100px;
+    height: 120px;
+    border: solid;
+    margin: 1em;
+    float: left;
+  }
+  .anchor {
+    border: solid blue 10px;
+    inset: 0;
+    place-self: center;
+    position: absolute;
+  }
+  .test {
+    border: solid 5px #0084;
+    box-sizing: border-box;
+    position: absolute;
+  }
+  .start-inline {
+    margin-inline: 0 -10px;
+  }
+  .start-block {
+    margin-block: 0 -10px;
+  }
+  .end-inline {
+    margin-inline: -10px 0;
+  }
+  .end-block {
+    margin-block: -10px 0;
+  }
+  .center-inline {
+    margin-inline: -5px;
+  }
+  .center-block {
+    margin-block: -5px;
+  }
+</style>
+
+<div class="container" title="TB LTR">
+  <div>
+    <div class="anchor"></div>
+    <div class="test start-inline start-block" style="inset: 0 60px 70px 0"></div>
+    <div class="test start-inline start-block" style="inset: 70px 0 0 60px"></div>
+    <div class="test center-inline center-block" style="inset: 50px 40px 50px 40px"></div>
+  </div>
+</div>
+
+<div class="container" title="TB LTR">
+  <div class="anchor"></div>
+  <div class="test start-inline start-block" style="inset: 0 0 70px"></div>
+  <div class="test start-inline start-block" style="inset: 70px 0 0"></div>
+  <div class="test center-inline start-block" style="inset: 0 40px"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-rl" title="RL TTB">
+  <div class="anchor"></div>
+  <div class="test start-inline start-block" style="inset: 0 60px 70px 0"></div>
+  <div class="test start-inline start-block" style="inset: 70px 0 0 60px"></div>
+  <div class="test center-inline center-block" style="inset: 50px 40px 50px 40px"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-rl" title="RL TTB">
+  <div class="anchor"></div>
+  <div class="test start-inline start-block" style="inset: 0 0 70px"></div>
+  <div class="test start-inline start-block" style="inset: 70px 0 0"></div>
+  <div class="test center-block start-inline" style="inset: 0 40px"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-lr; direction: rtl;" title="LR BTT">
+  <div class="anchor"></div>
+  <div class="test start-inline start-block" style="inset: 0 60px 70px 0"></div>
+  <div class="test start-inline start-block" style="inset: 70px 0 0 60px"></div>
+  <div class="test center-inline center-block" style="inset: 50px 40px 50px 40px"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-lr; direction: rtl;" title="LR BTT">
+  <div class="anchor"></div>
+  <div class="test start-inline start-block" style="inset: 0 0 70px"></div>
+  <div class="test start-inline start-block" style="inset: 70px 0 0"></div>
+  <div class="test center-block start-inline" style="inset: 0 40px"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-overflow-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-overflow-001-ref.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<title>Reference: position-area normal alignment overflow in a scrollable container</title>
+<style>
+  .container {
+    position: relative;
+    overflow: scroll;
+    scrollbar-width: none;
+    width: 100px;
+    height: 120px;
+    border: solid;
+    margin: 1em;
+    float: left;
+  }
+  .anchor {
+    border: solid blue 10px;
+    inset: 0;
+    place-self: center;
+    position: absolute;
+  }
+  .test {
+    border: solid 5px #0084;
+    box-sizing: border-box;
+    position: absolute;
+  }
+  .start-inline {
+    margin-inline: 0 -10px;
+  }
+  .start-block {
+    margin-block: 0 -10px;
+  }
+  .end-inline {
+    margin-inline: -10px 0;
+  }
+  .end-block {
+    margin-block: -10px 0;
+  }
+  .center-inline {
+    margin-inline: -5px;
+  }
+  .center-block {
+    margin-block: -5px;
+  }
+</style>
+
+<div class="container" title="TB LTR">
+  <div>
+    <div class="anchor"></div>
+    <div class="test start-inline start-block" style="inset: 0 60px 70px 0"></div>
+    <div class="test start-inline start-block" style="inset: 70px 0 0 60px"></div>
+    <div class="test center-inline center-block" style="inset: 50px 40px 50px 40px"></div>
+  </div>
+</div>
+
+<div class="container" title="TB LTR">
+  <div class="anchor"></div>
+  <div class="test start-inline start-block" style="inset: 0 0 70px"></div>
+  <div class="test start-inline start-block" style="inset: 70px 0 0"></div>
+  <div class="test center-inline start-block" style="inset: 0 40px"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-rl" title="RL TTB">
+  <div class="anchor"></div>
+  <div class="test start-inline start-block" style="inset: 0 60px 70px 0"></div>
+  <div class="test start-inline start-block" style="inset: 70px 0 0 60px"></div>
+  <div class="test center-inline center-block" style="inset: 50px 40px 50px 40px"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-rl" title="RL TTB">
+  <div class="anchor"></div>
+  <div class="test start-inline start-block" style="inset: 0 0 70px"></div>
+  <div class="test start-inline start-block" style="inset: 70px 0 0"></div>
+  <div class="test center-block start-inline" style="inset: 0 40px"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-lr; direction: rtl;" title="LR BTT">
+  <div class="anchor"></div>
+  <div class="test start-inline start-block" style="inset: 0 60px 70px 0"></div>
+  <div class="test start-inline start-block" style="inset: 70px 0 0 60px"></div>
+  <div class="test center-inline center-block" style="inset: 50px 40px 50px 40px"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-lr; direction: rtl;" title="LR BTT">
+  <div class="anchor"></div>
+  <div class="test start-inline start-block" style="inset: 0 0 70px"></div>
+  <div class="test start-inline start-block" style="inset: 70px 0 0"></div>
+  <div class="test center-block start-inline" style="inset: 0 40px"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-overflow-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-overflow-001.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<title>Test: position-area normal alignment overflow in a scrollable container</title>
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#auto-safety-position">
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#position-area-alignment">
+<meta name="assert" content="Test passes if alignment overflow is kept away from the unscrollable region (only).">
+<style>
+  .container {
+    position: relative;
+    overflow: scroll;
+    scrollbar-width: none;
+    width: 100px;
+    height: 120px;
+    border: solid;
+    margin: 1em;
+    float: left;
+  }
+  .anchor {
+    border: solid blue 10px;
+    anchor-name: --foo;
+    inset: 0;
+    place-self: center;
+    position: absolute;
+  }
+  .test {
+    border: solid 5px #0084;
+    position: absolute;
+    position-anchor: --foo;
+    width: 100%;
+    height: 100%;
+  }
+</style>
+
+<div class="container" title="TB LTR">
+  <div class="anchor"></div>
+  <div class="test" style="position-area: top left"></div>
+  <div class="test" style="position-area: bottom right"></div>
+  <div class="test" style="position-area: center"></div>
+</div>
+
+<div class="container" title="TB LTR">
+  <div class="anchor"></div>
+  <div class="test" style="position-area: top"></div>
+  <div class="test" style="position-area: bottom"></div>
+  <div class="test" style="position-area: span-all center"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-rl" title="RL TTB">
+  <div class="anchor"></div>
+  <div class="test" style="position-area: top left"></div>
+  <div class="test" style="position-area: bottom right"></div>
+  <div class="test" style="position-area: center"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-rl" title="RL TTB">
+  <div class="anchor"></div>
+  <div class="test" style="position-area: top"></div>
+  <div class="test" style="position-area: bottom"></div>
+  <div class="test" style="position-area: center span-all"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-lr; direction: rtl;" title="LR BTT">
+  <div class="anchor"></div>
+  <div class="test" style="position-area: top left"></div>
+  <div class="test" style="position-area: bottom right"></div>
+  <div class="test" style="position-area: center"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-lr; direction: rtl;" title="LR BTT">
+  <div class="anchor"></div>
+  <div class="test" style="position-area: top"></div>
+  <div class="test" style="position-area: bottom"></div>
+  <div class="test" style="position-area: center span-all"></div>
+</div>

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -98,6 +98,7 @@ private:
     void captureGridArea();
     void captureAnchorGeometry();
     LayoutRange adjustForPositionArea(const LayoutRange rangeToAdjust, const LayoutRange anchorArea, const BoxAxis containerAxis);
+    std::pair<bool, bool> containerAllowsInfiniteOverflow() const;
 
     bool needsGridAreaAdjustmentBeforeStaticPositioning() const;
     std::optional<LayoutUnit> remainingSpaceForStaticAlignment(LayoutUnit itemSize) const;


### PR DESCRIPTION
#### c16b70c96c646bfce4101af8807a1f1e6067a6a6
<pre>
Enable safe scrollable overflow of scrollable containing blocks by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=300837">https://bugs.webkit.org/show_bug.cgi?id=300837</a>
<a href="https://rdar.apple.com/162722820">rdar://162722820</a>

Reviewed by Alan Baradlay.

In <a href="https://github.com/w3c/csswg-drafts/issues/12106">https://github.com/w3c/csswg-drafts/issues/12106</a> the CSSWG resolved to allow
positioned boxes in scrollable containing blocks to overflow in the scrollable
directions by default. This changes the default handling of alignment overflow
to limit by the containing block&apos;s start edges only.

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-overflow-001-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-overflow-001.html
* LayoutTests/TestExpectations:

Pass one more test.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-overflow-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-overflow-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-overflow-001.html: Added.

Add a more comprehensive and focused test for this behavior.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::resolveAlignmentShift const):

Update alignment limit logic to check for allowable overflow.

(WebCore::PositionedLayoutConstraints::containerAllowsInfiniteOverflow const):
* Source/WebCore/rendering/PositionedLayoutConstraints.h:

Using RenderBox::allowedLayoutOverflow() ensures we stay synchronized with
however the container handles overflow. Add a helper method to extract the
correct axis.

Canonical link: <a href="https://commits.webkit.org/302259@main">https://commits.webkit.org/302259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab9cecf5eabd2f6f01733f243b3bc213c0a83a5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135914 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79955 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a37f8cdd-956a-494d-bcad-f97867bd8815) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97838 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/59765be7-f1af-49d2-b651-de06ed606bc0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78450 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8bd33538-dd6a-4eb1-ac2f-13440d7ed35a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33255 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79197 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138363 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106374 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106188 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27052 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/527 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30027 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/52978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/683 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63883 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/565 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/637 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->