### PR TITLE
[HDR] IMG tag CSS features position and transform switch HDR JPEG with gainmap to SDR

### DIFF
--- a/LayoutTests/compositing/hdr/hdr-image-positioned-expected.txt
+++ b/LayoutTests/compositing/hdr/hdr-image-positioned-expected.txt
@@ -1,0 +1,40 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 4
+        (GraphicsLayer
+          (position 8.00 42.00)
+          (bounds 220.00 120.00)
+          (drawsContent 1)
+          (drawsHDRContent 1)
+        )
+        (GraphicsLayer
+          (position 8.00 162.00)
+          (bounds 220.00 120.00)
+          (drawsContent 1)
+          (drawsHDRContent 1)
+        )
+        (GraphicsLayer
+          (position 8.00 282.00)
+          (bounds 220.00 120.00)
+          (drawsContent 1)
+          (drawsHDRContent 1)
+        )
+        (GraphicsLayer
+          (position 8.00 402.00)
+          (bounds 220.00 120.00)
+          (drawsContent 1)
+          (drawsHDRContent 1)
+        )
+      )
+    )
+  )
+)
+
+
+
+

--- a/LayoutTests/compositing/hdr/hdr-image-positioned.html
+++ b/LayoutTests/compositing/hdr/hdr-image-positioned.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<style>
+    .container {
+        will-change: transform;
+        padding: 10px;
+        width: 200px;
+        height: 100px;
+    }
+    
+    .intermediate {
+        position: relative;
+        padding: 10px;
+    }
+    
+    img {
+        width: 50px;
+        height: 50px;
+    }
+    
+    pre {
+        min-height: 16px;
+    }
+    
+</style>
+<body>
+    <pre id="layers">Layer tree goes here in DRT</pre>
+    <div class="container">
+        <img>
+    </div>
+
+    <div class="container">
+        <div>
+            <div class="intermediate">
+                <div>
+                    <img style="position: relative">
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="container">
+        <img style="opacity: 0.8">
+    </div>
+
+    <div class="container">
+        <img style="scale: 1.1">
+    </div>
+
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+ 
+        var image = new Image;
+        image.onload = (() => {
+            if (window.internals)
+                internals.setHasHDRContentForTesting(image);
+
+            const images = document.getElementsByTagName('img');
+            for (let img of images)
+                img.src = image.src;
+
+            if (window.testRunner) {
+                document.getElementById("layers").textContent = internals.layerTreeAsText(document);
+                testRunner.notifyDone();
+            }
+        });
+        image.src = "../../fast/images/resources/green-400x400.png";
+    </script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -570,7 +570,6 @@ public:
 
     struct PaintedContentRequest {
         PaintedContentRequest() = default;
-        PaintedContentRequest(const RenderLayer& owningLayer);
 
         void setHasPaintedContent() { hasPaintedContent = RequestState::True; }
         void makePaintedContentUndetermined() { hasPaintedContent = RequestState::Undetermined; }
@@ -580,7 +579,8 @@ public:
 #if HAVE(SUPPORT_HDR_DISPLAY)
         void setHasHDRContent() { hasHDRContent = RequestState::True; }
         void makeHDRContentFalse() { hasHDRContent = RequestState::False; }
-        void makeHDRContentUnknown() { hasHDRContent = RequestState::Unknown; }
+
+        void setHDRRequestState(RequestState state) { hasHDRContent = state; }
         bool isHDRContentSatisfied() const { return hasHDRContent != RequestState::Unknown; }
 #endif
 


### PR DESCRIPTION
#### 52936d4f17f0b2acb5fa0d5013ef392bebe765ee
<pre>
[HDR] IMG tag CSS features position and transform switch HDR JPEG with gainmap to SDR
<a href="https://bugs.webkit.org/show_bug.cgi?id=301398">https://bugs.webkit.org/show_bug.cgi?id=301398</a>
<a href="https://rdar.apple.com/156858374">rdar://156858374</a>

Reviewed by Said Abou-Hallawa.

HDR images which had their own RenderLayer (by virtue of being positioned, transformed,
opacity etc) failed to render as HDR. This is because
`RenderLayerBacking::determineNonCompositedLayerDescendantsPaintedContent()` failed to
test for HDR content on the RenderLayer&apos;s immediate renderer. The fix is in two parts;
first, `RenderLayer::isVisuallyNonEmpty()` needs to detect HDR on this renderer when
asked, and we have to avoid clobbering `request.hasHDRContent` with `localRequest.hasHDRContent`
in `RenderLayerBacking::determineNonCompositedLayerDescendantsPaintedContent()`; we should
only pass on `RequestState::True`.

This PR also cleans up the usage of `PaintedContentRequest` a little. Instead of
having a constructor that always triggers HDR detection when the document has HDR
images, we make it a responsibility of the client to ask for HDR when it wants to;
this avoids potentially wasting time detecting HDR when no-one has asked.

Finally rename the HDR-related members of `PaintedContentsInfo` from `m_hasHDRContent`/
`m_rendererHDRContent` to `m_hdrContent`/`m_rendererHDRContent` since these represent
query state, not &quot;have&quot; state.

Test: compositing/hdr/hdr-image-positioned.html

* LayoutTests/compositing/hdr/hdr-image-positioned-expected.txt: Added.
* LayoutTests/compositing/hdr/hdr-image-positioned.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
(WebCore::RenderLayer::PaintedContentRequest::PaintedContentRequest): Deleted.
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::PaintedContentsInfo::PaintedContentsInfo):
(WebCore::PaintedContentsInfo::setDetectsHDRContent):
(WebCore::PaintedContentsInfo::isPaintsContentSatisfied const):
(WebCore::PaintedContentsInfo::paintsHDRContent):
(WebCore::PaintedContentsInfo::isContentsTypeSatisfied const):
(WebCore::PaintedContentsInfo::rendererHasHDRContent):
(WebCore::PaintedContentsInfo::determinePaintsContent):
(WebCore::PaintedContentsInfo::determineContentsType):
(WebCore::RenderLayerBacking::updateDrawsContent):
(WebCore::RenderLayerBacking::determineNonCompositedLayerDescendantsPaintedContent const):
Rename childElement to childRenderElement.

Canonical link: <a href="https://commits.webkit.org/302200@main">https://commits.webkit.org/302200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42becdb2f3679a1b70d4ebe7a3293a974bbeff18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79794 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6bb7bf2d-d7f5-4dfe-9bb3-8122486ab5fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97679 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65582 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c28a4ae6-3f8e-4b02-ae9b-e486a3ceb870) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78270 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a4b68913-4c48-4ebb-bdba-bb1b99a81544) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/350 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33069 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79004 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108734 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138172 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106217 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106017 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27018 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/363 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29853 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52759 "Hash 42becdb2 for PR 52982 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63671 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/396 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/463 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/459 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->