### PR TITLE
[iOS Debug] TestWebKitAPI.IndexedDB.IndexedDBSuspendImminently is a failure/timeout

### DIFF
--- a/Source/WTF/wtf/SuspendableWorkQueue.cpp
+++ b/Source/WTF/wtf/SuspendableWorkQueue.cpp
@@ -161,4 +161,12 @@ void SuspendableWorkQueue::suspendIfNeeded()
     RELEASE_LOG_IF(m_shouldLog, SuspendableWorkQueue, "%p - SuspendableWorkQueue::suspendIfNeeded end suspension", this);
 }
 
+bool SuspendableWorkQueue::isSuspended() const
+{
+    ASSERT(isMainThread());
+    Locker suspensionLocker { m_suspensionLock };
+
+    return m_state == State::Suspended;
+}
+
 } // namespace WTF

--- a/Source/WTF/wtf/SuspendableWorkQueue.h
+++ b/Source/WTF/wtf/SuspendableWorkQueue.h
@@ -43,6 +43,7 @@ public:
     void dispatch(Function<void()>&&) final;
     void dispatchAfter(Seconds, Function<void()>&&) final;
     void dispatchSync(Function<void()>&&) final;
+    bool isSuspended() const;
 
 private:
     SuspendableWorkQueue(ASCIILiteral name, QOS, ShouldLog);
@@ -56,7 +57,7 @@ private:
     enum class State : uint8_t { Running, WillSuspend, Suspended };
     static ASCIILiteral stateString(State);
 
-    Lock m_suspensionLock;
+    mutable Lock m_suspensionLock;
     Condition m_suspensionCondition;
     State m_state WTF_GUARDED_BY_LOCK(m_suspensionLock) { State::Running };
     Function<void()> m_suspendFunction WTF_GUARDED_BY_LOCK(m_suspensionLock);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2424,6 +2424,15 @@ void NetworkProcess::runningOrTerminatingServiceWorkerCountForTesting(PAL::Sessi
     completionHandler(session->ensureSWServer().runningOrTerminatingCount());
 }
 
+void NetworkProcess::isStorageSuspendedForTesting(PAL::SessionID sessionID, CompletionHandler<void(bool)>&& completionHandler)
+{
+    CheckedPtr session = networkSession(sessionID);
+    if (!session)
+        return completionHandler(true);
+
+    completionHandler(session->storageManager().isSuspended());
+}
+
 void NetworkProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime, CompletionHandler<void()>&& completionHandler)
 {
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h.orig
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h.orig
@@ -216,7 +216,6 @@ public:
     void addStorageSession(PAL::SessionID, const WebsiteDataStoreParameters&);
 
     void processWillSuspendImminentlyForTestingSync(CompletionHandler<void()>&&);
-    void isStorageSuspendedForTesting(PAL::SessionID, CompletionHandler<void(bool)>&&);
     void prepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime, CompletionHandler<void()>&&);
     void processDidResume(bool forForegroundActivity);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -84,6 +84,7 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     SetCacheModelSynchronouslyForTesting(enum:uint8_t WebKit::CacheModel cacheModel) -> () Synchronous
 
     ProcessWillSuspendImminentlyForTestingSync() -> () Synchronous
+    IsStorageSuspendedForTesting(PAL::SessionID sessionID) -> (bool isStorageSuspended)
     PrepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime) -> ()
     ProcessDidResume(bool forForegroundActivity)
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1332,6 +1332,13 @@ void NetworkStorageManager::suspend(CompletionHandler<void()>&& completionHandle
     }, WTFMove(completionHandler));
 }
 
+bool NetworkStorageManager::isSuspended() const
+{
+    ASSERT(RunLoop::isMain());
+
+    return workQueue().isSuspended();
+}
+
 void NetworkStorageManager::resume()
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -126,6 +126,7 @@ public:
     void moveData(OptionSet<WebsiteDataType>, WebCore::SecurityOriginData&& source, WebCore::SecurityOriginData&& target, CompletionHandler<void()>&&);
     void getOriginDirectory(WebCore::ClientOrigin&&, WebsiteDataType, CompletionHandler<void(const String&)>&&);
     void suspend(CompletionHandler<void()>&&);
+    bool isSuspended() const;
     void resume();
     void handleLowMemoryWarning();
     void syncLocalStorage(CompletionHandler<void()>&&);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1603,6 +1603,14 @@ struct WKWebsiteData {
     }).get()];
 }
 
+- (void)_isStorageSuspendedForTesting:(void(^)(BOOL))completionHandler
+{
+    auto completionHandlerCopy = makeBlockPtr(completionHandler);
+    protectedWebsiteDataStore(self)->isStorageSuspendedForTesting([completionHandlerCopy = WTFMove(completionHandlerCopy)](auto result) {
+        completionHandlerCopy(result);
+    });
+}
+
 @end
 
 #if PLATFORM(IOS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -160,6 +160,8 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 - (void)_fetchDataOfTypes:(NSSet<NSString *> *)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSData *))completionHandler WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 - (void)_restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 
+- (void)_isStorageSuspendedForTesting:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1372,6 +1372,11 @@ void NetworkProcessProxy::sendProcessWillSuspendImminentlyForTesting()
         sendSync(Messages::NetworkProcess::ProcessWillSuspendImminentlyForTestingSync(), 0);
 }
 
+void NetworkProcessProxy::isStorageSuspendedForTesting(PAL::SessionID sessionID, CompletionHandler<void(bool)>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::NetworkProcess::IsStorageSuspendedForTesting(sessionID), WTFMove(completionHandler), 0, { }, ShouldStartProcessThrottlerActivity::No);
+}
+
 static bool s_suspensionAllowedForTesting { true };
 void NetworkProcessProxy::setSuspensionAllowedForTesting(bool allowed)
 {

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -293,6 +293,8 @@ public:
     void getPaymentCoordinatorEmbeddingUserAgent(WebPageProxyIdentifier, CompletionHandler<void(const String&)>&&);
 #endif
 
+    void isStorageSuspendedForTesting(PAL::SessionID, CompletionHandler<void(bool)>&&);
+
     // ProcessThrottlerClient
     void sendPrepareToSuspend(IsSuspensionImminent, double remainingRunTime, CompletionHandler<void()>&&) final;
     void updateBundleIdentifier(const String&, CompletionHandler<void()>&&);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2944,4 +2944,9 @@ void WebsiteDataStore::clearStorageAccessForTesting(CompletionHandler<void()>&& 
     protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::ClearStorageAccessForTesting(m_sessionID), WTFMove(completionHandler));
 }
 
+void WebsiteDataStore::isStorageSuspendedForTesting(CompletionHandler<void(bool)>&& completionHandler) const
+{
+    protectedNetworkProcess()->isStorageSuspendedForTesting(m_sessionID, WTFMove(completionHandler));
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -521,6 +521,7 @@ public:
 
     void setStorageAccessPermissionForTesting(bool, WebPageProxyIdentifier, const String& topFrameDomain, const String& subFrameDomain, CompletionHandler<void()>&&);
     void clearStorageAccessForTesting(CompletionHandler<void()>&&);
+    void isStorageSuspendedForTesting(CompletionHandler<void(bool)>&&) const;
 
 private:
     enum class ForceReinitialization : bool { No, Yes };


### PR DESCRIPTION
#### d6d6abb3a36698632c2ff61b7737c28d6d84adbe
<pre>
[iOS Debug] TestWebKitAPI.IndexedDB.IndexedDBSuspendImminently is a failure/timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=290203">https://bugs.webkit.org/show_bug.cgi?id=290203</a>
<a href="https://rdar.apple.com/147599411">rdar://147599411</a>

Reviewed by Per Arne Vollan.

The current flow of API test IndexedDB.IndexedDBSuspendImminently is:
1. UI process sends suspend message to network process
2. Network process handles suspend message, aborting active transaction and suspending storage work queue
3. Web process sends message to network process to put record (test script keeps updating record)
4. Network process handles put record message and replies with error (as the transaction is no longer active)
5. Web process receives request error and sends message to network process to abort transaction due to error
6. Network process handles abort transaction message and replies with success (as the requested transaction is aborted)
7. Web process receives request success and fire abort event to IDBTransaction -- this is where &quot;Expected Abort For
Suspension&quot; message is sent to UI process
8. UI process sends resume message to network process
9. Network process handles resume message, resuming storage work queue to proceed pending requests
10. (Test script continues: new transaction will be started and will succeed)

The test is timed out because &quot;Expected Abort For Suspension&quot; message is never sent. The cause is, after step 2, storage
work queue in network process is suspended and will no longer proceeds storage message. This means step 4 or step 6
will not happen as expected. To fix this, now we make UI process send the resume message after it notices the storage
queue has been suspended with IsStorageSuspendedForTesting message. If the storage queue has been suspended, that means
the active transaction is aborted (IDBStorageManager::stopDatabaseActivitiesForSuspend is called), and the test can
continue to validate the transaction states as expected.

The new test flow is essentially moving step 8 and step 9 to after step 2 and after UI process knows storage queue has
been suspended.

* Source/WTF/wtf/SuspendableWorkQueue.cpp:
(WTF::SuspendableWorkQueue::isSuspended const):
* Source/WTF/wtf/SuspendableWorkQueue.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::isStorageSuspendedForTesting):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h.orig: Copied from Source/WebKit/NetworkProcess/NetworkProcess.h.
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::isSuspended const):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _isStorageSuspendedForTesting:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::isStorageSuspendedForTesting):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::isStorageSuspendedForTesting const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBSuspendImminently.mm:
(TEST(IndexedDB, IndexedDBSuspendImminently)):
(TEST(IndexedDB, DISABLED_IndexedDBSuspendImminently)): Deleted.

Canonical link: <a href="https://commits.webkit.org/302265@main">https://commits.webkit.org/302265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ab5fc2d54622a5e794aea564b4ec753dd2dd3b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79952 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/80607ba2-d6bd-4787-9dbe-f698ec25b371) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130391 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97837 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65751 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1a5e17bf-0706-4abf-bcc8-0b3c48b2bcd8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78449 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d5c83595-f5d6-48df-99f4-01282de4a7f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33253 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79194 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120533 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138360 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126979 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106372 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106186 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27055 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/522 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30026 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52960 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/680 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63880 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160001 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/562 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39960 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/634 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->