### PR TITLE
[Swift in WebKit] Fix incorrect quoted imports in WTF

### DIFF
--- a/Source/WTF/wtf/AutodrainedPool.h
+++ b/Source/WTF/wtf/AutodrainedPool.h
@@ -28,9 +28,7 @@
 
 #pragma once
 
-#if defined(__OBJC__) && !defined(__clang_tapi__)
-#error Please use @autoreleasepool instead of AutodrainedPool.
-#endif
+#if !(defined(__OBJC__) && !defined(__clang_tapi__))
 
 #include <wtf/Noncopyable.h>
 
@@ -62,3 +60,5 @@ private:
 } // namespace WTF
 
 using WTF::AutodrainedPool;
+
+#endif // !(defined(__OBJC__) && !defined(__clang_tapi__))

--- a/Source/WTF/wtf/RefTrackerMixin.h
+++ b/Source/WTF/wtf/RefTrackerMixin.h
@@ -19,12 +19,12 @@
 
 #pragma once
 
-#include "Compiler.h"
-#include "DataLog.h"
-#include "HashMap.h"
-#include "Lock.h"
-#include "StackShot.h"
-#include "StackTrace.h"
+#include <wtf/Compiler.h>
+#include <wtf/DataLog.h>
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
+#include <wtf/StackShot.h>
+#include <wtf/StackTrace.h>
 
 #include <atomic>
 

--- a/Source/WTF/wtf/SIMDUTF.cpp
+++ b/Source/WTF/wtf/SIMDUTF.cpp
@@ -33,7 +33,7 @@ IGNORE_WARNINGS_BEGIN("cast-align")
 IGNORE_WARNINGS_BEGIN("documentation")
 IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage")
 
-#include "simdutf_impl.cpp.h"
+#include "simdutf/simdutf_impl.cpp.h"
 
 IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END

--- a/Source/WTF/wtf/cocoa/AutodrainedPool.cpp
+++ b/Source/WTF/wtf/cocoa/AutodrainedPool.cpp
@@ -27,7 +27,7 @@
  */
 
 #import "config.h"
-#import "AutodrainedPool.h"
+#import <wtf/AutodrainedPool.h>
 
 #import <wtf/spi/cocoa/objcSPI.h>
 

--- a/Source/WTF/wtf/cocoa/CrashReporter.cpp
+++ b/Source/WTF/wtf/cocoa/CrashReporter.cpp
@@ -24,7 +24,7 @@
 */
 
 #include "config.h"
-#include "CrashReporter.h"
+#include <wtf/cocoa/CrashReporter.h>
 
 #include <wtf/NeverDestroyed.h>
 #include <wtf/spi/cocoa/CrashReporterClientSPI.h>

--- a/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
@@ -24,13 +24,13 @@
 */
 
 #import "config.h"
-#import "SystemTracing.h"
+#import <wtf/SystemTracing.h>
 
 #if HAVE(OS_SIGNPOST)
 
-#import "ContinuousTime.h"
 #import <dispatch/dispatch.h>
 #import <mach/mach_time.h>
+#import <wtf/ContinuousTime.h>
 
 bool WTFSignpostIndirectLoggingEnabled;
 

--- a/Source/WTF/wtf/cocoa/UUIDCocoa.mm
+++ b/Source/WTF/wtf/cocoa/UUIDCocoa.mm
@@ -24,10 +24,10 @@
  */
 
 #import "config.h"
-#import "UUID.h"
+#import <wtf/UUID.h>
 
-#import "RetainPtr.h"
-#import "TypeCastsCocoa.h"
+#import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
@@ -27,7 +27,7 @@
  */
 
 #include "config.h"
-#include "FileHandle.h"
+#include <wtf/FileHandle.h>
 
 #include <sys/file.h>
 #include <sys/stat.h>

--- a/Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp
+++ b/Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp
@@ -24,7 +24,7 @@
  */
 
 #include "config.h"
-#include "MappedFileData.h"
+#include <wtf/MappedFileData.h>
 
 namespace WTF::FileSystemImpl {
 

--- a/Source/WTF/wtf/text/cocoa/StringImplCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/StringImplCocoa.mm
@@ -19,9 +19,9 @@
  */
 
 #import "config.h"
-#import "StringImpl.h"
+#import <wtf/text/StringImpl.h>
 
-#import "RetainPtr.h"
+#import <wtf/RetainPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WTF {


### PR DESCRIPTION
#### 2922690cd8f1d59392597dbb961a0c4ede335925
<pre>
[Swift in WebKit] Fix incorrect quoted imports in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=301554">https://bugs.webkit.org/show_bug.cgi?id=301554</a>
<a href="https://rdar.apple.com/163536176">rdar://163536176</a>

Reviewed by Abrar Rahman Protyasha.

Most WTF files properly import each other using angled brackets, but there are a few that incorrectly don&apos;t.
Fix those, since Swift and modules are more strict about correctness.

Also fix the AutodrainedPool.h file by making it be able to be included in any context, and instead just compile
out the contents of the file instead of failing to compile just because the header was included.

* Source/WTF/wtf/AutodrainedPool.h:
* Source/WTF/wtf/RefTrackerMixin.h:
* Source/WTF/wtf/SIMDUTF.cpp:
* Source/WTF/wtf/cocoa/AutodrainedPool.cpp:
* Source/WTF/wtf/cocoa/CrashReporter.cpp:
* Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp:
* Source/WTF/wtf/cocoa/UUIDCocoa.mm:
* Source/WTF/wtf/posix/FileHandlePOSIX.cpp:
* Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp:
* Source/WTF/wtf/text/cocoa/StringImplCocoa.mm:

Canonical link: <a href="https://commits.webkit.org/302225@main">https://commits.webkit.org/302225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3df58144a1ffa0bb39834afa4c3ba7775ddacc1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79873 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97753 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78363 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33164 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79098 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120435 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138265 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126881 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/501 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106294 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106106 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27025 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/439 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29941 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52855 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/585 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63772 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159905 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/481 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39937 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/540 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->