### PR TITLE
REGRESSION(300109@main): Cookie partitioning with 3p cookie blocking not supported by WebKitTestRunner

### DIFF
--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2066,7 +2066,7 @@ if (window.testRunner) {
     };
     testRunner.setStatisticsShouldBlockThirdPartyCookies = async (value, callback, onlyOnSitesWithoutUserInteraction, onlyUnpartitionedCookies) => { // NOLINT
         let message = 'SetStatisticsShouldBlockThirdPartyCookies';
-        if (onlyOnSitesWithoutUserInteraction || onlyUnpartitionedCookies)
+        if (onlyOnSitesWithoutUserInteraction)
             message = 'SetStatisticsShouldBlockThirdPartyCookiesOnSitesWithoutUserInteraction';
         else if (onlyUnpartitionedCookies)
             message = 'SetStatisticsShouldBlockThirdPartyCookiesExceptPartitioned';


### PR DESCRIPTION
#### e87c97504475406d905b1c9783ac8834873587a4
<pre>
REGRESSION(300109@main): Cookie partitioning with 3p cookie blocking not supported by WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=301528">https://bugs.webkit.org/show_bug.cgi?id=301528</a>
<a href="https://rdar.apple.com/163509455">rdar://163509455</a>

Reviewed by Alex Christensen.

300109@main made a substantial change to how the TestRunner API is exposed to
LayoutTest web content, unfortunately there was a small mistake when
translating the C++ into JavaScript where `OnSitesWithoutUserInteraction` is
used when either of the two parameters `onlyOnSitesWithoutUserInteraction` or
`onlyUnpartitionedCookies` are true. The C++ implementation only set
`OnSitesWithoutUserInteraction` when the `onlyOnSitesWithoutUserInteraction`
parameter was true. This patch re-aligns
testRunner.setStatisticsShouldBlockThirdPartyCookies with the previous
behavior.

* Tools/WebKitTestRunner/TestController.cpp:

Canonical link: <a href="https://commits.webkit.org/302605@main">https://commits.webkit.org/302605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e03fadbe2ce31314166263fec5e669ce908974da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79803 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8092de9c-5887-4546-a774-28dbaef8aa19) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97684 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65587 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c9834b63-2dde-43db-b438-33bdf0234b41) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78276 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bb26e784-d7aa-443c-8416-367724f68272) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33090 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79013 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138181 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106221 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111317 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106021 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27274 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/369 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29866 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52773 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/506 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/405 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/472 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/468 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->