### PR TITLE
Fix outstanding safer C++ warnings

### DIFF
--- a/Source/WebKit/UIProcess/API/APIStringMatcher.cpp
+++ b/Source/WebKit/UIProcess/API/APIStringMatcher.cpp
@@ -39,8 +39,8 @@ StringMatcher::StringMatcher(Ref<WebCore::SharedBuffer>&& sharedBuffer)
 
 RefPtr<WebCore::SharedMemory> StringMatcher::sharedMemory()
 {
-    if (m_sharedBuffer && !m_sharedMemory)
-        m_sharedMemory = WebCore::SharedMemory::copyBuffer(*m_sharedBuffer);
+    if (RefPtr sharedBuffer = m_sharedBuffer; sharedBuffer && !m_sharedMemory)
+        m_sharedMemory = WebCore::SharedMemory::copyBuffer(*sharedBuffer);
     return m_sharedMemory;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -866,7 +866,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     if (!isEnhancedSecurityFeatureEnabled())
         return WKSecurityRestrictionModeNone;
-    if (_websitePolicies->lockdownModeEnabled())
+    if (Ref { *_websitePolicies }->lockdownModeEnabled())
         return WKSecurityRestrictionModeLockdown;
     if (_websitePolicies->enhancedSecurityEnabled())
         return WKSecurityRestrictionModeMaximizeCompatibility;

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -112,7 +112,7 @@ UserContentControllerParameters WebUserContentControllerProxy::parametersForProc
     Vector<WebStringMatcherData> stringMatchers;
     for (auto& [pair, matcher] : m_stringMatchers) {
         if (RefPtr world = API::ContentWorld::worldForIdentifier(pair.first))
-            stringMatchers.append(WebStringMatcherData { matcher->sharedMemory(), world->worldDataForProcess(process), pair.second });
+            stringMatchers.append(WebStringMatcherData { matcher.copyRef()->sharedMemory(), world->worldDataForProcess(process), pair.second });
     }
 
     auto messageHandlers = WTF::map(m_scriptMessageHandlers, [&](auto entry) {


### PR DESCRIPTION
#### 09a00510626ed64215e19047ffba22980db0b8b5
<pre>
Fix outstanding safer C++ warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=301456">https://bugs.webkit.org/show_bug.cgi?id=301456</a>

Reviewed by Chris Dumez.

Fix the outstanding safer C++ clang static analyzer warnings.

* Source/WebKit/UIProcess/API/APIStringMatcher.cpp:
(API::StringMatcher::sharedMemory):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences securityRestrictionMode]):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::parametersForProcess const):

Canonical link: <a href="https://commits.webkit.org/302132@main">https://commits.webkit.org/302132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e65659ba5d12b9f96ca2700b6f408048a2d2ed08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79609 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2e206451-7c6d-4f21-9cea-73e03aa6519e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97529 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65421 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/60c30845-d1b2-4d0b-b9ae-1baffb6324c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78099 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8371c575-29b9-4b55-aa41-c0ed89933f98) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78790 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108556 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137970 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106057 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/281 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105796 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/189 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29663 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52434 "Hash e65659ba for PR 52983 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20017 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/297 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/61805 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/206 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/279 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/256 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->