### PR TITLE
[iOS] Double tap does not result in dblclick event dispatch even when the Window object has a listener

### DIFF
--- a/LayoutTests/fast/events/touch/ios/double-tap-for-double-click-on-window-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/double-tap-for-double-click-on-window-expected.txt
@@ -1,0 +1,3 @@
+Test for double tap triggering dblclick event on window. To run manually, double tap anywhere in the viewport.
+
+PASS: Received dblclick event on window.

--- a/LayoutTests/fast/events/touch/ios/double-tap-for-double-click-on-window.html
+++ b/LayoutTests/fast/events/touch/ios/double-tap-for-double-click-on-window.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../../resources/ui-helper.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+async function runTest() {
+    if (!testRunner.runUIScript)
+        return;
+
+    let dblclickFired = false;
+
+    window.addEventListener("dblclick", () => {
+        dblclickFired = true;
+    });
+
+    await UIHelper.waitForDoubleTapDelay();
+    await UIHelper.humanSpeedDoubleTapAt(50, 50);
+
+    if (dblclickFired)
+        document.getElementById("result").textContent = "PASS: Received dblclick event on window.";
+    else
+        document.getElementById("result").textContent = `FAIL: Did not receive dblclick event on window.`;
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+window.addEventListener("load", runTest, false);
+</script>
+</head>
+<body>
+<p>Test for double tap triggering dblclick event on window. To run manually, double tap anywhere in the viewport.</p>
+<p id="result"></p>
+</body>
+</html>

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -126,7 +126,7 @@ public:
     CheckedPtr<FrameConsoleClient> checkedConsole() const;
 
     WindowProxy* opener() const;
-    Document* documentIfLocal();
+    WEBCORE_EXPORT Document* documentIfLocal();
     RefPtr<Document> protectedDocumentIfLocal();
 
     WindowProxy* top() const;

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -289,7 +289,7 @@ Node* LocalFrame::qualifyingNodeAtViewportLocation(const FloatPoint& viewportLoc
 
     // We have the candidate node at the location, check whether it or one of its ancestors passes
     // the qualifier function, which typically checks if the node responds to a particular event type.
-    Node* approximateNode = nodeQualifierFunction(candidateInfo, 0, 0);
+    Node* approximateNode = nodeQualifierFunction(candidateInfo, nullptr, nullptr);
 
     if (shouldFindRootEditableElement == ShouldFindRootEditableElement::Yes && approximateNode && approximateNode->isContentEditable()) {
         // If we are in editable content, we look for the root editable element.

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
@@ -53,7 +53,7 @@ struct InteractionInformationAtPosition {
     InteractionInformationRequest request;
 
     bool canBeValid { true };
-    std::optional<bool> nodeAtPositionHasDoubleClickHandler;
+    std::optional<bool> hitNodeOrWindowHasDoubleClickListener;
 
     enum class Selectability : uint8_t {
         Selectable,

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
@@ -33,7 +33,7 @@ struct WebKit::InteractionInformationAtPosition {
     WebKit::InteractionInformationRequest request;
 
     bool canBeValid;
-    std::optional<bool> nodeAtPositionHasDoubleClickHandler;
+    std::optional<bool> hitNodeOrWindowHasDoubleClickListener;
 
     WebKit::InteractionInformationAtPosition::Selectability selectability;
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3513,7 +3513,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             if (![self ensurePositionInformationIsUpToDate:request])
                 return NO;
         }
-        return _positionInformation.nodeAtPositionHasDoubleClickHandler.value_or(false);
+        return _positionInformation.hitNodeOrWindowHasDoubleClickListener.value_or(false);
     }
 
     if (gestureRecognizer == _highlightLongPressGestureRecognizer

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -98,6 +98,8 @@
 #import <WebCore/ElementAncestorIteratorInlines.h>
 #import <WebCore/ElementAnimationContext.h>
 #import <WebCore/EventHandler.h>
+#import <WebCore/EventNames.h>
+#import <WebCore/EventTargetInlines.h>
 #import <WebCore/File.h>
 #import <WebCore/FloatQuad.h>
 #import <WebCore/FrameDestructionObserverInlines.h>
@@ -135,6 +137,7 @@
 #import <WebCore/InputMode.h>
 #import <WebCore/KeyboardEvent.h>
 #import <WebCore/LibWebRTCProvider.h>
+#import <WebCore/LocalDOMWindow.h>
 #import <WebCore/LocalFrame.h>
 #import <WebCore/LocalFrameLoaderClient.h>
 #import <WebCore/LocalFrameView.h>
@@ -1091,15 +1094,37 @@ void WebPage::attemptSyntheticClick(const IntPoint& point, OptionSet<WebEventMod
         handleSyntheticClick(std::nullopt, *nodeRespondingToClick, adjustedPoint, modifiers);
 }
 
+static RefPtr<LocalDOMWindow> windowWithDoubleClickEventListener(RefPtr<LocalFrame> frame)
+{
+    if (!frame)
+        return nullptr;
+
+    RefPtr window = frame->window();
+    if (!window || !window->hasEventListeners(WebCore::eventNames().dblclickEvent))
+        return nullptr;
+
+    return window;
+}
+
 void WebPage::handleDoubleTapForDoubleClickAtPoint(const IntPoint& point, OptionSet<WebEventModifier> modifiers, TransactionID lastLayerTreeTransactionId)
 {
     FloatPoint adjustedPoint;
     RefPtr localMainFrame = m_page->localMainFrame();
     auto* nodeRespondingToDoubleClick = localMainFrame ? localMainFrame->nodeRespondingToDoubleClickEvent(point, adjustedPoint) : nullptr;
-    if (!nodeRespondingToDoubleClick)
+
+    RefPtr windowListeningToDoubleClickEvents = windowWithDoubleClickEventListener(localMainFrame);
+
+    if (!nodeRespondingToDoubleClick && !windowListeningToDoubleClickEvents)
         return;
 
-    auto* frameRespondingToDoubleClick = nodeRespondingToDoubleClick->document().frame();
+    RefPtr<LocalFrame> frameRespondingToDoubleClick;
+    if (nodeRespondingToDoubleClick)
+        frameRespondingToDoubleClick = nodeRespondingToDoubleClick->document().frame();
+    else if (windowListeningToDoubleClickEvents) {
+        RefPtr document = windowListeningToDoubleClickEvents->documentIfLocal();
+        frameRespondingToDoubleClick = document ? document->frame() : nullptr;
+    }
+
     if (!frameRespondingToDoubleClick)
         return;
 
@@ -1111,10 +1136,10 @@ void WebPage::handleDoubleTapForDoubleClickAtPoint(const IntPoint& point, Option
 
     auto platformModifiers = platform(modifiers);
     auto roundedAdjustedPoint = roundedIntPoint(adjustedPoint);
-    nodeRespondingToDoubleClick->document().frame()->eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, MouseButton::Left, PlatformEvent::Type::MousePressed, 2, platformModifiers, MonotonicTime::now(), 0, WebCore::SyntheticClickType::OneFingerTap));
+    frameRespondingToDoubleClick->eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, MouseButton::Left, PlatformEvent::Type::MousePressed, 2, platformModifiers, MonotonicTime::now(), 0, WebCore::SyntheticClickType::OneFingerTap));
     if (m_isClosed)
         return;
-    nodeRespondingToDoubleClick->document().frame()->eventHandler().handleMouseReleaseEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, MouseButton::Left, PlatformEvent::Type::MouseReleased, 2, platformModifiers, MonotonicTime::now(), 0, WebCore::SyntheticClickType::OneFingerTap));
+    frameRespondingToDoubleClick->eventHandler().handleMouseReleaseEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, MouseButton::Left, PlatformEvent::Type::MouseReleased, 2, platformModifiers, MonotonicTime::now(), 0, WebCore::SyntheticClickType::OneFingerTap));
 }
 
 void WebPage::requestFocusedElementInformation(CompletionHandler<void(const std::optional<FocusedElementInformation>&)>&& completionHandler)
@@ -3900,7 +3925,7 @@ InteractionInformationAtPosition WebPage::positionInformation(const InteractionI
     info.adjustedPointForNodeRespondingToClickEvents = adjustedPoint;
 
     if (request.includeHasDoubleClickHandler)
-        info.nodeAtPositionHasDoubleClickHandler = localMainFrame->nodeRespondingToDoubleClickEvent(request.point, adjustedPoint);
+        info.hitNodeOrWindowHasDoubleClickListener = localMainFrame->nodeRespondingToDoubleClickEvent(request.point, adjustedPoint) || windowWithDoubleClickEventListener(localMainFrame);
 
     auto hitTestRequestTypes = OptionSet<HitTestRequest::Type> {
         HitTestRequest::Type::ReadOnly,


### PR DESCRIPTION
#### dc2b216b9f0f9e15edeae2f97b3c2149e3e0bbe7
<pre>
[iOS] Double tap does not result in dblclick event dispatch even when the Window object has a listener
<a href="https://bugs.webkit.org/show_bug.cgi?id=301558">https://bugs.webkit.org/show_bug.cgi?id=301558</a>
<a href="https://rdar.apple.com/162546881">rdar://162546881</a>

Reviewed by Ryosuke Niwa.

Currently, we walk up the DOM tree from our hit test point to determine
whether any node requires dblclick dispatch.

However, in the case that _only_ the Window object has a dblclick event
listener, we think there is no node responding to double click events,
because the Window object does not show up in the node traversal logic
in LocalFrame::nodeRespondingToDoubleClickEvent().

In this patch, we address this shortcoming by introducing some special
casing for Window. After checking for an appropriate target node (for
dblclick dispatch), we now apply the same logic for Window.

Test: fast/events/touch/ios/double-tap-for-double-click-on-window.html

* LayoutTests/fast/events/touch/ios/double-tap-for-double-click-on-window-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/double-tap-for-double-click-on-window.html: Added.
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::qualifyingNodeAtViewportLocation):
Drive-by rewrite: nullptr is clearer than 0 at the callsite about what
kind of data we are passing in.

* Source/WebKit/Shared/ios/InteractionInformationAtPosition.h:
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in:
Now that the InteractionInformationAtPosition structure captures more
than just &quot;can the hit tested node respond to dblclick events&quot;, we
rename the flag to `hitNodeOrWindowHasDoubleClickListener`. This
reflects the expanded scope of the bit.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView gestureRecognizerShouldBegin:]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::windowWithDoubleClickEventListener):
(WebKit::WebPage::handleDoubleTapForDoubleClickAtPoint):
(WebKit::WebPage::positionInformation):

Canonical link: <a href="https://commits.webkit.org/302274@main">https://commits.webkit.org/302274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8047a6929ce02041174168545a896a9ca14e2b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79944 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eda23a0b-fc33-4d2b-b3d2-d05481219f4a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97831 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65745 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8822d5c2-9beb-4a46-9d46-190a27a33789) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78443 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dc85956f-6dd0-4f99-b360-7b77aea2c607) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/474 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33246 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79184 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138350 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106366 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106180 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27059 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/515 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52950 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/670 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63870 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/554 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/615 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/624 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->