### PR TITLE
Stop capturing raw pointers in RunLoop::Timer constructors

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -93,7 +93,6 @@ runtime/JSCJSValueInlines.h
 runtime/JSFinalizationRegistry.cpp
 runtime/JSGlobalObject.cpp
 runtime/JSObject.cpp
-runtime/JSRunLoopTimer.cpp
 runtime/JSString.cpp
 runtime/JSSymbolTableObject.h
 runtime/KeyAtomStringCacheInlines.h

--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
@@ -44,9 +45,10 @@ public:
     typedef void TimerNotificationType();
     using TimerNotificationCallback = RefPtr<WTF::SharedTask<TimerNotificationType>>;
 
-    class Manager {
+    class Manager final : public CanMakeThreadSafeCheckedPtr<Manager> {
         WTF_MAKE_NONCOPYABLE(Manager);
         WTF_MAKE_TZONE_ALLOCATED(Manager);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Manager);
         void timerDidFireCallback();
 
         Manager() = default;
@@ -55,6 +57,7 @@ public:
 
     public:
         static Manager& singleton();
+
         void registerVM(VM&);
         void unregisterVM(VM&);
         void scheduleTimer(JSRunLoopTimer&, Seconds nextFireTime);

--- a/Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,2 +1,1 @@
-wtf/RunLoop.h
 wtf/ThreadSafeWeakPtr.h

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -28,6 +28,7 @@
 
 #include <atomic>
 #include <ctime>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
@@ -82,7 +83,7 @@ struct MemoryPressureHandlerConfiguration {
     Seconds pollInterval;
 };
 
-class MemoryPressureHandler {
+class MemoryPressureHandler : public CanMakeWeakPtr<MemoryPressureHandler> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(MemoryPressureHandler);
     friend class WTF::LazyNeverDestroyed<MemoryPressureHandler>;
 public:

--- a/Source/WTF/wtf/linux/RealTimeThreads.h
+++ b/Source/WTF/wtf/linux/RealTimeThreads.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/ThreadGroup.h>
 
@@ -32,7 +33,7 @@ typedef struct _GDBusProxy GDBusProxy;
 
 namespace WTF {
 
-class RealTimeThreads {
+class RealTimeThreads : public CanMakeWeakPtr<RealTimeThreads> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(RealTimeThreads);
     friend class LazyNeverDestroyed<RealTimeThreads>;
 public:

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #if USE(ATSPI)
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
@@ -41,7 +42,7 @@ class AccessibilityRootAtspi;
 enum class AccessibilityRole : uint8_t;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AccessibilityAtspi);
-class AccessibilityAtspi {
+class AccessibilityAtspi : public CanMakeWeakPtr<AccessibilityAtspi> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AccessibilityAtspi, AccessibilityAtspi);
     WTF_MAKE_NONCOPYABLE(AccessibilityAtspi);
     friend NeverDestroyed<AccessibilityAtspi>;

--- a/Source/WebCore/platform/MainThreadSharedTimer.h
+++ b/Source/WebCore/platform/MainThreadSharedTimer.h
@@ -31,12 +31,17 @@
 #include <wtf/TZoneMalloc.h>
 
 #if !USE(CF) && !OS(WINDOWS)
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
 #endif
 
 namespace WebCore {
 
-class MainThreadSharedTimer final : public SharedTimer {
+class MainThreadSharedTimer final : public SharedTimer
+#if !USE(CF) && !OS(WINDOWS)
+    , public CanMakeWeakPtr<MainThreadSharedTimer>
+#endif
+{
     WTF_MAKE_TZONE_ALLOCATED(MainThreadSharedTimer);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MainThreadSharedTimer);
     friend class NeverDestroyed<MainThreadSharedTimer>;

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
@@ -28,6 +28,7 @@
 #if ENABLE(GAMEPAD)
 
 #include <WebCore/GamepadProvider.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
@@ -40,7 +41,7 @@ namespace WebCore {
 class GameControllerGamepad;
 class GamepadProviderClient;
 
-class GameControllerGamepadProvider : public GamepadProvider {
+class GameControllerGamepadProvider : public GamepadProvider, public CanMakeWeakPtr<GameControllerGamepadProvider> {
     WTF_MAKE_NONCOPYABLE(GameControllerGamepadProvider);
     friend class NeverDestroyed<GameControllerGamepadProvider>;
 public:

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
@@ -30,6 +30,7 @@
 
 #include "GamepadProvider.h"
 #include <wpe/wpe.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/RunLoop.h>
 
@@ -39,7 +40,7 @@ namespace WebCore {
 
 class GamepadLibWPE;
 
-class GamepadProviderLibWPE final : public GamepadProvider {
+class GamepadProviderLibWPE final : public GamepadProvider, public CanMakeWeakPtr<GamepadProviderLibWPE> {
     WTF_MAKE_NONCOPYABLE(GamepadProviderLibWPE);
     friend class NeverDestroyed<GamepadProviderLibWPE>;
 

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
@@ -30,6 +30,7 @@
 
 #include "GamepadProvider.h"
 #include <libmanette.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/RunLoop.h>
 
@@ -38,7 +39,7 @@ namespace WebCore {
 class ManetteGamepad;
 class GamepadProviderClient;
 
-class ManetteGamepadProvider final : public GamepadProvider {
+class ManetteGamepadProvider final : public GamepadProvider, public CanMakeWeakPtr<ManetteGamepadProvider> {
     WTF_MAKE_NONCOPYABLE(ManetteGamepadProvider);
     friend class NeverDestroyed<ManetteGamepadProvider>;
 public:

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
@@ -46,7 +46,7 @@ namespace WebCore {
 
 class DestinatationColorSpace;
 
-class IOSurfacePool : public ThreadSafeRefCounted<IOSurfacePool> {
+class IOSurfacePool : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<IOSurfacePool> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(IOSurfacePool, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(IOSurfacePool);
     friend class LazyNeverDestroyed<IOSurfacePool>;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.h
@@ -21,7 +21,7 @@
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
 #include "GRefPtrGStreamer.h"
-#include <wtf/CheckedRef.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
@@ -29,13 +29,16 @@
 
 namespace WebCore {
 
-class GStreamerVideoFrameConverter final : public CanMakeCheckedPtr<GStreamerVideoFrameConverter> {
+class GStreamerVideoFrameConverter final : public CanMakeWeakPtr<GStreamerVideoFrameConverter> {
     WTF_MAKE_TZONE_ALLOCATED(GStreamerVideoFrameConverter);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GStreamerVideoFrameConverter);
     friend NeverDestroyed<GStreamerVideoFrameConverter>;
 
 public:
     static GStreamerVideoFrameConverter& singleton();
+
+    // Do nothing since this is a singleton object.
+    void ref() const { }
+    void deref() const { }
 
     WARN_UNUSED_RETURN GRefPtr<GstSample> convert(const GRefPtr<GstSample>&, const GRefPtr<GstCaps>&);
 

--- a/Source/WebCore/platform/graphics/win/DisplayRefreshMonitorWin.h
+++ b/Source/WebCore/platform/graphics/win/DisplayRefreshMonitorWin.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include "DisplayRefreshMonitor.h"
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
 
 namespace WebCore {
 
-class DisplayRefreshMonitorWin : public DisplayRefreshMonitor {
+class DisplayRefreshMonitorWin : public DisplayRefreshMonitor, public CanMakeWeakPtr<DisplayRefreshMonitorWin> {
 public:
     static RefPtr<DisplayRefreshMonitorWin> create(PlatformDisplayID);
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -65,7 +65,7 @@ public:
     virtual void deviceWillBeRemoved(const String& persistentId) = 0;
 };
 
-class WEBCORE_EXPORT RealtimeMediaSourceCenter : public ThreadSafeRefCounted<RealtimeMediaSourceCenter, WTF::DestructionThread::MainRunLoop> {
+class WEBCORE_EXPORT RealtimeMediaSourceCenter : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeMediaSourceCenter, WTF::DestructionThread::MainRunLoop> {
 public:
     ~RealtimeMediaSourceCenter();
 

--- a/Source/WebCore/platform/mock/MockAudioDestinationCocoa.h
+++ b/Source/WebCore/platform/mock/MockAudioDestinationCocoa.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_AUDIO) && PLATFORM(COCOA)
 
 #include "AudioDestinationCocoa.h"
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WorkQueue.h>
@@ -36,7 +37,7 @@ namespace WebCore {
 
 class AudioIOCallback;
 
-class MockAudioDestinationCocoa final : public AudioDestinationCocoa {
+class MockAudioDestinationCocoa final : public AudioDestinationCocoa, public CanMakeWeakPtr<MockAudioDestinationCocoa> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(MockAudioDestinationCocoa, WEBCORE_EXPORT);
 public:
     static Ref<AudioDestination> create(const CreationOptions& options)

--- a/Source/WebKit/NetworkProcess/glib/DNSCache.h
+++ b/Source/WebKit/NetworkProcess/glib/DNSCache.h
@@ -28,7 +28,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/MonotonicTime.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
@@ -38,7 +38,7 @@ typedef struct _GInetAddress GInetAddress;
 
 namespace WebKit {
 
-class DNSCache : public RefCounted<DNSCache> {
+class DNSCache : public RefCountedAndCanMakeWeakPtr<DNSCache> {
 public:
     static Ref<DNSCache> create();
 

--- a/Source/WebKit/Shared/API/APISerializedScriptValue.cpp
+++ b/Source/WebKit/Shared/API/APISerializedScriptValue.cpp
@@ -28,6 +28,7 @@
 
 #include <JavaScriptCore/JSRemoteInspector.h>
 #include <JavaScriptCore/JSRetainPtr.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
 #include <wtf/RuntimeApplicationChecks.h>
@@ -36,7 +37,7 @@ namespace API {
 
 static constexpr auto SharedJSContextWKMaxIdleTime = 10_s;
 
-class SharedJSContextWK {
+class SharedJSContextWK : public CanMakeWeakPtr<SharedJSContextWK> {
 public:
     static SharedJSContextWK& singleton()
     {

--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.h
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.h
@@ -30,7 +30,7 @@
 
 namespace WebKit {
 
-class IconDatabase : public ThreadSafeRefCounted<IconDatabase> {
+class IconDatabase : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<IconDatabase> {
 public:
     enum class AllowDatabaseWrite : bool { No, Yes };
 

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
@@ -31,6 +31,7 @@
 #include <WebCore/IntPoint.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/ListHashSet.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
 #include <wtf/Vector.h>
@@ -128,7 +129,7 @@ public:
     Vector<StateEntry> states;
 };
 
-class SimulatedInputDispatcher : public RefCounted<SimulatedInputDispatcher> {
+class SimulatedInputDispatcher : public RefCountedAndCanMakeWeakPtr<SimulatedInputDispatcher> {
     WTF_MAKE_NONCOPYABLE(SimulatedInputDispatcher);
 public:
     class Client {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h
@@ -31,7 +31,7 @@
 #include <WebCore/Timer.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -39,7 +39,7 @@ namespace WebKit {
 
 class WebExtensionContext;
 
-class WebExtensionAlarm : public RefCounted<WebExtensionAlarm> {
+class WebExtensionAlarm : public RefCountedAndCanMakeWeakPtr<WebExtensionAlarm> {
     WTF_MAKE_NONCOPYABLE(WebExtensionAlarm);
     WTF_MAKE_TZONE_ALLOCATED(WebExtensionAlarm);
 

--- a/Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.h
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)
 #include <WebCore/GamepadProvider.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Vector.h>
@@ -38,7 +39,7 @@ typedef struct _WPEGamepadManager WPEGamepadManager;
 namespace WebKit {
 class PlatformGamepadWPE;
 
-class GamepadProviderWPE final : public WebCore::GamepadProvider {
+class GamepadProviderWPE final : public WebCore::GamepadProvider, public CanMakeWeakPtr<GamepadProviderWPE> {
     WTF_MAKE_NONCOPYABLE(GamepadProviderWPE);
     friend class NeverDestroyed<GamepadProviderWPE>;
 public:

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/Page.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
@@ -35,7 +36,7 @@ namespace WebKit {
 class WebPageProxy;
 class WebProcessPool;
 
-class PerActivityStateCPUUsageSampler {
+class PerActivityStateCPUUsageSampler : public CanMakeWeakPtr<PerActivityStateCPUUsageSampler> {
     WTF_MAKE_TZONE_ALLOCATED(PerActivityStateCPUUsageSampler);
 public:
     explicit PerActivityStateCPUUsageSampler(WebProcessPool&);

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -32,6 +32,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/EnumTraits.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -89,7 +90,7 @@ public:
     }
 
 private:
-    class CachedAssertion : public RefCounted<CachedAssertion> {
+    class CachedAssertion : public RefCountedAndCanMakeWeakPtr<CachedAssertion> {
         WTF_MAKE_TZONE_ALLOCATED(CachedAssertion);
     public:
         static Ref<CachedAssertion> create(ProcessAssertionCache& cache, Ref<ProcessAssertion>&& assertion)

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -88,7 +88,7 @@ private:
     IsQuietActivity m_isQuietActivity;
 };
 
-class ProcessThrottlerTimedActivity : public RefCounted<ProcessThrottlerTimedActivity> {
+class ProcessThrottlerTimedActivity : public RefCountedAndCanMakeWeakPtr<ProcessThrottlerTimedActivity> {
     WTF_MAKE_TZONE_ALLOCATED(ProcessThrottlerTimedActivity);
     WTF_MAKE_NONCOPYABLE(ProcessThrottlerTimedActivity);
     using Activity = ProcessThrottlerActivity;

--- a/Source/WebKit/UIProcess/ResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/ResponsivenessTimer.h
@@ -28,13 +28,13 @@
 
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/FastMalloc.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
 
-class ResponsivenessTimer : public RefCounted<ResponsivenessTimer> {
+class ResponsivenessTimer : public RefCountedAndCanMakeWeakPtr<ResponsivenessTimer> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ResponsivenessTimer);
 public:
     class Client : public AbstractRefCountedAndCanMakeWeakPtr<Client> {

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -29,7 +29,7 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -39,7 +39,7 @@ class SuspendedPageProxy;
 class WebBackForwardCache;
 class WebProcessProxy;
 
-class WebBackForwardCacheEntry : public RefCounted<WebBackForwardCacheEntry> {
+class WebBackForwardCacheEntry : public RefCountedAndCanMakeWeakPtr<WebBackForwardCacheEntry> {
     WTF_MAKE_TZONE_ALLOCATED(WebBackForwardCacheEntry);
 public:
     static Ref<WebBackForwardCacheEntry> create(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, RefPtr<SuspendedPageProxy>&&);

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -32,6 +32,7 @@
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
@@ -74,7 +75,7 @@ private:
     static Seconds clearingDelayAfterApplicationResignsActive;
     static int capacityOverride;
 
-    class CachedProcess : public RefCounted<CachedProcess> {
+    class CachedProcess : public RefCountedAndCanMakeWeakPtr<CachedProcess> {
         WTF_MAKE_TZONE_ALLOCATED(CachedProcess);
     public:
         static Ref<CachedProcess> create(Ref<WebProcessProxy>&&, Seconds);

--- a/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h
+++ b/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import <wtf/CanMakeWeakPtr.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/Noncopyable.h>
 #import <wtf/RetainPtr.h>
@@ -39,7 +40,7 @@
 
 namespace WebKit {
 
-class GestureRecognizerConsistencyEnforcer {
+class GestureRecognizerConsistencyEnforcer : public CanMakeWeakPtr<GestureRecognizerConsistencyEnforcer> {
     WTF_MAKE_TZONE_ALLOCATED(GestureRecognizerConsistencyEnforcer);
     WTF_MAKE_NONCOPYABLE(GestureRecognizerConsistencyEnforcer);
 public:

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -31,6 +31,7 @@
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceLoader.h>
 #include <WebCore/ResourceResponse.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/RunLoop.h>
@@ -49,7 +50,7 @@ class WebPage;
 class WebProcess;
 class WebURLSchemeTaskProxy;
 
-class WebLoaderStrategy final : public WebCore::LoaderStrategy {
+class WebLoaderStrategy final : public WebCore::LoaderStrategy, public CanMakeWeakPtr<WebLoaderStrategy> {
     WTF_MAKE_TZONE_ALLOCATED(WebLoaderStrategy);
     WTF_MAKE_NONCOPYABLE(WebLoaderStrategy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebLoaderStrategy);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -67,7 +67,7 @@ class AcceleratedSurface;
 namespace WebKit {
 class WebPage;
 
-class AcceleratedSurface final : public ThreadSafeRefCounted<AcceleratedSurface, WTF::DestructionThread::MainRunLoop>
+class AcceleratedSurface final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AcceleratedSurface, WTF::DestructionThread::MainRunLoop>
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
     , public IPC::MessageReceiver
 #endif
@@ -78,8 +78,8 @@ public:
     ~AcceleratedSurface();
 
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
-    void ref() const final { ThreadSafeRefCounted::ref(); }
-    void deref() const final { ThreadSafeRefCounted::deref(); }
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 #endif
 
 public:

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -52,7 +52,7 @@ class CoordinatedSceneState;
 class LayerTreeHost;
 struct RenderProcessInfo;
 
-class ThreadedCompositor : public ThreadSafeRefCounted<ThreadedCompositor>, public CanMakeThreadSafeCheckedPtr<ThreadedCompositor> {
+class ThreadedCompositor : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ThreadedCompositor>, public CanMakeThreadSafeCheckedPtr<ThreadedCompositor> {
     WTF_MAKE_TZONE_ALLOCATED(ThreadedCompositor);
     WTF_MAKE_NONCOPYABLE(ThreadedCompositor);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ThreadedCompositor);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedDisplayRefreshMonitorPlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedDisplayRefreshMonitorPlayStation.h
@@ -28,13 +28,14 @@
 #include <WebCore/DisplayRefreshMonitor.h>
 
 #if USE(COORDINATED_GRAPHICS)
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
 
 namespace WebKit {
 
 class ThreadedCompositor;
 
-class ThreadedDisplayRefreshMonitor : public WebCore::DisplayRefreshMonitor {
+class ThreadedDisplayRefreshMonitor : public WebCore::DisplayRefreshMonitor, public CanMakeWeakPtr<ThreadedDisplayRefreshMonitor> {
 public:
     class Client {
     public:

--- a/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
@@ -120,7 +120,7 @@ TEST(WTF_RunLoop, CallOnMainCrossThreadWhileNested)
     Util::run(&done);
 }
 
-class DerivedOneShotTimer : public RunLoop::Timer, public CanMakeCheckedPtr<DerivedOneShotTimer> {
+class DerivedOneShotTimer : public CanMakeWeakPtr<DerivedOneShotTimer>, public CanMakeCheckedPtr<DerivedOneShotTimer>, public RunLoop::Timer {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DerivedOneShotTimer);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DerivedOneShotTimer);
 public:
@@ -154,7 +154,7 @@ TEST(WTF_RunLoop, OneShotTimer)
     Util::run(&testFinished);
 }
 
-class DerivedRepeatingTimer : public RunLoop::Timer, public CanMakeCheckedPtr<DerivedRepeatingTimer> {
+class DerivedRepeatingTimer : public CanMakeWeakPtr<DerivedRepeatingTimer>, public CanMakeCheckedPtr<DerivedRepeatingTimer>, public RunLoop::Timer {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DerivedRepeatingTimer);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DerivedRepeatingTimer);
 public:


### PR DESCRIPTION
#### 9f9402e226ed168712b8cafddb7c96b9b53354f2
<pre>
Stop capturing raw pointers in RunLoop::Timer constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=301496">https://bugs.webkit.org/show_bug.cgi?id=301496</a>

Reviewed by Ryosuke Niwa.

Stop capturing raw pointers in RunLoop::Timer constructors, as this isn&apos;t safe.
Capture weak pointers instead.

* Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp:
(JSC::JSRunLoopTimer::Manager::singleton):
* Source/JavaScriptCore/runtime/JSRunLoopTimer.h:
(JSC::JSRunLoopTimer::Manager::ref const): Deleted.
(JSC::JSRunLoopTimer::Manager::deref const): Deleted.
* Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WTF/wtf/MemoryPressureHandler.h:
* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/linux/RealTimeThreads.h:
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.h:
* Source/WebCore/platform/MainThreadSharedTimer.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h:
* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h:
* Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h:
* Source/WebCore/platform/graphics/cg/IOSurfacePool.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.h:
* Source/WebCore/platform/graphics/win/DisplayRefreshMonitorWin.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:
* Source/WebCore/platform/mock/MockAudioDestinationCocoa.h:
* Source/WebKit/NetworkProcess/glib/DNSCache.h:
* Source/WebKit/Shared/API/APISerializedScriptValue.cpp:
* Source/WebKit/UIProcess/API/glib/IconDatabase.h:
* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h:
* Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.h:
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/ResponsivenessTimer.h:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
* Source/WebKit/UIProcess/WebProcessCache.h:
* Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedDisplayRefreshMonitorPlayStation.h:
* Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp:

Canonical link: <a href="https://commits.webkit.org/302261@main">https://commits.webkit.org/302261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6e15413ca44feee5813fc670845e8ad1974bd35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135857 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79908 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d6e9f0d3-7338-430e-88bf-560bae49408d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130335 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97794 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65702 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3d05c8dc-a934-49dd-ba0b-e2092dca97e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115095 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78405 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2b06501f-45ed-4285-8727-908152172043) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33203 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79139 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120477 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138306 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126923 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106335 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106145 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27053 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29977 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52905 "Hash f6e15413 for PR 53018 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/626 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63820 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159946 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/516 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39947 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/579 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/583 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->