### PR TITLE
Add missing WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
@@ -46,6 +46,7 @@ class InjectedScriptManager;
 class JS_EXPORT_PRIVATE InspectorHeapAgent : public InspectorAgentBase, public HeapBackendDispatcherHandler, public JSC::HeapObserver, public JSC::HeapSnapshotBuilder::Client {
     WTF_MAKE_NONCOPYABLE(InspectorHeapAgent);
     WTF_MAKE_TZONE_ALLOCATED(InspectorHeapAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorHeapAgent);
 public:
     InspectorHeapAgent(AgentContext&);
     ~InspectorHeapAgent() override;

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -50,6 +50,7 @@ class AudioContext final
     , public MediaCanStartListener
     , private PlatformMediaSessionClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioContext);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioContext);
 public:
     // Create an AudioContext for rendering to the audio hardware.
     static ExceptionOr<Ref<AudioContext>> create(Document&, AudioContextOptions&&);

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
@@ -50,6 +50,7 @@ struct WorkletParameters;
 
 class AudioWorkletGlobalScope final : public WorkletGlobalScope {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioWorkletGlobalScope);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioWorkletGlobalScope);
 public:
     static RefPtr<AudioWorkletGlobalScope> tryCreate(AudioWorkletThread&, const WorkletParameters&);
     ~AudioWorkletGlobalScope();

--- a/Source/WebCore/dom/DeviceMotionClient.h
+++ b/Source/WebCore/dom/DeviceMotionClient.h
@@ -38,6 +38,7 @@ class Page;
 class DeviceMotionClient : public DeviceClient {
     WTF_MAKE_TZONE_ALLOCATED(DeviceMotionClient);
     WTF_MAKE_NONCOPYABLE(DeviceMotionClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceMotionClient);
 public:
     DeviceMotionClient() = default;
     virtual ~DeviceMotionClient() = default;

--- a/Source/WebCore/dom/DeviceOrientationClient.h
+++ b/Source/WebCore/dom/DeviceOrientationClient.h
@@ -40,6 +40,7 @@ class Page;
 class DeviceOrientationClient : public DeviceClient {
     WTF_MAKE_TZONE_ALLOCATED(DeviceOrientationClient);
     WTF_MAKE_NONCOPYABLE(DeviceOrientationClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceOrientationClient);
 public:
     DeviceOrientationClient() = default;
     virtual ~DeviceOrientationClient() = default;

--- a/Source/WebCore/html/BaseTextInputType.h
+++ b/Source/WebCore/html/BaseTextInputType.h
@@ -39,6 +39,7 @@ namespace WebCore {
 // They support maxlength, selection functions, and so on.
 class BaseTextInputType : public TextFieldInputType {
     WTF_MAKE_TZONE_ALLOCATED(BaseTextInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BaseTextInputType);
 public:
     bool patternMismatch(const String&) const final;
 

--- a/Source/WebCore/html/EmailInputType.h
+++ b/Source/WebCore/html/EmailInputType.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class EmailInputType final : public BaseTextInputType {
     WTF_MAKE_TZONE_ALLOCATED(EmailInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EmailInputType);
 public:
     static Ref<EmailInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
@@ -33,6 +33,7 @@ class FormAssociatedCustomElement;
 
 class HTMLMaybeFormAssociatedCustomElement final : public HTMLElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLMaybeFormAssociatedCustomElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMaybeFormAssociatedCustomElement);
 public:
     static Ref<HTMLMaybeFormAssociatedCustomElement> create(const QualifiedName& tagName, Document&);
 

--- a/Source/WebCore/html/NumberInputType.h
+++ b/Source/WebCore/html/NumberInputType.h
@@ -38,6 +38,7 @@ namespace WebCore {
 
 class NumberInputType final : public TextFieldInputType {
     WTF_MAKE_TZONE_ALLOCATED(NumberInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NumberInputType);
 public:
     static Ref<NumberInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/PasswordInputType.h
+++ b/Source/WebCore/html/PasswordInputType.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class PasswordInputType final : public BaseTextInputType {
     WTF_MAKE_TZONE_ALLOCATED(PasswordInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PasswordInputType);
 public:
     static Ref<PasswordInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/PluginDocument.h
+++ b/Source/WebCore/html/PluginDocument.h
@@ -33,6 +33,7 @@ class PluginViewBase;
 
 class PluginDocument final : public HTMLDocument {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PluginDocument);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PluginDocument);
 public:
     static Ref<PluginDocument> create(LocalFrame& frame, const URL& url)
     {

--- a/Source/WebCore/html/SearchInputType.h
+++ b/Source/WebCore/html/SearchInputType.h
@@ -41,6 +41,7 @@ class SearchFieldResultsButtonElement;
 
 class SearchInputType final : public BaseTextInputType {
     WTF_MAKE_TZONE_ALLOCATED(SearchInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SearchInputType);
 public:
     static Ref<SearchInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/TelephoneInputType.h
+++ b/Source/WebCore/html/TelephoneInputType.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class TelephoneInputType final : public BaseTextInputType {
     WTF_MAKE_TZONE_ALLOCATED(TelephoneInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TelephoneInputType);
 public:
     static Ref<TelephoneInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -47,7 +47,7 @@ class TextControlInnerTextElement;
 // The class represents types of which UI contain text fields.
 // It supports not only the types for BaseTextInputType but also type=number.
 class TextFieldInputType : public InputType, protected SpinButtonOwner, protected AutoFillButtonElement::AutoFillButtonOwner
-    , private DataListSuggestionsClient, protected DataListButtonElement::DataListButtonOwner
+    , protected DataListSuggestionsClient, protected DataListButtonElement::DataListButtonOwner
 {
     WTF_MAKE_TZONE_ALLOCATED(TextFieldInputType);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextFieldInputType);

--- a/Source/WebCore/html/TextInputType.h
+++ b/Source/WebCore/html/TextInputType.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class TextInputType final : public BaseTextInputType {
     WTF_MAKE_TZONE_ALLOCATED(TextInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextInputType);
 public:
     static Ref<TextInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/URLInputType.h
+++ b/Source/WebCore/html/URLInputType.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class URLInputType final : public BaseTextInputType {
     WTF_MAKE_TZONE_ALLOCATED(URLInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(URLInputType);
 public:
     static Ref<URLInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/inspector/agents/WebHeapAgent.h
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.h
@@ -39,6 +39,7 @@ struct GarbageCollectionData;
 class WebHeapAgent : public Inspector::InspectorHeapAgent {
     WTF_MAKE_NONCOPYABLE(WebHeapAgent);
     WTF_MAKE_TZONE_ALLOCATED(WebHeapAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebHeapAgent);
     friend class SendGarbageCollectionEventsTask;
 public:
     WebHeapAgent(WebAgentContext&);

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.h
@@ -36,6 +36,7 @@ namespace WebCore {
 class PageHeapAgent final : public WebHeapAgent {
     WTF_MAKE_NONCOPYABLE(PageHeapAgent);
     WTF_MAKE_TZONE_ALLOCATED(PageHeapAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageHeapAgent);
 public:
     PageHeapAgent(PageAgentContext&);
     ~PageHeapAgent();

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -276,6 +276,7 @@ class EmptyDragClient final : public DragClient {
 
 class EmptyEditorClient final : public EditorClient {
     WTF_MAKE_TZONE_ALLOCATED(EmptyEditorClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EmptyEditorClient);
 private:
     bool shouldDeleteRange(const std::optional<SimpleRange>&) final { return false; }
     bool smartInsertDeleteEnabled() final { return false; }

--- a/Source/WebCore/platform/OpacityCaretAnimator.h
+++ b/Source/WebCore/platform/OpacityCaretAnimator.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class OpacityCaretAnimator final : public CaretAnimator {
     WTF_MAKE_TZONE_ALLOCATED(OpacityCaretAnimator);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(OpacityCaretAnimator);
 public:
     explicit OpacityCaretAnimator(CaretAnimationClient&, std::optional<LayoutRect> = std::nullopt);
 

--- a/Source/WebCore/platform/ios/DeviceMotionClientIOS.h
+++ b/Source/WebCore/platform/ios/DeviceMotionClientIOS.h
@@ -41,6 +41,7 @@ namespace WebCore {
 
 class DeviceMotionClientIOS : public DeviceMotionClient, public MotionManagerClient {
     WTF_MAKE_TZONE_ALLOCATED(DeviceMotionClientIOS);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceMotionClientIOS);
 public:
     DeviceMotionClientIOS(RefPtr<DeviceOrientationUpdateProvider>&&);
     ~DeviceMotionClientIOS() override;

--- a/Source/WebCore/platform/ios/DeviceOrientationClientIOS.h
+++ b/Source/WebCore/platform/ios/DeviceOrientationClientIOS.h
@@ -41,6 +41,7 @@ namespace WebCore {
 
 class DeviceOrientationClientIOS : public DeviceOrientationClient, public MotionManagerClient {
     WTF_MAKE_TZONE_ALLOCATED(DeviceOrientationClientIOS);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceOrientationClientIOS);
 public:
     DeviceOrientationClientIOS(RefPtr<DeviceOrientationUpdateProvider>&&);
     ~DeviceOrientationClientIOS() override;

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
@@ -42,6 +42,7 @@ class DeviceOrientationController;
 // client when running DumpRenderTree.
 class DeviceOrientationClientMock final : public DeviceOrientationClient {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(DeviceOrientationClientMock, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceOrientationClientMock);
 public:
     WEBCORE_EXPORT DeviceOrientationClientMock();
 

--- a/Source/WebCore/worklets/PaintWorkletGlobalScope.h
+++ b/Source/WebCore/worklets/PaintWorkletGlobalScope.h
@@ -62,6 +62,7 @@ struct PaintDefinition : public CanMakeWeakPtr<PaintDefinition> {
 
 class PaintWorkletGlobalScope final : public WorkletGlobalScope {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PaintWorkletGlobalScope);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PaintWorkletGlobalScope);
 public:
     static RefPtr<PaintWorkletGlobalScope> tryCreate(Document&, ScriptSourceCode&&);
 

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -54,6 +54,7 @@ using WorkletGlobalScopeIdentifier = ObjectIdentifier<WorkletGlobalScopeIdentifi
 
 class WorkletGlobalScope : public WorkerOrWorkletGlobalScope {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WorkletGlobalScope);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkletGlobalScope);
 public:
     virtual ~WorkletGlobalScope();
 

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -35,6 +35,7 @@
 namespace IPC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(StreamClientConnection);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StreamClientConnection::DedicatedConnectionClient);
 
 // FIXME(http://webkit.org/b/238986): Workaround for not being able to deliver messages from the dedicated connection to the work queue the client uses.
 

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -137,7 +137,9 @@ private:
 
     const Ref<Connection> m_connection;
     class DedicatedConnectionClient final : public Connection::Client {
+        WTF_MAKE_TZONE_ALLOCATED(DedicatedConnectionClient);
         WTF_MAKE_NONCOPYABLE(DedicatedConnectionClient);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DedicatedConnectionClient);
     public:
         DedicatedConnectionClient(StreamClientConnection&, Connection::Client&);
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -48,6 +48,7 @@
 
 class WebEditorClient final : public WebCore::EditorClient, public WebCore::TextCheckerClient {
     WTF_MAKE_TZONE_ALLOCATED(WebEditorClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebEditorClient);
 public:
     WebEditorClient(WebView *);
     virtual ~WebEditorClient();


### PR DESCRIPTION
#### 193346967bdd39dbd4f732877ea59958d693c238
<pre>
Add missing WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR
<a href="https://bugs.webkit.org/show_bug.cgi?id=301488">https://bugs.webkit.org/show_bug.cgi?id=301488</a>

Reviewed by Geoffrey Garen.

Add the missing WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR to subclasses of a CheckedPtr capable type.

No new tests since there should be no behavior change.

* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h:
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h:
* Source/WebCore/dom/DeviceMotionClient.h:
* Source/WebCore/dom/DeviceOrientationClient.h:
* Source/WebCore/html/BaseTextInputType.h:
* Source/WebCore/html/EmailInputType.h:
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h:
* Source/WebCore/html/NumberInputType.h:
* Source/WebCore/html/PasswordInputType.h:
* Source/WebCore/html/PluginDocument.h:
* Source/WebCore/html/SearchInputType.h:
* Source/WebCore/html/TelephoneInputType.h:
* Source/WebCore/html/TextInputType.h:
* Source/WebCore/html/URLInputType.h:
* Source/WebCore/inspector/agents/WebHeapAgent.h:
* Source/WebCore/inspector/agents/page/PageHeapAgent.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/platform/OpacityCaretAnimator.h:
* Source/WebCore/platform/ios/DeviceMotionClientIOS.h:
* Source/WebCore/platform/ios/DeviceOrientationClientIOS.h:
* Source/WebCore/platform/mock/DeviceOrientationClientMock.h:
* Source/WebCore/worklets/PaintWorkletGlobalScope.h:
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h:

Canonical link: <a href="https://commits.webkit.org/302167@main">https://commits.webkit.org/302167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc6b827f910d4ed1f9d179ae1b54e74cfe748144

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135605 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79697 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6d8e0d32-008b-48b2-a2a0-9951ff88cee4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97597 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65501 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4110708b-b8af-4215-95c8-6427218147a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114852 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78170 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a68db159-7bcf-45f1-9d33-3c44788906f7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/257 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32960 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78880 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120239 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138058 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126669 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/321 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106125 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105907 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/269 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29748 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52606 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20035 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/62934 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159695 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/296 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39874 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/367 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/353 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->