### PR TITLE
position-area normal alignment with single auto inset aligns towards opposite side

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-inset-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-inset-001-expected.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<title>position-area normal alignment vs insets</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#position-area-alignment">
+<meta name="assert" content="Test passes if normal alignment aligns towards the non-auto inset.">
+<style>
+  .container {
+    position: relative;
+    width: 100px;
+    height: 120px;
+    border: solid;
+    margin: 1em;
+    float: left;
+  }
+  .anchor {
+    border: solid blue 10px;
+    inset: 0;
+    place-self: center;
+    position: absolute;
+  }
+  .test {
+    border: solid 5px;
+    position: absolute;
+    width: 0;
+    height: 0;
+  }
+  .inset1 {
+    margin-bottom: auto;
+    margin-left: auto;
+    border-color: orange;
+  }
+  .inset2 {
+    margin-top: auto;
+    margin-right: auto;
+    border-color: teal;
+  }
+  .center {
+    margin: auto;
+    border-color: aqua;
+  }
+</style>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="test inset1" style="inset: 0 60px 70px 0"></div>
+  <div class="test center" style="inset: 0 60px 70px 0"></div>
+  <div class="test inset2" style="inset: 0 60px 70px 0"></div>
+
+  <div class="test inset1" style="inset: 70px 0 0 60px"></div>
+  <div class="test center" style="inset: 70px 0 0 60px"></div>
+  <div class="test inset2" style="inset: 70px 0 0 60px"></div>
+
+  <div class="test inset1" style="inset: 50px 40px 50px 40px"></div>
+  <div class="test center" style="inset: 50px 40px 50px 40px"></div>
+  <div class="test inset2" style="inset: 50px 40px 50px 40px"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="test inset1" style="inset: 0 0 70px"></div>
+  <div class="test center" style="inset: 0 0 70px"></div>
+  <div class="test inset2" style="inset: 0 0 70px"></div>
+
+  <div class="test inset1" style="inset: 70px 0 0"></div>
+  <div class="test center" style="inset: 70px 0 0"></div>
+  <div class="test inset2" style="inset: 70px 0 0"></div>
+
+  <div class="test inset1" style="inset: 50px 0"></div>
+  <div class="test center" style="inset: 50px 0"></div>
+  <div class="test inset2" style="inset: 50px 0"></div>
+</div>
+
+
+<div class="container" style="writing-mode: vertical-rl">
+  <div class="anchor"></div>
+  <div class="test inset1" style="inset: 0 60px 70px 0"></div>
+  <div class="test center" style="inset: 0 60px 70px 0"></div>
+  <div class="test inset2" style="inset: 0 60px 70px 0"></div>
+
+  <div class="test inset1" style="inset: 70px 0 0 60px"></div>
+  <div class="test center" style="inset: 70px 0 0 60px"></div>
+  <div class="test inset2" style="inset: 70px 0 0 60px"></div>
+
+  <div class="test inset1" style="inset: 50px 40px 50px 40px"></div>
+  <div class="test center" style="inset: 50px 40px 50px 40px"></div>
+  <div class="test inset2" style="inset: 50px 40px 50px 40px"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-rl">
+  <div class="anchor"></div>
+  <div class="test inset1" style="inset: 0 0 70px"></div>
+  <div class="test center" style="inset: 0 0 70px"></div>
+  <div class="test inset2" style="inset: 0 0 70px"></div>
+
+  <div class="test inset1" style="inset: 70px 0 0"></div>
+  <div class="test center" style="inset: 70px 0 0"></div>
+  <div class="test inset2" style="inset: 70px 0 0"></div>
+
+  <div class="test inset1" style="inset: 0 40px"></div>
+  <div class="test center" style="inset: 0 40px"></div>
+  <div class="test inset2" style="inset: 0 40px"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-inset-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-inset-001-ref.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<title>position-area normal alignment vs insets</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#position-area-alignment">
+<meta name="assert" content="Test passes if normal alignment aligns towards the non-auto inset.">
+<style>
+  .container {
+    position: relative;
+    width: 100px;
+    height: 120px;
+    border: solid;
+    margin: 1em;
+    float: left;
+  }
+  .anchor {
+    border: solid blue 10px;
+    inset: 0;
+    place-self: center;
+    position: absolute;
+  }
+  .test {
+    border: solid 5px;
+    position: absolute;
+    width: 0;
+    height: 0;
+  }
+  .inset1 {
+    margin-bottom: auto;
+    margin-left: auto;
+    border-color: orange;
+  }
+  .inset2 {
+    margin-top: auto;
+    margin-right: auto;
+    border-color: teal;
+  }
+  .center {
+    margin: auto;
+    border-color: aqua;
+  }
+</style>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="test inset1" style="inset: 0 60px 70px 0"></div>
+  <div class="test center" style="inset: 0 60px 70px 0"></div>
+  <div class="test inset2" style="inset: 0 60px 70px 0"></div>
+
+  <div class="test inset1" style="inset: 70px 0 0 60px"></div>
+  <div class="test center" style="inset: 70px 0 0 60px"></div>
+  <div class="test inset2" style="inset: 70px 0 0 60px"></div>
+
+  <div class="test inset1" style="inset: 50px 40px 50px 40px"></div>
+  <div class="test center" style="inset: 50px 40px 50px 40px"></div>
+  <div class="test inset2" style="inset: 50px 40px 50px 40px"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="test inset1" style="inset: 0 0 70px"></div>
+  <div class="test center" style="inset: 0 0 70px"></div>
+  <div class="test inset2" style="inset: 0 0 70px"></div>
+
+  <div class="test inset1" style="inset: 70px 0 0"></div>
+  <div class="test center" style="inset: 70px 0 0"></div>
+  <div class="test inset2" style="inset: 70px 0 0"></div>
+
+  <div class="test inset1" style="inset: 50px 0"></div>
+  <div class="test center" style="inset: 50px 0"></div>
+  <div class="test inset2" style="inset: 50px 0"></div>
+</div>
+
+
+<div class="container" style="writing-mode: vertical-rl">
+  <div class="anchor"></div>
+  <div class="test inset1" style="inset: 0 60px 70px 0"></div>
+  <div class="test center" style="inset: 0 60px 70px 0"></div>
+  <div class="test inset2" style="inset: 0 60px 70px 0"></div>
+
+  <div class="test inset1" style="inset: 70px 0 0 60px"></div>
+  <div class="test center" style="inset: 70px 0 0 60px"></div>
+  <div class="test inset2" style="inset: 70px 0 0 60px"></div>
+
+  <div class="test inset1" style="inset: 50px 40px 50px 40px"></div>
+  <div class="test center" style="inset: 50px 40px 50px 40px"></div>
+  <div class="test inset2" style="inset: 50px 40px 50px 40px"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-rl">
+  <div class="anchor"></div>
+  <div class="test inset1" style="inset: 0 0 70px"></div>
+  <div class="test center" style="inset: 0 0 70px"></div>
+  <div class="test inset2" style="inset: 0 0 70px"></div>
+
+  <div class="test inset1" style="inset: 70px 0 0"></div>
+  <div class="test center" style="inset: 70px 0 0"></div>
+  <div class="test inset2" style="inset: 70px 0 0"></div>
+
+  <div class="test inset1" style="inset: 0 40px"></div>
+  <div class="test center" style="inset: 0 40px"></div>
+  <div class="test inset2" style="inset: 0 40px"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-inset-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-inset-001.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<title>position-area normal alignment vs insets</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#position-area-alignment">
+<meta name="assert" content="Test passes if normal alignment aligns towards the non-auto inset.">
+<style>
+  .container {
+    position: relative;
+    width: 100px;
+    height: 120px;
+    border: solid;
+    margin: 1em;
+    float: left;
+  }
+  .anchor {
+    border: solid blue 10px;
+    anchor-name: --foo;
+    inset: 0;
+    place-self: center;
+    position: absolute;
+  }
+  .test {
+    border: solid 5px;
+    position: absolute;
+    position-anchor: --foo;
+  }
+  .inset1 {
+    top: 0;
+    right: 0;
+    border-color: orange;
+  }
+  .inset2 {
+    bottom: 0;
+    left: 0;
+    border-color: teal;
+  }
+  .center {
+    place-self: center;
+    border-color: aqua;
+  }
+</style>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="test inset1" style="position-area: top left"></div>
+  <div class="test center" style="position-area: top left"></div>
+  <div class="test inset2" style="position-area: top left"></div>
+
+  <div class="test inset1" style="position-area: bottom right"></div>
+  <div class="test center" style="position-area: bottom right"></div>
+  <div class="test inset2" style="position-area: bottom right"></div>
+
+  <div class="test inset1" style="position-area: center"></div>
+  <div class="test center" style="position-area: center"></div>
+  <div class="test inset2" style="position-area: center"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="test inset1" style="position-area: top"></div>
+  <div class="test center" style="position-area: top"></div>
+  <div class="test inset2" style="position-area: top"></div>
+
+  <div class="test inset1" style="position-area: bottom"></div>
+  <div class="test center" style="position-area: bottom"></div>
+  <div class="test inset2" style="position-area: bottom"></div>
+
+  <div class="test inset1" style="position-area: center span-all"></div>
+  <div class="test center" style="position-area: center span-all"></div>
+  <div class="test inset2" style="position-area: center span-all"></div>
+</div>
+
+
+<div class="container" style="writing-mode: vertical-rl">
+  <div class="anchor"></div>
+  <div class="test inset1" style="position-area: top left"></div>
+  <div class="test center" style="position-area: top left"></div>
+  <div class="test inset2" style="position-area: top left"></div>
+
+  <div class="test inset1" style="position-area: bottom right"></div>
+  <div class="test center" style="position-area: bottom right"></div>
+  <div class="test inset2" style="position-area: bottom right"></div>
+
+  <div class="test inset1" style="position-area: center"></div>
+  <div class="test center" style="position-area: center"></div>
+  <div class="test inset2" style="position-area: center"></div>
+</div>
+
+<div class="container" style="writing-mode: vertical-rl">
+  <div class="anchor"></div>
+  <div class="test inset1" style="position-area: top"></div>
+  <div class="test center" style="position-area: top"></div>
+  <div class="test inset2" style="position-area: top"></div>
+
+  <div class="test inset1" style="position-area: bottom"></div>
+  <div class="test center" style="position-area: bottom"></div>
+  <div class="test inset2" style="position-area: bottom"></div>
+
+  <div class="test inset1" style="position-area: center span-all"></div>
+  <div class="test center" style="position-area: center span-all"></div>
+  <div class="test inset2" style="position-area: center span-all"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-valid.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-valid.tentative.html
@@ -18,8 +18,7 @@
     width: 100px;
     height: 100px;
     background: red;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-after-scroll-in-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-after-scroll-in-document.html
@@ -28,8 +28,7 @@
     height: 100px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-after-scroll-in.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-after-scroll-in.html
@@ -33,8 +33,7 @@
     height: 100px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-chained-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-chained-004.html
@@ -38,8 +38,7 @@
     height: 50px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 
   #chained {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-change-anchor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-change-anchor.html
@@ -38,8 +38,7 @@
     height: 100px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-change-css-visibility.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-change-css-visibility.html
@@ -27,8 +27,7 @@
     height: 100px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-in-overflow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-in-overflow-expected.html
@@ -32,8 +32,7 @@
     height: 50px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
   #target-b {
     position-anchor: --anchor;
@@ -43,8 +42,7 @@
     height: 50px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
   #target-c {
     position-anchor: --anchor;
@@ -54,8 +52,7 @@
     height: 50px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-in-overflow-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-in-overflow-ref.html
@@ -32,8 +32,7 @@
     height: 50px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
   #target-b {
     position-anchor: --anchor;
@@ -43,8 +42,7 @@
     height: 50px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
   #target-c {
     position-anchor: --anchor;
@@ -54,8 +52,7 @@
     height: 50px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-in-overflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-in-overflow.html
@@ -36,8 +36,7 @@
     height: 50px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
   #target-b {
     position-anchor: --anchor;
@@ -47,8 +46,7 @@
     height: 50px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
   #target-c {
     position-anchor: --anchor;
@@ -58,8 +56,7 @@
     height: 50px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-with-position.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-with-position.html
@@ -32,8 +32,7 @@
     height: 100px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-remove-anchors-visible.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-remove-anchors-visible.html
@@ -33,8 +33,7 @@
     height: 100px;
     background: green;
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-remove-no-overflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-remove-no-overflow.html
@@ -25,8 +25,7 @@
     width: 100px;
     height: 100px;
     background: green;
-    top: 0;
-    left: 0;
+    inset: 0;
   }
 </style>
 

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -79,6 +79,7 @@ public:
     LayoutUnit marginAfterValue() const { return Style::evaluateMinimum<LayoutUnit>(m_marginAfter, m_containingInlineSize, m_style.usedZoomForLength()); }
     LayoutUnit insetBeforeValue() const { return Style::evaluateMinimum<LayoutUnit>(m_insetBefore, containingSize(), m_style.usedZoomForLength()); }
     LayoutUnit insetAfterValue() const { return Style::evaluateMinimum<LayoutUnit>(m_insetAfter, containingSize(), m_style.usedZoomForLength()); }
+    bool insetFitsContent() const; // One or both insets are auto for sizing purposes.
 
     LayoutUnit insetModifiedContainingSize() const { return m_insetModifiedContainingRange.size(); }
     LayoutRange insetModifiedContainingRange() const { return m_insetModifiedContainingRange; }

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4170,9 +4170,7 @@ void RenderBox::computeOutOfFlowPositionedLogicalWidth(LogicalExtentComputedValu
 template<typename SizeType> LayoutUnit RenderBox::computeOutOfFlowPositionedLogicalWidthUsing(const SizeType& logicalWidth, const PositionedLayoutConstraints& inlineConstraints) const
 {
     auto fallback = [&] -> LayoutUnit {
-        bool logicalLeftIsAuto = inlineConstraints.insetBefore().isAuto();
-        bool logicalRightIsAuto = inlineConstraints.insetAfter().isAuto();
-        bool shrinkToFit = logicalLeftIsAuto || logicalRightIsAuto || !inlineConstraints.alignmentAppliesStretch(ItemPosition::Stretch);
+        bool shrinkToFit = inlineConstraints.insetFitsContent() || !inlineConstraints.alignmentAppliesStretch(ItemPosition::Stretch);
         if (shrinkToFit) {
             auto preferredWidth = maxPreferredLogicalWidth() - inlineConstraints.bordersPlusPadding();
             auto preferredMinWidth = minPreferredLogicalWidth() - inlineConstraints.bordersPlusPadding();
@@ -4183,10 +4181,8 @@ template<typename SizeType> LayoutUnit RenderBox::computeOutOfFlowPositionedLogi
 
     auto intrinsic = [&](const auto& keyword) -> LayoutUnit {
         auto availableSpace = inlineConstraints.containingSize();
-        if (!inlineConstraints.insetBefore().isAuto())
-            availableSpace -= inlineConstraints.insetBeforeValue();
-        if (!inlineConstraints.insetAfter().isAuto())
-            availableSpace -= inlineConstraints.insetAfterValue();
+        availableSpace -= inlineConstraints.insetBeforeValue();
+        availableSpace -= inlineConstraints.insetAfterValue();
         return std::max(0_lu, computeIntrinsicLogicalWidthUsing(keyword, availableSpace, inlineConstraints.bordersPlusPadding()) - inlineConstraints.bordersPlusPadding());
     };
 
@@ -4319,9 +4315,7 @@ LayoutUnit RenderBox::computeOutOfFlowPositionedLogicalHeightUsing(const Style::
         return adjustContentBoxLogicalHeightForBoxSizing(Style::evaluate<LayoutUnit>(logicalHeight, blockConstraints.containingSize(), style().usedZoomForLength()));
     }
 
-    bool logicalLeftIsAuto = blockConstraints.insetBefore().isAuto();
-    bool logicalRightIsAuto = blockConstraints.insetAfter().isAuto();
-    bool shrinkToFit = logicalLeftIsAuto || logicalRightIsAuto || !blockConstraints.alignmentAppliesStretch(ItemPosition::Stretch);
+    bool shrinkToFit = blockConstraints.insetFitsContent() || !blockConstraints.alignmentAppliesStretch(ItemPosition::Stretch);
     if (!shrinkToFit)
         return std::max<LayoutUnit>(0, blockConstraints.availableContentSpace());
 

--- a/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
+++ b/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
@@ -60,6 +60,13 @@ public:
     ItemPositionType positionType() const { return static_cast<ItemPositionType>(m_positionType); }
     OverflowAlignment overflow() const { return static_cast<OverflowAlignment>(m_overflow); }
 
+    bool isNormal(ItemPosition autoAlignment = ItemPosition::Normal) const
+    {
+        if (position() == ItemPosition::Auto)
+            return autoAlignment == ItemPosition::Normal;
+        return position() == ItemPosition::Normal;
+    }
+
     // Must resolve Auto before calling. Normal treated as Start.
     // Returns position adjustment from container's start edge.
     static LayoutUnit adjustmentFromStartEdge(LayoutUnit extraSpace, ItemPosition alignmentPosition, LogicalBoxAxis containerAxis, WritingMode containerWritingMode, WritingMode selfWritingMode);


### PR DESCRIPTION
#### 60916eecfe7bb999a9a73cea63855430d1b6dd79
<pre>
position-area normal alignment with single auto inset aligns towards opposite side
<a href="https://bugs.webkit.org/show_bug.cgi?id=301406">https://bugs.webkit.org/show_bug.cgi?id=301406</a>
<a href="https://rdar.apple.com/163317238">rdar://163317238</a>

Reviewed by Alan Baradlay.

Updates PositionedLayoutConstraints::resolvePosition() to unsafe-align to the
non-auto inset when only one inset is auto.

See:
  <a href="https://www.w3.org/TR/css-anchor-position/#position-area">https://www.w3.org/TR/css-anchor-position/#position-area</a>
  <a href="https://github.com/w3c/csswg-drafts/issues/12512">https://github.com/w3c/csswg-drafts/issues/12512</a>

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-inset-001-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-inset-001.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-inset-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-inset-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-alignment-inset-001.html: Added.

Add new tests.
See <a href="https://github.com/web-platform-tests/wpt/pull/55722">https://github.com/web-platform-tests/wpt/pull/55722</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-valid.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-after-scroll-in-document.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-after-scroll-in.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-chained-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-change-anchor.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-change-css-visibility.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-in-overflow-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-in-overflow-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-in-overflow.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-with-position.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-remove-anchors-visible.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-remove-no-overflow.html:

Modify existing tests that (unnecessarily) assumed the previous behavior.
See <a href="https://github.com/web-platform-tests/wpt/pull/55722">https://github.com/web-platform-tests/wpt/pull/55722</a>

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::captureInsets):

Don&apos;t overwrite auto insets in our capture.

(WebCore::PositionedLayoutConstraints::resolvePosition const):

Check for position-area etc. directly in resolvePosition() instead.

(WebCore::PositionedLayoutConstraints::insetFitsContent const):
* Source/WebCore/rendering/PositionedLayoutConstraints.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeOutOfFlowPositionedLogicalWidthUsing const):
(WebCore::RenderBox::computeOutOfFlowPositionedLogicalHeightUsing const):

Update sizing code to not rely on insetBefore/After().isAuto().

* Source/WebCore/rendering/style/StyleSelfAlignmentData.h:
(WebCore::StyleSelfAlignmentData::isNormal const):

Add convenience method.

Canonical link: <a href="https://commits.webkit.org/302299@main">https://commits.webkit.org/302299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3adfcf1162708a27c85fa71e8143924d2f85ee9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79949 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/568e35f7-83a2-45ed-88a1-1f4e934e26a3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97835 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65805 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a3cb9a1e-1b54-48aa-9689-99289b06a64b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78447 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33249 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79190 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138356 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106370 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106184 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27073 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/521 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30022 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52956 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/676 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63876 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/559 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/630 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->