### PR TITLE
facebook.com: Unable to drag and drop images (from Photos, Finder) into new album

### DIFF
--- a/Source/WebCore/dom/DataTransferItem.cpp
+++ b/Source/WebCore/dom/DataTransferItem.cpp
@@ -45,9 +45,9 @@
 
 namespace WebCore {
 
-Ref<DataTransferItem> DataTransferItem::create(WeakPtr<DataTransferItemList>&& list, const String& type)
+Ref<DataTransferItem> DataTransferItem::create(WeakPtr<DataTransferItemList>&& list, const String& type, Kind kind)
 {
-    return adoptRef(*new DataTransferItem(WTFMove(list), type));
+    return adoptRef(*new DataTransferItem(WTFMove(list), type, kind));
 }
 
 Ref<DataTransferItem> DataTransferItem::create(WeakPtr<DataTransferItemList>&& list, const String& type, Ref<File>&& file)
@@ -55,15 +55,17 @@ Ref<DataTransferItem> DataTransferItem::create(WeakPtr<DataTransferItemList>&& l
     return adoptRef(*new DataTransferItem(WTFMove(list), type, WTFMove(file)));
 }
 
-DataTransferItem::DataTransferItem(WeakPtr<DataTransferItemList>&& list, const String& type)
+DataTransferItem::DataTransferItem(WeakPtr<DataTransferItemList>&& list, const String& type, Kind kind)
     : m_list(WTFMove(list))
     , m_type(type)
+    , m_kind(kind)
 {
 }
 
 DataTransferItem::DataTransferItem(WeakPtr<DataTransferItemList>&& list, const String& type, Ref<File>&& file)
     : m_list(WTFMove(list))
     , m_type(type)
+    , m_kind(Kind::File)
     , m_file(WTFMove(file))
 {
 }
@@ -75,9 +77,21 @@ void DataTransferItem::clearListAndPutIntoDisabledMode()
     m_list.clear();
 }
 
+bool DataTransferItem::isFile() const
+{
+    return m_kind == Kind::File;
+}
+
 String DataTransferItem::kind() const
 {
-    return m_file ? "file"_s : "string"_s;
+    switch (m_kind) {
+    case Kind::String:
+        return "string"_s;
+    case Kind::File:
+        return "file"_s;
+    }
+    ASSERT_NOT_REACHED();
+    return { };
 }
 
 String DataTransferItem::type() const

--- a/Source/WebCore/dom/DataTransferItem.h
+++ b/Source/WebCore/dom/DataTransferItem.h
@@ -49,7 +49,9 @@ class StringCallback;
 
 class DataTransferItem : public RefCounted<DataTransferItem> {
 public:
-    static Ref<DataTransferItem> create(WeakPtr<DataTransferItemList>&&, const String&);
+    enum class Kind : uint8_t { String, File };
+
+    static Ref<DataTransferItem> create(WeakPtr<DataTransferItemList>&&, const String&, Kind);
     static Ref<DataTransferItem> create(WeakPtr<DataTransferItemList>&&, const String&, Ref<File>&&);
 
     ~DataTransferItem();
@@ -57,7 +59,7 @@ public:
     RefPtr<File> file() { return m_file; }
     void clearListAndPutIntoDisabledMode();
 
-    bool isFile() const { return m_file; }
+    bool isFile() const;
     String kind() const;
     String type() const;
     void getAsString(Document&, RefPtr<StringCallback>&&) const;
@@ -65,13 +67,14 @@ public:
     RefPtr<FileSystemEntry> getAsEntry(ScriptExecutionContext&) const;
 
 private:
-    DataTransferItem(WeakPtr<DataTransferItemList>&&, const String&);
+    DataTransferItem(WeakPtr<DataTransferItemList>&&, const String& type, Kind);
     DataTransferItem(WeakPtr<DataTransferItemList>&&, const String&, Ref<File>&&);
 
     bool isInDisabledMode() const { return !m_list; }
 
     WeakPtr<DataTransferItemList> m_list;
     const String m_type;
+    Kind m_kind { Kind::String };
     RefPtr<File> m_file;
 };
 

--- a/Source/WebCore/platform/DragData.h
+++ b/Source/WebCore/platform/DragData.h
@@ -87,7 +87,7 @@ public:
         const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation>, OptionSet<DragApplicationFlags> = { }, OptionSet<DragDestinationAction> = anyDragDestinationAction(), std::optional<PageIdentifier> pageID = std::nullopt);
 
 #if PLATFORM(COCOA)
-    WEBCORE_EXPORT DragData(const String& dragStorageName, const IntPoint& clientPosition, const IntPoint& globalPosition, const Vector<String>&, OptionSet<DragOperation>, OptionSet<DragApplicationFlags> = { }, OptionSet<DragDestinationAction> = anyDragDestinationAction(), std::optional<PageIdentifier> pageID = std::nullopt);
+    WEBCORE_EXPORT DragData(const String& dragStorageName, const IntPoint& clientPosition, const IntPoint& globalPosition, const Vector<String>&, Vector<String>&& /* promisedFileMIMETypes */, OptionSet<DragOperation>, OptionSet<DragApplicationFlags> = { }, OptionSet<DragDestinationAction> = anyDragDestinationAction(), std::optional<PageIdentifier> pageID = std::nullopt);
 #endif
     // This constructor should used only by WebKit2 IPC because DragData
     // is initialized by the decoder and not in the constructor.
@@ -118,6 +118,8 @@ public:
     OptionSet<DragDestinationAction> dragDestinationActionMask() const { return m_dragDestinationActionMask; }
     void setFileNames(Vector<String>& fileNames) { m_fileNames = WTFMove(fileNames); }
     const Vector<String>& fileNames() const { return m_fileNames; }
+    void setPromisedFileMIMETypes(Vector<String>&& types) { m_promisedFileMIMETypes = WTFMove(types); }
+    const Vector<String>& promisedFileMIMETypes() const { return m_promisedFileMIMETypes; }
     void disallowFileAccess();
 #if PLATFORM(COCOA)
     const String& pasteboardName() const { return m_pasteboardName; }
@@ -138,6 +140,7 @@ private:
     OptionSet<DragOperation> m_draggingSourceOperationMask;
     OptionSet<DragApplicationFlags> m_applicationFlags;
     Vector<String> m_fileNames;
+    Vector<String> m_promisedFileMIMETypes;
     OptionSet<DragDestinationAction> m_dragDestinationActionMask;
     std::optional<PageIdentifier> m_pageID;
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -285,8 +285,9 @@ public:
 #endif
 
 #if PLATFORM(MAC)
-    explicit Pasteboard(std::unique_ptr<PasteboardContext>&&, const String& pasteboardName, const Vector<String>& promisedFilePaths = { });
+    explicit Pasteboard(std::unique_ptr<PasteboardContext>&&, const String& pasteboardName, const Vector<String>& promisedFilePaths = { }, const Vector<String>& promisedFileMIMETypes = { });
 #endif
+    const Vector<String>& promisedFileMIMETypes() const { return m_promisedFileMIMETypes; }
 
 #if PLATFORM(COCOA)
 #if ENABLE(DRAG_SUPPORT)
@@ -385,6 +386,7 @@ private:
 #if PLATFORM(MAC)
     Vector<String> m_promisedFilePaths;
 #endif
+    Vector<String> m_promisedFileMIMETypes;
 
 #if PLATFORM(WIN)
     HWND m_owner;

--- a/Source/WebCore/platform/cocoa/DragDataCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragDataCocoa.mm
@@ -146,12 +146,13 @@ DragData::DragData(const String& dragStorageName, const IntPoint& clientPosition
 {
 }
 
-DragData::DragData(const String& dragStorageName, const IntPoint& clientPosition, const IntPoint& globalPosition, const Vector<String>& fileNames, OptionSet<DragOperation> sourceOperationMask, OptionSet<DragApplicationFlags> flags, OptionSet<DragDestinationAction> destinationActionMask, std::optional<PageIdentifier> pageID)
+DragData::DragData(const String& dragStorageName, const IntPoint& clientPosition, const IntPoint& globalPosition, const Vector<String>& fileNames, Vector<String>&& promisedFileMIMETypes, OptionSet<DragOperation> sourceOperationMask, OptionSet<DragApplicationFlags> flags, OptionSet<DragDestinationAction> destinationActionMask, std::optional<PageIdentifier> pageID)
     : m_clientPosition(clientPosition)
     , m_globalPosition(globalPosition)
     , m_draggingSourceOperationMask(sourceOperationMask)
     , m_applicationFlags(flags)
     , m_fileNames(fileNames)
+    , m_promisedFileMIMETypes(WTFMove(promisedFileMIMETypes))
     , m_dragDestinationActionMask(destinationActionMask)
     , m_pageID(pageID)
     , m_pasteboardName(dragStorageName)

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -95,11 +95,12 @@ Pasteboard::Pasteboard(std::unique_ptr<PasteboardContext>&& context)
 {
 }
 
-Pasteboard::Pasteboard(std::unique_ptr<PasteboardContext>&& context, const String& pasteboardName, const Vector<String>& promisedFilePaths)
+Pasteboard::Pasteboard(std::unique_ptr<PasteboardContext>&& context, const String& pasteboardName, const Vector<String>& promisedFilePaths, const Vector<String>& promisedFileMIMETypes)
     : m_context(WTFMove(context))
     , m_pasteboardName(pasteboardName)
     , m_changeCount(platformStrategies()->pasteboardStrategy()->changeCount(m_pasteboardName, m_context.get()))
     , m_promisedFilePaths(promisedFilePaths)
+    , m_promisedFileMIMETypes(promisedFileMIMETypes)
 {
     ASSERT(pasteboardName);
 }
@@ -122,7 +123,7 @@ std::unique_ptr<Pasteboard> Pasteboard::createForDragAndDrop(std::unique_ptr<Pas
 
 std::unique_ptr<Pasteboard> Pasteboard::create(const DragData& dragData)
 {
-    return makeUnique<Pasteboard>(dragData.createPasteboardContext(), dragData.pasteboardName(), dragData.fileNames());
+    return makeUnique<Pasteboard>(dragData.createPasteboardContext(), dragData.pasteboardName(), dragData.fileNames(), dragData.promisedFileMIMETypes());
 }
 #endif
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2720,6 +2720,7 @@ class WebCore::DragData {
     WebCore::IntPoint globalPosition();
 #if PLATFORM(COCOA)
     Vector<String> fileNames();
+    Vector<String> promisedFileMIMETypes();
 #endif
     OptionSet<WebCore::DragOperation> draggingSourceOperationMask();
     OptionSet<WebCore::DragApplicationFlags> flags();

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.h
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.h
@@ -40,6 +40,7 @@ std::optional<WebCore::ScrollbarOverlayStyle> toCoreScrollbarStyle(_WKOverlayScr
 - (void)insertText:(id)string replacementRange:(NSRange)replacementRange;
 
 - (void)_resetSecureInputState;
+- (Vector<String>)_promisedFileMIMETypes:(id<NSDraggingInfo>)info;
 
 @end
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4215,16 +4215,17 @@ static OptionSet<WebCore::DragApplicationFlags> applicationFlagsForDrag(NSView *
     if ([NSApp currentEvent].modifierFlags & NSEventModifierFlagOption)
         flags.add(WebCore::DragApplicationFlags::IsCopyKeyDown);
     return flags;
-
 }
 
 NSDragOperation WebViewImpl::draggingEntered(id<NSDraggingInfo> draggingInfo)
 {
-    WebCore::IntPoint client([m_view.get() convertPoint:draggingInfo.draggingLocation fromView:nil]);
-    WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, retainPtr([m_view.get() window]).get()));
-    auto dragDestinationActionMask = coreDragDestinationActionMask([m_view.get() _web_dragDestinationActionForDraggingInfo:draggingInfo]);
+    RetainPtr view = m_view.get();
+    WebCore::IntPoint client([view convertPoint:draggingInfo.draggingLocation fromView:nil]);
+    WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, retainPtr([view window]).get()));
+    auto dragDestinationActionMask = coreDragDestinationActionMask([view _web_dragDestinationActionForDraggingInfo:draggingInfo]);
     auto dragOperationMask = coreDragOperationMask(draggingInfo.draggingSourceOperationMask);
-    WebCore::DragData dragData(draggingInfo, client, global, dragOperationMask, applicationFlagsForDrag(m_view.get().get(), draggingInfo), dragDestinationActionMask, m_page->webPageIDInMainFrameProcess());
+    WebCore::DragData dragData(draggingInfo, client, global, dragOperationMask, applicationFlagsForDrag(view.get(), draggingInfo), dragDestinationActionMask, m_page->webPageIDInMainFrameProcess());
+    dragData.setPromisedFileMIMETypes([view _promisedFileMIMETypes:draggingInfo]);
 
     m_page->resetCurrentDragInformation();
     m_page->dragEntered(dragData, draggingInfo.draggingPasteboard.name);
@@ -4258,11 +4259,13 @@ static NSDragOperation kit(std::optional<WebCore::DragOperation> dragOperation)
 
 NSDragOperation WebViewImpl::draggingUpdated(id<NSDraggingInfo> draggingInfo)
 {
-    WebCore::IntPoint client([m_view.get() convertPoint:draggingInfo.draggingLocation fromView:nil]);
-    WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, retainPtr([m_view.get() window]).get()));
-    auto dragDestinationActionMask = coreDragDestinationActionMask([m_view.get() _web_dragDestinationActionForDraggingInfo:draggingInfo]);
+    RetainPtr view = m_view.get();
+    WebCore::IntPoint client([view convertPoint:draggingInfo.draggingLocation fromView:nil]);
+    WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, retainPtr([view window]).get()));
+    auto dragDestinationActionMask = coreDragDestinationActionMask([view _web_dragDestinationActionForDraggingInfo:draggingInfo]);
     auto dragOperationMask = coreDragOperationMask(draggingInfo.draggingSourceOperationMask);
-    WebCore::DragData dragData(draggingInfo, client, global, dragOperationMask, applicationFlagsForDrag(m_view.get().get(), draggingInfo), dragDestinationActionMask, m_page->webPageIDInMainFrameProcess());
+    WebCore::DragData dragData(draggingInfo, client, global, dragOperationMask, applicationFlagsForDrag(view.get(), draggingInfo), dragDestinationActionMask, m_page->webPageIDInMainFrameProcess());
+    dragData.setPromisedFileMIMETypes([view _promisedFileMIMETypes:draggingInfo]);
     m_page->dragUpdated(dragData, draggingInfo.draggingPasteboard.name);
 
     NSInteger numberOfValidItemsForDrop = m_page->currentDragNumberOfFilesToBeAccepted();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/image-and-file-upload.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/image-and-file-upload.html
@@ -20,9 +20,16 @@
     }
 </style>
 <script>
+    function handleDragUpdate(event) {
+        event.preventDefault();
+        document.getElementById(`${event.type}Items`).textContent = JSON.stringify([...event.dataTransfer.items].map(item => {
+            return { kind: item.kind, type: item.type, file: item.getAsFile() };
+        }));
+    }
+
     function runTest() {
-        destination.addEventListener("dragenter", event => event.preventDefault());
-        destination.addEventListener("dragover", event => event.preventDefault());
+        destination.addEventListener("dragenter", handleDragUpdate);
+        destination.addEventListener("dragover", handleDragUpdate);
         destination.addEventListener("drop", event => {
             filecount.textContent = event.dataTransfer.files.length;
             destination.setAttribute("src", URL.createObjectURL(event.dataTransfer.files[0]));
@@ -42,6 +49,8 @@
     <div id="output">
         <div>Number of files: <span id="filecount">N/A</span></div>
         <div>Image loaded? <span style="color: red" id="imageload">false</span></div>
+        <div>dragenter items: <span id="dragenterItems"></span></div>
+        <div>dragover items: <span id="dragoverItems"></span></div>
     </div>
 </body>
 </html>

--- a/Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm
@@ -113,6 +113,9 @@ TEST(DragAndDropTests, DragPromisedImageFileIntoFileUpload)
     TestWebKitAPI::Util::waitForConditionWithLogging([&] () -> bool {
         return [webView stringByEvaluatingJavaScript:@"imageload.textContent"].boolValue;
     }, 2, @"Expected image to finish loading.");
+    static constexpr auto expectedDataTransferItems = "[{\"kind\":\"file\",\"type\":\"image/gif\",\"file\":null}]";
+    EXPECT_WK_STREQ(expectedDataTransferItems, [webView stringByEvaluatingJavaScript:@"dragenterItems.textContent"]);
+    EXPECT_WK_STREQ(expectedDataTransferItems, [webView stringByEvaluatingJavaScript:@"dragoverItems.textContent"]);
     EXPECT_EQ(1, [webView stringByEvaluatingJavaScript:@"filecount.textContent"].integerValue);
 
     TestDraggingInfo *draggingInfo = [simulator draggingInfo];


### PR DESCRIPTION
#### ddcd91a27bd801bebc876705a4d6e1e062f9ad2e
<pre>
facebook.com: Unable to drag and drop images (from Photos, Finder) into new album
<a href="https://bugs.webkit.org/show_bug.cgi?id=301472">https://bugs.webkit.org/show_bug.cgi?id=301472</a>
<a href="https://rdar.apple.com/150848219">rdar://150848219</a>

Reviewed by Abrar Rahman Protyasha.

When dragging an image from either Photos or Finder and dropping into the album creation UI on
facebook.com in Safari, the file drop is effectively ignored. This happens because Facebook&apos;s script
expects the `dragenter` event to contain a non-empty list of DataTransfer items, with:

1. `item.kind` equal to `&quot;file&quot;`
2. A non-empty `item.type` that&apos;s not `text/html`, `text/plain`, or `text/uri-list`.

WebKit currently exposes an empty list of items (due to restrictions on reading drag items before
the drop is being performed), which causes Facebook&apos;s script to avoid calling `preventDefault()` on
`dragenter`. Both Blink and Gecko expose a list of data transfer items in this case that contains
the dropped file(s) and their MIME types, but attempts to get the file (`getAsFile()`) before the
`drop` event has been fired will result in a null `File` object. This patch aligns WebKit&apos;s behavior
to the other engines (with some caveats — see below), which fixes this bug on Facebook.

Tests: added to DragAndDropTests.DragPromisedImageFileIntoFileUpload

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/image-and-file-upload.html
       Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm
       Tools/TestWebKitAPI/mac/TestDraggingInfo.mm
* Source/WebCore/dom/DataTransferItem.cpp:
(WebCore::DataTransferItem::create):

Add a `Kind` argument to this creation method, to create a `DataTransferItem` with a given type,
representing either a `String` or a placeholder for a `File`. Use this when dispatching drag update
events to expose file data transfer items that only expose type information.

(WebCore::DataTransferItem::DataTransferItem):
(WebCore::DataTransferItem::isFile const):
(WebCore::DataTransferItem::kind const):
* Source/WebCore/dom/DataTransferItem.h:

Introduce an `m_kind` member variable, and use it for the `kind()` attribute instead of basing it
off of the presence of `m_file`. This is because `file` items may now have a null `m_file`, before
the `drop` event is dispatched.

(WebCore::DataTransferItem::isFile const): Deleted.
* Source/WebCore/dom/DataTransferItemList.cpp:
(WebCore::DataTransferItemList::add):
(WebCore::DataTransferItemList::ensureItems const):

Apply the main fix here — only expose `File`-backed `DataTransferItem`s when the `DataTransfer` can
read data; when the `DataTransfer` can only read types, we instead expose a list of items based on
the promised MIME types.

In order to reduce fingerprinting surface when the user drags over unintended drop targets, we
additionally only expose known image and media types.

(WebCore::DataTransferItemList::didSetStringData):
* Source/WebCore/platform/DragData.h:
(WebCore::DragData::DragData):
(WebCore::DragData::setPromisedFileMIMETypes):
(WebCore::DragData::promisedFileMIMETypes const):

Add a list of MIME types of promised files when dragging over drop targets.

* Source/WebCore/platform/Pasteboard.h:
(WebCore::Pasteboard::Pasteboard):
(WebCore::Pasteboard::promisedFileMIMETypes const):
* Source/WebCore/platform/cocoa/DragDataCocoa.mm:
(WebCore::DragData::DragData):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::Pasteboard::Pasteboard):
(WebCore::Pasteboard::create):

Plumb the list of promised file MIME types from `DragData` → `Pasteboard`.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _promisedFileMIMETypes:]):

Add a helper method to extract a list of MIME types for promised files in the drag session, before
the drag operation (drop) is performed. We get this via `-[NSFilePromiseReceiver fileTypes]` on the
dragged items, and otherwise fall back to getting preferred MIME types from dragged file URLs.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::applicationFlagsForDrag):
(WebKit::WebViewImpl::draggingEntered):
(WebKit::WebViewImpl::draggingUpdated):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/image-and-file-upload.html:
* Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm:
(TEST(DragAndDropTests, DragPromisedImageFileIntoFileUpload)):

Augment an existing API test to also exercise this scenario by dumping the contents of the
`e.dataTransfer.items` while dragging.

* Tools/TestWebKitAPI/mac/TestDraggingInfo.mm:
(-[TestDraggingInfo enumerateDraggingItemsWithOptions:forView:classes:searchOptions:usingBlock:]):

Adjust this testing helper class to lazily generate `NSFilePromiseReceiver`s when WebKit asks to
`-enumerateDraggingItemsWithOptions:forView:classes:searchOptions:usingBlock:` to ensure that we
don&apos;t end up with dozens of redundant file promise receivers when simulating a drop. This was
previously not necessary because we only called this once when performing a drop, but we now need to
call it continually while dragging over the view.

Canonical link: <a href="https://commits.webkit.org/302156@main">https://commits.webkit.org/302156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/251400c262459e84fa8aba5cc1ebcbb55b409707

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79662 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8a1c0c92-8bc1-4975-a9f8-741296bd5226) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97568 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65466 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b84f3cad-b2c0-4440-826e-65dd68b08e45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78139 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d50aa851-6cb0-4b73-bdbd-a0878b2d12a6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32934 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78846 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138025 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106097 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105881 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26984 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/242 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29722 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52553 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/355 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/62444 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/262 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/336 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/320 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->