### PR TITLE
Null deref in CMUtilities' toCMSampleBuffer

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -519,8 +519,11 @@ Expected<RetainPtr<CMSampleBufferRef>, CString> toCMSampleBuffer(const MediaSamp
     if (!samples.info() || !samples.info()->encryptionData)
         return adoptCF(rawSampleBuffer);
 
-    RetainPtr attachmentsArray = PAL::CMSampleBufferGetSampleAttachmentsArray(rawSampleBuffer, false);
-    if (!attachmentsArray || static_cast<size_t>(CFArrayGetCount(attachmentsArray.get())) < samples.size()) {
+    RetainPtr attachmentsArray = PAL::CMSampleBufferGetSampleAttachmentsArray(rawSampleBuffer, true);
+    ASSERT(attachmentsArray);
+    if (!attachmentsArray)
+        return makeUnexpected("No sample attachment found");
+    if (static_cast<size_t>(CFArrayGetCount(attachmentsArray.get())) < samples.size()) {
         RELEASE_LOG_DEBUG(Media, "Encrypted sample doesn't contain sufficient attachments: %u (expected:%u)", static_cast<unsigned>(CFArrayGetCount(attachmentsArray.get())), static_cast<unsigned>(samples.size()));
         return adoptCF(rawSampleBuffer);
     }


### PR DESCRIPTION
#### f12eb6a08e4b7f83a1b489ba37dd4081767234f4
<pre>
Null deref in CMUtilities&apos; toCMSampleBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=301482">https://bugs.webkit.org/show_bug.cgi?id=301482</a>
<a href="https://rdar.apple.com/163432969">rdar://163432969</a>

Reviewed by Eric Carlson.

A logic error was introduced 302086@main in the logging. But it actually
exposed a problem when creating an audio CMSampleBuffer where we wouldn&apos;t
create the attachment array required to store the encrypted information.

* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::toCMSampleBuffer):
(WebCore::samplesBlockFromCMSampleBuffer): Deleted.
(WebCore::attachColorSpaceToPixelBuffer): Deleted.
(WebCore::PacketDurationParser::PacketDurationParser): Deleted.
(WebCore::PacketDurationParser::framesInPacket): Deleted.
(WebCore::PacketDurationParser::reset): Deleted.
(WebCore::getPacketDescriptions): Deleted.
(WebCore::ensureContiguousBlockBuffer): Deleted.
(WebCore::sharedBufferFromCMBlockBuffer): Deleted.
(WebCore::getKeyIDs): Deleted.

Canonical link: <a href="https://commits.webkit.org/302168@main">https://commits.webkit.org/302168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4e584fb046a87e8f662313f1cff844b57b85739

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135597 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79688 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/012983b6-7d80-4470-9efd-98e88ce6b4ea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97591 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65492 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/351e680e-e849-425d-bd4f-6782cac783c4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/260 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114846 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78164 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c987ad14-5fd9-4f30-a9ce-5e0d5e5424dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/250 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32954 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78871 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138050 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106119 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105902 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26993 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/261 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29742 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52593 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/380 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/62792 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/287 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/360 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/345 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->