### PR TITLE
Add a debug assertion for subclasses of CanMakeCheckedPtr to be always heap allocated

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
@@ -46,6 +46,7 @@ class InjectedScriptManager;
 class JS_EXPORT_PRIVATE InspectorHeapAgent : public InspectorAgentBase, public HeapBackendDispatcherHandler, public JSC::HeapObserver, public JSC::HeapSnapshotBuilder::Client {
     WTF_MAKE_NONCOPYABLE(InspectorHeapAgent);
     WTF_MAKE_TZONE_ALLOCATED(InspectorHeapAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorHeapAgent);
 public:
     InspectorHeapAgent(AgentContext&);
     ~InspectorHeapAgent() override;

--- a/Source/WTF/wtf/AbstractCanMakeCheckedPtr.h
+++ b/Source/WTF/wtf/AbstractCanMakeCheckedPtr.h
@@ -35,6 +35,7 @@ public:
     virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
     virtual void incrementCheckedPtrCount() const = 0;
     virtual void decrementCheckedPtrCount() const = 0;
+    virtual void setBegunCheckedPtrDeletion() = 0;
 
 protected:
     virtual ~AbstractCanMakeCheckedPtr() = default;

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -276,13 +276,21 @@ template<typename P> struct DefaultHash<CheckedRef<P>> : PtrHash<CheckedRef<P>> 
 
 enum class DefaultedOperatorEqual : bool { No, Yes };
 
-template <typename StorageType, typename PtrCounterType> class CanMakeCheckedPtrBase {
+// DO NOT make use of this enum in new code. An object which supports CanMakeCheckedPtr must be heap allocated on its own.
+enum class CheckedPtrDeleteCheckException : bool { No, Yes };
+
+template <typename StorageType, typename PtrCounterType, typename DeletionFlagType, CheckedPtrDeleteCheckException deleteException> class CanMakeCheckedPtrBase {
 public:
     CanMakeCheckedPtrBase() = default;
     CanMakeCheckedPtrBase(CanMakeCheckedPtrBase&&) { }
     CanMakeCheckedPtrBase& operator=(CanMakeCheckedPtrBase&&) { return *this; }
     CanMakeCheckedPtrBase(const CanMakeCheckedPtrBase&) { }
     CanMakeCheckedPtrBase& operator=(const CanMakeCheckedPtrBase&) { return *this; }
+
+    ~CanMakeCheckedPtrBase()
+    {
+        ASSERT(m_hasBegunDeletion || deleteException == CheckedPtrDeleteCheckException::Yes);
+    }
 
     PtrCounterType checkedPtrCount() const { return m_checkedPtrCount; }
     void incrementCheckedPtrCount() const { ++m_checkedPtrCount; }
@@ -303,12 +311,22 @@ public:
             return m_checkedPtrCount.valueWithoutThreadCheck();
     }
 
+    void setBegunCheckedPtrDeletion()
+    {
+#if ASSERT_ENABLED
+        m_hasBegunDeletion = true;
+#endif
+    }
+
 private:
     mutable StorageType m_checkedPtrCount { 0 };
+#if ASSERT_ENABLED
+    DeletionFlagType m_hasBegunDeletion { false };
+#endif
 };
 
-template<typename T, DefaultedOperatorEqual defaultedOperatorEqual = DefaultedOperatorEqual::No>
-class CanMakeCheckedPtr : public CanMakeCheckedPtrBase<SingleThreadIntegralWrapper<uint32_t>, uint32_t> {
+template<typename T, DefaultedOperatorEqual defaultedOperatorEqual = DefaultedOperatorEqual::No, CheckedPtrDeleteCheckException deleteException = CheckedPtrDeleteCheckException::No>
+class CanMakeCheckedPtr : public CanMakeCheckedPtrBase<SingleThreadIntegralWrapper<uint32_t>, uint32_t, bool, deleteException> {
 public:
     ~CanMakeCheckedPtr()
     {
@@ -323,8 +341,8 @@ public:
     }
 };
 
-template<typename T, DefaultedOperatorEqual defaultedOperatorEqual = DefaultedOperatorEqual::No>
-class CanMakeThreadSafeCheckedPtr : public CanMakeCheckedPtrBase<std::atomic<uint32_t>, uint32_t> {
+template<typename T, DefaultedOperatorEqual defaultedOperatorEqual = DefaultedOperatorEqual::No, CheckedPtrDeleteCheckException deleteException = CheckedPtrDeleteCheckException::No>
+class CanMakeThreadSafeCheckedPtr : public CanMakeCheckedPtrBase<std::atomic<uint32_t>, uint32_t, std::atomic<bool>, deleteException> {
 public:
     ~CanMakeThreadSafeCheckedPtr()
     {

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -647,6 +647,7 @@ using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
 #define WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(T) \
 void operator delete(T* object, std::destroying_delete_t, size_t size) { \
     ASSERT_UNUSED(size, sizeof(T) == size); \
+    object->setBegunCheckedPtrDeletion(); \
     object->T::~T(); \
     if (object->checkedPtrCountWithoutThreadCheck()) [[unlikely]] { \
         zeroBytes(*object); \

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -45,7 +45,7 @@ class FetchBodySource;
 class FormData;
 class ReadableStream;
 
-class FetchBodyConsumer final : public CanMakeWeakPtr<FetchBodyConsumer>, public CanMakeCheckedPtr<FetchBodyConsumer> {
+class FetchBodyConsumer final : public CanMakeWeakPtr<FetchBodyConsumer>, public CanMakeCheckedPtr<FetchBodyConsumer, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(FetchBodyConsumer);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FetchBodyConsumer);
 public:

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -889,13 +889,13 @@ String SQLiteIDBBackingStore::fullDatabasePath() const
 
 std::optional<IDBDatabaseNameAndVersion> SQLiteIDBBackingStore::databaseNameAndVersionFromFile(const String& databasePath)
 {
-    SQLiteDatabase database;
-    if (!database.open(databasePath)) {
+    auto database = makeUniqueRef<SQLiteDatabase>();
+    if (!database->open(databasePath)) {
         LOG_ERROR("Failed to open SQLite database at path '%s' when getting database name", databasePath.utf8().data());
         return std::nullopt;
     }
-    if (!database.tableExists("IDBDatabaseInfo"_s)) {
-        LOG_ERROR("Could not find IDBDatabaseInfo table and get database name(%i) - %s", database.lastError(), database.lastErrorMsg());
+    if (!database->tableExists("IDBDatabaseInfo"_s)) {
+        LOG_ERROR("Could not find IDBDatabaseInfo table and get database name(%i) - %s", database->lastError(), database->lastErrorMsg());
         return std::nullopt;
     }
 
@@ -907,7 +907,7 @@ std::optional<IDBDatabaseNameAndVersion> SQLiteIDBBackingStore::databaseNameAndV
     }
 
     auto databaseName = result.value().second;
-    auto versql = database.prepareStatement("SELECT value FROM IDBDatabaseInfo WHERE key = 'DatabaseVersion';"_s);
+    auto versql = database->prepareStatement("SELECT value FROM IDBDatabaseInfo WHERE key = 'DatabaseVersion';"_s);
     String stringVersion = versql ? CheckedRef { *versql }->columnText(0) : String();
     auto databaseVersion = parseInteger<uint64_t>(stringVersion);
     if (!databaseVersion) {

--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h
@@ -55,6 +55,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
 private:
     // PermissionObserver

--- a/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
@@ -66,6 +66,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
 private:
     // RealtimeMediaSource::AudioSampleObserver

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -50,6 +50,7 @@ class AudioContext final
     , public MediaCanStartListener
     , private PlatformMediaSessionClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioContext);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioContext);
 public:
     // Create an AudioContext for rendering to the audio hardware.
     static ExceptionOr<Ref<AudioContext>> create(Document&, AudioContextOptions&&);

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
@@ -50,6 +50,7 @@ struct WorkletParameters;
 
 class AudioWorkletGlobalScope final : public WorkletGlobalScope {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioWorkletGlobalScope);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioWorkletGlobalScope);
 public:
     static RefPtr<AudioWorkletGlobalScope> tryCreate(AudioWorkletThread&, const WorkletParameters&);
     ~AudioWorkletGlobalScope();

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
@@ -61,6 +61,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::setBegunCheckedPtrDeletion(); }
 
 private:
     explicit AudioWorkletMessagingProxy(AudioWorklet&);

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp
@@ -90,7 +90,8 @@ DatabaseTracker& DatabaseTracker::singleton()
 }
 
 DatabaseTracker::DatabaseTracker(const String& databasePath)
-    : m_databaseDirectoryPath(databasePath.isolatedCopy())
+    : m_database(*new SQLiteDatabase)
+    , m_databaseDirectoryPath(databasePath.isolatedCopy())
 {
 }
 
@@ -103,7 +104,7 @@ void DatabaseTracker::openTrackerDatabase(TrackerCreationAction createAction)
 {
     ASSERT(m_databaseGuard.isHeld());
 
-    if (m_database.isOpen())
+    if (m_database->isOpen())
         return;
 
     // If createIfDoesNotExist is false, SQLiteFileSystem::ensureDatabaseFileExists()
@@ -116,22 +117,22 @@ void DatabaseTracker::openTrackerDatabase(TrackerCreationAction createAction)
     if (!SQLiteFileSystem::ensureDatabaseFileExists(databasePath, createAction == CreateIfDoesNotExist))
         return;
 
-    if (!m_database.open(databasePath)) {
+    if (!m_database->open(databasePath)) {
         // FIXME: What do do here?
         LOG_ERROR("Failed to open databasePath %s.", databasePath.utf8().data());
         return;
     }
-    m_database.disableThreadingChecks();
+    m_database->disableThreadingChecks();
 
-    if (!m_database.tableExists("Origins"_s)) {
-        if (!m_database.executeCommand("CREATE TABLE Origins (origin TEXT UNIQUE ON CONFLICT REPLACE, quota INTEGER NOT NULL ON CONFLICT FAIL);"_s)) {
+    if (!m_database->tableExists("Origins"_s)) {
+        if (!m_database->executeCommand("CREATE TABLE Origins (origin TEXT UNIQUE ON CONFLICT REPLACE, quota INTEGER NOT NULL ON CONFLICT FAIL);"_s)) {
             // FIXME: and here
             LOG_ERROR("Failed to create Origins table");
         }
     }
 
-    if (!m_database.tableExists("Databases"_s)) {
-        if (!m_database.executeCommand("CREATE TABLE Databases (guid INTEGER PRIMARY KEY AUTOINCREMENT, origin TEXT, name TEXT, displayName TEXT, estimatedSize INTEGER, path TEXT);"_s)) {
+    if (!m_database->tableExists("Databases"_s)) {
+        if (!m_database->executeCommand("CREATE TABLE Databases (guid INTEGER PRIMARY KEY AUTOINCREMENT, origin TEXT, name TEXT, displayName TEXT, estimatedSize INTEGER, path TEXT);"_s)) {
             // FIXME: and here
             LOG_ERROR("Failed to create Databases table");
         }
@@ -229,10 +230,10 @@ bool DatabaseTracker::hasEntryForOriginNoLock(const SecurityOriginData& origin)
 {
     ASSERT(m_databaseGuard.isHeld());
     openTrackerDatabase(DontCreateIfDoesNotExist);
-    if (!m_database.isOpen())
+    if (!m_database->isOpen())
         return false;
 
-    auto statement = m_database.prepareStatement("SELECT origin FROM Origins where origin=?;"_s);
+    auto statement = m_database->prepareStatement("SELECT origin FROM Origins where origin=?;"_s);
     if (!statement) {
         LOG_ERROR("Failed to prepare statement.");
         return false;
@@ -247,13 +248,13 @@ bool DatabaseTracker::hasEntryForDatabase(const SecurityOriginData& origin, cons
 {
     ASSERT(m_databaseGuard.isHeld());
     openTrackerDatabase(DontCreateIfDoesNotExist);
-    if (!m_database.isOpen()) {
+    if (!m_database->isOpen()) {
         // No "tracker database". Hence, no entry for the database of interest.
         return false;
     }
 
     // We've got a tracker database. Set up a query to ask for the db of interest:
-    auto statement = m_database.prepareStatement("SELECT guid FROM Databases WHERE origin=? AND name=?;"_s);
+    auto statement = m_database->prepareStatement("SELECT guid FROM Databases WHERE origin=? AND name=?;"_s);
 
     if (!statement)
         return false;
@@ -320,11 +321,11 @@ String DatabaseTracker::fullPathForDatabaseNoLock(const SecurityOriginData& orig
         return String();
 
     // See if we have a path for this database yet
-    if (!m_database.isOpen())
+    if (!m_database->isOpen())
         return String();
 
     {
-        auto statement = m_database.prepareStatement("SELECT path FROM Databases WHERE origin=? AND name=?;"_s);
+        auto statement = m_database->prepareStatement("SELECT path FROM Databases WHERE origin=? AND name=?;"_s);
         if (!statement)
             return String();
 
@@ -366,10 +367,10 @@ Vector<SecurityOriginData> DatabaseTracker::origins()
     Locker lockDatabase { m_databaseGuard };
 
     openTrackerDatabase(DontCreateIfDoesNotExist);
-    if (!m_database.isOpen())
+    if (!m_database->isOpen())
         return { };
 
-    auto statement = m_database.prepareStatement("SELECT origin FROM Origins"_s);
+    auto statement = m_database->prepareStatement("SELECT origin FROM Origins"_s);
     if (!statement) {
         LOG_ERROR("Failed to prepare statement.");
         return { };
@@ -393,10 +394,10 @@ Vector<String> DatabaseTracker::databaseNamesNoLock(const SecurityOriginData& or
 {
     ASSERT(m_databaseGuard.isHeld());
     openTrackerDatabase(DontCreateIfDoesNotExist);
-    if (!m_database.isOpen())
+    if (!m_database->isOpen())
         return { };
 
-    auto statement = m_database.prepareStatement("SELECT name FROM Databases where origin=?;"_s);
+    auto statement = m_database->prepareStatement("SELECT name FROM Databases where origin=?;"_s);
     if (!statement)
         return { };
 
@@ -432,9 +433,9 @@ DatabaseDetails DatabaseTracker::detailsForNameAndOrigin(const String& name, con
         Locker lockDatabase { m_databaseGuard };
 
         openTrackerDatabase(DontCreateIfDoesNotExist);
-        if (!m_database.isOpen())
+        if (!m_database->isOpen())
             return DatabaseDetails();
-        auto statement = m_database.prepareStatement("SELECT displayName, estimatedSize FROM Databases WHERE origin=? AND name=?"_s);
+        auto statement = m_database->prepareStatement("SELECT displayName, estimatedSize FROM Databases WHERE origin=? AND name=?"_s);
         if (!statement)
             return DatabaseDetails();
 
@@ -467,11 +468,11 @@ void DatabaseTracker::setDatabaseDetails(const SecurityOriginData& origin, const
     Locker lockDatabase { m_databaseGuard };
 
     openTrackerDatabase(CreateIfDoesNotExist);
-    if (!m_database.isOpen())
+    if (!m_database->isOpen())
         return;
 
     {
-        auto statement = m_database.prepareStatement("SELECT guid FROM Databases WHERE origin=? AND name=?"_s);
+        auto statement = m_database->prepareStatement("SELECT guid FROM Databases WHERE origin=? AND name=?"_s);
         if (!statement)
             return;
 
@@ -495,7 +496,7 @@ void DatabaseTracker::setDatabaseDetails(const SecurityOriginData& origin, const
         }
     }
 
-    auto updateStatement = m_database.prepareStatement("UPDATE Databases SET displayName=?, estimatedSize=? WHERE guid=?"_s);
+    auto updateStatement = m_database->prepareStatement("UPDATE Databases SET displayName=?, estimatedSize=? WHERE guid=?"_s);
     if (!updateStatement)
         return;
 
@@ -631,10 +632,10 @@ uint64_t DatabaseTracker::quotaNoLock(const SecurityOriginData& origin)
     uint64_t quota = 0;
 
     openTrackerDatabase(DontCreateIfDoesNotExist);
-    if (!m_database.isOpen())
+    if (!m_database->isOpen())
         return quota;
 
-    auto statement = m_database.prepareStatement("SELECT quota FROM Origins where origin=?;"_s);
+    auto statement = m_database->prepareStatement("SELECT quota FROM Origins where origin=?;"_s);
     if (!statement) {
         LOG_ERROR("Failed to prepare statement.");
         return quota;
@@ -661,14 +662,14 @@ void DatabaseTracker::setQuota(const SecurityOriginData& origin, uint64_t quota)
         return;
 
     openTrackerDatabase(CreateIfDoesNotExist);
-    if (!m_database.isOpen())
+    if (!m_database->isOpen())
         return;
     
     bool insertedNewOrigin = false;
 
     bool originEntryExists = hasEntryForOriginNoLock(origin);
     if (!originEntryExists) {
-        auto statement = m_database.prepareStatement("INSERT INTO Origins VALUES (?, ?)"_s);
+        auto statement = m_database->prepareStatement("INSERT INTO Origins VALUES (?, ?)"_s);
         if (!statement) {
             LOG_ERROR("Unable to establish origin %s in the tracker", origin.databaseIdentifier().utf8().data());
         } else {
@@ -681,7 +682,7 @@ void DatabaseTracker::setQuota(const SecurityOriginData& origin, uint64_t quota)
                 insertedNewOrigin = true;
         }
     } else {
-        auto statement = m_database.prepareStatement("UPDATE Origins SET quota=? WHERE origin=?"_s);
+        auto statement = m_database->prepareStatement("UPDATE Origins SET quota=? WHERE origin=?"_s);
         bool error = !statement;
         if (!error) {
             statement->bindInt64(1, quota);
@@ -705,13 +706,13 @@ bool DatabaseTracker::addDatabase(const SecurityOriginData& origin, const String
 {
     ASSERT(m_databaseGuard.isHeld());
     openTrackerDatabase(CreateIfDoesNotExist);
-    if (!m_database.isOpen())
+    if (!m_database->isOpen())
         return false;
 
     // New database should never be added until the origin has been established
     ASSERT(hasEntryForOriginNoLock(origin));
 
-    auto statement = m_database.prepareStatement("INSERT INTO Databases (origin, name, path) VALUES (?, ?, ?);"_s);
+    auto statement = m_database->prepareStatement("INSERT INTO Databases (origin, name, path) VALUES (?, ?, ?);"_s);
 
     if (!statement)
         return false;
@@ -721,7 +722,7 @@ bool DatabaseTracker::addDatabase(const SecurityOriginData& origin, const String
     statement->bindText(3, path);
 
     if (!statement->executeCommand()) {
-        LOG_ERROR("Failed to add database %s to origin %s: %s\n", name.utf8().data(), origin.databaseIdentifier().utf8().data(), m_database.lastErrorMsg());
+        LOG_ERROR("Failed to add database %s to origin %s: %s\n", name.utf8().data(), origin.databaseIdentifier().utf8().data(), m_database->lastErrorMsg());
         return false;
     }
 
@@ -787,7 +788,7 @@ bool DatabaseTracker::deleteOrigin(const SecurityOriginData& origin, DeletionMod
     {
         Locker lockDatabase { m_databaseGuard };
         openTrackerDatabase(DontCreateIfDoesNotExist);
-        if (!m_database.isOpen())
+        if (!m_database->isOpen())
             return false;
 
         databaseNames = databaseNamesNoLock(origin);
@@ -845,7 +846,7 @@ bool DatabaseTracker::deleteOrigin(const SecurityOriginData& origin, DeletionMod
         transaction.begin();
 
         {
-            auto statement = m_database.prepareStatement("DELETE FROM Databases WHERE origin=?"_s);
+            auto statement = m_database->prepareStatement("DELETE FROM Databases WHERE origin=?"_s);
             if (!statement) {
                 LOG_ERROR("Unable to prepare deletion of databases from origin %s from tracker", origin.databaseIdentifier().utf8().data());
                 return false;
@@ -858,7 +859,7 @@ bool DatabaseTracker::deleteOrigin(const SecurityOriginData& origin, DeletionMod
                 return false;
             }
 
-            auto originStatement = m_database.prepareStatement("DELETE FROM Origins WHERE origin=?"_s);
+            auto originStatement = m_database->prepareStatement("DELETE FROM Origins WHERE origin=?"_s);
             if (!originStatement) {
                 LOG_ERROR("Unable to prepare deletion of origin %s from tracker", origin.databaseIdentifier().utf8().data());
                 return false;
@@ -879,8 +880,8 @@ bool DatabaseTracker::deleteOrigin(const SecurityOriginData& origin, DeletionMod
         bool isEmpty = true;
 
         openTrackerDatabase(DontCreateIfDoesNotExist);
-        if (m_database.isOpen()) {
-            auto statement = m_database.prepareStatement("SELECT origin FROM Origins"_s);
+        if (m_database->isOpen()) {
+            auto statement = m_database->prepareStatement("SELECT origin FROM Origins"_s);
             if (!statement)
                 LOG_ERROR("Failed to prepare statement.");
             else if (statement->step() == SQLITE_ROW)
@@ -889,8 +890,8 @@ bool DatabaseTracker::deleteOrigin(const SecurityOriginData& origin, DeletionMod
 
         // If we removed the last origin, do some additional deletion.
         if (isEmpty) {
-            if (m_database.isOpen())
-                m_database.close();
+            if (m_database->isOpen())
+                m_database->close();
            SQLiteFileSystem::deleteDatabaseFile(trackerDatabasePath());
            SQLiteFileSystem::deleteEmptyDatabaseDirectory(m_databaseDirectoryPath);
         }
@@ -1020,7 +1021,7 @@ bool DatabaseTracker::deleteDatabase(const SecurityOriginData& origin, const Str
     {
         Locker lockDatabase { m_databaseGuard };
         openTrackerDatabase(DontCreateIfDoesNotExist);
-        if (!m_database.isOpen())
+        if (!m_database->isOpen())
             return false;
 
         if (!canDeleteDatabase(origin, name)) {
@@ -1040,7 +1041,7 @@ bool DatabaseTracker::deleteDatabase(const SecurityOriginData& origin, const Str
 
     Locker lockDatabase { m_databaseGuard };
 
-    auto statement = m_database.prepareStatement("DELETE FROM Databases WHERE origin=? AND name=?"_s);
+    auto statement = m_database->prepareStatement("DELETE FROM Databases WHERE origin=? AND name=?"_s);
     if (!statement) {
         LOG_ERROR("Unable to prepare deletion of database %s from origin %s from tracker", name.utf8().data(), origin.databaseIdentifier().utf8().data());
         doneDeletingDatabase(origin, name);
@@ -1131,7 +1132,7 @@ void DatabaseTracker::removeDeletedOpenedDatabases() WTF_IGNORES_THREAD_SAFETY_A
         Locker lockDatabase { m_databaseGuard };
         openTrackerDatabase(DontCreateIfDoesNotExist);
 
-        if (!m_database.isOpen())
+        if (!m_database->isOpen())
             return;
     }
     
@@ -1154,7 +1155,7 @@ void DatabaseTracker::removeDeletedOpenedDatabases() WTF_IGNORES_THREAD_SAFETY_A
             for (auto& databases : openDatabase.value) {
                 String databaseName = databases.key;
                 String databaseFileName;
-                if (auto statement = m_database.prepareStatement("SELECT path FROM Databases WHERE origin=? AND name=?;"_s)) {
+                if (auto statement = m_database->prepareStatement("SELECT path FROM Databases WHERE origin=? AND name=?;"_s)) {
                     statement->bindText(1, origin.databaseIdentifier());
                     statement->bindText(2, databaseName);
                     if (statement->step() == SQLITE_ROW)

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
@@ -171,7 +171,7 @@ private:
 
     // This lock protects m_database, m_originLockMap, m_databaseDirectoryPath, m_originsBeingDeleted, m_beingCreated, and m_beingDeleted.
     Lock m_databaseGuard;
-    SQLiteDatabase m_database WTF_GUARDED_BY_LOCK(m_databaseGuard);
+    UniqueRef<SQLiteDatabase> m_database WTF_GUARDED_BY_LOCK(m_databaseGuard);
 
     using OriginLockMap = HashMap<String, Ref<OriginLock>>;
     OriginLockMap m_originLockMap WTF_GUARDED_BY_LOCK(m_databaseGuard);

--- a/Source/WebCore/dom/DeviceMotionClient.h
+++ b/Source/WebCore/dom/DeviceMotionClient.h
@@ -38,6 +38,7 @@ class Page;
 class DeviceMotionClient : public DeviceClient {
     WTF_MAKE_TZONE_ALLOCATED(DeviceMotionClient);
     WTF_MAKE_NONCOPYABLE(DeviceMotionClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceMotionClient);
 public:
     DeviceMotionClient() = default;
     virtual ~DeviceMotionClient() = default;

--- a/Source/WebCore/dom/DeviceOrientationClient.h
+++ b/Source/WebCore/dom/DeviceOrientationClient.h
@@ -40,6 +40,7 @@ class Page;
 class DeviceOrientationClient : public DeviceClient {
     WTF_MAKE_TZONE_ALLOCATED(DeviceOrientationClient);
     WTF_MAKE_NONCOPYABLE(DeviceOrientationClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceOrientationClient);
 public:
     DeviceOrientationClient() = default;
     virtual ~DeviceOrientationClient() = default;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -444,6 +444,12 @@ public:
     USING_CAN_MAKE_WEAKPTR(EventTarget);
     USING_CAN_MAKE_CHECKEDPTR(ScriptExecutionContext);
 
+    void setBegunCheckedPtrDeletion()
+    {
+        ContainerNode::setBegunCheckedPtrDeletion();
+        ScriptExecutionContext::setBegunCheckedPtrDeletion();
+    }
+
     inline static Ref<Document> create(const Settings&, const URL&);
     static Ref<Document> createNonRenderedPlaceholder(LocalFrame&, const URL&);
     static Ref<Document> create(Document&);

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -57,6 +57,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     enum ExecutionType { ASYNC_EXECUTION, IN_ORDER_EXECUTION };
     void queueScriptForExecution(ScriptElement&, LoadableScript&, ExecutionType);

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -91,7 +91,6 @@ inline WindowEventLoop::WindowEventLoop(const String& agentClusterKey)
     : m_agentClusterKey(agentClusterKey)
     , m_timer(*this, &WindowEventLoop::didReachTimeToRun)
     , m_idleTimer(*this, &WindowEventLoop::didFireIdleTimer)
-    , m_perpetualTaskGroupForSimilarOriginWindowAgents(*this)
 {
 }
 
@@ -101,6 +100,13 @@ WindowEventLoop::~WindowEventLoop()
         return;
     auto didRemove = windowEventLoopMap().remove(m_agentClusterKey);
     RELEASE_ASSERT(didRemove);
+}
+
+EventLoopTaskGroup& WindowEventLoop::perpetualTaskGroupForSimilarOriginWindowAgents()
+{
+    if (!m_perpetualTaskGroupForSimilarOriginWindowAgents)
+        lazyInitialize(m_perpetualTaskGroupForSimilarOriginWindowAgents, makeUnique<EventLoopTaskGroup>(*this));
+    return *m_perpetualTaskGroupForSimilarOriginWindowAgents;
 }
 
 void WindowEventLoop::scheduleToRun()
@@ -242,7 +248,7 @@ void WindowEventLoop::queueMutationObserverCompoundMicrotask()
     if (m_mutationObserverCompoundMicrotaskQueuedFlag)
         return;
     m_mutationObserverCompoundMicrotaskQueuedFlag = true;
-    m_perpetualTaskGroupForSimilarOriginWindowAgents.queueMicrotask([weakThis = WeakPtr { *this }] {
+    perpetualTaskGroupForSimilarOriginWindowAgents().queueMicrotask([weakThis = WeakPtr { *this }] {
         // We can't make a Ref to WindowEventLoop in the lambda capture as that would result in a reference cycle & leak.
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
@@ -263,7 +269,7 @@ CustomElementQueue& WindowEventLoop::backupElementQueue()
 {
     if (!m_processingBackupElementQueue) {
         m_processingBackupElementQueue = true;
-        m_perpetualTaskGroupForSimilarOriginWindowAgents.queueMicrotask([weakThis = WeakPtr { *this }] {
+        perpetualTaskGroupForSimilarOriginWindowAgents().queueMicrotask([weakThis = WeakPtr { *this }] {
             // We can't make a Ref to WindowEventLoop in the lambda capture as that would result in a reference cycle & leak.
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -66,6 +66,8 @@ private:
     static Ref<WindowEventLoop> create(const String&);
     WindowEventLoop(const String&);
 
+    EventLoopTaskGroup& perpetualTaskGroupForSimilarOriginWindowAgents();
+
     void scheduleToRun() final;
     bool isContextThread() const final;
     MicrotaskQueue& microtaskQueue() final;
@@ -87,7 +89,7 @@ private:
     // Each task scheduled in event loop is associated with a document so that it can be suspened or stopped
     // when the associated document is suspened or stopped. This task group is used to schedule a task
     // which is not scheduled to a specific document, and should only be used when it's absolutely required.
-    EventLoopTaskGroup m_perpetualTaskGroupForSimilarOriginWindowAgents;
+    const std::unique_ptr<EventLoopTaskGroup> m_perpetualTaskGroupForSimilarOriginWindowAgents;
 
     bool m_mutationObserverCompoundMicrotaskQueuedFlag { false };
     bool m_deliveringMutationRecords { false }; // FIXME: This flag doesn't exist in the spec.

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -128,7 +128,7 @@ struct RevealSelectionOptions {
     OnlyAllowForwardScrolling onlyAllowForwardScrolling { OnlyAllowForwardScrolling::No };
 };
 
-class FrameSelection final : private CaretBase, public CaretAnimationClient, public CanMakeCheckedPtr<FrameSelection> {
+class FrameSelection final : private CaretBase, public CaretAnimationClient, public CanMakeCheckedPtr<FrameSelection, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(FrameSelection, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(FrameSelection);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameSelection);

--- a/Source/WebCore/fileapi/FileReaderSync.cpp
+++ b/Source/WebCore/fileapi/FileReaderSync.cpp
@@ -46,31 +46,31 @@ FileReaderSync::FileReaderSync()
 
 ExceptionOr<RefPtr<ArrayBuffer>> FileReaderSync::readAsArrayBuffer(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
 {
-    FileReaderLoader loader(FileReaderLoader::ReadAsArrayBuffer, nullptr);
-    auto result = startLoading(scriptExecutionContext, loader, blob);
+    auto loader = makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadAsArrayBuffer, nullptr);
+    auto result = startLoading(scriptExecutionContext, loader.get(), blob);
     if (result.hasException())
         return result.releaseException();
-    return loader.arrayBufferResult();
+    return loader->arrayBufferResult();
 }
 
 ExceptionOr<String> FileReaderSync::readAsBinaryString(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
 {
-    FileReaderLoader loader(FileReaderLoader::ReadAsBinaryString, nullptr);
-    return startLoadingString(scriptExecutionContext, loader, blob);
+    auto loader makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadAsBinaryString, nullptr);
+    return startLoadingString(scriptExecutionContext, loader.get(), blob);
 }
 
 ExceptionOr<String> FileReaderSync::readAsText(ScriptExecutionContext& scriptExecutionContext, Blob& blob, const String& encoding)
 {
-    FileReaderLoader loader(FileReaderLoader::ReadAsText, nullptr);
-    loader.setEncoding(encoding);
-    return startLoadingString(scriptExecutionContext, loader, blob);
+    auto loader = makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadAsText, nullptr);
+    loader->setEncoding(encoding);
+    return startLoadingString(scriptExecutionContext, loader.get(), blob);
 }
 
 ExceptionOr<String> FileReaderSync::readAsDataURL(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
 {
-    FileReaderLoader loader(FileReaderLoader::ReadAsDataURL, nullptr);
-    loader.setDataType(blob.type());
-    return startLoadingString(scriptExecutionContext, loader, blob);
+    auto loader = makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadAsDataURL, nullptr);
+    loader->setDataType(blob.type());
+    return startLoadingString(scriptExecutionContext, loader.get(), blob);
 }
 
 ExceptionOr<void> FileReaderSync::startLoading(ScriptExecutionContext& scriptExecutionContext, FileReaderLoader& loader, Blob& blob)

--- a/Source/WebCore/html/BaseTextInputType.h
+++ b/Source/WebCore/html/BaseTextInputType.h
@@ -39,6 +39,7 @@ namespace WebCore {
 // They support maxlength, selection functions, and so on.
 class BaseTextInputType : public TextFieldInputType {
     WTF_MAKE_TZONE_ALLOCATED(BaseTextInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BaseTextInputType);
 public:
     bool patternMismatch(const String&) const final;
 

--- a/Source/WebCore/html/EmailInputType.h
+++ b/Source/WebCore/html/EmailInputType.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class EmailInputType final : public BaseTextInputType {
     WTF_MAKE_TZONE_ALLOCATED(EmailInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EmailInputType);
 public:
     static Ref<EmailInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
@@ -33,6 +33,7 @@ class FormAssociatedCustomElement;
 
 class HTMLMaybeFormAssociatedCustomElement final : public HTMLElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLMaybeFormAssociatedCustomElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMaybeFormAssociatedCustomElement);
 public:
     static Ref<HTMLMaybeFormAssociatedCustomElement> create(const QualifiedName& tagName, Document&);
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -736,6 +736,11 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeCheckedPtr<Node>::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const { CanMakeCheckedPtr<Node>::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const { CanMakeCheckedPtr<Node>::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion()
+    {
+        PlatformMediaSessionClient::setBegunCheckedPtrDeletion();
+        CanMakeCheckedPtr<Node>::setBegunCheckedPtrDeletion();
+    }
 
     void forceStereoDecoding() { m_forceStereoDecoding = true; }
 protected:

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -796,7 +796,7 @@ public:
 private:
     PendingImageBitmap(ScriptExecutionContext& scriptExecutionContext, RefPtr<Blob>&& blob, ImageBitmapOptions&& options, std::optional<IntRect> rect, ImageBitmap::ImageBitmapCompletionHandler&& completionHandler)
         : ActiveDOMObject(&scriptExecutionContext)
-        , m_blobLoader(FileReaderLoader::ReadAsArrayBuffer, this)
+        , m_blobLoader(makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadAsArrayBuffer, this))
         , m_blob(WTFMove(blob))
         , m_options(WTFMove(options))
         , m_rect(WTFMove(rect))
@@ -807,7 +807,7 @@ private:
     void start(ScriptExecutionContext& scriptExecutionContext)
     {
         m_pendingActivity = makePendingActivity(*this); // Prevent destruction until the load has finished.
-        m_blobLoader.start(&scriptExecutionContext, *m_blob);
+        m_blobLoader->start(&scriptExecutionContext, *m_blob);
     }
 
     // ActiveDOMObject
@@ -818,7 +818,7 @@ private:
     void didReceiveData() final { }
     void didFinishLoading() final
     {
-        createImageBitmapAndCallCompletionHandlerSoon(m_blobLoader.arrayBufferResult());
+        createImageBitmapAndCallCompletionHandlerSoon(m_blobLoader->arrayBufferResult());
     }
     void didFail(ExceptionCode) final
     {
@@ -843,10 +843,10 @@ private:
             return;
         }
 
-        ImageBitmap::createFromBuffer(*scriptExecutionContext(), m_arrayBufferToProcess.releaseNonNull(), m_blob->type(), m_blob->size(), m_blobLoader.url(), WTFMove(m_options), WTFMove(m_rect), WTFMove(m_completionHandler));
+        ImageBitmap::createFromBuffer(*scriptExecutionContext(), m_arrayBufferToProcess.releaseNonNull(), m_blob->type(), m_blob->size(), m_blobLoader->url(), WTFMove(m_options), WTFMove(m_rect), WTFMove(m_completionHandler));
     }
 
-    FileReaderLoader m_blobLoader;
+    const UniqueRef<FileReaderLoader> m_blobLoader;
     RefPtr<Blob> m_blob;
     ImageBitmapOptions m_options;
     std::optional<IntRect> m_rect;

--- a/Source/WebCore/html/NumberInputType.h
+++ b/Source/WebCore/html/NumberInputType.h
@@ -38,6 +38,7 @@ namespace WebCore {
 
 class NumberInputType final : public TextFieldInputType {
     WTF_MAKE_TZONE_ALLOCATED(NumberInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NumberInputType);
 public:
     static Ref<NumberInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/PasswordInputType.h
+++ b/Source/WebCore/html/PasswordInputType.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class PasswordInputType final : public BaseTextInputType {
     WTF_MAKE_TZONE_ALLOCATED(PasswordInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PasswordInputType);
 public:
     static Ref<PasswordInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/PluginDocument.h
+++ b/Source/WebCore/html/PluginDocument.h
@@ -33,6 +33,7 @@ class PluginViewBase;
 
 class PluginDocument final : public HTMLDocument {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PluginDocument);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PluginDocument);
 public:
     static Ref<PluginDocument> create(LocalFrame& frame, const URL& url)
     {

--- a/Source/WebCore/html/SearchInputType.h
+++ b/Source/WebCore/html/SearchInputType.h
@@ -41,6 +41,7 @@ class SearchFieldResultsButtonElement;
 
 class SearchInputType final : public BaseTextInputType {
     WTF_MAKE_TZONE_ALLOCATED(SearchInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SearchInputType);
 public:
     static Ref<SearchInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/TelephoneInputType.h
+++ b/Source/WebCore/html/TelephoneInputType.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class TelephoneInputType final : public BaseTextInputType {
     WTF_MAKE_TZONE_ALLOCATED(TelephoneInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TelephoneInputType);
 public:
     static Ref<TelephoneInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -47,7 +47,7 @@ class TextControlInnerTextElement;
 // The class represents types of which UI contain text fields.
 // It supports not only the types for BaseTextInputType but also type=number.
 class TextFieldInputType : public InputType, protected SpinButtonOwner, protected AutoFillButtonElement::AutoFillButtonOwner
-    , private DataListSuggestionsClient, protected DataListButtonElement::DataListButtonOwner
+    , public DataListSuggestionsClient, protected DataListButtonElement::DataListButtonOwner
 {
     WTF_MAKE_TZONE_ALLOCATED(TextFieldInputType);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextFieldInputType);

--- a/Source/WebCore/html/TextInputType.h
+++ b/Source/WebCore/html/TextInputType.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class TextInputType final : public BaseTextInputType {
     WTF_MAKE_TZONE_ALLOCATED(TextInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextInputType);
 public:
     static Ref<TextInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/URLInputType.h
+++ b/Source/WebCore/html/URLInputType.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class URLInputType final : public BaseTextInputType {
     WTF_MAKE_TZONE_ALLOCATED(URLInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(URLInputType);
 public:
     static Ref<URLInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -59,6 +59,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     HTMLDocumentParser* asHTMLDocumentParser() final { return this; }
 

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
@@ -50,6 +50,7 @@ using namespace Inspector;
 
 InspectorAuditResourcesObject::InspectorAuditResourcesObject(InspectorAuditAgent& auditAgent)
     : m_auditAgent(auditAgent)
+    , m_cachedImageClient(makeUniqueRef<InspectorAuditCachedImageClient>())
 {
 }
 
@@ -125,7 +126,7 @@ CachedResourceClient& InspectorAuditResourcesObject::clientForResource(const Cac
         return m_cachedFontClient;
 
     if (is<CachedImage>(cachedResource))
-        return m_cachedImageClient;
+        return m_cachedImageClient.get();
 
     if (is<CachedRawResource>(cachedResource))
         return m_cachedRawResourceClient;

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.h
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.h
@@ -36,6 +36,7 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/UniqueRef.h>
 
 namespace WebCore {
 
@@ -83,7 +84,7 @@ private:
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(InspectorAuditCachedImageClient);
         WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorAuditCachedImageClient);
     };
-    InspectorAuditCachedImageClient m_cachedImageClient;
+    UniqueRef<InspectorAuditCachedImageClient> m_cachedImageClient;
 
     class InspectorAuditCachedRawResourceClient : public CachedRawResourceClient { };
     InspectorAuditCachedRawResourceClient m_cachedRawResourceClient;

--- a/Source/WebCore/inspector/agents/WebHeapAgent.h
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.h
@@ -39,6 +39,7 @@ struct GarbageCollectionData;
 class WebHeapAgent : public Inspector::InspectorHeapAgent {
     WTF_MAKE_NONCOPYABLE(WebHeapAgent);
     WTF_MAKE_TZONE_ALLOCATED(WebHeapAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebHeapAgent);
     friend class SendGarbageCollectionEventsTask;
 public:
     WebHeapAgent(WebAgentContext&);

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.h
@@ -36,6 +36,7 @@ namespace WebCore {
 class PageHeapAgent final : public WebHeapAgent {
     WTF_MAKE_NONCOPYABLE(PageHeapAgent);
     WTF_MAKE_TZONE_ALLOCATED(PageHeapAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageHeapAgent);
 public:
     PageHeapAgent(PageAgentContext&);
     ~PageHeapAgent();

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
@@ -43,7 +43,7 @@ struct PaintInfo;
 
 namespace LayoutIntegration {
 
-class FlexLayout final : public CanMakeCheckedPtr<FlexLayout> {
+class FlexLayout final : public CanMakeCheckedPtr<FlexLayout, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED(FlexLayout);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FlexLayout);
 public:

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -276,6 +276,7 @@ class EmptyDragClient final : public DragClient {
 
 class EmptyEditorClient final : public EditorClient {
     WTF_MAKE_TZONE_ALLOCATED(EmptyEditorClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EmptyEditorClient);
 private:
     bool shouldDeleteRange(const std::optional<SimpleRange>&) final { return false; }
     bool smartInsertDeleteEnabled() final { return false; }

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -65,7 +65,7 @@ struct UpdateScrollInfoAfterLayoutTransaction {
     SingleThreadWeakHashSet<RenderBlock> blocks;
 };
 
-class LocalFrameViewLayoutContext final : public CanMakeCheckedPtr<LocalFrameViewLayoutContext> {
+class LocalFrameViewLayoutContext final : public CanMakeCheckedPtr<LocalFrameViewLayoutContext, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED(LocalFrameViewLayoutContext);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LocalFrameViewLayoutContext);
 public:

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -97,7 +97,7 @@ enum class IncludeReportOnlyPolicies : bool {
 using HashAlgorithmSet = uint8_t;
 using HashAlgorithmSetCollection = FixedVector<std::pair<HashAlgorithmSet, FixedVector<String>>>;
 
-class ContentSecurityPolicy final : public CanMakeThreadSafeCheckedPtr<ContentSecurityPolicy> {
+class ContentSecurityPolicy final : public CanMakeThreadSafeCheckedPtr<ContentSecurityPolicy, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ContentSecurityPolicy, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ContentSecurityPolicy);
 public:

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -42,7 +42,7 @@ class ScrollingStateFrameScrollingNode;
 // will be informed and will schedule a timer that will clone the new state tree and send it over to
 // the scrolling thread, avoiding locking. 
 
-class ScrollingStateTree final : public CanMakeCheckedPtr<ScrollingStateTree> {
+class ScrollingStateTree final : public CanMakeCheckedPtr<ScrollingStateTree, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingStateTree, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollingStateTree);
     friend class ScrollingStateNode;

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -47,7 +47,7 @@ class ScrollerPairMac;
 
 struct ScrollbarColor;
 
-class ScrollerMac final : public CanMakeThreadSafeCheckedPtr<ScrollerMac> {
+class ScrollerMac final : public CanMakeThreadSafeCheckedPtr<ScrollerMac, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ScrollerMac);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollerMac);
     friend class ScrollerPairMac;

--- a/Source/WebCore/platform/CaretAnimator.h
+++ b/Source/WebCore/platform/CaretAnimator.h
@@ -73,7 +73,7 @@ public:
     virtual Node* caretNode() = 0;
 };
 
-class CaretAnimator : public CanMakeCheckedPtr<CaretAnimator> {
+class CaretAnimator : public CanMakeCheckedPtr<CaretAnimator, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED(CaretAnimator);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CaretAnimator);
 public:

--- a/Source/WebCore/platform/OpacityCaretAnimator.h
+++ b/Source/WebCore/platform/OpacityCaretAnimator.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class OpacityCaretAnimator final : public CaretAnimator {
     WTF_MAKE_TZONE_ALLOCATED(OpacityCaretAnimator);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(OpacityCaretAnimator);
 public:
     explicit OpacityCaretAnimator(CaretAnimationClient&, std::optional<LayoutRect> = std::nullopt);
 

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -84,6 +84,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     USING_CAN_MAKE_WEAKPTR(Widget);
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -65,6 +65,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     WEBCORE_EXPORT void setMediaElement(HTMLMediaElement*);
     HTMLMediaElement* mediaElement() const { return m_mediaElement.get(); }

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -71,6 +71,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     void videoDimensionsChanged(const FloatSize& videoDimensions)
     {

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -85,7 +85,7 @@ FontCascade::FontCascade(FontCascadeDescription&& description, const FontCascade
 
 FontCascade::FontCascade(const FontCascade& other)
     : CanMakeWeakPtr<FontCascade>()
-    , CanMakeCheckedPtr<FontCascade>()
+    , CanMakeCheckedPtr<FontCascade, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes>()
     , m_fontDescription(other.m_fontDescription)
     , m_spacing(other.m_spacing)
     , m_fonts(other.m_fonts)

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -118,7 +118,7 @@ public:
     void operator()(TextLayout*) const;
 };
 
-class FontCascade final : public CanMakeWeakPtr<FontCascade>, public CanMakeCheckedPtr<FontCascade> {
+class FontCascade final : public CanMakeWeakPtr<FontCascade>, public CanMakeCheckedPtr<FontCascade, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED(FontCascade);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FontCascade);
 public:

--- a/Source/WebCore/platform/graphics/TextRun.h
+++ b/Source/WebCore/platform/graphics/TextRun.h
@@ -42,7 +42,7 @@ class Font;
 
 struct GlyphData;
 
-class TextRun final : public CanMakeCheckedPtr<TextRun> {
+class TextRun final : public CanMakeCheckedPtr<TextRun, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED(TextRun);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextRun);
     friend void add(Hasher&, const TextRun&);

--- a/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
@@ -83,6 +83,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     void durationChanged(double) final { }
     void currentTimeChanged(double, double) final { }

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -103,6 +103,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     const Ref<NullPlaybackSessionInterface> m_playbackSessionInterface;
     ThreadSafeWeakPtr<VideoPresentationModel> m_videoPresentationModel;

--- a/Source/WebCore/platform/ios/DeviceMotionClientIOS.h
+++ b/Source/WebCore/platform/ios/DeviceMotionClientIOS.h
@@ -41,6 +41,7 @@ namespace WebCore {
 
 class DeviceMotionClientIOS : public DeviceMotionClient, public MotionManagerClient {
     WTF_MAKE_TZONE_ALLOCATED(DeviceMotionClientIOS);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceMotionClientIOS);
 public:
     DeviceMotionClientIOS(RefPtr<DeviceOrientationUpdateProvider>&&);
     ~DeviceMotionClientIOS() override;

--- a/Source/WebCore/platform/ios/DeviceOrientationClientIOS.h
+++ b/Source/WebCore/platform/ios/DeviceOrientationClientIOS.h
@@ -41,6 +41,7 @@ namespace WebCore {
 
 class DeviceOrientationClientIOS : public DeviceOrientationClient, public MotionManagerClient {
     WTF_MAKE_TZONE_ALLOCATED(DeviceOrientationClientIOS);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceOrientationClientIOS);
 public:
     DeviceOrientationClientIOS(RefPtr<DeviceOrientationUpdateProvider>&&);
     ~DeviceOrientationClientIOS() override;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -106,10 +106,11 @@ protected:
     WeakPtr<PlaybackSessionModel> m_playbackSessionModel;
 
     // CheckedPtr interface
-    uint32_t checkedPtrCount() const final;
-    uint32_t checkedPtrCountWithoutThreadCheck() const final;
-    void incrementCheckedPtrCount() const final;
-    void decrementCheckedPtrCount() const final;
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     WeakPtr<VideoPresentationInterfaceIOS> m_videoPresentationInterface;
 

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
@@ -136,27 +136,6 @@ WTFLogChannel& PlaybackSessionInterfaceIOS::logChannel() const
 {
     return LogMedia;
 }
-
-uint32_t PlaybackSessionInterfaceIOS::checkedPtrCount() const
-{
-    return CanMakeCheckedPtr::checkedPtrCount();
-}
-
-uint32_t PlaybackSessionInterfaceIOS::checkedPtrCountWithoutThreadCheck() const
-{
-    return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck();
-}
-
-void PlaybackSessionInterfaceIOS::incrementCheckedPtrCount() const
-{
-    CanMakeCheckedPtr::incrementCheckedPtrCount();
-}
-
-void PlaybackSessionInterfaceIOS::decrementCheckedPtrCount() const
-{
-    CanMakeCheckedPtr::decrementCheckedPtrCount();
-}
-
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -81,6 +81,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     // VideoPresentationModelClient
     void hasVideoChanged(bool) override { }

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -130,6 +130,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     // VideoPresentationModelClient
     void hasVideoChanged(bool) override;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -100,10 +100,11 @@ private:
     PlaybackSessionInterfaceMac(PlaybackSessionModel&);
 
     // CheckedPtr interface
-    uint32_t checkedPtrCount() const final;
-    uint32_t checkedPtrCountWithoutThreadCheck() const final;
-    void incrementCheckedPtrCount() const final;
-    void decrementCheckedPtrCount() const final;
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     WeakPtr<PlaybackSessionModel> m_playbackSessionModel;
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -299,26 +299,6 @@ void PlaybackSessionInterfaceMac::updatePlaybackControlsManagerTiming(double cur
     manager.get().timing = [getAVValueTimingClassSingleton() valueTimingWithAnchorValue:currentTime anchorTimeStamp:effectiveAnchorTime rate:effectivePlaybackRate];
 }
 
-uint32_t PlaybackSessionInterfaceMac::checkedPtrCount() const
-{
-    return CanMakeCheckedPtr::checkedPtrCount();
-}
-
-uint32_t PlaybackSessionInterfaceMac::checkedPtrCountWithoutThreadCheck() const
-{
-    return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck();
-}
-
-void PlaybackSessionInterfaceMac::incrementCheckedPtrCount() const
-{
-    CanMakeCheckedPtr::incrementCheckedPtrCount();
-}
-
-void PlaybackSessionInterfaceMac::decrementCheckedPtrCount() const
-{
-    CanMakeCheckedPtr::decrementCheckedPtrCount();
-}
-
 RetainPtr<WebPlaybackControlsManager> PlaybackSessionInterfaceMac::protectedPlayBackControlsManager()
 {
     return playBackControlsManager();

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -135,6 +135,8 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
+
     void setDocumentBecameVisibleCallback(Function<void()>&& callback) { m_documentBecameVisibleCallback = WTFMove(callback); }
 
 private:

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h
@@ -63,6 +63,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     struct AudioVideoSelectedTracks {
         MediaStreamTrackPrivate* audioTrack { nullptr };

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
@@ -82,6 +82,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     static RefPtr<AudioMediaStreamTrackRenderer> createRenderer(AudioTrackPrivateMediaStream&);
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
@@ -70,6 +70,7 @@ private:
         uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
         void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
         void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+        void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     private:
         bool preventSourceFromEnding() final { return true; }

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -87,6 +87,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     std::function<void(Function<void()>&&)> getPostTask()
     {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -640,6 +640,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     void flush()
     {

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.h
@@ -50,6 +50,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     void audioSamplesAvailable(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
 

--- a/Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h
@@ -55,6 +55,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     // WebAudioSourceProviderCocoa
     void hasNewClient(AudioSourceProviderClient*) final;

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h
@@ -54,6 +54,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     void audioSamplesAvailable(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
 

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -78,9 +78,10 @@ public:
 
     // ScreenCaptureSessionSourceObserver.
     uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
 private:
     // DisplayCaptureSourceCocoa::Capturer

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
@@ -42,6 +42,7 @@ class DeviceOrientationController;
 // client when running DumpRenderTree.
 class DeviceOrientationClientMock final : public DeviceOrientationClient {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(DeviceOrientationClientMock, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceOrientationClientMock);
 public:
     WEBCORE_EXPORT DeviceOrientationClientMock();
 

--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -89,6 +89,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeThreadSafeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     void retain() override { ref(); }
     void release() override { deref(); }

--- a/Source/WebCore/rendering/MarkedText.h
+++ b/Source/WebCore/rendering/MarkedText.h
@@ -39,7 +39,7 @@ class RenderedDocumentMarker;
 struct TextBoxSelectableRange;
 enum class DocumentMarkerType : uint32_t;
 
-struct MarkedText : public CanMakeCheckedPtr<MarkedText, WTF::DefaultedOperatorEqual::Yes> {
+struct MarkedText : public CanMakeCheckedPtr<MarkedText, WTF::DefaultedOperatorEqual::Yes, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(MarkedText);
     WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(MarkedText);
 

--- a/Source/WebCore/rendering/RegionContext.h
+++ b/Source/WebCore/rendering/RegionContext.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class Path;
 
-class RegionContext : public CanMakeCheckedPtr<RegionContext> {
+class RegionContext : public CanMakeCheckedPtr<RegionContext, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED(RegionContext);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RegionContext);
 public:

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -65,6 +65,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     RenderLayer& layer() { return m_layer; }
 

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -52,6 +52,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     HTMLSelectElement& selectElement() const;
 

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -53,6 +53,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return RenderFlexibleBox::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { RenderFlexibleBox::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { RenderFlexibleBox::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
 #if !PLATFORM(IOS_FAMILY)
     bool popupIsVisible() const { return m_popupIsVisible; }

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -51,6 +51,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return RenderTextControlSingleLine::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { RenderTextControlSingleLine::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { RenderTextControlSingleLine::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
 private:
     void willBeDestroyed() override;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -440,7 +440,7 @@ struct PseudoStyleCache {
 };
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(RenderStyle);
-class RenderStyle final : public CanMakeCheckedPtr<RenderStyle> {
+class RenderStyle final : public CanMakeCheckedPtr<RenderStyle, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(RenderStyle, RenderStyle);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderStyle);
 private:

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -56,7 +56,7 @@ struct TextUpdate {
     std::optional<std::unique_ptr<RenderStyle>> inheritedDisplayContentsStyle;
 };
 
-class Update final : public CanMakeCheckedPtr<Update> {
+class Update final : public CanMakeCheckedPtr<Update, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED(Update);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Update);
 public:

--- a/Source/WebCore/style/TreeResolutionState.h
+++ b/Source/WebCore/style/TreeResolutionState.h
@@ -32,7 +32,7 @@ namespace WebCore {
 namespace Style {
 
 // This state has lifetime of a single style resolution cycle, including any layout interleaving.
-struct TreeResolutionState : public CanMakeCheckedPtr<TreeResolutionState> {
+struct TreeResolutionState : public CanMakeCheckedPtr<TreeResolutionState, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     AnchorPositionedStates anchorPositionedStates;
 
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(TreeResolutionState);

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -42,6 +42,11 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const { return SVGFilterPrimitiveStandardAttributes::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const { SVGFilterPrimitiveStandardAttributes::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const { SVGFilterPrimitiveStandardAttributes::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion()
+    {
+        SVGFilterPrimitiveStandardAttributes::setBegunCheckedPtrDeletion();
+        CachedImageClient::setBegunCheckedPtrDeletion();
+    }
 
     bool renderingTaintsOrigin() const;
 

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -79,7 +79,7 @@ private:
     Ref<SVGAnimatedLength> m_width { SVGAnimatedLength::create(this, SVGLengthMode::Width) };
     Ref<SVGAnimatedLength> m_height { SVGAnimatedLength::create(this, SVGLengthMode::Height) };
     Ref<SVGAnimatedPreserveAspectRatio> m_preserveAspectRatio { SVGAnimatedPreserveAspectRatio::create(this) };
-    SVGImageLoader m_imageLoader;
+    const UniqueRef<SVGImageLoader> m_imageLoader;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1636,6 +1636,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 #endif // ENABLE(MEDIA_STREAM)
 
     Document* contextDocument() const;

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -48,10 +48,11 @@ public:
     explicit WorkerMessagingProxy(Worker&);
     virtual ~WorkerMessagingProxy();
 
-    uint32_t checkedPtrCount() const { return CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::decrementCheckedPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::setBegunCheckedPtrDeletion(); }
 
 private:
     // Implementations of WorkerGlobalScopeProxy.

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -78,10 +78,11 @@ public:
     }
 
     // CanMakeCheckedPtr.
-    uint32_t checkedPtrCount() const { return CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::decrementCheckedPtrCount(); }
+    uint32_t checkedPtrCount() const final  { return CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final  { return CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final  { CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final  { CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::setBegunCheckedPtrDeletion(); }
 
 private:
     void postExceptionToWorkerObject(const String&, int, int, const String&) final { };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -105,10 +105,11 @@ public:
     ServiceWorkerDebuggable& remoteDebuggable() { return m_remoteDebuggable; }
 #endif
 
-    uint32_t checkedPtrCount() const { return CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::decrementCheckedPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::setBegunCheckedPtrDeletion(); }
 
 private:
     WEBCORE_EXPORT ServiceWorkerThreadProxy(Ref<Page>&&, ServiceWorkerContextData&&, ServiceWorkerData&&, String&& userAgent, WorkerThreadMode, CacheStorageProvider&, std::unique_ptr<NotificationClient>&&);

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
@@ -61,10 +61,11 @@ public:
     bool isTerminatingOrTerminated() const { return m_isTerminatingOrTerminated; }
     void setAsTerminatingOrTerminated() { m_isTerminatingOrTerminated = true; }
 
-    uint32_t checkedPtrCount() const { return CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::decrementCheckedPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::setBegunCheckedPtrDeletion(); }
 
 private:
     WEBCORE_EXPORT SharedWorkerThreadProxy(Ref<Page>&&, SharedWorkerIdentifier, const ClientOrigin&, WorkerFetchResult&&, WorkerOptions&&, WorkerInitializationData&&, CacheStorageProvider&);

--- a/Source/WebCore/worklets/PaintWorkletGlobalScope.h
+++ b/Source/WebCore/worklets/PaintWorkletGlobalScope.h
@@ -62,6 +62,7 @@ struct PaintDefinition : public CanMakeWeakPtr<PaintDefinition> {
 
 class PaintWorkletGlobalScope final : public WorkletGlobalScope {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PaintWorkletGlobalScope);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PaintWorkletGlobalScope);
 public:
     static RefPtr<PaintWorkletGlobalScope> tryCreate(Document&, ScriptSourceCode&&);
 

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -54,6 +54,7 @@ using WorkletGlobalScopeIdentifier = ObjectIdentifier<WorkletGlobalScopeIdentifi
 
 class WorkletGlobalScope : public WorkerOrWorkletGlobalScope {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WorkletGlobalScope);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkletGlobalScope);
 public:
     virtual ~WorkletGlobalScope();
 

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -102,6 +102,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     void insert(SegmentedString&&) final;
     void append(RefPtr<StringImpl>&&) final;

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -345,6 +345,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     void sourceStopped() final
     {

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -67,7 +67,7 @@ using namespace WebCore;
 
 #define ITP_DEBUG_MODE_RELEASE_LOG(fmt, ...) RELEASE_LOG_INFO(ITPDebug, "ResourceLoadStatisticsStore: " fmt, ##__VA_ARGS__)
 #define ITP_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(ResourceLoadStatistics, "%p - [sessionID=%" PRIu64 "] - ResourceLoadStatisticsStore::" fmt, this, m_sessionID.toUInt64(), ##__VA_ARGS__)
-#define ITP_RELEASE_LOG_DATABASE_ERROR(fmt, ...) RELEASE_LOG_ERROR(ResourceLoadStatistics, "%p - [sessionID=%" PRIu64 ", error=%d, message=%" PRIVATE_LOG_STRING "] - ResourceLoadStatisticsStore::" fmt, this, m_sessionID.toUInt64(), m_database.lastError(), m_database.lastErrorMsg(), ##__VA_ARGS__)
+#define ITP_RELEASE_LOG_DATABASE_ERROR(fmt, ...) RELEASE_LOG_ERROR(ResourceLoadStatistics, "%p - [sessionID=%" PRIu64 ", error=%d, message=%" PRIVATE_LOG_STRING "] - ResourceLoadStatisticsStore::" fmt, this, m_sessionID.toUInt64(), m_database->lastError(), m_database->lastErrorMsg(), ##__VA_ARGS__)
 
 
 constexpr unsigned operatingDatesWindowLong { 30 }; // days
@@ -356,7 +356,7 @@ ResourceLoadStatisticsStore::ResourceLoadStatisticsStore(WebResourceLoadStatisti
     openAndUpdateSchemaIfNecessary();
     enableForeignKeys();
 
-    if (!m_database.turnOnIncrementalAutoVacuum())
+    if (!m_database->turnOnIncrementalAutoVacuum())
         ITP_RELEASE_LOG_DATABASE_ERROR("ResourceLoadStatisticsStore: failed to turn on auto vacuum");
 
     includeTodayAsOperatingDateIfNecessary();
@@ -469,7 +469,7 @@ HashSet<RegistrableDomain> ResourceLoadStatisticsStore::loadWebsitesWithUserInte
     ASSERT(!RunLoop::isMain());
 
     HashSet<RegistrableDomain> results;
-    auto statement = m_database.prepareStatement(domainWithUserInteractionQuery);
+    auto statement = m_database->prepareStatement(domainWithUserInteractionQuery);
     if (!statement)
         return { };
 
@@ -868,7 +868,7 @@ bool ResourceLoadStatisticsStore::tableExists(StringView tableName)
 void ResourceLoadStatisticsStore::deleteTable(StringView tableName)
 {
     ASSERT(tableExists(tableName));
-    auto dropTableQuery = m_database.prepareStatementSlow(makeString("DROP TABLE "_s, tableName));
+    auto dropTableQuery = m_database->prepareStatementSlow(makeString("DROP TABLE "_s, tableName));
     ASSERT(dropTableQuery);
     if (!dropTableQuery || dropTableQuery->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("deleteTable: failed to step statement");
@@ -876,7 +876,7 @@ void ResourceLoadStatisticsStore::deleteTable(StringView tableName)
 
 bool ResourceLoadStatisticsStore::missingUniqueIndices()
 {
-    auto statement = m_database.prepareStatement("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index'"_s);
+    auto statement = m_database->prepareStatement("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index'"_s);
     if (!statement) {
         ITP_RELEASE_LOG_DATABASE_ERROR("missingUniqueIndices: failed to prepare statement");
         return false;
@@ -921,7 +921,7 @@ void ResourceLoadStatisticsStore::migrateDataToPCMDatabaseIfNecessary()
     Vector<WebCore::PrivateClickMeasurement> unattributed;
     {
         constexpr auto allUnattributedPrivateClickMeasurementAttributionsQuery = "SELECT * FROM UnattributedPrivateClickMeasurement"_s;
-        auto unattributedScopedStatement = m_database.prepareStatement(allUnattributedPrivateClickMeasurementAttributionsQuery);
+        auto unattributedScopedStatement = m_database->prepareStatement(allUnattributedPrivateClickMeasurementAttributionsQuery);
         if (!unattributedScopedStatement) {
             ITP_RELEASE_LOG_DATABASE_ERROR("migrateDataToPCMDatabaseIfNecessary: failed to prepare unattributedScopedStatement");
             return;
@@ -933,7 +933,7 @@ void ResourceLoadStatisticsStore::migrateDataToPCMDatabaseIfNecessary()
     Vector<WebCore::PrivateClickMeasurement> attributed;
     {
         constexpr auto allAttributedPrivateClickMeasurementQuery = "SELECT * FROM AttributedPrivateClickMeasurement"_s;
-        auto attributedScopedStatement = m_database.prepareStatement(allAttributedPrivateClickMeasurementQuery);
+        auto attributedScopedStatement = m_database->prepareStatement(allAttributedPrivateClickMeasurementQuery);
         if (!attributedScopedStatement) {
             ITP_RELEASE_LOG_DATABASE_ERROR("migrateDataToPCMDatabaseIfNecessary: failed to prepare attributedScopedStatement");
             return;
@@ -972,7 +972,7 @@ void ResourceLoadStatisticsStore::addMissingTablesIfNecessary()
 
     for (auto& table : *missingTables) {
         auto createTableQuery = expectedTableAndIndexQueries().get(table).first;
-        if (!m_database.executeCommandSlow(createTableQuery))
+        if (!m_database->executeCommandSlow(createTableQuery))
             ITP_RELEASE_LOG_DATABASE_ERROR("addMissingTablesIfNecessary: failed to execute statement");
     }
 
@@ -1067,18 +1067,18 @@ bool ResourceLoadStatisticsStore::isEmpty() const
 
 bool ResourceLoadStatisticsStore::createUniqueIndices()
 {
-    if (!m_database.executeCommand(createUniqueIndexStorageAccessUnderTopFrameDomains)
-        || !m_database.executeCommand(createUniqueIndexTopFrameUniqueRedirectsTo)
-        || !m_database.executeCommand(createUniqueIndexTopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement)
-        || !m_database.executeCommand(createUniqueIndexTopFrameUniqueRedirectsFrom)
-        || !m_database.executeCommand(createUniqueIndexTopFrameLinkDecorationsFrom)
-        || !m_database.executeCommand(createUniqueIndexTopFrameLoadedThirdPartyScripts)
-        || !m_database.executeCommand(createUniqueIndexSubframeUnderTopFrameDomains)
-        || !m_database.executeCommand(createUniqueIndexSubresourceUnderTopFrameDomains)
-        || !m_database.executeCommand(createUniqueIndexSubresourceUniqueRedirectsTo)
-        || !m_database.executeCommand(createUniqueIndexSubresourceUniqueRedirectsFrom)
-        || !m_database.executeCommand(createUniqueIndexSubresourceUnderTopFrameDomains)
-        || !m_database.executeCommand(createUniqueIndexOperatingDates)) {
+    if (!m_database->executeCommand(createUniqueIndexStorageAccessUnderTopFrameDomains)
+        || !m_database->executeCommand(createUniqueIndexTopFrameUniqueRedirectsTo)
+        || !m_database->executeCommand(createUniqueIndexTopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement)
+        || !m_database->executeCommand(createUniqueIndexTopFrameUniqueRedirectsFrom)
+        || !m_database->executeCommand(createUniqueIndexTopFrameLinkDecorationsFrom)
+        || !m_database->executeCommand(createUniqueIndexTopFrameLoadedThirdPartyScripts)
+        || !m_database->executeCommand(createUniqueIndexSubframeUnderTopFrameDomains)
+        || !m_database->executeCommand(createUniqueIndexSubresourceUnderTopFrameDomains)
+        || !m_database->executeCommand(createUniqueIndexSubresourceUniqueRedirectsTo)
+        || !m_database->executeCommand(createUniqueIndexSubresourceUniqueRedirectsFrom)
+        || !m_database->executeCommand(createUniqueIndexSubresourceUnderTopFrameDomains)
+        || !m_database->executeCommand(createUniqueIndexOperatingDates)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createUniqueIndices: failed to execute statement");
         return false;
     }
@@ -1089,68 +1089,68 @@ bool ResourceLoadStatisticsStore::createSchema()
 {
     ASSERT(!RunLoop::isMain());
 
-    if (!m_database.executeCommand(createObservedDomain)) {
+    if (!m_database->executeCommand(createObservedDomain)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createObservedDomain");
         return false;
     }
 
     // FIXME: drop TopLevelDomains table as it is not used.
-    if (!m_database.executeCommand(createTopLevelDomains)) {
+    if (!m_database->executeCommand(createTopLevelDomains)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createTopLevelDomains");
         return false;
     }
 
-    if (!m_database.executeCommand(createStorageAccessUnderTopFrameDomains)) {
+    if (!m_database->executeCommand(createStorageAccessUnderTopFrameDomains)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createStorageAccessUnderTopFrameDomains");
         return false;
     }
 
-    if (!m_database.executeCommand(createTopFrameUniqueRedirectsTo)) {
+    if (!m_database->executeCommand(createTopFrameUniqueRedirectsTo)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createTopFrameUniqueRedirectsTo");
         return false;
     }
 
-    if (!m_database.executeCommand(createTopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement)) {
+    if (!m_database->executeCommand(createTopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createTopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement");
         return false;
     }
 
-    if (!m_database.executeCommand(createTopFrameUniqueRedirectsFrom)) {
+    if (!m_database->executeCommand(createTopFrameUniqueRedirectsFrom)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createTopFrameUniqueRedirectsFrom");
         return false;
     }
 
-    if (!m_database.executeCommand(createTopFrameLinkDecorationsFrom)) {
+    if (!m_database->executeCommand(createTopFrameLinkDecorationsFrom)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createTopFrameLinkDecorationsFrom");
         return false;
     }
 
-    if (!m_database.executeCommand(createTopFrameLoadedThirdPartyScripts)) {
+    if (!m_database->executeCommand(createTopFrameLoadedThirdPartyScripts)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createTopFrameLoadedThirdPartyScripts");
         return false;
     }
 
-    if (!m_database.executeCommand(createSubframeUnderTopFrameDomains)) {
+    if (!m_database->executeCommand(createSubframeUnderTopFrameDomains)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createSubframeUnderTopFrameDomains");
         return false;
     }
 
-    if (!m_database.executeCommand(createSubresourceUnderTopFrameDomains)) {
+    if (!m_database->executeCommand(createSubresourceUnderTopFrameDomains)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createSubresourceUnderTopFrameDomains");
         return false;
     }
 
-    if (!m_database.executeCommand(createSubresourceUniqueRedirectsTo)) {
+    if (!m_database->executeCommand(createSubresourceUniqueRedirectsTo)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createSubresourceUniqueRedirectsTo");
         return false;
     }
 
-    if (!m_database.executeCommand(createSubresourceUniqueRedirectsFrom)) {
+    if (!m_database->executeCommand(createSubresourceUniqueRedirectsFrom)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createSubresourceUniqueRedirectsFrom");
         return false;
     }
 
-    if (!m_database.executeCommand(createOperatingDates)) {
+    if (!m_database->executeCommand(createOperatingDates)) {
         ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createOperatingDates");
         return false;
     }
@@ -1287,7 +1287,7 @@ String ResourceLoadStatisticsStore::ensureAndMakeDomainList(const HashSet<Regist
 
 void ResourceLoadStatisticsStore::insertDomainRelationshipList(const String& statement, const HashSet<RegistrableDomain>& domainList, unsigned domainID)
 {
-    auto insertRelationshipStatement = m_database.prepareStatementSlow(makeString(statement, ensureAndMakeDomainList(domainList), " );"_s));
+    auto insertRelationshipStatement = m_database->prepareStatementSlow(makeString(statement, ensureAndMakeDomainList(domainList), " );"_s));
 
     if (!insertRelationshipStatement || insertRelationshipStatement->bindInt(1, domainID) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("insertDomainRelationshipList: failed to bind first parameter");
@@ -1457,7 +1457,7 @@ Vector<ITPThirdPartyData> ResourceLoadStatisticsStore::aggregatedThirdPartyData(
 
     Vector<ITPThirdPartyData> thirdPartyDataList;
     const auto prevalentDomainsBindParameter = thirdPartyCookieBlockingMode() == ThirdPartyCookieBlockingMode::All ? "%"_s : "1"_s;
-    auto sortedStatistics = m_database.prepareStatement(joinSubStatisticsForSorting());
+    auto sortedStatistics = m_database->prepareStatement(joinSubStatisticsForSorting());
     if (!sortedStatistics
         || sortedStatistics->bindText(1, prevalentDomainsBindParameter)
         || sortedStatistics->bindText(2, "%"_s) != SQLITE_OK) {
@@ -1478,7 +1478,7 @@ void ResourceLoadStatisticsStore::incrementRecordsDeletedCountForDomains(HashSet
 {
     ASSERT(!RunLoop::isMain());
 
-    auto domainsToUpdateStatement = m_database.prepareStatementSlow(makeString("UPDATE ObservedDomains SET dataRecordsRemoved = dataRecordsRemoved + 1 WHERE registrableDomain IN ("_s, buildList(domains), ')'));
+    auto domainsToUpdateStatement = m_database->prepareStatementSlow(makeString("UPDATE ObservedDomains SET dataRecordsRemoved = dataRecordsRemoved + 1 WHERE registrableDomain IN ("_s, buildList(domains), ')'));
     if (!domainsToUpdateStatement || domainsToUpdateStatement->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("incrementRecordsDeletedCountForDomains: failed to step statement");
 }
@@ -1497,7 +1497,7 @@ unsigned ResourceLoadStatisticsStore::recursivelyFindNonPrevalentDomainsThatRedi
     ++numberOfRecursiveCalls;
 
     StdSet<unsigned> newlyIdentifiedDomains;
-    auto findSubresources = m_database.prepareStatement("SELECT SubresourceUniqueRedirectsFrom.fromDomainID from SubresourceUniqueRedirectsFrom INNER JOIN ObservedDomains ON ObservedDomains.domainID = SubresourceUniqueRedirectsFrom.fromDomainID WHERE subresourceDomainID = ? AND ObservedDomains.isPrevalent = 0"_s);
+    auto findSubresources = m_database->prepareStatement("SELECT SubresourceUniqueRedirectsFrom.fromDomainID from SubresourceUniqueRedirectsFrom INNER JOIN ObservedDomains ON ObservedDomains.domainID = SubresourceUniqueRedirectsFrom.fromDomainID WHERE subresourceDomainID = ? AND ObservedDomains.isPrevalent = 0"_s);
     if (!findSubresources || findSubresources->bindInt(1, primaryDomainID) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("recursivelyFindNonPrevalentDomainsThatRedirectedToThisDomain: failed to bind parameter for findSubresources");
         return 0;
@@ -1510,7 +1510,7 @@ unsigned ResourceLoadStatisticsStore::recursivelyFindNonPrevalentDomainsThatRedi
             newlyIdentifiedDomains.insert(newDomainID);
     }
 
-    auto findTopFrames = m_database.prepareStatement("SELECT TopFrameUniqueRedirectsFrom.fromDomainID from TopFrameUniqueRedirectsFrom INNER JOIN ObservedDomains ON ObservedDomains.domainID = TopFrameUniqueRedirectsFrom.fromDomainID WHERE targetDomainID = ? AND ObservedDomains.isPrevalent = 0"_s);
+    auto findTopFrames = m_database->prepareStatement("SELECT TopFrameUniqueRedirectsFrom.fromDomainID from TopFrameUniqueRedirectsFrom INNER JOIN ObservedDomains ON ObservedDomains.domainID = TopFrameUniqueRedirectsFrom.fromDomainID WHERE targetDomainID = ? AND ObservedDomains.isPrevalent = 0"_s);
     if (!findTopFrames
         || findTopFrames->bindInt(1, primaryDomainID) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("recursivelyFindNonPrevalentDomainsThatRedirectedToThisDomain: failed to bind parameter for findTopFrames");
@@ -1538,19 +1538,19 @@ void ResourceLoadStatisticsStore::markAsPrevalentIfHasRedirectedToPrevalent()
     ASSERT(!RunLoop::isMain());
 
     StdSet<unsigned> prevalentDueToRedirect;
-    auto subresourceRedirectStatement = m_database.prepareStatement("SELECT DISTINCT SubresourceUniqueRedirectsTo.subresourceDomainID FROM SubresourceUniqueRedirectsTo JOIN ObservedDomains ON ObservedDomains.domainID = SubresourceUniqueRedirectsTo.toDomainID AND ObservedDomains.isPrevalent = 1"_s);
+    auto subresourceRedirectStatement = m_database->prepareStatement("SELECT DISTINCT SubresourceUniqueRedirectsTo.subresourceDomainID FROM SubresourceUniqueRedirectsTo JOIN ObservedDomains ON ObservedDomains.domainID = SubresourceUniqueRedirectsTo.toDomainID AND ObservedDomains.isPrevalent = 1"_s);
     if (subresourceRedirectStatement) {
         while (subresourceRedirectStatement->step() == SQLITE_ROW)
             prevalentDueToRedirect.insert(subresourceRedirectStatement->columnInt(0));
     }
 
-    auto topFrameRedirectStatement = m_database.prepareStatement("SELECT DISTINCT TopFrameUniqueRedirectsTo.sourceDomainID FROM TopFrameUniqueRedirectsTo JOIN ObservedDomains ON ObservedDomains.domainID = TopFrameUniqueRedirectsTo.toDomainID AND ObservedDomains.isPrevalent = 1"_s);
+    auto topFrameRedirectStatement = m_database->prepareStatement("SELECT DISTINCT TopFrameUniqueRedirectsTo.sourceDomainID FROM TopFrameUniqueRedirectsTo JOIN ObservedDomains ON ObservedDomains.domainID = TopFrameUniqueRedirectsTo.toDomainID AND ObservedDomains.isPrevalent = 1"_s);
     if (topFrameRedirectStatement) {
         while (topFrameRedirectStatement->step() == SQLITE_ROW)
             prevalentDueToRedirect.insert(topFrameRedirectStatement->columnInt(0));
     }
 
-    auto markPrevalentStatement = m_database.prepareStatementSlow(makeString("UPDATE ObservedDomains SET isPrevalent = 1 WHERE domainID IN ("_s, buildList(prevalentDueToRedirect), ')'));
+    auto markPrevalentStatement = m_database->prepareStatementSlow(makeString("UPDATE ObservedDomains SET isPrevalent = 1 WHERE domainID IN ("_s, buildList(prevalentDueToRedirect), ')'));
     if (!markPrevalentStatement || markPrevalentStatement->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("markAsPrevalentIfHasRedirectedToPrevalent: failed to step statement");
 }
@@ -1560,7 +1560,7 @@ HashMap<unsigned, ResourceLoadStatisticsStore::NotVeryPrevalentResources> Resour
     ASSERT(!RunLoop::isMain());
 
     HashMap<unsigned, NotVeryPrevalentResources> results;
-    auto notVeryPrevalentResourcesStatement = m_database.prepareStatement("SELECT domainID, registrableDomain, isPrevalent FROM ObservedDomains WHERE isVeryPrevalent = 0"_s);
+    auto notVeryPrevalentResourcesStatement = m_database->prepareStatement("SELECT domainID, registrableDomain, isPrevalent FROM ObservedDomains WHERE isVeryPrevalent = 0"_s);
     if (notVeryPrevalentResourcesStatement) {
         while (notVeryPrevalentResourcesStatement->step() == SQLITE_ROW) {
             unsigned key = static_cast<unsigned>(notVeryPrevalentResourcesStatement->columnInt(0));
@@ -1575,7 +1575,7 @@ HashMap<unsigned, ResourceLoadStatisticsStore::NotVeryPrevalentResources> Resour
 
     auto domainIDsOfInterest = buildList(results.keys());
 
-    auto subresourceUnderTopFrameDomainsStatement = m_database.prepareStatementSlow(makeString("SELECT subresourceDomainID, COUNT(topFrameDomainID) FROM SubresourceUnderTopFrameDomains WHERE subresourceDomainID IN ("_s, domainIDsOfInterest, ") GROUP BY subresourceDomainID"_s));
+    auto subresourceUnderTopFrameDomainsStatement = m_database->prepareStatementSlow(makeString("SELECT subresourceDomainID, COUNT(topFrameDomainID) FROM SubresourceUnderTopFrameDomains WHERE subresourceDomainID IN ("_s, domainIDsOfInterest, ") GROUP BY subresourceDomainID"_s));
     if (subresourceUnderTopFrameDomainsStatement) {
         while (subresourceUnderTopFrameDomainsStatement->step() == SQLITE_ROW) {
             unsigned domainID = static_cast<unsigned>(subresourceUnderTopFrameDomainsStatement->columnInt(0));
@@ -1588,7 +1588,7 @@ HashMap<unsigned, ResourceLoadStatisticsStore::NotVeryPrevalentResources> Resour
         }
     }
 
-    auto subresourceUniqueRedirectsToCountStatement = m_database.prepareStatementSlow(makeString("SELECT subresourceDomainID, COUNT(toDomainID) FROM SubresourceUniqueRedirectsTo WHERE subresourceDomainID IN ("_s, domainIDsOfInterest, ") GROUP BY subresourceDomainID"_s));
+    auto subresourceUniqueRedirectsToCountStatement = m_database->prepareStatementSlow(makeString("SELECT subresourceDomainID, COUNT(toDomainID) FROM SubresourceUniqueRedirectsTo WHERE subresourceDomainID IN ("_s, domainIDsOfInterest, ") GROUP BY subresourceDomainID"_s));
     if (subresourceUniqueRedirectsToCountStatement) {
         while (subresourceUniqueRedirectsToCountStatement->step() == SQLITE_ROW) {
             unsigned domainID = static_cast<unsigned>(subresourceUniqueRedirectsToCountStatement->columnInt(0));
@@ -1601,7 +1601,7 @@ HashMap<unsigned, ResourceLoadStatisticsStore::NotVeryPrevalentResources> Resour
         }
     }
 
-    auto subframeUnderTopFrameDomainsCountStatement = m_database.prepareStatementSlow(makeString("SELECT subframeDomainID, COUNT(topFrameDomainID) FROM SubframeUnderTopFrameDomains WHERE subframeDomainID IN ("_s, domainIDsOfInterest, ") GROUP BY subframeDomainID"_s));
+    auto subframeUnderTopFrameDomainsCountStatement = m_database->prepareStatementSlow(makeString("SELECT subframeDomainID, COUNT(topFrameDomainID) FROM SubframeUnderTopFrameDomains WHERE subframeDomainID IN ("_s, domainIDsOfInterest, ") GROUP BY subframeDomainID"_s));
     if (subframeUnderTopFrameDomainsCountStatement) {
         while (subframeUnderTopFrameDomainsCountStatement->step() == SQLITE_ROW) {
             unsigned domainID = static_cast<unsigned>(subframeUnderTopFrameDomainsCountStatement->columnInt(0));
@@ -1614,7 +1614,7 @@ HashMap<unsigned, ResourceLoadStatisticsStore::NotVeryPrevalentResources> Resour
         }
     }
 
-    auto topFrameUniqueRedirectsToCountStatement = m_database.prepareStatementSlow(makeString("SELECT sourceDomainID, COUNT(toDomainID) FROM TopFrameUniqueRedirectsTo WHERE sourceDomainID IN ("_s, domainIDsOfInterest, ") GROUP BY sourceDomainID"_s));
+    auto topFrameUniqueRedirectsToCountStatement = m_database->prepareStatementSlow(makeString("SELECT sourceDomainID, COUNT(toDomainID) FROM TopFrameUniqueRedirectsTo WHERE sourceDomainID IN ("_s, domainIDsOfInterest, ") GROUP BY sourceDomainID"_s));
     if (topFrameUniqueRedirectsToCountStatement) {
         while (topFrameUniqueRedirectsToCountStatement->step() == SQLITE_ROW) {
             unsigned domainID = static_cast<unsigned>(topFrameUniqueRedirectsToCountStatement->columnInt(0));
@@ -1661,7 +1661,7 @@ void ResourceLoadStatisticsStore::classifyPrevalentResources()
 void ResourceLoadStatisticsStore::runIncrementalVacuumCommand()
 {
     ASSERT(!RunLoop::isMain());
-    m_database.runIncrementalVacuumCommand();
+    m_database->runIncrementalVacuumCommand();
 }
 
 bool ResourceLoadStatisticsStore::hasStorageAccess(const TopFrameDomain& topFrameDomain, const SubFrameDomain& subFrameDomain) const
@@ -1752,7 +1752,7 @@ void ResourceLoadStatisticsStore::requestStorageAccess(SubFrameDomain&& subFrame
 
     auto transactionScope = beginTransactionIfNecessary();
 
-    auto incrementStorageAccess = m_database.prepareStatement("UPDATE ObservedDomains SET timesAccessedAsFirstPartyDueToStorageAccessAPI = timesAccessedAsFirstPartyDueToStorageAccessAPI + 1 WHERE domainID = ?"_s);
+    auto incrementStorageAccess = m_database->prepareStatement("UPDATE ObservedDomains SET timesAccessedAsFirstPartyDueToStorageAccessAPI = timesAccessedAsFirstPartyDueToStorageAccessAPI + 1 WHERE domainID = ?"_s);
     if (!incrementStorageAccess
         || incrementStorageAccess->bindInt(1, *subFrameStatus.second) != SQLITE_OK
         || incrementStorageAccess->step() != SQLITE_DONE) {
@@ -1815,7 +1815,7 @@ void ResourceLoadStatisticsStore::revokeStorageAccessPermission(const Registrabl
     if (!targetResult.second)
         return;
 
-    auto removeStorageAccess = m_database.prepareStatement("DELETE FROM StorageAccessUnderTopFrameDomains WHERE domainID = ?"_s);
+    auto removeStorageAccess = m_database->prepareStatement("DELETE FROM StorageAccessUnderTopFrameDomains WHERE domainID = ?"_s);
     if (!removeStorageAccess
         || removeStorageAccess->bindInt(1, *targetResult.second) != SQLITE_OK
         || removeStorageAccess->step() != SQLITE_DONE) {
@@ -1929,7 +1929,7 @@ void ResourceLoadStatisticsStore::grandfatherDataForDomains(const HashSet<Regist
         UNUSED_PARAM(result);
     }
 
-    auto domainsToUpdateStatement = m_database.prepareStatementSlow(makeString("UPDATE ObservedDomains SET grandfathered = 1 WHERE registrableDomain IN ("_s, buildList(domains), ')'));
+    auto domainsToUpdateStatement = m_database->prepareStatementSlow(makeString("UPDATE ObservedDomains SET grandfathered = 1 WHERE registrableDomain IN ("_s, buildList(domains), ')'));
     if (!domainsToUpdateStatement || domainsToUpdateStatement->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("grandfatherDataForDomains: failed to step statement");
 }
@@ -2059,7 +2059,7 @@ void ResourceLoadStatisticsStore::clearTopFrameUniqueRedirectsToSinceSameSiteStr
     if (!targetResult.second)
         return completionHandler();
 
-    auto removeRedirectsToSinceSameSite = m_database.prepareStatement("DELETE FROM TopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement WHERE sourceDomainID = ?"_s);
+    auto removeRedirectsToSinceSameSite = m_database->prepareStatement("DELETE FROM TopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement WHERE sourceDomainID = ?"_s);
     if (!removeRedirectsToSinceSameSite
         || removeRedirectsToSinceSameSite->bindInt(1, *targetResult.second) != SQLITE_OK
         || removeRedirectsToSinceSameSite->step() != SQLITE_DONE)
@@ -2199,7 +2199,7 @@ void ResourceLoadStatisticsStore::setDomainsAsPrevalent(StdSet<unsigned>&& domai
 {
     ASSERT(!RunLoop::isMain());
 
-    auto domainsToUpdateStatement = m_database.prepareStatementSlow(makeString("UPDATE ObservedDomains SET isPrevalent = 1 WHERE domainID IN ("_s, buildList(domains), ')'));
+    auto domainsToUpdateStatement = m_database->prepareStatementSlow(makeString("UPDATE ObservedDomains SET isPrevalent = 1 WHERE domainID IN ("_s, buildList(domains), ')'));
     if (!domainsToUpdateStatement || domainsToUpdateStatement->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("setDomainsAsPrevalent: failed to step statement");
 }
@@ -2533,7 +2533,7 @@ std::pair<ResourceLoadStatisticsStore::AddedRecord, std::optional<unsigned>> Res
 
 void ResourceLoadStatisticsStore::clearDatabaseContents()
 {
-    m_database.clearAllTables();
+    m_database->clearAllTables();
 
     if (!createSchema())
         ITP_RELEASE_LOG_ERROR("clearDatabaseContents: failed to create schema");
@@ -2613,7 +2613,7 @@ CookieAccess ResourceLoadStatisticsStore::cookieAccess(const SubResourceDomain& 
 {
     ASSERT(!RunLoop::isMain());
 
-    auto statement = m_database.prepareStatement("SELECT isPrevalent, hadUserInteraction FROM ObservedDomains WHERE registrableDomain = ?"_s);
+    auto statement = m_database->prepareStatement("SELECT isPrevalent, hadUserInteraction FROM ObservedDomains WHERE registrableDomain = ?"_s);
     if (!statement || statement->bindText(1, subresourceDomain.string()) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("cookieAccess: failed to bind parameter");
         return CookieAccess::CannotRequest;
@@ -2642,7 +2642,7 @@ StorageAccessPromptWasShown ResourceLoadStatisticsStore::hasUserGrantedStorageAc
 
     auto firstPartyPrimaryDomainID = *result.second;
 
-    auto statement = m_database.prepareStatement("SELECT COUNT(*) FROM StorageAccessUnderTopFrameDomains WHERE domainID = ? AND topLevelDomainID = ?"_s);
+    auto statement = m_database->prepareStatement("SELECT COUNT(*) FROM StorageAccessUnderTopFrameDomains WHERE domainID = ? AND topLevelDomainID = ?"_s);
     if (!statement
         || statement->bindInt(1, requestingDomainID) != SQLITE_OK
         || statement->bindInt(2, firstPartyPrimaryDomainID) != SQLITE_OK
@@ -2657,7 +2657,7 @@ Vector<RegistrableDomain> ResourceLoadStatisticsStore::domainsToBlockAndDeleteCo
     ASSERT(!RunLoop::isMain());
 
     Vector<RegistrableDomain> results;
-    auto statement = m_database.prepareStatement("SELECT registrableDomain FROM ObservedDomains WHERE isPrevalent = 1 AND hadUserInteraction = 0"_s);
+    auto statement = m_database->prepareStatement("SELECT registrableDomain FROM ObservedDomains WHERE isPrevalent = 1 AND hadUserInteraction = 0"_s);
     if (!statement)
         return results;
 
@@ -2672,7 +2672,7 @@ Vector<RegistrableDomain> ResourceLoadStatisticsStore::domainsToBlockButKeepCook
     ASSERT(!RunLoop::isMain());
 
     Vector<RegistrableDomain> results;
-    auto statement = m_database.prepareStatement("SELECT registrableDomain FROM ObservedDomains WHERE isPrevalent = 1 AND hadUserInteraction = 1"_s);
+    auto statement = m_database->prepareStatement("SELECT registrableDomain FROM ObservedDomains WHERE isPrevalent = 1 AND hadUserInteraction = 1"_s);
     if (!statement)
         return results;
 
@@ -2687,7 +2687,7 @@ Vector<RegistrableDomain> ResourceLoadStatisticsStore::domainsWithUserInteractio
     ASSERT(!RunLoop::isMain());
 
     Vector<RegistrableDomain> results;
-    auto statement = m_database.prepareStatement("SELECT registrableDomain FROM ObservedDomains WHERE hadUserInteraction = 1"_s);
+    auto statement = m_database->prepareStatement("SELECT registrableDomain FROM ObservedDomains WHERE hadUserInteraction = 1"_s);
     if (!statement)
         return results;
 
@@ -2702,7 +2702,7 @@ HashMap<TopFrameDomain, Vector<SubResourceDomain>> ResourceLoadStatisticsStore::
     ASSERT(!RunLoop::isMain());
 
     HashMap<WebCore::RegistrableDomain, Vector<WebCore::RegistrableDomain>> results;
-    auto statement = m_database.prepareStatement("SELECT subFrameDomain, registrableDomain FROM (SELECT o.registrableDomain as subFrameDomain, s.topLevelDomainID as topLevelDomainID FROM ObservedDomains as o INNER JOIN StorageAccessUnderTopFrameDomains as s WHERE o.domainID = s.domainID) as z INNER JOIN ObservedDomains ON domainID = z.topLevelDomainID;"_s);
+    auto statement = m_database->prepareStatement("SELECT subFrameDomain, registrableDomain FROM (SELECT o.registrableDomain as subFrameDomain, s.topLevelDomainID as topLevelDomainID FROM ObservedDomains as o INNER JOIN StorageAccessUnderTopFrameDomains as s WHERE o.domainID = s.domainID) as z INNER JOIN ObservedDomains ON domainID = z.topLevelDomainID;"_s);
     if (!statement)
         return results;
 
@@ -2753,7 +2753,7 @@ Vector<ResourceLoadStatisticsStore::DomainData> ResourceLoadStatisticsStore::dom
     ASSERT(!RunLoop::isMain());
 
     Vector<DomainData> results;
-    auto statement = m_database.prepareStatement("SELECT domainID, registrableDomain, mostRecentUserInteractionTime, mostRecentWebPushInteractionTime, hadUserInteraction, grandfathered, isScheduledForAllButCookieDataRemoval, countOfTopFrameRedirects FROM ObservedDomains LEFT JOIN (SELECT sourceDomainID, COUNT(*) as countOfTopFrameRedirects from TopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement GROUP BY sourceDomainID) as z ON z.sourceDomainID = domainID"_s);
+    auto statement = m_database->prepareStatement("SELECT domainID, registrableDomain, mostRecentUserInteractionTime, mostRecentWebPushInteractionTime, hadUserInteraction, grandfathered, isScheduledForAllButCookieDataRemoval, countOfTopFrameRedirects FROM ObservedDomains LEFT JOIN (SELECT sourceDomainID, COUNT(*) as countOfTopFrameRedirects from TopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement GROUP BY sourceDomainID) as z ON z.sourceDomainID = domainID"_s);
     if (!statement)
         return results;
 
@@ -2781,7 +2781,7 @@ void ResourceLoadStatisticsStore::clearGrandfathering(Vector<unsigned>&& domainI
 
     auto listToClear = buildList(domainIDsToClear);
 
-    auto clearGrandfatheringStatement = m_database.prepareStatementSlow(makeString("UPDATE ObservedDomains SET grandfathered = 0 WHERE domainID IN ("_s, listToClear, ')'));
+    auto clearGrandfatheringStatement = m_database->prepareStatementSlow(makeString("UPDATE ObservedDomains SET grandfathered = 0 WHERE domainID IN ("_s, listToClear, ')'));
     if (!clearGrandfatheringStatement)
         return;
 
@@ -2937,7 +2937,7 @@ void ResourceLoadStatisticsStore::pruneStatisticsIfNeeded()
     size_t countLeftToPrune = count - parameters().pruneEntriesDownTo;
     ASSERT(countLeftToPrune);
 
-    auto recordsToPrune = m_database.prepareStatement("SELECT domainID FROM ObservedDomains ORDER BY hadUserInteraction, isPrevalent, lastSeen LIMIT ?"_s);
+    auto recordsToPrune = m_database->prepareStatement("SELECT domainID FROM ObservedDomains ORDER BY hadUserInteraction, isPrevalent, lastSeen LIMIT ?"_s);
     if (!recordsToPrune || recordsToPrune->bindInt(1, countLeftToPrune) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("pruneStatisticsIfNeeded: failed to bind parameter");
         return;
@@ -2949,7 +2949,7 @@ void ResourceLoadStatisticsStore::pruneStatisticsIfNeeded()
 
     auto listToPrune = buildList(entriesToPrune);
 
-    auto pruneCommand = m_database.prepareStatementSlow(makeString("DELETE from ObservedDomains WHERE domainID IN ("_s, listToPrune, ')'));
+    auto pruneCommand = m_database->prepareStatementSlow(makeString("DELETE from ObservedDomains WHERE domainID IN ("_s, listToPrune, ')'));
     if (!pruneCommand || pruneCommand->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("pruneStatisticsIfNeeded: failed to step statement");
 }
@@ -3022,9 +3022,9 @@ void ResourceLoadStatisticsStore::updateDataRecordsRemoved(const RegistrableDoma
 
 bool ResourceLoadStatisticsStore::isCorrectSubStatisticsCount(const RegistrableDomain& subframeDomain, const TopFrameDomain& topFrameDomain)
 {
-    auto subFrameUnderTopFrameCount = m_database.prepareStatement(countSubframeUnderTopFrameQuery);
-    auto subresourceUnderTopFrameCount = m_database.prepareStatement(countSubresourceUnderTopFrameQuery);
-    auto subresourceUniqueRedirectsTo = m_database.prepareStatement(countSubresourceUniqueRedirectsToQuery);
+    auto subFrameUnderTopFrameCount = m_database->prepareStatement(countSubframeUnderTopFrameQuery);
+    auto subresourceUnderTopFrameCount = m_database->prepareStatement(countSubresourceUnderTopFrameQuery);
+    auto subresourceUniqueRedirectsTo = m_database->prepareStatement(countSubresourceUniqueRedirectsToQuery);
 
     if (!subFrameUnderTopFrameCount || !subresourceUnderTopFrameCount || !subresourceUniqueRedirectsTo) {
         ITP_RELEASE_LOG_DATABASE_ERROR("isCorrectSubStatisticsCount: failed to prepare statement");
@@ -3109,7 +3109,7 @@ void ResourceLoadStatisticsStore::appendSubStatisticList(StringBuilder& builder,
     if (!query.length())
         return;
 
-    auto data = m_database.prepareStatement(query);
+    auto data = m_database->prepareStatement(query);
 
     if (!data || data->bindInt(1, domainID(RegistrableDomain::uncheckedCreateFromHost(domain)).value()) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("appendSubStatisticList: failed to bind parameter");
@@ -3239,9 +3239,9 @@ bool ResourceLoadStatisticsStore::domainIDExistsInDatabase(int domainID)
 
 void ResourceLoadStatisticsStore::updateOperatingDatesParameters()
 {
-    auto countOperatingDatesStatement = m_database.prepareStatement("SELECT COUNT(*) FROM OperatingDates;"_s);
-    auto getMostRecentOperatingDateStatement = m_database.prepareStatement("SELECT * FROM OperatingDates ORDER BY year DESC, month DESC, monthDay DESC LIMIT 1;"_s);
-    auto getOperatingDateWindowStatement = m_database.prepareStatement("SELECT * FROM OperatingDates ORDER BY year DESC, month DESC, monthDay DESC LIMIT 1 OFFSET ?;"_s);
+    auto countOperatingDatesStatement = m_database->prepareStatement("SELECT COUNT(*) FROM OperatingDates;"_s);
+    auto getMostRecentOperatingDateStatement = m_database->prepareStatement("SELECT * FROM OperatingDates ORDER BY year DESC, month DESC, monthDay DESC LIMIT 1;"_s);
+    auto getOperatingDateWindowStatement = m_database->prepareStatement("SELECT * FROM OperatingDates ORDER BY year DESC, month DESC, monthDay DESC LIMIT 1 OFFSET ?;"_s);
 
     if (!countOperatingDatesStatement || countOperatingDatesStatement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("updateOperatingDatesParameters: failed to step countOperatingDatesStatement");
@@ -3295,7 +3295,7 @@ void ResourceLoadStatisticsStore::includeTodayAsOperatingDateIfNecessary()
 
     int rowsToPrune = m_operatingDatesSize - operatingDatesWindowLong + 1;
     if (rowsToPrune > 0) {
-        auto deleteLeastRecentOperatingDateStatement = m_database.prepareStatement("DELETE FROM OperatingDates ORDER BY year, month, monthDay LIMIT ?;"_s);
+        auto deleteLeastRecentOperatingDateStatement = m_database->prepareStatement("DELETE FROM OperatingDates ORDER BY year, month, monthDay LIMIT ?;"_s);
         if (!deleteLeastRecentOperatingDateStatement
             || deleteLeastRecentOperatingDateStatement->bindInt(1, rowsToPrune) != SQLITE_OK
             || deleteLeastRecentOperatingDateStatement->step() != SQLITE_DONE) {
@@ -3304,7 +3304,7 @@ void ResourceLoadStatisticsStore::includeTodayAsOperatingDateIfNecessary()
         }
     }
 
-    auto insertOperatingDateStatement = m_database.prepareStatement("INSERT OR IGNORE INTO OperatingDates (year, month, monthDay) SELECT ?, ?, ?;"_s);
+    auto insertOperatingDateStatement = m_database->prepareStatement("INSERT OR IGNORE INTO OperatingDates (year, month, monthDay) SELECT ?, ?, ?;"_s);
     if (!insertOperatingDateStatement
         || insertOperatingDateStatement->bindInt(1, today.year()) != SQLITE_OK
         || insertOperatingDateStatement->bindInt(2, today.month()) != SQLITE_OK
@@ -3356,7 +3356,7 @@ void ResourceLoadStatisticsStore::insertExpiredStatisticForTesting(const Registr
         daysAgoInSeconds = nowTime(m_timeAdvanceForTesting).secondsSinceEpoch().value() - daysToSubtract;
         auto dateToInsert = OperatingDate::fromWallTime(WallTime::fromRawSeconds(daysAgoInSeconds));
 
-        auto insertOperatingDateStatement = m_database.prepareStatement("INSERT OR IGNORE INTO OperatingDates (year, month, monthDay) SELECT ?, ?, ?;"_s);
+        auto insertOperatingDateStatement = m_database->prepareStatement("INSERT OR IGNORE INTO OperatingDates (year, month, monthDay) SELECT ?, ?, ?;"_s);
         if (!insertOperatingDateStatement
             || insertOperatingDateStatement->bindInt(1, dateToInsert.year()) != SQLITE_OK
             || insertOperatingDateStatement->bindInt(2, dateToInsert.month()) != SQLITE_OK

--- a/Source/WebKit/NetworkProcess/DatabaseUtilities.h
+++ b/Source/WebKit/NetworkProcess/DatabaseUtilities.h
@@ -70,7 +70,7 @@ protected:
     WebCore::PrivateClickMeasurement buildPrivateClickMeasurementFromDatabase(WebCore::SQLiteStatement&, PrivateClickMeasurementAttributionType) const;
 
     const String m_storageFilePath;
-    mutable WebCore::SQLiteDatabase m_database;
+    mutable UniqueRef<WebCore::SQLiteDatabase> m_database;
     mutable WebCore::SQLiteTransaction m_transaction;
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -151,6 +151,14 @@ public:
     USING_CAN_MAKE_WEAKPTR(MessageReceiver);
     USING_CAN_MAKE_CHECKEDPTR(IPC::Connection::Client);
 
+    void setBegunCheckedPtrDeletion()
+    {
+#if ENABLE(APPLE_PAY_REMOTE_UI)
+        WebPaymentCoordinatorProxy::Client::setBegunCheckedPtrDeletion();
+#endif
+        IPC::Connection::Client::setBegunCheckedPtrDeletion();
+    }
+
     using RegistrableDomain = WebCore::RegistrableDomain;
 
     static Ref<NetworkConnectionToWebProcess> create(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -164,6 +164,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return AuxiliaryProcess::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { AuxiliaryProcess::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { AuxiliaryProcess::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { AuxiliaryProcess::setBegunCheckedPtrDeletion(); }
 
     template<typename T>
     T* supplement()

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -162,6 +162,7 @@ NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSess
     , m_persistedDomains(parameters.resourceLoadStatisticsParameters.persistedDomains)
     , m_privateClickMeasurement(managerOrProxy(*this, networkProcess, parameters))
     , m_privateClickMeasurementDebugModeEnabled(parameters.enablePrivateClickMeasurementDebugMode)
+    , m_prefetchCache(makeUniqueRef<PrefetchCache>())
     , m_broadcastChannelRegistry(NetworkBroadcastChannelRegistry::create(networkProcess))
     , m_testSpeedMultiplier(parameters.testSpeedMultiplier)
     , m_allowsServerPreconnect(parameters.allowsServerPreconnect)
@@ -932,7 +933,7 @@ void NetworkSession::setPersistedDomains(HashSet<WebCore::RegistrableDomain>&& d
 
 CheckedRef<PrefetchCache> NetworkSession::checkedPrefetchCache()
 {
-    return m_prefetchCache;
+    return m_prefetchCache.get();
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -128,6 +128,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     PAL::SessionID sessionID() const { return m_sessionID; }
     NetworkProcess& networkProcess() { return m_networkProcess; }
@@ -198,7 +199,7 @@ public:
     NetworkCache::Cache* cache() { return m_cache.get(); }
 
     CheckedRef<PrefetchCache> checkedPrefetchCache();
-    void clearPrefetchCache() { m_prefetchCache.clear(); }
+    void clearPrefetchCache() { m_prefetchCache->clear(); }
 
     virtual RefPtr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::StoredCredentialsPolicy);
     virtual void removeWebSocketTask(SessionSet&, WebSocketTask&) { }
@@ -371,7 +372,7 @@ protected:
     };
     HashMap<NetworkResourceLoadIdentifier, Ref<CachedNetworkResourceLoader>> m_loadersAwaitingWebProcessTransfer;
 
-    PrefetchCache m_prefetchCache;
+    UniqueRef<PrefetchCache> m_prefetchCache;
 
 #if ASSERT_ENABLED
     bool m_isInvalidated { false };

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
@@ -39,25 +39,25 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSWOriginStore);
 using namespace WebCore;
 
 WebSWOriginStore::WebSWOriginStore()
-    : m_store(*this)
+    : m_store(makeUniqueRef<SharedStringHashStore>(*this))
 {
 }
 
 void WebSWOriginStore::addToStore(const SecurityOriginData& origin)
 {
-    m_store.scheduleAddition(computeSharedStringHash(origin.toString()));
-    m_store.flushPendingChanges();
+    m_store->scheduleAddition(computeSharedStringHash(origin.toString()));
+    m_store->flushPendingChanges();
 }
 
 void WebSWOriginStore::removeFromStore(const SecurityOriginData& origin)
 {
-    m_store.scheduleRemoval(computeSharedStringHash(origin.toString()));
-    m_store.flushPendingChanges();
+    m_store->scheduleRemoval(computeSharedStringHash(origin.toString()));
+    m_store->flushPendingChanges();
 }
 
 void WebSWOriginStore::clearStore()
 {
-    m_store.clear();
+    m_store->clear();
 }
 
 void WebSWOriginStore::importComplete()
@@ -71,7 +71,7 @@ void WebSWOriginStore::registerSWServerConnection(WebSWServerConnection& connect
 {
     m_webSWServerConnections.add(connection);
 
-    if (!m_store.isEmpty())
+    if (!m_store->isEmpty())
         sendStoreHandle(connection);
 
     if (m_isImported)
@@ -85,7 +85,7 @@ void WebSWOriginStore::unregisterSWServerConnection(WebSWServerConnection& conne
 
 void WebSWOriginStore::sendStoreHandle(WebSWServerConnection& connection)
 {
-    auto handle = m_store.createSharedMemoryHandle();
+    auto handle = m_store->createSharedMemoryHandle();
     if (!handle)
         return;
     connection.send(Messages::WebSWClientConnection::SetSWOriginTableSharedMemory(WTFMove(*handle)));

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.h
@@ -28,13 +28,14 @@
 #include "SharedStringHashStore.h"
 #include <WebCore/SWOriginStore.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebKit {
 
 class WebSWServerConnection;
 
-class WebSWOriginStore final : public WebCore::SWOriginStore, private SharedStringHashStore::Client {
+class WebSWOriginStore final : public WebCore::SWOriginStore, public SharedStringHashStore::Client {
     WTF_MAKE_TZONE_ALLOCATED(WebSWOriginStore);
 public:
     WebSWOriginStore();
@@ -53,7 +54,7 @@ private:
     // SharedStringHashStore::Client.
     void didInvalidateSharedMemory() final;
 
-    SharedStringHashStore m_store;
+    UniqueRef<SharedStringHashStore> m_store;
     bool m_isImported { false };
     WeakHashSet<WebSWServerConnection> m_webSWServerConnections;
 };

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -77,9 +77,10 @@ struct SessionWrapper : public CanMakeWeakPtr<SessionWrapper>, public CanMakeChe
 struct IsolatedSession {
     WTF_MAKE_TZONE_ALLOCATED(IsolatedSession);
 public:
-    CheckedRef<SessionWrapper> checkedSessionWithCredentialStorage() { return sessionWithCredentialStorage; }
+    explicit IsolatedSession() : sessionWithCredentialStorage(makeUniqueRef<SessionWrapper>()) {}
+    CheckedRef<SessionWrapper> checkedSessionWithCredentialStorage() { return sessionWithCredentialStorage.get(); }
 
-    SessionWrapper sessionWithCredentialStorage;
+    UniqueRef<SessionWrapper> sessionWithCredentialStorage;
     WallTime lastUsed;
 };
 
@@ -97,15 +98,18 @@ public:
 
     std::unique_ptr<IsolatedSession> appBoundSession;
 
-    CheckedRef<SessionWrapper> checkedSessionWithCredentialStorage() { return sessionWithCredentialStorage; }
-    CheckedRef<SessionWrapper> checkedEphemeralStatelessSession() { return ephemeralStatelessSession; }
+    CheckedRef<SessionWrapper> checkedSessionWithCredentialStorage() { return sessionWithCredentialStorage.get(); }
+    CheckedRef<SessionWrapper> checkedEphemeralStatelessSession() { return ephemeralStatelessSession.get(); }
 
-    SessionWrapper sessionWithCredentialStorage;
-    SessionWrapper ephemeralStatelessSession;
+    UniqueRef<SessionWrapper> sessionWithCredentialStorage;
+    UniqueRef<SessionWrapper> ephemeralStatelessSession;
 
 private:
 
-    SessionSet() = default;
+    SessionSet()
+        : sessionWithCredentialStorage(makeUniqueRef<SessionWrapper>())
+        , ephemeralStatelessSession(makeUniqueRef<SessionWrapper>())
+    { }
 };
 
 class NetworkSessionCocoa final : public NetworkSession {

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1296,7 +1296,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 _NSHSTSStorage *NetworkSessionCocoa::hstsStorage() const
 {
-    return m_defaultSessionSet->sessionWithCredentialStorage.session.get().configuration._hstsStorage;
+    return m_defaultSessionSet->sessionWithCredentialStorage->session.get().configuration._hstsStorage;
 }
 
 RetainPtr<_NSHSTSStorage> NetworkSessionCocoa::protectedHSTSStorage() const
@@ -1306,7 +1306,7 @@ RetainPtr<_NSHSTSStorage> NetworkSessionCocoa::protectedHSTSStorage() const
 
 NSURLCredentialStorage *NetworkSessionCocoa::nsCredentialStorage() const
 {
-    return m_defaultSessionSet->sessionWithCredentialStorage.session.get().configuration.URLCredentialStorage;
+    return m_defaultSessionSet->sessionWithCredentialStorage->session.get().configuration.URLCredentialStorage;
 }
     
 const String& NetworkSessionCocoa::boundInterfaceIdentifier() const
@@ -1594,11 +1594,11 @@ SessionWrapper& NetworkSessionCocoa::initializeEphemeralStatelessSessionIfNeeded
 
 SessionWrapper& SessionSet::initializeEphemeralStatelessSessionIfNeeded(NavigatingToAppBoundDomain isNavigatingToAppBoundDomain, NetworkSessionCocoa& session)
 {
-    if (ephemeralStatelessSession.session)
-        return ephemeralStatelessSession;
+    if (ephemeralStatelessSession->session)
+        return ephemeralStatelessSession.get();
 
     RetainPtr configuration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
-    RetainPtr<NSURLSessionConfiguration> existingConfiguration = sessionWithCredentialStorage.session.get().configuration;
+    RetainPtr<NSURLSessionConfiguration> existingConfiguration = sessionWithCredentialStorage->session.get().configuration;
 
     configuration.get().HTTPCookieAcceptPolicy = NSHTTPCookieAcceptPolicyNever;
     configuration.get().URLCredentialStorage = nil;
@@ -1622,7 +1622,7 @@ SessionWrapper& SessionSet::initializeEphemeralStatelessSessionIfNeeded(Navigati
 
     checkedEphemeralStatelessSession()->initialize(configuration.get(), session, WebCore::StoredCredentialsPolicy::EphemeralStateless, isNavigatingToAppBoundDomain);
 
-    return ephemeralStatelessSession;
+    return ephemeralStatelessSession.get();
 }
 
 SessionWrapper& NetworkSessionCocoa::sessionWrapperForTask(std::optional<WebPageProxyIdentifier> webPageProxyID, const WebCore::ResourceRequest& request, WebCore::StoredCredentialsPolicy storedCredentialsPolicy, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain)
@@ -1660,7 +1660,7 @@ SessionWrapper& NetworkSessionCocoa::appBoundSession(std::optional<WebPageProxyI
     
     if (!sessionSet.appBoundSession) {
         sessionSet.appBoundSession = makeUnique<IsolatedSession>();
-        sessionSet.appBoundSession->checkedSessionWithCredentialStorage()->initialize(sessionSet.sessionWithCredentialStorage.session.get().configuration, *this, WebCore::StoredCredentialsPolicy::Use, NavigatingToAppBoundDomain::Yes);
+        sessionSet.appBoundSession->checkedSessionWithCredentialStorage()->initialize(sessionSet.sessionWithCredentialStorage->session.get().configuration, *this, WebCore::StoredCredentialsPolicy::Use, NavigatingToAppBoundDomain::Yes);
     }
 
     auto& sessionWrapper = [&](auto storedCredentialsPolicy) -> SessionWrapper& {
@@ -1706,7 +1706,7 @@ SessionWrapper& SessionSet::isolatedSession(WebCore::StoredCredentialsPolicy sto
 {
     auto& entry = isolatedSessions.ensure(firstPartyDomain, [this, &session, isNavigatingToAppBoundDomain] {
         auto newEntry = makeUnique<IsolatedSession>();
-        newEntry->checkedSessionWithCredentialStorage()->initialize(retainPtr(sessionWithCredentialStorage.session.get().configuration).get(), session, WebCore::StoredCredentialsPolicy::Use, isNavigatingToAppBoundDomain);
+        newEntry->checkedSessionWithCredentialStorage()->initialize(retainPtr(sessionWithCredentialStorage->session.get().configuration).get(), session, WebCore::StoredCredentialsPolicy::Use, isNavigatingToAppBoundDomain);
         return newEntry;
     }).iterator->value;
 
@@ -1763,20 +1763,20 @@ void NetworkSessionCocoa::clearIsolatedSessions()
 
 void NetworkSessionCocoa::invalidateAndCancelSessionSet(SessionSet& sessionSet)
 {
-    [sessionSet.sessionWithCredentialStorage.session invalidateAndCancel];
-    [sessionSet.ephemeralStatelessSession.session invalidateAndCancel];
-    [sessionSet.sessionWithCredentialStorage.delegate sessionInvalidated];
-    [sessionSet.ephemeralStatelessSession.delegate sessionInvalidated];
+    [sessionSet.sessionWithCredentialStorage->session invalidateAndCancel];
+    [sessionSet.ephemeralStatelessSession->session invalidateAndCancel];
+    [sessionSet.sessionWithCredentialStorage->delegate sessionInvalidated];
+    [sessionSet.ephemeralStatelessSession->delegate sessionInvalidated];
 
     for (auto& session : sessionSet.isolatedSessions.values()) {
-        [session->sessionWithCredentialStorage.session invalidateAndCancel];
-        [session->sessionWithCredentialStorage.delegate sessionInvalidated];
+        [session->sessionWithCredentialStorage->session invalidateAndCancel];
+        [session->sessionWithCredentialStorage->delegate sessionInvalidated];
     }
     sessionSet.isolatedSessions.clear();
 
     if (sessionSet.appBoundSession) {
-        [sessionSet.appBoundSession->sessionWithCredentialStorage.session invalidateAndCancel];
-        [sessionSet.appBoundSession->sessionWithCredentialStorage.delegate sessionInvalidated];
+        [sessionSet.appBoundSession->sessionWithCredentialStorage->session invalidateAndCancel];
+        [sessionSet.appBoundSession->sessionWithCredentialStorage->delegate sessionInvalidated];
     }
 }
 
@@ -1969,7 +1969,7 @@ RefPtr<WebSocketTask> NetworkSessionCocoa::createWebSocketTask(WebPageProxyIdent
     enableAdvancedPrivacyProtections(ensureMutableRequest().get(), advancedPrivacyProtections);
 
     Ref sessionSet = sessionSetForPage(webPageProxyID);
-    RetainPtr task = [sessionSet->sessionWithCredentialStorage.session webSocketTaskWithRequest:nsRequest.get()];
+    RetainPtr task = [sessionSet->sessionWithCredentialStorage->session webSocketTaskWithRequest:nsRequest.get()];
     
     // Although the WebSocket protocol allows full 64-bit lengths, Chrome and Firefox limit the length to 2^63 - 1.
     // Use NSIntegerMax instead of 2^63 - 1 for 32-bit systems.
@@ -1980,7 +1980,7 @@ RefPtr<WebSocketTask> NetworkSessionCocoa::createWebSocketTask(WebPageProxyIdent
 
 void NetworkSessionCocoa::addWebSocketTask(WebPageProxyIdentifier webPageProxyID, WebSocketTask& task)
 {
-    auto& webSocketDataTaskMap = sessionSetForPage(webPageProxyID).sessionWithCredentialStorage.webSocketDataTaskMap;
+    auto& webSocketDataTaskMap = sessionSetForPage(webPageProxyID).sessionWithCredentialStorage->webSocketDataTaskMap;
     auto addResult = webSocketDataTaskMap.add(task.identifier(), &task);
     RELEASE_ASSERT(addResult.isNewEntry);
     RELEASE_LOG(NetworkSession, "NetworkSessionCocoa::addWebSocketTask, web socket count is %u", webSocketDataTaskMap.size());
@@ -1988,7 +1988,7 @@ void NetworkSessionCocoa::addWebSocketTask(WebPageProxyIdentifier webPageProxyID
 
 void NetworkSessionCocoa::removeWebSocketTask(SessionSet& sessionSet, WebSocketTask& task)
 {
-    auto& webSocketDataTaskMap = sessionSet.sessionWithCredentialStorage.webSocketDataTaskMap;
+    auto& webSocketDataTaskMap = sessionSet.sessionWithCredentialStorage->webSocketDataTaskMap;
     bool contained = webSocketDataTaskMap.remove(task.identifier());
     RELEASE_ASSERT(contained);
     RELEASE_LOG(NetworkSession, "NetworkSessionCocoa::removeWebSocketTask, web socket count is %u", webSocketDataTaskMap.size());
@@ -2004,7 +2004,7 @@ void NetworkSessionCocoa::addWebPageNetworkParameters(WebPageProxyIdentifier pag
 
     auto addResult2 = m_perPageSessionSets.add(pageID, SessionSet::create());
     ASSERT(addResult2.isNewEntry);
-    RetainPtr<NSURLSessionConfiguration> configuration = adoptNS([m_defaultSessionSet->sessionWithCredentialStorage.session.get().configuration copy]);
+    RetainPtr<NSURLSessionConfiguration> configuration = adoptNS([m_defaultSessionSet->sessionWithCredentialStorage->session.get().configuration copy]);
 #if USE(APPLE_INTERNAL_SDK)
     configuration.get()._attributedBundleIdentifier = parameters.attributedBundleIdentifier().createNSString().get();
 #endif
@@ -2226,7 +2226,7 @@ Vector<WebCore::SecurityOriginData> NetworkSessionCocoa::hostNamesWithAlternativ
 {
 #if HAVE(ALTERNATIVE_SERVICE)
     Vector<WebCore::SecurityOriginData> origins;
-    RetainPtr<_NSHTTPAlternativeServicesStorage> storage = m_defaultSessionSet->sessionWithCredentialStorage.session.get().configuration._alternativeServicesStorage;
+    RetainPtr<_NSHTTPAlternativeServicesStorage> storage = m_defaultSessionSet->sessionWithCredentialStorage->session.get().configuration._alternativeServicesStorage;
     RetainPtr<NSArray<_NSHTTPAlternativeServiceEntry *>> entries = [storage HTTPServiceEntriesWithFilter:_NSHTTPAlternativeServicesFilter.emptyFilter];
 
     for (_NSHTTPAlternativeServiceEntry* entry in entries.get()) {
@@ -2281,7 +2281,7 @@ void NetworkSessionCocoa::donateToSKAdNetwork(WebCore::PrivateClickMeasurement&&
 void NetworkSessionCocoa::deleteAlternativeServicesForHostNames(const Vector<String>& hosts)
 {
 #if HAVE(ALTERNATIVE_SERVICE)
-    RetainPtr<_NSHTTPAlternativeServicesStorage> storage = m_defaultSessionSet->sessionWithCredentialStorage.session.get().configuration._alternativeServicesStorage;
+    RetainPtr<_NSHTTPAlternativeServicesStorage> storage = m_defaultSessionSet->sessionWithCredentialStorage->session.get().configuration._alternativeServicesStorage;
     for (auto& host : hosts)
         [storage removeHTTPAlternativeServiceEntriesWithRegistrableDomain:host.createNSString().get()];
 #else
@@ -2292,7 +2292,7 @@ void NetworkSessionCocoa::deleteAlternativeServicesForHostNames(const Vector<Str
 void NetworkSessionCocoa::clearAlternativeServices(WallTime modifiedSince)
 {
 #if HAVE(ALTERNATIVE_SERVICE)
-    RetainPtr<_NSHTTPAlternativeServicesStorage> storage = m_defaultSessionSet->sessionWithCredentialStorage.session.get().configuration._alternativeServicesStorage;
+    RetainPtr<_NSHTTPAlternativeServicesStorage> storage = m_defaultSessionSet->sessionWithCredentialStorage->session.get().configuration._alternativeServicesStorage;
     NSTimeInterval timeInterval = modifiedSince.secondsSinceEpoch().seconds();
     RetainPtr date = [NSDate dateWithTimeIntervalSince1970:timeInterval];
     [storage removeHTTPAlternativeServiceEntriesCreatedAfterDate:date.get()];

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -35,6 +35,7 @@
 namespace IPC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(StreamClientConnection);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StreamClientConnection::DedicatedConnectionClient);
 
 // FIXME(http://webkit.org/b/238986): Workaround for not being able to deliver messages from the dedicated connection to the work queue the client uses.
 
@@ -121,7 +122,7 @@ void StreamClientConnection::setMaxBatchSize(unsigned size)
 
 void StreamClientConnection::open(Connection::Client& receiver, SerialFunctionDispatcher& dispatcher)
 {
-    m_dedicatedConnectionClient.emplace(*this, receiver);
+    lazyInitialize(m_dedicatedConnectionClient, makeUniqueWithoutRefCountedCheck<DedicatedConnectionClient>(*this, receiver));
     m_connection->open(Ref { *m_dedicatedConnectionClient }.get(), dispatcher);
 }
 

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -137,7 +137,9 @@ private:
 
     const Ref<Connection> m_connection;
     class DedicatedConnectionClient final : public Connection::Client {
+        WTF_MAKE_TZONE_ALLOCATED(DedicatedConnectionClient);
         WTF_MAKE_NONCOPYABLE(DedicatedConnectionClient);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DedicatedConnectionClient);
     public:
         DedicatedConnectionClient(StreamClientConnection&, Connection::Client&);
 
@@ -153,7 +155,7 @@ private:
         const CheckedRef<StreamClientConnection> m_owner;
         WeakPtr<Connection::Client> m_receiver;
     };
-    std::optional<DedicatedConnectionClient> m_dedicatedConnectionClient;
+    const std::unique_ptr<DedicatedConnectionClient> m_dedicatedConnectionClient;
     uint64_t m_currentDestinationID { 0 };
     StreamClientConnectionBuffer m_buffer;
     unsigned m_maxBatchSize { 100 }; // Number of messages marked as StreamBatched to accumulate before notifying the server.

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -85,7 +85,7 @@ struct ChangedLayers {
     ~ChangedLayers();
 };
 
-class RemoteLayerTreeTransaction : public CanMakeCheckedPtr<RemoteLayerTreeTransaction> {
+class RemoteLayerTreeTransaction final : public CanMakeCheckedPtr<RemoteLayerTreeTransaction, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeTransaction);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeTransaction);
 public:

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
@@ -48,6 +48,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     void prepareToDisplay() final;
     void clearBackingStore() final;

--- a/Source/WebKit/Shared/WebEvent.h
+++ b/Source/WebKit/Shared/WebEvent.h
@@ -46,7 +46,7 @@ class Encoder;
 
 namespace WebKit {
 
-class WebEvent : public CanMakeThreadSafeCheckedPtr<WebEvent> {
+class WebEvent : public CanMakeThreadSafeCheckedPtr<WebEvent, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED(WebEvent);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebEvent);
 public:

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -84,6 +84,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return IPC::Connection::Client::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { IPC::Connection::Client::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { IPC::Connection::Client::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { IPC::Connection::Client::setBegunCheckedPtrDeletion(); }
 
     virtual ~AuxiliaryProcessProxy();
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -72,6 +72,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     // PlaybackSessionModel
     void addClient(WebCore::PlaybackSessionModelClient&) final;

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -512,7 +512,7 @@ private:
     bool m_didCallEndSwipeGesture { false };
     bool m_removeSnapshotImmediatelyWhenGestureEnds { false };
 
-    SnapshotRemovalTracker m_snapshotRemovalTracker;
+    const UniqueRef<SnapshotRemovalTracker> m_snapshotRemovalTracker;
     WTF::Function<void()> m_loadCallback;
 };
 

--- a/Source/WebKit/UIProcess/VisitedLinkStore.h
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.h
@@ -39,7 +39,7 @@ namespace WebKit {
 
 class WebProcessProxy;
     
-class VisitedLinkStore final : public API::ObjectImpl<API::Object::Type::VisitedLinkStore>, public IPC::MessageReceiver, public Identified<VisitedLinkTableIdentifier>, private SharedStringHashStore::Client {
+class VisitedLinkStore final : public API::ObjectImpl<API::Object::Type::VisitedLinkStore>, public IPC::MessageReceiver, public Identified<VisitedLinkTableIdentifier>, public SharedStringHashStore::Client {
 public:
     static Ref<VisitedLinkStore> create();
     VisitedLinkStore();
@@ -70,7 +70,7 @@ private:
     void sendStoreHandleToProcess(WebProcessProxy&);
 
     WeakHashSet<WebProcessProxy> m_processes;
-    SharedStringHashStore m_linkHashStore;
+    UniqueRef<SharedStringHashStore> m_linkHashStore;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -237,6 +237,14 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const { return WebPopupMenuProxy::Client::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const { WebPopupMenuProxy::Client::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const { WebPopupMenuProxy::Client::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion()
+    {
+        WebPopupMenuProxy::Client::setBegunCheckedPtrDeletion();
+#if ENABLE(APPLE_PAY)
+        WebPaymentCoordinatorProxy::Client::setBegunCheckedPtrDeletion();
+#endif
+        WebColorPickerClient::setBegunCheckedPtrDeletion();
+    }
 
 #if PLATFORM(MACCATALYST)
     // EndowmentStateTrackerClient

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -31,6 +31,7 @@
 #include "APIPageHandle.h"
 #include "APIUIClient.h"
 #include "AuthenticatorManager.h"
+#include "DisplayLinkProcessProxyClient.h"
 #include "DownloadProxyMap.h"
 #include "GPUProcessConnectionParameters.h"
 #include "GoToBackForwardItemParameters.h"
@@ -307,10 +308,12 @@ Ref<WebProcessProxy> WebProcessProxy::createForRemoteWorkers(RemoteWorkerType wo
 WebProcessProxy::WebProcessProxy(WebProcessPool& processPool, WebsiteDataStore* websiteDataStore, IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode, LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity)
     : AuxiliaryProcessProxy(processPool.shouldTakeUIBackgroundAssertion() ? ShouldTakeUIBackgroundAssertion::Yes : ShouldTakeUIBackgroundAssertion::No
     , processPool.alwaysRunsAtBackgroundPriority() ? AlwaysRunsAtBackgroundPriority::Yes : AlwaysRunsAtBackgroundPriority::No)
-    , m_backgroundResponsivenessTimer(*this)
+    , m_backgroundResponsivenessTimer(makeUniqueRef<BackgroundProcessResponsivenessTimer>(*this))
     , m_processPool(processPool, isPrewarmed == IsPrewarmed::Yes ? IsWeak::Yes : IsWeak::No)
     , m_mayHaveUniversalFileReadSandboxExtension(false)
-    , m_numberOfTimesSuddenTerminationWasDisabled(0)
+#if HAVE(DISPLAY_LINK)
+    , m_displayLinkClient(makeUniqueRef<DisplayLinkProcessProxyClient>())
+#endif
     , m_isResponsive(NoOrMaybe::Maybe)
     , m_visiblePageCounter([this](RefCounterEvent) { updateBackgroundResponsivenessTimer(); })
     , m_websiteDataStore(websiteDataStore)
@@ -373,7 +376,7 @@ WebProcessProxy::~WebProcessProxy()
 
 #if HAVE(DISPLAY_LINK)
     if (RefPtr<WebProcessPool> processPool = m_processPool.get())
-        processPool->displayLinks().stopDisplayLinks(m_displayLinkClient);
+        processPool->displayLinks().stopDisplayLinks(m_displayLinkClient.get());
 #endif
 
     auto isResponsiveCallbacks = WTFMove(m_isResponsiveCallbacks);
@@ -656,7 +659,7 @@ void WebProcessProxy::connectionWillOpen(IPC::Connection& connection)
     connection.setOnlySendMessagesAsDispatchWhenWaitingForSyncReplyWhenProcessingSuchAMessage(true);
 
 #if HAVE(DISPLAY_LINK)
-    m_displayLinkClient.setConnection(&connection);
+    m_displayLinkClient->setConnection(&connection);
 #endif
 }
 
@@ -666,8 +669,8 @@ void WebProcessProxy::processWillShutDown(IPC::Connection& connection)
     ASSERT_UNUSED(connection, &this->connection() == &connection);
 
 #if HAVE(DISPLAY_LINK)
-    m_displayLinkClient.setConnection(nullptr);
-    Ref<WebProcessPool> { processPool() }->displayLinks().stopDisplayLinks(m_displayLinkClient);
+    m_displayLinkClient->setConnection(nullptr);
+    Ref<WebProcessPool> { processPool() }->displayLinks().stopDisplayLinks(m_displayLinkClient.get());
 #endif
 }
 
@@ -680,22 +683,22 @@ std::optional<unsigned> WebProcessProxy::nominalFramesPerSecondForDisplay(WebCor
 void WebProcessProxy::startDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    protectedProcessPool()->displayLinks().startDisplayLink(m_displayLinkClient, observerID, displayID, preferredFramesPerSecond);
+    protectedProcessPool()->displayLinks().startDisplayLink(m_displayLinkClient.get(), observerID, displayID, preferredFramesPerSecond);
 }
 
 void WebProcessProxy::stopDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID)
 {
-    protectedProcessPool()->displayLinks().stopDisplayLink(m_displayLinkClient, observerID, displayID);
+    protectedProcessPool()->displayLinks().stopDisplayLink(m_displayLinkClient.get(), observerID, displayID);
 }
 
 void WebProcessProxy::setDisplayLinkPreferredFramesPerSecond(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)
 {
-    protectedProcessPool()->displayLinks().setDisplayLinkPreferredFramesPerSecond(m_displayLinkClient, observerID, displayID, preferredFramesPerSecond);
+    protectedProcessPool()->displayLinks().setDisplayLinkPreferredFramesPerSecond(m_displayLinkClient.get(), observerID, displayID, preferredFramesPerSecond);
 }
 
 void WebProcessProxy::setDisplayLinkForDisplayWantsFullSpeedUpdates(WebCore::PlatformDisplayID displayID, bool wantsFullSpeedUpdates)
 {
-    protectedProcessPool()->displayLinks().setDisplayLinkForDisplayWantsFullSpeedUpdates(m_displayLinkClient, displayID, wantsFullSpeedUpdates);
+    protectedProcessPool()->displayLinks().setDisplayLinkForDisplayWantsFullSpeedUpdates(m_displayLinkClient.get(), displayID, wantsFullSpeedUpdates);
 }
 #endif
 
@@ -716,7 +719,7 @@ void WebProcessProxy::shutDown()
         destroyWasmDebuggerTarget();
 #endif
 
-    m_backgroundResponsivenessTimer.invalidate();
+    m_backgroundResponsivenessTimer->invalidate();
     m_audibleMediaActivity = std::nullopt;
     m_mediaStreamingActivity = std::nullopt;
     m_foregroundToken = nullptr;
@@ -1441,7 +1444,7 @@ void WebProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connect
 #endif
 
     protectedProcessPool()->processDidFinishLaunching(*this);
-    m_backgroundResponsivenessTimer.updateState();
+    m_backgroundResponsivenessTimer->updateState();
 
 #if ENABLE(REMOTE_INSPECTOR) && ENABLE(WEBASSEMBLY)
     if (JSC::Options::enableWasmDebugger()) [[unlikely]]
@@ -1561,7 +1564,7 @@ void WebProcessProxy::consumeIfNotVerifiablyFromUIProcess(PageIdentifier pageID,
 
 bool WebProcessProxy::isResponsive() const
 {
-    return responsivenessTimer().isResponsive() && m_backgroundResponsivenessTimer.isResponsive();
+    return responsivenessTimer().isResponsive() && m_backgroundResponsivenessTimer->isResponsive();
 }
 
 void WebProcessProxy::didDestroyUserGestureToken(PageIdentifier pageID, UserGestureTokenIdentifier identifier)
@@ -1912,12 +1915,12 @@ void WebProcessProxy::didChangeThrottleState(ProcessThrottleState type)
     }
 
     ASSERT(!m_backgroundToken || !m_foregroundToken);
-    m_backgroundResponsivenessTimer.updateState();
+    m_backgroundResponsivenessTimer->updateState();
 }
 
 void WebProcessProxy::didDropLastAssertion()
 {
-    m_backgroundResponsivenessTimer.updateState();
+    m_backgroundResponsivenessTimer->updateState();
     updateRuntimeStatistics();
 }
 
@@ -2066,13 +2069,13 @@ bool WebProcessProxy::isJITEnabled() const
 
 void WebProcessProxy::didReceiveBackgroundResponsivenessPing()
 {
-    m_backgroundResponsivenessTimer.didReceiveBackgroundResponsivenessPong();
+    m_backgroundResponsivenessTimer->didReceiveBackgroundResponsivenessPong();
 }
 
 void WebProcessProxy::processTerminated()
 {
     WEBPROCESSPROXY_RELEASE_LOG(Process, "processTerminated:");
-    m_backgroundResponsivenessTimer.processTerminated();
+    m_backgroundResponsivenessTimer->processTerminated();
 }
 
 void WebProcessProxy::logDiagnosticMessageForResourceLimitTermination(const String& limitKey)
@@ -2186,7 +2189,7 @@ void WebProcessProxy::didExceedCPULimit()
 
 void WebProcessProxy::updateBackgroundResponsivenessTimer()
 {
-    m_backgroundResponsivenessTimer.updateState();
+    m_backgroundResponsivenessTimer->updateState();
 }
 
 #if !PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -389,7 +389,7 @@ public:
 #endif
 
 #if HAVE(DISPLAY_LINK)
-    DisplayLink::Client& displayLinkClient() { return m_displayLinkClient; }
+    DisplayLink::Client& displayLinkClient() { return m_displayLinkClient.get(); }
     std::optional<unsigned> nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID);
 
     void startDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
@@ -767,7 +767,7 @@ private:
         RefPtr<T> m_strongObject;
     };
 
-    BackgroundProcessResponsivenessTimer m_backgroundResponsivenessTimer;
+    UniqueRef<BackgroundProcessResponsivenessTimer> m_backgroundResponsivenessTimer;
     
     WeakOrStrongPtr<WebProcessPool> m_processPool; // Pre-warmed and cached processes do not hold a strong reference to their pool.
 
@@ -784,13 +784,13 @@ private:
 
     WeakHashMap<VisitedLinkStore, HashSet<WebPageProxyIdentifier>> m_visitedLinkStoresWithUsers;
 
-    int m_numberOfTimesSuddenTerminationWasDisabled;
+    int m_numberOfTimesSuddenTerminationWasDisabled { 0 };
     ForegroundWebProcessToken m_foregroundToken;
     BackgroundWebProcessToken m_backgroundToken;
     bool m_areThrottleStateChangesEnabled { true };
 
 #if HAVE(DISPLAY_LINK)
-    DisplayLinkProcessProxyClient m_displayLinkClient;
+    UniqueRef<DisplayLinkProcessProxyClient> m_displayLinkClient;
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -624,7 +624,7 @@ void ViewGestureController::draw(cairo_t* cr, cairo_pattern_t* pageGroup)
 
 void ViewGestureController::removeSwipeSnapshot()
 {
-    m_snapshotRemovalTracker.reset();
+    m_snapshotRemovalTracker->reset();
 
     m_hasOutstandingRepaintRequest = false;
 

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -351,7 +351,7 @@ void ViewGestureController::willEndSwipeGesture(WebBackForwardListItem& targetIt
     }
 
     // FIXME: Should we wait for VisuallyNonEmptyLayout like we do on Mac?
-    m_snapshotRemovalTracker.start(SnapshotRemovalTracker::RenderTreeSizeThreshold
+    m_snapshotRemovalTracker->start(SnapshotRemovalTracker::RenderTreeSizeThreshold
         | SnapshotRemovalTracker::RepaintAfterNavigation
         | SnapshotRemovalTracker::MainFrameLoad
         | SnapshotRemovalTracker::SubresourceLoads
@@ -460,7 +460,7 @@ void ViewGestureController::willCommitPostSwipeTransitionLayerTree(bool successf
 
 void ViewGestureController::removeSwipeSnapshot()
 {
-    m_snapshotRemovalTracker.reset();
+    m_snapshotRemovalTracker->reset();
 
     if (m_activeGestureType != ViewGestureType::Swipe)
         return;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -112,6 +112,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     WeakObjCPtr<WKFullScreenViewController> m_parent;
     RefPtr<WebCore::PlaybackSessionInterfaceIOS> m_interface;

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -605,7 +605,7 @@ void ViewGestureController::didMoveSwipeSnapshotLayer()
 
 void ViewGestureController::removeSwipeSnapshot()
 {
-    m_snapshotRemovalTracker.reset();
+    m_snapshotRemovalTracker->reset();
 
     m_hasOutstandingRepaintRequest = false;
 

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
@@ -57,6 +57,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     void showPopupMenu(const WebCore::IntRect&, WebCore::TextDirection, double pageScaleFactor, const Vector<WebPopupItem>&, const PlatformPopupMenuData&, int32_t selectedIndex) override;
     void hidePopupMenu() override;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -81,6 +81,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     unsigned nativeImageCountForTesting() const { return m_nativeImages.size(); }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -127,6 +127,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeThreadSafeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     void startLoading();
     void destroy();

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -93,6 +93,7 @@ public:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
 private:
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
@@ -122,6 +122,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return WebCore::PasteboardStrategy::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { WebCore::PasteboardStrategy::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { WebCore::PasteboardStrategy::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { WebCore::PasteboardStrategy::setBegunCheckedPtrDeletion(); }
 #endif
 };
 

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -214,6 +214,7 @@ private:
     JSIPCStreamClientConnection(JSIPC& jsIPC, RefPtr<IPC::StreamClientConnection> connection)
         : m_jsIPC(jsIPC)
         , m_streamConnection { WTFMove(connection) }
+        , m_dummyMessageReceiver { makeUniqueRefWithoutRefCountedCheck<MessageReceiver>(*this) }
     {
     }
 
@@ -263,7 +264,8 @@ private:
 
     private:
         WeakRef<JSIPCStreamClientConnection> m_connection;
-    } m_dummyMessageReceiver { *this };
+    };
+    const UniqueRef<MessageReceiver> m_dummyMessageReceiver;
 };
 
 class JSIPCStreamServerConnectionHandle : public RefCounted<JSIPCStreamServerConnectionHandle> {
@@ -1057,7 +1059,7 @@ JSValueRef JSIPCStreamClientConnection::open(JSContextRef context, JSObjectRef, 
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    jsIPC->m_streamConnection->open(jsIPC->m_dummyMessageReceiver);
+    jsIPC->m_streamConnection->open(jsIPC->m_dummyMessageReceiver.get());
     return JSValueMakeUndefined(context);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -37,6 +37,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -73,7 +74,7 @@ public:
     void graphicsLayerDidEnterContext(GraphicsLayerCARemote&);
     void graphicsLayerWillLeaveContext(GraphicsLayerCARemote&);
 
-    WebCore::LayerPool& layerPool() { return m_layerPool; }
+    WebCore::LayerPool& layerPool() { return m_layerPool.get(); }
 
     float deviceScaleFactor() const;
     
@@ -137,7 +138,7 @@ private:
 
     const UniqueRef<RemoteLayerBackingStoreCollection> m_backingStoreCollection;
 
-    WebCore::LayerPool m_layerPool;
+    const UniqueRef<WebCore::LayerPool> m_layerPool;
 
     CheckedPtr<RemoteLayerTreeTransaction> m_currentTransaction;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -56,6 +56,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeContext);
 RemoteLayerTreeContext::RemoteLayerTreeContext(WebPage& webPage)
     : m_webPage(webPage)
     , m_backingStoreCollection(makeUniqueRefWithoutRefCountedCheck<RemoteLayerBackingStoreCollection>(*this))
+    , m_layerPool(makeUniqueRef<LayerPool>())
 {
 }
 

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -85,6 +85,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     // PlaybackSessionModelClient
     void durationChanged(double) final;

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -116,6 +116,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     void videoDimensionsChanged(const WebCore::FloatSize&) override;
     void setPlayerIdentifier(std::optional<WebCore::MediaPlayerIdentifier>) final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -48,6 +48,7 @@
 
 class WebEditorClient final : public WebCore::EditorClient, public WebCore::TextCheckerClient {
     WTF_MAKE_TZONE_ALLOCATED(WebEditorClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebEditorClient);
 public:
     WebEditorClient(WebView *);
     virtual ~WebEditorClient();

--- a/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
@@ -96,6 +96,7 @@ private:
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setBegunCheckedPtrDeletion() final { CanMakeCheckedPtr::setBegunCheckedPtrDeletion(); }
 
     Vector<String> m_headers;
     Vector<uint8_t> m_data;


### PR DESCRIPTION
#### e87f9700abbc563835c45e485cea1fcaddaf52c4
<pre>
Add a debug assertion for subclasses of CanMakeCheckedPtr to be always heap allocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=301458">https://bugs.webkit.org/show_bug.cgi?id=301458</a>

Reviewed by NOBODY (OOPS!).

This PR adds a debug assertion in the destructor of CanMakeCheckedPtrBase to assert that
the deletion is initiated with operator delete of the corresponding class.

In addition, this PR also updates various objects to be heap-allocated on its own memory
region in order to secure the memory safety of CheckedPtr / CheckedRef.

Finally, this PR also adds the ability to suppress the aforementioned debug assertion,
and deploys the suppression mechanism in places that currently do not use operator delete
for destruction but are either too complicated to refactor in this PR or perf sensitive.

No new tests since there should be no behavioral differences.

* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h:
* Source/WTF/wtf/AbstractCanMakeCheckedPtr.h:
* Source/WTF/wtf/CheckedRef.h:
(WTF::CanMakeCheckedPtrBase::~CanMakeCheckedPtrBase):
(WTF::CanMakeCheckedPtrBase::setBegunCheckedPtrDeletion):
* Source/WTF/wtf/FastMalloc.h:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::databaseNameAndVersionFromFile):
* Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h:
* Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h:
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h:
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h:
* Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp:
(WebCore::DatabaseTracker::DatabaseTracker):
(WebCore::DatabaseTracker::openTrackerDatabase):
(WebCore::DatabaseTracker::hasEntryForOriginNoLock):
(WebCore::DatabaseTracker::hasEntryForDatabase):
(WebCore::DatabaseTracker::fullPathForDatabaseNoLock):
(WebCore::DatabaseTracker::origins):
(WebCore::DatabaseTracker::databaseNamesNoLock):
(WebCore::DatabaseTracker::detailsForNameAndOrigin):
(WebCore::DatabaseTracker::setDatabaseDetails):
(WebCore::DatabaseTracker::quotaNoLock):
(WebCore::DatabaseTracker::setQuota):
(WebCore::DatabaseTracker::addDatabase):
(WebCore::DatabaseTracker::deleteOrigin):
(WebCore::DatabaseTracker::deleteDatabase):
* Source/WebCore/Modules/webdatabase/DatabaseTracker.h:
* Source/WebCore/dom/DeviceMotionClient.h:
* Source/WebCore/dom/DeviceOrientationClient.h:
* Source/WebCore/dom/Document.h:
(WebCore::Document::setBegunCheckedPtrDeletion):
* Source/WebCore/dom/ScriptRunner.h:
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::WindowEventLoop):
(WebCore::WindowEventLoop::perpetualTaskGroupForSimilarOriginWindowAgents):
(WebCore::WindowEventLoop::queueMutationObserverCompoundMicrotask):
(WebCore::WindowEventLoop::backupElementQueue):
* Source/WebCore/dom/WindowEventLoop.h:
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/fileapi/FileReaderSync.cpp:
(WebCore::FileReaderSync::readAsArrayBuffer):
(WebCore::FileReaderSync::readAsBinaryString):
(WebCore::FileReaderSync::readAsText):
(WebCore::FileReaderSync::readAsDataURL):
* Source/WebCore/html/BaseTextInputType.h:
* Source/WebCore/html/EmailInputType.h:
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h:
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::setBegunCheckedPtrDeletion):
* Source/WebCore/html/ImageBitmap.cpp:
* Source/WebCore/html/NumberInputType.h:
* Source/WebCore/html/PasswordInputType.h:
* Source/WebCore/html/PluginDocument.h:
* Source/WebCore/html/SearchInputType.h:
* Source/WebCore/html/TelephoneInputType.h:
* Source/WebCore/html/TextFieldInputType.h:
* Source/WebCore/html/TextInputType.h:
* Source/WebCore/html/URLInputType.h:
* Source/WebCore/html/parser/HTMLDocumentParser.h:
* Source/WebCore/inspector/InspectorAuditResourcesObject.cpp:
(WebCore::InspectorAuditResourcesObject::InspectorAuditResourcesObject):
(WebCore::InspectorAuditResourcesObject::clientForResource):
* Source/WebCore/inspector/InspectorAuditResourcesObject.h:
* Source/WebCore/inspector/agents/WebHeapAgent.h:
* Source/WebCore/inspector/agents/page/PageHeapAgent.h:
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/platform/CaretAnimator.h:
* Source/WebCore/platform/OpacityCaretAnimator.h:
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::FontCascade):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/TextRun.h:
* Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h:
* Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h:
* Source/WebCore/platform/ios/DeviceMotionClientIOS.h:
* Source/WebCore/platform/ios/DeviceOrientationClientIOS.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm:
(WebCore::PlaybackSessionInterfaceIOS::logChannel const):
(WebCore::PlaybackSessionInterfaceIOS::checkedPtrCount const): Deleted.
(WebCore::PlaybackSessionInterfaceIOS::checkedPtrCountWithoutThreadCheck const): Deleted.
(WebCore::PlaybackSessionInterfaceIOS::incrementCheckedPtrCount const): Deleted.
(WebCore::PlaybackSessionInterfaceIOS::decrementCheckedPtrCount const): Deleted.
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm:
(WebCore::PlaybackSessionInterfaceMac::checkedPtrCount const): Deleted.
(WebCore::PlaybackSessionInterfaceMac::checkedPtrCountWithoutThreadCheck const): Deleted.
(WebCore::PlaybackSessionInterfaceMac::incrementCheckedPtrCount const): Deleted.
(WebCore::PlaybackSessionInterfaceMac::decrementCheckedPtrCount const): Deleted.
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h:
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h:
* Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp:
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.h:
* Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h:
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/mock/DeviceOrientationClientMock.h:
* Source/WebCore/platform/network/curl/CurlRequest.h:
* Source/WebCore/rendering/MarkedText.h:
* Source/WebCore/rendering/RegionContext.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/RenderListBox.h:
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/rendering/RenderSearchField.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/StyleUpdate.h:
* Source/WebCore/style/TreeResolutionState.h:
* Source/WebCore/svg/SVGFEImageElement.h:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::SVGImageElement):
(WebCore::SVGImageElement::cachedImage const):
(WebCore::SVGImageElement::attributeChanged):
(WebCore::SVGImageElement::svgAttributeChanged):
(WebCore::SVGImageElement::haveLoadedRequiredResources):
(WebCore::SVGImageElement::didAttachRenderers):
(WebCore::SVGImageElement::insertedIntoAncestor):
(WebCore::SVGImageElement::didMoveToNewDocument):
(WebCore::SVGImageElement::decode):
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/testing/Internals.h:
* Source/WebCore/workers/WorkerMessagingProxy.h:
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h:
* Source/WebCore/worklets/PaintWorkletGlobalScope.h:
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::ResourceLoadStatisticsStore):
(WebKit::ResourceLoadStatisticsStore::loadWebsitesWithUserInteraction):
(WebKit::ResourceLoadStatisticsStore::deleteTable):
(WebKit::ResourceLoadStatisticsStore::missingUniqueIndices):
(WebKit::ResourceLoadStatisticsStore::migrateDataToPCMDatabaseIfNecessary):
(WebKit::ResourceLoadStatisticsStore::addMissingTablesIfNecessary):
(WebKit::ResourceLoadStatisticsStore::createUniqueIndices):
(WebKit::ResourceLoadStatisticsStore::createSchema):
(WebKit::ResourceLoadStatisticsStore::insertDomainRelationshipList):
(WebKit::ResourceLoadStatisticsStore::aggregatedThirdPartyData const):
(WebKit::ResourceLoadStatisticsStore::incrementRecordsDeletedCountForDomains):
(WebKit::ResourceLoadStatisticsStore::recursivelyFindNonPrevalentDomainsThatRedirectedToThisDomain):
(WebKit::ResourceLoadStatisticsStore::markAsPrevalentIfHasRedirectedToPrevalent):
(WebKit::ResourceLoadStatisticsStore::findNotVeryPrevalentResources):
(WebKit::ResourceLoadStatisticsStore::runIncrementalVacuumCommand):
(WebKit::ResourceLoadStatisticsStore::requestStorageAccess):
(WebKit::ResourceLoadStatisticsStore::revokeStorageAccessPermission):
(WebKit::ResourceLoadStatisticsStore::grandfatherDataForDomains):
(WebKit::ResourceLoadStatisticsStore::clearTopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement):
(WebKit::ResourceLoadStatisticsStore::setDomainsAsPrevalent):
(WebKit::ResourceLoadStatisticsStore::clearDatabaseContents):
(WebKit::ResourceLoadStatisticsStore::cookieAccess):
(WebKit::ResourceLoadStatisticsStore::hasUserGrantedStorageAccessThroughPrompt):
(WebKit::ResourceLoadStatisticsStore::domainsToBlockAndDeleteCookiesFor const):
(WebKit::ResourceLoadStatisticsStore::domainsToBlockButKeepCookiesFor const):
(WebKit::ResourceLoadStatisticsStore::domainsWithUserInteractionAsFirstParty const):
(WebKit::ResourceLoadStatisticsStore::domainsWithStorageAccess const):
(WebKit::ResourceLoadStatisticsStore::domains const):
(WebKit::ResourceLoadStatisticsStore::clearGrandfathering):
(WebKit::ResourceLoadStatisticsStore::pruneStatisticsIfNeeded):
(WebKit::ResourceLoadStatisticsStore::isCorrectSubStatisticsCount):
(WebKit::ResourceLoadStatisticsStore::appendSubStatisticList const):
(WebKit::ResourceLoadStatisticsStore::updateOperatingDatesParameters):
(WebKit::ResourceLoadStatisticsStore::includeTodayAsOperatingDateIfNecessary):
(WebKit::ResourceLoadStatisticsStore::insertExpiredStatisticForTesting):
* Source/WebKit/NetworkProcess/DatabaseUtilities.cpp:
(WebKit::DatabaseUtilities::DatabaseUtilities):
(WebKit::DatabaseUtilities::scopedStatement const):
(WebKit::DatabaseUtilities::openDatabaseAndCreateSchemaIfNecessary):
(WebKit::DatabaseUtilities::enableForeignKeys):
(WebKit::DatabaseUtilities::close):
(WebKit::DatabaseUtilities::interrupt):
(WebKit::DatabaseUtilities::currentTableAndIndexQueries):
(WebKit::DatabaseUtilities::migrateDataToNewTablesIfNecessary):
(WebKit::DatabaseUtilities::columnsForTable):
(WebKit::DatabaseUtilities::addMissingColumnToTable):
* Source/WebKit/NetworkProcess/DatabaseUtilities.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::NetworkSession):
(WebKit::NetworkSession::checkedPrefetchCache):
* Source/WebKit/NetworkProcess/NetworkSession.h:
(WebKit::NetworkSession::setBegunCheckedPtrDeletion):
(WebKit::NetworkSession::clearPrefetchCache):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
(WebKit::PCM::Database::createUniqueIndices):
(WebKit::PCM::Database::createSchema):
(WebKit::PCM::Database::insertPrivateClickMeasurement):
(WebKit::PCM::Database::markAllUnattributedPrivateClickMeasurementAsExpiredForTesting):
(WebKit::PCM::Database::findPrivateClickMeasurement):
(WebKit::PCM::Database::removeUnattributed):
(WebKit::PCM::Database::allAttributedPrivateClickMeasurement):
(WebKit::PCM::Database::privateClickMeasurementToStringForTesting const):
(WebKit::PCM::Database::markAttributedPrivateClickMeasurementsAsExpiredForTesting):
(WebKit::PCM::Database::clearPrivateClickMeasurement):
(WebKit::PCM::Database::clearExpiredPrivateClickMeasurement):
(WebKit::PCM::Database::clearSentAttribution):
(WebKit::PCM::Database::markReportAsSentToDestination):
(WebKit::PCM::Database::markReportAsSentToSource):
(WebKit::PCM::Database::earliestTimesToSend):
(WebKit::PCM::Database::domainID):
(WebKit::PCM::Database::getDomainStringFromDomainID const):
(WebKit::PCM::Database::ensureDomainID):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp:
(WebKit::WebSWOriginStore::WebSWOriginStore):
(WebKit::WebSWOriginStore::addToStore):
(WebKit::WebSWOriginStore::removeFromStore):
(WebKit::WebSWOriginStore::clearStore):
(WebKit::WebSWOriginStore::registerSWServerConnection):
(WebKit::WebSWOriginStore::sendStoreHandle):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
(WebKit::IsolatedSession::IsolatedSession):
(WebKit::IsolatedSession::checkedSessionWithCredentialStorage):
(WebKit::SessionSet::checkedSessionWithCredentialStorage):
(WebKit::SessionSet::checkedEphemeralStatelessSession):
(WebKit::SessionSet::SessionSet):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::hstsStorage const):
(WebKit::NetworkSessionCocoa::nsCredentialStorage const):
(WebKit::SessionSet::initializeEphemeralStatelessSessionIfNeeded):
(WebKit::NetworkSessionCocoa::appBoundSession):
(WebKit::SessionSet::isolatedSession):
(WebKit::NetworkSessionCocoa::invalidateAndCancelSessionSet):
(WebKit::NetworkSessionCocoa::createWebSocketTask):
(WebKit::NetworkSessionCocoa::addWebSocketTask):
(WebKit::NetworkSessionCocoa::removeWebSocketTask):
(WebKit::NetworkSessionCocoa::addWebPageNetworkParameters):
(WebKit::NetworkSessionCocoa::hostNamesWithAlternativeServices const):
(WebKit::NetworkSessionCocoa::deleteAlternativeServicesForHostNames):
(WebKit::NetworkSessionCocoa::clearAlternativeServices):
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::open):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
(WebKit::RemoteLayerTreeTransaction::rootLayerID const): Deleted.
(WebKit::RemoteLayerTreeTransaction::createdLayers const): Deleted.
(WebKit::RemoteLayerTreeTransaction::destroyedLayers const): Deleted.
(WebKit::RemoteLayerTreeTransaction::layerIDsWithNewlyUnreachableBackingStore const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setRemoteContextHostedIdentifier): Deleted.
(WebKit::RemoteLayerTreeTransaction::remoteContextHostedIdentifier const): Deleted.
(WebKit::RemoteLayerTreeTransaction::isMainFrameProcessTransaction const): Deleted.
(WebKit::RemoteLayerTreeTransaction::contentsSize const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setContentsSize): Deleted.
(WebKit::RemoteLayerTreeTransaction::scrollGeometryContentSize const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setScrollGeometryContentSize): Deleted.
(WebKit::RemoteLayerTreeTransaction::scrollOrigin const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setScrollOrigin): Deleted.
(WebKit::RemoteLayerTreeTransaction::baseLayoutViewportSize const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setBaseLayoutViewportSize): Deleted.
(WebKit::RemoteLayerTreeTransaction::minStableLayoutViewportOrigin const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setMinStableLayoutViewportOrigin): Deleted.
(WebKit::RemoteLayerTreeTransaction::maxStableLayoutViewportOrigin const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setMaxStableLayoutViewportOrigin): Deleted.
(WebKit::RemoteLayerTreeTransaction::themeColor const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setThemeColor): Deleted.
(WebKit::RemoteLayerTreeTransaction::pageExtendedBackgroundColor const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setPageExtendedBackgroundColor): Deleted.
(WebKit::RemoteLayerTreeTransaction::sampledPageTopColor const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setSampledPageTopColor): Deleted.
(WebKit::RemoteLayerTreeTransaction::scrollPosition const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setScrollPosition): Deleted.
(WebKit::RemoteLayerTreeTransaction::pageScaleFactor const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setPageScaleFactor): Deleted.
(WebKit::RemoteLayerTreeTransaction::scaleWasSetByUIProcess const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setScaleWasSetByUIProcess): Deleted.
(WebKit::RemoteLayerTreeTransaction::pageScalingLayerID const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setPageScalingLayerID): Deleted.
(WebKit::RemoteLayerTreeTransaction::scrolledContentsLayerID const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setScrolledContentsLayerID): Deleted.
(WebKit::RemoteLayerTreeTransaction::mainFrameClipLayerID const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setMainFrameClipLayerID): Deleted.
(WebKit::RemoteLayerTreeTransaction::renderTreeSize const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setRenderTreeSize): Deleted.
(WebKit::RemoteLayerTreeTransaction::minimumScaleFactor const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setMinimumScaleFactor): Deleted.
(WebKit::RemoteLayerTreeTransaction::maximumScaleFactor const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setMaximumScaleFactor): Deleted.
(WebKit::RemoteLayerTreeTransaction::initialScaleFactor const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setInitialScaleFactor): Deleted.
(WebKit::RemoteLayerTreeTransaction::viewportMetaTagInteractiveWidget const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setViewportMetaTagInteractiveWidget): Deleted.
(WebKit::RemoteLayerTreeTransaction::viewportMetaTagWidth const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setViewportMetaTagWidth): Deleted.
(WebKit::RemoteLayerTreeTransaction::viewportMetaTagWidthWasExplicit const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setViewportMetaTagWidthWasExplicit): Deleted.
(WebKit::RemoteLayerTreeTransaction::viewportMetaTagCameFromImageDocument const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setViewportMetaTagCameFromImageDocument): Deleted.
(WebKit::RemoteLayerTreeTransaction::isInStableState const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setIsInStableState): Deleted.
(WebKit::RemoteLayerTreeTransaction::allowsUserScaling const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setAllowsUserScaling): Deleted.
(WebKit::RemoteLayerTreeTransaction::avoidsUnsafeArea const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setAvoidsUnsafeArea): Deleted.
(WebKit::RemoteLayerTreeTransaction::transactionID const): Deleted.
(WebKit::RemoteLayerTreeTransaction::callbackIDs const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setCallbackIDs): Deleted.
(WebKit::RemoteLayerTreeTransaction::newlyReachedPaintingMilestones const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setNewlyReachedPaintingMilestones): Deleted.
(WebKit::RemoteLayerTreeTransaction::hasEditorState const): Deleted.
(WebKit::RemoteLayerTreeTransaction::editorState const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setEditorState): Deleted.
(WebKit::RemoteLayerTreeTransaction::dynamicViewportSizeUpdateID const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setDynamicViewportSizeUpdateID): Deleted.
(WebKit::RemoteLayerTreeTransaction::fixedContainerEdges const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setFixedContainerEdges): Deleted.
(WebKit::RemoteLayerTreeTransaction::timelines const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setTimelines): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h:
* Source/WebKit/Shared/WebEvent.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::ViewGestureController):
(WebKit::ViewGestureController::didStartProvisionalOrSameDocumentLoadForMainFrame):
(WebKit::ViewGestureController::didFirstVisuallyNonEmptyLayoutForMainFrame):
(WebKit::ViewGestureController::didRepaintAfterNavigation):
(WebKit::ViewGestureController::didHitRenderTreeSizeThreshold):
(WebKit::ViewGestureController::didRestoreScrollPosition):
(WebKit::ViewGestureController::didReachNavigationTerminalState):
(WebKit::ViewGestureController::didSameDocumentNavigationForMainFrame):
(WebKit::ViewGestureController::checkForActiveLoads):
(WebKit::ViewGestureController::willEndSwipeGesture):
(WebKit::ViewGestureController::endSwipeGesture):
(WebKit::ViewGestureController::requestRenderTreeSizeNotificationIfNeeded):
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/VisitedLinkStore.cpp:
(WebKit::VisitedLinkStore::VisitedLinkStore):
(WebKit::VisitedLinkStore::addProcess):
(WebKit::VisitedLinkStore::addVisitedLinkHash):
(WebKit::VisitedLinkStore::containsVisitedLinkHash):
(WebKit::VisitedLinkStore::removeVisitedLinkHash):
(WebKit::VisitedLinkStore::removeAll):
(WebKit::VisitedLinkStore::sendStoreHandleToProcess):
* Source/WebKit/UIProcess/VisitedLinkStore.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::WebProcessProxy):
(WebKit::WebProcessProxy::~WebProcessProxy):
(WebKit::WebProcessProxy::connectionWillOpen):
(WebKit::WebProcessProxy::processWillShutDown):
(WebKit::WebProcessProxy::startDisplayLink):
(WebKit::WebProcessProxy::stopDisplayLink):
(WebKit::WebProcessProxy::setDisplayLinkPreferredFramesPerSecond):
(WebKit::WebProcessProxy::setDisplayLinkForDisplayWantsFullSpeedUpdates):
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::didFinishLaunching):
(WebKit::WebProcessProxy::isResponsive const):
(WebKit::WebProcessProxy::didChangeThrottleState):
(WebKit::WebProcessProxy::didDropLastAssertion):
(WebKit::WebProcessProxy::didReceiveBackgroundResponsivenessPing):
(WebKit::WebProcessProxy::processTerminated):
(WebKit::WebProcessProxy::updateBackgroundResponsivenessTimer):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp:
(WebKit::ViewGestureController::removeSwipeSnapshot):
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::willEndSwipeGesture):
(WebKit::ViewGestureController::removeSwipeSnapshot):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::removeSwipeSnapshot):
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::open):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
(WebKit::RemoteLayerTreeContext::layerPool):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::RemoteLayerTreeContext):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h:
* Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e87f9700abbc563835c45e485cea1fcaddaf52c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128203 "13 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/488 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39035 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135601 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79692 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/59af6564-4a5e-4952-baaa-a12143da0b95) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130075 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/415 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/358 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/135601 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/79692 "Hash e87f9700 for PR 52985 does not build (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131151 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/415 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/39035 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/135601 "Hash e87f9700 for PR 52985 does not build (failure)") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/415 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/39035 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78875 "Hash e87f9700 for PR 52985 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120234 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/415 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/39035 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138054 "Hash e87f9700 for PR 52985 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126664 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/338 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/358 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/138054 "Hash e87f9700 for PR 52985 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/370 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/39035 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/138054 "Hash e87f9700 for PR 52985 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/39035 "Hash e87f9700 for PR 52985 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/384 "Hash e87f9700 for PR 52985 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/62903 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159690 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/291 "Hash e87f9700 for PR 52985 does not build (failure)") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39871 "Passed tests") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/364 "Hash e87f9700 for PR 52985 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/349 "Hash e87f9700 for PR 52985 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->