### PR TITLE
[JSC] Introduce non-local wasm inlining decision

### DIFF
--- a/JSTests/wasm/stress/cc-int-to-int-tail-call.js
+++ b/JSTests/wasm/stress/cc-int-to-int-tail-call.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSizeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-tail-calls-throw.js
+++ b/JSTests/wasm/stress/simd-tail-calls-throw.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmSIMD=1", "--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simple-inline-stacktrace-2.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-2.js
@@ -1,5 +1,5 @@
 //@ skip if $memoryLimited
-//@ runDefaultWasm("--maximumWasmDepthForInlining=10", "--maximumWasmCalleeSizeForInlining=10000000", "--maximumWasmCallerSizeForInlining=10000000", "--useBBQJIT=0")
+//@ runDefaultWasm("--wasmInliningMaximumDepth=10", "--wasmInliningMaximumWasmCalleeSize=10000000", "--wasmInliningBudget=100000", "--useBBQJIT=0")
 var wasm_code = read('simple-inline-stacktrace.wasm', 'binary')
 var wasm_module = new WebAssembly.Module(wasm_code);
 var wasm_instance = new WebAssembly.Instance(wasm_module, { a: { doThrow: () => { throw new Error() } } });

--- a/JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("--maximumWasmDepthForInlining=10", "--maximumWasmCalleeSizeForInlining=10000000", "--maximumWasmCallerSizeForInlining=10000000", "--useBBQJIT=0")
+//@ runDefaultWasm("--wasmInliningMaximumDepth=10", "--wasmInliningMaximumWasmCalleeSize=10000000", "--wasmInliningBudget=100000", "--useBBQJIT=0")
 var wasm_code = read('simple-inline-stacktrace-with-catch.wasm', 'binary')
 var wasm_module = new WebAssembly.Module(wasm_code);
 let throwCounter = 0

--- a/JSTests/wasm/stress/tail-call-across-modules.js
+++ b/JSTests/wasm/stress/tail-call-across-modules.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSizeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tail-call-double.js
+++ b/JSTests/wasm/stress/tail-call-double.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tail-call-js.js
+++ b/JSTests/wasm/stress/tail-call-js.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tail-call-simple-i64.js
+++ b/JSTests/wasm/stress/tail-call-simple-i64.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tail-call-simple-int.js
+++ b/JSTests/wasm/stress/tail-call-simple-int.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tail-call-simple.js
+++ b/JSTests/wasm/stress/tail-call-simple.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tail-call.js
+++ b/JSTests/wasm/stress/tail-call.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSizeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
 import * as assert from "../assert.js";
 import Builder from "../Builder.js";
 

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2051,6 +2051,7 @@
 		E383500A2390D93B0036316D /* WasmGlobal.h in Headers */ = {isa = PBXBuildFile; fileRef = E38350092390D9370036316D /* WasmGlobal.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E38416422E6FC06000591840 /* WasmBaselineData.h in Headers */ = {isa = PBXBuildFile; fileRef = E38416412E6FC06000591840 /* WasmBaselineData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3850B15226ED641009ABF9C /* DFGMinifiedIDInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3850B14226ED63E009ABF9C /* DFGMinifiedIDInlines.h */; };
+		E385CF202EAAE1300022B769 /* WasmInliningDecision.h in Headers */ = {isa = PBXBuildFile; fileRef = E385CF1E2EAAE1300022B769 /* WasmInliningDecision.h */; };
 		E38652E3237CA0C900E1D5EE /* BlockDirectoryBits.h in Headers */ = {isa = PBXBuildFile; fileRef = E38652E2237CA0C800E1D5EE /* BlockDirectoryBits.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E386FD7B26E867B800E4C28B /* TemporalPlainTimeConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7526E867B700E4C28B /* TemporalPlainTimeConstructor.h */; };
 		E386FD7E26E867B800E4C28B /* TemporalPlainTime.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7826E867B800E4C28B /* TemporalPlainTime.h */; };
@@ -5878,6 +5879,8 @@
 		E38350092390D9370036316D /* WasmGlobal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmGlobal.h; sourceTree = "<group>"; };
 		E38416412E6FC06000591840 /* WasmBaselineData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmBaselineData.h; sourceTree = "<group>"; };
 		E3850B14226ED63E009ABF9C /* DFGMinifiedIDInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DFGMinifiedIDInlines.h; path = dfg/DFGMinifiedIDInlines.h; sourceTree = "<group>"; };
+		E385CF1E2EAAE1300022B769 /* WasmInliningDecision.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmInliningDecision.h; sourceTree = "<group>"; };
+		E385CF1F2EAAE1300022B769 /* WasmInliningDecision.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmInliningDecision.cpp; sourceTree = "<group>"; };
 		E38652E2237CA0C800E1D5EE /* BlockDirectoryBits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockDirectoryBits.h; sourceTree = "<group>"; };
 		E386FD7426E867B700E4C28B /* TemporalPlainTimeConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TemporalPlainTimeConstructor.cpp; sourceTree = "<group>"; };
 		E386FD7526E867B700E4C28B /* TemporalPlainTimeConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemporalPlainTimeConstructor.h; sourceTree = "<group>"; };
@@ -8067,6 +8070,8 @@
 				148521D726EAEBFE00CC1D1A /* WasmHandlerInfo.h */,
 				AD8FF3961EB5BD850087FF82 /* WasmIndexOrName.cpp */,
 				AD8FF3951EB5BD850087FF82 /* WasmIndexOrName.h */,
+				E385CF1F2EAAE1300022B769 /* WasmInliningDecision.cpp */,
+				E385CF1E2EAAE1300022B769 /* WasmInliningDecision.h */,
 				E338C4A72E7B23D500C039A5 /* WasmInstanceAnchor.cpp */,
 				E338C4A62E7B23D500C039A5 /* WasmInstanceAnchor.h */,
 				F3D9C2382A426CB7006EE152 /* WasmIPIntGenerator.cpp */,
@@ -12285,6 +12290,7 @@
 				E383500A2390D93B0036316D /* WasmGlobal.h in Headers */,
 				148521D826EAEBFE00CC1D1A /* WasmHandlerInfo.h in Headers */,
 				AD8FF3981EB5BDB20087FF82 /* WasmIndexOrName.h in Headers */,
+				E385CF202EAAE1300022B769 /* WasmInliningDecision.h in Headers */,
 				E338C4A92E7B23D500C039A5 /* WasmInstanceAnchor.h in Headers */,
 				F3D9C2392A426CB8006EE152 /* WasmIPIntGenerator.h in Headers */,
 				F3D9C23B2A426CB8006EE152 /* WasmIPIntPlan.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1158,6 +1158,7 @@ wasm/WasmFunctionIPIntMetadataGenerator.cpp
 wasm/WasmGlobal.cpp
 wasm/WasmHandlerInfo.cpp
 wasm/WasmIndexOrName.cpp
+wasm/WasmInliningDecision.cpp
 wasm/WasmInstanceAnchor.cpp
 wasm/WasmIPIntGenerator.cpp
 wasm/WasmIPIntPlan.cpp

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -329,10 +329,14 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maximumBinaryStringSwitchTotalLength, 2000, Normal, nullptr) \
     v(Unsigned, maximumRegExpTestInlineCodesize, 500, Normal, "Maximum code size in bytes for inlined RegExp.test JIT code."_s) \
     \
-    v(Unsigned, maximumWasmDepthForInlining, isIOS() ? 2 : 8, Normal, "Maximum inlining depth to consider inlining a wasm function."_s) \
-    v(Unsigned, maximumWasmCalleeSizeForInlining, 200, Normal, "Maximum wasm size in bytes to consider inlining a wasm function."_s) \
-    v(Unsigned, maximumWasmCallerSizeForInlining, 10000, Normal, "Maximum wasm size in bytes for the caller of an inlined function."_s) \
-    v(Unsigned, maximumWasmSelfRecursionDepthForInlining, 5, Normal, "Maximum self cursion inlining depth to consider inlining a wasm function."_s) \
+    v(Unsigned, wasmInliningMaximumDepth, 7, Normal, "Maximum inlining depth to consider inlining a wasm function."_s) \
+    v(Unsigned, wasmInliningMaximumWasmCalleeSize, 500, Normal, "Maximum wasm size in bytes to consider inlining a wasm function."_s) \
+    v(Unsigned, wasmInliningMaximumCount, 60, Normal, "Maximum inlining count to consider inlining a wasm function."_s) \
+    v(Unsigned, wasmInliningMinimumBudget, 50, Normal, "Minimum budget for which the wasmInliningFactor does not apply"_s) \
+    v(Unsigned, wasmInliningFactor, 5, Normal, "Maximum multiple budget in comparison to initial wasm size"_s) \
+    v(Unsigned, wasmInliningBudget, 6000, Normal, "Maximum budget that allows inlining more"_s) \
+    v(Unsigned, wasmInliningTinyFunctionThreshold, 12, Normal, "Wasm size threshold for tiny wasm functions"_s) \
+    v(Unsigned, wasmInliningSmallFunctionThreshold, 50, Normal, "Wasm size threshold for small wasm functions"_s) \
     \
     v(Double, jitPolicyScale, 1.0, Normal, "scale JIT thresholds to this specified ratio between 0.0 (compile ASAP) and 1.0 (compile like normal)."_s) \
     v(Bool, forceEagerCompilation, false, Normal, nullptr) \

--- a/Source/JavaScriptCore/wasm/WasmCallProfile.h
+++ b/Source/JavaScriptCore/wasm/WasmCallProfile.h
@@ -97,7 +97,7 @@ public:
     static_assert(!(JSValue::NativeCalleeTag & calleeMask));
 #endif
 
-    static constexpr size_t maxPolymorphicCallees = 3;
+    static constexpr size_t maxPolymorphicCallees = 4;
 
     class alignas(16) PolymorphicCallee final : public TrailingArray<PolymorphicCallee, CallProfile> {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(PolymorphicCallee);

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -233,13 +233,13 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, FunctionSpac
     , m_metadata(WTFMove(generator.m_metadata))
     , m_argumINTBytecode(WTFMove(generator.m_argumINTBytecode))
     , m_uINTBytecode(WTFMove(generator.m_uINTBytecode))
+    , m_callTargets(WTFMove(generator.m_callTargets))
     , m_topOfReturnStackFPOffset(generator.m_topOfReturnStackFPOffset)
     , m_localSizeToAlloc(roundUpToMultipleOf<2>(generator.m_numLocals))
     , m_numRethrowSlotsToAlloc(generator.m_numAlignedRethrowSlots)
     , m_numLocals(generator.m_numLocals)
     , m_numArgumentsOnStack(generator.m_numArgumentsOnStack)
     , m_maxFrameSizeInV128(generator.m_maxFrameSizeInV128)
-    , m_numCallProfiles(generator.m_numCallProfiles)
     , m_tierUpCounter(WTFMove(generator.m_tierUpCounter))
 {
     if (size_t count = generator.m_exceptionHandlers.size()) {
@@ -290,7 +290,7 @@ const RegisterAtOffsetList* IPIntCallee::calleeSaveRegistersImpl()
 
 bool IPIntCallee::needsProfiling() const
 {
-    return m_numCallProfiles;
+    return numCallProfiles();
 }
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -442,11 +442,15 @@ public:
     unsigned localSizeToAlloc() const { return m_localSizeToAlloc; }
     unsigned rethrowSlots() const { return m_numRethrowSlotsToAlloc; }
 
-    unsigned numCallProfiles() const { return m_numCallProfiles; }
+    const Vector<FunctionSpaceIndex>& callTargets() const { return m_callTargets; }
+    unsigned numCallProfiles() const { return m_callTargets.size(); }
 
     bool needsProfiling() const;
 
     IPIntTierUpCounter& tierUpCounter() { return m_tierUpCounter; }
+    const IPIntTierUpCounter& tierUpCounter() const { return m_tierUpCounter; }
+
+    FunctionSpaceIndex callTarget(unsigned callProfileIndex) const { return m_callTargets[callProfileIndex]; }
 
     using OutOfLineJumpTargets = UncheckedKeyHashMap<unsigned, int>;
 
@@ -465,6 +469,7 @@ private:
     Vector<uint8_t> m_metadata;
     Vector<uint8_t> m_argumINTBytecode;
     Vector<uint8_t> m_uINTBytecode;
+    Vector<FunctionSpaceIndex> m_callTargets;
 
     unsigned m_topOfReturnStackFPOffset;
 
@@ -473,7 +478,6 @@ private:
     unsigned m_numLocals;
     unsigned m_numArgumentsOnStack;
     unsigned m_maxFrameSizeInV128;
-    unsigned m_numCallProfiles;
 
     IPIntTierUpCounter m_tierUpCounter;
 };

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -135,6 +135,7 @@ public:
 
     RefPtr<JITCallee> tryGetReplacementConcurrently(FunctionCodeIndex functionIndex) const WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
 #if ENABLE(WEBASSEMBLY_BBQJIT)
+    RefPtr<BBQCallee> tryGetBBQCallee(FunctionCodeIndex) WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
     RefPtr<BBQCallee> tryGetBBQCalleeForLoopOSRConcurrently(VM&, FunctionCodeIndex) WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
 #endif
 #if ENABLE(WEBASSEMBLY_OMGJIT)

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -93,6 +93,13 @@ public:
 
     const RTT* addSignature(const TypeDefinition&);
 
+    void addCallTarget(unsigned callProfileIndex, FunctionSpaceIndex target)
+    {
+        if (callProfileIndex >= m_callTargets.size())
+            m_callTargets.insertFill(m_callTargets.size(), FunctionSpaceIndex { }, callProfileIndex - m_callTargets.size() + 1);
+        m_callTargets[callProfileIndex] = target;
+    }
+
 private:
     struct MetadataBufferMalloc final : public FastMalloc {
         static constexpr ALWAYS_INLINE size_t nextCapacity(size_t capacity) { return capacity + capacity; }
@@ -132,7 +139,7 @@ private:
     unsigned m_numArguments { 0 };
     unsigned m_numArgumentsOnStack { 0 };
     unsigned m_nonArgLocalOffset { 0 };
-    unsigned m_numCallProfiles { 0 };
+    Vector<FunctionSpaceIndex> m_callTargets { };
     Vector<uint8_t, 16> m_argumINTBytecode { };
 
     UncheckedKeyHashMap<IPIntPC, IPIntTierUpCounter::OSREntryData> m_tierUpCounter;

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -3010,6 +3010,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCall(unsigned callProfileInd
 {
     const FunctionSignature& signature = *type.as<FunctionSignature>();
     const CallInformation& callConvention = cachedCallInformationFor(signature);
+    m_metadata->addCallTarget(callProfileIndex, index);
 
     if (callType == CallType::TailCall) {
         // on a tail call, we need to:
@@ -3055,6 +3056,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned callPr
 {
     const FunctionSignature& signature = *originalSignature.expand().as<FunctionSignature>();
     const CallInformation& callConvention = cachedCallInformationFor(signature);
+    m_metadata->addCallTarget(callProfileIndex, { });
 
     if (callType == CallType::TailCall) {
         const unsigned callIndex = 1;
@@ -3105,6 +3107,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallRef(unsigned callProfile
 {
     const FunctionSignature& signature = *originalSignature.expand().as<FunctionSignature>();
     const CallInformation& callConvention = cachedCallInformationFor(signature);
+    m_metadata->addCallTarget(callProfileIndex, { });
 
     if (callType == CallType::TailCall) {
         const unsigned callIndex = 1;
@@ -3173,7 +3176,8 @@ std::unique_ptr<FunctionIPIntMetadataGenerator> IPIntGenerator::finalize()
     m_metadata->m_maxFrameSizeInV128 = roundUpToMultipleOf<2>(m_metadata->m_numLocals) / 2;
     m_metadata->m_maxFrameSizeInV128 += m_metadata->m_numAlignedRethrowSlots / 2;
     m_metadata->m_maxFrameSizeInV128 += m_maxStackSize;
-    m_metadata->m_numCallProfiles = m_parser->numCallProfiles();
+    if (m_metadata->m_callTargets.size() < m_parser->numCallProfiles())
+        m_metadata->m_callTargets.insertFill(m_metadata->m_callTargets.size(), FunctionSpaceIndex { }, m_parser->numCallProfiles() - m_metadata->m_callTargets.size());
 
     return WTFMove(m_metadata);
 }

--- a/Source/JavaScriptCore/wasm/WasmInliningDecision.cpp
+++ b/Source/JavaScriptCore/wasm/WasmInliningDecision.cpp
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 the V8 project authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WasmInliningDecision.h"
+
+#include "WasmMergedProfile.h"
+#include "WasmModule.h"
+#include "WasmModuleInformation.h"
+#include <wtf/PriorityQueue.h>
+#include <wtf/TZoneMallocInlines.h>
+
+#if ENABLE(WEBASSEMBLY)
+
+namespace JSC::Wasm {
+namespace WasmInliningDecisionInternal {
+static constexpr bool verbose = false;
+}
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InliningNode);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InliningDecision);
+
+
+InliningNode::InliningNode(const IPIntCallee& callee, InliningNode* caller, uint8_t caseIndex, unsigned callProfileIndex, size_t wasmSize, double relativeCallCount)
+    : m_callee(callee)
+    , m_caller(caller)
+    , m_caseIndex(caseIndex)
+    , m_depth(caller ? caller->m_depth + 1 : 0)
+    , m_callProfileIndex(callProfileIndex)
+    , m_wasmSize(wasmSize)
+    , m_relativeCallCount(relativeCallCount)
+{
+}
+
+double InliningNode::score() const
+{
+    if (!m_wasmSize)
+        return 0.0;
+    return m_relativeCallCount / m_wasmSize;
+}
+
+// candidate given the initial graph size and the already inlined wire bytes.
+bool InliningDecision::canInline(InliningNode* target, size_t initialWasmSize, size_t inlinedWasmSize)
+{
+    size_t wasmSize = target->wasmSize();
+    if (wasmSize > Options::wasmInliningMaximumWasmCalleeSize())
+        return false;
+
+    // FIXME: There's no fundamental reason we can't inline these including imports.
+    if (m_module.moduleInformation().callCanClobberInstance(target->callee().index()))
+        return false;
+
+    // For tiny functions, let's be a bit more generous.
+    if (wasmSize < Options::wasmInliningTinyFunctionThreshold()) {
+        if (inlinedWasmSize > 100)
+            inlinedWasmSize -= 100;
+        else
+            inlinedWasmSize = 0;
+    }
+
+    // For small-ish functions, the inlining budget is defined by the larger of
+    // 1) the wasmInliningMinimumBudget and
+    // 2) the m_maxGrowthFactor * initialWasmSize.
+    // Inlining a little bit should always be fine even for tiny functions (1),
+    // otherwise (2) makes sure that the budget scales in relation with the
+    // original function size, to limit the compile time increase caused by
+    // inlining.
+    size_t budgetSmallFunction = std::max<size_t>(Options::wasmInliningMinimumBudget(), m_maxGrowthFactor * initialWasmSize);
+
+    // For large functions, growing by the same factor would add too much
+    // compilation effort, so we also apply a fixed cap. However, independent
+    // of the budget cap, for large functions we should still allow a little
+    // inlining, which is why we allow 10% of the graph size is the minimal
+    // budget even for large functions that exceed the regular budget.
+    //
+    // Note for future tuning: it might make sense to allow 20% here, and in
+    // turn perhaps lower --wasmInliningBudget. The drawback is that this
+    // would allow truly huge functions to grow even bigger; the benefit is
+    // that we wouldn't fall off as steep a cliff when hitting the cap.
+    size_t budgetLargeFunction = std::max<size_t>(m_budgetCap, initialWasmSize * 1.1);
+    size_t totalSize = initialWasmSize + inlinedWasmSize + wasmSize;
+    return totalSize < std::min<size_t>(budgetSmallFunction, budgetLargeFunction);
+}
+
+InliningNode* InliningNode::callTarget(FunctionSpaceIndex functionIndexSpace, unsigned callProfileIndex)
+{
+    if (m_callSites.size() <= callProfileIndex)
+        return nullptr;
+
+    auto& callSite = m_callSites[callProfileIndex];
+    for (auto* inlining : callSite) {
+        if (inlining->callee().index() == functionIndexSpace) {
+            if (inlining->isInlined())
+                return inlining;
+            return nullptr;
+        }
+    }
+    return nullptr;
+}
+
+void InliningNode::inlineNode(InliningDecision& decision)
+{
+    m_isInlined = true;
+    SUPPRESS_UNCOUNTED_ARG auto* profile = decision.profileForCallee(m_callee);
+    if (!profile->merged())
+        return;
+
+    m_isUnused = false;
+    m_callSites.grow(profile->size());
+
+    for (unsigned index = 0; index < m_callSites.size(); ++index) {
+        if (!profile->isCalled(index))
+            continue;
+
+        if (profile->isMegamorphic(index))
+            continue;
+
+        auto& callSite = m_callSites[index];
+        auto candidates = profile->candidates(index);
+        for (auto& [candidateCallee, callCount] : candidates.callees()) {
+            if (candidateCallee->compilationMode() != Wasm::CompilationMode::IPIntMode)
+                continue;
+            SUPPRESS_UNCOUNTED_LOCAL auto& target = uncheckedDowncast<const IPIntCallee>(*candidateCallee);
+
+            double relativeCallCount = 0;
+            if (profile->totalCount())
+                relativeCallCount = callCount / profile->totalCount();
+            size_t wasmSize = decision.m_module.moduleInformation().functionWasmSizeImportSpace(candidateCallee->index());
+            auto& child = decision.m_arena.alloc(target, this, callSite.size(), index, wasmSize, relativeCallCount);
+            callSite.append(&child);
+        }
+    }
+}
+
+static double budgetScaleFactor(const Module& module)
+{
+    // If there are few small functions, that indicates that the toolchain
+    // already performed significant inlining, so we reduce the budget
+    // significantly as further inlining has diminishing benefits.
+    // For both major knobs, we apply a smoothened step function based on
+    // the module's percentage of small functions (sfp):
+    //   sfp <= 25%: use "low" budget
+    //   sfp >= 50%: use "high" budget
+    //   25% < sfp < 50%: interpolate linearly between both budgets.
+    double smallFunctionPercentage = module.moduleInformation().m_numSmallFunctions * 100.0 / module.moduleInformation().internalFunctionCount();
+    if (smallFunctionPercentage <= 25)
+        return 0;
+    if (smallFunctionPercentage >= 50)
+        return 1;
+
+    return (smallFunctionPercentage - 25) / 25;
+}
+
+InliningDecision::InliningDecision(Module& module, const IPIntCallee& rootCallee)
+    : m_module(module)
+    , m_root(m_arena.alloc(rootCallee, nullptr, 0, 0, module.moduleInformation().functionWasmSizeImportSpace(rootCallee.index()), 1.0))
+{
+    double scaled = budgetScaleFactor(module);
+    int highGrowth = Options::wasmInliningFactor();
+
+    // A value of 1 would be equivalent to disabling inlining entirely.
+    constexpr int lowestUsefulValue = 2;
+    int lowGrowth = std::max(lowestUsefulValue, highGrowth - 3);
+    m_maxGrowthFactor = lowGrowth * (1 - scaled) + highGrowth * scaled;
+
+    double highCap = Options::wasmInliningBudget();
+    double lowCap = highCap / 10;
+    m_budgetCap = lowCap * (1 - scaled) + highCap * scaled;
+}
+
+MergedProfile* InliningDecision::profileForCallee(const IPIntCallee& callee)
+{
+    SUPPRESS_UNCOUNTED_ARG return m_profiles.ensure(&callee, [&] {
+        return m_module.createMergedProfile(callee);
+    }).iterator->value.get();
+}
+
+static bool isHigherPriority(InliningNode* const& lhs, InliningNode* const& rhs)
+{
+    // The ordering is, higher score, lower index, lower pointer.
+    return std::tuple { lhs->score(), rhs->callee().index(), rhs } > std::tuple { rhs->score(), lhs->callee().index(), lhs };
+}
+
+void InliningDecision::expand()
+{
+    PriorityQueue<InliningNode*, isHigherPriority> queue;
+
+    auto addChildrenToQueue = [&](InliningNode* target) {
+        if (target->depth() >= Options::wasmInliningMaximumDepth()) {
+            dataLogLnIf(WasmInliningDecisionInternal::verbose, "max inlining depth reached]");
+            return;
+        }
+
+        unsigned actual = 0;
+        for (const auto& callSite : target->callSites()) {
+            for (auto* node : callSite) {
+                queue.enqueue(node);
+                ++actual;
+            }
+        }
+        dataLogLnIf(WasmInliningDecisionInternal::verbose, "queueing ", actual, " callees in ", target->callSites().size(), " sites]");
+    };
+
+    uint32_t initialWasmSize = m_root.wasmSize();
+    uint32_t inlinedWasmSize = 0;
+
+
+    dataLogIf(WasmInliningDecisionInternal::verbose, "[function ", m_root.callee().index(), ": expanding topmost caller... ");
+    m_root.inlineNode(*this);
+    ++m_inlinedCount;
+    addChildrenToQueue(&m_root);
+
+    while (!queue.isEmpty()) {
+        if (!Options::useOMGInlining()) {
+            dataLogLnIf(WasmInliningDecisionInternal::verbose, "    [function ", m_root.callee().index(), ": inlining is disabled, stopping...]");
+            break;
+        }
+
+        if (m_inlinedCount >= Options::wasmInliningMaximumCount()) {
+            dataLogLnIf(WasmInliningDecisionInternal::verbose, "    [function ", m_root.callee().index(), ": too many inlining candidates, stopping...]");
+            break;
+        }
+
+        auto* target = queue.dequeue();
+        dataLogIf(WasmInliningDecisionInternal::verbose, "    [function ", m_root.callee().index(), ": in function ", target->caller()->callee().index(), ", considering call #", target->callProfileIndex(), ", case #", target->caseIndex(), ", to function ", target->callee().index(), " relativeCallCount:(", target->relativeCallCount(), "),size:(", target->wasmSize(), "),score:(", target->score(), ")... ");
+
+        if (target->wasmSize() >= Options::wasmInliningTinyFunctionThreshold()) {
+            if (target->score() < 0.0001) {
+                dataLogLnIf(WasmInliningDecisionInternal::verbose, "not called often enough]");
+                continue;
+            }
+        }
+
+        if (!canInline(target, initialWasmSize, inlinedWasmSize)) {
+            dataLogLnIf(WasmInliningDecisionInternal::verbose, "not enough inlining budget]");
+            continue;
+        }
+
+        dataLogIf(WasmInliningDecisionInternal::verbose, "decided to inline! ");
+        target->inlineNode(*this);
+        ++m_inlinedCount;
+        addChildrenToQueue(target);
+
+        constexpr size_t oneLessCall = 6; // Guesstimated savings per call.
+        size_t addition = target->wasmSize();
+        if (addition >= oneLessCall)
+            inlinedWasmSize += (addition - oneLessCall);
+    }
+}
+
+} // namespace JSC::Wasm
+
+#endif

--- a/Source/JavaScriptCore/wasm/WasmInliningDecision.h
+++ b/Source/JavaScriptCore/wasm/WasmInliningDecision.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 the V8 project authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <JavaScriptCore/WasmBaselineData.h>
+#include <JavaScriptCore/WasmCallProfile.h>
+#include <JavaScriptCore/WasmCallee.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/WTFString.h>
+
+namespace JSC::Wasm {
+
+class MergedProfile;
+class Module;
+class InliningDecision;
+
+class InliningNode {
+    WTF_MAKE_TZONE_ALLOCATED(InliningNode);
+    WTF_MAKE_NONMOVABLE(InliningNode);
+public:
+    using CallSite = Vector<InliningNode*, CallProfile::maxPolymorphicCallees>;
+
+    InliningNode(const IPIntCallee&, InliningNode* caller, uint8_t caseIndex, unsigned callProfileIndex, size_t wasmSize, double relativeCallCount);
+
+    void inlineNode(InliningDecision&);
+
+    const IPIntCallee& callee() const { return m_callee; }
+    InliningNode* caller() const { return m_caller; }
+    const Vector<CallSite>& callSites() const { return m_callSites; }
+    bool isInlined() const { return m_isInlined; }
+    bool isUnused() const { return m_isUnused; }
+    uint8_t caseIndex() const { return m_caseIndex; }
+    uint32_t depth() const { return m_depth; }
+    unsigned callProfileIndex() const { return m_callProfileIndex; }
+    double relativeCallCount() const { return m_relativeCallCount; }
+    size_t wasmSize() const { return m_wasmSize; }
+    double score() const;
+
+    InliningNode* callTarget(FunctionSpaceIndex functionIndexSpace, unsigned callProfileIndex);
+
+private:
+    SUPPRESS_UNCOUNTED_MEMBER const IPIntCallee& m_callee;
+    InliningNode* m_caller;
+    Vector<CallSite> m_callSites;
+    bool m_isInlined { false };
+    bool m_isUnused { true };
+    uint8_t m_caseIndex { 0 };
+    uint32_t m_depth { 0 };
+    unsigned m_callProfileIndex { 0 };
+    size_t m_wasmSize { 0 };
+    double m_relativeCallCount { 0.0 };
+};
+
+class InliningDecision final {
+    WTF_MAKE_TZONE_ALLOCATED(InliningDecision);
+    WTF_MAKE_NONMOVABLE(InliningDecision);
+    friend class Module;
+    friend class InliningNode;
+public:
+    InliningDecision(Module&, const IPIntCallee& rootCallee);
+
+    MergedProfile* profileForCallee(const IPIntCallee&);
+
+    void expand();
+
+    InliningNode* root() { return &m_root; }
+
+private:
+    bool canInline(InliningNode*, size_t initialWasmSize, size_t inlinedWasmSize);
+
+    SUPPRESS_UNCOUNTED_MEMBER Module& m_module;
+    SegmentedVector<InliningNode, 16> m_arena;
+    UncheckedKeyHashMap<const IPIntCallee*, std::unique_ptr<MergedProfile>> m_profiles;
+    InliningNode& m_root;
+    uint32_t m_inlinedCount { 0 };
+    double m_maxGrowthFactor { 0 };
+    size_t m_budgetCap { 0 };
+};
+
+} // namespace JSC::Wasm
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmMergedProfile.h
+++ b/Source/JavaScriptCore/wasm/WasmMergedProfile.h
@@ -56,7 +56,7 @@ public:
         bool isMegamorphic() const { return m_isMegamorphic; }
         uint32_t totalCount() const { return m_totalCount; }
 
-        void merge(const CallProfile&);
+        void merge(IPIntCallee*, const CallProfile&);
         Candidates finalize() const;
 
     private:
@@ -69,15 +69,20 @@ public:
         std::array<std::tuple<Callee*, uint32_t>, CallProfile::maxPolymorphicCallees> m_callees { };
     };
 
-    MergedProfile(const IPIntCallee&);
+    MergedProfile(const IPIntCallee&, double totalCount);
+    unsigned size() const { return m_callSites.size(); }
     bool isCalled(size_t index) const { return m_callSites[index].isCalled(); }
     Candidates candidates(size_t index) const { return m_callSites[index].finalize(); }
     bool isMegamorphic(size_t index) const { return m_callSites[index].isMegamorphic(); }
 
-    void merge(BaselineData&);
+    void merge(const Module&, const IPIntCallee&, BaselineData&);
+    bool merged() const { return m_merged; }
+    double totalCount() const { return m_totalCount; }
 
 private:
     Vector<Candidates> m_callSites;
+    double m_totalCount { 0 };
+    bool m_merged { false };
 };
 
 } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -148,9 +148,19 @@ Ref<Wasm::InstanceAnchor> Module::registerAnchor(JSWebAssemblyInstance* instance
     return anchor;
 }
 
-std::unique_ptr<MergedProfile> Module::createMergedProfile(IPIntCallee& callee)
+std::unique_ptr<MergedProfile> Module::createMergedProfile(const IPIntCallee& callee)
 {
-    auto result = makeUnique<MergedProfile>(callee);
+    double totalCount = callee.tierUpCounter().count();
+#if ENABLE(WEBASSEMBLY_BBQJIT)
+    for (unsigned i = 0; i < numberOfMemoryModes; ++i) {
+        if (RefPtr group = m_calleeGroups[i]) {
+            if (RefPtr bbq = group->tryGetBBQCallee(callee.functionIndex()))
+                totalCount += bbq->tierUpCounter().count();
+        }
+    }
+#endif
+
+    auto result = makeUnique<MergedProfile>(callee, totalCount);
     for (Ref anchor : m_anchors) {
         RefPtr<BaselineData> data;
         {
@@ -160,7 +170,7 @@ std::unique_ptr<MergedProfile> Module::createMergedProfile(IPIntCallee& callee)
         }
         if (!data)
             continue;
-        result->merge(*data);
+        result->merge(*this, callee, *data);
     }
     return result;
 }

--- a/Source/JavaScriptCore/wasm/WasmModule.h
+++ b/Source/JavaScriptCore/wasm/WasmModule.h
@@ -89,7 +89,7 @@ public:
 
     Ref<Wasm::InstanceAnchor> registerAnchor(JSWebAssemblyInstance*);
 
-    std::unique_ptr<MergedProfile> createMergedProfile(IPIntCallee&);
+    std::unique_ptr<MergedProfile> createMergedProfile(const IPIntCallee&);
 
     uint32_t debugId() const;
     void setDebugId(uint32_t);

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -219,6 +219,7 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     mutable FixedBitVector m_referencedFunctions;
     mutable FixedBitVector m_clobberingTailCalls;
     size_t m_totalFunctionSize { 0 };
+    uint32_t m_numSmallFunctions { 0 };
 
 private:
     void populateImportShouldBeHidden();

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -166,6 +166,8 @@ auto StreamingParser::parseFunctionSize(uint32_t functionSize) -> State
 {
     m_functionSize = functionSize;
     WASM_PARSER_FAIL_IF(functionSize > maxFunctionSize, "Code function's size "_s, functionSize, " is too big"_s);
+    if (functionSize < Options::wasmInliningSmallFunctionThreshold())
+        ++m_info->m_numSmallFunctions;
     return State::FunctionPayload;
 }
 

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1864,7 +1864,7 @@ def runWebAssembly
         end
         if $isFTLPlatform
             run("wasm-simd", "-m", "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "-m", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-aggressive-inline", "-m", "--wasmInliningMaximumWasmCalleeSize=2147483647", "--wasmInliningBudget=100000", "--wasmInliningMaximumDepth=10", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
             # FIXME: remove with rdar://144792585
             run("wasm-graph-reg-alloc", "-m", "--airUseGreedyRegAlloc=false", *FTL_OPTIONS)
         end
@@ -1897,7 +1897,7 @@ def runWebAssemblyJetStream2
         end
         if $isFTLPlatform
             run("wasm-simd", "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-aggressive-inline", "--wasmInliningMaximumWasmCalleeSize=2147483647", "--wasmInliningBudget=100000", "--wasmInliningMaximumDepth=10", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
             # FIXME: remove with rdar://144792585
             run("wasm-graph-reg-alloc", "--airUseGreedyRegAlloc=false", *FTL_OPTIONS)
         end
@@ -1937,7 +1937,7 @@ def runWebAssemblySuite(*optionalTestSpecificOptions)
         end
         if $isFTLPlatform
             run("wasm-simd", "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-aggressive-inline", "--wasmInliningMaximumWasmCalleeSize=2147483647", "--wasmInliningBudget=100000", "--wasmInliningMaximumDepth=10", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?(:wasm_aggressive_inline)
             # FIXME: remove with rdar://144792585
             run("wasm-graph-reg-alloc", "--airUseGreedyRegAlloc=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         end
@@ -1970,7 +1970,7 @@ def runV8WebAssemblySuite(*optionalTestSpecificOptions)
         end        
         if $isFTLPlatform
             run("wasm-simd", "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-aggressive-inline", "--wasmInliningMaximumWasmCalleeSize=2147483647", "--wasmInliningBudget=100000", "--wasmInliningMaximumDepth=10", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?(:wasm_aggressive_inline)
             # FIXME: remove with rdar://144792585
             run("wasm-graph-reg-alloc", "--airUseGreedyRegAlloc=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         end
@@ -2019,7 +2019,7 @@ def runWebAssemblyWithHarness(*optionalTestSpecificOptions)
         end
         if $isFTLPlatform
             runWasmHarnessTest("wasm-simd", "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
-            runWasmHarnessTest("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
+            runWasmHarnessTest("wasm-aggressive-inline", "--wasmInliningMaximumWasmCalleeSize=2147483647", "--wasmInliningBudget=100000", "--wasmInliningMaximumDepth=10", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
             # FIXME: remove with rdar://144792585
             runWasmHarnessTest("wasm-graph-reg-alloc", "--airUseGreedyRegAlloc=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         end
@@ -2049,7 +2049,7 @@ def runWebAssemblyEmscripten(mode)
         end
         if $isFTLPlatform
             run("wasm-simd", "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-aggressive-inline", "--wasmInliningMaximumWasmCalleeSize=2147483647", "--wasmInliningBudget=100000", "--wasmInliningMaximumDepth=10", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
             # FIXME: remove with rdar://144792585
             run("wasm-graph-reg-alloc", "--airUseGreedyRegAlloc=false", *FTL_OPTIONS)
         end


### PR DESCRIPTION
#### cfbd6fb2d1c38e82f36f7bd8a8b4cae94bb89a7f
<pre>
[JSC] Introduce non-local wasm inlining decision
<a href="https://bugs.webkit.org/show_bug.cgi?id=301465">https://bugs.webkit.org/show_bug.cgi?id=301465</a>
<a href="https://rdar.apple.com/163406661">rdar://163406661</a>

Reviewed by Dan Hecht.

This patch introduces Wasm::InliningDecision, which overviews the
entire function and deciding which callsite should be inlined. Previous
implementation was deciding inlining locally: we check earlier callsite
and do inlining and we stop inlining when it reaches to the threshold.
Instead, we should check the entire graph of the function and select
inlining candidates globally.

To do this massive design change, we start with V8&apos;s algorithm for
inlining heuristics. We will tune and add more behavior changes after
this but this patch starts with V8&apos;s one. InliningDecision implements
V8&apos;s current inlining heuristics mechanism. And InliningDecision fully
computes which callsite should be inlined a-priori, and OMG compiler
just follows to this decision after all computation is done. We also
increase maxPolymorphicCallees to 4 to align to V8&apos;s heuristics.

* JSTests/wasm/stress/cc-int-to-int-tail-call.js:
* JSTests/wasm/stress/simd-tail-calls-throw.js:
* JSTests/wasm/stress/simple-inline-stacktrace-2.js:
* JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js:
* JSTests/wasm/stress/tail-call-across-modules.js:
* JSTests/wasm/stress/tail-call-double.js:
* JSTests/wasm/stress/tail-call-js.js:
* JSTests/wasm/stress/tail-call-simple-i64.js:
* JSTests/wasm/stress/tail-call-simple-int.js:
* JSTests/wasm/stress/tail-call-simple.js:
* JSTests/wasm/stress/tail-call.js:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmCallProfile.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
(JSC::Wasm::IPIntCallee::needsProfiling const):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::tryGetBBQCallee):
(JSC::Wasm::CalleeGroup::tryGetBBQCalleeForLoopOSRConcurrently):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addCallTarget):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addCall):
(JSC::Wasm::IPIntGenerator::addCallIndirect):
(JSC::Wasm::IPIntGenerator::addCallRef):
(JSC::Wasm::IPIntGenerator::finalize):
* Source/JavaScriptCore/wasm/WasmInliningDecision.cpp: Added.
(JSC::Wasm::InliningNode::InliningNode):
(JSC::Wasm::InliningNode::score const):
(JSC::Wasm::InliningDecision::canInline):
(JSC::Wasm::InliningNode::callTarget):
(JSC::Wasm::InliningNode::inlineNode):
(JSC::Wasm::budgetScaleFactor):
(JSC::Wasm::InliningDecision::InliningDecision):
(JSC::Wasm::InliningDecision::profileForCallee):
(JSC::Wasm::isHigherPriority):
(JSC::Wasm::InliningDecision::expand):
* Source/JavaScriptCore/wasm/WasmInliningDecision.h: Added.
(JSC::Wasm::InliningNode::callee const):
(JSC::Wasm::InliningNode::caller const):
(JSC::Wasm::InliningNode::callSites const):
(JSC::Wasm::InliningNode::isInlined const):
(JSC::Wasm::InliningNode::isUnused const):
(JSC::Wasm::InliningNode::caseIndex const):
(JSC::Wasm::InliningNode::depth const):
(JSC::Wasm::InliningNode::callProfileIndex const):
(JSC::Wasm::InliningNode::relativeCallCount const):
(JSC::Wasm::InliningNode::wasmSize const):
* Source/JavaScriptCore/wasm/WasmMergedProfile.cpp:
(JSC::Wasm::MergedProfile::MergedProfile):
(JSC::Wasm::MergedProfile::Candidates::merge):
(JSC::Wasm::MergedProfile::Candidates::finalize const):
(JSC::Wasm::MergedProfile::merge):
* Source/JavaScriptCore/wasm/WasmMergedProfile.h:
(JSC::Wasm::MergedProfile::size const):
(JSC::Wasm::MergedProfile::merged const):
(JSC::Wasm::MergedProfile::totalCount const):
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::Module::createMergedProfile):
* Source/JavaScriptCore/wasm/WasmModule.h:
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::OMGIRGenerator):
(JSC::Wasm::OMGIRGenerator::canInline const):
(JSC::Wasm::OMGIRGenerator::emitInlineDirectCall):
(JSC::Wasm::OMGIRGenerator::emitDirectCall):
(JSC::Wasm::OMGIRGenerator::tryInliningPolymorphicCalls):
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
(JSC::Wasm::OMGIRGenerator::addCallRef):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::OMGIRGenerator):
(JSC::Wasm::OMGIRGenerator::canInline const):
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
(JSC::Wasm::OMGIRGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::StreamingParser::parseFunctionSize):
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/302215@main">https://commits.webkit.org/302215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53246ea00e61b29d05c7d2a9bf41ff6c26ab9100

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128358 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135750 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79825 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/132943ab-81bf-4528-83f8-c1e6afb77c32) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97707 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/54cc7552-cb46-4a34-b5fd-5975d0c45d24) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78300 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6de92b8b-530a-4cae-a2f0-2af428dc81fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33101 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79037 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120379 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138204 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126818 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106241 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106045 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29883 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52796 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20055 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/530 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63706 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159842 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/426 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39923 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/492 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/491 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->