### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for WebAVSampleBufferListenerClient

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.h
+++ b/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <CoreMedia/CMTime.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakPtr.h>
 
@@ -36,17 +37,8 @@ OBJC_CLASS WebAVSampleBufferListenerPrivate;
 OBJC_PROTOCOL(WebSampleBufferVideoRendering);
 
 namespace WebCore {
-class WebAVSampleBufferListenerClient;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::WebAVSampleBufferListenerClient> : std::true_type { };
-}
-
-namespace WebCore {
-
-class WebAVSampleBufferListenerClient : public CanMakeWeakPtr<WebAVSampleBufferListenerClient> {
+class WebAVSampleBufferListenerClient : public AbstractRefCountedAndCanMakeWeakPtr<WebAVSampleBufferListenerClient> {
 public:
     virtual ~WebAVSampleBufferListenerClient() = default;
     virtual void videoRendererDidReceiveError(WebSampleBufferVideoRendering *, NSError *) { }

--- a/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
@@ -173,7 +173,7 @@ static bool isSampleBufferVideoRenderer(id object)
 
             ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), error = WTFMove(error)] {
                 ASSERT(_videoRenderers.contains(renderer.get()));
-                if (auto client = _client.get())
+                if (RefPtr client = _client.get())
                     client->videoRendererDidReceiveError(renderer.get(), error.get());
             });
             return;
@@ -184,7 +184,7 @@ static bool isSampleBufferVideoRenderer(id object)
 
             ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), error = WTFMove(error)] {
                 ASSERT(_audioRenderers.contains(renderer.get()));
-                if (auto client = _client.get())
+                if (RefPtr client = _client.get())
                     client->audioRendererDidReceiveError(renderer.get(), error.get());
             });
             return;
@@ -200,7 +200,7 @@ static bool isSampleBufferVideoRenderer(id object)
 
         ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), isObscured] {
             ASSERT(_videoRenderers.contains(renderer.get()));
-            if (auto client = _client.get())
+            if (RefPtr client = _client.get())
                 client->outputObscuredDueToInsufficientExternalProtectionChanged(isObscured);
         });
         return;
@@ -217,7 +217,7 @@ static bool isSampleBufferVideoRenderer(id object)
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), error = WTFMove(error)] {
         if (!_videoRenderers.contains(renderer.get()))
             return;
-        if (auto client = _client.get())
+        if (RefPtr client = _client.get())
             client->videoRendererDidReceiveError(renderer.get(), error.get());
     });
 }
@@ -230,7 +230,7 @@ static bool isSampleBufferVideoRenderer(id object)
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), requiresFlush] {
         if (!_videoRenderers.contains(renderer.get()))
             return;
-        if (auto client = _client.get())
+        if (RefPtr client = _client.get())
             client->videoRendererRequiresFlushToResumeDecodingChanged(renderer.get(), requiresFlush);
     });
 }
@@ -246,7 +246,7 @@ static bool isSampleBufferVideoRenderer(id object)
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, layer = WTFMove(layer), isReadyForDisplay] {
         if (!_videoRenderers.contains(layer.get()))
             return;
-        if (auto client = _client.get())
+        if (RefPtr client = _client.get())
             client->videoRendererReadyForDisplayChanged(layer.get(), isReadyForDisplay);
     });
 }
@@ -259,7 +259,7 @@ static bool isSampleBufferVideoRenderer(id object)
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), flushTime] {
         if (!_audioRenderers.contains(renderer.get()))
             return;
-        if (auto client = _client.get())
+        if (RefPtr client = _client.get())
             client->audioRendererWasAutomaticallyFlushed(renderer.get(), flushTime);
     });
 }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -78,7 +78,7 @@ class MediaPlayerPrivateWebM
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaPlayerPrivateWebM, WTF::DestructionThread::Main> {
     WTF_MAKE_TZONE_ALLOCATED(MediaPlayerPrivateWebM);
 public:
-    MediaPlayerPrivateWebM(MediaPlayer*);
+    static Ref<MediaPlayerPrivateWebM> create(MediaPlayer*);
     ~MediaPlayerPrivateWebM();
 
     constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::CocoaWebM; }
@@ -88,6 +88,8 @@ public:
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 private:
+    explicit MediaPlayerPrivateWebM(MediaPlayer*);
+
     void setPreload(MediaPlayer::Preload) final;
     void doPreload();
     void load(const URL&, const LoadOptions&) final;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -88,6 +88,11 @@ Ref<AudioVideoRenderer> MediaPlayerPrivateWebM::createRenderer(LoggerHelper& log
     return AudioVideoRendererAVFObjC::create(Ref { loggerHelper.logger() }, loggerHelper.logIdentifier());
 }
 
+Ref<MediaPlayerPrivateWebM> MediaPlayerPrivateWebM::create(MediaPlayer* player)
+{
+    return adoptRef(*new MediaPlayerPrivateWebM(player));
+}
+
 MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
     : m_player(player)
     , m_parser(SourceBufferParserWebM::create().releaseNonNull())
@@ -1371,7 +1376,7 @@ private:
 
     Ref<MediaPlayerPrivateInterface> createMediaEnginePlayer(MediaPlayer* player) const final
     {
-        return adoptRef(*new MediaPlayerPrivateWebM(player));
+        return MediaPlayerPrivateWebM::create(player);
     }
 
     void getSupportedTypes(HashSet<String>& types) const final

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -65,6 +65,9 @@ public:
     static Ref<VideoMediaSampleRenderer> create(WebSampleBufferVideoRendering *renderer) { return adoptRef(*new VideoMediaSampleRenderer(renderer)); }
     ~VideoMediaSampleRenderer();
 
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+
     using Preferences = VideoRendererPreferences;
     bool prefersDecompressionSession() const;
     void setPreferences(Preferences);


### PR DESCRIPTION
#### 42ae502c4d3f02c115ebfeaa6a813b3ededfa772
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for WebAVSampleBufferListenerClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=301498">https://bugs.webkit.org/show_bug.cgi?id=301498</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.h:
* Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm:
(-[WebAVSampleBufferListenerPrivate observeValueForKeyPath:ofObject:change:context:]):
(-[WebAVSampleBufferListenerPrivate layerFailedToDecode:]):
(-[WebAVSampleBufferListenerPrivate layerRequiresFlushToResumeDecodingChanged:]):
(-[WebAVSampleBufferListenerPrivate layerReadyForDisplayChanged:]):
(-[WebAVSampleBufferListenerPrivate audioRendererWasAutomaticallyFlushed:]):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::create):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:

Canonical link: <a href="https://commits.webkit.org/302182@main">https://commits.webkit.org/302182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5687a5236f5b11a01f95c5e592ee8a712348831e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135645 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79736 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/daa2a8e7-1aeb-4de6-879e-f82a02d01d4d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97622 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65531 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e4062305-1100-41d9-83a9-e0a6ca68fbdd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114894 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78209 "Found 4 new API test failures: WPE/TestWebKitWebView:/webkit/WebKitWebView/ephemeral, WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak, WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp, WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c20438cb-2b0a-449a-a714-a6c89d93dcef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/294 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33002 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78933 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138099 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106159 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105959 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27005 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/302 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29789 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52673 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/429 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63319 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/337 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/407 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/394 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->