### PR TITLE
Implement the scriptlevel attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt
@@ -1,130 +1,130 @@
 
 PASS mathvariant on the math element is not mapped to CSS text-transform
-FAIL scriptlevel on the math element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the math element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the math element are not mapped to math-depth(...)
 PASS displaystyle on the math element is mapped to CSS math-style
 PASS mathvariant on the annotation element is not mapped to CSS text-transform
-FAIL scriptlevel on the annotation element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the annotation element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the annotation element are not mapped to math-depth(...)
 PASS displaystyle on the annotation element is mapped to CSS math-style
 PASS mathvariant on the annotation-xml element is not mapped to CSS text-transform
-FAIL scriptlevel on the annotation-xml element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the annotation-xml element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the annotation-xml element are not mapped to math-depth(...)
 PASS displaystyle on the annotation-xml element is mapped to CSS math-style
 PASS mathvariant on the maction element is not mapped to CSS text-transform
-FAIL scriptlevel on the maction element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the maction element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the maction element are not mapped to math-depth(...)
 PASS displaystyle on the maction element is mapped to CSS math-style
 PASS mathvariant on the menclose element is not mapped to CSS text-transform
-FAIL scriptlevel on the menclose element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the menclose element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the menclose element are not mapped to math-depth(...)
 PASS displaystyle on the menclose element is mapped to CSS math-style
 PASS mathvariant on the merror element is not mapped to CSS text-transform
-FAIL scriptlevel on the merror element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the merror element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the merror element are not mapped to math-depth(...)
 PASS displaystyle on the merror element is mapped to CSS math-style
 PASS mathvariant on the mfrac element is not mapped to CSS text-transform
-FAIL scriptlevel on the mfrac element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mfrac element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mfrac element are not mapped to math-depth(...)
 PASS displaystyle on the mfrac element is mapped to CSS math-style
 FAIL mathvariant on the mi element is  mapped to CSS text-transform assert_equals: no attribute expected "math-auto" but got "none"
-FAIL scriptlevel on the mi element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mi element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mi element are not mapped to math-depth(...)
 PASS displaystyle on the mi element is mapped to CSS math-style
 PASS mathvariant on the mmultiscripts element is not mapped to CSS text-transform
-FAIL scriptlevel on the mmultiscripts element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mmultiscripts element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mmultiscripts element are not mapped to math-depth(...)
 PASS displaystyle on the mmultiscripts element is mapped to CSS math-style
 PASS mathvariant on the mn element is not mapped to CSS text-transform
-FAIL scriptlevel on the mn element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mn element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mn element are not mapped to math-depth(...)
 PASS displaystyle on the mn element is mapped to CSS math-style
 PASS mathvariant on the mo element is not mapped to CSS text-transform
-FAIL scriptlevel on the mo element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mo element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mo element are not mapped to math-depth(...)
 PASS displaystyle on the mo element is mapped to CSS math-style
 PASS mathvariant on the mover element is not mapped to CSS text-transform
-FAIL scriptlevel on the mover element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mover element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mover element are not mapped to math-depth(...)
 PASS displaystyle on the mover element is mapped to CSS math-style
 PASS mathvariant on the mpadded element is not mapped to CSS text-transform
-FAIL scriptlevel on the mpadded element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mpadded element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mpadded element are not mapped to math-depth(...)
 PASS displaystyle on the mpadded element is mapped to CSS math-style
 PASS mathvariant on the mphantom element is not mapped to CSS text-transform
-FAIL scriptlevel on the mphantom element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mphantom element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mphantom element are not mapped to math-depth(...)
 PASS displaystyle on the mphantom element is mapped to CSS math-style
 PASS mathvariant on the mprescripts element is not mapped to CSS text-transform
-FAIL scriptlevel on the mprescripts element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "1"
+PASS scriptlevel on the mprescripts element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mprescripts element are not mapped to math-depth(...)
 PASS displaystyle on the mprescripts element is mapped to CSS math-style
 PASS mathvariant on the mroot element is not mapped to CSS text-transform
-FAIL scriptlevel on the mroot element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mroot element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mroot element are not mapped to math-depth(...)
 PASS displaystyle on the mroot element is mapped to CSS math-style
 PASS mathvariant on the mrow element is not mapped to CSS text-transform
-FAIL scriptlevel on the mrow element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mrow element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mrow element are not mapped to math-depth(...)
 PASS displaystyle on the mrow element is mapped to CSS math-style
 PASS mathvariant on the ms element is not mapped to CSS text-transform
-FAIL scriptlevel on the ms element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the ms element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the ms element are not mapped to math-depth(...)
 PASS displaystyle on the ms element is mapped to CSS math-style
 PASS mathvariant on the mspace element is not mapped to CSS text-transform
-FAIL scriptlevel on the mspace element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mspace element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mspace element are not mapped to math-depth(...)
 PASS displaystyle on the mspace element is mapped to CSS math-style
 PASS mathvariant on the msqrt element is not mapped to CSS text-transform
-FAIL scriptlevel on the msqrt element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the msqrt element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the msqrt element are not mapped to math-depth(...)
 PASS displaystyle on the msqrt element is mapped to CSS math-style
 PASS mathvariant on the mstyle element is not mapped to CSS text-transform
-FAIL scriptlevel on the mstyle element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mstyle element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mstyle element are not mapped to math-depth(...)
 PASS displaystyle on the mstyle element is mapped to CSS math-style
 PASS mathvariant on the msub element is not mapped to CSS text-transform
-FAIL scriptlevel on the msub element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the msub element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the msub element are not mapped to math-depth(...)
 PASS displaystyle on the msub element is mapped to CSS math-style
 PASS mathvariant on the msubsup element is not mapped to CSS text-transform
-FAIL scriptlevel on the msubsup element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the msubsup element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the msubsup element are not mapped to math-depth(...)
 PASS displaystyle on the msubsup element is mapped to CSS math-style
 PASS mathvariant on the msup element is not mapped to CSS text-transform
-FAIL scriptlevel on the msup element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the msup element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the msup element are not mapped to math-depth(...)
 PASS displaystyle on the msup element is mapped to CSS math-style
 PASS mathvariant on the mtable element is not mapped to CSS text-transform
-FAIL scriptlevel on the mtable element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mtable element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mtable element are not mapped to math-depth(...)
 PASS displaystyle on the mtable element is mapped to CSS math-style
 PASS mathvariant on the mtd element is not mapped to CSS text-transform
-FAIL scriptlevel on the mtd element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mtd element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mtd element are not mapped to math-depth(...)
 PASS displaystyle on the mtd element is mapped to CSS math-style
 PASS mathvariant on the mtext element is not mapped to CSS text-transform
-FAIL scriptlevel on the mtext element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mtext element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mtext element are not mapped to math-depth(...)
 PASS displaystyle on the mtext element is mapped to CSS math-style
 PASS mathvariant on the mtr element is not mapped to CSS text-transform
-FAIL scriptlevel on the mtr element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the mtr element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the mtr element are not mapped to math-depth(...)
 PASS displaystyle on the mtr element is mapped to CSS math-style
 PASS mathvariant on the munder element is not mapped to CSS text-transform
-FAIL scriptlevel on the munder element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the munder element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the munder element are not mapped to math-depth(...)
 PASS displaystyle on the munder element is mapped to CSS math-style
 PASS mathvariant on the munderover element is not mapped to CSS text-transform
-FAIL scriptlevel on the munderover element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the munderover element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the munderover element are not mapped to math-depth(...)
 PASS displaystyle on the munderover element is mapped to CSS math-style
 PASS mathvariant on the none element is not mapped to CSS text-transform
-FAIL scriptlevel on the none element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "1"
+PASS scriptlevel on the none element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the none element are not mapped to math-depth(...)
 PASS displaystyle on the none element is mapped to CSS math-style
 PASS mathvariant on the semantics element is not mapped to CSS text-transform
-FAIL scriptlevel on the semantics element is mapped to math-depth(...) assert_equals: attribute specified <U> expected "2" but got "0"
+PASS scriptlevel on the semantics element is mapped to math-depth(...)
 PASS invalid scriptlevel values on the semantics element are not mapped to math-depth(...)
 PASS displaystyle on the semantics element is mapped to CSS math-style
 

--- a/Source/WebCore/mathml/mathattrs.in
+++ b/Source/WebCore/mathml/mathattrs.in
@@ -40,6 +40,7 @@ numalign
 open
 rowspan
 rspace
+scriptlevel
 separator
 selection
 separators


### PR DESCRIPTION
#### 7f7a5d9197356c9e0116be1bd4e87176d3537fa2
<pre>
Implement the scriptlevel attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=49309">https://bugs.webkit.org/show_bug.cgi?id=49309</a>

Reviewed by Frédéric Wang.

Implements the scriptlevel (<a href="https://w3c.github.io/mathml-core/#dfn-scriptlevel)">https://w3c.github.io/mathml-core/#dfn-scriptlevel)</a>
attribute as defined in the MathML Core specification. Sets a presentational
hint with the corresponding math-depth value.

* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt:
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::hasPresentationalHintsForAttribute const):
(WebCore::MathMLElement::collectPresentationalHintsForAttribute):
* Source/WebCore/mathml/mathattrs.in:

Canonical link: <a href="https://commits.webkit.org/302841@main">https://commits.webkit.org/302841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e104a08f81b9c2eb977e2ea382d24792ea661b95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98541 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66437 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34021 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80042 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139239 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107064 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106908 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27430 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1166 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30754 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54093 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1506 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64869 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1323 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->