### PR TITLE
Add a quirk to make unique remote MediaStreamTrack labels

### DIFF
--- a/LayoutTests/webrtc/remote-track-label-quirks-expected.txt
+++ b/LayoutTests/webrtc/remote-track-label-quirks-expected.txt
@@ -1,0 +1,3 @@
+
+PASS remote-track-label-quirks
+

--- a/LayoutTests/webrtc/remote-track-label-quirks.html
+++ b/LayoutTests/webrtc/remote-track-label-quirks.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script src="routines.js"></script>
+        <script>
+promise_test(async (test) => {
+    if (!window.internals)
+        return;
+
+    window.internals.setTopDocumentURLForQuirks("https://www.facebook.com");
+
+    const localStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+    const stream = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            firstConnection.addTrack(localStream.getAudioTracks()[0], localStream);
+            firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
+        }, (secondConnection) => {
+            secondConnection.ontrack = (trackEvent) => {
+                resolve(trackEvent.streams[0]);
+            };
+        });
+        test.step_timeout(() => reject("Connections creation timed out"), 5000);
+    });
+
+    assert_equals(stream.getAudioTracks()[0].label, "remote audio - " + stream.getAudioTracks()[0].id, "remote audio track label");
+    assert_equals(stream.getVideoTracks()[0].label, "remote video - " + stream.getVideoTracks()[0].id, "remote video track label");
+});
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -92,8 +92,12 @@ MediaStreamTrack::MediaStreamTrack(ScriptExecutionContext& context, Ref<MediaStr
 
     m_private->addObserver(*this);
 
-    if (!isCaptureTrack())
+    if (!isCaptureTrack()) {
+        RefPtr document = dynamicDowncast<Document>(context);
+        if (document && document->quirks().shouldEnableRemoteTrackLabelQuirk())
+            m_private->updateLabelIfRemoteTrack();
         return;
+    }
 
     ASSERT(isMainThread());
     ASSERT(is<Document>(context));

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -970,6 +970,12 @@ bool Quirks::shouldEnableCameraAndMicrophonePermissionStateQuirk() const
 {
     return needsQuirks() && m_quirksData.shouldEnableCameraAndMicrophonePermissionStateQuirk;
 }
+
+bool Quirks::shouldEnableRemoteTrackLabelQuirk() const
+{
+    return needsQuirks() && m_quirksData.shouldEnableRemoteTrackLabelQuirk;
+}
+
 #endif
 
 bool Quirks::shouldEnableSpeakerSelectionPermissionsPolicyQuirk() const
@@ -2545,6 +2551,7 @@ static void handleFacebookQuirks(QuirksData& quirksData, const URL& quirksURL, c
 #if ENABLE(MEDIA_STREAM)
     // facebook.com rdar://158736355
     quirksData.shouldEnableCameraAndMicrophonePermissionStateQuirk = true;
+    quirksData.shouldEnableRemoteTrackLabelQuirk = true;
     // facebook.com rdar://41104397
     quirksData.shouldEnableFacebookFlagQuirk = true;
 #endif
@@ -2566,6 +2573,7 @@ static void handleFacebookMessengerQuirks(QuirksData& quirksData, const URL& qui
 #if ENABLE(MEDIA_STREAM)
     // facebook.com rdar://158736355
     quirksData.shouldEnableCameraAndMicrophonePermissionStateQuirk = true;
+    quirksData.shouldEnableRemoteTrackLabelQuirk = true;
 #endif
 #if ENABLE(WEB_RTC)
     // facebook.com rdar://158736355

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -155,6 +155,7 @@ public:
     bool shouldEnableSpeakerSelectionPermissionsPolicyQuirk() const;
     bool shouldEnableEnumerateDeviceQuirk() const;
     bool shouldEnableCameraAndMicrophonePermissionStateQuirk() const;
+    bool shouldEnableRemoteTrackLabelQuirk() const;
 #endif
 #if ENABLE(WEB_RTC)
     bool shouldEnableRTCEncodedStreamsQuirk() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -157,6 +157,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool shouldEnableSpeakerSelectionPermissionsPolicyQuirk : 1 { false };
     bool shouldEnableEnumerateDeviceQuirk : 1 { false };
     bool shouldEnableCameraAndMicrophonePermissionStateQuirk : 1 { false };
+    bool shouldEnableRemoteTrackLabelQuirk : 1 { false };
 #endif
 #if ENABLE(WEB_RTC)
     bool shouldEnableRTCEncodedStreamsQuirk : 1 { false };

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -386,6 +386,15 @@ bool MediaStreamTrackPrivate::isOnCreationThread()
 }
 #endif
 
+void MediaStreamTrackPrivate::updateLabelIfRemoteTrack()
+{
+    if (!isMainThread() || !(protectedSource()->isIncomingAudioSource() || protectedSource()->isIncomingVideoSource()))
+        return;
+
+    m_label = makeString(m_label, " - "_s, m_id);
+}
+
+
 void MediaStreamTrackPrivate::forEachObserver(NOESCAPE const Function<void(MediaStreamTrackPrivateObserver&)>& apply)
 {
     ASSERT(isOnCreationThread());

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -157,6 +157,8 @@ public:
     enum class ShouldClone : bool { No, Yes };
     UniqueRef<MediaStreamTrackDataHolder> toDataHolder(ShouldClone = ShouldClone::No);
 
+    void updateLabelIfRemoteTrack();
+
 private:
     MediaStreamTrackPrivate(Ref<const Logger>&&, Ref<RealtimeMediaSource>&&, String&& id, std::function<void(Function<void()>&&)>&&);
     MediaStreamTrackPrivate(Ref<const Logger>&&, UniqueRef<MediaStreamTrackDataHolder>&&, std::function<void(Function<void()>&&)>&&);

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
@@ -33,7 +33,7 @@ GST_DEBUG_CATEGORY(webkit_webrtc_incoming_audio_debug);
 namespace WebCore {
 
 RealtimeIncomingAudioSourceGStreamer::RealtimeIncomingAudioSourceGStreamer(AtomString&& audioTrackId)
-    : RealtimeIncomingSourceGStreamer(CaptureDevice { WTFMove(audioTrackId), CaptureDevice::DeviceType::Microphone, emptyString() })
+    : RealtimeIncomingSourceGStreamer(CaptureDevice { WTFMove(audioTrackId), CaptureDevice::DeviceType::Microphone, "remote audio"_s })
 {
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
@@ -34,7 +34,7 @@ GST_DEBUG_CATEGORY(webkit_webrtc_incoming_video_debug);
 namespace WebCore {
 
 RealtimeIncomingVideoSourceGStreamer::RealtimeIncomingVideoSourceGStreamer(AtomString&& videoTrackId)
-    : RealtimeIncomingSourceGStreamer(CaptureDevice { WTFMove(videoTrackId), CaptureDevice::DeviceType::Camera, emptyString() })
+    : RealtimeIncomingSourceGStreamer(CaptureDevice { WTFMove(videoTrackId), CaptureDevice::DeviceType::Camera, "remote video"_s })
 {
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {


### PR DESCRIPTION
#### 97ebd29ad20339f333d3bf60bd40c889e381a586
<pre>
Add a quirk to make unique remote MediaStreamTrack labels
<a href="https://rdar.apple.com/161192008">rdar://161192008</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301533">https://bugs.webkit.org/show_bug.cgi?id=301533</a>

Reviewed by Philippe Normand.

Google Chrome uses the track ID for remote track labels, while the spec is asking to use either `remote audio` or `remote video`.
Facebook is listening to WebRTC track events for new tracks, so as to send updates to different parts of the DB video call code base.
To send those updates, it generates a state as a JS object and compares it with the previous state.

If they are different, some processing is happening. If they are the same, no processing happens as a an optimization.
To check whether the state has changed, track labels are used.
In Chrome, track labels would change based on track ids, but not in Safari.
This would prevent some updates to happen and create flakky behaviours.

To workaround this limitation, we introduce a quirk that concatenates the spec label with the track ID.
We enable this quirk for Facebook and messenger web sites.

We also update GStream incoming audio/video sources so that they provide the correct label as per spec.

Manually tested and adding quirk specific test.

Canonical link: <a href="https://commits.webkit.org/302231@main">https://commits.webkit.org/302231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84b0f250ffc4bcbb6f675b02175399777252d9c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79887 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/da422c9d-58aa-494d-addb-06e41ede4403) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97770 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65673 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b9a29782-8511-4826-8fd8-8528d3b4e2e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78381 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6e96fa4d-17cc-429c-8048-ef0cfa3c49c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33179 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79115 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138282 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106312 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106122 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27031 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/454 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52872 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63792 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/495 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/554 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/558 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->