### PR TITLE
REGRESSION(Tahoe): CLoop build-and-test regressed

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapi.cpp
+++ b/Source/JavaScriptCore/API/tests/testapi.cpp
@@ -719,12 +719,19 @@ void TestAPI::proxyReturnedWithJSSubclassing()
     JSObjectRef subclass = const_cast<JSObjectRef>(result.value());
 
     check(scriptResultIs(evaluateScript("globalThis.triggeredProxy"), JSValueMakeUndefined(context)), "creating a subclass should not have triggered the proxy");
+
+    // As testapi.c defines ASSERT_ENABLED unconditionally, we use NDEBUG here instead.
+#ifdef NDEBUG
     // In a debug build using CLoop, the following test may fail with a stack overflow because
     // executing its code involves 3 nested calls to CLoop::execute, which requires a very large
     // stack frame when compiled with '-O0'. The frame size was reduced to an acceptable level by
     // https://bugs.webkit.org/show_bug.cgi?id=295796, but it still is close to the threshold.
     // If the failure returns, more work is needed to further reduce the frame size.
     check(functionReturnsTrue("(function (subclass, Superclass) { return subclass.__proto__ == Superclass.prototype; })", subclass, Superclass), "proxy's prototype should match Superclass.prototype");
+#else
+    UNUSED_VARIABLE(subclass);
+    UNUSED_VARIABLE(Superclass);
+#endif
 }
 
 void TestAPI::testJSObjectSetOnGlobalObjectSubclassDefinition()


### PR DESCRIPTION
#### adc6cc4e28fc911666da9c14a6dc8070c855bf26
<pre>
REGRESSION(Tahoe): CLoop build-and-test regressed
<a href="https://bugs.webkit.org/show_bug.cgi?id=301529">https://bugs.webkit.org/show_bug.cgi?id=301529</a>
<a href="https://rdar.apple.com/163510171">rdar://163510171</a>

Reviewed by Mark Lam.

Due to the nature of CLoop code generation, we cannot expect that O0
compiled CLoop can run reasonably. The auto-generated giantic code can
have significant size of frame without easy optimizations, but O0 means
&quot;do not optimize&quot;, so inherently we cannot run CLoop reliably with O0.
Let&apos;s disable not-working test for now when O0 is used.

Test: Source/JavaScriptCore/API/tests/testapi.cpp

* Source/JavaScriptCore/API/tests/testapi.cpp:
(TestAPI::proxyReturnedWithJSSubclassing):

Canonical link: <a href="https://commits.webkit.org/302209@main">https://commits.webkit.org/302209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58438c67519c18fb4fb3ae0a6299412773b6eae1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135742 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79817 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/887fb53c-0e81-45df-b857-001f7cf30d31) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97697 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65605 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/769c2390-d8ae-48fc-80fc-8d15f71dd63c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78291 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/69b18748-3bd6-4192-95ed-36007779669b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33093 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79029 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120371 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138196 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126810 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106232 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106034 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29875 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52788 "Hash 58438c67 for PR 53045 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20050 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/522 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63697 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159834 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/418 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39919 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/484 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/483 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->