### PR TITLE
[ iOS 26 ] scrollingcoordinator/ios/fixed-scrolling-with-keyboard.html is a constant text failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8314,9 +8314,6 @@ imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-co
 # https://bugs.webkit.org/show_bug.cgi?id=301243 [ iOS 26 ] imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html is a flaky text failure
 imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html [ Pass Failure ]
 
-# https://bugs.webkit.org/show_bug.cgi?id=301246 [ iOS 26 ] scrollingcoordinator/ios/fixed-scrolling-with-keyboard.html is a constant text failure
-scrollingcoordinator/ios/fixed-scrolling-with-keyboard.html [ Pass Failure ]
-
 # https://bugs.webkit.org/show_bug.cgi?id=301247 [ iOS 26 ] fast/forms/ios/inputmode-removing-none.html is a constant text failure
 fast/forms/ios/inputmode-removing-none.html [ Pass Failure ]
 

--- a/LayoutTests/platform/ipad/scrollingcoordinator/ios/fixed-scrolling-with-keyboard-expected.txt
+++ b/LayoutTests/platform/ipad/scrollingcoordinator/ios/fixed-scrolling-with-keyboard-expected.txt
@@ -2,22 +2,20 @@
 
 (scrolling tree
   (frame scrolling node
-    (scrollable area size width=810 height=1060)
-    (total content size width=810 height=4021)
+    (scrollable area size width=768 height=1004)
+    (total content size width=768 height=4021)
     (last committed scroll position (0,0))
     (scrollable area parameters
       (horizontal scroll elasticity 1)
       (vertical scroll elasticity 1)
       (horizontal scrollbar mode 0)
       (vertical scrollbar mode 0))
-    (layout viewport (0,0) width=810 height=1060)
+    (layout viewport (0,0) width=768 height=1004)
     (min layoutViewport origin (0,0))
-    (max layoutViewport origin (0,2961))
-    (override visual viewport size width=810 height=1005)
+    (max layoutViewport origin (0,3017))
     (behavior for fixed 1)
-    (visual viewport is smaller than layout viewport 1)
     (fixed node
       (fixed constraints
-        (viewport-rect-at-last-layout (0,0) width=810 height=1060)
+        (viewport-rect-at-last-layout (0,0) width=768 height=1004)
         (layer-position-at-last-layout (0,0)))
       (layer top left (0,0)))))


### PR DESCRIPTION
#### 6cb40c3570ca8fcfd9fce78b2a70a3898f1d342b
<pre>
[ iOS 26 ] scrollingcoordinator/ios/fixed-scrolling-with-keyboard.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=301246">https://bugs.webkit.org/show_bug.cgi?id=301246</a>
<a href="https://rdar.apple.com/163165505">rdar://163165505</a>

Unreviewed test gardening.

New iPad results for this test.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ipad/scrollingcoordinator/ios/fixed-scrolling-with-keyboard-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cb40c3570ca8fcfd9fce78b2a70a3898f1d342b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135767 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79840 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/08f5d980-0f3e-4844-a15f-67473a2e37d5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97717 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65633 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/13954946-6191-46f2-a541-ebc4e16179cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131322 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/412 "8 new passes 34 flakes 8 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78311 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ac63cef4-a1ff-4080-acde-dfc9ec2d66e1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33114 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79053 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138219 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/461 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106251 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106055 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/27193 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/402 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29895 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52811 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/546 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/442 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/508 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/506 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->