### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for NativePromiseRequest

### DIFF
--- a/Source/WebCore/dom/ScriptExecutionContextInlines.h
+++ b/Source/WebCore/dom/ScriptExecutionContextInlines.h
@@ -71,8 +71,8 @@ inline void ScriptExecutionContext::postCrossThreadTask(Arguments&&... arguments
 template<typename Promise, typename TaskType>
 void ScriptExecutionContext::enqueueTaskWhenSettled(Ref<Promise>&& promise, TaskSource taskSource, TaskType&& task)
 {
-    auto request = makeUnique<NativePromiseRequest>();
-    WeakPtr weakRequest { *request };
+    auto request = NativePromiseRequest::create();
+    WeakPtr weakRequest { request.get() };
     auto command = promise->whenSettled(nativePromiseDispatcher(), [weakThis = WeakPtr { *this }, taskSource, task = WTFMove(task), request = WTFMove(request)] (auto&& result) mutable {
         request->complete();
         RefPtr protectedThis = weakThis.get();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -339,7 +339,7 @@ private:
     Timer m_seekTimer;
     bool m_seeking { false };
     std::optional<SeekTarget> m_pendingSeek;
-    NativePromiseRequest m_rendererSeekRequest;
+    const Ref<NativePromiseRequest> m_rendererSeekRequest;
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     ThreadSafeWeakPtr<CDMSessionAVContentKeySession> m_session;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -377,7 +377,7 @@ private:
     MediaTime m_lastSeekTime;
     std::optional<SeekTarget> m_pendingSeek;
     std::optional<GenericPromise::Producer> m_waitForTimeBufferedPromise;
-    NativePromiseRequest m_rendererSeekRequest;
+    const Ref<NativePromiseRequest> m_rendererSeekRequest;
     bool m_seeking { false };
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_defaultSpatialTrackingLabel;


### PR DESCRIPTION
#### a54bf8d0c9acc783e14bde3dbae3c990783e948e
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for NativePromiseRequest
<a href="https://bugs.webkit.org/show_bug.cgi?id=301478">https://bugs.webkit.org/show_bug.cgi?id=301478</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/NativePromise.h:
(WTF::NativePromiseRequest::~NativePromiseRequest): Deleted.
(WTF::NativePromiseRequest::track): Deleted.
(WTF::NativePromiseRequest::operator bool const): Deleted.
(WTF::NativePromiseRequest::complete): Deleted.
(WTF::NativePromiseRequest::disconnect): Deleted.
* Source/WebCore/dom/ScriptExecutionContextInlines.h:
(WebCore::ScriptExecutionContext::enqueueTaskWhenSettled):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::startSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::cancelPendingSeek):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::cancelPendingSeek):
(WebCore::MediaPlayerPrivateWebM::startSeek):
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::TEST(NativePromise, GenericPromise)):
(TestWebKitAPI::TEST(NativePromise, PromiseRequest)):
(TestWebKitAPI::TEST(NativePromise, PromiseRequestDisconnected1)):
(TestWebKitAPI::TEST(NativePromise, PromiseRequestDisconnected2)):
(TestWebKitAPI::TEST(NativePromise, Chaining)):
(TestWebKitAPI::TEST(NativePromise, HeterogeneousChaining)):
(TestWebKitAPI::TEST(NativePromise, DisconnectNotOwnedInstance)):

Canonical link: <a href="https://commits.webkit.org/302170@main">https://commits.webkit.org/302170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a65482122bf0fd41b3972a0f4c62f4af97e80c90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79687 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/70feb213-e31d-4368-bbfd-c99ff0b70647) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130070 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97590 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65494 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4692bfff-abcc-4d13-a548-1f3fccc2f83a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78162 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/169a5128-6dbf-452e-ac82-8e6db481fcb0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/249 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32953 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78870 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120229 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138049 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126659 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106118 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111187 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105901 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26995 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/260 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29741 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52592 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/379 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/62776 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159685 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/286 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39868 "Found 16 new JSC stress test failures: wasm.yaml/wasm/stress/osr-entry-live-fpr.js.default-wasm, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-bbq, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-collect-continuously, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-eager, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-eager-jettison, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-no-cjit, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-slow-memory, wasm.yaml/wasm/stress/osr-entry-live-stack.js.default-wasm, wasm.yaml/wasm/stress/osr-entry-live-stack.js.wasm-bbq ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/359 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/344 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->