### PR TITLE
Use C++20 std::ranges::none_of in WebCore and WebKit

### DIFF
--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -327,12 +327,12 @@ struct MediaStreamAndTrackItem {
 static void setAssociatedRemoteStreams(RTCRtpReceiver& receiver, const PeerConnectionBackend::TransceiverState& state, Vector<MediaStreamAndTrackItem>& addList, Vector<MediaStreamAndTrackItem>& removeList)
 {
     for (auto& currentStream : receiver.associatedStreams()) {
-        if (currentStream && !std::ranges::any_of(state.receiverStreams, [&currentStream](auto& stream) { return stream->id() == currentStream->id(); }))
+        if (currentStream && std::ranges::none_of(state.receiverStreams, [&currentStream](auto& stream) { return stream->id() == currentStream->id(); }))
             removeList.append({ Ref { *currentStream }, Ref { receiver.track() } });
     }
 
     for (auto& stream : state.receiverStreams) {
-        if (!std::ranges::any_of(receiver.associatedStreams(), [&stream](auto& currentStream) { return stream->id() == currentStream->id(); }))
+        if (std::ranges::none_of(receiver.associatedStreams(), [&stream](auto& currentStream) { return stream->id() == currentStream->id(); }))
             addList.append({ stream, Ref { receiver.track() } });
     }
 
@@ -465,7 +465,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
         Vector<MediaStreamAndTrackItem> removeList;
         if (transceiverStates) {
             for (auto& transceiver : peerConnection.currentTransceivers()) {
-                if (!std::ranges::any_of(*transceiverStates, [&transceiver](auto& state) { return state.mid == transceiver->mid(); })) {
+                if (std::ranges::none_of(*transceiverStates, [&transceiver](auto& state) { return state.mid == transceiver->mid(); })) {
                     for (auto& stream : transceiver->receiver().associatedStreams()) {
                         if (stream)
                             removeList.append({ Ref { *stream }, Ref { transceiver->receiver().track() } });

--- a/Source/WebCore/Modules/webcodecs/OpusEncoderConfig.h
+++ b/Source/WebCore/Modules/webcodecs/OpusEncoderConfig.h
@@ -37,7 +37,7 @@ struct OpusEncoderConfig {
     bool isValid()
     {
         float frameDurationMs = frameDuration / 1000.0;
-        if (!std::ranges::any_of(std::initializer_list<float> { 2.5, 5, 10, 20, 40, 60, 120 }, [frameDurationMs](auto value) {
+        if (std::ranges::none_of(std::initializer_list<float> { 2.5, 5, 10, 20, 40, 60, 120 }, [frameDurationMs](auto value) {
             return WTF::areEssentiallyEqual(value, frameDurationMs);
         })) {
             return false;

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -135,7 +135,7 @@ void WebXRInputSourceArray::handleRemovedInputSources(const InputSourceList& inp
     //  3.1 Let inputSource be the XRInputSource in session's list of active XR input sources associated with the XR input source.
     //  3.2 Add inputSource to removed.
     m_inputSources.removeAllMatching([&inputSources, &removed, &removedWithInputEvents, &inputEvents](auto& source) {
-        if (!std::ranges::any_of(inputSources, [&source](auto& item) { return item.handle == source->handle(); })) {
+        if (std::ranges::none_of(inputSources, [&source](auto& item) { return item.handle == source->handle(); })) {
             Vector<Ref<XRInputSourceEvent>> sourceInputEvents;
             source->disconnect();
             source->pollEvents(sourceInputEvents);

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -327,7 +327,7 @@ Vector<AtomString> CDMPrivateFairPlayStreaming::supportedInitDataTypes() const
 
 bool CDMPrivateFairPlayStreaming::supportsConfiguration(const CDMKeySystemConfiguration& configuration) const
 {
-    if (!std::ranges::any_of(configuration.initDataTypes, [](auto& initDataType) { return validInitDataTypes().contains(initDataType); })) {
+    if (std::ranges::none_of(configuration.initDataTypes, [](auto& initDataType) { return validInitDataTypes().contains(initDataType); })) {
         INFO_LOG(LOGIDENTIFIER, " false, no initDataType supported");
         return false;
     }
@@ -352,13 +352,13 @@ bool CDMPrivateFairPlayStreaming::supportsConfiguration(const CDMKeySystemConfig
     }
 
     if (!configuration.audioCapabilities.isEmpty()
-        && !std::ranges::any_of(configuration.audioCapabilities, CDMInstanceFairPlayStreamingAVFObjC::supportsMediaCapability)) {
+        && std::ranges::none_of(configuration.audioCapabilities, CDMInstanceFairPlayStreamingAVFObjC::supportsMediaCapability)) {
         INFO_LOG(LOGIDENTIFIER, "false, no audio configuration supported");
         return false;
     }
 
     if (!configuration.videoCapabilities.isEmpty()
-        && !std::ranges::any_of(configuration.videoCapabilities, CDMInstanceFairPlayStreamingAVFObjC::supportsMediaCapability)) {
+        && std::ranges::none_of(configuration.videoCapabilities, CDMInstanceFairPlayStreamingAVFObjC::supportsMediaCapability)) {
             INFO_LOG(LOGIDENTIFIER, "false, no video configuration supported");
         return false;
     }

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -590,7 +590,7 @@ std::optional<OrganizationStorageAccessPromptQuirk> NetworkStorageSession::stora
         auto entry = quirkDomains.find(topDomain);
         if (entry == quirkDomains.end())
             continue;
-        if (!std::ranges::any_of(entry->value, [&subDomain](auto&& entry) { return entry == subDomain; }))
+        if (std::ranges::none_of(entry->value, [&subDomain](auto&& entry) { return entry == subDomain; }))
             break;
         return quirk;
     }

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -149,10 +149,10 @@ bool MockCDM::supportsConfiguration(const MediaKeySystemConfiguration& configura
         return true;
     };
 
-    if (!configuration.audioCapabilities.isEmpty() && !std::ranges::any_of(configuration.audioCapabilities, capabilityHasSupportedEncryptionScheme))
+    if (!configuration.audioCapabilities.isEmpty() && std::ranges::none_of(configuration.audioCapabilities, capabilityHasSupportedEncryptionScheme))
         return false;
 
-    if (!configuration.videoCapabilities.isEmpty() && !std::ranges::any_of(configuration.videoCapabilities, capabilityHasSupportedEncryptionScheme))
+    if (!configuration.videoCapabilities.isEmpty() && std::ranges::none_of(configuration.videoCapabilities, capabilityHasSupportedEncryptionScheme))
         return false;
 
     return true;

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -847,9 +847,9 @@ bool UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForCamera
     if (!protocolHostAndPortAreEqual(URL(page->protectedPageLoadState()->activeURL()), origin.topOrigin.toURL()))
         return true;
 
-    return !std::ranges::any_of(m_deniedRequests, [](auto& request) { return request.isVideoDenied; })
-        && !std::ranges::any_of(m_pregrantedRequests, [](auto& request) { return request->requiresVideoCapture(); })
-        && !std::ranges::any_of(m_grantedRequests, [](auto& request) { return request->requiresVideoCapture(); });
+    return std::ranges::none_of(m_deniedRequests, [](auto& request) { return request.isVideoDenied; })
+        && std::ranges::none_of(m_pregrantedRequests, [](auto& request) { return request->requiresVideoCapture(); })
+        && std::ranges::none_of(m_grantedRequests, [](auto& request) { return request->requiresVideoCapture(); });
 }
 
 bool UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForMicrophone(const ClientOrigin& origin) const
@@ -861,9 +861,9 @@ bool UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForMicrop
     if (!protocolHostAndPortAreEqual(URL(page->protectedPageLoadState()->activeURL()), origin.topOrigin.toURL()))
         return true;
 
-    return !std::ranges::any_of(m_deniedRequests, [](auto& request) { return request.isAudioDenied; })
-        && !std::ranges::any_of(m_pregrantedRequests, [](auto& request) { return request->requiresAudioCapture(); })
-        && !std::ranges::any_of(m_grantedRequests, [](auto& request) { return request->requiresAudioCapture(); });
+    return std::ranges::none_of(m_deniedRequests, [](auto& request) { return request.isAudioDenied; })
+        && std::ranges::none_of(m_pregrantedRequests, [](auto& request) { return request->requiresAudioCapture(); })
+        && std::ranges::none_of(m_grantedRequests, [](auto& request) { return request->requiresAudioCapture(); });
 }
 
 bool UserMediaPermissionRequestManagerProxy::shouldChangePromptToGrantForCamera(const ClientOrigin& origin) const


### PR DESCRIPTION
#### 2cf227834d87fd4bf9c7331740f9c4c8eb74a28d
<pre>
Use C++20 std::ranges::none_of in WebCore and WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=301473">https://bugs.webkit.org/show_bug.cgi?id=301473</a>
<a href="https://rdar.apple.com/163415662">rdar://163415662</a>

Reviewed by Chris Dumez.

* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::setAssociatedRemoteStreams):
(WebCore::PeerConnectionBackend::setRemoteDescriptionSucceeded):
* Source/WebCore/Modules/webcodecs/OpusEncoderConfig.h:
(WebCore::OpusEncoderConfig::isValid):
* Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp:
(WebCore::WebXRInputSourceArray::handleRemovedInputSources):
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::CDMPrivateFairPlayStreaming::supportsConfiguration const):
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::storageAccessQuirkForDomainPair):
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDM::supportsConfiguration const):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForCamera const):
(WebKit::UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForMicrophone const):

Canonical link: <a href="https://commits.webkit.org/302154@main">https://commits.webkit.org/302154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d22c29101dfad03bd77147e7f582b5762146b7ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128164 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79652 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97562 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65465 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78137 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/220 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32922 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78837 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138016 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106090 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/331 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111157 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105851 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26982 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29711 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52534 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/345 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/62355 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/252 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/312 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->