### PR TITLE
Follow-up #2: [iOS] Add a pop-up menu for selecting caption style profiles

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
@@ -45,7 +45,7 @@
 @interface NSMenu (PrivateHighlightItem)
 - (void)highlightItem:(NSMenuItem *)item;
 @end
-#else
+#elif USE(UICONTEXTMENU)
 @interface UIContextMenuInteraction (PrivatePresentMenu)
 - (void)_presentMenuAtLocation:(CGPoint)location;
 @end
@@ -193,7 +193,7 @@ public:
 
         [menu popUpMenuPositioningItem:nil atLocation:NSMakePoint(0, 0) inView:[window contentView]];
         Util::run(&done);
-#elif PLATFORM(IOS_FAMILY)
+#elif USE(UICONTEXTMENU)
         RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:NSMakeRect(0, 0, 300, 300)]);
 
         RetainPtr viewController = adoptNS([[UIViewController alloc] init]);


### PR DESCRIPTION
#### 1de430c40e7a7f6786c363919ee20c27ee8befb9
<pre>
Follow-up #2: [iOS] Add a pop-up menu for selecting caption style profiles
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=301376">https://bugs.webkit.org/show_bug.cgi?id=301376</a>&gt;
&lt;<a href="https://rdar.apple.com/problem/163297495">rdar://problem/163297495</a>&gt;

Unreviewed build fix for watchOS.

Follow-up fix for 302143@main and 302150@main.

* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm:
(TestWebKitAPI::CaptionPreferenceTests::showMenuAndThen):
- Make use of USE(UICONTEXTMENU) to exclude code on watchOS.

Canonical link: <a href="https://commits.webkit.org/302152@main">https://commits.webkit.org/302152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/026453dae356bc150bd3b2740dee61b9510a21c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79651 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4802160e-66dc-49fa-801a-086e42f0dfd7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130035 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97561 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65452 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b91029da-5876-4d0e-940b-c926504dee0d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114813 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78130 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/67d7a4c9-7d72-4d85-bbae-46b53aac2621) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32920 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78836 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138015 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/298 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/280 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106087 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105825 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/228 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29709 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52533 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20030 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/344 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/251 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/323 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/302 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->