### PR TITLE
[TAPI] libpas headers emit warnings on arm64_32

### DIFF
--- a/Source/JavaScriptCore/API/ExtraSymbolsForTAPI.h
+++ b/Source/JavaScriptCore/API/ExtraSymbolsForTAPI.h
@@ -40,3 +40,21 @@ namespace WTF {
 // old that all supported versions of Safari have the change.
 WTF_EXPORT_PRIVATE unsigned weakRandomUint32();
 }
+
+// MARK: bmalloc
+
+#if PLATFORM(WATCHOS) && BENABLE(LIBPAS)
+// On watchOS, libpas is disabled for arm64_32 and its headers do not parse
+// correctly, so we hide libpas headers from TAPI. But this hides the headers
+// on all architectures, so we need to redeclare libpas's API surface here.
+extern "C" {
+BEXPORT extern bool pas_system_heap_is_enabled(void);
+BEXPORT extern void* pas_system_heap_malloc(void);
+BEXPORT extern void* pas_system_heap_memalign(void);
+BEXPORT extern void* pas_system_heap_realloc(void);
+BEXPORT extern void* pas_system_heap_malloc_compact(void);
+BEXPORT extern void* pas_system_heap_memalign_compact(void);
+BEXPORT extern void* pas_system_heap_realloc_compact(void);
+BEXPORT extern void pas_system_heap_free(void);
+}
+#endif

--- a/Source/JavaScriptCore/Configurations/JavaScriptCore.xcconfig
+++ b/Source/JavaScriptCore/Configurations/JavaScriptCore.xcconfig
@@ -107,6 +107,11 @@ OTHER_TAPI_FLAGS_STATICLIBS_NO = -filelist $(BUILT_PRODUCTS_DIR)/usr/local/inclu
 OTHER_TAPI_FLAGS_STATICLIBS_YES = -filelist $(DERIVED_FILE_DIR)/bmalloc.json -filelist $(DERIVED_FILE_DIR)/WTF.json
 OTHER_TAPI_FLAGS_SPI_CHECKING_YES = -sdkdb-output-dir $(BUILT_PRODUCTS_DIR)/SDKDB;
 
+// libpas is disabled on arm64_32 only, and its headers do not parse correctly
+// on that architecture. Hide them from TAPI for the entire platform.
+// ExtraSymbolsForTAPI.h declares the symbols that *do* exist on arm64e watchOS.
+OTHER_TAPI_FLAGS[sdk=watch*] = $(inherited) -exclude-private-header **/*_heap.h -exclude-private-header **/*_heap_config.h -exclude-private-header **/*_heap_innards.h -exclude-private-header **/*_heap_ref.h -exclude-private-header **/*_heap_config_root_data.h -exclude-private-header **/bmalloc_type.h -exclude-private-header **/bmalloc_heap_inlines.h -exclude-private-header **/pas_*.h;
+
 WK_AUDIT_SPI_ALLOWLISTS = $(SRCROOT)/Configurations/AllowedSPI.toml $(SRCROOT)/Configurations/AllowedSPI-legacy.toml $(WK_AUDIT_SPI_ALLOWLISTS_$(USE_INTERNAL_SDK));
 WK_AUDIT_SPI_ALLOWLISTS_YES = $(WK_WEBKITADDITIONS_HEADERS_FOLDER_PATH)/AllowedSPI/AllowedSPI-JavaScriptCore.toml;
 


### PR DESCRIPTION
#### 666bc05ee5bd89e6e6bf060fdd661e26a86e01ff
<pre>
[TAPI] libpas headers emit warnings on arm64_32
<a href="https://bugs.webkit.org/show_bug.cgi?id=301448">https://bugs.webkit.org/show_bug.cgi?id=301448</a>
<a href="https://rdar.apple.com/163366617">rdar://163366617</a>

Reviewed by NOBODY (OOPS!).

libpas is disabled on this architecture, but we still pass its headers
to TAPI for InstallAPI verification, because they *are* used when
building arm64e. The result is that TAPI emits warnings when parsing for
arm64_32, like:

    In file included from WebKitBuild/Release-watchos/usr/local/include/bmalloc/pas_segregated_size_directory.h:34:
    WebKitBuild/Release-watchos/usr/local/include/bmalloc/pas_compact_tagged_page_granule_use_count_ptr.h:34:1: warning: shift count &gt;= width of type [-Wshift-count-overflow]
       34 | PAS_DEFINE_COMPACT_TAGGED_PTR(pas_page_granule_use_count*,
          | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       35 |                               pas_compact_tagged_page_granule_use_count_ptr);
          |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

It is not possible to give TAPI different headers for different
architectures. Instead, work around by excluding libpas headers from
TAPI on *all* builds of watchOS, and then redeclaring the actual API
surface in ExtraSymbolsForTAPI.

This trades accuracy of the InstallAPI verification on arm64e watchOS
for a cleanup on arm64_32.

* Source/JavaScriptCore/API/ExtraSymbolsForTAPI.h:
* Source/JavaScriptCore/Configurations/JavaScriptCore.xcconfig:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/666bc05ee5bd89e6e6bf060fdd661e26a86e01ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135438 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79570 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aca9070b-69dc-4224-ab5c-37b34b3ee128) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97496 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65384 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b74093b3-67cd-4d75-a4f3-3bda1b5ad48a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114723 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78062 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/64f1e1b7-4d39-45ab-a661-28fc3c57b570) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32830 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78748 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120104 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108523 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137927 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126532 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/206 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106024 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105762 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/156 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29622 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52384 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/254 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/61722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159552 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/169 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39828 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/243 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/215 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->