### PR TITLE
Array Allocation Sinking Should Track Initialized Indicies

### DIFF
--- a/JSTests/stress/array-sink-conditional-initialization.js
+++ b/JSTests/stress/array-sink-conditional-initialization.js
@@ -1,0 +1,58 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// Test with Int32 array
+function testInt32ArraySinkingWithConditionalWrite(shouldInitialize) {
+    let arr = new Array(2);
+
+    if (shouldInitialize) {
+        arr[0] = 42;
+    }
+
+    return arr[0];
+}
+noInline(testInt32ArraySinkingWithConditionalWrite);
+
+// Test with Double array
+function testDoubleArraySinkingWithConditionalWrite(shouldInitialize) {
+    let arr = new Array(2);
+
+    if (shouldInitialize) {
+        arr[0] = 42.5;
+    }
+
+    return arr[0];
+}
+noInline(testDoubleArraySinkingWithConditionalWrite);
+
+// Test with Contiguous (JSValue) array
+function testContiguousArraySinkingWithConditionalWrite(shouldInitialize) {
+    let arr = new Array(2);
+
+    if (shouldInitialize) {
+        arr[0] = {value: 42};
+    }
+
+    return arr[0];
+}
+noInline(testContiguousArraySinkingWithConditionalWrite);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    // Test Int32 array - initialized path
+    shouldBe(testInt32ArraySinkingWithConditionalWrite(true), 42);
+    // Test Int32 array - uninitialized path (hole)
+    shouldBe(testInt32ArraySinkingWithConditionalWrite(false), undefined);
+
+    // Test Double array - initialized path
+    shouldBe(testDoubleArraySinkingWithConditionalWrite(true), 42.5);
+    // Test Double array - uninitialized path (hole)
+    shouldBe(testDoubleArraySinkingWithConditionalWrite(false), undefined);
+
+    // Test Contiguous array - initialized path
+    let resultInitialized = testContiguousArraySinkingWithConditionalWrite(true);
+    shouldBe(resultInitialized.value, 42);
+    // Test Contiguous array - uninitialized path (hole)
+    shouldBe(testContiguousArraySinkingWithConditionalWrite(false), undefined);
+}

--- a/JSTests/stress/array-sink-diamond-initialization-then-read.js
+++ b/JSTests/stress/array-sink-diamond-initialization-then-read.js
@@ -1,0 +1,15 @@
+function test1(obj, flag) {
+    let array = new Array(4);
+    if (flag)
+        array[0] = 1;
+    else
+        array[0] = obj.foo;
+    return array[0];
+}
+noInline(test1);
+
+
+let obj1 = { foo: 1 };
+for (let i = 0; i < testLoopCount; ++i) {
+    test1(obj1, i % 2);
+}

--- a/JSTests/stress/array-sink-read-uninitialized-hole.js
+++ b/JSTests/stress/array-sink-read-uninitialized-hole.js
@@ -1,0 +1,45 @@
+function test1() {
+  function fn6(obj) {
+    let array = new Array(4);
+    array[0] = obj[1];
+    var test = {
+      f: array[1] ? array : 0
+    };
+    return obj;
+  }
+}
+noInline(test1);
+
+function test2() {
+  function fn6(obj) {
+    let array = new Array(4);
+    array[0] = obj[1];
+    var test = {
+      f: array[1] ? array : 0
+    };
+    return obj;
+  }
+}
+noInline(test2);
+
+function test3() {
+  function fn6(obj) {
+    let array = new Array(4);
+    array[0] = obj[1];
+    var test = {
+      f: array[1] ? array : 0
+    };
+    return obj;
+  }
+}
+noInline(test3);
+
+let obj1 = { 1: 1 };
+let obj2 = { 1: 1.4 };
+let obj3 = { 1: { } };
+for (let i = 0; i < testLoopCount; ++i) {
+    test1(obj1);
+    test2(obj2);
+    test3(obj3);
+}
+


### PR DESCRIPTION
#### a1a6185cc83ec55675fd01a100117d0202701d28
<pre>
Array Allocation Sinking Should Track Initialized Indicies
<a href="https://bugs.webkit.org/show_bug.cgi?id=301468">https://bugs.webkit.org/show_bug.cgi?id=301468</a>
<a href="https://rdar.apple.com/162617198">rdar://162617198</a>

Reviewed by Yusuke Suzuki.

After fixing conditional writes in 300888@main there was still a remaining issue.
If there ended up being a read from a conditionally initialized index of the
array we could end up forwarding the hole value to that read rather than `undefined`.

To fix this we add a bit vector that tracks whether a particular index is guaranteed
to be initialized on every path to this point.

Lastly this change removes an unused size argument passed to the ArrayButterly&apos;s
Allocation. As of this change that would trigger an additional allocation and is
unused.

Tests: JSTests/stress/array-sink-diamond-initialization-then-read.js
       JSTests/stress/array-sink-read-uninitialized-hole.js
       JSTests/stress/array-sink-conditional-initialization.js

Canonical link: <a href="https://commits.webkit.org/302153@main">https://commits.webkit.org/302153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef030a580ad7e61e1fe398467369af3574c8be34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79644 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97553 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65448 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2d1a3773-69f8-4203-9d05-a79da79f0c18) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78122 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7277d934-511c-474d-af3c-57568d0c3e30) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32906 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78827 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120187 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138006 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126615 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106081 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105819 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/220 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29695 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52520 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20031 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/335 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/62270 "") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159633 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/242 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39851 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/314 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/294 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->