### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for MediaStreamPrivateObserver

### DIFF
--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.h
@@ -38,6 +38,7 @@
 
 #include <WebCore/FloatSize.h>
 #include <WebCore/MediaStreamTrackPrivate.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Function.h>
 #include <wtf/MediaTime.h>
 #include <wtf/RefPtr.h>
@@ -47,20 +48,11 @@
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
-class MediaStreamPrivateObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaStreamPrivateObserver> : std::true_type { };
-}
-
-namespace WebCore {
 
 class MediaStream;
 class OrientationNotifier;
 
-class MediaStreamPrivateObserver : public CanMakeWeakPtr<MediaStreamPrivateObserver> {
+class MediaStreamPrivateObserver : public AbstractRefCountedAndCanMakeWeakPtr<MediaStreamPrivateObserver> {
 public:
     virtual ~MediaStreamPrivateObserver() = default;
 


### PR DESCRIPTION
#### 54a5cde2308f7bb4e4d52add04d40a5355a53e92
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for MediaStreamPrivateObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=301464">https://bugs.webkit.org/show_bug.cgi?id=301464</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/mediastream/MediaStreamPrivate.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(WebKitMediaStreamObserver::create):
(WebKitMediaStreamObserver::~WebKitMediaStreamObserver):
(WebKitMediaStreamObserver::WebKitMediaStreamObserver):
(webkitMediaStreamSrcConstructed):

Canonical link: <a href="https://commits.webkit.org/302158@main">https://commits.webkit.org/302158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca7304efc984723e95f12e02c97390cc3a3b9520

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135495 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79625 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c031a43e-5c25-4f70-8b67-d7beda591016) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97538 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65433 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/17fc69fc-13e6-43d2-aa93-8df33f0033b8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78108 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b1f488bd-1ff5-4523-a4ce-8e4297b3e773) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32886 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78806 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137985 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106066 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111122 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105805 "Found 1 new API test failure: WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26986 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/201 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29676 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52489 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/62134 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/222 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/295 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/272 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->