### PR TITLE
Adopt more smart pointers for TiledCoreAnimationDrawingArea.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -74,5 +74,4 @@ WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 [ iOS ] WebProcess/WebPage/WebPage.cpp
 [ iOS ] WebProcess/WebPage/ios/FindControllerIOS.mm
 [ iOS ] WebProcess/WebPage/ios/WebPageIOS.mm
-[ Mac ] WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 [ iOS ] WebProcess/WebProcess.cpp

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -180,7 +180,7 @@ void TiledCoreAnimationDrawingArea::updateRenderingWithForcedRepaint()
     if (m_layerTreeStateIsFrozen)
         return;
 
-    m_webPage->protectedCorePage()->forceRepaintAllFrames();
+    Ref { m_webPage.get() }->protectedCorePage()->forceRepaintAllFrames();
     updateRendering();
     [CATransaction flush];
     [CATransaction synchronize];
@@ -197,7 +197,8 @@ void TiledCoreAnimationDrawingArea::updateRenderingWithForcedRepaintAsync(WebPag
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler();
-        protectedThis->m_webPage->protectedDrawingArea()->updateRenderingWithForcedRepaint();
+        Ref protectedPage = protectedThis->m_webPage.get();
+        protectedPage->protectedDrawingArea()->updateRenderingWithForcedRepaint();
         completionHandler();
     });
 }
@@ -643,7 +644,8 @@ bool TiledCoreAnimationDrawingArea::shouldUseTiledBackingForFrameView(const Loca
 
 PlatformCALayer* TiledCoreAnimationDrawingArea::layerForTransientZoom() const
 {
-    RefPtr scaledLayer = dynamicDowncast<GraphicsLayerCA>(m_webPage->checkedLocalMainFrameView()->graphicsLayerForPageScale());
+    CheckedPtr frameView =  Ref { m_webPage.get() }->localMainFrameView();
+    RefPtr scaledLayer = dynamicDowncast<GraphicsLayerCA>(frameView->graphicsLayerForPageScale());
     if (!scaledLayer)
         return nullptr;
 
@@ -657,7 +659,8 @@ RefPtr<WebCore::PlatformCALayer> TiledCoreAnimationDrawingArea::protectedLayerFo
 
 PlatformCALayer* TiledCoreAnimationDrawingArea::shadowLayerForTransientZoom() const
 {
-    RefPtr shadowLayer = dynamicDowncast<GraphicsLayerCA>(m_webPage->checkedLocalMainFrameView()->graphicsLayerForTransientZoomShadow());
+    CheckedPtr frameView =  Ref { m_webPage.get() }->localMainFrameView();
+    RefPtr shadowLayer = dynamicDowncast<GraphicsLayerCA>(frameView->graphicsLayerForTransientZoomShadow());
     if (!shadowLayer)
         return nullptr;
 


### PR DESCRIPTION
#### af0fb1c4102b84142e4b556d07e995d16308ec33
<pre>
Adopt more smart pointers for TiledCoreAnimationDrawingArea.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=301562">https://bugs.webkit.org/show_bug.cgi?id=301562</a>

Reviewed by Ryosuke Niwa.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.</a>

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::updateRenderingWithForcedRepaint):
(WebKit::TiledCoreAnimationDrawingArea::updateRenderingWithForcedRepaintAsync):
(WebKit::TiledCoreAnimationDrawingArea::layerForTransientZoom const):
(WebKit::TiledCoreAnimationDrawingArea::shadowLayerForTransientZoom const):

Canonical link: <a href="https://commits.webkit.org/302393@main">https://commits.webkit.org/302393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a3a6378b82ca2e98fbb93ff366c8f992927d7fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136367 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80344 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98202 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66107 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131934 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78853 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79647 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109280 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138835 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1042 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1014 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106737 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106576 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27122 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/868 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53530 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1117 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64438 "Found 25 new failures in Platform/IPC/ArgumentCoders.h, AutomationProtocolObjects.h, WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp, WebDriverBidiProtocolObjects.h, WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp, WebProcess/WebPage/WebFrame.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/952 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->