### PR TITLE
Refactor HTMLTreeBuilder to use direct stack operations instead of processFakeEndTag

### DIFF
--- a/LayoutTests/fast/parser/optgroup-end-tag-processing-expected.txt
+++ b/LayoutTests/fast/parser/optgroup-end-tag-processing-expected.txt
@@ -1,0 +1,28 @@
+This test validates the refactored processEndTag() function for optgroup elements in HTMLTreeBuilder.cpp. The parser should directly pop elements from the stack instead of calling processFakeEndTag().
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Test 1: Optgroup with unclosed option element
+PASS optgroups1.length is 2
+PASS options1.length is 3
+PASS group1Options.length is 2
+PASS group2Options.length is 1
+PASS allOptionsParented is true
+
+Test 2: Multiple optgroups with auto-closed options
+PASS optgroups2.length is 3
+PASS options2.length is 5
+PASS directOptions.length is 0
+
+Test 3: Unclosed optgroups (parser generates implied end tags)
+PASS hasNestedOptgroups is false
+PASS optgroups3.length is 2
+
+Tests exercise processEndTag() for optgroup which calls:
+  m_tree.openElements().pop() when option is inside optgroup
+  Direct stack manipulation instead of processFakeEndTag()
+

--- a/LayoutTests/fast/parser/optgroup-end-tag-processing.html
+++ b/LayoutTests/fast/parser/optgroup-end-tag-processing.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script>
+description("This test validates the refactored processEndTag() function for optgroup elements in HTMLTreeBuilder.cpp. The parser should directly pop elements from the stack instead of calling processFakeEndTag().");
+
+function runTests() {
+    debug('Test 1: Optgroup with unclosed option element');
+    select1 = document.getElementById('select1');
+    optgroups1 = select1.querySelectorAll('optgroup');
+    options1 = select1.querySelectorAll('option');
+
+    shouldBe('optgroups1.length', '2');
+    shouldBe('options1.length', '3');
+
+    // Verify proper nesting
+    group1Options = optgroups1[0].querySelectorAll('option');
+    group2Options = optgroups1[1].querySelectorAll('option');
+    shouldBe('group1Options.length', '2');
+    shouldBe('group2Options.length', '1');
+
+    // Verify all options are children of optgroups
+    allOptionsParented = Array.from(options1).every(opt => opt.parentElement.tagName === 'OPTGROUP');
+    shouldBeTrue('allOptionsParented');
+
+    debug('');
+
+    debug('Test 2: Multiple optgroups with auto-closed options');
+    select2 = document.getElementById('select2');
+    optgroups2 = select2.querySelectorAll('optgroup');
+    options2 = select2.querySelectorAll('option');
+
+    shouldBe('optgroups2.length', '3');
+    shouldBe('options2.length', '5');
+
+    // Verify no orphaned options
+    directOptions = Array.from(select2.children).filter(c => c.tagName === 'OPTION');
+    shouldBe('directOptions.length', '0');
+
+    debug('');
+
+    debug('Test 3: Unclosed optgroups (parser generates implied end tags)');
+    select3 = document.getElementById('select3');
+    optgroups3 = select3.querySelectorAll('optgroup');
+
+    // Check for improper nesting (optgroups should not be nested)
+    hasNestedOptgroups = Array.from(optgroups3).some(grp => grp.querySelectorAll('optgroup').length > 0);
+    shouldBeFalse('hasNestedOptgroups');
+    shouldBe('optgroups3.length', '2');
+
+    debug('');
+    debug('Tests exercise processEndTag() for optgroup which calls:');
+    debug('  m_tree.openElements().pop() when option is inside optgroup');
+    debug('  Direct stack manipulation instead of processFakeEndTag()');
+}
+</script>
+</head>
+<body onload="runTests()">
+
+<!-- Test 1: Optgroup with unclosed option -->
+<select id="select1">
+    <optgroup label="Group 1">
+        <option>Option 1</option>
+        <option>Option 2
+    </optgroup>
+    <optgroup label="Group 2">
+        <option>Option 3</option>
+    </optgroup>
+</select>
+
+<!-- Test 2: Multiple optgroups with unclosed options -->
+<select id="select2">
+    <optgroup label="Fruits">
+        <option>Apple</option>
+        <option>Banana
+    </optgroup>
+    <optgroup label="Vegetables">
+        <option>Carrot</option>
+        <option>Lettuce
+    </optgroup>
+    <optgroup label="Grains">
+        <option>Rice</option>
+    </optgroup>
+</select>
+
+<!-- Test 3: Unclosed optgroups -->
+<select id="select3">
+    <optgroup label="Category A">
+        <option>Item A1
+        <option>Item A2
+    <optgroup label="Category B">
+        <option>Item B1
+</select>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/parser/table-cell-implicit-close-expected.txt
+++ b/LayoutTests/fast/parser/table-cell-implicit-close-expected.txt
@@ -1,0 +1,34 @@
+This test validates the refactored closeTheCell() function in HTMLTreeBuilder.cpp. The parser should implicitly close TD/TH cells when encountering new table rows.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Test 1: TD cell implicit closure when encountering new TR
+PASS rows1.length is 2
+PASS nestedRows.length is 0
+
+Test 2: TH cell implicit closure
+PASS rows2.length is 2
+PASS thCells.length is 2
+PASS tdCells.length is 2
+PASS firstRowCellTypes is true
+PASS secondRowCellTypes is true
+
+Test 3: Nested table with proper cell closure
+PASS allCells.length is 3
+PASS innerTable && outerCells[0] && outerCells[0].contains(innerTable) is true
+
+All tests exercise closeTheCell() which calls:
+  m_tree.generateImpliedEndTags()
+  m_tree.openElements().popUntilPopped()
+  m_tree.activeFormattingElements().clearToLastMarker()
+Cell 1
+Cell 2 - Forces closeTheCell()
+Header 1	Header 2
+Data 1	Data 2
+Outer Cell
+Inner Cell
+Another Cell

--- a/LayoutTests/fast/parser/table-cell-implicit-close.html
+++ b/LayoutTests/fast/parser/table-cell-implicit-close.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script>
+description("This test validates the refactored closeTheCell() function in HTMLTreeBuilder.cpp. The parser should implicitly close TD/TH cells when encountering new table rows.");
+
+function runTests() {
+    debug('Test 1: TD cell implicit closure when encountering new TR');
+    container1 = document.getElementById('container1');
+    table1 = container1.querySelector('table');
+    rows1 = table1.querySelectorAll('tr');
+    cells1 = table1.querySelectorAll('td');
+
+    shouldBe('rows1.length', '2');
+
+    // Verify rows are siblings, not nested
+    firstCell = rows1[0].querySelector('td');
+    nestedRows = firstCell.querySelectorAll('tr');
+    shouldBe('nestedRows.length', '0');
+
+    debug('');
+
+    debug('Test 2: TH cell implicit closure');
+    container2 = document.getElementById('container2');
+    table2 = container2.querySelector('table');
+    rows2 = table2.querySelectorAll('tr');
+    thCells = table2.querySelectorAll('th');
+    tdCells = table2.querySelectorAll('td');
+
+    shouldBe('rows2.length', '2');
+    shouldBe('thCells.length', '2');
+    shouldBe('tdCells.length', '2');
+
+    // Verify TH cells are only in first row
+    firstRowCellTypes = Array.from(rows2[0].children).every(c => c.tagName === 'TH');
+    secondRowCellTypes = Array.from(rows2[1].children).every(c => c.tagName === 'TD');
+    shouldBeTrue('firstRowCellTypes');
+    shouldBeTrue('secondRowCellTypes');
+
+    debug('');
+
+    debug('Test 3: Nested table with proper cell closure');
+    container3 = document.getElementById('container3');
+    outerTable = container3.querySelector('table');
+    innerTable = outerTable.querySelector('table');
+    allCells = container3.querySelectorAll('td');
+    outerCells = Array.from(outerTable.querySelectorAll(':scope > tbody > tr > td'));
+
+    shouldBe('allCells.length', '3');
+    shouldBeTrue('innerTable && outerCells[0] && outerCells[0].contains(innerTable)');
+
+    debug('');
+    debug('All tests exercise closeTheCell() which calls:');
+    debug('  m_tree.generateImpliedEndTags()');
+    debug('  m_tree.openElements().popUntilPopped()');
+    debug('  m_tree.activeFormattingElements().clearToLastMarker()');
+}
+</script>
+</head>
+<body onload="runTests()">
+
+<!-- Test 1: Unclosed TD followed by new TR -->
+<div id="container1">
+<table>
+    <tr>
+        <td>Cell 1
+        <tr><td>Cell 2 - Forces closeTheCell()</td></tr>
+    </tr>
+</table>
+</div>
+
+<!-- Test 2: Unclosed TH cells -->
+<div id="container2">
+<table>
+    <tr>
+        <th>Header 1
+        <th>Header 2
+    </tr>
+    <tr>
+        <td>Data 1</td>
+        <td>Data 2</td>
+    </tr>
+</table>
+</div>
+
+<!-- Test 3: Nested table -->
+<div id="container3">
+<table>
+    <tbody>
+        <tr>
+            <td>Outer Cell
+                <table>
+                    <tr><td>Inner Cell</td></tr>
+                </table>
+            </td>
+            <td>Another Cell</td>
+        </tr>
+    </tbody>
+</table>
+</div>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/PerformanceTests/Parser/optgroup-implicit-close.html
+++ b/PerformanceTests/Parser/optgroup-implicit-close.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/runner.js"></script>
+<script>
+// Generate select with many optgroups and unclosed options
+function generateSelectHTML(numGroups, optionsPerGroup) {
+    var html = '<select>';
+    for (var i = 0; i < numGroups; i++) {
+        html += '<optgroup label="Group ' + i + '">';
+        for (var j = 0; j < optionsPerGroup; j++) {
+            // Unclosed option - forces parser to call pop() when encountering next optgroup
+            html += '<option>Option ' + (i * optionsPerGroup + j);
+        }
+        // No closing tags - parser must implicitly close options and optgroup
+    }
+    html += '</select>';
+    return html;
+}
+
+// Generate select with mixed closed and unclosed options
+function generateMixedSelectHTML(numGroups) {
+    var html = '<select>';
+    for (var i = 0; i < numGroups; i++) {
+        html += '<optgroup label="Category ' + i + '">';
+        html += '<option>Item 1';  // Unclosed
+        html += '<option>Item 2</option>';  // Closed
+        html += '<option>Item 3';  // Unclosed
+        html += '<option>Item 4';  // Unclosed
+        // Unclosed optgroup - parser auto-closes
+    }
+    html += '</select>';
+    return html;
+}
+
+// Generate deeply nested structure with multiple selects
+function generateMultipleSelects(count) {
+    var html = '';
+    for (var i = 0; i < count; i++) {
+        html += '<select>';
+        html += '<optgroup label="A">';
+        html += '<option>A1<option>A2';
+        html += '<optgroup label="B">';
+        html += '<option>B1<option>B2<option>B3';
+        html += '</select>';
+    }
+    return html;
+}
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+
+// Test 1: Many unclosed options (exercises processEndTag() for optgroup heavily)
+var selectHTML = generateSelectHTML(50, 20); // 50 groups * 20 options = 1000 option closures
+
+// Test 2: Mixed closed/unclosed options
+var mixedHTML = generateMixedSelectHTML(100); // 100 groups * 4 options each
+
+// Test 3: Multiple select elements
+var multipleSelectsHTML = generateMultipleSelects(30); // 30 selects * 2 optgroups * options
+
+PerfTestRunner.measureRunsPerSecond({
+    description: "This benchmark tests HTML optgroup/option parsing performance when elements require implicit closing (processEndTag()). Tests the refactored code path that uses direct stack operations instead of processFakeEndTag().",
+    run: function() {
+        // Test many unclosed options in optgroups
+        div.innerHTML = selectHTML;
+        div.innerHTML = "";
+
+        // Test mixed closed/unclosed options
+        div.innerHTML = mixedHTML;
+        div.innerHTML = "";
+
+        // Test multiple select elements
+        div.innerHTML = multipleSelectsHTML;
+        div.innerHTML = "";
+    }
+});
+</script>
+</body>
+</html>

--- a/PerformanceTests/Parser/table-cell-implicit-close.html
+++ b/PerformanceTests/Parser/table-cell-implicit-close.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/runner.js"></script>
+<script>
+// Generate HTML with many table cells that require implicit closing
+function generateTableHTML(rows, cellsPerRow) {
+    var html = '<table>';
+    for (var i = 0; i < rows; i++) {
+        html += '<tr>';
+        for (var j = 0; j < cellsPerRow; j++) {
+            // Unclosed TD - forces parser to call closeTheCell() when encountering next TR
+            html += '<td>Cell ' + (i * cellsPerRow + j);
+        }
+        // No closing tags - parser must implicitly close cells
+    }
+    html += '</table>';
+    return html;
+}
+
+// Generate HTML with TH cells that need implicit closing
+function generateTableWithHeaders(rows) {
+    var html = '<table><tr>';
+    // Multiple unclosed TH cells
+    for (var i = 0; i < 10; i++) {
+        html += '<th>Header ' + i;
+    }
+    html += '</tr>';
+
+    for (var i = 0; i < rows; i++) {
+        html += '<tr>';
+        for (var j = 0; j < 10; j++) {
+            html += '<td>Data ' + (i * 10 + j);
+        }
+    }
+    html += '</table>';
+    return html;
+}
+
+// Generate nested tables with cell closure
+function generateNestedTables(depth, width) {
+    if (depth === 0) {
+        return '<td>Leaf cell</td>';
+    }
+
+    var html = '<table><tr>';
+    for (var i = 0; i < width; i++) {
+        html += '<td>Outer ' + i + '<table><tr>' + generateNestedTables(depth - 1, width) + '</tr></table></td>';
+    }
+    html += '</tr></table>';
+    return html;
+}
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+
+// Test 1: Many unclosed TD cells (exercises closeTheCell() heavily)
+var tableHTML = generateTableHTML(100, 20); // 100 rows * 20 cells = 2000 cell closures
+
+// Test 2: Headers with unclosed TH cells
+var headerTableHTML = generateTableWithHeaders(50); // 10 TH + 500 TD
+
+// Test 3: Nested tables
+var nestedTableHTML = generateNestedTables(3, 5);
+
+PerfTestRunner.measureRunsPerSecond({
+    description: "This benchmark tests HTML table cell parsing performance when cells require implicit closing (closeTheCell()). Tests the refactored code path that uses direct stack operations.",
+    run: function() {
+        // Test unclosed TD cells
+        div.innerHTML = tableHTML;
+        div.innerHTML = "";
+
+        // Test unclosed TH cells
+        div.innerHTML = headerTableHTML;
+        div.innerHTML = "";
+
+        // Test nested tables with cell closure
+        div.innerHTML = nestedTableHTML;
+        div.innerHTML = "";
+    }
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -1067,13 +1067,15 @@ void HTMLTreeBuilder::closeTheCell()
 {
     ASSERT(m_insertionMode == InsertionMode::InCell);
     if (m_tree.openElements().inTableScope(HTML::td)) {
-        ASSERT(!m_tree.openElements().inTableScope(HTML::th));
-        processFakeEndTag(TagName::td);
-        return;
+        m_tree.generateImpliedEndTags();
+        m_tree.openElements().popUntilPopped(elementNameForTag(Namespace::HTML, TagName::td));
     }
-    ASSERT(m_tree.openElements().inTableScope(HTML::th));
-    processFakeEndTag(TagName::th);
-    ASSERT(m_insertionMode == InsertionMode::InRow);
+    if (m_tree.openElements().inTableScope(HTML::th)) {
+        m_tree.generateImpliedEndTags();
+        m_tree.openElements().popUntilPopped(elementNameForTag(Namespace::HTML, TagName::th));
+    }
+    m_tree.activeFormattingElements().clearToLastMarker();
+    m_insertionMode = InsertionMode::InRow;
 }
 
 void HTMLTreeBuilder::processStartTagForInTable(AtomHTMLToken&& token)
@@ -2421,8 +2423,11 @@ void HTMLTreeBuilder::processEndTag(AtomHTMLToken&& token)
         ASSERT(m_insertionMode == InsertionMode::InSelect || m_insertionMode == InsertionMode::InSelectInTable);
         switch (token.tagName()) {
         case TagName::optgroup:
-            if (m_tree.currentStackItem().elementName() == HTML::option && m_tree.oneBelowTop() && m_tree.oneBelowTop()->elementName() == HTML::optgroup)
-                processFakeEndTag(TagName::option);
+            if (m_tree.currentStackItem().elementName() == HTML::option && m_tree.oneBelowTop() && m_tree.oneBelowTop()->elementName() == HTML::optgroup) {
+                m_tree.openElements().pop();
+                m_tree.openElements().pop();
+                return;
+            }
             if (m_tree.currentStackItem().elementName() == HTML::optgroup) {
                 m_tree.openElements().pop();
                 return;


### PR DESCRIPTION
#### 837aac0123734947aba1bf1877d2cb218fbca542
<pre>
Refactor HTMLTreeBuilder to use direct stack operations instead of processFakeEndTag
<a href="https://bugs.webkit.org/show_bug.cgi?id=301541">https://bugs.webkit.org/show_bug.cgi?id=301541</a>
<a href="https://rdar.apple.com/157176196">rdar://157176196</a>

Reviewed by NOBODY (OOPS!).

Replace processFakeEndTag() with direct element stack manipulation in
closeTheCell() and processEndTag() for optgroup. This eliminates token
creation overhead and state machine traversal, making the code more
explicit and efficient.

Tests: fast/parser/optgroup-end-tag-processing.html
       fast/parser/table-cell-implicit-close.html

* LayoutTests/fast/parser/optgroup-end-tag-processing-expected.txt: Added.
* LayoutTests/fast/parser/optgroup-end-tag-processing.html: Added.
* LayoutTests/fast/parser/table-cell-implicit-close-expected.txt: Added.
* LayoutTests/fast/parser/table-cell-implicit-close.html: Added.
* PerformanceTests/Parser/optgroup-implicit-close.html: Added.
* PerformanceTests/Parser/table-cell-implicit-close.html: Added.
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::closeTheCell):
(WebCore::HTMLTreeBuilder::processEndTag):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/837aac0123734947aba1bf1877d2cb218fbca542

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136300 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98148 "Passed tests") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78775 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33597 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79580 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109216 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138767 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106683 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106496 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/805 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30345 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53441 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1054 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64370 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->