### PR TITLE
Deploy more smart pointers in EditorCommand

### DIFF
--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -356,16 +356,16 @@ static bool executeDeleteToEndOfParagraph(LocalFrame& frame, Event*, EditorComma
 
 static bool executeDeleteToMark(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
-    auto& editor = frame.editor();
+    Ref editor = frame.editor();
     auto& selection = frame.selection();
-    auto markRange = editor.mark().toNormalizedRange();
+    auto markRange = editor->mark().toNormalizedRange();
     auto selectionRange = selection.selection().toNormalizedRange();
     if (markRange && selectionRange) {
         if (!selection.setSelectedRange(unionRange(*markRange, *selectionRange), Affinity::Downstream, FrameSelection::ShouldCloseTyping::Yes))
             return false;
     }
-    editor.performDelete();
-    editor.setMark(selection.selection());
+    editor->performDelete();
+    editor->setMark(selection.selection());
     return true;
 }
 
@@ -1079,9 +1079,9 @@ static bool executeSelectSentence(LocalFrame& frame, Event*, EditorCommandSource
 
 static bool executeSelectToMark(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
-    auto& editor = frame.editor();
+    Ref editor = frame.editor();
     auto& selection = frame.selection();
-    auto markRange = editor.mark().toNormalizedRange();
+    auto markRange = editor->mark().toNormalizedRange();
     auto selectionRange = selection.selection().toNormalizedRange();
     if (!markRange || !selectionRange) {
         SystemSoundManager::singleton().systemBeep();
@@ -1238,11 +1238,11 @@ static bool supportedFromMenuOrKeyBinding(LocalFrame*)
 
 static bool defaultValueForSupportedCopyCut(LocalFrame& frame)
 {
-    auto& settings = frame.settings();
-    if (settings.javaScriptCanAccessClipboard())
+    Ref settings = frame.settings();
+    if (settings->javaScriptCanAccessClipboard())
         return true;
     
-    switch (settings.clipboardAccessPolicy()) {
+    switch (settings->clipboardAccessPolicy()) {
     case ClipboardAccessPolicy::Allow:
     case ClipboardAccessPolicy::RequiresUserGesture:
         return true;
@@ -1267,11 +1267,11 @@ static bool supportedCopyCut(LocalFrame* frame)
 
 static bool defaultValueForSupportedPaste(LocalFrame& frame)
 {
-    auto& settings = frame.settings();
-    if (settings.javaScriptCanAccessClipboard() && settings.domPasteAllowed())
+    Ref settings = frame.settings();
+    if (settings->javaScriptCanAccessClipboard() && settings->domPasteAllowed())
         return true;
 
-    return settings.domPasteAccessRequestsEnabled();
+    return settings->domPasteAccessRequestsEnabled();
 }
 
 static bool supportedPaste(LocalFrame* frame)
@@ -1327,11 +1327,11 @@ static bool enableCaretInEditableText(LocalFrame& frame, Event* event, EditorCom
 
 static bool allowCopyCutFromDOM(LocalFrame& frame)
 {
-    auto& settings = frame.settings();
-    if (settings.javaScriptCanAccessClipboard())
+    Ref settings = frame.settings();
+    if (settings->javaScriptCanAccessClipboard())
         return true;
     
-    switch (settings.clipboardAccessPolicy()) {
+    switch (settings->clipboardAccessPolicy()) {
     case ClipboardAccessPolicy::Allow:
         return true;
     case ClipboardAccessPolicy::Deny:
@@ -1424,11 +1424,11 @@ static bool enabledInRichlyEditableText(LocalFrame& frame, Event*, EditorCommand
 
 static bool allowPasteFromDOM(LocalFrame& frame)
 {
-    auto& settings = frame.settings();
-    if (settings.javaScriptCanAccessClipboard() && settings.domPasteAllowed())
+    Ref settings = frame.settings();
+    if (settings->javaScriptCanAccessClipboard() && settings->domPasteAllowed())
         return true;
 
-    return settings.domPasteAccessRequestsEnabled() && UserGestureIndicator::processingUserGesture();
+    return settings->domPasteAccessRequestsEnabled() && UserGestureIndicator::processingUserGesture();
 }
 
 static bool enabledPaste(LocalFrame& frame, Event*, EditorCommandSource source)


### PR DESCRIPTION
#### bc83b88f5878ecd6a57b678ac9414f434676299b
<pre>
Deploy more smart pointers in EditorCommand
<a href="https://bugs.webkit.org/show_bug.cgi?id=301517">https://bugs.webkit.org/show_bug.cgi?id=301517</a>

Reviewed by NOBODY (OOPS!).

Deploy more smart pointers in EditorCommand

* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::executeDeleteToMark):
(WebCore::executeSelectToMark):
(WebCore::defaultValueForSupportedCopyCut):
(WebCore::defaultValueForSupportedPaste):
(WebCore::allowCopyCutFromDOM):
(WebCore::allowPasteFromDOM):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc83b88f5878ecd6a57b678ac9414f434676299b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135707 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79785 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97669 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65571 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/339 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33058 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78995 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138162 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106306 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/476 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106006 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/357 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52746 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/488 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63659 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->