### PR TITLE
Unreviewed, reverting 302173@main (a110c7735591)

### DIFF
--- a/LayoutTests/fast/animation/request-animation-frame-throttling-aggressiveThermalMitigation.html
+++ b/LayoutTests/fast/animation/request-animation-frame-throttling-aggressiveThermalMitigation.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ RespondToThermalPressureAggressively=true PreferPageRenderingUpdatesNear60FPSEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ RespondToThermalPressureAggressively=true ] -->
 <html>
 <body>
     <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2557,6 +2557,8 @@ webgl/2.0.y/conformance/glsl/bugs/sampler-array-using-loop-index.html [ Pass Fai
 webgl/2.0.y/conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html [ Pass Failure ]
 inspector/timeline/timeline-event-CancelAnimationFrame.html [ Pass Crash ]
 
+webkit.org/b/300994 fast/animation/request-animation-frame-throttling-aggressiveThermalMitigation.html [ Pass Failure ]
+
 webkit.org/b/300997 webrtc/filtering-ice-candidate-after-reload.html [ Pass Failure ]
 
 # https://bugs.webkit.org/show_bug.cgi?id=300996 [ macOS Tahoe ] 4 fast/forms tests (layout-tests) are constant image failures

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2769,7 +2769,7 @@ void Page::handleThermalMitigationChange(bool thermalMitigationEnabled)
 
     m_throttlingReasons.set(ThrottlingReason::ThermalMitigation, thermalMitigationEnabled);
 
-    if (settings().respondToThermalPressureAggressively() && canUpdateThrottlingReason(ThrottlingReason::AggressiveThermalMitigation)) {
+    if (settings().respondToThermalPressureAggressively()) {
         m_throttlingReasons.set(ThrottlingReason::AggressiveThermalMitigation, thermalMitigationEnabled);
         if (CheckedPtr scheduler = existingRenderingUpdateScheduler())
             scheduler->adjustRenderingUpdateFrequency();


### PR DESCRIPTION
#### 6f5cfe74149ddb152c12441015a9f48f6b714e57
<pre>
Unreviewed, reverting 302173@main (a110c7735591)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301438">https://bugs.webkit.org/show_bug.cgi?id=301438</a>
<a href="https://rdar.apple.com/162876219">rdar://162876219</a>

Did not fix test flakiness.

Reverted change:

    fast/animation/request-animation-frame-throttling-aggressiveThermalMitigation.html is a flaky failure
    <a href="https://bugs.webkit.org/show_bug.cgi?id=301438">https://bugs.webkit.org/show_bug.cgi?id=301438</a>
    <a href="https://rdar.apple.com/162876219">rdar://162876219</a>
    302173@main (a110c7735591)

Canonical link: <a href="https://commits.webkit.org/302191@main">https://commits.webkit.org/302191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f20275888b2d2d74c8404bf3fb4d71be665df4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79772 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8a8764e6-c685-461b-8985-4b6149cbf5a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/453 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97658 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65564 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b70b023d-4122-4491-b1e9-7dbcf590c37c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/347 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/114943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78249 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9638db3-cf4b-4d84-b61a-5495e683d374) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/33049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78983 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108714 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/33534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138150 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/402 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106197 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/463 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/111284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105997 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27012 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/342 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52724 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/475 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63585 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/374 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/443 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/439 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->