### PR TITLE
Always allocate FetchBodyConsumer in heap

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -554,10 +554,10 @@ void FetchBodyConsumer::loadingSucceeded(const String& contentType)
     }
 }
 
-FetchBodyConsumer FetchBodyConsumer::clone()
+UniqueRef<FetchBodyConsumer> FetchBodyConsumer::clone()
 {
-    FetchBodyConsumer clone { m_type };
-    clone.m_buffer = m_buffer;
+    auto clone = makeUniqueRef<FetchBodyConsumer>(m_type);
+    clone->m_buffer = m_buffer;
     return clone;
 }
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -45,7 +45,7 @@ class FetchBodySource;
 class FormData;
 class ReadableStream;
 
-class FetchBodyConsumer final : public CanMakeWeakPtr<FetchBodyConsumer>, public CanMakeCheckedPtr<FetchBodyConsumer, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
+class FetchBodyConsumer final : public CanMakeWeakPtr<FetchBodyConsumer>, public CanMakeCheckedPtr<FetchBodyConsumer> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(FetchBodyConsumer);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FetchBodyConsumer);
 public:
@@ -56,7 +56,7 @@ public:
     ~FetchBodyConsumer();
     FetchBodyConsumer& operator=(FetchBodyConsumer&&);
 
-    FetchBodyConsumer clone();
+    UniqueRef<FetchBodyConsumer> clone();
 
     void append(const SharedBuffer&);
 


### PR DESCRIPTION
#### a97fb762a2d2d16e56a8da3d6a39f0cb146b09ca
<pre>
Always allocate FetchBodyConsumer in heap
<a href="https://bugs.webkit.org/show_bug.cgi?id=301557">https://bugs.webkit.org/show_bug.cgi?id=301557</a>

Reviewed by Geoffrey Garen.

Always allocate in FetchBodyConsumer in heap so that operator delete will be used for its destruction.

No new tests since there should be no behavioral difference.

* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::arrayBuffer):
(WebCore::FetchBody::blob):
(WebCore::FetchBody::bytes):
(WebCore::FetchBody::json):
(WebCore::FetchBody::text):
(WebCore::FetchBody::formData):
(WebCore::FetchBody::consumeOnceLoadingFinished):
(WebCore::FetchBody::consume):
(WebCore::FetchBody::consumeAsStream):
(WebCore::FetchBody::consumeArrayBuffer):
(WebCore::FetchBody::consumeArrayBufferView):
(WebCore::FetchBody::consumeText):
(WebCore::FetchBody::consumeBlob):
(WebCore::FetchBody::consumeFormData):
(WebCore::FetchBody::loadingFailed):
(WebCore::FetchBody::loadingSucceeded):
(WebCore::FetchBody::bodyAsFormData const):
(WebCore::FetchBody::take):
(WebCore::FetchBody::consumer):
(WebCore::FetchBody::clone):
* Source/WebCore/Modules/fetch/FetchBody.h:
(WebCore::FetchBody::cleanConsumer):
(WebCore::FetchBody::hasConsumerPendingActivity const):
(WebCore::FetchBody::FetchBody):
(WebCore::FetchBody::consumer): Deleted.
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::clone):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:

Canonical link: <a href="https://commits.webkit.org/302415@main">https://commits.webkit.org/302415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/735cbb75ebb09631c61357a89c693c72fed67321

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128954 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136333 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80317 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1deb2598-8d3e-45bc-99c9-f704d5373646) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98174 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66089 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78801 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/de074b0e-9c1a-49d7-991a-fc980ca688e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33628 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79614 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109248 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138800 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106711 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1069 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106531 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/838 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30374 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53478 "Hash 735cbb75 for PR 53073 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20146 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1084 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64499 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/918 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/971 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1015 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->