### PR TITLE
Drop unsafe Timer constructor now that it is no longer required

### DIFF
--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -186,17 +186,6 @@ public:
     {
     }
 
-    // FIXME: This constructor isn't as safe as the other ones and should ideally be removed.
-    template <typename TimerFiredClass, typename TimerFiredBaseClass>
-    requires (!WTF::HasRefPtrMemberFunctions<TimerFiredClass>::value && !WTF::HasCheckedPtrMemberFunctions<TimerFiredClass>::value)
-    Timer(TimerFiredClass& object, void (TimerFiredBaseClass::*function)())
-        : m_function(std::bind(function, &object))
-    {
-        static_assert(WTF::IsDeprecatedTimerSmartPointerException<std::remove_cv_t<TimerFiredClass>>::value,
-            "Classes that use Timer should be ref-counted or CanMakeCheckedPtr. Please do not add new exceptions."
-        );
-    }
-
     Timer(Function<void()>&& function)
         : m_function(WTFMove(function))
     {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
@@ -36,6 +36,7 @@
 #include <WebCore/PlatformScreen.h>
 #include <WebCore/TextureMapperFPSCounter.h>
 #include <WebCore/Timer.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -48,20 +49,12 @@ class Page;
 }
 
 namespace WebKit {
-class LayerTreeHost;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebKit::LayerTreeHost> : std::true_type { };
-}
-
-namespace WebKit {
 
 class WebPage;
 
-class LayerTreeHost : public WebCore::GraphicsLayerClient {
+class LayerTreeHost final : public WebCore::GraphicsLayerClient, public CanMakeCheckedPtr<LayerTreeHost> {
     WTF_MAKE_TZONE_ALLOCATED(LayerTreeHost);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LayerTreeHost);
 public:
     explicit LayerTreeHost(WebPage&);
     ~LayerTreeHost();


### PR DESCRIPTION
#### f6709fc04fa85b2dfce3ee781e50889a6f60e090
<pre>
Drop unsafe Timer constructor now that it is no longer required
<a href="https://bugs.webkit.org/show_bug.cgi?id=301492">https://bugs.webkit.org/show_bug.cgi?id=301492</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/Timer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h:
(WebKit::LayerTreeHost::layerTreeContext const): Deleted.
(WebKit::LayerTreeHost::displayID const): Deleted.

Canonical link: <a href="https://commits.webkit.org/302183@main">https://commits.webkit.org/302183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/672a7a6729169c6cbdc8c6d54e5ec2f7d574b8ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135638 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79730 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9ce90c33-f2b7-421e-abf4-9a176eba9286) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97623 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65525 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/92070714-05e9-4782-93a3-9d055fd18a0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114888 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78210 "Found 2 new API test failures: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp, WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/11978392-c4af-4213-8dbe-d929c3f4fc31) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32992 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78925 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138090 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/350 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106160 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/409 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111226 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105957 "Found 1 new API test failure: WebKitGTK/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/295 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29780 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52664 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/422 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63289 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/330 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/400 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->