### PR TITLE
REGRESSION (iOS 26): Sliding side menu looks bad (fixed element not extending under address bar)

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-sidebar-and-header-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-sidebar-and-header-expected.txt
@@ -1,0 +1,22 @@
+PASS colorsBeforeOpeningSidebar.top is "rgb(0, 122, 255)"
+PASS colorsBeforeOpeningSidebar.left is null
+PASS colorsBeforeOpeningSidebar.right is null
+PASS colorsBeforeOpeningSidebar.bottom is null
+PASS colorsAfterOpeningSidebar.top is "rgb(0, 122, 255)"
+PASS colorsAfterOpeningSidebar.left is "rgb(100, 100, 100)"
+PASS colorsAfterOpeningSidebar.right is null
+PASS colorsAfterOpeningSidebar.bottom is non-null.
+PASS ['multiple', 'rgb(100, 100, 100)'].includes(colorsAfterOpeningSidebar.bottom) is true
+PASS colorsAfterClosingSidebar.top is "rgb(0, 122, 255)"
+PASS colorsAfterClosingSidebar.left is null
+PASS colorsAfterClosingSidebar.right is null
+PASS colorsAfterClosingSidebar.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Toggle sidebar
+Main content area
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-sidebar-and-header.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-sidebar-and-header.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=50 obscuredInset.left=50 ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<style>
+body, html {
+    font-family: system-ui;
+    font-size: 16px;
+    background: #eee;
+    margin: 0;
+    padding: 0;
+}
+
+.header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 60px;
+    background: rgb(0, 122, 255);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    padding: 0 20px;
+    box-sizing: border-box;
+}
+
+button {
+    position: absolute;
+    right: 1em;
+}
+
+.sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 60vw;
+    height: 100%;
+    background: rgb(100, 100, 100);
+    z-index: 101;
+    transform: translateX(-100%);
+    display: none;
+}
+
+.sidebar.visible {
+    transform: translateX(0);
+    display: block;
+}
+
+.content {
+    margin-top: 80px;
+    padding: 20px;
+}
+
+.tall {
+    height: 300vh;
+}
+</style>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    const button = document.querySelector("button");
+    const sidebar = document.querySelector(".sidebar");
+    button.addEventListener("click", () => {
+        sidebar.classList.toggle("visible");
+    });
+
+    await UIHelper.setObscuredInsets(50, 50, 50, 50);
+    await UIHelper.ensurePresentationUpdate();
+
+    colorsBeforeOpeningSidebar = await UIHelper.fixedContainerEdgeColors();
+    shouldBeEqualToString("colorsBeforeOpeningSidebar.top", "rgb(0, 122, 255)");
+    shouldBeNull("colorsBeforeOpeningSidebar.left");
+    shouldBeNull("colorsBeforeOpeningSidebar.right");
+    shouldBeNull("colorsBeforeOpeningSidebar.bottom");
+
+    button.click();
+    await UIHelper.ensurePresentationUpdate();
+
+    colorsAfterOpeningSidebar = await UIHelper.fixedContainerEdgeColors();
+    shouldBeEqualToString("colorsAfterOpeningSidebar.top", "rgb(0, 122, 255)");
+    shouldBeEqualToString("colorsAfterOpeningSidebar.left", "rgb(100, 100, 100)");
+    shouldBeNull("colorsAfterOpeningSidebar.right");
+    shouldBeNonNull("colorsAfterOpeningSidebar.bottom");
+    shouldBeTrue("['multiple', 'rgb(100, 100, 100)'].includes(colorsAfterOpeningSidebar.bottom)");
+
+    button.click();
+    await UIHelper.ensurePresentationUpdate();
+
+    colorsAfterClosingSidebar = await UIHelper.fixedContainerEdgeColors();
+    shouldBeEqualToString("colorsAfterClosingSidebar.top", "rgb(0, 122, 255)");
+    shouldBeNull("colorsAfterClosingSidebar.left");
+    shouldBeNull("colorsAfterClosingSidebar.right");
+    shouldBeNull("colorsAfterClosingSidebar.bottom");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="header">
+        <button>Toggle sidebar</button>
+    </div>
+    <div class="sidebar"></div>
+    <div class="content">
+        <p>Main content area</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        <div class="tall"></div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
#### e94e53c6825e344270e2df160f0a59db1fca467d
<pre>
REGRESSION (iOS 26): Sliding side menu looks bad (fixed element not extending under address bar)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301425">https://bugs.webkit.org/show_bug.cgi?id=301425</a>
<a href="https://rdar.apple.com/163352309">rdar://163352309</a>

Reviewed by Abrar Rahman Protyasha.

Adjust the fixed color extension heuristic to err on the side of extending colors past the edges of
the layout viewport in the case where the hit-tested element is not viewport-sized on the sampled
edge, but _is_ viewport-sized or larger on the adjacent side. In practice, this causes us to
automatically apply color extensions in cases where the fixed element is similar to a sidebar that
fills up at least half of the width of the viewport, instead of leaving gaps either above or below
the sidebar.

Test: fast/page-color-sampling/color-sampling-sidebar-and-header.html

* LayoutTests/fast/page-color-sampling/color-sampling-sidebar-and-header-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-sidebar-and-header.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Also give this scenario its own candidate result type (`IsSidebar`), so that we can defer to any
existing sampled fixed colors on that edge to maintain color sampling stability (similar to what we
do for popups and other viewport-sized overlays).

Canonical link: <a href="https://commits.webkit.org/302171@main">https://commits.webkit.org/302171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d820be4466412d4ee67f2f7636843445dd8801b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79710 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f94c424e-b62b-4c51-aa00-597ec73f1472) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97605 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65507 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f7113a3d-9997-4143-87e5-8a67b86f909a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114864 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78178 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b3d8b4ce-e7d4-4aa4-b04a-7fab07bb455c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32972 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78895 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108645 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138069 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/331 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106132 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105914 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26996 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/276 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29760 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52626 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63095 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/309 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/380 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/366 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->