### PR TITLE
Fix TAPI verification errors on ARM64_32 builds.

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 
 #include "pas_config.h"
 
+#if LIBPAS_ENABLED
 #if PAS_ENABLE_BMALLOC
 
 #include "bmalloc_type.h"
@@ -87,5 +88,5 @@ PAS_END_EXTERN_C;
 
 #endif /* PAS_ENABLE_BMALLOC */
 
+#endif /* LIBPAS_ENABLED */
 #endif /* BMALLOC_HEAP_CONFIG_H */
-

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,9 @@
 #ifndef BMALLOC_HEAP_INLINES_H
 #define BMALLOC_HEAP_INLINES_H
 
-#include "pas_platform.h"
+#include "pas_config.h"
+
+#if LIBPAS_ENABLED
 
 PAS_IGNORE_WARNINGS_BEGIN("missing-field-initializers")
 
@@ -410,5 +412,5 @@ PAS_END_EXTERN_C;
 
 PAS_IGNORE_WARNINGS_END
 
+#endif /* LIBPAS_ENABLED */
 #endif /* BMALLOC_HEAP_INLINES_H */
-

--- a/Source/bmalloc/libpas/src/libpas/hotbit_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/hotbit_heap_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,8 @@
 #define HOTBIT_HEAP_CONFIG_H
 
 #include "pas_config.h"
+
+#if LIBPAS_ENABLED
 
 #if PAS_ENABLE_HOTBIT
 
@@ -88,5 +90,5 @@ PAS_END_EXTERN_C;
 
 #endif /* PAS_ENABLE_HOTBIT */
 
+#endif /* LIBPAS_ENABLED */
 #endif /* HOTBIT_HEAP_CONFIG_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator_inlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,8 @@
 #include "pas_epoch.h"
 #include "pas_fast_path_allocation_result.h"
 #include "pas_segregated_size_directory_inlines.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -203,5 +205,5 @@ pas_bitfit_allocator_try_allocate(pas_bitfit_allocator* allocator,
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_BITFIT_ALLOCATOR_INLINES_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_compact_tagged_page_granule_use_count_ptr.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_tagged_page_granule_use_count_ptr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Apple Inc. All rights reserved.
+ * Copyright (c) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,8 @@
 #include "pas_compact_tagged_ptr.h"
 #include "pas_page_granule_use_count.h"
 
+#if LIBPAS_ENABLED
+
 PAS_BEGIN_EXTERN_C;
 
 PAS_DEFINE_COMPACT_TAGGED_PTR(pas_page_granule_use_count*,
@@ -36,5 +38,5 @@ PAS_DEFINE_COMPACT_TAGGED_PTR(pas_page_granule_use_count*,
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_COMPACT_TAGGED_PAGE_GRANULE_USE_COUNT_PTR_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_compact_tagged_unsigned_ptr.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_tagged_unsigned_ptr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Apple Inc. All rights reserved.
+ * Copyright (c) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,11 +28,13 @@
 
 #include "pas_compact_tagged_ptr.h"
 
+#if LIBPAS_ENABLED
+
 PAS_BEGIN_EXTERN_C;
 
 PAS_DEFINE_COMPACT_TAGGED_PTR(unsigned*, pas_compact_tagged_unsigned_ptr);
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_COMPACT_TAGGED_UNSIGNED_PTR_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_compact_thread_local_cache_layout_node.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_thread_local_cache_layout_node.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,8 @@
 #include "pas_compact_tagged_ptr.h"
 #include "pas_thread_local_cache_layout_node.h"
 
+#if LIBPAS_ENABLED
+
 PAS_BEGIN_EXTERN_C;
 
 PAS_DEFINE_COMPACT_TAGGED_PTR(pas_thread_local_cache_layout_node,
@@ -36,5 +38,5 @@ PAS_DEFINE_COMPACT_TAGGED_PTR(pas_thread_local_cache_layout_node,
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_COMPACT_THREAD_LOCAL_CACHE_LAYOUT_NODE_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,7 +51,11 @@
 #define PAS_LOG_LEVEL (PAS_LOG_NONE)
 #define PAS_SHOULD_LOG(level) (PAS_LOG_LEVEL & level)
 
+#if PAS_CPU(ADDRESS64)
 #define LIBPAS_ENABLED 1
+#else
+#define LIBPAS_ENABLED 0
+#endif
 
 #if defined(PAS_BMALLOC)
 #include "BPlatform.h"

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,6 +38,8 @@
 #include "pas_system_heap.h"
 #include "pas_thread_local_cache.h"
 #include "pas_utils.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -223,5 +225,5 @@ static PAS_ALWAYS_INLINE void pas_deallocate(void* ptr,
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_DEALLOCATE_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_designated_intrinsic_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_designated_intrinsic_heap_inlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,8 @@
 #include "pas_designated_intrinsic_heap.h"
 #include "pas_local_allocator.h"
 #include "pas_segregated_size_directory_inlines.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -128,5 +130,5 @@ static PAS_ALWAYS_INLINE pas_designated_index_result pas_designated_intrinsic_he
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_DESIGNATED_INTRINSIC_HEAP_INLINES_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_exclusive_view_template_memo_table.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_exclusive_view_template_memo_table.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Apple Inc. All rights reserved.
+ * Copyright (c) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,8 @@
 
 #include "pas_hashtable.h"
 #include "pas_segregated_size_directory.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -121,5 +123,5 @@ PAS_API extern pas_exclusive_view_template_memo_table pas_exclusive_view_templat
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_EXCLUSIVE_VIEW_TEMPLATE_MEMO_TABLE_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_full_alloc_bits_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_full_alloc_bits_inlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,8 @@
 #include "pas_segregated_partial_view.h"
 #include "pas_segregated_size_directory.h"
 #include "pas_segregated_view.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -103,5 +105,5 @@ pas_full_alloc_bits_create_for_view(
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_FULL_ALLOC_BITS_INLINES_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_inlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,8 @@
 #include "pas_heap.h"
 #include "pas_log.h"
 #include "pas_segregated_heap_inlines.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -79,5 +81,5 @@ pas_heap_ensure_size_directory_for_size(
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_HEAP_INLINES_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,8 @@
 #include "pas_thread_local_cache.h"
 #include "pas_thread_local_cache_node.h"
 #include "pas_zero_memory.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -1887,5 +1889,5 @@ pas_local_allocator_try_allocate(pas_local_allocator* allocator,
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_LOCAL_ALLOCATOR_INLINES_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_exclusive_view_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_exclusive_view_inlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +35,8 @@
 #include "pas_segregated_page.h"
 #include "pas_thread_local_cache.h"
 #include "pas_thread_local_cache_node.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -219,5 +221,5 @@ static PAS_ALWAYS_INLINE void pas_segregated_exclusive_view_note_eligibility(
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_SEGREGATED_EXCLUSIVE_VIEW_INLINES_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,8 @@
 #include "pas_segregated_shared_handle_inlines.h"
 #include "pas_thread_local_cache_node.h"
 #include "pas_zero_memory.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -643,5 +645,5 @@ static PAS_ALWAYS_INLINE void pas_segregated_page_log_or_deallocate(
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_SEGREGATED_PAGE_INLINES_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,8 @@
 #include "pas_segregated_directory.h"
 #include "pas_segregated_size_directory_creation_mode.h"
 #include "pas_zero_memory.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -371,5 +373,5 @@ PAS_API void pas_segregated_size_directory_dump_for_spectrum(
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_SEGREGATED_SIZE_DIRECTORY_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory_inlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Apple Inc. All rights reserved.
+ * Copyright (c) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,8 @@
 #include "pas_segregated_heap.h"
 #include "pas_segregated_size_directory.h"
 #include "pas_thread_local_cache.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -231,5 +233,5 @@ pas_segregated_size_directory_take_first_eligible_impl(
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_SEGREGATED_GLOBAL_SIZE_DIRECTORY_INLINES_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,8 @@
 #include "pas_segregated_page_inlines.h"
 #include "pas_segregated_partial_view.h"
 #include "pas_segregated_view.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -451,5 +453,5 @@ pas_segregated_view_did_stop_allocating(pas_segregated_view view,
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_SEGREGATED_VIEW_ALLOCATOR_INLINES_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,8 @@
 #include "pas_zero_memory.h"
 
 #include "pas_thread.h"
+
+#if LIBPAS_ENABLED
 
 #define PAS_THREAD_LOCAL_CACHE_DESTROYED 1
 
@@ -432,5 +434,5 @@ PAS_API void pas_thread_local_cache_shrink(pas_thread_local_cache* thread_local_
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_THREAD_LOCAL_CACHE_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +35,8 @@
 #include "pas_thread_local_cache_layout_node.h"
 #include "pas_utils.h"
 #include "pas_zero_memory.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -113,5 +115,5 @@ static PAS_ALWAYS_INLINE pas_thread_local_cache_layout_node pas_thread_local_cac
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_THREAD_LOCAL_CACHE_LAYOUT_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout_entry.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout_entry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,8 @@
 
 #include "pas_allocator_index.h"
 #include "pas_compact_thread_local_cache_layout_node.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -84,5 +86,5 @@ static inline bool pas_thread_local_cache_layout_key_is_equal(pas_thread_local_c
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_THREAD_LOCAL_CACHE_LAYOUT_ENTRY_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,8 @@
 #include "pas_segregated_heap.h"
 #include "pas_thread_local_cache.h"
 #include "pas_try_allocate_common.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -155,5 +157,5 @@ typedef pas_allocation_result (*pas_try_allocate)(pas_heap_ref* heap_ref, pas_al
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_TRY_ALLOCATE_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_array.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_array.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,8 @@
 #include "pas_local_allocator_inlines.h"
 #include "pas_physical_memory_transaction.h"
 #include "pas_segregated_heap.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -238,5 +240,5 @@ typedef pas_allocation_result (*pas_try_allocate_array_for_realloc)(
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_TRY_ALLOCATE_ARRAY_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,8 @@
 #include "pas_segregated_heap_inlines.h"
 #include "pas_system_heap.h"
 #include "pas_utils.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -328,5 +330,5 @@ typedef pas_allocation_result (*pas_try_allocate_common)(
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_TRY_ALLOCATE_COMMON_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,8 @@
 #include "pas_heap.h"
 #include "pas_intrinsic_heap_support.h"
 #include "pas_try_allocate_common.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -332,5 +334,5 @@ typedef pas_allocation_result (*pas_try_allocate_intrinsic_for_realloc)(size_t s
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_TRY_ALLOCATE_INTRINSIC_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_primitive.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_primitive.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,8 @@
 #include "pas_local_allocator_inlines.h"
 #include "pas_physical_memory_transaction.h"
 #include "pas_primitive_heap_ref.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -261,5 +263,5 @@ typedef pas_allocation_result (*pas_try_allocate_primitive_for_realloc)(
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_TRY_ALLOCATE_PRIMITIVE_H */
-

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,8 @@
 #include "pas_try_allocate_array.h"
 #include "pas_try_allocate_intrinsic.h"
 #include "pas_try_allocate_primitive.h"
+
+#if LIBPAS_ENABLED
 
 PAS_BEGIN_EXTERN_C;
 
@@ -630,5 +632,5 @@ pas_try_reallocate_primitive(
 
 PAS_END_EXTERN_C;
 
+#endif /* LIBPAS_ENABLED */
 #endif /* PAS_TRY_REALLOCATE_H */
-


### PR DESCRIPTION
#### 501c1d5fe26dba28fcd1b4584a367caaebc909a0
<pre>
Fix TAPI verification errors on ARM64_32 builds.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301453">https://bugs.webkit.org/show_bug.cgi?id=301453</a>
<a href="https://rdar.apple.com/163372818">rdar://163372818</a>

Reviewed by Keith Miller and Yusuke Suzuki.

The fix entails:
1. Change pas_config.h&apos;s default setting of LIBPAS_ENABLED to 1 only apply when PAS_CPU(ADDRESS64).
   Otherwise default it to 0.
2. Add #if LIBPAS_ENABLED + #endif around the content of many libpas header files that TAPI
   complains about for ARM64_32 builds.

libpas does not support ARM64_32 targets.  Hence, on ARM64_32 builds, libpas is disabled.  So, it
is correct to #if out all the libpas code in those header files.

No new tests needed because the build verifies the fix.
.
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h:
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h:
* Source/bmalloc/libpas/src/libpas/hotbit_heap_config.h:
* Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_compact_tagged_page_granule_use_count_ptr.h:
* Source/bmalloc/libpas/src/libpas/pas_compact_tagged_unsigned_ptr.h:
* Source/bmalloc/libpas/src/libpas/pas_compact_thread_local_cache_layout_node.h:
* Source/bmalloc/libpas/src/libpas/pas_config.h:
* Source/bmalloc/libpas/src/libpas/pas_deallocate.h:
* Source/bmalloc/libpas/src/libpas/pas_designated_intrinsic_heap_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_exclusive_view_template_memo_table.h:
* Source/bmalloc/libpas/src/libpas/pas_full_alloc_bits_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_exclusive_view_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h:
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout.h:
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout_entry.h:
* Source/bmalloc/libpas/src/libpas/pas_try_allocate.h:
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_array.h:
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h:
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h:
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_primitive.h:
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:

Canonical link: <a href="https://commits.webkit.org/302174@main">https://commits.webkit.org/302174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b842f5341a5972a28898ff8ab3b93af9336fb3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135461 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79588 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c2c2de58-aa91-4bdb-b572-1584329093fa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97516 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65398 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1f176060-17b2-451b-9252-d05ca6e0e018) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78085 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/86aec8b6-d003-4461-a9f9-1b2baed22757) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32857 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78771 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120128 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108541 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137951 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126556 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106044 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105782 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/172 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29648 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52410 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20036 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/277 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159576 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/186 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39832 "Found 16 new JSC stress test failures: wasm.yaml/wasm/stress/osr-entry-live-fpr.js.default-wasm, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-bbq, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-collect-continuously, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-eager, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-eager-jettison, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-no-cjit, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-slow-memory, wasm.yaml/wasm/stress/osr-entry-live-stack.js.default-wasm, wasm.yaml/wasm/stress/osr-entry-live-stack.js.wasm-bbq ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/260 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/236 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->