### PR TITLE
Move FontPlatformSerializedAttributes off of using a CFArray for serialization

### DIFF
--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -183,6 +183,13 @@ struct FontPlatformOpticalSize {
     Variant<RetainPtr<CFNumberRef>, String> opticalSize;
 };
 
+struct FontPlatformFeatureSetting {
+    std::optional<RetainPtr<CFNumberRef>> type;
+    std::optional<RetainPtr<CFNumberRef>> selector;
+    std::optional<RetainPtr<CFStringRef>> tag;
+    std::optional<RetainPtr<CFNumberRef>> value;
+};
+
 struct FontPlatformSerializedAttributes {
     static std::optional<FontPlatformSerializedAttributes> fromCF(CFDictionaryRef);
     RetainPtr<CFDictionaryRef> toCFDictionary() const;
@@ -211,8 +218,7 @@ struct FontPlatformSerializedAttributes {
     std::optional<FontPlatformOpticalSize> opticalSize;
     std::optional<FontPlatformSerializedTraits> traits;
 
-    // FIXME: featureSettings is an array of CFDictionaries whose layouts are highly variable
-    std::optional<RetainPtr<CFArrayRef>> featureSettings;
+    std::optional<Vector<FontPlatformFeatureSetting>> featureSettings;
 
 #if HAVE(ADDITIONAL_FONT_PLATFORM_SERIALIZED_ATTRIBUTES)
     std::optional<RetainPtr<CFNumberRef>> additionalNumber;

--- a/Source/WebKit/Shared/WebCoreFont.serialization.in
+++ b/Source/WebKit/Shared/WebCoreFont.serialization.in
@@ -110,6 +110,13 @@ header: <WebCore/FontPlatformData.h>
     Variant<RetainPtr<CFNumberRef>, String> opticalSize;
 };
 
+[CustomHeader] struct WebCore::FontPlatformFeatureSetting {
+    std::optional<RetainPtr<CFNumberRef>> type;
+    std::optional<RetainPtr<CFNumberRef>> selector;
+    std::optional<RetainPtr<CFStringRef>> tag;
+    std::optional<RetainPtr<CFNumberRef>> value;
+};
+
 [CustomHeader] struct WebCore::FontPlatformSerializedAttributes {
     String fontName;
     String descriptorLanguage;
@@ -135,7 +142,7 @@ header: <WebCore/FontPlatformData.h>
     std::optional<WebCore::FontPlatformOpticalSize> opticalSize;
     std::optional<WebCore::FontPlatformSerializedTraits> traits;
 
-    std::optional<RetainPtr<CFArrayRef>> featureSettings;
+    std::optional<Vector<WebCore::FontPlatformFeatureSetting>> featureSettings;
 
 #if HAVE(ADDITIONAL_FONT_PLATFORM_SERIALIZED_ATTRIBUTES)
     std::optional<RetainPtr<CFNumberRef>> additionalNumber;

--- a/Source/WebKit/Shared/cf/CFTypes.serialization.in
+++ b/Source/WebKit/Shared/cf/CFTypes.serialization.in
@@ -31,9 +31,6 @@
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFString()] CFStringRef wrapped by WTF::String {
 }
 
-[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFArray()] CFArrayRef wrapped by WebKit::CoreIPCCFArray {
-}
-
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFDictionary()] CFDictionaryRef wrapped by WebKit::CoreIPCCFDictionary {
 }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -102,7 +102,6 @@ struct CFHolderForTesting {
 
     using ValueType = Variant<
         std::nullptr_t,
-        RetainPtr<CFArrayRef>,
         RetainPtr<CFBooleanRef>,
         RetainPtr<CFCharacterSetRef>,
         RetainPtr<CFDataRef>,
@@ -288,8 +287,6 @@ CFHolderForTesting cfHolder(CFTypeRef type)
     if (!type)
         return { nullptr };
     CFTypeID typeID = CFGetTypeID(type);
-    if (typeID == CFArrayGetTypeID())
-        return { (CFArrayRef)type };
     if (typeID == CFBooleanGetTypeID())
         return { (CFBooleanRef)type };
     if (typeID == CFCharacterSetGetTypeID())
@@ -1263,20 +1260,6 @@ TEST(IPCSerialization, Basic)
         (id)accessControlRef.get(),
         @{ @"key": NSNull.null }
     ];
-
-    runTestCFWithExpectedResult({ (__bridge CFArrayRef)@[
-        nestedArray,
-        (id)trust.get(),
-        NSUUID.UUID, // Removed when encoding because CFUUIDRef is not a recognized type in CFArrayRef or CFDictionaryRef
-        @{
-            @"should be removed before encoding" : NSUUID.UUID,
-            NSUUID.UUID : @"should also be removed before encoding"
-        }
-    ] }, { (__bridge CFArrayRef)@[
-        nestedArray,
-        (id)trust.get(),
-        @{ }
-    ] });
 
     runTestCFWithExpectedResult({ (__bridge CFDictionaryRef) @{
         @"key" : nestedArray,


### PR DESCRIPTION
#### 233654426e8b5fbefd907fa2376a273ed7f30c37
<pre>
Move FontPlatformSerializedAttributes off of using a CFArray for serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=301567">https://bugs.webkit.org/show_bug.cgi?id=301567</a>
<a href="https://rdar.apple.com/163561063">rdar://163561063</a>

Reviewed by Brady Eidson.

Moves FontPlatformSerializedAttributes off of using a CFArray to serialize
it&apos;s featureSettings. Instead, we explicitly breakout the featureSettings to
expose it&apos;s inner structure. This was the last CFArray being directly serialized, so
we also removed the CFArray exposure to our .serialization.in files.

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm

* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformSerializedAttributes::fromCF):
(WebCore::FontPlatformSerializedAttributes::toCFDictionary const):
* Source/WebKit/Shared/WebCoreFont.serialization.in:
* Source/WebKit/Shared/cf/CFTypes.serialization.in:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(cfHolder):
(TEST(IPCSerialization, Basic)):

Canonical link: <a href="https://commits.webkit.org/302347@main">https://commits.webkit.org/302347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10d71c4dae0ed18fb5e50bd62dbe35d378fb7423

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136185 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80174 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/936 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98059 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65966 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115389 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78668 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33502 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79465 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138645 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/855 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106599 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27097 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/722 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30257 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53317 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64234 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/796 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/851 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/886 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->