### PR TITLE
[WebGPU] Very poor texture upload performance when passing canvas

### DIFF
--- a/LayoutTests/fast/webgpu/repro_294602-expected.txt
+++ b/LayoutTests/fast/webgpu/repro_294602-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Blocked access to external URL https://webgpufundamentals.org/webgpu/resources/webgpu-lesson.css
+CONSOLE MESSAGE: Blocked access to external URL https://webgpufundamentals.org/3rdparty/wgpu-matrix.module.js
+CONSOLE MESSAGE: Blocked access to external URL https://webgpufundamentals.org/3rdparty/muigui-0.x.module.js
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (0,0) size 800x600
+      RenderHTMLCanvas {CANVAS} at (0,0) size 800x600
+layer at (0,0) size 13x13
+  RenderBlock (positioned) {PRE} at (0,0) size 13x13 [color=#FFFFFF] [bgcolor=#000000]

--- a/LayoutTests/fast/webgpu/repro_294602.html
+++ b/LayoutTests/fast/webgpu/repro_294602.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>WebGPU Simple Textured Quad - Import Canvas (speed check, update 100 textures, no mips)</title>
+    <style>
+@import url(https://webgpufundamentals.org/webgpu/resources/webgpu-lesson.css);
+html, body {
+  margin: 0;       /* remove the default margin          */
+  height: 100%;    /* make the html,body fill the page   */
+}
+canvas {
+  display: block;  /* make the canvas act like a block   */
+  width: 100%;     /* make the canvas fill its container */
+  height: 100%;
+}
+#info {
+  position: absolute;
+  left: 0;
+  top: 0;
+  background-color: black;
+  color: white;
+  margin: 0;
+  padding: 0.5em;
+}
+    </style>
+  </head>
+  <body>
+<canvas></canvas>
+<pre id="info"></pre>
+  </body>
+  <script type="module">
+// WebGPU Simple Textured Quad - Import Canvas
+// from https://webgpufundamentals.org/webgpu/webgpu-simple-textured-quad-import-canvas.html
+
+
+// see https://webgpufundamentals.org/webgpu/lessons/webgpu-utils.html#wgpu-matrix
+import {mat4} from 'https://webgpufundamentals.org/3rdparty/wgpu-matrix.module.js';
+import GUI from 'https://webgpufundamentals.org/3rdparty/muigui-0.x.module.js';
+
+async function main() {
+  const adapter = await navigator.gpu?.requestAdapter();
+  const device = await adapter?.requestDevice();
+  if (!device) {
+    fail('need a browser that supports WebGPU');
+    return;
+  }
+
+  // Get a WebGPU context from the canvas and configure it
+  const canvas = document.querySelector('canvas');
+  const context = canvas.getContext('webgpu');
+  const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
+  context.configure({
+    device,
+    format: presentationFormat,
+  });
+
+  const module = device.createShaderModule({
+    label: 'our hardcoded textured quad shaders',
+    code: `
+      struct OurVertexShaderOutput {
+        @builtin(position) position: vec4f,
+        @location(0) texcoord: vec2f,
+      };
+
+      struct Uniforms {
+        matrix: mat4x4f,
+      };
+
+      @group(0) @binding(2) var<uniform> uni: Uniforms;
+
+      @vertex fn vs(
+        @builtin(vertex_index) vertexIndex : u32
+      ) -> OurVertexShaderOutput {
+        let pos = array(
+          vec3f(-0.5, 0.5,-0.5),
+          vec3f( 0.5, 0.5,-0.5),
+          vec3f(-0.5, 0.5, 0.5),
+          vec3f(-0.5, 0.5, 0.5),
+          vec3f( 0.5, 0.5,-0.5),
+          vec3f( 0.5, 0.5, 0.5),
+        );
+
+        var vsOutput: OurVertexShaderOutput;
+        let xyz = pos[vertexIndex];
+        vsOutput.position = uni.matrix * vec4f(xyz, 1.0);
+        vsOutput.texcoord = (xyz.xz + 0.5) * vec2f(1, 50);
+        return vsOutput;
+      }
+
+      @group(0) @binding(0) var ourSampler: sampler;
+      @group(0) @binding(1) var ourTexture: texture_2d<f32>;
+
+      @fragment fn fs(fsInput: OurVertexShaderOutput) -> @location(0) vec4f {
+        return textureSample(ourTexture, ourSampler, fsInput.texcoord);
+      }
+    `,
+  });
+
+  const pipeline = device.createRenderPipeline({
+    label: 'hardcoded textured quad pipeline',
+    layout: 'auto',
+    vertex: {
+      module,
+    },
+    fragment: {
+      module,
+      targets: [{ format: presentationFormat }],
+    },
+    depthStencil: {
+      depthWriteEnabled: true,
+      depthCompare: 'less',
+      format: 'depth24plus',
+    },
+  });
+
+  const numMipLevels = (...sizes) => {
+    const maxSize = Math.max(...sizes);
+    return 1 + Math.log2(maxSize) | 0;
+  };
+
+  function copySourceToTexture(device, texture, source, {flipY} = {}) {
+    device.queue.copyExternalImageToTexture(
+      { source, flipY, },
+      { texture },
+      { width: source.width, height: source.height },
+    );
+
+    if (texture.mipLevelCount > 1) {
+      //generateMips(device, texture);
+    }
+  }
+
+  function createTextureFromSource(device, source, options = {}) {
+    const texture = device.createTexture({
+      format: 'rgba8unorm',
+      mipLevelCount: options.mips ? numMipLevels(source.width, source.height) : 1,
+      size: [source.width, source.height],
+      usage: GPUTextureUsage.TEXTURE_BINDING |
+             GPUTextureUsage.COPY_DST |
+             GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    copySourceToTexture(device, texture, source, options);
+    return texture;
+  }
+
+  const generateMips = (() => {
+    let sampler;
+    let module;
+    const pipelineByFormat = {};
+
+    return function generateMips(device, texture) {
+      if (!module) {
+        module = device.createShaderModule({
+          label: 'textured quad shaders for mip level generation',
+          code: `
+            struct VSOutput {
+              @builtin(position) position: vec4f,
+              @location(0) texcoord: vec2f,
+            };
+
+            @vertex fn vs(
+              @builtin(vertex_index) vertexIndex : u32
+            ) -> VSOutput {
+              let pos = array(
+
+                vec2f( 0.0,  0.0),  // center
+                vec2f( 1.0,  0.0),  // right, center
+                vec2f( 0.0,  1.0),  // center, top
+
+                // 2st triangle
+                vec2f( 0.0,  1.0),  // center, top
+                vec2f( 1.0,  0.0),  // right, center
+                vec2f( 1.0,  1.0),  // right, top
+              );
+
+              var vsOutput: VSOutput;
+              let xy = pos[vertexIndex];
+              vsOutput.position = vec4f(xy * 2.0 - 1.0, 0.0, 1.0);
+              vsOutput.texcoord = vec2f(xy.x, 1.0 - xy.y);
+              return vsOutput;
+            }
+
+            @group(0) @binding(0) var ourSampler: sampler;
+            @group(0) @binding(1) var ourTexture: texture_2d<f32>;
+
+            @fragment fn fs(fsInput: VSOutput) -> @location(0) vec4f {
+              return textureSample(ourTexture, ourSampler, fsInput.texcoord);
+            }
+          `,
+        });
+
+        sampler = device.createSampler({
+          minFilter: 'linear',
+        });
+      }
+
+      if (!pipelineByFormat[texture.format]) {
+        pipelineByFormat[texture.format] = device.createRenderPipeline({
+          label: 'mip level generator pipeline',
+          layout: 'auto',
+          vertex: {
+            module,
+          },
+          fragment: {
+            module,
+            targets: [{ format: texture.format }],
+          },
+        });
+      }
+      const pipeline = pipelineByFormat[texture.format];
+
+      const encoder = device.createCommandEncoder({
+        label: 'mip gen encoder',
+      });
+
+      let width = texture.width;
+      let height = texture.height;
+      let baseMipLevel = 0;
+      while (width > 1 || height > 1) {
+        width = Math.max(1, width / 2 | 0);
+        height = Math.max(1, height / 2 | 0);
+
+        const bindGroup = device.createBindGroup({
+          layout: pipeline.getBindGroupLayout(0),
+          entries: [
+            { binding: 0, resource: sampler },
+            { binding: 1, resource: texture.createView({baseMipLevel, mipLevelCount: 1}) },
+          ],
+        });
+
+        ++baseMipLevel;
+
+        const renderPassDescriptor = {
+          label: 'our basic canvas renderPass',
+          colorAttachments: [
+            {
+              view: texture.createView({baseMipLevel, mipLevelCount: 1}),
+              loadOp: 'clear',
+              storeOp: 'store',
+            },
+          ],
+        };
+
+        const pass = encoder.beginRenderPass(renderPassDescriptor);
+        pass.setPipeline(pipeline);
+        pass.setBindGroup(0, bindGroup);
+        pass.draw(6);  // call our vertex shader 6 times
+        pass.end();
+      }
+
+      const commandBuffer = encoder.finish();
+      device.queue.submit([commandBuffer]);
+    };
+  })();
+
+  const size = 2048;
+  const half = size / 2;
+
+  const ctx = document.createElement('canvas').getContext('2d');
+  ctx.canvas.width = size;
+  ctx.canvas.height = size;
+
+  const hsl = (h, s, l) => `hsl(${h * 360 | 0}, ${s * 100}%, ${l * 100 | 0}%)`;
+
+  function update2DCanvas(time) {
+    time *= 0.0001;
+    ctx.fillStyle = hsl(time + 0.5, 1, 0.125)
+    ctx.fillRect(0, 0, size, size);
+    ctx.font = `${size * 0.5 | 0}px monospace`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.save();
+    ctx.translate(half, half);
+    const num = 20;
+    const t = (time * 1000).toFixed(0);
+    ctx.scale(0.1, 0.1);
+    for (let i = 0; i < num; ++i) {
+      ctx.fillStyle = hsl(i / num * 0.4 + time, 1, i % 2 * 0.5);
+      ctx.fillText(t, 0, 0);
+      ctx.translate(0, size / num * 0.5);
+      ctx.scale(1.1, 1.1);
+    }
+    ctx.restore();
+  }
+  update2DCanvas(0);
+
+  const maxTextures = 400;
+  const textures = new Array(maxTextures).fill(0).map(_ => createTextureFromSource(device, ctx.canvas, {mips: false}));
+
+  // offsets to the various uniform values in float32 indices
+  const kMatrixOffset = 0;
+
+  const objectInfos = [];
+  for (let j = 0; j < maxTextures; j += 8) {
+    for (let i = 0; i < 8; ++i) {
+      if (i + j >= maxTextures) {
+        break;
+      }
+      const sampler = device.createSampler({
+        addressModeU: 'repeat',
+        addressModeV: 'repeat',
+        magFilter: (i & 1) ? 'linear' : 'nearest',
+        minFilter: (i & 2) ? 'linear' : 'nearest',
+        mipmapFilter: (i & 4) ? 'linear' : 'nearest',
+      });
+
+      // create a buffer for the uniform values
+      const uniformBufferSize =
+        16 * 4; // matrix is 16 32bit floats (4bytes each)
+      const uniformBuffer = device.createBuffer({
+        label: 'uniforms for quad',
+        size: uniformBufferSize,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+      });
+
+      // create a typedarray to hold the values for the uniforms in JavaScript
+      const uniformValues = new Float32Array(uniformBufferSize / 4);
+      const matrix = uniformValues.subarray(kMatrixOffset, 16);
+
+      const bindGroup = device.createBindGroup({
+        layout: pipeline.getBindGroupLayout(0),
+        entries: [
+          { binding: 0, resource: sampler },
+          { binding: 1, resource: textures[i + j].createView() },
+          { binding: 2, resource: { buffer: uniformBuffer }},
+        ],
+      });
+
+      // Save the data we need to render this object.
+      objectInfos.push({
+        bindGroup,
+        matrix,
+        uniformValues,
+        uniformBuffer,
+      });
+    }
+  }
+
+  const renderPassDescriptor = {
+    label: 'our basic canvas renderPass',
+    colorAttachments: [
+      {
+        // view: <- to be filled out when we render
+        clearValue: [0.3, 0.3, 0.3, 1],
+        loadOp: 'clear',
+        storeOp: 'store',
+      },
+    ],
+    depthStencilAttachment: {
+      // view: undefined,  // Assigned later
+      depthClearValue: 1.0,
+      depthLoadOp: 'clear',
+      depthStoreOp: 'store',
+    },
+  };
+
+  let ticks = [{time: 0, deltaTime: 1/60}];
+  let deltaAvg = 0;
+  const info = document.querySelector('#info');
+  const settings = {
+    copyCount: 40,
+  };
+  const gui = new GUI();
+  gui.add(settings, 'copyCount', 1, maxTextures, 1);
+
+  let depthTexture;
+
+  function render(time) {
+    let last = ticks[ticks.length - 1]
+    let deltaCur = time - last.time;
+    deltaAvg = ((deltaAvg * ticks.length) + deltaCur) / (ticks.length + 1)
+    ticks.push({time: time, deltaTime: deltaCur})
+    if (ticks.length > 60) {
+      deltaAvg = ((deltaAvg * ticks.length) - ticks[0].deltaTime) / (ticks.length - 1)
+      ticks.shift()
+    }
+    
+    info.textContent = `fps: ${(1000 / deltaAvg).toFixed(0)}`;
+    update2DCanvas(time);
+    for (let i = 0; i < settings.copyCount; ++i) {
+      copySourceToTexture(device, textures[i], ctx.canvas);
+    }
+
+    const fov = 60 * Math.PI / 180;  // 60 degrees in radians
+    const aspect = canvas.clientWidth / canvas.clientHeight;
+    const zNear  = 1;
+    const zFar   = 2000;
+    const projectionMatrix = mat4.perspective(fov, aspect, zNear, zFar);
+
+    const cameraPosition = [0, 0, 2];
+    const up = [0, 1, 0];
+    const target = [0, 0, 0];
+    const viewMatrix = mat4.lookAt(cameraPosition, target, up);
+    const viewProjectionMatrix = mat4.multiply(projectionMatrix, viewMatrix);
+
+    // Get the current texture from the canvas context and
+    // set it as the texture to render to.
+    const canvasTexture = context.getCurrentTexture();
+    renderPassDescriptor.colorAttachments[0].view = canvasTexture.createView();
+
+    if (!depthTexture || depthTexture.width !== canvasTexture.width || depthTexture.height !== canvasTexture.height) {
+      depthTexture?.destroy();
+
+      depthTexture = device.createTexture({
+        size: [canvasTexture.width, canvasTexture.height],
+        format: 'depth24plus',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+      });
+      renderPassDescriptor.depthStencilAttachment.view = depthTexture.createView();
+    }
+
+    const encoder = device.createCommandEncoder({
+      label: 'render quad encoder',
+    });
+    const pass = encoder.beginRenderPass(renderPassDescriptor);
+    pass.setPipeline(pipeline);
+
+    const ss = [
+      { x: -1, y:  1, zRot: 0, /*magFilter: gl.NEAREST, minFilter: gl.NEAREST,                */ },
+      { x:  0, y:  1, zRot: 0, /*magFilter: gl.LINEAR,  minFilter: gl.LINEAR,                 */ },
+      { x:  1, y:  1, zRot: 0, /*magFilter: gl.LINEAR,  minFilter: gl.NEAREST_MIPMAP_NEAREST, */ },
+      { x: -1, y: -1, zRot: 1, /*magFilter: gl.LINEAR,  minFilter: gl.LINEAR_MIPMAP_NEAREST,  */ },
+      { x:  0, y: -1, zRot: 1, /*magFilter: gl.LINEAR,  minFilter: gl.NEAREST_MIPMAP_LINEAR,  */ },
+      { x:  1, y: -1, zRot: 1, /*magFilter: gl.LINEAR,  minFilter: gl.LINEAR_MIPMAP_LINEAR,   */ },
+    ];
+
+    const xSpacing = 1.2;
+    const ySpacing = 0.7;
+    const zDepth = 50;
+    for (let j = 0; j < objectInfos.length; j += 6) {
+      ss.forEach(function(s, i) {
+        if (j + i >= objectInfos.length) {
+          return;
+        }
+
+        const {bindGroup, matrix, uniformBuffer, uniformValues} = objectInfos[j + i];
+        mat4.translate(viewProjectionMatrix, [s.x * xSpacing + j * 0.1, s.y * ySpacing, -zDepth * 0.5], matrix);
+        mat4.rotateZ(matrix, s.zRot * Math.PI, matrix);
+        mat4.scale(matrix, [1, 1, zDepth], matrix);
+      
+        // copy the values from JavaScript to the GPU
+        device.queue.writeBuffer(uniformBuffer, 0, uniformValues);
+
+        pass.setBindGroup(0, bindGroup);
+        pass.draw(6);  // call our vertex shader 6 times
+      });
+    }
+
+    pass.end();
+
+    const commandBuffer = encoder.finish();
+    device.queue.submit([commandBuffer]);
+
+    requestAnimationFrame(render);
+  }
+  requestAnimationFrame(render);
+
+  const observer = new ResizeObserver(entries => {
+    for (const entry of entries) {
+      const canvas = entry.target;
+      const width = entry.contentBoxSize[0].inlineSize;
+      const height = entry.contentBoxSize[0].blockSize;
+      canvas.width = Math.max(1, Math.min(width, device.limits.maxTextureDimension2D));
+      canvas.height = Math.max(1, Math.min(height, device.limits.maxTextureDimension2D));
+    }
+  });
+  observer.observe(canvas);
+
+
+  canvas.addEventListener('click', () => {
+    texNdx = (texNdx + 1) % textures.length;
+  });
+}
+
+function fail(msg) {
+  // eslint-disable-next-line no-alert
+  alert(msg);
+}
+
+main();
+  
+  </script>
+</html>

--- a/Source/WebCore/Modules/WebGPU/GPUImageCopyExternalImage.h
+++ b/Source/WebCore/Modules/WebGPU/GPUImageCopyExternalImage.h
@@ -52,7 +52,7 @@ struct GPUImageCopyExternalImage {
     WebGPU::ImageCopyExternalImage convertToBacking() const
     {
         return {
-            // FIXME: Handle the canvas element.
+            source,
             origin ? std::optional { WebCore::convertToBacking(*origin) } : std::nullopt,
             flipY,
         };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -167,7 +167,7 @@ RefPtr<Sampler> DeviceImpl::createSampler(const SamplerDescriptor& descriptor)
     return SamplerImpl::create(adoptWebGPU(wgpuDeviceCreateSampler(m_backing.get(), &backingDescriptor)), convertToBackingContext);
 }
 
-static WGPUColorSpace convertToWGPUColorSpace(const PredefinedColorSpace& colorSpace)
+WGPUColorSpace convertToWGPUColorSpace(const PredefinedColorSpace& colorSpace)
 {
     switch (colorSpace) {
     case PredefinedColorSpace::SRGB:

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.h
@@ -108,6 +108,8 @@ private:
     const Ref<QueueImpl> m_queue;
 };
 
+WGPUColorSpace convertToWGPUColorSpace(const PredefinedColorSpace&);
+
 } // namespace WebCore::WebGPU
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
@@ -92,7 +92,10 @@ private:
     void copyExternalImageToTexture(
         const ImageCopyExternalImage& source,
         const ImageCopyTextureTagged& destination,
-        const Extent3D& copySize) final;
+        unsigned width,
+        unsigned height,
+        CompletionHandler<void(bool)>&&,
+        RetainPtr<IOSurfaceRef>) final;
 
     void setLabelInternal(const String&) final;
     RefPtr<WebCore::NativeImage> getNativeImage(WebCore::VideoFrame&) final;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyExternalImage.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyExternalImage.h
@@ -25,13 +25,29 @@
 
 #pragma once
 
+#include <WebCore/HTMLCanvasElement.h>
+#include <WebCore/HTMLImageElement.h>
+#include <WebCore/HTMLVideoElement.h>
+#include <WebCore/ImageBitmap.h>
+#include <WebCore/ImageData.h>
+#include <WebCore/OffscreenCanvas.h>
+#include <WebCore/WebCodecsVideoFrame.h>
 #include <WebCore/WebGPUOrigin2D.h>
 #include <optional>
 
 namespace WebCore::WebGPU {
 
+using SourceType = Variant<RefPtr<WebCore::ImageBitmap>,
+#if ENABLE(VIDEO) && ENABLE(WEB_CODECS)
+RefPtr<WebCore::ImageData>, RefPtr<WebCore::HTMLImageElement>, RefPtr<WebCore::HTMLVideoElement>, RefPtr<WebCore::WebCodecsVideoFrame>,
+#endif
+#if ENABLE(OFFSCREEN_CANVAS)
+RefPtr<WebCore::OffscreenCanvas>,
+#endif
+RefPtr<WebCore::HTMLCanvasElement>>;
+
 struct ImageCopyExternalImage {
-    // FIXME: Handle the source.
+    SourceType source;
     std::optional<Origin2D> origin;
     bool flipY { false };
 };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
@@ -96,7 +96,10 @@ public:
     virtual void copyExternalImageToTexture(
         const ImageCopyExternalImage& source,
         const ImageCopyTextureTagged& destination,
-        const Extent3D& copySize) = 0;
+        unsigned width,
+        unsigned height,
+        CompletionHandler<void(bool)>&&,
+        RetainPtr<IOSurfaceRef> = nullptr) = 0;
 
     virtual RefPtr<WebCore::NativeImage> getNativeImage(WebCore::VideoFrame&) = 0;
     virtual bool isRemoteQueueProxy() const { return false; }

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -79,7 +79,7 @@ public:
 
     virtual void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&) { }
 
-    RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
+    WEBCORE_EXPORT RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
 
     size_t memoryCost() const;
 #if ENABLE(RESOURCE_USAGE)

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -124,9 +124,9 @@ public:
     static Ref<ImageBitmap> create(ScriptExecutionContext&, DetachedImageBitmap);
     static Ref<ImageBitmap> create(Ref<ImageBuffer>, bool originClean, bool premultiplyAlpha = false, bool forciblyPremultiplyAlpha = false);
 
-    ~ImageBitmap();
+    WEBCORE_EXPORT ~ImageBitmap();
 
-    ImageBuffer* buffer() const;
+    WEBCORE_EXPORT ImageBuffer* buffer() const;
 
     RefPtr<ImageBuffer> takeImageBuffer();
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -192,7 +192,7 @@ public:
     RefPtr<NativeImage> filteredNativeImage(Filter&, Function<void(GraphicsContext&)> drawCallback);
 
 #if HAVE(IOSURFACE)
-    IOSurface* surface();
+    WEBCORE_EXPORT IOSurface* surface();
 #endif
 
 #if USE(CAIRO)

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -76,7 +76,7 @@ public:
     Page* internalPage() { return m_page.get(); }
     WEBCORE_EXPORT RefPtr<SVGSVGElement> rootElement() const;
 
-    RefPtr<NativeImage> nativeImage(const FloatSize&, const DestinationColorSpace& = DestinationColorSpace::SRGB());
+    WEBCORE_EXPORT RefPtr<NativeImage> nativeImage(const FloatSize&, const DestinationColorSpace& = DestinationColorSpace::SRGB());
 
 private:
     friend class SVGImageChromeClient;

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -105,6 +105,7 @@ public:
     void synchronizeResourceAndWait(id<MTLBuffer>);
     id<MTLIndirectCommandBuffer> trimICB(id<MTLIndirectCommandBuffer> dest, id<MTLIndirectCommandBuffer> src, NSUInteger newSize);
     id<MTLDevice> _Nullable metalDevice() const;
+    void copyExternalImageToTexture(unsigned originX, unsigned originY, bool flipY, RetainPtr<IOSurfaceRef>, const WGPUImageCopyTextureTagged&, unsigned width, unsigned height);
 
 private:
     Queue(id<MTLCommandQueue>, Adapter&, Device&);
@@ -118,6 +119,7 @@ private:
     bool isSchedulingIdle() const { return m_submittedCommandBufferCount == m_scheduledCommandBufferCount; }
     void removeMTLCommandBufferInternal(id<MTLCommandBuffer>);
     void clearTextureIfNeeded(Texture&, uint32_t mipLevelCount, uint32_t arrayLayerCount, uint32_t baseMipLevel, uint32_t baseArrayLayer);
+    id<MTLRenderPipelineState> copyPSO(id<MTLTexture>);
 
     NSString * _Nullable errorValidatingWriteTexture(const WGPUImageCopyTexture&, const WGPUTextureDataLayout&, const WGPUExtent3D&, size_t, const Texture&) const;
 
@@ -141,6 +143,7 @@ private:
     NSMapTable<id<MTLCommandBuffer>, id<MTLCommandEncoder>> * _Nullable m_openCommandEncoders;
     const ThreadSafeWeakPtr<Instance> m_instance;
     id<MTLBuffer> _Nullable m_temporaryBuffer;
+    NSMutableDictionary<NSNumber*, id<MTLRenderPipelineState>>* m_copyPSO { nil };
     uint64_t m_temporaryBufferOffset;
 } SWIFT_SHARED_REFERENCE(refQueue, derefQueue) SWIFT_PRIVATE_FILEID("WebGPU/Queue.swift");
 

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -44,6 +44,7 @@
 #include <array>
 #include <optional>
 #include <wtf/Forward.h>
+#include <wtf/RetainPtr.h>
 #include <wtf/StdLibExtras.h>
 
 #if defined(WGPU_SHARED_LIBRARY)
@@ -1230,6 +1231,15 @@ typedef struct WGPUImageCopyTexture {
     WGPUTextureAspect aspect;
 } WGPUImageCopyTexture WGPU_STRUCTURE_ATTRIBUTE;
 
+typedef struct WGPUImageCopyTextureTagged {
+    WGPUTexture texture;
+    uint32_t mipLevel;
+    WGPUOrigin3D origin;
+    WGPUTextureAspect aspect;
+    WGPUColorSpace colorSpace;
+    WGPUBool premultipliedAlpha;
+} WGPUImageCopyTextureTagged WGPU_STRUCTURE_ATTRIBUTE;
+
 typedef struct WGPUProgrammableStageDescriptor {
     WGPUShaderModule module;
     char const * entryPoint;
@@ -1746,6 +1756,7 @@ WGPU_EXPORT void wgpuQueueWriteBuffer(WGPUQueue queue, WGPUBuffer buffer, uint64
 WGPU_EXPORT void wgpuQueueWriteTexture(WGPUQueue queue, WGPUImageCopyTexture const * destination, std::span<uint8_t> data, WGPUTextureDataLayout const * dataLayout, WGPUExtent3D const * writeSize) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueReference(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueRelease(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuCopyExternalImageToTexture(WGPUQueue queue, unsigned originX, unsigned originY, WGPUBool flipY, IOSurfaceRef sourceIOSurface, const WGPUImageCopyTextureTagged* backingDestination, unsigned width, unsigned height) WGPU_FUNCTION_ATTRIBUTE;
 
 // Methods of RenderBundle
 WGPU_EXPORT void wgpuRenderBundleSetLabel(WGPURenderBundle renderBundle, char const * label) WGPU_FUNCTION_ATTRIBUTE;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -162,12 +162,6 @@ private:
     const Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
     const Ref<RemoteQueue> m_queue;
-#if ENABLE(VIDEO)
-    const Ref<RemoteVideoFrameObjectHeap> m_videoFrameObjectHeap;
-#if PLATFORM(COCOA)
-    SharedVideoFrameReader m_sharedVideoFrameReader;
-#endif
-#endif
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     WeakRef<RemoteGPU> m_gpu;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -31,6 +31,7 @@
 #include "RemoteGPURequestAdapterResponse.h"
 #include "RemoteVideoFrameIdentifier.h"
 #include "SharedPreferencesForWebProcess.h"
+#include "SharedVideoFrame.h"
 #include "StreamConnectionWorkQueue.h"
 #include "StreamMessageReceiver.h"
 #include "StreamServerConnection.h"
@@ -62,6 +63,7 @@ struct DDMeshDescriptor;
 }
 
 namespace WebCore {
+class ImageBuffer;
 class MediaPlayer;
 class NativeImage;
 class VideoFrame;
@@ -96,6 +98,8 @@ public:
 
     void paintNativeImageToImageBuffer(WebCore::NativeImage&, WebCore::RenderingResourceIdentifier);
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() const;
+    SharedVideoFrameReader& sharedVideoFrameReader() { return m_sharedVideoFrameReader; }
+    RefPtr<WebCore::ImageBuffer> imageBuffer(WebCore::RenderingResourceIdentifier);
 
 private:
     friend class WebGPU::ObjectHeap;
@@ -143,6 +147,12 @@ private:
     Ref<DDModel::ObjectHeap> m_modelObjectHeap WTF_GUARDED_BY_CAPABILITY(workQueue());
     const WebGPUIdentifier m_identifier;
     Ref<RemoteRenderingBackend> m_renderingBackend;
+#if ENABLE(VIDEO)
+    const Ref<RemoteVideoFrameObjectHeap> m_videoFrameObjectHeap;
+#if PLATFORM(COCOA)
+    SharedVideoFrameReader m_sharedVideoFrameReader;
+#endif
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
@@ -65,9 +65,9 @@ class ObjectHeap;
 class RemoteQueue final : public IPC::StreamMessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(RemoteQueue);
 public:
-    static Ref<RemoteQueue> create(WebCore::WebGPU::Queue& queue, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
+    static Ref<RemoteQueue> create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, WebCore::WebGPU::Queue& queue, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteQueue(queue, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteQueue(gpuConnectionToWebProcess, queue, objectHeap, WTFMove(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteQueue();
@@ -79,7 +79,7 @@ public:
 private:
     friend class WebGPU::ObjectHeap;
 
-    RemoteQueue(WebCore::WebGPU::Queue&, WebGPU::ObjectHeap&, Ref<IPC::StreamServerConnection>&&, RemoteGPU&, WebGPUIdentifier);
+    RemoteQueue(GPUConnectionToWebProcess&, WebCore::WebGPU::Queue&, WebGPU::ObjectHeap&, Ref<IPC::StreamServerConnection>&&, RemoteGPU&, WebGPUIdentifier);
 
     RemoteQueue(const RemoteQueue&) = delete;
     RemoteQueue(RemoteQueue&&) = delete;
@@ -124,7 +124,9 @@ private:
     void copyExternalImageToTexture(
         const WebGPU::ImageCopyExternalImage& source,
         const WebGPU::ImageCopyTextureTagged& destination,
-        const WebGPU::Extent3D& copySize);
+        WebCore::WebGPU::IntegerCoordinate width,
+        WebCore::WebGPU::IntegerCoordinate height,
+        CompletionHandler<void(bool)>&&);
 
     void setLabel(String&&);
     void destruct();
@@ -133,6 +135,7 @@ private:
     WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     const Ref<IPC::StreamServerConnection> m_streamConnection;
     WeakRef<RemoteGPU> m_gpu;
+    ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     WebGPUIdentifier m_identifier;
 };
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in
@@ -36,7 +36,9 @@ messages -> RemoteQueue Stream {
     void WriteBuffer(WebKit::WebGPUIdentifier identifier, WebCore::WebGPU::Size64 bufferOffset, std::optional<WebCore::SharedMemory::Handle> data) -> (bool success) NotStreamEncodable
     void WriteTexture(WebKit::WebGPU::ImageCopyTexture destination, std::optional<WebCore::SharedMemory::Handle> dataHandle, WebKit::WebGPU::ImageDataLayout imageDataLayout, WebKit::WebGPU::Extent3D size) -> (bool success) NotStreamEncodable
     void WriteTextureWithCopy(WebKit::WebGPU::ImageCopyTexture destination, Vector<uint8_t> data, WebKit::WebGPU::ImageDataLayout imageDataLayout, WebKit::WebGPU::Extent3D size)
-    void CopyExternalImageToTexture(WebKit::WebGPU::ImageCopyExternalImage source, WebKit::WebGPU::ImageCopyTextureTagged destination, WebKit::WebGPU::Extent3D copySize)
+#if ENABLE(VIDEO) && ENABLE(WEB_CODECS)
+    void CopyExternalImageToTexture(WebKit::WebGPU::ImageCopyExternalImage source, WebKit::WebGPU::ImageCopyTextureTagged destination, WebCore::WebGPU::IntegerCoordinate width, WebCore::WebGPU::IntegerCoordinate height) -> (bool success) NotStreamEncodable
+#endif
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -138,6 +138,8 @@ def types_that_must_be_moved():
         'MachSendRight',
         'std::optional<WebKit::SharedVideoFrame>',
         'Vector<WebCore::SharedMemory::Handle>',
+        'WebKit::WebGPU::ImageCopyExternalImage',
+        'WebKit::WebGPU::ImageCopyTextureTagged',
         'WebKit::WebGPU::ExternalTextureDescriptor',
         'WebCore::GraphicsContextGL::ExternalImageSource',
         'WebCore::GraphicsContextGL::ExternalSyncSource',

--- a/Source/WebKit/Shared/WebGPU/WebGPUConvertToBackingContext.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUConvertToBackingContext.h
@@ -35,6 +35,7 @@
 #include "WebGPUOrigin2D.h"
 #include "WebGPUOrigin3D.h"
 #include "WebGPURenderPassTimestampWrites.h"
+#include <WebCore/VideoFrame.h>
 #include <WebCore/WebGPUColor.h>
 #include <WebCore/WebGPUComputePassTimestampWrites.h>
 #include <WebCore/WebGPUError.h>
@@ -236,7 +237,7 @@ public:
     std::optional<FragmentState> convertToBacking(const WebCore::WebGPU::FragmentState&);
     std::optional<Identifier> convertToBacking(const WebCore::WebGPU::Identifier&);
     std::optional<ImageCopyBuffer> convertToBacking(const WebCore::WebGPU::ImageCopyBuffer&);
-    std::optional<ImageCopyExternalImage> convertToBacking(const WebCore::WebGPU::ImageCopyExternalImage&);
+    std::optional<ImageCopyExternalImage> convertToBacking(const WebCore::WebGPU::ImageCopyExternalImage&, RefPtr<WebCore::VideoFrame>&);
     std::optional<ImageCopyTexture> convertToBacking(const WebCore::WebGPU::ImageCopyTexture&);
     std::optional<ImageCopyTextureTagged> convertToBacking(const WebCore::WebGPU::ImageCopyTextureTagged&);
     std::optional<ImageDataLayout> convertToBacking(const WebCore::WebGPU::ImageDataLayout&);

--- a/Source/WebKit/Shared/WebGPU/WebGPUImageCopyExternalImage.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUImageCopyExternalImage.h
@@ -27,13 +27,23 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "SharedVideoFrame.h"
 #include "WebGPUOrigin2D.h"
+#include <WebCore/MediaPlayerIdentifier.h>
+#include <WebCore/RenderingResourceIdentifier.h>
 #include <optional>
+#include <wtf/MachSendRight.h>
 
 namespace WebKit::WebGPU {
 
+using SourceType = Variant<std::optional<WebCore::RenderingResourceIdentifier>,
+#if ENABLE(VIDEO) && ENABLE(WEB_CODECS)
+std::optional<WebCore::MediaPlayerIdentifier>, std::optional<WebKit::SharedVideoFrame>,
+#endif
+std::optional<MachSendRight>>;
+
 struct ImageCopyExternalImage {
-    // FIXME: Handle the source.
+    SourceType source;
     std::optional<Origin2D> origin;
     bool flipY { false };
 };

--- a/Source/WebKit/Shared/WebGPU/WebGPUImageCopyExternalImage.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUImageCopyExternalImage.serialization.in
@@ -20,8 +20,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE(GPU_PROCESS)
-[AdditionalEncoder=StreamConnectionEncoder] struct WebKit::WebGPU::ImageCopyExternalImage {
+#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO) && ENABLE(WEB_CODECS)
+[RValue] struct WebKit::WebGPU::ImageCopyExternalImage {
+    Variant<std::optional<WebCore::RenderingResourceIdentifier>, std::optional<WebCore::MediaPlayerIdentifier>, std::optional<WebKit::SharedVideoFrame>, std::optional<WTF::MachSendRight>> source;
     std::optional<WebKit::WebGPU::Origin2D> origin;
     bool flipY;
 };

--- a/Source/WebKit/Shared/WebGPU/WebGPUImageCopyTextureTagged.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUImageCopyTextureTagged.serialization.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(GPU_PROCESS)
-[AdditionalEncoder=StreamConnectionEncoder] struct WebKit::WebGPU::ImageCopyTextureTagged : WebKit::WebGPU::ImageCopyTexture {
+[RValue] struct WebKit::WebGPU::ImageCopyTextureTagged : WebKit::WebGPU::ImageCopyTexture {
     WebCore::WebGPU::PredefinedColorSpace colorSpace;
     bool premultipliedAlpha;
 };

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
@@ -28,6 +28,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "RemoteGPUProxy.h"
+#include "SharedVideoFrame.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUAdapter.h>
 #include <wtf/TZoneMalloc.h>
@@ -52,7 +53,7 @@ public:
 
     RemoteGPUProxy& parent() const { return m_parent; }
     RemoteGPUProxy& root() { return m_parent->root(); }
-
+    WebKit::SharedVideoFrameWriter& sharedVideoFrameWriter() { return m_sharedVideoFrameWriter; }
 private:
     friend class DowncastConvertToBackingContext;
 
@@ -82,6 +83,9 @@ private:
     void requestDevice(const WebCore::WebGPU::DeviceDescriptor&, CompletionHandler<void(RefPtr<WebCore::WebGPU::Device>&&)>&&) final;
 
     WebGPUIdentifier m_backing;
+#if PLATFORM(COCOA) && ENABLE(VIDEO)
+    WebKit::SharedVideoFrameWriter m_sharedVideoFrameWriter;
+#endif
     const Ref<ConvertToBackingContext> m_convertToBackingContext;
     const Ref<RemoteGPUProxy> m_parent;
     bool m_xrCompatible { false };

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -185,7 +185,7 @@ RefPtr<WebCore::WebGPU::ExternalTexture> RemoteDeviceProxy::importExternalTextur
     if (!convertedDescriptor->mediaIdentifier) {
         auto* videoFrame = std::get_if<RefPtr<WebCore::VideoFrame>>(&descriptor.videoBacking);
         if (videoFrame && videoFrame->get()) {
-            convertedDescriptor->sharedFrame = m_sharedVideoFrameWriter.write(*videoFrame->get(), [this, protectedThis = Ref { *this }](auto& semaphore) {
+            convertedDescriptor->sharedFrame = m_parent->sharedVideoFrameWriter().write(*videoFrame->get(), [this, protectedThis = Ref { *this }](auto& semaphore) {
                 auto sendResult = send(Messages::RemoteDevice::SetSharedVideoFrameSemaphore { semaphore });
                 UNUSED_VARIABLE(sendResult);
             }, [this, protectedThis = Ref { *this }](WebCore::SharedMemory::Handle&& handle) {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -130,9 +130,6 @@ private:
     const Ref<ConvertToBackingContext> m_convertToBackingContext;
     const Ref<RemoteAdapterProxy> m_parent;
     const Ref<RemoteQueueProxy> m_queue;
-#if PLATFORM(COCOA) && ENABLE(VIDEO)
-    WebKit::SharedVideoFrameWriter m_sharedVideoFrameWriter;
-#endif
     const Ref<WebCore::WebGPU::CommandEncoder> m_invalidCommandEncoder;
     const Ref<WebCore::WebGPU::RenderPassEncoder> m_invalidRenderPassEncoder;
     const Ref<WebCore::WebGPU::ComputePassEncoder> m_invalidComputePassEncoder;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -107,7 +107,10 @@ private:
     void copyExternalImageToTexture(
         const WebCore::WebGPU::ImageCopyExternalImage& source,
         const WebCore::WebGPU::ImageCopyTextureTagged& destination,
-        const WebCore::WebGPU::Extent3D& copySize) final;
+        unsigned width,
+        unsigned height,
+        CompletionHandler<void(bool)>&&,
+        RetainPtr<IOSurfaceRef>) final;
 
     void setLabelInternal(const String&) final;
 #if ENABLE(VIDEO)


### PR DESCRIPTION
#### a881e82c03423415229a1bac6ff2e6bf06524530
<pre>
[WebGPU] Very poor texture upload performance when passing canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=294602">https://bugs.webkit.org/show_bug.cgi?id=294602</a>
<a href="https://rdar.apple.com/153642354">rdar://153642354</a>

Reviewed by NOBODY (OOPS!).

Skip WCP &lt;-&gt; GPUP readbacks when data is already in an IOSurface.

PR is a draft and illustrates PoC implementation. Need to clean
up some color space conversions and correctly import the source
data.

Test: fast/webgpu/repro_294602.html

* LayoutTests/fast/webgpu/repro_294602-expected.txt: Added.
* LayoutTests/fast/webgpu/repro_294602.html: Added.
* Source/WebCore/Modules/WebGPU/GPUImageCopyExternalImage.h:
(WebCore::GPUImageCopyExternalImage::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::GPUQueue::copyExternalImageToTexture):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::convertToWGPUColorSpace):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::copyExternalImageToTexture):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyExternalImage.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h:
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/ImageBitmap.h:
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/svg/graphics/SVGImage.h:
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::copyPSO):
(WebGPU::Queue::writeTexture): Deleted.
(WebGPU::Queue::setLabel): Deleted.
(WebGPU::Queue::scheduleWork): Deleted.
(WebGPU::Queue::clearTextureViewIfNeeded): Deleted.
(WebGPU::Queue::metalDevice const): Deleted.
(wgpuQueueReference): Deleted.
(wgpuQueueRelease): Deleted.
(wgpuQueueOnSubmittedWorkDone): Deleted.
(wgpuQueueOnSubmittedWorkDoneWithBlock): Deleted.
(wgpuQueueSubmit): Deleted.
(wgpuQueueWriteBuffer): Deleted.
(wgpuQueueWriteTexture): Deleted.
(wgpuQueueSetLabel): Deleted.
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::RemoteDevice):
(WebKit::RemoteDevice::setSharedVideoFrameSemaphore):
(WebKit::RemoteDevice::setSharedVideoFrameMemory):
(WebKit::RemoteDevice::importExternalTextureFromVideoFrame):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::RemoteGPU):
(WebKit::RemoteGPU::imageBuffer):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp:
(WebKit::RemoteQueue::RemoteQueue):
(WebKit::RemoteQueue::copyExternalImageToTexture):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_must_be_moved):
* Source/WebKit/Shared/WebGPU/WebGPUConvertToBackingContext.h:
* Source/WebKit/Shared/WebGPU/WebGPUImageCopyExternalImage.cpp:
(WebKit::WebGPU::convertSourceTypeToBacking):
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::convertSourceTypeFromBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUImageCopyExternalImage.h:
* Source/WebKit/Shared/WebGPU/WebGPUImageCopyExternalImage.serialization.in:
* Source/WebKit/Shared/WebGPU/WebGPUImageCopyTextureTagged.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::importExternalTexture):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::copyExternalImageToTexture):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a881e82c03423415229a1bac6ff2e6bf06524530

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128496 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/764 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39327 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135888 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79936 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ddd24707-caca-4621-8d1e-06d88242a76b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130368 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/708 "Hash a881e82c for PR 53089 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/637 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/135888 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/79936 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d31b8837-2034-459f-ac7f-1401c8caaffe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131444 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/708 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/39327 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/135888 "Hash a881e82c for PR 53089 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bc48cc74-0777-4285-8502-7860ceb3747c) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/127847 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/708 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/39327 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79171 "Hash a881e82c for PR 53089 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/708 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/39327 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138337 "Hash a881e82c for PR 53089 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/601 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/571 "Found 5 new test failures: fast/webgpu/nocrash/fuzz-282995.html fast/webgpu/nocrash/fuzz-291988b.html http/tests/webgpu/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.html http/tests/webgpu/webgpu/web_platform/copyToTexture/image_file.html ipc/serialized-type-info.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/138337 "Hash a881e82c for PR 53089 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/645 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/39327 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/138337 "Hash a881e82c for PR 53089 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/39327 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52940 "Hash a881e82c for PR 53089 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/657 "Hash a881e82c for PR 53089 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63856 "Found 33 new failures in AutomationProtocolObjects.h, WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp, GPUProcess/graphics/WebGPU/RemoteQueue.cpp, WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm, WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm, WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp, WebDriverBidiProtocolObjects.h, WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/546 "Hash a881e82c for PR 53089 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/607 "Hash a881e82c for PR 53089 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/612 "Hash a881e82c for PR 53089 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->