### PR TITLE
Show Largest Contentful Paints in the timeline and event list

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/Timeline.json
+++ b/Source/JavaScriptCore/inspector/protocol/Timeline.json
@@ -31,6 +31,8 @@
                 "CancelAnimationFrame",
                 "FireAnimationFrame",
                 "ObserverCallback",
+                "FirstContentfulPaint",
+                "LargestContentfulPaint",
                 "Screenshot"
             ]
         },

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -55,6 +55,7 @@
 #include "InspectorWorkerAgent.h"
 #include "InstrumentingAgents.h"
 #include "KeyframeEffect.h"
+#include "LargestContentfulPaint.h"
 #include "LoaderStrategy.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
@@ -999,6 +1000,18 @@ void InspectorInstrumentation::performanceMarkImpl(InstrumentingAgents& instrume
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
         timelineAgent->didPerformanceMark(label, timestamp);
+}
+
+void InspectorInstrumentation::didEnqueueFirstContentfulPaintImpl(InstrumentingAgents& instrumentingAgents)
+{
+    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
+        timelineAgent->didEnqueueFirstContentfulPaint();
+}
+
+void InspectorInstrumentation::didEnqueueLargestContentfulPaintImpl(InstrumentingAgents& instrumentingAgents, const LargestContentfulPaint& entry)
+{
+    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
+        timelineAgent->didEnqueueLargestContentfulPaint(entry.element(), entry.size());
 }
 
 void InspectorInstrumentation::consoleStartRecordingCanvasImpl(InstrumentingAgents& instrumentingAgents, CanvasRenderingContext& context, JSC::JSGlobalObject& exec, JSC::JSObject* options)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -82,6 +82,7 @@ class HTTPHeaderMap;
 class InspectorTimelineAgent;
 class InstrumentingAgents;
 class KeyframeEffect;
+class LargestContentfulPaint;
 class LocalFrame;
 class LocalFrameView;
 class NetworkLoadMetrics;
@@ -281,6 +282,9 @@ public:
     static void consoleStopRecordingCanvas(CanvasRenderingContext&);
 
     static void performanceMark(ScriptExecutionContext&, const String&, std::optional<MonotonicTime>);
+
+    static void didEnqueueFirstContentfulPaint(ScriptExecutionContext&);
+    static void didEnqueueLargestContentfulPaint(ScriptExecutionContext&, const LargestContentfulPaint&);
 
     static void didRequestAnimationFrame(ScriptExecutionContext&, int callbackId);
     static void didCancelAnimationFrame(ScriptExecutionContext&, int callbackId);
@@ -484,6 +488,8 @@ private:
     static void consoleStopRecordingCanvasImpl(InstrumentingAgents&, CanvasRenderingContext&);
 
     static void performanceMarkImpl(InstrumentingAgents&, const String& label, std::optional<MonotonicTime>);
+    static void didEnqueueFirstContentfulPaintImpl(InstrumentingAgents&);
+    static void didEnqueueLargestContentfulPaintImpl(InstrumentingAgents&, const LargestContentfulPaint&);
 
     static void didRequestAnimationFrameImpl(InstrumentingAgents&, int callbackId, ScriptExecutionContext&);
     static void didCancelAnimationFrameImpl(InstrumentingAgents&, int callbackId);
@@ -1658,6 +1664,20 @@ inline void InspectorInstrumentation::performanceMark(ScriptExecutionContext& co
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(context))
         performanceMarkImpl(*agents, label, WTFMove(startTime));
+}
+
+inline void InspectorInstrumentation::didEnqueueFirstContentfulPaint(ScriptExecutionContext& context)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(context))
+        didEnqueueFirstContentfulPaintImpl(*agents);
+}
+
+inline void InspectorInstrumentation::didEnqueueLargestContentfulPaint(ScriptExecutionContext& context, const LargestContentfulPaint& entry)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(context))
+        didEnqueueLargestContentfulPaintImpl(*agents, entry);
 }
 
 inline void InspectorInstrumentation::didRequestAnimationFrame(ScriptExecutionContext& scriptExecutionContext, int callbackId)

--- a/Source/WebCore/inspector/TimelineRecordFactory.cpp
+++ b/Source/WebCore/inspector/TimelineRecordFactory.cpp
@@ -126,6 +126,15 @@ Ref<JSON::Object> TimelineRecordFactory::createTimeStampData(const String& messa
     return data;
 }
 
+Ref<JSON::Object> TimelineRecordFactory::createLargestContentfulPaintData(Inspector::Protocol::DOM::NodeId nodeId, unsigned area)
+{
+    Ref<JSON::Object> data = JSON::Object::create();
+    data->setInteger("area"_s, area);
+    if (nodeId)
+        data->setInteger("nodeId"_s, nodeId);
+    return data;
+}
+
 Ref<JSON::Object> TimelineRecordFactory::createAnimationFrameData(int callbackId)
 {
     Ref<JSON::Object> data = JSON::Object::create();

--- a/Source/WebCore/inspector/TimelineRecordFactory.h
+++ b/Source/WebCore/inspector/TimelineRecordFactory.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include <JavaScriptCore/DebuggerPrimitives.h>
+#include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/Forward.h>
 #include <wtf/JSONValues.h>
 #include <wtf/Seconds.h>
@@ -55,6 +56,7 @@ public:
     static Ref<JSON::Object> createTimerInstallData(int timerId, Seconds timeout, bool singleShot);
     static Ref<JSON::Object> createEvaluateScriptData(const String&, int lineNumber, int columnNumber);
     static Ref<JSON::Object> createTimeStampData(const String&);
+    static Ref<JSON::Object> createLargestContentfulPaintData(Inspector::Protocol::DOM::NodeId, unsigned area);
     static Ref<JSON::Object> createAnimationFrameData(int callbackId);
     static Ref<JSON::Object> createObserverCallbackData(const String& callbackType);
     static Ref<JSON::Object> createPaintData(const FloatQuad&);

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
@@ -45,6 +45,7 @@
 
 namespace WebCore {
 
+class Element;
 class Event;
 class FloatQuad;
 class RenderObject;
@@ -78,6 +79,9 @@ enum class TimelineRecordType {
     FireAnimationFrame,
     
     ObserverCallback,
+
+    FirstContentfulPaint,
+    LargestContentfulPaint,
 
     Screenshot,
 };
@@ -116,6 +120,8 @@ public:
     void didEvaluateScript();
     void didTimeStamp(const String& message);
     void didPerformanceMark(const String& label, std::optional<MonotonicTime>);
+    void didEnqueueFirstContentfulPaint();
+    void didEnqueueLargestContentfulPaint(Element*, unsigned area);
     void didRequestAnimationFrame(int callbackId);
     void didCancelAnimationFrame(int callbackId);
     void willFireAnimationFrame(int callbackId);

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -41,6 +41,7 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "ExceptionOr.h"
+#include "InspectorInstrumentation.h"
 #include "LargestContentfulPaint.h"
 #include "LocalFrame.h"
 #include "Logging.h"
@@ -375,6 +376,9 @@ void Performance::setResourceTimingBufferSize(unsigned size)
 
 void Performance::reportFirstContentfulPaint(DOMHighResTimeStamp timestamp)
 {
+    if (RefPtr context = scriptExecutionContext())
+        InspectorInstrumentation::didEnqueueFirstContentfulPaint(*context);
+
     ASSERT(!m_firstContentfulPaint);
     m_firstContentfulPaint = PerformancePaintTiming::createFirstContentfulPaint(timestamp);
     queueEntry(*m_firstContentfulPaint);
@@ -382,6 +386,9 @@ void Performance::reportFirstContentfulPaint(DOMHighResTimeStamp timestamp)
 
 void Performance::enqueueLargestContentfulPaint(Ref<LargestContentfulPaint>&& paintEntry)
 {
+    if (RefPtr context = scriptExecutionContext())
+        InspectorInstrumentation::didEnqueueLargestContentfulPaint(*context, paintEntry.get());
+
     m_largestContentfulPaint = RefPtr { WTFMove(paintEntry) };
     queueEntry(*m_largestContentfulPaint);
 }

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -794,6 +794,7 @@ localizedStrings["Filter Full URL"] = "Filter Full URL";
 localizedStrings["Filter:"] = "Filter:";
 localizedStrings["Find Next (%s)"] = "Find Next (%s)";
 localizedStrings["Find Previous (%s)"] = "Find Previous (%s)";
+localizedStrings["First Contentful Paint"] = "First Contentful Paint";
 /* Flexbox layout section name */
 localizedStrings["Flexbox @ Elements details sidebar"] = "Flexbox";
 localizedStrings["Flows"] = "Flows";
@@ -989,6 +990,7 @@ localizedStrings["Key Path"] = "Key Path";
 /* Label indicating that network activity is being simulated with LTE connectivity */
 localizedStrings["LTE"] = "LTE";
 localizedStrings["Label"] = "Label";
+localizedStrings["Largest Contentful Paint"] = "Largest Contentful Paint";
 localizedStrings["Latency"] = "Latency";
 localizedStrings["Layer Count: %d"] = "Layer Count: %d";
 localizedStrings["Layer Info"] = "Layer Info";

--- a/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
@@ -851,15 +851,26 @@ WI.TimelineManager = class TimelineManager extends WI.Object
 
         case InspectorBackend.Enum.Timeline.EventType.Layout:
             var layoutRecordType = sourceCodeLocation ? WI.LayoutTimelineRecord.EventType.ForcedLayout : WI.LayoutTimelineRecord.EventType.Layout;
-            var quad = new WI.Quad(recordPayload.data.root);
-            return new WI.LayoutTimelineRecord(layoutRecordType, startTime, endTime, stackTrace, sourceCodeLocation, quad);
+            return new WI.LayoutTimelineRecord(layoutRecordType, startTime, endTime, stackTrace, sourceCodeLocation, {
+                quad: new WI.Quad(recordPayload.data.root),
+            });
 
         case InspectorBackend.Enum.Timeline.EventType.Paint:
-            var quad = new WI.Quad(recordPayload.data.clip);
-            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.Paint, startTime, endTime, stackTrace, sourceCodeLocation, quad);
+            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.Paint, startTime, endTime, stackTrace, sourceCodeLocation, {
+                quad: new WI.Quad(recordPayload.data.clip),
+            });
 
         case InspectorBackend.Enum.Timeline.EventType.Composite:
             return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.Composite, startTime, endTime, stackTrace, sourceCodeLocation);
+
+        case InspectorBackend.Enum.Timeline.EventType.FirstContentfulPaint:
+            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.FirstContentfulPaint, startTime, startTime, stackTrace, sourceCodeLocation);
+
+        case InspectorBackend.Enum.Timeline.EventType.LargestContentfulPaint:
+            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.LargestContentfulPaint, startTime, startTime, stackTrace, sourceCodeLocation, {
+                area: recordPayload.data.area,
+                domNode: WI.domManager.nodeForId(recordPayload.data.nodeId),
+            });
 
         case InspectorBackend.Enum.Timeline.EventType.RenderingFrame:
             if (!recordPayload.children || !recordPayload.children.length)

--- a/Source/WebInspectorUI/UserInterface/Images/TypeIcons.svg
+++ b/Source/WebInspectorUI/UserInterface/Images/TypeIcons.svg
@@ -349,6 +349,8 @@
     <g id="Object-light" class="light yellow"><use href="#box"/><use href="#O"/></g>
     <g id="PausedBreakpoint-dark" class="dark red"><use href="#box"/><use href="#P"/></g>
     <g id="PausedBreakpoint-light" class="light red"><use href="#box"/><use href="#P"/></g>
+    <g id="PerformanceEntry-dark" class="dark teal"><use href="#box"/><use href="#P"/></g>
+    <g id="PerformanceEntry-light" class="light teal"><use href="#box"/><use href="#P"/></g>
     <g id="Program-dark" class="dark purple"><use href="#box"/><use href="#S"/></g>
     <g id="Program-light" class="light purple"><use href="#box"/><use href="#S"/></g>
     <g id="PseudoElement-dark" class="dark red"><use href="#box"/><use href="#P"/></g>

--- a/Source/WebInspectorUI/UserInterface/Models/LayoutTimelineRecord.js
+++ b/Source/WebInspectorUI/UserInterface/Models/LayoutTimelineRecord.js
@@ -25,7 +25,7 @@
 
 WI.LayoutTimelineRecord = class LayoutTimelineRecord extends WI.TimelineRecord
 {
-    constructor(eventType, startTime, endTime, stackTrace, sourceCodeLocation, quad)
+    constructor(eventType, startTime, endTime, stackTrace, sourceCodeLocation, {quad, area, domNode} = {})
     {
         super(WI.TimelineRecord.Type.Layout, startTime, endTime, stackTrace, sourceCodeLocation);
 
@@ -37,6 +37,8 @@ WI.LayoutTimelineRecord = class LayoutTimelineRecord extends WI.TimelineRecord
 
         this._eventType = eventType;
         this._quad = quad || null;
+        this._area = area || null;
+        this._domNode = domNode || null;
     }
 
     // Static
@@ -58,6 +60,10 @@ WI.LayoutTimelineRecord = class LayoutTimelineRecord extends WI.TimelineRecord
             return WI.repeatedUIString.timelineRecordPaint();
         case WI.LayoutTimelineRecord.EventType.Composite:
             return WI.repeatedUIString.timelineRecordComposite();
+        case WI.LayoutTimelineRecord.EventType.FirstContentfulPaint:
+            return WI.UIString("First Contentful Paint");
+        case WI.LayoutTimelineRecord.EventType.LargestContentfulPaint:
+            return WI.UIString("Largest Contentful Paint");
         }
     }
 
@@ -67,7 +73,7 @@ WI.LayoutTimelineRecord = class LayoutTimelineRecord extends WI.TimelineRecord
     {
         let {eventType, startTime, endTime, stackTrace, sourceCodeLocation, quad} = json;
         quad = quad ? WI.Quad.fromJSON(quad) : null;
-        return new WI.LayoutTimelineRecord(eventType, startTime, endTime, stackTrace, sourceCodeLocation, quad);
+        return new WI.LayoutTimelineRecord(eventType, startTime, endTime, stackTrace, sourceCodeLocation, {quad});
     }
 
     toJSON()
@@ -103,12 +109,17 @@ WI.LayoutTimelineRecord = class LayoutTimelineRecord extends WI.TimelineRecord
 
     get area()
     {
-        return this.width * this.height;
+        return this._area ?? this.width * this.height;;
     }
 
     get quad()
     {
         return this._quad;
+    }
+
+    get domNode()
+    {
+        return this._domNode;
     }
 
     saveIdentityToCookie(cookie)
@@ -126,7 +137,9 @@ WI.LayoutTimelineRecord.EventType = {
     ForcedLayout: "forced-layout",
     Layout: "layout",
     Paint: "paint",
-    Composite: "composite"
+    Composite: "composite",
+    FirstContentfulPaint: "first-contentful-paint",
+    LargestContentfulPaint: "largest-contentful-paint",
 };
 
 WI.LayoutTimelineRecord.TypeIdentifier = "layout-timeline-record";

--- a/Source/WebInspectorUI/UserInterface/Views/CPUTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CPUTimelineView.js
@@ -1260,6 +1260,8 @@ WI.CPUTimelineView = class CPUTimelineView extends WI.TimelineView
 
             case WI.LayoutTimelineRecord.EventType.InvalidateStyles:
             case WI.LayoutTimelineRecord.EventType.InvalidateLayout:
+            case WI.LayoutTimelineRecord.EventType.FirstContentfulPaint:
+            case WI.LayoutTimelineRecord.EventType.LargestContentfulPaint:
                 // These event types have no time range.
                 return false;
 
@@ -1581,6 +1583,8 @@ WI.CPUTimelineView = class CPUTimelineView extends WI.TimelineView
                 return true;
             case WI.LayoutTimelineRecord.EventType.InvalidateStyles:
             case WI.LayoutTimelineRecord.EventType.InvalidateLayout:
+            case WI.LayoutTimelineRecord.EventType.FirstContentfulPaint:
+            case WI.LayoutTimelineRecord.EventType.LargestContentfulPaint:
                 return false;
             default:
                 console.error("Unhandled LayoutTimelineRecord.EventType", record.eventType);

--- a/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineDataGridNode.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineDataGridNode.js
@@ -44,7 +44,7 @@ WI.LayoutTimelineDataGridNode = class LayoutTimelineDataGridNode extends WI.Time
         this._cachedData.name = this.displayName();
         this._cachedData.width = this.record.width;
         this._cachedData.height = this.record.height;
-        this._cachedData.area = this.record.width * this.record.height;
+        this._cachedData.area = this.record.area;
         this._cachedData.startTime = this.record.startTime - (this.graphDataSource ? this.graphDataSource.zeroTime : 0);
         this._cachedData.totalTime = this.record.duration;
         this._cachedData.initiator = this.record.initiatorCallFrame;
@@ -60,6 +60,20 @@ WI.LayoutTimelineDataGridNode = class LayoutTimelineDataGridNode extends WI.Time
         switch (columnIdentifier) {
         case "name":
             cell.classList.add(...this.iconClassNames());
+
+            if (this.record.eventType == WI.LayoutTimelineRecord.EventType.LargestContentfulPaint) {
+                let fragment = document.createDocumentFragment();
+                fragment.append(value);
+
+                if (this.record.domNode) {
+                    let goToArrow = fragment.appendChild(WI.createGoToArrowButton());
+                    goToArrow.addEventListener("click", (event) => {
+                        WI.showMainFrameDOMTree(this.record.domNode, {ignoreSearchTab: true});
+                    });
+                }
+
+                return fragment;
+            }
             return value;
 
         case "width":

--- a/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineView.js
@@ -278,6 +278,12 @@ WI.LayoutTimelineView = class LayoutTimelineView extends WI.TimelineView
 
         this._showingHighlightForRecord = record;
 
+        if (record.domNode) {
+            record.domNode.highlight();
+            this._showingHighlight = true;
+            return;
+        }
+
         let target = WI.assumingMainTarget();
 
         const contentColor = {r: 111, g: 168, b: 220, a: 0.66};

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineIcons.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineIcons.css
@@ -89,6 +89,10 @@
     content: url(../Images/TypeIcons.svg#RenderingFrame-light);
 }
 
+.performance-entry .icon {
+    content: url(../Images/TypeIcons.svg#PerformanceEntry-light);
+}
+
 .api-record .icon {
     content: url(../Images/TypeIcons.svg#TimelineRecordAPI-light);
 }
@@ -204,6 +208,10 @@
 
     .rendering-frame-record .icon {
         content: url(../Images/TypeIcons.svg#RenderingFrame-dark);
+    }
+
+    .performance-entry .icon {
+        content: url(../Images/TypeIcons.svg#PerformanceEntry-dark);
     }
 
     .api-record .icon {

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRecordBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRecordBar.css
@@ -139,6 +139,11 @@ body[dir=rtl] .timeline-record-bar > .segment:last-of-type {
     --record-bar-segment-border-color: hsl(79, 45%, 51%);
 }
 
+.timeline-record-bar.timeline-record-type-layout:is(.first-contentful-paint, .largest-contentful-paint) > .segment {
+    background-color: hsl(172, 48%, 75%);
+    --record-bar-segment-border-color: hsl(173, 46%, 45%);
+}
+
 .timeline-record-bar.timeline-record-type-script > .segment {
     background-color: hsl(269, 65%, 74%);
     --record-bar-segment-border-color: hsl(273, 33%, 58%);

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRecordTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRecordTreeElement.js
@@ -109,6 +109,7 @@ WI.TimelineRecordTreeElement.RenderingFrameRecordIconStyleClass = "rendering-fra
 WI.TimelineRecordTreeElement.APIRecordIconStyleClass = "api-record";
 WI.TimelineRecordTreeElement.EvaluatedRecordIconStyleClass = "evaluated-record";
 WI.TimelineRecordTreeElement.EventRecordIconStyleClass = "event-record";
+WI.TimelineRecordTreeElement.PerformanceEntryIconStyleClass = "performance-entry";
 WI.TimelineRecordTreeElement.TimerRecordIconStyleClass = "timer-record";
 WI.TimelineRecordTreeElement.ProbeRecordIconStyleClass = "probe-record";
 WI.TimelineRecordTreeElement.ConsoleProfileIconStyleClass = "console-profile-record";

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.js
@@ -213,10 +213,12 @@ WI.TimelineTabContentView = class TimelineTabContentView extends WI.ContentBrows
                 return WI.TimelineRecordTreeElement.PaintRecordIconStyleClass;
             case WI.LayoutTimelineRecord.EventType.Composite:
                 return WI.TimelineRecordTreeElement.CompositeRecordIconStyleClass;
+            case WI.LayoutTimelineRecord.EventType.FirstContentfulPaint:
+            case WI.LayoutTimelineRecord.EventType.LargestContentfulPaint:
+                return WI.TimelineRecordTreeElement.PerformanceEntryIconStyleClass;
             default:
                 console.error("Unknown LayoutTimelineRecord eventType: " + timelineRecord.eventType, timelineRecord);
             }
-
             break;
 
         case WI.TimelineRecord.Type.Script:


### PR DESCRIPTION
#### 6e6554f10c46eaa882c721c1c22cbdbfb1c72d17
<pre>
Show Largest Contentful Paints in the timeline and event list
<a href="https://bugs.webkit.org/show_bug.cgi?id=301450">https://bugs.webkit.org/show_bug.cgi?id=301450</a>
<a href="https://rdar.apple.com/160480088">rdar://160480088</a>

Reviewed by Devin Rousso.

Add support for displaying &quot;First Contentful Paint&quot; and &quot;Largest Contentful Paint&quot; in the
web inspector timeline.

Add `InspectorInstrumentation::didEnqueue...()` which is called when we enqueue one of
these paint entries. The LCP entry passes the element and an area, so inspector can show
these.

`InspectorTimelineAgent::didEnqueue...()` then creates timeline entries with the right
type, adding the metadata as a appropriate.

To `inspector/protocol/Timeline.json` we add two new event types. When `TimelineManager`
encounters one of these, it creates a `WI.LayoutTimelineRecord` for FCP or LCP. The latter
takes the extra metadata.

`LayoutTimelineRecord` gains the ability to store a `domNode` and `area`. Area cannot be
derived from a quad here, because the LCP area results in math on a scalar value[1], so we
have to store area separately.

Enhance `LayoutTimelineDataGridNode` to be able to create a &quot;go to arrow&quot; which provides a
button to jump to the element when hovered.

I chose a teal color with a `P` for the performance entry icons, and used teal as the
timeline pip color.

[1] <a href="https://w3c.github.io/largest-contentful-paint/#sec-effective-visual-size">https://w3c.github.io/largest-contentful-paint/#sec-effective-visual-size</a>

* Source/JavaScriptCore/inspector/protocol/Timeline.json:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didEnqueueFirstContentfulPaintImpl):
(WebCore::InspectorInstrumentation::didEnqueueLargestContentfulPaintImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didEnqueueFirstContentfulPaint):
(WebCore::InspectorInstrumentation::didEnqueueLargestContentfulPaint):
* Source/WebCore/inspector/TimelineRecordFactory.cpp:
(WebCore::TimelineRecordFactory::createLargestContentfulPaintData):
* Source/WebCore/inspector/TimelineRecordFactory.h:
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::didEnqueueFirstContentfulPaint):
(WebCore::InspectorTimelineAgent::didEnqueueLargestContentfulPaint):
(WebCore::toProtocol):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.h:
* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::reportFirstContentfulPaint):
(WebCore::Performance::enqueueLargestContentfulPaint):
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js:
(WI.TimelineManager.prototype._processRecord):
* Source/WebInspectorUI/UserInterface/Images/TypeIcons.svg:
* Source/WebInspectorUI/UserInterface/Models/LayoutTimelineRecord.js:
(WI.LayoutTimelineRecord.displayNameForEventType):
(WI.LayoutTimelineRecord.async fromJSON):
(WI.LayoutTimelineRecord.prototype.get area):
(WI.LayoutTimelineRecord.prototype.get domNode):
* Source/WebInspectorUI/UserInterface/Views/CPUTimelineView.js:
(WI.CPUTimelineView.prototype._attemptSelectIndicatatorTimelineRecord):
* Source/WebInspectorUI/UserInterface/Views/LayoutTimelineDataGridNode.js:
(WI.LayoutTimelineDataGridNode.prototype.get data):
(WI.LayoutTimelineDataGridNode.prototype.createCellContent):
(WI.LayoutTimelineDataGridNode):
* Source/WebInspectorUI/UserInterface/Views/LayoutTimelineView.js:
(WI.LayoutTimelineView.prototype._showHighlightForRecord):
* Source/WebInspectorUI/UserInterface/Views/TimelineIcons.css:
(.performance-entry .icon):
(@media (prefers-color-scheme: dark) .performance-entry .icon):
* Source/WebInspectorUI/UserInterface/Views/TimelineRecordBar.css:
(.timeline-record-bar.timeline-record-type-layout:is(.first-contentful-paint, .largest-contentful-paint) &gt; .segment):
* Source/WebInspectorUI/UserInterface/Views/TimelineRecordTreeElement.js:
* Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.js:
(WI.TimelineTabContentView.iconClassNameForRecord):

Canonical link: <a href="https://commits.webkit.org/302248@main">https://commits.webkit.org/302248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b934b469c4aa99d02f776c6c4939df520da0064e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135713 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79791 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c67d847f-1638-4d4d-8019-6f1fdd876f69) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97675 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65580 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f16b590f-aef3-4048-b4c8-b1ff1a346de1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78266 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/06fe16fe-35b7-4703-899c-27bcea1d2ef5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33065 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79001 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120343 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138169 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126782 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106213 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106013 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27046 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/360 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29849 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52755 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/494 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63666 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159806 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/393 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39916 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/456 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->