### PR TITLE
Selection reveal mode is not reset after reveal, and later results in an

### DIFF
--- a/LayoutTests/editing/selection/selection-in-scrolled-iframe-expected.txt
+++ b/LayoutTests/editing/selection/selection-in-scrolled-iframe-expected.txt
@@ -1,0 +1,6 @@
+PASS window.scrollY is document.body.scrollHeight - window.innerHeight
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/editing/selection/selection-in-scrolled-iframe.html
+++ b/LayoutTests/editing/selection/selection-in-scrolled-iframe.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Testing bug #301539</title>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+
+<style>
+#input {
+    /* make the page scrollable */
+    margin-bottom: 3000px;
+}
+</style>
+
+<script>
+    jsTestIsAsync = true;
+
+    async function init() {
+        await UIHelper.animationFrame();
+        document.getElementById("input").focus();
+        document.getElementById("input").select();
+
+        await UIHelper.animationFrame();
+        const fullScrollHeight = document.body.scrollHeight - window.innerHeight;
+        window.scrollTo(0, fullScrollHeight);
+
+        await UIHelper.animationFrame();
+        const iframe = document.querySelector("iframe");
+        const target = iframe.contentDocument.getElementById("input");
+        target.select();
+
+        await UIHelper.animationFrame();
+        shouldBe("window.scrollY", "document.body.scrollHeight - window.innerHeight");
+        finishJSTest();
+    }
+</script>
+<body onload="init()">
+    <input id="input" value="birthday">
+    <br>
+    <iframe width="500" height="300" srcdoc="<!DOCTYPE html><input id='input' value='hello'>"></iframe>
+</body>

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2684,6 +2684,8 @@ void FrameSelection::revealSelection(const RevealSelectionOptions& revealSelecti
         return;
 #endif
 
+    m_selectionRevealMode = SelectionRevealMode::DoNotReveal;
+
     // FIXME: This code only handles scrolling the startContainer's layer, but
     // the selection rect could intersect more than just that.
     // See <rdar://problem/4799899>.


### PR DESCRIPTION
#### 20e8b7686ab9c970d4f395e6cc2e33e70e76ffcb
<pre>
Selection reveal mode is not reset after reveal, and later results in an
unwanted scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=301539">https://bugs.webkit.org/show_bug.cgi?id=301539</a>
<a href="https://rdar.apple.com/163232293">rdar://163232293</a>

Reviewed by Ryosuke Niwa.

Once the selection has been revealed, we can clear the flag to be sure
that it&apos;s not accidentally revealed again later (in which case, it could
result in incorrect scrolling).

Test: editing/selection/selection-in-scrolled-iframe.html

Test: editing/selection/selection-in-scrolled-iframe.html

* LayoutTests/editing/selection/selection-in-scrolled-iframe-expected.txt: Added.
* LayoutTests/editing/selection/selection-in-scrolled-iframe.html: Added.
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::revealSelection):

Canonical link: <a href="https://commits.webkit.org/302228@main">https://commits.webkit.org/302228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48863da41b4db0e6c36c8ba946ec3d3173c27ee2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135812 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79871 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d56a08db-1f79-45fe-9f16-9abaeef6b283) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97751 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f9a23245-e3e4-427c-bc8d-03eee40cd367) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78360 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6d8b90c4-8532-41d5-bbd8-c123fb36fdd1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33156 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79096 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138262 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106292 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111390 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106103 "Failed to checkout and rebase branch from PR 53061") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27026 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/433 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29933 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52853 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/582 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63769 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/479 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/538 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/541 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->