### PR TITLE
Reduce unsafeness of Navigator classes

### DIFF
--- a/Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp
@@ -51,7 +51,7 @@ RefPtr<DOMAudioSession> NavigatorAudioSession::audioSession(Navigator& navigator
 
 NavigatorAudioSession* NavigatorAudioSession::from(Navigator& navigator)
 {
-    auto* supplement = static_cast<NavigatorAudioSession*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    auto* supplement = downcast<NavigatorAudioSession>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorAudioSession>();
         supplement = newSupplement.get();
@@ -60,11 +60,6 @@ NavigatorAudioSession* NavigatorAudioSession::from(Navigator& navigator)
     return supplement;
 }
 
-ASCIILiteral NavigatorAudioSession::supplementName()
-{
-    return "NavigatorAudioSession"_s;
-}
-
-}
+} // namespace WebCore
 
 #endif // ENABLE(DOM_AUDIO_SESSION)

--- a/Source/WebCore/Modules/audiosession/NavigatorAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/NavigatorAudioSession.h
@@ -46,11 +46,16 @@ public:
 
 private:
     static NavigatorAudioSession* from(Navigator&);
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorAudioSession"_s; }
+    bool isNavigatorAudioSession() const final { return true; }
 
     RefPtr<DOMAudioSession> m_audioSession;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorAudioSession)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorAudioSession(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(DOM_AUDIO_SESSION)

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -55,18 +55,13 @@ NavigatorBeacon::~NavigatorBeacon()
 
 NavigatorBeacon* NavigatorBeacon::from(Navigator& navigator)
 {
-    auto* supplement = static_cast<NavigatorBeacon*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    auto* supplement = downcast<NavigatorBeacon>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorBeacon>(navigator);
         supplement = newSupplement.get();
         provideTo(&navigator, supplementName(), WTFMove(newSupplement));
     }
     return supplement;
-}
-
-ASCIILiteral NavigatorBeacon::supplementName()
-{
-    return "NavigatorBeacon"_s;
 }
 
 void NavigatorBeacon::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.h
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.h
@@ -55,7 +55,8 @@ public:
 private:
     ExceptionOr<bool> sendBeacon(Document&, const String& url, std::optional<FetchBody::Init>&&);
 
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorBeacon"_s; }
+    bool isNavigatorBeacon() const final { return true; }
 
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
     void logError(const ResourceError&);
@@ -64,4 +65,8 @@ private:
     Vector<CachedResourceHandle<CachedRawResource>> m_inflightBeacons;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorBeacon)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorBeacon(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/contact-picker/NavigatorContacts.cpp
+++ b/Source/WebCore/Modules/contact-picker/NavigatorContacts.cpp
@@ -56,7 +56,7 @@ RefPtr<ContactsManager> NavigatorContacts::contacts()
 
 NavigatorContacts* NavigatorContacts::from(Navigator& navigator)
 {
-    auto* supplement = static_cast<NavigatorContacts*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    auto* supplement = downcast<NavigatorContacts>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorContacts>(navigator);
         supplement = newSupplement.get();
@@ -65,9 +65,4 @@ NavigatorContacts* NavigatorContacts::from(Navigator& navigator)
     return supplement;
 }
 
-ASCIILiteral NavigatorContacts::supplementName()
-{
-    return "NavigatorContacts"_s;
-}
-
-}
+} // namespace WebCore

--- a/Source/WebCore/Modules/contact-picker/NavigatorContacts.h
+++ b/Source/WebCore/Modules/contact-picker/NavigatorContacts.h
@@ -46,10 +46,15 @@ public:
 
 private:
     static NavigatorContacts* from(Navigator&);
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorContacts"_s; }
+    bool isNavigatorContacts() const final { return true; }
 
     RefPtr<ContactsManager> m_contactsManager;
     const CheckedRef<Navigator> m_navigator;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorContacts)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorContacts(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp
@@ -42,11 +42,6 @@ NavigatorCredentials::NavigatorCredentials() = default;
 
 NavigatorCredentials::~NavigatorCredentials() = default;
 
-ASCIILiteral NavigatorCredentials::supplementName()
-{
-    return "NavigatorCredentials"_s;
-}
-
 CredentialsContainer* NavigatorCredentials::credentials(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document)
 {
     if (!m_credentialsContainer)
@@ -64,7 +59,7 @@ CredentialsContainer* NavigatorCredentials::credentials(Navigator& navigator)
 
 NavigatorCredentials* NavigatorCredentials::from(Navigator* navigator)
 {
-    NavigatorCredentials* supplement = static_cast<NavigatorCredentials*>(Supplement<Navigator>::from(navigator, supplementName()));
+    NavigatorCredentials* supplement = downcast<NavigatorCredentials>(Supplement<Navigator>::from(navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorCredentials>();
         supplement = newSupplement.get();

--- a/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h
+++ b/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h
@@ -50,11 +50,16 @@ private:
     CredentialsContainer* credentials(WeakPtr<Document, WeakPtrImplWithEventTargetData>&&);
 
     static NavigatorCredentials* from(Navigator*);
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorCredentials"_s; }
+    bool isNavigatorCredentials() const final { return true; }
 
     RefPtr<CredentialsContainer> m_credentialsContainer;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorCredentials)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorCredentials(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/geolocation/NavigatorGeolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/NavigatorGeolocation.cpp
@@ -44,14 +44,9 @@ NavigatorGeolocation::NavigatorGeolocation(Navigator& navigator)
 
 NavigatorGeolocation::~NavigatorGeolocation() = default;
 
-ASCIILiteral NavigatorGeolocation::supplementName()
-{
-    return "NavigatorGeolocation"_s;
-}
-
 NavigatorGeolocation* NavigatorGeolocation::from(Navigator& navigator)
 {
-    NavigatorGeolocation* supplement = static_cast<NavigatorGeolocation*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    auto* supplement = downcast<NavigatorGeolocation>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorGeolocation>(navigator);
         supplement = newSupplement.get();

--- a/Source/WebCore/Modules/geolocation/NavigatorGeolocation.h
+++ b/Source/WebCore/Modules/geolocation/NavigatorGeolocation.h
@@ -47,12 +47,17 @@ public:
 #endif // PLATFORM(IOS_FAMILY)
 
 private:
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorGeolocation"_s; }
+    bool isNavigatorGeolocation() const final { return true; }
 
     const RefPtr<Geolocation> m_geolocation;
     const CheckedRef<Navigator> m_navigator;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorGeolocation)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorGeolocation(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GEOLOCATION)

--- a/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
@@ -41,14 +41,9 @@ NavigatorMediaCapabilities::NavigatorMediaCapabilities()
 
 NavigatorMediaCapabilities::~NavigatorMediaCapabilities() = default;
 
-ASCIILiteral NavigatorMediaCapabilities::supplementName()
-{
-    return "NavigatorMediaCapabilities"_s;
-}
-
 NavigatorMediaCapabilities& NavigatorMediaCapabilities::from(Navigator& navigator)
 {
-    NavigatorMediaCapabilities* supplement = static_cast<NavigatorMediaCapabilities*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    auto* supplement = downcast<NavigatorMediaCapabilities>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorMediaCapabilities>();
         supplement = newSupplement.get();

--- a/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h
@@ -44,9 +44,14 @@ public:
 
     MediaCapabilities& mediaCapabilities() const;
 private:
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorMediaCapabilities"_s; }
+    bool isNavigatorMediaCapabilities() const final { return true; }
 
     const Ref<MediaCapabilities> m_mediaCapabilities;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorMediaCapabilities)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorMediaCapabilities(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/mediasession/NavigatorMediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/NavigatorMediaSession.cpp
@@ -68,7 +68,7 @@ RefPtr<MediaSession> NavigatorMediaSession::mediaSessionIfExists()
 
 NavigatorMediaSession* NavigatorMediaSession::from(Navigator& navigator)
 {
-    auto* supplement = static_cast<NavigatorMediaSession*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    auto* supplement = downcast<NavigatorMediaSession>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorMediaSession>(navigator);
         supplement = newSupplement.get();
@@ -77,11 +77,6 @@ NavigatorMediaSession* NavigatorMediaSession::from(Navigator& navigator)
     return supplement;
 }
 
-ASCIILiteral NavigatorMediaSession::supplementName()
-{
-    return "NavigatorMediaSession"_s;
-}
-
-}
+} // namespace WebCore
 
 #endif // ENABLE(MEDIA_SESSION)

--- a/Source/WebCore/Modules/mediasession/NavigatorMediaSession.h
+++ b/Source/WebCore/Modules/mediasession/NavigatorMediaSession.h
@@ -50,12 +50,17 @@ public:
 
 private:
     static NavigatorMediaSession* from(Navigator&);
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorMediaSession"_s; }
+    bool isNavigatorMediaSession() const final { return true; }
 
     const RefPtr<MediaSession> m_mediaSession;
     const CheckedRef<Navigator> m_navigator;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorMediaSession)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorMediaSession(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(MEDIA_SESSION)

--- a/Source/WebCore/Modules/mediastream/NavigatorMediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/NavigatorMediaDevices.cpp
@@ -52,7 +52,7 @@ NavigatorMediaDevices::~NavigatorMediaDevices() = default;
 
 NavigatorMediaDevices* NavigatorMediaDevices::from(Navigator* navigator)
 {
-    NavigatorMediaDevices* supplement = reinterpret_cast<NavigatorMediaDevices*>(Supplement<Navigator>::from(navigator, supplementName()));
+    auto* supplement = downcast<NavigatorMediaDevices>(Supplement<Navigator>::from(navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorMediaDevices>(navigator->window());
         supplement = newSupplement.get();
@@ -71,11 +71,6 @@ MediaDevices* NavigatorMediaDevices::mediaDevices() const
     if (!m_mediaDevices && frame())
         m_mediaDevices = MediaDevices::create(*frame()->protectedDocument());
     return m_mediaDevices.get();
-}
-
-ASCIILiteral NavigatorMediaDevices::supplementName()
-{
-    return "NavigatorMediaDevices"_s;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/NavigatorMediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/NavigatorMediaDevices.h
@@ -52,11 +52,16 @@ public:
     MediaDevices* mediaDevices() const;
 
 private:
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorMediaDevices"_s; }
+    bool isNavigatorMediaDevices() const final { return true; }
 
     mutable RefPtr<MediaDevices> m_mediaDevices;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorMediaDevices)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorMediaDevices(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/Modules/permissions/NavigatorPermissions.cpp
+++ b/Source/WebCore/Modules/permissions/NavigatorPermissions.cpp
@@ -54,7 +54,7 @@ Permissions& NavigatorPermissions::permissions()
 
 NavigatorPermissions& NavigatorPermissions::from(Navigator& navigator)
 {
-    auto* supplement = static_cast<NavigatorPermissions*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    auto* supplement = downcast<NavigatorPermissions>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorPermissions>(navigator);
         supplement = newSupplement.get();
@@ -62,11 +62,6 @@ NavigatorPermissions& NavigatorPermissions::from(Navigator& navigator)
     }
 
     return *supplement;
-}
-
-ASCIILiteral NavigatorPermissions::supplementName()
-{
-    return "NavigatorPermissions"_s;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/permissions/NavigatorPermissions.h
+++ b/Source/WebCore/Modules/permissions/NavigatorPermissions.h
@@ -44,10 +44,15 @@ public:
 
 private:
     static NavigatorPermissions& from(Navigator&);
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorPermissions"_s; }
+    bool isNavigatorPermissions() const final { return true; }
 
     const RefPtr<Permissions> m_permissions;
     const WTF::CheckedRef<Navigator> m_navigator;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorPermissions)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorPermissions(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
@@ -45,18 +45,13 @@ NavigatorScreenWakeLock::~NavigatorScreenWakeLock() = default;
 
 NavigatorScreenWakeLock* NavigatorScreenWakeLock::from(Navigator& navigator)
 {
-    auto* supplement = static_cast<NavigatorScreenWakeLock*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    auto* supplement = downcast<NavigatorScreenWakeLock>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorScreenWakeLock>(navigator);
         supplement = newSupplement.get();
         provideTo(&navigator, supplementName(), WTFMove(newSupplement));
     }
     return supplement;
-}
-
-ASCIILiteral NavigatorScreenWakeLock::supplementName()
-{
-    return "NavigatorScreenWakeLock"_s;
 }
 
 WakeLock& NavigatorScreenWakeLock::wakeLock(Navigator& navigator)

--- a/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.h
+++ b/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.h
@@ -48,10 +48,15 @@ public:
 private:
     WakeLock& wakeLock();
 
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorScreenWakeLock"_s; }
+    bool isNavigatorScreenWakeLock() const final { return true; }
 
     const RefPtr<WakeLock> m_wakeLock;
     const CheckedRef<Navigator> m_navigator;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorScreenWakeLock)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorScreenWakeLock(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp
+++ b/Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp
@@ -41,11 +41,6 @@ NavigatorWebDriver::NavigatorWebDriver() = default;
 
 NavigatorWebDriver::~NavigatorWebDriver() = default;
 
-ASCIILiteral NavigatorWebDriver::supplementName()
-{
-    return "NavigatorWebDriver"_s;
-}
-
 bool NavigatorWebDriver::isControlledByAutomation(const Navigator& navigator)
 {
     RefPtr frame = navigator.frame();
@@ -57,7 +52,7 @@ bool NavigatorWebDriver::isControlledByAutomation(const Navigator& navigator)
 
 NavigatorWebDriver* NavigatorWebDriver::from(Navigator* navigator)
 {
-    NavigatorWebDriver* supplement = static_cast<NavigatorWebDriver*>(Supplement<Navigator>::from(navigator, supplementName()));
+    auto* supplement = downcast<NavigatorWebDriver>(Supplement<Navigator>::from(navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorWebDriver>();
         supplement = newSupplement.get();

--- a/Source/WebCore/Modules/webdriver/NavigatorWebDriver.h
+++ b/Source/WebCore/Modules/webdriver/NavigatorWebDriver.h
@@ -41,8 +41,13 @@ public:
     static NavigatorWebDriver* from(Navigator*);
     static bool webdriver(const Navigator&);
 private:
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorWebDriver"_s; }
+    bool isNavigatorWebDriver() const final { return true; }
     static bool isControlledByAutomation(const Navigator&);
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorWebDriver)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorWebDriver(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -5,41 +5,24 @@ Modules/Model/Implementation/ModelDowncastConvertToBackingContext.cpp
 Modules/WebGPU/Implementation/WebGPUBindGroupImpl.cpp
 Modules/WebGPU/Implementation/WebGPUDowncastConvertToBackingContext.cpp
 Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
-Modules/audiosession/NavigatorAudioSession.cpp
-Modules/beacon/NavigatorBeacon.cpp
-Modules/contact-picker/NavigatorContacts.cpp
-Modules/credentialmanagement/NavigatorCredentials.cpp
 Modules/encryptedmedia/MediaKeySystemController.cpp
 Modules/geolocation/NavigatorGeolocation.cpp
-Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
 Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
-Modules/mediasession/NavigatorMediaSession.cpp
-Modules/mediastream/NavigatorMediaDevices.cpp
 Modules/mediastream/PeerConnectionBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
 Modules/notifications/NotificationController.h
-Modules/permissions/NavigatorPermissions.cpp
 Modules/permissions/WorkerNavigatorPermissions.cpp
 Modules/pictureinpicture/DocumentPictureInPicture.cpp
 Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
 Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
-Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
 Modules/speech/LocalDOMWindowSpeechSynthesis.cpp
 Modules/speech/SpeechSynthesis.cpp
 Modules/webaudio/WaveShaperProcessor.cpp
-Modules/webdriver/NavigatorWebDriver.cpp
 SVGNames.cpp
 TagName.cpp
-[ Mac ] page/mac/EventHandlerMac.mm
-[ Mac ] platform/graphics/mac/controls/ControlMac.mm
-[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
-[ iOS ] platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
-[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
-[ iOS ] platform/ios/wak/WAKView.mm
-[ iOS ] platform/ios/wak/WAKWindow.mm
 bindings/js/DOMGCOutputConstraint.cpp
 bindings/js/JSDOMAsyncIterator.h
 bindings/js/JSDOMConvertWebGL.cpp
@@ -84,7 +67,6 @@ domjit/JSDocumentDOMJIT.cpp
 domjit/JSNodeDOMJIT.cpp
 editing/TypingCommand.cpp
 html/InputType.cpp
-html/NavigatorUserActivation.cpp
 html/track/TextTrackCueGeneric.cpp
 inspector/CommandLineAPIModule.cpp
 inspector/agents/InspectorCSSAgent.cpp
@@ -92,10 +74,16 @@ layout/layouttree/LayoutIterator.h
 layout/layouttree/LayoutTreeBuilder.cpp
 loader/cache/CachedResourceClientWalker.h
 mathml/MathMLRowElement.cpp
-page/NavigatorLoginStatus.cpp
+[ Mac ] page/mac/EventHandlerMac.mm
+[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
 platform/graphics/GraphicsLayer.cpp
 platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+[ Mac ] platform/graphics/mac/controls/ControlMac.mm
+[ iOS ] platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
+[ iOS ] platform/ios/wak/WAKView.mm
+[ iOS ] platform/ios/wak/WAKWindow.mm
 rendering/BidiRun.cpp
 rendering/BidiRun.h
 rendering/RenderAncestorIterator.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -403,7 +403,6 @@ page/LocalFrameViewLayoutContext.cpp
 page/Location.cpp
 page/MemoryRelease.cpp
 page/NavigateEvent.cpp
-page/Navigator.cpp
 [ iOS ] page/Page.cpp
 page/PageColorSampler.cpp
 page/PageOverlay.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -276,7 +276,6 @@ page/ScreenOrientation.cpp
 page/ScrollBehavior.cpp
 page/SpatialNavigation.cpp
 page/TextIndicator.cpp
-page/WorkerNavigator.cpp
 [ iOS ] page/ios/ContentChangeObserver.cpp
 [ iOS ] page/ios/EventHandlerIOS.mm
 [ iOS ] page/ios/FrameIOS.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -573,8 +573,6 @@ page/Location.cpp
 page/NavigateEvent.cpp
 page/NavigationDestination.cpp
 page/NavigationDestination.h
-page/Navigator.cpp
-page/NavigatorLoginStatus.cpp
 page/PageColorSampler.cpp
 page/PageOverlay.cpp
 page/PageOverlayController.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -41,10 +41,11 @@ loader/NetscapePlugInStreamLoader.cpp
 loader/WorkerThreadableLoader.cpp
 page/ImageAnalysisQueue.cpp
 page/IntelligenceTextEffectsSupport.cpp
-page/Navigator.cpp
 page/ShareDataReader.cpp
 page/cocoa/ResourceUsageOverlayCocoa.mm
+[ iOS ] page/ios/FrameIOS.mm
 page/writing-tools/WritingToolsController.mm
+[ iOS ] platform/PreviewConverter.cpp
 platform/ScrollableArea.cpp
 platform/cocoa/NetworkExtensionContentFilter.mm
 platform/encryptedmedia/CDMProxy.cpp
@@ -53,11 +54,15 @@ platform/graphics/ShadowBlur.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
+[ iOS ] platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 platform/graphics/filters/FilterOperation.cpp
+[ iOS ] platform/ios/DragImageIOS.mm
 platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
 platform/mediastream/RealtimeVideoCaptureSource.cpp
 platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
+[ iOS ] platform/mediastream/ios/ReplayKitCaptureSource.mm
+[ iOS ] platform/mediastream/mac/CoreAudioSharedUnit.cpp
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
 rendering/BackgroundPainter.cpp
@@ -90,9 +95,3 @@ workers/Worker.cpp
 workers/WorkerMessagingProxy.cpp
 workers/WorkerOrWorkletThread.cpp
 workers/shared/SharedWorkerObjectConnection.cpp
-[ iOS ] page/ios/FrameIOS.mm
-[ iOS ] platform/PreviewConverter.cpp
-[ iOS ] platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
-[ iOS ] platform/ios/DragImageIOS.mm
-[ iOS ] platform/mediastream/ios/ReplayKitCaptureSource.mm
-[ iOS ] platform/mediastream/mac/CoreAudioSharedUnit.cpp

--- a/Source/WebCore/html/NavigatorUserActivation.cpp
+++ b/Source/WebCore/html/NavigatorUserActivation.cpp
@@ -49,7 +49,7 @@ UserActivation& NavigatorUserActivation::userActivation(Navigator& navigator)
 
 NavigatorUserActivation* NavigatorUserActivation::from(Navigator& navigator)
 {
-    auto* supplement = static_cast<NavigatorUserActivation*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    auto* supplement = downcast<NavigatorUserActivation>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorUserActivation>(navigator);
         supplement = newSupplement.get();
@@ -58,9 +58,4 @@ NavigatorUserActivation* NavigatorUserActivation::from(Navigator& navigator)
     return supplement;
 }
 
-ASCIILiteral NavigatorUserActivation::supplementName()
-{
-    return "NavigatorUserActivation"_s;
-}
-
-}
+} // namespace WebCore

--- a/Source/WebCore/html/NavigatorUserActivation.h
+++ b/Source/WebCore/html/NavigatorUserActivation.h
@@ -45,9 +45,14 @@ public:
 
 private:
     static NavigatorUserActivation* from(Navigator&);
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorUserActivation"_s; }
+    bool isNavigatorUserActivation() const final { return true; }
 
     const Ref<UserActivation> m_userActivation;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorUserActivation)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorUserActivation(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/page/NavigatorLoginStatus.cpp
+++ b/Source/WebCore/page/NavigatorLoginStatus.cpp
@@ -43,18 +43,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigatorLoginStatus);
 
 NavigatorLoginStatus* NavigatorLoginStatus::from(Navigator& navigator)
 {
-    auto* supplement = static_cast<NavigatorLoginStatus*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    auto* supplement = downcast<NavigatorLoginStatus>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorLoginStatus>(navigator);
         supplement = newSupplement.get();
         provideTo(&navigator, supplementName(), WTFMove(newSupplement));
     }
     return supplement;
-}
-
-ASCIILiteral NavigatorLoginStatus::supplementName()
-{
-    return "NavigatorLoginStatus"_s;
 }
 
 void NavigatorLoginStatus::setStatus(Navigator& navigator, IsLoggedIn isLoggedIn, Ref<DeferredPromise>&& promise)
@@ -96,7 +91,7 @@ void NavigatorLoginStatus::setStatus(IsLoggedIn isLoggedIn, Ref<DeferredPromise>
         promise->reject();
         return;
     }
-    page->chrome().client().setLoginStatus(RegistrableDomain::uncheckedCreateFromHost(document->securityOrigin().host()), isLoggedIn, [promise = WTFMove(promise)] {
+    page->chrome().client().setLoginStatus(RegistrableDomain::uncheckedCreateFromHost(document->protectedSecurityOrigin()->host()), isLoggedIn, [promise = WTFMove(promise)] {
         promise->resolve();
     });
 }
@@ -114,7 +109,7 @@ void NavigatorLoginStatus::isLoggedIn(Ref<DeferredPromise>&& promise)
         promise->reject();
         return;
     }
-    page->chrome().client().isLoggedIn(RegistrableDomain::uncheckedCreateFromHost(document->securityOrigin().host()), [promise = WTFMove(promise)] (bool isLoggedIn) {
+    page->chrome().client().isLoggedIn(RegistrableDomain::uncheckedCreateFromHost(document->protectedSecurityOrigin()->host()), [promise = WTFMove(promise)] (bool isLoggedIn) {
         promise->resolve<IDLBoolean>(isLoggedIn);
     });
 }

--- a/Source/WebCore/page/NavigatorLoginStatus.h
+++ b/Source/WebCore/page/NavigatorLoginStatus.h
@@ -52,10 +52,15 @@ private:
     void isLoggedIn(Ref<DeferredPromise>&&);
 
     static NavigatorLoginStatus* from(Navigator&);
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorLoginStatus"_s; }
+    bool isNavigatorLoginStatus() const final { return true; }
     bool hasSameOrigin() const;
 
     const CheckedRef<Navigator> m_navigator;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorLoginStatus)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorLoginStatus(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -103,7 +103,7 @@ void WorkerNavigator::setAppBadge(std::optional<unsigned long long> badge, Ref<D
         return;
     }
 
-    if (auto* workerBadgeProxy = scope->thread()->workerBadgeProxy())
+    if (CheckedPtr workerBadgeProxy = scope->thread()->workerBadgeProxy())
         workerBadgeProxy->setAppBadge(badge);
     promise->resolve();
 }

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -82,9 +82,22 @@ public:
 
     virtual bool isDOMWindowCaches() const { return false; }
     virtual bool isDOMWindowIndexedDatabase() const { return false; }
+    virtual bool isNavigatorAudioSession() const { return false; }
+    virtual bool isNavigatorBeacon() const { return false; }
     virtual bool isNavigatorClipboard() const { return false; }
+    virtual bool isNavigatorContacts() const { return false; }
     virtual bool isNavigatorCookieConsent() const { return false; }
+    virtual bool isNavigatorCredentials() const { return false; }
     virtual bool isNavigatorGamepad() const { return false; }
+    virtual bool isNavigatorGeolocation() const { return false; }
+    virtual bool isNavigatorLoginStatus() const { return false; }
+    virtual bool isNavigatorMediaCapabilities() const { return false; }
+    virtual bool isNavigatorMediaDevices() const { return false; }
+    virtual bool isNavigatorMediaSession() const { return false; }
+    virtual bool isNavigatorPermissions() const { return false; }
+    virtual bool isNavigatorScreenWakeLock() const { return false; }
+    virtual bool isNavigatorUserActivation() const { return false; }
+    virtual bool isNavigatorWebDriver() const { return false; }
     virtual bool isUserMediaController() const { return false; }
     virtual bool isWorkerGlobalScopeCaches() const { return false; }
     virtual bool isLocalDOMWindowMediaControls() const { return false; }


### PR DESCRIPTION
#### 3c0eefa9e18b39b79c2229f366e608e9589acd67
<pre>
Reduce unsafeness of Navigator classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=301578">https://bugs.webkit.org/show_bug.cgi?id=301578</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/302285@main">https://commits.webkit.org/302285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d423f93dfbe8b72817cbe299410624e6abe95cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80020 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e307dd33-efa7-428a-80df-0daa590a4da0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/755 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97907 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65817 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1f617f06-62de-4bb8-81c9-d0ceb93edf99) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131563 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115233 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/78524 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/009f8af0-516d-4114-b1d9-49a006600c8a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33342 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79286 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108992 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138456 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/677 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106443 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111573 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/106267 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/598 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53063 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20087 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/769 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64004 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/636 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/693 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/719 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->