### PR TITLE
Address safer CPP warnings in generated extensions code

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
@@ -57,16 +57,16 @@ public:
 
     WebExtensionAPIObject(WebExtensionContentWorldType contentWorldType, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context)
         : m_contentWorldType(contentWorldType)
-        , m_runtime(&runtime)
         , m_extensionContext(&context)
     {
+        lazyInitialize(m_runtime, Ref { runtime });
     }
 
     WebExtensionAPIObject(const WebExtensionAPIObject& parentObject)
         : m_contentWorldType(parentObject.contentWorldType())
-        , m_runtime(&parentObject.runtime())
         , m_extensionContext(parentObject.m_extensionContext) // Using parentObject.extensionContext() is not safe for APIWebPage objects.
     {
+        lazyInitialize(m_runtime, Ref { parentObject.runtime() });
     }
 
     virtual ~WebExtensionAPIObject() = default;
@@ -92,7 +92,7 @@ public:
 
 private:
     WebExtensionContentWorldType m_contentWorldType { WebExtensionContentWorldType::Main };
-    RefPtr<WebExtensionAPIRuntimeBase> m_runtime;
+    const RefPtr<WebExtensionAPIRuntimeBase> m_runtime;
     RefPtr<WebExtensionContextProxy> m_extensionContext;
     String m_propertyPath;
 };


### PR DESCRIPTION
#### 655a16f4a6bba2c16c05afefff2bfe37e80bb0bb
<pre>
Address safer CPP warnings in generated extensions code
<a href="https://bugs.webkit.org/show_bug.cgi?id=301513">https://bugs.webkit.org/show_bug.cgi?id=301513</a>

Reviewed by Timothy Hatcher.

There are plenty of Safer CPP warnings due to access to
impl-&gt;runtime() in generated bindings code, it looks like these
resolve to WebExtensionAPIObject::runtime(), which accesses the
m_runtime member. Marking it const and lazy-initializing it will
probably fix those warnings.

* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h:
(WebKit::WebExtensionAPIObject::WebExtensionAPIObject):

Canonical link: <a href="https://commits.webkit.org/302192@main">https://commits.webkit.org/302192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc72fa01edabf000aaa5831a9b8abf2c74c3ed12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135691 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79769 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97656 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65560 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114939 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/326 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78980 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138147 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106195 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/460 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105995 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27013 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29830 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52719 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/472 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63548 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/371 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/440 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->