### PR TITLE
[iOS] [Speculative Fix] Occasional crash in Mail compose when deleting an address from the CC field

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -31,6 +31,7 @@
 #import "APIUIClient.h"
 #import "CocoaImage.h"
 #import "CompletionHandlerCallChecker.h"
+#import "DefaultWebBrowserChecks.h"
 #import "DocumentEditingContext.h"
 #import "ImageAnalysisUtilities.h"
 #import "InsertTextOptions.h"
@@ -1147,10 +1148,13 @@ static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> se
 #endif
 @end
 
-#define RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED() do { \
+#define ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED() do { \
     if (self.shouldUseAsyncInteractions) [[unlikely]] { \
         RELEASE_LOG_ERROR(TextInteraction, "Received unexpected call to %s", __PRETTY_FUNCTION__); \
-        RELEASE_ASSERT_NOT_REACHED(); \
+        if (WebKit::isFullWebBrowserOrRunningTest()) \
+            RELEASE_ASSERT_NOT_REACHED(); \
+        else \
+            ASSERT_NOT_REACHED(); \
     } \
 } while (0)
 
@@ -1831,7 +1835,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)startAutoscroll:(CGPoint)pointInDocument
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     _page->startAutoscrollAtPosition(pointInDocument);
 }
@@ -1844,7 +1848,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)scrollSelectionToVisible:(BOOL)animated
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
     // Used to scroll selection on keyboard up; we already scroll to visible.
 }
 
@@ -2966,7 +2970,7 @@ static inline WebCore::FloatSize tapHighlightBorderRadius(WebCore::FloatSize bor
 
 - (CGRect)_selectionClipRect
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     return self.selectionClipRect;
 }
@@ -3776,7 +3780,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSArray *)webSelectionRects
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     if (!_page->editorState().hasPostLayoutAndVisualData() || _page->editorState().selectionIsNone)
         return nil;
@@ -4121,7 +4125,7 @@ static void cancelPotentialTapIfNecessary(WKContentView* contentView)
 
 - (void)clearSelection
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _internalClearSelection];
 }
@@ -4292,7 +4296,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 
 - (void)_lookupForWebView:(id)sender
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self lookupForWebView:sender];
 }
@@ -4328,7 +4332,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 
 - (void)_shareForWebView:(id)sender
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self shareForWebView:sender];
 }
@@ -4350,7 +4354,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 
 - (void)_translateForWebView:(id)sender
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self translateForWebView:sender];
 }
@@ -4377,7 +4381,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 
 - (void)_addShortcutForWebView:(id)sender
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self addShortcutForWebView:sender];
 }
@@ -4443,7 +4447,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 
 - (void)_promptForReplaceForWebView:(id)sender
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self promptForReplaceForWebView:sender];
 }
@@ -4461,7 +4465,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 
 - (void)_transliterateChineseForWebView:(id)sender
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self transliterateChineseForWebView:sender];
 }
@@ -5056,7 +5060,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_defineForWebView:(id)sender
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self lookupForWebView:sender];
 }
@@ -5534,7 +5538,7 @@ static void selectionChangedWithTouch(WKTextInteractionWrapper *interaction, con
 // The completion handler can pass nil if input does not match the actual text preceding the insertion point.
 - (void)requestAutocorrectionRectsForString:(NSString *)input withCompletionHandler:(void (^)(UIWKAutocorrectionRects *rectsForInput))completionHandler
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     if (!completionHandler) {
         [NSException raise:NSInvalidArgumentException format:@"Expected a nonnull completion handler in %s.", __PRETTY_FUNCTION__];
@@ -5914,7 +5918,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
 - (BOOL)_selectionAtDocumentStart
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     return self.selectionAtDocumentStart;
 }
@@ -5965,7 +5969,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 // The completion handler should pass the rect of the correction text after replacing the input text, or nil if the replacement could not be performed.
 - (void)applyAutocorrection:(NSString *)correction toString:(NSString *)input isCandidate:(BOOL)isCandidate withCompletionHandler:(void (^)(UIWKAutocorrectionRects *rectsForCorrection))completionHandler
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _internalReplaceText:input withText:correction isCandidate:isCandidate completion:[completionHandler = makeBlockPtr(completionHandler), view = retainPtr(self)](bool wasApplied) {
         completionHandler(wasApplied ? [WKAutocorrectionRects autocorrectionRectsWithFirstCGRect:view->_autocorrectionData.textFirstRect lastCGRect:view->_autocorrectionData.textLastRect] : nil);
@@ -6013,7 +6017,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
 - (void)requestAutocorrectionContextWithCompletionHandler:(void (^)(UIWKAutocorrectionContext *autocorrectionContext))completionHandler
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     if (!completionHandler) {
         [NSException raise:NSInvalidArgumentException format:@"Expected a nonnull completion handler in %s.", __PRETTY_FUNCTION__];
@@ -6341,14 +6345,14 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
 - (BOOL)_allowAnimatedUpdateSelectionRectViews
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     return NO;
 }
 
 - (void)beginSelectionChange
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _internalBeginSelectionChange];
 }
@@ -6375,7 +6379,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
 - (void)endSelectionChange
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _internalEndSelectionChange];
 }
@@ -7200,7 +7204,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 - (UITextInputTraits *)textInputTraits
 {
     if (!self._requiresLegacyTextInputTraits)
-        RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+        ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     _legacyTextInputTraits = [_webView _textInputTraits];
     return _legacyTextInputTraits.get();
@@ -7405,7 +7409,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 // (i.e. selectionRange) has shipped as API.
 - (NSRange)selectionRange
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     return NSMakeRange(NSNotFound, 0);
 }
@@ -7433,7 +7437,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 // Modify text without starting a new undo grouping.
 - (void)replaceRangeWithTextWithoutClosingTyping:(UITextRange *)range replacementText:(NSString *)text
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 }
 
 // Caret rect support.  Shouldn't be necessary, but firstRectForRange doesn't offer precisely
@@ -7544,7 +7548,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (void)modifierFlagsDidChangeFrom:(UIKeyModifierFlags)oldFlags to:(UIKeyModifierFlags)newFlags
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     auto dispatchSyntheticFlagsChangedEvents = [&] (UIKeyModifierFlags flags, bool keyDown) {
         if (flags & UIKeyModifierShift)
@@ -7630,7 +7634,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (void)handleKeyWebEvent:(::WebEvent *)theEvent
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _internalHandleKeyWebEvent:theEvent];
 }
@@ -7642,7 +7646,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (void)handleKeyWebEvent:(::WebEvent *)event withCompletionHandler:(void (^)(::WebEvent *theEvent, BOOL wasHandled))completionHandler
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _internalHandleKeyWebEvent:event withCompletionHandler:completionHandler];
 }
@@ -7911,56 +7915,56 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (void)_deleteByWord
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:@"deleteWordBackward"];
 }
 
 - (void)_deleteForwardByWord
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:@"deleteWordForward"];
 }
 
 - (void)_deleteToStartOfLine
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:@"deleteToBeginningOfLine"];
 }
 
 - (void)_deleteToEndOfLine
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:@"deleteToEndOfLine"];
 }
 
 - (void)_deleteForwardAndNotify:(BOOL)notify
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:@"deleteForward"];
 }
 
 - (void)_deleteToEndOfParagraph
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:@"deleteToEndOfParagraph"];
 }
 
 - (void)_transpose
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self transposeCharactersAroundSelection];
 }
 
 - (UITextInputArrowKeyHistory *)_moveUp:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:extending ? @"moveUpAndModifySelection" : @"moveUp"];
     return nil;
@@ -7968,7 +7972,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (UITextInputArrowKeyHistory *)_moveDown:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:extending ? @"moveDownAndModifySelection" : @"moveDown"];
     return nil;
@@ -7976,7 +7980,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (UITextInputArrowKeyHistory *)_moveLeft:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:extending? @"moveLeftAndModifySelection" : @"moveLeft"];
     return nil;
@@ -7984,7 +7988,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (UITextInputArrowKeyHistory *)_moveRight:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:extending ? @"moveRightAndModifySelection" : @"moveRight"];
     return nil;
@@ -7992,7 +7996,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (UITextInputArrowKeyHistory *)_moveToStartOfWord:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:extending ? @"moveWordBackwardAndModifySelection" : @"moveWordBackward"];
     return nil;
@@ -8000,7 +8004,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (UITextInputArrowKeyHistory *)_moveToStartOfParagraph:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:extending ? @"moveBackwardAndModifySelection" : @"moveBackward"];
     [self _executeEditCommand:extending ? @"moveToBeginningOfParagraphAndModifySelection" : @"moveToBeginningOfParagraph"];
@@ -8009,7 +8013,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (UITextInputArrowKeyHistory *)_moveToStartOfLine:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:extending ? @"moveToBeginningOfLineAndModifySelection" : @"moveToBeginningOfLine"];
     return nil;
@@ -8017,7 +8021,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (UITextInputArrowKeyHistory *)_moveToStartOfDocument:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:extending ? @"moveToBeginningOfDocumentAndModifySelection" : @"moveToBeginningOfDocument"];
     return nil;
@@ -8025,7 +8029,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (UITextInputArrowKeyHistory *)_moveToEndOfWord:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:extending ? @"moveWordForwardAndModifySelection" : @"moveWordForward"];
     return nil;
@@ -8033,7 +8037,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (UITextInputArrowKeyHistory *)_moveToEndOfParagraph:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:extending ? @"moveForwardAndModifySelection" : @"moveForward"];
     [self _executeEditCommand:extending ? @"moveToEndOfParagraphAndModifySelection" : @"moveToEndOfParagraph"];
@@ -8042,7 +8046,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (UITextInputArrowKeyHistory *)_moveToEndOfLine:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:extending ? @"moveToEndOfLineAndModifySelection" : @"moveToEndOfLine"];
     return nil;
@@ -8050,7 +8054,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (UITextInputArrowKeyHistory *)_moveToEndOfDocument:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _executeEditCommand:extending ? @"moveToEndOfDocumentAndModifySelection" : @"moveToEndOfDocument"];
     return nil;
@@ -8059,12 +8063,12 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 // Sets a buffer to make room for autocorrection views
 - (void)setBottomBufferHeight:(CGFloat)bottomBuffer
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 }
 
 - (UIView *)automaticallySelectedOverlay
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     return [self unscaledView];
 }
@@ -8104,7 +8108,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (BOOL)hasContent
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     return self._hasContent;
 }
@@ -8117,12 +8121,12 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (void)selectAll
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 }
 
 - (BOOL)hasSelection
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     return NO;
 }
@@ -8160,7 +8164,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
 - (void)takeTraitsFrom:(UITextInputTraits *)traits
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [[self textInputTraits] takeTraitsFrom:traits];
 }
@@ -9508,7 +9512,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 #if ENABLE(REVEAL)
 - (void)requestRVItemInSelectedRangeWithCompletionHandler:(void(^)(RVItem *item))completionHandler
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     _page->requestRVItemInCurrentSelectedRange([completionHandler = makeBlockPtr(completionHandler), weakSelf = WeakObjCPtr<WKContentView>(self)](const WebKit::RevealItem& item) {
         auto strongSelf = weakSelf.get();
@@ -9521,7 +9525,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 
 - (void)prepareSelectionForContextMenuWithLocationInView:(CGPoint)locationInView completionHandler:(void(^)(BOOL shouldPresentMenu, RVItem *item))completionHandler
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self _internalSelectTextForContextMenuWithLocationInView:locationInView completionHandler:[completionHandler = makeBlockPtr(completionHandler)](BOOL shouldPresentMenu, const WebKit::RevealItem& item) {
         completionHandler(shouldPresentMenu, item.item());
@@ -9564,7 +9568,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 
 - (BOOL)_shouldSuppressSelectionCommands
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     return self.shouldSuppressEditMenu;
 }
@@ -11910,7 +11914,7 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
 
 - (void)adjustSelectionWithDelta:(NSRange)deltaRange completionHandler:(void (^)(void))completionHandler
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     // UIKit is putting casted signed integers into NSRange. Cast them back to reveal any negative values.
     [self _internalAdjustSelectionWithOffset:static_cast<NSInteger>(deltaRange.location) lengthDelta:static_cast<NSInteger>(deltaRange.length) completionHandler:completionHandler];
@@ -12667,7 +12671,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
 - (void)_findSelectedForWebView:(id)sender
 {
-    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+    ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
     [self findSelectedForWebView:sender];
 }
@@ -14215,14 +14219,14 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
 
 - (UIView *)_selectionContainerViewAboveText
 {
-    // FIXME: Consider adding RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED()
+    // FIXME: Consider adding ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED()
     // once the changes in rdar://150645383 are in all relevant builds.
     return self._selectionContainerViewInternal;
 }
 
 - (UIView *)selectionContainerView
 {
-    // FIXME: Consider adding RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED()
+    // FIXME: Consider adding ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED()
     // once the changes in rdar://150645383 are in all relevant builds.
     return self._selectionContainerViewInternal;
 }


### PR DESCRIPTION
#### a616135fc8d3b7a112db4c993e86fae86626f1d1
<pre>
[iOS] [Speculative Fix] Occasional crash in Mail compose when deleting an address from the CC field
<a href="https://bugs.webkit.org/show_bug.cgi?id=301577">https://bugs.webkit.org/show_bug.cgi?id=301577</a>
<a href="https://rdar.apple.com/163410036">rdar://163410036</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

This is a speculative fix for a crash observed in Mail compose, when attempting to delete an address
from the CC field. From the stack trace, it seems that it&apos;s possible for UIKit to still call into
these legacy selectors on the **web view**, when a native text field is first responder.

For now, address this by downgrading the release assertion to a debug assertion, only in the case
where the app is not a web browser or running tests.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:

Rename `RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED` → `ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED`.

(-[WKContentView startAutoscroll:]):
(-[WKContentView scrollSelectionToVisible:]):
(-[WKContentView _selectionClipRect]):
(-[WKContentView webSelectionRects]):
(-[WKContentView clearSelection]):
(-[WKContentView _lookupForWebView:]):
(-[WKContentView _shareForWebView:]):
(-[WKContentView _translateForWebView:]):
(-[WKContentView _addShortcutForWebView:]):
(-[WKContentView _promptForReplaceForWebView:]):
(-[WKContentView _transliterateChineseForWebView:]):
(-[WKContentView _defineForWebView:]):
(-[WKContentView requestAutocorrectionRectsForString:withCompletionHandler:]):
(-[WKContentView _selectionAtDocumentStart]):
(-[WKContentView applyAutocorrection:toString:isCandidate:withCompletionHandler:]):
(-[WKContentView requestAutocorrectionContextWithCompletionHandler:]):
(-[WKContentView _allowAnimatedUpdateSelectionRectViews]):
(-[WKContentView beginSelectionChange]):
(-[WKContentView endSelectionChange]):
(-[WKContentView textInputTraits]):
(-[WKContentView selectionRange]):
(-[WKContentView replaceRangeWithTextWithoutClosingTyping:replacementText:]):
(-[WKContentView modifierFlagsDidChangeFrom:to:]):
(-[WKContentView handleKeyWebEvent:]):
(-[WKContentView handleKeyWebEvent:withCompletionHandler:]):
(-[WKContentView _deleteByWord]):
(-[WKContentView _deleteForwardByWord]):
(-[WKContentView _deleteToStartOfLine]):
(-[WKContentView _deleteToEndOfLine]):
(-[WKContentView _deleteForwardAndNotify:]):
(-[WKContentView _deleteToEndOfParagraph]):
(-[WKContentView _transpose]):
(-[WKContentView _moveUp:withHistory:]):
(-[WKContentView _moveDown:withHistory:]):
(-[WKContentView _moveLeft:withHistory:]):
(-[WKContentView _moveRight:withHistory:]):
(-[WKContentView _moveToStartOfWord:withHistory:]):
(-[WKContentView _moveToStartOfParagraph:withHistory:]):
(-[WKContentView _moveToStartOfLine:withHistory:]):
(-[WKContentView _moveToStartOfDocument:withHistory:]):
(-[WKContentView _moveToEndOfWord:withHistory:]):
(-[WKContentView _moveToEndOfParagraph:withHistory:]):
(-[WKContentView _moveToEndOfLine:withHistory:]):
(-[WKContentView _moveToEndOfDocument:withHistory:]):
(-[WKContentView setBottomBufferHeight:]):
(-[WKContentView automaticallySelectedOverlay]):
(-[WKContentView hasContent]):
(-[WKContentView selectAll]):
(-[WKContentView hasSelection]):
(-[WKContentView takeTraitsFrom:]):
(-[WKContentView requestRVItemInSelectedRangeWithCompletionHandler:]):
(-[WKContentView prepareSelectionForContextMenuWithLocationInView:completionHandler:]):
(-[WKContentView _shouldSuppressSelectionCommands]):
(-[WKContentView adjustSelectionWithDelta:completionHandler:]):
(-[WKContentView _findSelectedForWebView:]):
(-[WKContentView _selectionContainerViewAboveText]):
(-[WKContentView selectionContainerView]):

Canonical link: <a href="https://commits.webkit.org/302246@main">https://commits.webkit.org/302246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd55ab8e29456fb9054dfc9158e7329ea63df145

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79932 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/070ace3e-1c61-4533-89bf-4d3c023f22cb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97814 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cb75d2f4-6e85-4651-930e-256a78d92a4c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131440 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78424 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1b330b23-7ee0-4851-957d-7b43c5d1c612) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79167 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138333 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106353 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111458 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106164 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27044 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/504 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29998 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52936 "Hash bd55ab8e for PR 53087 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/653 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63851 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/542 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/603 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/608 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->