### PR TITLE
[JSC] Fix assert in array.new_elem slow path

### DIFF
--- a/JSTests/wasm/gc/array_new_elem.js
+++ b/JSTests/wasm/gc/array_new_elem.js
@@ -849,6 +849,43 @@ function testRecGroup() {
     `);
 }
 
+function testZeroLengthDeclarativeElemAndNewElem() {
+    let m = instantiate(`
+       (module
+         (type $array (array (mut anyref)))
+         (elem declare anyref)
+         (func $create_zero_array (result (ref null $array))
+           (array.new_elem $array 0
+             (i32.const 0)  ;; offset in elem segment
+             (i32.const 0)  ;; size of array to create
+           )
+         )
+         (export "create_zero_array" (func $create_zero_array))
+       )
+    `);
+
+    m.exports.create_zero_array();
+}
+
+function testZeroLengthActiveElemAndNewElem() {
+    let m = instantiate(`
+       (module
+         (table 10 funcref)
+         (type $array (array (mut funcref)))
+         (elem (i32.const 0))
+         (func $create_zero_array (result (ref null $array))
+           (array.new_elem $array 0
+             (i32.const 0)  ;; offset in elem segment
+             (i32.const 0)  ;; size of array to create
+           )
+         )
+         (export "create_zero_array" (func $create_zero_array))
+       )
+    `);
+
+    m.exports.create_zero_array();
+}
+
 testRefCallNullary();
 testRefCall();
 testArrayNewCanonElemExternref();
@@ -872,3 +909,5 @@ testNullFunctionIndex();
 testImportFunctions();
 testJSFunctions();
 testRecGroup();
+testZeroLengthDeclarativeElemAndNewElem();
+testZeroLengthActiveElemAndNewElem();

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -274,7 +274,7 @@ inline EncodedJSValue arrayNewElem(JSWebAssemblyInstance* instance, uint32_t typ
 
     VM& vm = instance->vm();
     StorageType arrayType = structure->typeDefinition().as<ArrayType>()->elementType().type;
-    ASSERT_UNUSED(arrayType, isSubtype(StorageType(element->elementType), arrayType));
+    ASSERT_UNUSED(arrayType, !arraySize || isSubtype(StorageType(element->elementType), arrayType));
     auto* array = JSWebAssemblyArray::tryCreate(vm, structure, arraySize);
     if (!array) [[unlikely]]
         return JSValue::encode(jsNull());
@@ -287,7 +287,7 @@ inline EncodedJSValue arrayNewElem(JSWebAssemblyInstance* instance, uint32_t typ
     WTF::storeStoreFence();
     array->setIsUnpopulated(false);
 #endif
-    ASSERT(Wasm::isRefType(element->elementType));
+    ASSERT(!arraySize || Wasm::isRefType(element->elementType));
     vm.writeBarrier(array);
     return JSValue::encode(array);
 }


### PR DESCRIPTION
#### 23c7a806a33e184a9288c84a12aa9bca7fd73f1b
<pre>
[JSC] Fix assert in array.new_elem slow path
<a href="https://bugs.webkit.org/show_bug.cgi?id=301466">https://bugs.webkit.org/show_bug.cgi?id=301466</a>
<a href="https://rdar.apple.com/163407647">rdar://163407647</a>

Reviewed by Yusuke Suzuki.

There are 3 elem segment types: passive, active, or declarative. Only passive
elem segments are available at runtime and get a non-nullptr `element`.
array.new_elem can still refer to active and declarative elem segments, usually
this traps, because those element segments would be considered 0-lengthed and
the array being created usually have length &gt; 0. This doesn&apos;t trap when the
array size is 0, but in that case the `element` is a nullptr and the debug
asserts crash. This PR fixes the asserts to allow the array to be 0-lengthed.

New test cases are added to array_new_elem.js

Canonical link: <a href="https://commits.webkit.org/302224@main">https://commits.webkit.org/302224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e10508c9fa9696074a5cd8d967845b77496a50d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135807 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c6c4f551-513f-45ea-9b66-040f0fb61c2d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97745 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dfd8062f-5bd7-4795-bc34-3533ce493f9c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131361 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78354 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f5488e00-f13a-4288-a01b-cbbed46224e3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33152 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79091 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120427 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138257 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126873 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/528 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/495 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106286 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106097 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/431 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/52849 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20059 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/578 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63764 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159897 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/475 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39934 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/534 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/537 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->