### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for RTCDataChannelHandlerClient

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp
@@ -55,27 +55,32 @@ RTCDataChannelRemoteHandler::~RTCDataChannelRemoteHandler() = default;
 
 void RTCDataChannelRemoteHandler::didChangeReadyState(RTCDataChannelState state)
 {
-    m_client->didChangeReadyState(state);
+    if (RefPtr client = m_client.get())
+        client->didChangeReadyState(state);
 }
 
 void RTCDataChannelRemoteHandler::didReceiveStringData(String&& text)
 {
-    m_client->didReceiveStringData(text);
+    if (RefPtr client = m_client.get())
+        client->didReceiveStringData(text);
 }
 
 void RTCDataChannelRemoteHandler::didReceiveRawData(std::span<const uint8_t> data)
 {
-    m_client->didReceiveRawData(data);
+    if (RefPtr client = m_client.get())
+        client->didReceiveRawData(data);
 }
 
 void RTCDataChannelRemoteHandler::didDetectError(Ref<RTCError>&& error)
 {
-    m_client->didDetectError(WTFMove(error));
+    if (RefPtr client = m_client.get())
+        client->didDetectError(WTFMove(error));
 }
 
 void RTCDataChannelRemoteHandler::bufferedAmountIsDecreasing(size_t amount)
 {
-    m_client->bufferedAmountIsDecreasing(amount);
+    if (RefPtr client = m_client.get())
+        client->bufferedAmountIsDecreasing(amount);
 }
 
 void RTCDataChannelRemoteHandler::readyToSend()
@@ -92,7 +97,7 @@ void RTCDataChannelRemoteHandler::readyToSend()
 
 void RTCDataChannelRemoteHandler::setClient(RTCDataChannelHandlerClient& client, std::optional<ScriptExecutionContextIdentifier> contextIdentifier)
 {
-    m_client = &client;
+    m_client = client;
     m_connection->connectToSource(*this, contextIdentifier, *m_localIdentifier, m_remoteIdentifier);
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h
@@ -77,7 +77,7 @@ private:
     RTCDataChannelIdentifier m_remoteIdentifier;
     Markable<RTCDataChannelIdentifier> m_localIdentifier;
 
-    RTCDataChannelHandlerClient* m_client { nullptr };
+    WeakPtr<RTCDataChannelHandlerClient> m_client;
     const Ref<RTCDataChannelRemoteHandlerConnection> m_connection;
 
     struct Message {

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.cpp
@@ -36,6 +36,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RTCDataChannelRemoteSource);
 
+Ref<RTCDataChannelRemoteSource> RTCDataChannelRemoteSource::create(RTCDataChannelIdentifier identifier, UniqueRef<RTCDataChannelHandler>&& handler, Ref<RTCDataChannelRemoteSourceConnection>&& connection)
+{
+    return adoptRef(*new RTCDataChannelRemoteSource(identifier, WTFMove(handler), WTFMove(connection)));
+}
+
 RTCDataChannelRemoteSource::RTCDataChannelRemoteSource(RTCDataChannelIdentifier identifier, UniqueRef<RTCDataChannelHandler>&& handler, Ref<RTCDataChannelRemoteSourceConnection>&& connection)
     : m_identifier(identifier)
     , m_handler(WTFMove(handler))

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.h
@@ -31,22 +31,27 @@
 #include <WebCore/RTCDataChannelIdentifier.h>
 #include <WebCore/RTCDataChannelRemoteSourceConnection.h>
 #include <WebCore/RTCError.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebCore {
 
-class RTCDataChannelRemoteSource : public RTCDataChannelHandlerClient {
+class RTCDataChannelRemoteSource : public RTCDataChannelHandlerClient, public RefCounted<RTCDataChannelRemoteSource> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(RTCDataChannelRemoteSource, WEBCORE_EXPORT);
 public:
-    WEBCORE_EXPORT RTCDataChannelRemoteSource(RTCDataChannelIdentifier, UniqueRef<RTCDataChannelHandler>&&, Ref<RTCDataChannelRemoteSourceConnection>&&);
+    WEBCORE_EXPORT static Ref<RTCDataChannelRemoteSource> create(RTCDataChannelIdentifier, UniqueRef<RTCDataChannelHandler>&&, Ref<RTCDataChannelRemoteSourceConnection>&&);
     ~RTCDataChannelRemoteSource();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void sendStringData(const CString& text) { m_handler->sendStringData(text); }
     void sendRawData(std::span<const uint8_t> data) { m_handler->sendRawData(data); }
     void close() { m_handler->close(); }
 
 private:
+    WEBCORE_EXPORT RTCDataChannelRemoteSource(RTCDataChannelIdentifier, UniqueRef<RTCDataChannelHandler>&&, Ref<RTCDataChannelRemoteSourceConnection>&&);
 
     // RTCDataChannelHandlerClient
     void didChangeReadyState(RTCDataChannelState state) final { m_connection->didChangeReadyState(m_identifier, state); }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
@@ -175,7 +175,8 @@ void LibWebRTCDataChannelHandler::checkState()
         m_bufferedMessages.append(StateChange { state, WTFMove(error) });
         return;
     }
-    postTask([client = m_client, state, error = WTFMove(error)] {
+    postTask([weakClient = m_client, state, error = WTFMove(error)] {
+        RefPtr client = weakClient.get();
         if (!client)
             return;
         if (error && !error->ok()) {
@@ -201,7 +202,8 @@ void LibWebRTCDataChannelHandler::OnMessage(const webrtc::DataBuffer& buffer)
     }
 
     std::unique_ptr<webrtc::DataBuffer> protectedBuffer(new webrtc::DataBuffer(buffer));
-    postTask([client = m_client, buffer = WTFMove(protectedBuffer)] {
+    postTask([weakClient = m_client, buffer = WTFMove(protectedBuffer)] {
+        RefPtr client = weakClient.get();
         if (!client)
             return;
 
@@ -219,8 +221,8 @@ void LibWebRTCDataChannelHandler::OnBufferedAmountChange(uint64_t amount)
     if (!m_hasClient)
         return;
 
-    postTask([client = m_client, amount] {
-        if (client)
+    postTask([weakClient = m_client, amount] {
+        if (RefPtr client = weakClient.get())
             client->bufferedAmountIsDecreasing(static_cast<uint64_t>(amount));
     });
 }

--- a/Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.h
@@ -28,24 +28,15 @@
 #if ENABLE(WEB_RTC)
 
 #include <WebCore/RTCDataChannelState.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
-
-namespace WebCore {
-class RTCDataChannelHandlerClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::RTCDataChannelHandlerClient> : std::true_type { };
-}
 
 namespace WebCore {
 
 class RTCError;
 
-class RTCDataChannelHandlerClient : public CanMakeWeakPtr<RTCDataChannelHandlerClient, WeakPtrFactoryInitialization::Eager> {
+class RTCDataChannelHandlerClient : public AbstractRefCountedAndCanMakeWeakPtr<RTCDataChannelHandlerClient, WeakPtrFactoryInitialization::Eager> {
 public:
     virtual ~RTCDataChannelHandlerClient() = default;
 

--- a/Source/WebCore/platform/mock/RTCDataChannelHandlerMock.cpp
+++ b/Source/WebCore/platform/mock/RTCDataChannelHandlerMock.cpp
@@ -47,26 +47,32 @@ RTCDataChannelHandlerMock::RTCDataChannelHandlerMock(const String& label, const 
 void RTCDataChannelHandlerMock::setClient(RTCDataChannelHandlerClient& client, std::optional<ScriptExecutionContextIdentifier>)
 {
     ASSERT(!m_client);
-    m_client = &client;
-    auto notifier = adoptRef(*new DataChannelStateNotifier(m_client, RTCDataChannelState::Open));
+    m_client = client;
+    auto notifier = adoptRef(*new DataChannelStateNotifier(&client, RTCDataChannelState::Open));
     m_timerEvents.append(adoptRef(new TimerEvent(this, WTFMove(notifier))));
 }
 
 bool RTCDataChannelHandlerMock::sendStringData(const CString& string)
 {
-    m_client->didReceiveStringData(String::fromUTF8(string.span()));
+    if (RefPtr client = m_client.get())
+        client->didReceiveStringData(String::fromUTF8(string.span()));
     return true;
 }
 
 bool RTCDataChannelHandlerMock::sendRawData(std::span<const uint8_t> data)
 {
-    m_client->didReceiveRawData(data);
+    if (RefPtr client = m_client.get())
+        client->didReceiveRawData(data);
     return true;
 }
 
 void RTCDataChannelHandlerMock::close()
 {
-    auto notifier = adoptRef(*new DataChannelStateNotifier(m_client, RTCDataChannelState::Closed));
+    RefPtr client = m_client.get();
+    if (!client)
+        return;
+
+    auto notifier = adoptRef(*new DataChannelStateNotifier(client.get(), RTCDataChannelState::Closed));
     m_timerEvents.append(adoptRef(new TimerEvent(this, WTFMove(notifier))));
 }
 

--- a/Source/WebCore/platform/mock/RTCDataChannelHandlerMock.h
+++ b/Source/WebCore/platform/mock/RTCDataChannelHandlerMock.h
@@ -45,7 +45,7 @@ private:
     bool sendRawData(std::span<const uint8_t>) final;
     void close() final;
 
-    RTCDataChannelHandlerClient* m_client { nullptr };
+    WeakPtr<RTCDataChannelHandlerClient> m_client;
 
     String m_label;
     String m_protocol;

--- a/Source/WebCore/platform/mock/RTCNotifiersMock.cpp
+++ b/Source/WebCore/platform/mock/RTCNotifiersMock.cpp
@@ -109,7 +109,8 @@ DataChannelStateNotifier::DataChannelStateNotifier(RTCDataChannelHandlerClient* 
 
 void DataChannelStateNotifier::fire()
 {
-    m_client->didChangeReadyState(m_state);
+    if (RefPtr client = m_client.get())
+        client->didChangeReadyState(m_state);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mock/RTCNotifiersMock.h
+++ b/Source/WebCore/platform/mock/RTCNotifiersMock.h
@@ -104,7 +104,7 @@ public:
     void fire() override;
 
 private:
-    RTCDataChannelHandlerClient* m_client;
+    WeakPtr<RTCDataChannelHandlerClient> m_client;
     RTCDataChannelState m_state;
 };
 

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
@@ -74,7 +74,7 @@ bool RTCDataChannelRemoteManager::connectToRemoteSource(WebCore::RTCDataChannelI
     if (!handler)
         return false;
 
-    auto iterator = m_sources.add(remoteIdentifier.object(), makeUniqueRef<WebCore::RTCDataChannelRemoteSource>(remoteIdentifier, makeUniqueRefFromNonNullUniquePtr(WTFMove(handler)), remoteSourceConnection()));
+    auto iterator = m_sources.add(remoteIdentifier.object(), WebCore::RTCDataChannelRemoteSource::create(remoteIdentifier, makeUniqueRefFromNonNullUniquePtr(WTFMove(handler)), remoteSourceConnection()));
     return iterator.isNewEntry;
 }
 
@@ -120,7 +120,7 @@ WebCore::RTCDataChannelRemoteSource* RTCDataChannelRemoteManager::sourceFromIden
 
 void RTCDataChannelRemoteManager::sendData(WebCore::RTCDataChannelIdentifier sourceIdentifier, bool isRaw, std::span<const uint8_t> data)
 {
-    if (auto* source = sourceFromIdentifier(sourceIdentifier)) {
+    if (RefPtr source = sourceFromIdentifier(sourceIdentifier)) {
         if (isRaw)
             source->sendRawData(data);
         else
@@ -130,7 +130,7 @@ void RTCDataChannelRemoteManager::sendData(WebCore::RTCDataChannelIdentifier sou
 
 void RTCDataChannelRemoteManager::close(WebCore::RTCDataChannelIdentifier sourceIdentifier)
 {
-    if (auto* source = sourceFromIdentifier(sourceIdentifier))
+    if (RefPtr source = sourceFromIdentifier(sourceIdentifier))
         source->close();
 }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
@@ -108,7 +108,7 @@ private:
     const Ref<IPC::Connection> m_connection;
     RefPtr<RemoteHandlerConnection> m_remoteHandlerConnection;
     RefPtr<RemoteSourceConnection> m_remoteSourceConnection;
-    HashMap<WebCore::RTCDataChannelLocalIdentifier, UniqueRef<WebCore::RTCDataChannelRemoteSource>> m_sources;
+    HashMap<WebCore::RTCDataChannelLocalIdentifier, Ref<WebCore::RTCDataChannelRemoteSource>> m_sources;
     HashMap<WebCore::RTCDataChannelLocalIdentifier, RemoteHandler> m_handlers;
 };
 


### PR DESCRIPTION
#### 0ea2b17a791b7044f37121d370aa6c55c8f84c38
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for RTCDataChannelHandlerClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=301499">https://bugs.webkit.org/show_bug.cgi?id=301499</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp:
(WebCore::RTCDataChannelRemoteHandler::didChangeReadyState):
(WebCore::RTCDataChannelRemoteHandler::didReceiveStringData):
(WebCore::RTCDataChannelRemoteHandler::didReceiveRawData):
(WebCore::RTCDataChannelRemoteHandler::didDetectError):
(WebCore::RTCDataChannelRemoteHandler::bufferedAmountIsDecreasing):
(WebCore::RTCDataChannelRemoteHandler::setClient):
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h:
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.cpp:
(WebCore::RTCDataChannelRemoteSource::create):
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp:
(WebCore::LibWebRTCDataChannelHandler::checkState):
(WebCore::LibWebRTCDataChannelHandler::OnMessage):
(WebCore::LibWebRTCDataChannelHandler::OnBufferedAmountChange):
* Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.h:
* Source/WebCore/platform/mock/RTCDataChannelHandlerMock.cpp:
(WebCore::RTCDataChannelHandlerMock::setClient):
(WebCore::RTCDataChannelHandlerMock::sendStringData):
(WebCore::RTCDataChannelHandlerMock::sendRawData):
(WebCore::RTCDataChannelHandlerMock::close):
* Source/WebCore/platform/mock/RTCDataChannelHandlerMock.h:
* Source/WebCore/platform/mock/RTCNotifiersMock.cpp:
(WebCore::DataChannelStateNotifier::fire):
* Source/WebCore/platform/mock/RTCNotifiersMock.h:
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp:
(WebKit::RTCDataChannelRemoteManager::connectToRemoteSource):
(WebKit::RTCDataChannelRemoteManager::sendData):
(WebKit::RTCDataChannelRemoteManager::close):
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h:

Canonical link: <a href="https://commits.webkit.org/302180@main">https://commits.webkit.org/302180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e68dd2287ec774d8c797a89a6f19de83ab49c25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135666 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/59a377e3-3537-4f5f-9465-c9573687e4f0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97635 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1a0c294a-1679-42b6-8395-d0468887e2bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114914 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78225 "Found 2 new API test failures: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak, WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a1243f90-ad40-479e-aa18-bd4421ed6733) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33021 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78954 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108683 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138120 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106173 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105975 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/314 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29807 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52690 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/447 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63376 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/353 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/412 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->