### PR TITLE
REGRESSION(294225@main): apple.com Careers menu items disappear after animating in.

### DIFF
--- a/LayoutTests/compositing/repaint/change-opacity-visibility-hidden-expected.txt
+++ b/LayoutTests/compositing/repaint/change-opacity-visibility-hidden-expected.txt
@@ -1,0 +1,5 @@
+There should be a repaint rect for the newly visible inner div
+(repaint rects
+  (rect 8 13 100 100)
+)
+

--- a/LayoutTests/compositing/repaint/change-opacity-visibility-hidden.html
+++ b/LayoutTests/compositing/repaint/change-opacity-visibility-hidden.html
@@ -1,0 +1,41 @@
+<!doctype HTML>
+<html>
+
+  <div id=hidden style="visibility:hidden; opacity: 0; position:absolute; transform: translateX(0px)">
+    <div style="visibility:visible; width: 100px; height: 100px; background: green; position:relative">There should be a repaint rect for the newly visible inner div</div>
+  </div>
+
+<pre id=result></pre>
+
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function timerAfterRAF(callback) {
+    return requestAnimationFrame(() => setTimeout(callback, 0));
+}
+
+function runTest() {
+    if (window.internals)
+        internals.startTrackingRepaints();
+    hidden.style.opacity = 1;  
+
+    timerAfterRAF(() => {
+        if (window.internals) {
+            result.innerText = internals.repaintRectsAsText();
+            internals.stopTrackingRepaints();
+        }
+        if (window.testRunner)
+            testRunner.notifyDone();
+
+    });
+};
+
+window.addEventListener('load', () => {
+    timerAfterRAF(runTest);
+}, false);
+
+</script>
+</html>

--- a/LayoutTests/fast/repaint/incorrect-repaint-when-child-layer-overflows-expected.txt
+++ b/LayoutTests/fast/repaint/incorrect-repaint-when-child-layer-overflows-expected.txt
@@ -1,5 +1,4 @@
 (repaint rects
-  (rect 0 0 200 200)
   (rect 0 0 50 50)
   (rect 0 0 200 200)
 )

--- a/LayoutTests/svg/compositing/transform-change-repainting-viewBox-repaintRects-expected.txt
+++ b/LayoutTests/svg/compositing/transform-change-repainting-viewBox-repaintRects-expected.txt
@@ -1,6 +1,7 @@
  (repaint rects
   (rect 124 24 270 270)
   (rect 124 24 270 270)
+  (rect 124 24 270 270)
   (rect 8 8 502 302)
 )
 (GraphicsLayer

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -460,10 +460,6 @@ void RenderElement::updateShapeImage(const Style::ShapeOutside* oldShapeValue, c
 
 bool RenderElement::repaintBeforeStyleChange(StyleDifference diff, const RenderStyle& oldStyle, const RenderStyle& newStyle)
 {
-    if (oldStyle.usedVisibility() == Visibility::Hidden) {
-        // Repaint on hidden renderer is a no-op.
-        return false;
-    }
     enum class RequiredRepaint { None, RendererOnly, RendererAndDescendantsRenderersWithLayers };
     auto shouldRepaintBeforeStyleChange = [&]() -> RequiredRepaint {
         if (!parent()) {
@@ -545,6 +541,10 @@ bool RenderElement::repaintBeforeStyleChange(StyleDifference diff, const RenderS
 
     if (shouldRepaintBeforeStyleChange == RequiredRepaint::RendererOnly) {
         if (isOutOfFlowPositioned() && downcast<RenderLayerModelObject>(*this).checkedLayer()->isSelfPaintingLayer()) {
+            if (oldStyle.usedVisibility() == Visibility::Hidden) {
+                // Repaint on hidden renderer is a no-op.
+                return false;
+            }
             if (auto cachedClippedOverflowRect = downcast<RenderLayerModelObject>(*this).checkedLayer()->cachedClippedOverflowRect()) {
                 repaintUsingContainer(containerForRepaint().renderer.get(), *cachedClippedOverflowRect);
                 return true;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1294,8 +1294,8 @@ void RenderLayer::recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFl
     auto repaintIfNecessary = [&](bool checkForRepaint) {
         if (mode == Verify) {
             WeakPtr repaintContainer = renderer().containerForRepaint().renderer.get();
-            LAYER_POSITIONS_ASSERT(repaintRects() || (isVisibilityHiddenOrOpacityZero() || !isSelfPaintingLayer()));
-            if (isVisibilityHiddenOrOpacityZero())
+            LAYER_POSITIONS_ASSERT(repaintRects() || (isSubtreeVisibilityHiddenOrOpacityZero() || !isSelfPaintingLayer()));
+            if (isSubtreeVisibilityHiddenOrOpacityZero())
                 LAYER_POSITIONS_ASSERT(!m_repaintContainer);
             else
                 LAYER_POSITIONS_ASSERT(m_repaintContainer == repaintContainer);
@@ -1487,12 +1487,12 @@ void RenderLayer::computeRepaintRects(const RenderLayerModelObject* repaintConta
 {
     ASSERT(!m_visibleContentStatusDirty);
 
-    if (isVisibilityHiddenOrOpacityZero() || !isSelfPaintingLayer())
+    if (isSubtreeVisibilityHiddenOrOpacityZero() || !isSelfPaintingLayer())
         clearRepaintRects();
     else
         setRepaintRects(renderer().rectsForRepaintingAfterLayout(repaintContainer, RepaintOutlineBounds::Yes));
 
-    if (isVisibilityHiddenOrOpacityZero())
+    if (isSubtreeVisibilityHiddenOrOpacityZero())
         m_repaintContainer = nullptr;
     else
         m_repaintContainer = repaintContainer;
@@ -6135,6 +6135,11 @@ bool RenderLayer::hasVisibleBoxDecorations() const
 bool RenderLayer::isVisibilityHiddenOrOpacityZero() const
 {
     return !hasVisibleContent() || renderer().style().opacity().isTransparent();
+}
+
+bool RenderLayer::isSubtreeVisibilityHiddenOrOpacityZero() const
+{
+    return (!hasVisibleContent() && !hasVisibleDescendant()) || renderer().style().opacity().isTransparent();
 }
 
 bool RenderLayer::isVisuallyNonEmpty(PaintedContentRequest* request) const

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -600,6 +600,7 @@ public:
     };
 
     bool isVisibilityHiddenOrOpacityZero() const;
+    bool isSubtreeVisibilityHiddenOrOpacityZero() const;
 
     // Returns true if this layer has visible content (ignoring any child layers).
     bool isVisuallyNonEmpty(PaintedContentRequest* = nullptr) const;


### PR DESCRIPTION
#### 4d0d8131db61c321e5283e641e87330612ae72f0
<pre>
REGRESSION(294225@main): apple.com Careers menu items disappear after animating in.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301538">https://bugs.webkit.org/show_bug.cgi?id=301538</a>
&lt;<a href="https://rdar.apple.com/161367545">rdar://161367545</a>&gt;

Reviewed by Simon Fraser.

Visibility hidden can be overriden by descendants, we need to track repaint rects if anything in the tree
is visible, not just the current layer.

Test: compositing/repaint/change-opacity-visibility-hidden.html

* LayoutTests/compositing/repaint/change-opacity-visibility-hidden-expected.txt: Added.
* LayoutTests/compositing/repaint/change-opacity-visibility-hidden.html: Added.
* LayoutTests/fast/repaint/incorrect-repaint-when-child-layer-overflows-expected.txt:
* LayoutTests/svg/compositing/transform-change-repainting-viewBox-repaintRects-expected.txt:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintBeforeStyleChange):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
(WebCore::RenderLayer::computeRepaintRects):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/302255@main">https://commits.webkit.org/302255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2931a2410446fdfebbd8059ebe2fa377f8f16b2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79848 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f7bf6b0e-8036-4c27-9847-2af739d9a719) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97727 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65639 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e842a4ca-681a-423f-a6a0-ffb57fabbb97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78321 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/afbcbb85-d130-4f60-98bb-80f87b9058ba) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33130 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79067 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138233 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106261 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106065 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27050 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/417 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29907 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52826 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/559 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63739 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/458 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/520 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->