### PR TITLE
Follow-up: [iOS] Add a pop-up menu for selecting caption style profiles

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h
+++ b/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h
@@ -47,7 +47,7 @@ WK_EXTERN
 @interface WKCaptionStyleMenuController : NSObject
 @property (weak, nonatomic) id<WKCaptionStyleMenuControllerDelegate> delegate;
 @property (readonly, nonatomic) PlatformMenu *captionStyleMenu;
-#if !TARGET_OS_OSX
+#if !TARGET_OS_OSX && !TARGET_OS_WATCH
 @property (readonly, nullable, nonatomic) UIContextMenuInteraction *contextMenuInteraction;
 #endif
 

--- a/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm
@@ -44,11 +44,17 @@ static const UIMenuIdentifier WKCaptionStyleMenuProfileGroupIdentifier = @"WKCap
 static const UIMenuIdentifier WKCaptionStyleMenuProfileIdentifier = @"WKCaptionStyleMenuProfileIdentifier";
 static const UIMenuIdentifier WKCaptionStyleMenuSystemSettingsIdentifier = @"WKCaptionStyleMenuSystemSettingsIdentifier";
 
+#if USE(UICONTEXTMENU)
 @interface WKCaptionStyleMenuController () <UIContextMenuInteractionDelegate> {
+#else
+@interface WKCaptionStyleMenuController () {
+#endif
     Vector<String> _profileIDs;
     String _savedActiveProfileID;
     RetainPtr<UIMenu> _menu;
+#if USE(UICONTEXTMENU)
     RetainPtr<UIContextMenuInteraction> _interaction;
+#endif
 }
 @end
 
@@ -120,16 +126,14 @@ static const UIMenuIdentifier WKCaptionStyleMenuSystemSettingsIdentifier = @"WKC
     return _menu.get();
 }
 
+#if USE(UICONTEXTMENU)
 - (UIContextMenuInteraction *)contextMenuInteraction
 {
-#if !PLATFORM(WATCHOS)
     if (!_interaction)
         _interaction = adoptNS([[UIContextMenuInteraction alloc] initWithDelegate:self]);
     return _interaction.get();
-#else
-    return nil;
-#endif
 }
+#endif
 
 #pragma mark - Actions
 
@@ -164,16 +168,13 @@ static const UIMenuIdentifier WKCaptionStyleMenuSystemSettingsIdentifier = @"WKC
         [delegate captionStyleMenuDidClose:_menu.get()];
 }
 
-- (nullable UIContextMenuConfiguration *)contextMenuInteraction:(nonnull UIContextMenuInteraction *)interaction configurationForMenuAtLocation:(CGPoint)location {
 #if USE(UICONTEXTMENU)
+- (nullable UIContextMenuConfiguration *)contextMenuInteraction:(nonnull UIContextMenuInteraction *)interaction configurationForMenuAtLocation:(CGPoint)location {
     return [UIContextMenuConfiguration configurationWithIdentifier:nil previewProvider:nil actionProvider:makeBlockPtr([weakSelf = WeakObjCPtr<WKCaptionStyleMenuController>(self)] (NSArray<UIMenuElement *> *) -> UIMenu * {
         if (auto strongSelf = weakSelf.get())
             return strongSelf->_menu.get();
         return nil;
     }).get()];
-#else
-    return nil;
-#endif
 }
 
 - (void)contextMenuInteraction:(UIContextMenuInteraction *)interaction willDisplayMenuForConfiguration:(UIContextMenuConfiguration *)configuration animator:(nullable id<UIContextMenuInteractionAnimating>)animator
@@ -185,6 +186,7 @@ static const UIMenuIdentifier WKCaptionStyleMenuSystemSettingsIdentifier = @"WKC
 {
     [self notifyMenuDidClose];
 }
+#endif // USE(UICONTEXTMENU)
 @end
 
 #endif


### PR DESCRIPTION
#### b7761411212c8c806d985a503c48bf21cb5fa5e1
<pre>
Follow-up: [iOS] Add a pop-up menu for selecting caption style profiles
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=301376">https://bugs.webkit.org/show_bug.cgi?id=301376</a>&gt;
&lt;<a href="https://rdar.apple.com/problem/163297495">rdar://problem/163297495</a>&gt;

Unreviewed build fix for internal watchOS.

This is a follow-up fix for 302143@main.

* Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h:
(WKCaptionStyleMenuController.contextMenuInteraction):
- Disable property on watchOS.
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm:
- Do not implement unavailable UIContextMenuInteractionDelegate protocol
  on watchOS.
(-[WKCaptionStyleMenuController contextMenuInteraction]):
(-[WKCaptionStyleMenuController contextMenuInteraction:configurationForMenuAtLocation:]):
(-[WKCaptionStyleMenuController contextMenuInteraction:willDisplayMenuForConfiguration:animator:]):
(-[WKCaptionStyleMenuController contextMenuInteraction:willEndForConfiguration:animator:]):
- Comment out WKCaptionStyleMenuController.contextMenuInteraction
  property and UIContextMenuInteractionDelegate protocol methods on
  watchOS.

Canonical link: <a href="https://commits.webkit.org/302150@main">https://commits.webkit.org/302150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/791f1977d16df4fa8f4d41a6c7314d8b8f104f9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128149 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79640 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3777cde7-3a3b-4997-b4fa-fa27c06eb03e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97551 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65447 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fab33a82-447c-456a-8708-1d04c77fbd7a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78121 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5234c4c6-3d9d-461f-a5e8-58cb99196568) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/210 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78825 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138002 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/284 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106080 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105818 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/221 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52513 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20029 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/331 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/62256 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/239 "Built successfully") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/311 "Hash 791f1977 for PR 52996 does not build (failure)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/289 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->