### PR TITLE
69 API tests started failing after 302184@main

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1092,7 +1092,7 @@ void Page::initGroup()
 {
     ASSERT(!m_singlePageGroup);
     ASSERT(!m_group);
-    m_singlePageGroup = makeUnique<PageGroup>(*this);
+    m_singlePageGroup = PageGroup::create(*this).moveToUniquePtr();
     m_group = m_singlePageGroup.get();
 }
 

--- a/Source/WebCore/page/PageGroup.cpp
+++ b/Source/WebCore/page/PageGroup.cpp
@@ -57,6 +57,16 @@ static unsigned getUniqueIdentifier()
 
 // --------
 
+UniqueRef<PageGroup> PageGroup::create(const String& name)
+{
+    return UniqueRef<PageGroup>(*new PageGroup(name));
+}
+
+UniqueRef<PageGroup> PageGroup::create(Page& page)
+{
+    return UniqueRef<PageGroup>(*new PageGroup(page));
+}
+
 PageGroup::PageGroup(const String& name)
     : m_name(name)
     , m_identifier(getUniqueIdentifier())

--- a/Source/WebCore/page/PageGroup.h
+++ b/Source/WebCore/page/PageGroup.h
@@ -28,6 +28,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
@@ -43,8 +44,8 @@ class PageGroup final : public CanMakeWeakPtr<PageGroup>, public CanMakeCheckedP
     WTF_MAKE_NONCOPYABLE(PageGroup);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageGroup);
 public:
-    WEBCORE_EXPORT explicit PageGroup(const String& name);
-    explicit PageGroup(Page&);
+    WEBCORE_EXPORT static UniqueRef<PageGroup> create(const String&);
+    WEBCORE_EXPORT static UniqueRef<PageGroup> create(Page&);
     WEBCORE_EXPORT ~PageGroup();
 
     WEBCORE_EXPORT static PageGroup* pageGroup(const String& groupName);
@@ -65,6 +66,9 @@ public:
 #endif
 
 private:
+    WEBCORE_EXPORT explicit PageGroup(const String&);
+    WEBCORE_EXPORT explicit PageGroup(Page&);
+
     String m_name;
     WeakHashSet<Page> m_pages;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
@@ -258,7 +258,7 @@ TEST_F(CaptionPreferenceTests, FontFace)
 {
     MediaAccessibilityShim shim;
 
-    PageGroup group { "CaptionPreferenceTests"_s };
+    UniqueRef group = PageGroup::create("CaptionPreferenceTests"_s);
     auto preferences = CaptionUserPreferencesMediaAF::create(group);
 
     SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyFontDescriptorForStyle, adoptCF(CTFontDescriptorCreateWithNameAndSize(CFSTR(".AppleSystemUIFontMonospaced-Romulan"), 10)));
@@ -278,7 +278,7 @@ TEST_F(CaptionPreferenceTests, FontSize)
 
     MediaAccessibilityShim shim;
 
-    PageGroup group { "CaptionPreferenceTests"_s };
+    UniqueRef group = PageGroup::create("CaptionPreferenceTests"_s);
     auto preferences = CaptionUserPreferencesMediaAF::create(group);
 
     SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetRelativeCharacterSize, 2.f);
@@ -293,7 +293,7 @@ TEST_F(CaptionPreferenceTests, Colors)
 {
     MediaAccessibilityShim shim;
 
-    PageGroup group { "CaptionPreferenceTests"_s };
+    UniqueRef group = PageGroup::create("CaptionPreferenceTests"_s);
     auto preferences = CaptionUserPreferencesMediaAF::create(group);
 
     SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyForegroundColor, cachedCGColor(Color::red));
@@ -317,7 +317,7 @@ TEST_F(CaptionPreferenceTests, BorderRadius)
 {
     MediaAccessibilityShim shim;
 
-    PageGroup group { "CaptionPreferenceTests"_s };
+    UniqueRef group = PageGroup::create("CaptionPreferenceTests"_s);
     auto preferences = CaptionUserPreferencesMediaAF::create(group);
 
     SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetWindowRoundedCornerRadius, 8.f);
@@ -328,7 +328,7 @@ TEST_F(CaptionPreferenceTests, TextEdge)
 {
     MediaAccessibilityShim shim;
 
-    PageGroup group { "CaptionPreferenceTests"_s };
+    UniqueRef group = PageGroup::create("CaptionPreferenceTests"_s);
     auto preferences = CaptionUserPreferencesMediaAF::create(group);
 
     EXPECT_STREQ(preferences->captionsTextEdgeCSS().utf8().data(), "");


### PR DESCRIPTION
#### 565b72caed986e3a0380a22d8c30504b1654b2f1
<pre>
69 API tests started failing after 302184@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=301545">https://bugs.webkit.org/show_bug.cgi?id=301545</a>

Reviewed by Chris Dumez.

Allocate various objects in heap instead of stack or a part of another object to avoid assertion failures.

No new tests since there should be no behavioral differences.

Canonical link: <a href="https://commits.webkit.org/302213@main">https://commits.webkit.org/302213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6f005f358e3bf186cb3c3dc2dafce14ad8212db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79838 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0d62840e-c8de-4b19-857c-f04548f7a4c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97716 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/60d16d4a-b531-4e20-bbc4-54601755a290) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78310 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aa43fcc4-d93c-40e8-a717-b4f09c4e0ce2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33115 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79051 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138217 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/493 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/460 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106250 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106054 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29896 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52809 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20053 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/544 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63721 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/440 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/506 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/504 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->