### PR TITLE
[HDR] CoreGraphics filters do not support float16 unaccelerated backing stores

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2512,6 +2512,7 @@ fast/images/hdr-border-image.html [ Skip ]
 fast/images/hdr-pseudo-before-image.html [ Skip ]
 fast/images/hdr-svg-inline-image.html [ Skip ]
 fast/images/hdr-unaccelerated-basic-image.html [ Skip ]
+fast/images/hdr-unaccelerated-image-blur-filter.html [ Skip ]
 
 # Experimental H265 support.
 webrtc/h265.html [ Pass Failure ]

--- a/LayoutTests/fast/images/hdr-unaccelerated-image-blur-filter-expected.html
+++ b/LayoutTests/fast/images/hdr-unaccelerated-image-blur-filter-expected.html
@@ -1,0 +1,15 @@
+<style>
+    .box {
+        width: 200px;
+        height: 200px;
+        display: inline-block;
+        background-color: lime;
+        will-change: transform;
+        filter: blur(4px);
+    }
+</style>
+<body>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <div class="box"></div>
+    </div>
+</body>

--- a/LayoutTests/fast/images/hdr-unaccelerated-image-blur-filter.html
+++ b/LayoutTests/fast/images/hdr-unaccelerated-image-blur-filter.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AcceleratedDrawingEnabled=false ] -->
+<meta name="fuzzy" content="maxDifference=0-12; totalPixels=0-44912" />
+<style>
+    .image-box {
+        width: 200px;
+        height: 200px;
+        will-change: transform;
+        filter: blur(4px);
+    }
+</style>
+<body>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <img class="image-box">
+    </div>
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.waitUntilDone();
+        }
+
+        var image = new Image;
+        image.onload = (() => {
+            if (window.internals)
+                internals.setHasHDRContentForTesting(image);
+
+            var imgElement = document.querySelector("img.image-box");
+            imgElement.src = image.src;
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+        image.src = "resources/gainmap-red-green-1920x1920.jpg";
+    </script>
+</body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4610,6 +4610,7 @@ fast/images/hdr-image-layer-sdr-dynamic-range-limit.html [ Pass ]
 fast/images/hdr-pseudo-before-image.html [ Pass ]
 fast/images/hdr-svg-inline-image.html [ Pass ]
 fast/images/hdr-unaccelerated-basic-image.html [ Pass ]
+fast/images/hdr-unaccelerated-image-blur-filter.html [ Pass ]
 
 # Re-enabling tests fixed by DocumentManager in iOS16+ rdar://102159271
 fast/forms/ios/show-file-upload-context-menu-above-keyboard.html [ Pass ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1477,6 +1477,7 @@ webkit.org/b/260113 [ arm64 ] http/wpt/webauthn/ctap-hid-failure.https.html [ Pa
 [ Sequoia+ ] fast/images/hdr-pseudo-before-image.html [ Pass ]
 [ Sequoia+ ] fast/images/hdr-svg-inline-image.html [ Pass ]
 [ Sequoia+ ] fast/images/hdr-unaccelerated-basic-image.html [ Pass ]
+[ Sequoia+ ] fast/images/hdr-unaccelerated-image-blur-filter.html [ Pass ]
 
 # The direct image codepath is not used with the remote layer tree.
 [ Sonoma+ ] compositing/images/direct-image-object-fit.html [ Skip ]

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3628,7 +3628,7 @@ GraphicsContext* RenderLayer::setupFilters(GraphicsContext& destinationContext, 
 
     auto rootRelativeBounds = calculateLayerBounds(paintingInfo.rootLayer, offsetFromRoot, { RenderLayer::PreserveAncestorFlags });
 
-    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, enclosingIntRect(rootRelativeBounds), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect), backgroundRect.rect());
+    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, paintingInfo.paintBehavior, enclosingIntRect(rootRelativeBounds), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect), backgroundRect.rect());
     if (!filterContext)
         return nullptr;
 
@@ -6368,7 +6368,6 @@ RenderLayerFilters& RenderLayer::ensureLayerFilters()
         return *m_filters;
     
     m_filters = makeUnique<RenderLayerFilters>(*this);
-    m_filters->setPreferredFilterRenderingModes(renderer().page().preferredFilterRenderingModes());
     m_filters->setFilterScale({ page().deviceScaleFactor(), page().deviceScaleFactor() });
     return *m_filters;
 }

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -63,7 +63,6 @@ public:
     void updateReferenceFilterClients(const Style::Filter&);
     void removeReferenceFilterClients();
 
-    void setPreferredFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) { m_preferredFilterRenderingModes = preferredFilterRenderingModes; }
     void setFilterScale(const FloatSize& filterScale) { m_filterScale = filterScale; }
 
     static bool isIdentity(RenderElement&);
@@ -72,7 +71,7 @@ public:
     // Per render
     LayoutRect repaintRect() const { return m_repaintRect; }
 
-    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect);
+    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, OptionSet<PaintBehavior>, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect);
     void applyFilterEffect(GraphicsContext& destinationContext);
 
 private:


### PR DESCRIPTION
#### 9f930ab5c13c419a60a30a2f273f57b73310891b
<pre>
[HDR] CoreGraphics filters do not support float16 unaccelerated backing stores
<a href="https://bugs.webkit.org/show_bug.cgi?id=301592">https://bugs.webkit.org/show_bug.cgi?id=301592</a>
<a href="https://rdar.apple.com/163220052">rdar://163220052</a>

Reviewed by Simon Fraser.

CoreGraphics fires an assertion when a blur filter is applied on a float16
unaccelerated backing store.

Disable CoreGraphics filters for float16 unaccelerated backing stores and use
software filters for now. Software filters do not support float16 backing stores,
But copying the sourceImage to 8-bit backing store converts the HDR display to
SDR. Therefore the filter works but on SDR backing store.

Test: fast/images/hdr-unaccelerated-image-blur-filter.html
* LayoutTests/TestExpectations:
* LayoutTests/fast/images/hdr-unaccelerated-image-blur-filter-expected.html: Added.
* LayoutTests/fast/images/hdr-unaccelerated-image-blur-filter.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::setupFilters):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/RenderLayerFilters.h:

Canonical link: <a href="https://commits.webkit.org/302306@main">https://commits.webkit.org/302306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3f2c636cc1b5497c6a3607b4f5b9cb5db362913

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136060 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80072 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c7f23bf9-0801-4809-9c8d-16c9dcc6c508) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97952 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3086edbd-8c5e-459e-a115-4dfdbdc297a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78570 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2796658b-b537-4d29-988f-db9112b2014d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33387 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79340 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109042 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138515 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/722 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106487 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106310 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27075 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/640 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30146 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53142 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/825 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64079 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/688 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/772 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->