### PR TITLE
Fix the internal watchOS build

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -63,7 +63,9 @@ class HideEditMenuScope {
 public:
     HideEditMenuScope(WKTextInteractionWrapper *wrapper, DeactivateSelection deactivateSelection)
         : m_wrapper { wrapper }
+#if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
         , m_reactivateSelection { deactivateSelection == DeactivateSelection::Yes }
+#endif
     {
         [wrapper.textInteractionAssistant willStartScrollingOverflow];
 #if USE(BROWSERENGINEKIT)
@@ -95,7 +97,9 @@ public:
 
 private:
     __weak WKTextInteractionWrapper *m_wrapper { nil };
+#if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     bool m_reactivateSelection { false };
+#endif
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HideEditMenuScope);


### PR DESCRIPTION
#### a449cd72e50a7b3db5ef8ef1dba2d147122a0e95
<pre>
Fix the internal watchOS build
<a href="https://bugs.webkit.org/show_bug.cgi?id=301474">https://bugs.webkit.org/show_bug.cgi?id=301474</a>
<a href="https://rdar.apple.com/163417901">rdar://163417901</a>

Unreviewed build fix.

On some SDKs, we start presenting this error:

```
In file included from /Build/Release-watchsimulator/DerivedSources/WebKit/unified-sources/UnifiedSource57-nonARC.mm:3:
/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:98:10: error: private field &apos;m_reactivateSelection&apos; is not used [-Werror,-Wunused-private-field]
   98 |     bool m_reactivateSelection { false };
1 error generated.
```

We address this error by gating the declaration behind
HAVE_UI_TEXT_SELECTION_DISPLAY_INTERACTION, matching all cases where the
field is accessed.

* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:

Canonical link: <a href="https://commits.webkit.org/302164@main">https://commits.webkit.org/302164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12e8733ffcb8749d148d76f0178a39f9d607bab2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79657 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/68bb0012-a3cd-42ab-8f91-a230a2a53623) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97565 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65459 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e58b499c-c994-4e2e-a6d7-b9c2f72e708a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114818 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78134 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9a07d0b5-4bff-44d0-b85c-5af1683dc0bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/224 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78842 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138021 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106094 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105864 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/234 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29714 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52541 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20033 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/350 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/62396 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/257 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/331 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/314 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->