### PR TITLE
[AutoFill Debugging] Add support for an interaction type to highlight and reveal text

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text-expected.txt
@@ -1,0 +1,17 @@
+PASS highlightedTexts.length is 3
+PASS highlightedTexts[0] is "Quote of the day"
+PASS highlightedTexts[1] is "jumped over"
+PASS highlightedTexts[2] is "troublemakers"
+PASS error1 is ""
+PASS error2 is ""
+PASS error3 is ""
+PASS error4 is "'This text is nowhere in the page' not found inside the target node"
+PASS scrolledAfterHighlighting is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+The quick brown fox jumped over the lazy dog.
+
+Quote of the day
+
+Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html
@@ -1,0 +1,84 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+    body, html {
+        font-size: 18px;
+        font-family: system-ui;
+        line-height: 1.5;
+    }
+
+    .tall {
+        height: 300vh;
+    }
+    </style>
+</head>
+<body>
+    <p aria-label="Document title" onclick="console.log(this)">The quick brown fox jumped over the lazy dog.</p>
+    <div contenteditable="plaintext-only">
+        <h3 onclick="console.log(this)" aria-label="Heading">Quote of the day</h3>
+        <div class="tall"></div>
+        <p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.</p>
+    </div>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        if (!window.testRunner)
+            return;
+
+        const debugText = await UIHelper.requestDebugText();
+
+        error1 = await UIHelper.performTextExtractionInteraction("highlightText", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Document title"),
+            text: "jumped over",
+            scrollToVisible: true
+        });
+
+        error2 = await UIHelper.performTextExtractionInteraction("highlightText", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Heading"),
+            scrollToVisible: true
+        });
+
+        scrolledAfterHighlighting = false;
+        addEventListener("scroll", () => scrolledAfterHighlighting = true, { once: true });
+
+        error3 = await UIHelper.performTextExtractionInteraction("highlightText", {
+            text: "troublemakers",
+            scrollToVisible: true
+        });
+
+        error4 = await UIHelper.performTextExtractionInteraction("highlightText", {
+            text: "This text is nowhere in the page",
+            scrollToVisible: true
+        });
+
+        await UIHelper.ensurePresentationUpdate();
+
+        highlightedTexts = internals.textExtractionHighlightRanges.map(highlightRange => {
+            const domRange = document.createRange();
+            domRange.setStart(highlightRange.startContainer, highlightRange.startOffset);
+            domRange.setEnd(highlightRange.endContainer, highlightRange.endOffset);
+            return domRange.toString();
+        });
+        highlightedTexts.sort();
+
+        shouldBe("highlightedTexts.length", "3");
+        shouldBeEqualToString("highlightedTexts[0]", "Quote of the day");
+        shouldBeEqualToString("highlightedTexts[1]", "jumped over");
+        shouldBeEqualToString("highlightedTexts[2]", "troublemakers");
+        shouldBeEqualToString("error1", "");
+        shouldBeEqualToString("error2", "");
+        shouldBeEqualToString("error3", "");
+        shouldBeEqualToString("error4", "'This text is nowhere in the page' not found inside the target node");
+        shouldBeTrue("scrolledAfterHighlighting");
+        finishJSTest();
+    });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -996,6 +996,8 @@ void Document::commonTeardown()
         highlightRegistry->clear();
     if (RefPtr fragmentHighlightRegistry = m_fragmentHighlightRegistry)
         fragmentHighlightRegistry->clear();
+    if (RefPtr textExtractionHighlightRegistry = m_textExtractionHighlightRegistry)
+        textExtractionHighlightRegistry->clear();
 #if ENABLE(APP_HIGHLIGHTS)
     if (RefPtr appHighlightRegistry = m_appHighlightRegistry)
         appHighlightRegistry->clear();
@@ -3881,6 +3883,7 @@ bool Document::hasHighlight() const
 {
     return (m_highlightRegistry && !m_highlightRegistry->isEmpty())
         || (m_fragmentHighlightRegistry && !m_fragmentHighlightRegistry->isEmpty())
+        || (m_textExtractionHighlightRegistry && !m_textExtractionHighlightRegistry->isEmpty())
 #if ENABLE(APP_HIGHLIGHTS)
         || (m_appHighlightRegistry && !m_appHighlightRegistry->isEmpty())
 #endif
@@ -3899,6 +3902,13 @@ HighlightRegistry& Document::fragmentHighlightRegistry()
     if (!m_fragmentHighlightRegistry)
         m_fragmentHighlightRegistry = HighlightRegistry::create();
     return *m_fragmentHighlightRegistry;
+}
+
+HighlightRegistry& Document::textExtractionHighlightRegistry()
+{
+    if (!m_textExtractionHighlightRegistry)
+        m_textExtractionHighlightRegistry = HighlightRegistry::create();
+    return *m_textExtractionHighlightRegistry;
 }
 
 #if ENABLE(APP_HIGHLIGHTS)
@@ -3957,6 +3967,8 @@ void Document::updateHighlightPositions()
         collectHighlightRangesFromRegister(highlightRanges, *m_highlightRegistry.get());
     if (m_fragmentHighlightRegistry)
         collectHighlightRangesFromRegister(highlightRanges, *m_fragmentHighlightRegistry.get());
+    if (m_textExtractionHighlightRegistry)
+        collectHighlightRangesFromRegister(highlightRanges, *m_textExtractionHighlightRegistry.get());
 #if ENABLE(APP_HIGHLIGHTS)
     if (m_appHighlightRegistry)
         collectHighlightRangesFromRegister(highlightRanges, *m_appHighlightRegistry.get());

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1922,12 +1922,15 @@ public:
     TextManipulationController* textManipulationControllerIfExists() { return m_textManipulationController.get(); }
 
     bool hasHighlight() const;
-    HighlightRegistry* highlightRegistryIfExists() { return m_highlightRegistry.get(); }
+    HighlightRegistry* highlightRegistryIfExists() const { return m_highlightRegistry.get(); }
     HighlightRegistry& highlightRegistry();
     void updateHighlightPositions();
 
-    HighlightRegistry* fragmentHighlightRegistryIfExists() { return m_fragmentHighlightRegistry.get(); }
+    HighlightRegistry* fragmentHighlightRegistryIfExists() const { return m_fragmentHighlightRegistry.get(); }
     HighlightRegistry& fragmentHighlightRegistry();
+
+    HighlightRegistry* textExtractionHighlightRegistryIfExists() const { return m_textExtractionHighlightRegistry.get(); }
+    HighlightRegistry& textExtractionHighlightRegistry();
         
 #if ENABLE(APP_HIGHLIGHTS)
     HighlightRegistry* appHighlightRegistryIfExists() { return m_appHighlightRegistry.get(); }
@@ -2468,6 +2471,7 @@ private:
         
     RefPtr<HighlightRegistry> m_highlightRegistry;
     RefPtr<HighlightRegistry> m_fragmentHighlightRegistry;
+    RefPtr<HighlightRegistry> m_textExtractionHighlightRegistry;
 #if ENABLE(APP_HIGHLIGHTS)
     RefPtr<HighlightRegistry> m_appHighlightRegistry;
     std::unique_ptr<AppHighlightStorage> m_appHighlightStorage;

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -75,6 +75,7 @@ class RenderView;
 class RenderWidget;
 class ScrollingCoordinator;
 class ScrollAnchoringController;
+class TemporarySelectionChange;
 class TiledBacking;
 
 struct FixedContainerEdges;
@@ -84,6 +85,7 @@ struct VelocityData;
 
 enum class NullGraphicsContextPaintInvalidationReasons : uint8_t;
 enum class StyleColorOptions : uint8_t;
+enum class TemporarySelectionOption : uint16_t;
 enum class TiledBackingScrollability : uint8_t;
 
 Pagination::Mode paginationModeForRenderStyle(const RenderStyle&);
@@ -759,6 +761,8 @@ public:
     IntSize totalScrollbarSpace() const final;
     int scrollbarGutterWidth(bool isHorizontalWritingMode = true) const;
     int insetForLeftScrollbarSpace() const final;
+
+    TemporarySelectionChange revealRangeWithTemporarySelection(const SimpleRange&, OptionSet<TemporarySelectionOption> extraOptions = { });
 
 #if ASSERT_ENABLED
     struct AutoPreventLayerAccess {

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -56,6 +56,7 @@
 #include "HTMLOptionElement.h"
 #include "HTMLSelectElement.h"
 #include "HandleUserInputEventResult.h"
+#include "HighlightRegistry.h"
 #include "HitTestResult.h"
 #include "ImageOverlay.h"
 #include "LocalFrame.h"
@@ -72,6 +73,7 @@
 #include "RenderObjectInlines.h"
 #include "RenderView.h"
 #include "SimpleRange.h"
+#include "StaticRange.h"
 #include "Text.h"
 #include "TextIterator.h"
 #include "TypedElementDescendantIteratorInlines.h"
@@ -956,6 +958,9 @@ Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page& page)
 
 static std::optional<SimpleRange> searchForText(Node& node, const String& searchText)
 {
+    if (searchText.isEmpty())
+        return std::nullopt;
+
     auto searchRange = makeRangeSelectingNodeContents(node);
     auto foundRange = findPlainText(searchRange, searchText, {
         FindOption::DoNotRevealSelection,
@@ -968,9 +973,12 @@ static std::optional<SimpleRange> searchForText(Node& node, const String& search
     return { WTFMove(foundRange) };
 }
 
-static String invalidNodeIdentifierDescription(NodeIdentifier identifier)
+static String invalidNodeIdentifierDescription(std::optional<NodeIdentifier>&& identifier)
 {
-    return makeString("Failed to resolve nodeIdentifier "_s, identifier.loggingString());
+    if (!identifier)
+        return "Missing nodeIdentifier"_s;
+
+    return makeString("Failed to resolve nodeIdentifier "_s, identifier->loggingString());
 }
 
 static String searchTextNotFoundDescription(const String& searchText)
@@ -1097,11 +1105,35 @@ static bool selectOptionByValue(NodeIdentifier identifier, const String& optionT
     return false;
 }
 
-static void selectText(NodeIdentifier identifier, const String& searchText, CompletionHandler<void(bool, String&&)>&& completion)
+static RefPtr<Node> resolveNodeWithBodyAsFallback(Page& page, std::optional<NodeIdentifier> identifier)
 {
-    RefPtr foundNode = Node::fromIdentifier(identifier);
+    if (identifier)
+        return Node::fromIdentifier(WTFMove(*identifier));
+
+    RefPtr mainFrame = page.localMainFrame();
+    if (!mainFrame)
+        return { };
+
+    RefPtr document = mainFrame->document();
+    if (!document)
+        return { };
+
+    return document->body();
+}
+
+static std::optional<SimpleRange> rangeForTextInContainer(const String& searchText, Ref<Node>&& node)
+{
+    if (searchText.isEmpty() && !is<HTMLBodyElement>(node))
+        return makeRangeSelectingNodeContents(node);
+
+    return searchForText(node, searchText);
+}
+
+static void selectText(Page& page, std::optional<NodeIdentifier>&& identifier, const String& searchText, bool revealText, CompletionHandler<void(bool, String&&)>&& completion)
+{
+    RefPtr foundNode = resolveNodeWithBodyAsFallback(page, identifier);
     if (!foundNode)
-        return completion(false, invalidNodeIdentifierDescription(identifier));
+        return completion(false, invalidNodeIdentifierDescription(WTFMove(identifier)));
 
     if (RefPtr control = dynamicDowncast<HTMLTextFormControlElement>(*foundNode)) {
         // FIXME: This should probably honor `searchText`.
@@ -1109,17 +1141,39 @@ static void selectText(NodeIdentifier identifier, const String& searchText, Comp
         return completion(true, { });
     }
 
-    std::optional<SimpleRange> targetRange;
-    if (searchText.isEmpty())
-        targetRange = makeRangeSelectingNodeContents(*foundNode);
-    else
-        targetRange = searchForText(*foundNode, searchText);
-
+    auto targetRange = rangeForTextInContainer(searchText, *foundNode);
     if (!targetRange)
         return completion(false, searchTextNotFoundDescription(searchText));
 
-    if (!foundNode->protectedDocument()->selection().setSelectedRange(*targetRange, Affinity::Downstream, FrameSelection::ShouldCloseTyping::Yes, UserTriggered::Yes))
+    Ref document = foundNode->document();
+    if (!document->selection().setSelectedRange(*targetRange, Affinity::Downstream, FrameSelection::ShouldCloseTyping::Yes, UserTriggered::Yes))
         return completion(false, "Failed to set selected range"_s);
+
+    if (revealText)
+        document->selection().revealSelection();
+
+    return completion(true, { });
+}
+
+static void highlightText(Page& page, std::optional<NodeIdentifier>&& identifier, const String& searchText, bool scrollToVisible, CompletionHandler<void(bool, String&&)>&& completion)
+{
+    RefPtr foundNode = resolveNodeWithBodyAsFallback(page, identifier);
+    if (!foundNode)
+        return completion(false, invalidNodeIdentifierDescription(WTFMove(identifier)));
+
+    auto range = rangeForTextInContainer(searchText, *foundNode);
+    if (!range)
+        return completion(false, searchTextNotFoundDescription(searchText));
+
+    Ref document = foundNode->document();
+    RefPtr view = document->view();
+    if (!view)
+        return completion(false, nullFrameDescription);
+
+    document->textExtractionHighlightRegistry().addAnnotationHighlightWithRange(StaticRange::create(*range));
+
+    if (scrollToVisible)
+        view->revealRangeWithTemporarySelection(*range);
 
     return completion(true, { });
 }
@@ -1247,13 +1301,14 @@ void handleInteraction(Interaction&& interaction, Page& page, CompletionHandler<
     }
     case Action::SelectText: {
         if (auto identifier = interaction.nodeIdentifier) {
-            if (selectOptionByValue(*identifier, interaction.text))
+            if (selectOptionByValue(WTFMove(*identifier), interaction.text))
                 return completion(true, interactedWithSelectElementDescription);
-
-            return selectText(*identifier, WTFMove(interaction.text), WTFMove(completion));
         }
 
-        return completion(false, "Missing nodeIdentifier"_s);
+        if (interaction.text.isEmpty() && !interaction.nodeIdentifier)
+            return completion(false, "Missing nodeIdentifier and/or text"_s);
+
+        return selectText(page, WTFMove(interaction.nodeIdentifier), WTFMove(interaction.text), interaction.scrollToVisible, WTFMove(completion));
     }
     case Action::TextInput: {
         if (auto identifier = interaction.nodeIdentifier)
@@ -1263,6 +1318,12 @@ void handleInteraction(Interaction&& interaction, Page& page, CompletionHandler<
     }
     case Action::KeyPress:
         return simulateKeyPress(page, WTFMove(interaction.nodeIdentifier), interaction.text, WTFMove(completion));
+    case Action::HighlightText: {
+        if (interaction.text.isEmpty() && !interaction.nodeIdentifier)
+            return completion(false, "Missing nodeIdentifier and/or text"_s);
+
+        return highlightText(page, WTFMove(interaction.nodeIdentifier), WTFMove(interaction.text), interaction.scrollToVisible, WTFMove(completion));
+    }
     default:
         ASSERT_NOT_REACHED();
         break;
@@ -1433,6 +1494,8 @@ InteractionDescription interactionDescription(const Interaction& interaction)
         case Action::TextInput:
         case Action::KeyPress:
             return "Enter text"_s;
+        case Action::HighlightText:
+            return "Highlight text"_s;
         }
         ASSERT_NOT_REACHED();
         return { };
@@ -1462,6 +1525,7 @@ InteractionDescription interactionDescription(const Interaction& interaction)
                 return " inside "_s;
             case Action::SelectMenuItem:
             case Action::KeyPress:
+            case Action::HighlightText:
                 return " in "_s;
             case Action::TextInput:
                 return " into "_s;
@@ -1472,8 +1536,14 @@ InteractionDescription interactionDescription(const Interaction& interaction)
         description.append(makeString(WTFMove(prefix), WTFMove(elementString)));
     }
 
-    if ((action == Action::KeyPress || action == Action::TextInput) && interaction.replaceAll)
+    bool appendedReplaceTextDescription = false;
+    if ((action == Action::KeyPress || action == Action::TextInput) && interaction.replaceAll) {
+        appendedReplaceTextDescription = true;
         description.append(", replacing any existing content"_s);
+    }
+
+    if ((action == Action::SelectText || action == Action::HighlightText) && interaction.scrollToVisible)
+        description.append(makeString(appendedReplaceTextDescription ? " and"_s : ","_s, " scrolling the targeted range into view"_s));
 
     return { description.toString(), WTFMove(stringsToValidate) };
 }

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -41,6 +41,7 @@ enum class Action : uint8_t {
     SelectMenuItem,
     TextInput,
     KeyPress,
+    HighlightText,
 };
 
 struct Interaction {
@@ -49,6 +50,7 @@ struct Interaction {
     std::optional<FloatPoint> locationInRootView;
     std::optional<NodeIdentifier> nodeIdentifier;
     bool replaceAll { false };
+    bool scrollToVisible { false };
 };
 
 struct ExtractedText {

--- a/Source/WebCore/rendering/MarkedText.h
+++ b/Source/WebCore/rendering/MarkedText.h
@@ -56,6 +56,7 @@ struct MarkedText : public CanMakeCheckedPtr<MarkedText, WTF::DefaultedOperatorE
         DictationAlternatives,
         Highlight,
         FragmentHighlight,
+        TextExtractionHighlight,
 #if ENABLE(APP_HIGHLIGHTS)
         AppHighlight,
 #endif

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -65,6 +65,8 @@ static void computeStyleForPseudoElementStyle(StyledMarkedText::Style& style, co
 
 static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, const StyledMarkedText::Style& baseStyle, const RenderText& renderer, const RenderStyle& lineStyle, const PaintInfo& paintInfo)
 {
+    static constexpr OptionSet systemAppearanceOptions { StyleColorOptions::UseSystemAppearance };
+
     auto style = baseStyle;
     switch (markedText.type) {
     case MarkedText::Type::Correction:
@@ -99,16 +101,20 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
             break;
         }
 
-        OptionSet<StyleColorOptions> styleColorOptions = { StyleColorOptions::UseSystemAppearance };
-        style.backgroundColor = renderer.theme().annotationHighlightBackgroundColor(styleColorOptions);
-        style.textStyles.fillColor = renderer.theme().annotationHighlightForegroundColor(styleColorOptions);
+        style.backgroundColor = renderer.theme().annotationHighlightBackgroundColor(systemAppearanceOptions);
+        style.textStyles.fillColor = renderer.theme().annotationHighlightForegroundColor(systemAppearanceOptions);
+        break;
+    }
+    case MarkedText::Type::TextExtractionHighlight: {
+        // FIXME: This just uses the same color as annotation highlights for now, but we may eventually require a different appearance.
+        style.backgroundColor = renderer.theme().annotationHighlightBackgroundColor(systemAppearanceOptions);
+        style.textStyles.fillColor = renderer.theme().annotationHighlightForegroundColor(systemAppearanceOptions);
         break;
     }
 #if ENABLE(APP_HIGHLIGHTS)
     case MarkedText::Type::AppHighlight: {
-        OptionSet<StyleColorOptions> styleColorOptions = { StyleColorOptions::UseSystemAppearance };
-        style.backgroundColor = renderer.theme().annotationHighlightBackgroundColor(styleColorOptions);
-        style.textStyles.fillColor = renderer.theme().annotationHighlightForegroundColor(styleColorOptions);
+        style.backgroundColor = renderer.theme().annotationHighlightBackgroundColor(systemAppearanceOptions);
+        style.textStyles.fillColor = renderer.theme().annotationHighlightForegroundColor(systemAppearanceOptions);
         break;
     }
 #endif
@@ -129,11 +135,10 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
     }
     case MarkedText::Type::TextMatch: {
         // Text matches always use the light system appearance.
-        OptionSet<StyleColorOptions> styleColorOptions = { StyleColorOptions::UseSystemAppearance };
 #if PLATFORM(MAC)
-        style.textStyles.fillColor = renderer.theme().systemColor(CSSValueAppleSystemLabel, styleColorOptions);
+        style.textStyles.fillColor = renderer.theme().systemColor(CSSValueAppleSystemLabel, systemAppearanceOptions);
 #endif
-        style.backgroundColor = renderer.theme().textSearchHighlightColor(styleColorOptions);
+        style.backgroundColor = renderer.theme().textSearchHighlightColor(systemAppearanceOptions);
         break;
     }
     }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7389,6 +7389,23 @@ unsigned Internals::numberOfAppHighlights()
 }
 #endif
 
+Vector<Ref<AbstractRange>> Internals::textExtractionHighlightRanges() const
+{
+    RefPtr document = contextDocument();
+    if (!document)
+        return { };
+
+    RefPtr registry = document->textExtractionHighlightRegistryIfExists();
+    if (!registry)
+        return { };
+
+    return flatMap(copyToVector(registry->map().values()), [](auto&& highlight) {
+        return highlight->highlightRanges().map([](auto& range) {
+            return Ref { range->range() };
+        });
+    });
+}
+
 bool Internals::supportsPictureInPicture()
 {
     return WebCore::supportsPictureInPicture();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1489,6 +1489,8 @@ public:
     unsigned numberOfAppHighlights();
 #endif
 
+    Vector<Ref<AbstractRange>> textExtractionHighlightRanges() const;
+
 #if ENABLE(WEBXR)
     ExceptionOr<RefPtr<WebXRTest>> xrTest();
 #endif

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1383,6 +1383,8 @@ enum ContentsFormat {
     [Conditional=APP_HIGHLIGHTS] readonly attribute sequence<DOMString> appHighlightContextMenuItemTitles;
     [Conditional=APP_HIGHLIGHTS] unsigned long numberOfAppHighlights();
 
+    readonly attribute sequence<AbstractRange> textExtractionHighlightRanges;
+
 #if defined(ENABLE_WEBXR) && ENABLE_WEBXR
     [Conditional=WEBXR] readonly attribute WebXRTest xrTest;
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6693,7 +6693,8 @@ header: <WebCore/TextExtractionTypes.h>
     SelectText,
     SelectMenuItem,
     TextInput,
-    KeyPress
+    KeyPress,
+    HighlightText
 };
 
 header: <WebCore/TextExtractionTypes.h>
@@ -6703,6 +6704,7 @@ header: <WebCore/TextExtractionTypes.h>
     std::optional<WebCore::FloatPoint> locationInRootView;
     std::optional<WebCore::NodeIdentifier> nodeIdentifier;
     bool replaceAll;
+    bool scrollToVisible;
 };
 
 header: <WebCore/TextExtractionTypes.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6729,6 +6729,8 @@ static inline std::optional<WebCore::NodeIdentifier> toNodeIdentifier(const Stri
             return WebCore::TextExtraction::Action::TextInput;
         case _WKTextExtractionActionKeyPress:
             return WebCore::TextExtraction::Action::KeyPress;
+        case _WKTextExtractionActionHighlightText:
+            return WebCore::TextExtraction::Action::HighlightText;
         default:
             ASSERT_NOT_REACHED();
             return WebCore::TextExtraction::Action::Click;
@@ -6745,6 +6747,7 @@ static inline std::optional<WebCore::NodeIdentifier> toNodeIdentifier(const Stri
     }
     interaction.text = wkInteraction.text;
     interaction.replaceAll = wkInteraction.replaceAll;
+    interaction.scrollToVisible = wkInteraction.scrollToVisible;
     return interaction;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -67,6 +67,7 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {
     _WKTextExtractionActionSelectMenuItem,
     _WKTextExtractionActionTextInput,
     _WKTextExtractionActionKeyPress,
+    _WKTextExtractionActionHighlightText,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
@@ -83,6 +84,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 @property (nonatomic, copy, nullable) NSString *nodeIdentifier;
 @property (nonatomic, copy, nullable) NSString *text;
 @property (nonatomic) BOOL replaceAll;
+@property (nonatomic) BOOL scrollToVisible;
 
 // Must be within the visible bounds of the web view.
 @property (nonatomic) CGPoint location;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -57,6 +57,7 @@
 @synthesize replaceAll = _replaceAll;
 @synthesize location = _location;
 @synthesize hasSetLocation = _hasSetLocation;
+@synthesize scrollToVisible = _scrollToVisible;
 
 - (instancetype)initWithAction:(_WKTextExtractionAction)action
 {

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -57,6 +57,7 @@ dictionary TextExtractionInteractionOptions {
     double x = -1;
     double y = -1;
     boolean replaceAll = false;
+    boolean scrollToVisible = false;
 };
 
 interface UIScriptController {

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -74,6 +74,7 @@ struct TextExtractionInteractionOptions {
     JSRetainPtr<JSStringRef> text;
     std::optional<std::pair<double, double>> location;
     bool replaceAll { false };
+    bool scrollToVisible { false };
 };
 
 TextExtractionInteractionOptions* toTextExtractionInteractionOptions(JSContextRef, JSValueRef);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -98,6 +98,7 @@ TextExtractionInteractionOptions* toTextExtractionInteractionOptions(JSContextRe
         options.text = nullptr;
 
     options.replaceAll = booleanProperty(context, (JSObjectRef)argument, "replaceAll");
+    options.scrollToVisible = booleanProperty(context, (JSObjectRef)argument, "scrollToVisible");
 
     if (auto locationObject = objectProperty(context, (JSObjectRef)argument, "location")) {
         options.location = {

--- a/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
@@ -60,6 +60,8 @@ std::ostream& operator<<(std::ostream& os, MarkedText::Type type)
         return os << "Highlight";
     case MarkedText::Type::FragmentHighlight:
         return os << "FragmentHighlight";
+    case MarkedText::Type::TextExtractionHighlight:
+        return os << "TextExtractionHighlight";
 #if ENABLE(APP_HIGHLIGHTS)
     case MarkedText::Type::AppHighlight:
         return os << "AppHighlight";

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -401,6 +401,8 @@ void UIScriptControllerCocoa::performTextExtractionInteraction(JSStringRef jsAct
         action = _WKTextExtractionActionTextInput;
     if (equalLettersIgnoringASCIICase(actionName, "keypress"))
         action = _WKTextExtractionActionKeyPress;
+    if (equalLettersIgnoringASCIICase(actionName, "highlighttext"))
+        action = _WKTextExtractionActionHighlightText;
 
     if (!action) {
         ASSERT_NOT_REACHED();
@@ -416,6 +418,7 @@ void UIScriptControllerCocoa::performTextExtractionInteraction(JSStringRef jsAct
         [interaction setText:toWTFString(options->text.get()).createNSString().get()];
 
     [interaction setReplaceAll:options->replaceAll];
+    [interaction setScrollToVisible:options->scrollToVisible];
 
     if (auto location = options->location) {
         auto [x, y] = *location;


### PR DESCRIPTION
#### 03a4ccf4165da8ea0669e72c23f4ad4f9462d335
<pre>
[AutoFill Debugging] Add support for an interaction type to highlight and reveal text
<a href="https://bugs.webkit.org/show_bug.cgi?id=301552">https://bugs.webkit.org/show_bug.cgi?id=301552</a>
<a href="https://rdar.apple.com/160326206">rdar://160326206</a>

Reviewed by Abrar Rahman Protyasha.

Add support for `_WKTextExtractionActionHighlightText`, which highlights text on the page (using an
internal, non-exposed CSS highlight registry) and optionally scrolls to reveal the range. See below
for more details.

Tests: fast/text-extraction/debug-text-extraction-highlight-text.html

* LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::commonTeardown):
(WebCore::Document::hasHighlight const):
(WebCore::Document::textExtractionHighlightRegistry):
(WebCore::Document::updateHighlightPositions):

Add `m_textExtractionHighlightRegistry` to `Document`, which exists alongside other internal CSS
highlight registries on the document.

* Source/WebCore/dom/Document.h:
(WebCore::Document::highlightRegistryIfExists const):
(WebCore::Document::fragmentHighlightRegistryIfExists const):

Drive-by fix: make this getter `const`.

(WebCore::Document::textExtractionHighlightRegistryIfExists const):
(WebCore::Document::highlightRegistryIfExists): Deleted.
(WebCore::Document::fragmentHighlightRegistryIfExists): Deleted.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToTextFragment):

Pull common logic to scroll to the given `SimpleRange` out into a separate helper method,
`revealRangeWithTemporarySelection`, and use it in a few places here to avoid code duplication. This
also allows us to use it from text extraction code below.

(WebCore::LocalFrameView::textFragmentIndicatorTimerFired):
(WebCore::LocalFrameView::revealRangeWithTemporarySelection):
(WebCore::LocalFrameView::scrollToPendingTextFragmentRange):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::searchForText):
(WebCore::TextExtraction::invalidNodeIdentifierDescription):
(WebCore::TextExtraction::resolveNodeWithBodyAsFallback):
(WebCore::TextExtraction::rangeForTextInContainer):

Pull common functionality to map text and node IDs to a range in the DOM out into separate helper
methods, so that we can use it for both the `SelectText` and new `HighlightText` interactions.

(WebCore::TextExtraction::selectText):

Use the above helpers.

(WebCore::TextExtraction::highlightText):

Add a helper method to handle this new interaction type, by finding the target range in the DOM,
adding a new highlight via the new highlight registry, and then (optionally) scrolling to reveal the
range using the new `LocalFrameView` method above.

(WebCore::TextExtraction::handleInteraction):
(WebCore::TextExtraction::interactionDescription):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForHighlights):

Pull common logic out into a separate lambda, `appendMarkedTextHighlights`, and then additionally
deploy it for this new CSS highlight registry.

* Source/WebCore/rendering/MarkedText.h:
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):

Add painting support for this new `TextExtraction` highlight marker type.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::textExtractionHighlightRanges const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _convertToWebCoreInteraction:]):

Add an optional `scrollToVisible` argument to the interaction object, which scrolls the target range
into view for `.selectText` and `.highlightText`. We may want to apply this to some of the other
types (clicking, typing) in the future.

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionInteractionOptions):
* Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp:
(WebCore::operator&lt;&lt;):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::performTextExtractionInteraction):

Canonical link: <a href="https://commits.webkit.org/302234@main">https://commits.webkit.org/302234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e021f3947ab4000d3ac331d0d5f9016810d862fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135804 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79864 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e61a0b4c-54ff-4924-9c79-45b01f7df2e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97747 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65647 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78356 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4de8a115-3149-4b65-ab24-93db08e148cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/408 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33151 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79088 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108812 "Found 1 new API test failure: TestWebKitAPI.EditorStateTests.SelectedTextRange_CaretSelectionWithZoom (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138254 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106290 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106101 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27034 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/430 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29928 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52846 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/575 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63761 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/472 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/531 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/534 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->