### PR TITLE
Add experimental feature flag to make WebAuthn unforgeable

### DIFF
--- a/LayoutTests/http/wpt/webauthn/webauthn-secure-api-protection.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/webauthn-secure-api-protection.https-expected.txt
@@ -1,0 +1,12 @@
+PASS: window.PublicKeyCredential cannot be overridden
+PASS: navigator.credentials.get cannot be overridden
+PASS: navigator.credentials.create cannot be overridden
+PASS: navigator.credentials returns real object even when navigator is shadowed
+PASS: Object.defineProperty on navigator blocked: Attempting to change configurable attribute of unconfigurable property.
+PASS: Object.defineProperty on navigator.credentials blocked: Cannot redefine credentials property
+PASS: Object.defineProperty on credentials.get blocked: Attempting to change configurable attribute of unconfigurable property.
+PASS: Object.defineProperty on credentials.create blocked: Attempting to change configurable attribute of unconfigurable property.
+PASS: PublicKeyCredential.isConditionalMediationAvailable cannot be overridden
+PASS: PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable cannot be overridden
+PASS: PublicKeyCredential.getClientCapabilities cannot be overridden
+

--- a/LayoutTests/http/wpt/webauthn/webauthn-secure-api-protection.https.html
+++ b/LayoutTests/http/wpt/webauthn/webauthn-secure-api-protection.https.html
@@ -1,0 +1,105 @@
+<!-- webkit-test-runner [ WebAuthenticationSecureEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <script type="text/javascript">
+        function log(msg)
+        {
+            document.getElementById('console').appendChild(document.createTextNode(msg + '\n'));
+        }
+    </script>
+</head>
+<body>
+    <pre id="console"></pre>
+    <script>
+        if (this.testRunner)
+            testRunner.dumpAsText();
+        // Test window.PublicKeyCredential replacement
+        var originalPublicKeyCredential = window.PublicKeyCredential;
+        window.PublicKeyCredential = 1;
+        log(window.PublicKeyCredential === originalPublicKeyCredential ? "PASS: window.PublicKeyCredential cannot be overridden" : "FAIL: window.PublicKeyCredential was overridden");
+
+        // Test CredentialsContainer.get protection
+        var originalGet = navigator.credentials.get;
+        navigator.credentials.get = 1;
+        log(navigator.credentials.get === originalGet ? "PASS: navigator.credentials.get cannot be overridden" : "FAIL: navigator.credentials.get was overridden");
+
+        // Test CredentialsContainer.create protection
+        var originalCreate = navigator.credentials.create;
+        navigator.credentials.create = 1;
+        log(navigator.credentials.create === originalCreate ? "PASS: navigator.credentials.create cannot be overridden" : "FAIL: navigator.credentials.create was overridden");
+
+        // Test navigator shadowing protection
+        var realCredentials = navigator.credentials;
+        window.navigator = {};
+        log(navigator.credentials === realCredentials ? "PASS: navigator.credentials returns real object even when navigator is shadowed" : "FAIL: navigator.credentials was affected by shadowing");
+
+        // Test navigator shadowing via Object.defineProperty
+        var realCredentials2 = navigator.credentials;
+        try {
+            Object.defineProperty(window, 'navigator', {
+                value: { credentials: { get: function() { return "fake"; }, create: function() { return "fake"; } } },
+                writable: false,
+                configurable: true
+            });
+            log(navigator.credentials === realCredentials2 ? "PASS: navigator.credentials returns real object even when navigator is redefined via Object.defineProperty" : "FAIL: navigator.credentials was affected by Object.defineProperty");
+        } catch (e) {
+            log("PASS: Object.defineProperty on navigator blocked: " + e.message);
+        }
+
+        // Test navigator.credentials shadowing via Object.defineProperty
+        var realCredentials3 = navigator.credentials;
+        try {
+            Object.defineProperty(navigator, 'credentials', {
+                value: { get: function() { return "fake"; }, create: function() { return "fake"; } },
+                writable: false,
+                configurable: true
+            });
+            log(navigator.credentials === realCredentials3 ? "PASS: navigator.credentials cannot be redefined via Object.defineProperty" : "FAIL: navigator.credentials was redefined via Object.defineProperty");
+        } catch (e) {
+            log("PASS: Object.defineProperty on navigator.credentials blocked: " + e.message);
+        }
+
+        // Test Object.defineProperty on credentials.get
+        var realGet2 = navigator.credentials.get;
+        try {
+            Object.defineProperty(navigator.credentials, 'get', {
+                value: function() { return "fake"; },
+                writable: false,
+                configurable: true
+            });
+            log(navigator.credentials.get === realGet2 ? "PASS: credentials.get cannot be redefined via Object.defineProperty" : "FAIL: credentials.get was redefined via Object.defineProperty");
+        } catch (e) {
+            log("PASS: Object.defineProperty on credentials.get blocked: " + e.message);
+        }
+
+        // Test Object.defineProperty on credentials.create
+        var realCreate2 = navigator.credentials.create;
+        try {
+            Object.defineProperty(navigator.credentials, 'create', {
+                value: function() { return "fake"; },
+                writable: false,
+                configurable: true
+            });
+            log(navigator.credentials.create === realCreate2 ? "PASS: credentials.create cannot be redefined via Object.defineProperty" : "FAIL: credentials.create was redefined via Object.defineProperty");
+        } catch (e) {
+            log("PASS: Object.defineProperty on credentials.create blocked: " + e.message);
+        }
+
+        // Test PublicKeyCredential.isConditionalMediationAvailable protection
+        var originalIsConditional = PublicKeyCredential.isConditionalMediationAvailable;
+        PublicKeyCredential.isConditionalMediationAvailable = 1;
+        log(PublicKeyCredential.isConditionalMediationAvailable === originalIsConditional ? "PASS: PublicKeyCredential.isConditionalMediationAvailable cannot be overridden" : "FAIL: PublicKeyCredential.isConditionalMediationAvailable was overridden");
+
+        // Test PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable protection
+        var originalIsUserVerifying = PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable;
+        PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = 1;
+        log(PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable === originalIsUserVerifying ? "PASS: PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable cannot be overridden" : "FAIL: PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable was overridden");
+
+        // Test PublicKeyCredential.getClientCapabilities protection
+        var originalGetClientCaps = PublicKeyCredential.getClientCapabilities;
+        PublicKeyCredential.getClientCapabilities = 1;
+        log(PublicKeyCredential.getClientCapabilities === originalGetClientCaps ? "PASS: PublicKeyCredential.getClientCapabilities cannot be overridden" : "FAIL: PublicKeyCredential.getClientCapabilities was overridden");
+    </script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8995,6 +8995,22 @@ WebAuthenticationEnabled:
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
+WebAuthenticationSecureEnabled:
+  type: bool
+  status: preview
+  category: security
+  humanReadableName: "Secure Web Authentication API"
+  humanReadableDescription: "Protect WebAuthn credentials API from being overridden by scripts and extensions"
+  condition: ENABLE(WEB_AUTHN)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 WebCodecsAV1Enabled:
   type: bool
   status: preview

--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.idl
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.idl
@@ -33,5 +33,5 @@
     readonly attribute USVString id;
     readonly attribute DOMString type;
 
-    [CallWith=CurrentDocument] static Promise<boolean> isConditionalMediationAvailable();
+    [CallWith=CurrentDocument, ConditionallyUnforgeableBySetting=WebAuthenticationSecureEnabled] static Promise<boolean> isConditionalMediationAvailable();
 };

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
@@ -31,8 +31,8 @@
     SecureContext,
     SkipVTableValidation,
 ] interface CredentialsContainer {
-    Promise<BasicCredential?> get(optional CredentialRequestOptions options);
+    [ConditionallyUnforgeableBySetting=WebAuthenticationSecureEnabled] Promise<BasicCredential?> get(optional CredentialRequestOptions options);
     Promise<BasicCredential> store(BasicCredential credential);
-    Promise<BasicCredential?> create(optional CredentialCreationOptions options);
+    [ConditionallyUnforgeableBySetting=WebAuthenticationSecureEnabled] Promise<BasicCredential?> create(optional CredentialCreationOptions options);
     Promise<undefined> preventSilentAccess();
 };

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.idl
@@ -38,8 +38,8 @@ typedef (RegistrationResponseJSON or AuthenticationResponseJSON) PublicKeyCreden
     AuthenticationExtensionsClientOutputs getClientExtensionResults();
     PublicKeyCredentialJSON toJSON();
 
-    [CallWith=CurrentDocument] static Promise<boolean> isUserVerifyingPlatformAuthenticatorAvailable();
-    [CallWith=CurrentDocument] static Promise<PublicKeyCredentialClientCapabilities> getClientCapabilities();
+    [CallWith=CurrentDocument, ConditionallyUnforgeableBySetting=WebAuthenticationSecureEnabled] static Promise<boolean> isUserVerifyingPlatformAuthenticatorAvailable();
+    [CallWith=CurrentDocument, ConditionallyUnforgeableBySetting=WebAuthenticationSecureEnabled] static Promise<PublicKeyCredentialClientCapabilities> getClientCapabilities();
     static PublicKeyCredentialCreationOptions parseCreationOptionsFromJSON(PublicKeyCredentialCreationOptionsJSON options);
     static PublicKeyCredentialRequestOptions parseRequestOptionsFromJSON(PublicKeyCredentialRequestOptionsJSON options);
 

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -58,6 +58,14 @@
 #include <JavaScriptCore/Lookup.h>
 #include <JavaScriptCore/Structure.h>
 
+#if ENABLE(WEB_AUTHN)
+#include "JSCredentialsContainer.h"
+#include "JSNavigator.h"
+#include "Navigator.h"
+#include "NavigatorCredentials.h"
+#include <JavaScriptCore/ProxyObject.h>
+#endif
+
 #if ENABLE(USER_MESSAGE_HANDLERS)
 #include "JSWebKitNamespace.h"
 #endif
@@ -72,6 +80,11 @@ using namespace JSC;
 static JSC_DECLARE_HOST_FUNCTION(jsDOMWindowInstanceFunction_openDatabase);
 #if ENABLE(USER_MESSAGE_HANDLERS)
 static JSC_DECLARE_CUSTOM_GETTER(jsDOMWindow_webkit);
+#endif
+
+#if ENABLE(WEB_AUTHN)
+static JSC_DECLARE_CUSTOM_GETTER(jsDOMWindow_navigatorWithCredentialsProtection);
+static JSC_DECLARE_HOST_FUNCTION(navigatorProxyGetTrap);
 #endif
 
 template<typename Visitor>
@@ -98,6 +111,77 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMWindow_webkit, (JSGlobalObject* lexicalGlobalObjec
     if (!localDOMWindow)
         return JSValue::encode(jsUndefined());
     return JSValue::encode(toJS(lexicalGlobalObject, castedThis->globalObject(), localDOMWindow->webkitNamespace()));
+}
+#endif
+
+#if ENABLE(WEB_AUTHN)
+JSC_DEFINE_HOST_FUNCTION(navigatorProxyGetTrap, (JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame))
+{
+    VM& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (callFrame->argumentCount() < 2)
+        return JSValue::encode(jsUndefined());
+
+    JSValue target = callFrame->argument(0);
+    JSValue property = callFrame->argument(1);
+
+    if (!property.isString())
+        return JSValue::encode(jsUndefined());
+
+    String propertyString = asString(property)->value(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (propertyString == "credentials"_s) {
+        auto* jsDOMWindow = jsDynamicCast<JSDOMWindow*>(lexicalGlobalObject);
+        if (!jsDOMWindow)
+            return JSValue::encode(jsUndefined());
+
+        RefPtr localDOMWindow = dynamicDowncast<LocalDOMWindow>(jsDOMWindow->wrapped());
+        if (!localDOMWindow)
+            return JSValue::encode(jsUndefined());
+
+        if (RefPtr frame = localDOMWindow->frame()) {
+            if (frame->settings().webAuthenticationSecureEnabled()) {
+                auto& realNavigator = localDOMWindow->navigator();
+                auto* realCredentials = NavigatorCredentials::credentials(realNavigator);
+                if (!realCredentials)
+                    return JSValue::encode(jsUndefined());
+                return JSValue::encode(toJS(lexicalGlobalObject, jsDOMWindow->globalObject(), realCredentials));
+            }
+        }
+    }
+
+    if (!target.isObject())
+        return JSValue::encode(jsUndefined());
+
+    scope.release();
+    return JSValue::encode(asObject(target)->get(lexicalGlobalObject, Identifier::fromString(vm, propertyString)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsDOMWindow_navigatorWithCredentialsProtection, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName))
+{
+    VM& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* castedThis = toJSDOMGlobalObject<JSDOMWindow>(vm, JSValue::decode(thisValue));
+    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, castedThis->wrapped()))
+        return JSValue::encode(jsUndefined());
+
+    RefPtr localDOMWindow = dynamicDowncast<LocalDOMWindow>(castedThis->wrapped());
+    if (!localDOMWindow)
+        return JSValue::encode(jsUndefined());
+
+    auto& realNavigator = localDOMWindow->navigator();
+    JSValue realNavigatorValue = toJS(lexicalGlobalObject, castedThis->globalObject(), &realNavigator);
+
+    // Always wrap navigator in a proxy that protects .credentials access
+    // This handles both direct assignment and Object.defineProperty shadowing
+    JSObject* handler = constructEmptyObject(lexicalGlobalObject);
+    JSFunction* getTrap = JSFunction::create(vm, lexicalGlobalObject, 2, "get"_s, navigatorProxyGetTrap, ImplementationVisibility::Public);
+    handler->putDirect(vm, vm.propertyNames->get, getTrap);
+
+    scope.release();
+    return JSValue::encode(ProxyObject::create(lexicalGlobalObject, asObject(realNavigatorValue), handler));
 }
 #endif
 
@@ -210,12 +294,6 @@ bool JSDOMWindow::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexicalGl
     if (thisObject->m_windowCloseWatchpoints->isStillValid())
         slot.setWatchpointSet(*thisObject->m_windowCloseWatchpoints);
 
-    // (2) Regular own properties.
-    if (Base::getOwnPropertySlot(thisObject, lexicalGlobalObject, propertyName, slot))
-        return true;
-    if (slot.isVMInquiry() && slot.isTaintedByOpaqueObject()) [[unlikely]]
-        return false;
-
 #if ENABLE(USER_MESSAGE_HANDLERS)
     RefPtr localDOMWindow = dynamicDowncast<LocalDOMWindow>(thisObject->wrapped());
     if (propertyName == builtinNames(lexicalGlobalObject->vm()).webkitPublicName() && localDOMWindow && localDOMWindow->shouldHaveWebKitNamespaceForWorld(thisObject->world(), lexicalGlobalObject)) {
@@ -223,6 +301,26 @@ bool JSDOMWindow::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexicalGl
         return true;
     }
 #endif
+
+#if ENABLE(WEB_AUTHN)
+#if !ENABLE(USER_MESSAGE_HANDLERS)
+    RefPtr localDOMWindow = dynamicDowncast<LocalDOMWindow>(thisObject->wrapped());
+#endif
+    if (propertyName == Identifier::fromString(lexicalGlobalObject->vm(), "navigator"_s) && localDOMWindow) {
+        if (RefPtr frame = localDOMWindow->frame()) {
+            if (frame->settings().webAuthenticationSecureEnabled()) {
+                slot.setCustom(thisObject, enumToUnderlyingType(JSC::PropertyAttribute::DontDelete), jsDOMWindow_navigatorWithCredentialsProtection);
+                return true;
+            }
+        }
+    }
+#endif
+
+    // (2) Regular own properties.
+    if (Base::getOwnPropertySlot(thisObject, lexicalGlobalObject, propertyName, slot))
+        return true;
+    if (slot.isVMInquiry() && slot.isTaintedByOpaqueObject()) [[unlikely]]
+        return false;
 
     return false;
 }
@@ -283,6 +381,18 @@ bool JSDOMWindow::put(JSCell* cell, JSGlobalObject* lexicalGlobalObject, Propert
         throwSecurityError(*lexicalGlobalObject, scope, errorMessage);
         return false;
     }
+
+#if ENABLE(WEB_AUTHN)
+    if (propertyName == Identifier::fromString(vm, "PublicKeyCredential"_s)) {
+        RefPtr localDOMWindow = dynamicDowncast<LocalDOMWindow>(thisObject->wrapped());
+        if (localDOMWindow) {
+            if (RefPtr frame = localDOMWindow->frame()) {
+                if (frame->settings().webAuthenticationSecureEnabled())
+                    return false;
+            }
+        }
+    }
+#endif
 
     if (parseIndex(propertyName) && !allowsLegacyExpandoIndexedProperties())
         return typeError(lexicalGlobalObject, scope, slot.isStrictMode(), makeUnsupportedIndexedSetterErrorMessage("Window"_s));

--- a/Source/WebCore/bindings/js/JSNavigatorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigatorCustom.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "JSNavigator.h"
 
+#include "LocalDOMWindow.h"
+#include "LocalFrame.h"
 #include "WebCoreJSBuiltinInternals.h"
 #include "WebCoreJSClientData.h"
 #include "WebCoreOpaqueRootInlines.h"
@@ -41,6 +43,31 @@ void JSNavigator::visitAdditionalChildren(Visitor& visitor)
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSNavigator);
+
+bool JSNavigator::defineOwnProperty(JSC::JSObject* object, JSC::JSGlobalObject* lexicalGlobalObject, JSC::PropertyName propertyName, const JSC::PropertyDescriptor& descriptor, bool shouldThrow)
+{
+#if ENABLE(WEB_AUTHN)
+    using namespace JSC;
+    VM& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (propertyName == Identifier::fromString(vm, "credentials"_s)) {
+        if (auto* window = jsDynamicCast<JSDOMWindow*>(lexicalGlobalObject)) {
+            if (RefPtr localDOMWindow = dynamicDowncast<LocalDOMWindow>(window->wrapped())) {
+                if (RefPtr frame = localDOMWindow->frame()) {
+                    if (frame->settings().webAuthenticationSecureEnabled())
+                        return typeError(lexicalGlobalObject, scope, shouldThrow, "Cannot redefine credentials property"_s);
+                }
+            }
+        }
+    }
+
+    scope.release();
+    return Base::defineOwnProperty(object, lexicalGlobalObject, propertyName, descriptor, shouldThrow);
+#else
+    return Base::defineOwnProperty(object, lexicalGlobalObject, propertyName, descriptor, shouldThrow);
+#endif
+}
 
 #if ENABLE(MEDIA_STREAM)
 JSC::JSValue JSNavigator::getUserMedia(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame)

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -5171,6 +5171,25 @@ sub GenerateImplementation
         push(@finishCreation, "#endif\n") if $conditionalString;
         $hasNonTrivialFinishCreation = 1;
     }
+
+    # Support for ConditionallyUnforgeableBySetting instance operations
+    my @conditionallyUnforgeableInstanceOps = grep { $_->extendedAttributes->{ConditionallyUnforgeableBySetting} && !$_->isStatic } @{$interface->operations};
+    foreach my $operation (@conditionallyUnforgeableInstanceOps) {
+        next if $operation->{overloadIndex} && $operation->{overloadIndex} > 1;
+        my $functionName = $operation->name;
+        my $settingName = $operation->extendedAttributes->{ConditionallyUnforgeableBySetting};
+        my $conditionalString = $codeGenerator->GenerateConditionalString($operation);
+        push(@finishCreation, "#if ${conditionalString}\n") if $conditionalString;
+        push(@finishCreation, "    if (downcast<Document>(jsCast<JSDOMGlobalObject*>(globalObject())->scriptExecutionContext())->settingsValues()." . ToMethodName($settingName) . ") {\n");
+        push(@finishCreation, "        auto propertyName = Identifier::fromString(vm, \"$functionName\"_s);\n");
+        push(@finishCreation, "        auto value = get(globalObject(), propertyName);\n");
+        push(@finishCreation, "        if (value)\n");
+        push(@finishCreation, "            putDirect(vm, propertyName, value, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);\n");
+        push(@finishCreation, "    }\n");
+        push(@finishCreation, "#endif\n") if $conditionalString;
+        $hasNonTrivialFinishCreation = 1;
+    }
+
     if ($interface->extendedAttributes->{ReportExtraMemoryCost}) {
         push(@finishCreation, "    vm.heap.reportExtraMemoryAllocated(this, wrapped().memoryCost());\n");
         $hasNonTrivialFinishCreation = 1;
@@ -8627,6 +8646,22 @@ sub GenerateConstructorHelperMethods
         $classForThis = "nullptr";
     }
     push(@$outputArray, "    reifyStaticProperties(vm, ${classForThis}, ${className}ConstructorTableValues, *this);\n") if ConstructorHasProperties($interface);
+
+    # Handle ConditionallyUnforgeableBySetting static properties
+    my @conditionallyUnforgeableProperties = grep { $_->extendedAttributes->{ConditionallyUnforgeableBySetting} && $_->isStatic } @{$interface->operations}, @{$interface->attributes};
+    foreach my $property (@conditionallyUnforgeableProperties) {
+        my $name = $property->name;
+        my $settingName = $property->extendedAttributes->{ConditionallyUnforgeableBySetting};
+        my $conditionalString = $codeGenerator->GenerateConditionalString($property);
+        push(@$outputArray, "#if ${conditionalString}\n") if $conditionalString;
+        push(@$outputArray, "    if (downcast<Document>(jsCast<JSDOMGlobalObject*>(&globalObject)->scriptExecutionContext())->settingsValues()." . ToMethodName($settingName) . ") {\n");
+        push(@$outputArray, "        auto propertyName = Identifier::fromString(vm, \"$name\"_s);\n");
+        push(@$outputArray, "        auto value = getDirect(vm, propertyName);\n");
+        push(@$outputArray, "        if (value)\n");
+        push(@$outputArray, "            putDirect(vm, propertyName, value, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);\n");
+        push(@$outputArray, "    }\n");
+        push(@$outputArray, "#endif\n") if $conditionalString;
+    }
 
     my @runtimeEnabledProperties = GetRuntimeEnabledStaticProperties($interface);
 

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -88,6 +88,10 @@
             "values": ["*"],
             "supportsConjunction": true
         },
+        "ConditionallyUnforgeableBySetting": {
+            "contextsAllowed": ["attribute", "operation"],
+            "values": ["*"]
+        },
         "ConstantsScope": {
             "contextsAllowed": ["interface"],
             "values": ["*"]

--- a/Source/WebCore/page/Navigator.idl
+++ b/Source/WebCore/page/Navigator.idl
@@ -18,6 +18,7 @@
 */
 
 [
+    CustomDefineOwnProperty,
     GenerateIsReachable=ReachableFromDOMWindow,
     JSCustomMarkFunction,
     Exposed=Window

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -866,6 +866,7 @@ static void setWebPreferencesForTestOptions(WebPreferences *preferences, const W
                     && ![feature.key isEqualToString:@"BeaconAPIEnabled"]
                     && ![feature.key isEqualToString:@"LocalFileContentSniffingEnabled"]
                     && ![feature.key isEqualToString:@"HTTPSByDefaultEnabled"]
+                    && ![feature.key isEqualToString:@"WebAuthenticationSecureEnabled"]
                     && ![feature.key isEqualToString:@"DeclarativeWebPush"]) {
                     [preferences _setEnabled:YES forFeature:feature];
                 }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1372,6 +1372,7 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
         if (enableAllExperimentalFeatures) {
             WKPreferencesEnableAllExperimentalFeatures(preferences);
             WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("SiteIsolationEnabled").get());
+            WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("WebAuthenticationSecureEnabled").get());
             WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("VerifyWindowOpenUserGestureFromUIProcess").get());
             WKPreferencesSetExperimentalFeatureForKey(preferences, true, toWK("WebGPUEnabled").get());
             WKPreferencesSetExperimentalFeatureForKey(preferences, true, toWK("ModelElementEnabled").get());


### PR DESCRIPTION
#### 161b99f901d47cbfb58fc0b4f117b9252f3db0b6
<pre>
Add experimental feature flag to make WebAuthn unforgeable
<a href="https://rdar.apple.com/163428507">rdar://163428507</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301479">https://bugs.webkit.org/show_bug.cgi?id=301479</a>

Reviewed by NOBODY (OOPS\!).

This adds an experimental feature flag WebAuthenticationSecureEnabled that protects
WebAuthn APIs from being overridden by scripts and extensions. It introduces a new
IDL attribute [ConditionallyUnforgeableBySetting] that makes properties unforgeable
(non-writable, non-deletable) when a runtime setting is enabled.

Protected APIs when the flag is on:
- Static methods: BasicCredential.isConditionalMediationAvailable,
  PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable, getClientCapabilities
- Instance methods: CredentialsContainer.get(), create()
- Constructor: window.PublicKeyCredential (via Window.put())
- Navigator shadowing: Proxy wrapper ensures navigator.credentials always returns real object

The implementation adds DontDelete|ReadOnly attributes conditionally at object initialization
time, with zero performance cost for APIs that don&apos;t use this feature.

Test: http/wpt/webauthn/webauthn-secure-api-protection.https.html

* LayoutTests/http/wpt/webauthn/webauthn-secure-api-protection.https-expected.txt: Added.
* LayoutTests/http/wpt/webauthn/webauthn-secure-api-protection.https.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Added WebAuthenticationSecureEnabled.
* Source/WebCore/Modules/credentialmanagement/BasicCredential.idl: Added ConditionallyUnforgeableBySetting.
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl: Added ConditionallyUnforgeableBySetting.
* Source/WebCore/Modules/webauthn/PublicKeyCredential.idl: Added ConditionallyUnforgeableBySetting.
* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp: Added navigator proxy and window.PublicKeyCredential protection.
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm: Implemented ConditionallyUnforgeableBySetting.
* Source/WebCore/bindings/scripts/IDLAttributes.json: Registered ConditionallyUnforgeableBySetting.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/161b99f901d47cbfb58fc0b4f117b9252f3db0b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79931 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cc39b4e3-4bde-4b6e-8771-4033ec7b2848) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97818 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65731 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bca57349-4463-4873-9e95-90fbeb685663) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78429 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/972c695d-9716-4ba8-91a1-dc02a7c02d15) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33231 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79166 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120505 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108883 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138332 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126951 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106358 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106170 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/500 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30004 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52935 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/652 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63850 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159973 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/541 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39952 "Found 16 new JSC stress test failures: wasm.yaml/wasm/stress/osr-entry-live-fpr.js.default-wasm, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-bbq, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-collect-continuously, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-eager, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-eager-jettison, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-no-cjit, wasm.yaml/wasm/stress/osr-entry-live-fpr.js.wasm-slow-memory, wasm.yaml/wasm/stress/osr-entry-live-stack.js.default-wasm, wasm.yaml/wasm/stress/osr-entry-live-stack.js.wasm-bbq ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/602 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/607 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->