### PR TITLE
[visionOS] We do not need to teardown the inline layer when going into docking mode

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -174,14 +174,15 @@ private:
     Ref<GenericPromise> ensureLayerOrVideoRenderer();
     void ensureLayer();
     void destroyLayer();
-    void destroyVideoLayerIfNeeded();
     void ensureVideoRenderer();
     void destroyVideoRenderer();
+    void destroyExpiringVideoRenderersIfNeeded();
     Ref<GenericPromise> setVideoRenderer(WebSampleBufferVideoRendering *);
     void configureHasAvailableVideoFrameCallbackIfNeeded();
     void configureLayerOrVideoRenderer(WebSampleBufferVideoRendering *);
     Ref<GenericPromise> stageVideoRenderer(WebSampleBufferVideoRendering *);
     void destroyVideoTrack();
+    void removeRendererFromSynchronizerIfNeeded(id);
 
     enum class AcceleratedVideoMode: uint8_t {
         Layer = 0,
@@ -310,6 +311,13 @@ private:
     RetainPtr<AVSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
     RetainPtr<AVSampleBufferVideoRenderer> m_sampleBufferVideoRenderer;
     RefPtr<VideoMediaSampleRenderer> m_videoRenderer;
+    Vector<RetainPtr<AVSampleBufferVideoRenderer>> m_expiringSampleBufferVideoRenderers;
+    enum class SampleBufferLayerState : uint8_t {
+        AddedToSynchronizer,
+        PendingRemovalFromSynchronizer,
+        RemovedFromSynchronizer
+    };
+    SampleBufferLayerState m_sampleBufferDisplayLayerState { SampleBufferLayerState::RemovedFromSynchronizer };
     bool m_renderingCanBeAccelerated { false };
     bool m_visible { false };
     IntSize m_presentationSize;
@@ -346,7 +354,6 @@ private:
     String m_spatialTrackingLabel;
 #endif
 
-    bool m_needsDestroyVideoLayer { false };
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     RetainPtr<FigVideoTargetRef> m_videoTarget;
 #endif


### PR DESCRIPTION
#### a538d16e607844ee32de2443f414d1dfa9ddc718
<pre>
[visionOS] We do not need to teardown the inline layer when going into docking mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=301442">https://bugs.webkit.org/show_bug.cgi?id=301442</a>
<a href="https://rdar.apple.com/163362289">rdar://163362289</a>

Reviewed by Jer Noble.

To speed up the transition between figVideoTarget and AVSampleBufferDisplayLayer
we do not tear-down the AVSampleBufferDisplayLayer, instead we only remove it
from the synchronizer.
When we exit docking mode, we directly re-use this AVSBDL and start enqueueing
frame directly into it. This allows to reduce slightly the motion-hiccup
happening when exiting docking.

Additionally, in 302104@main we used a timer to determine when to release
the AVSampleBufferVideoRenderer holding the figVideoTarget.
Instead we use the signal from the UI process indicating that we have fully
exited docking, and the figVideoTarget is no longer visible.

Manually tested, testing infrastructure doesn&apos;t entering/exiting docking mode.
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::isInFullscreenOrPictureInPictureChanged):
(WebCore::AudioVideoRendererAVFObjC::destroyAudioRenderer):
(WebCore::AudioVideoRendererAVFObjC::ensureLayer):
(WebCore::AudioVideoRendererAVFObjC::destroyLayer):
(WebCore::AudioVideoRendererAVFObjC::ensureVideoRenderer):
(WebCore::AudioVideoRendererAVFObjC::destroyVideoRenderer):
(WebCore::AudioVideoRendererAVFObjC::destroyExpiringVideoRenderersIfNeeded):
(WebCore::AudioVideoRendererAVFObjC::configureLayerOrVideoRenderer):
(WebCore::AudioVideoRendererAVFObjC::stageVideoRenderer):
(WebCore::AudioVideoRendererAVFObjC::removeRendererFromSynchronizerIfNeeded):
(WebCore::AudioVideoRendererAVFObjC::destroyVideoLayerIfNeeded): Deleted.

Canonical link: <a href="https://commits.webkit.org/302155@main">https://commits.webkit.org/302155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a4660c79095fd972d514816279e21e0e2dbea0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79661 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/596e3cc2-601d-4a81-b518-c4f90e1a301c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/328 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65463 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/289097a6-70cc-48d8-b08a-005a69462f91) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/238 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/114824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78138 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b571b029-32b2-4431-b959-cf66097e0a88) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32932 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78845 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138024 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106096 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105877 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26983 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/241 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29720 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52552 "Hash 8a4660c7 for PR 52972 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/354 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/62439 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/261 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/334 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/319 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->