### PR TITLE
Update WKDDActionContext serialization to use WKSecureCoding interface

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -245,7 +245,6 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCCFURL.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCCVPixelBufferRef.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCColor.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCContacts.serialization.in
-$(PROJECT_DIR)/Shared/Cocoa/CoreIPCDDActionContext.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCData.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDate.serialization.in
@@ -513,6 +512,7 @@ $(PROJECT_DIR)/Shared/ios/InteractionInformationAtPosition.serialization.in
 $(PROJECT_DIR)/Shared/ios/InteractionInformationRequest.serialization.in
 $(PROJECT_DIR)/Shared/ios/WebAutocorrectionContext.serialization.in
 $(PROJECT_DIR)/Shared/ios/WebAutocorrectionData.serialization.in
+$(PROJECT_DIR)/Shared/mac/CoreIPCDDSecureActionContext.serialization.in
 $(PROJECT_DIR)/Shared/mac/PDFContextMenuItem.serialization.in
 $(PROJECT_DIR)/Shared/mac/SecItemRequestData.serialization.in
 $(PROJECT_DIR)/Shared/mac/SecItemResponseData.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -656,7 +656,6 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCCFURL.serialization.in \
 	Shared/Cocoa/CoreIPCColor.serialization.in \
 	Shared/Cocoa/CoreIPCContacts.serialization.in \
-	Shared/Cocoa/CoreIPCDDActionContext.serialization.in \
 	Shared/Cocoa/CoreIPCDDScannerResult.serialization.in \
 	Shared/Cocoa/CoreIPCData.serialization.in \
 	Shared/Cocoa/CoreIPCDate.serialization.in \
@@ -741,6 +740,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/ios/DragInitiationResult.serialization.in \
 	Shared/ios/WebAutocorrectionContext.serialization.in \
 	Shared/ios/WebAutocorrectionData.serialization.in \
+	Shared/mac/CoreIPCDDSecureActionContext.serialization.in \
 	Shared/JavaScriptCore.serialization.in \
 	Shared/LayerTreeContext.serialization.in \
 	Shared/LoadParameters.serialization.in \

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -95,9 +95,6 @@ enum class NSType : uint8_t {
 #endif
 #if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
     DDScannerResult,
-#if PLATFORM(MAC)
-    WKDDActionContext,
-#endif
 #endif
     NSDateComponents,
     Data,

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -412,10 +412,6 @@ NSType typeFromObject(id object)
 #if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
     SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<DDScannerResult>()])
         return NSType::DDScannerResult;
-#if PLATFORM(MAC)
-    SUPPRESS_UNRETAINED_ARG if ([object isKindOfClass:getClass<WKDDActionContext>()])
-        return NSType::WKDDActionContext;
-#endif
 #endif
     if ([object isKindOfClass:[NSDateComponents class]])
         return NSType::NSDateComponents;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -52,9 +52,6 @@ class CoreIPCCNPostalAddress;
 #endif
 #if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
 class CoreIPCDDScannerResult;
-#if PLATFORM(MAC)
-class CoreIPCDDSecureActionContext;
-#endif
 #endif
 class CoreIPCData;
 class CoreIPCDate;
@@ -102,9 +99,6 @@ using ObjectValue = Variant<
 #endif
 #if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
     CoreIPCDDScannerResult,
-#if PLATFORM(MAC)
-    CoreIPCDDSecureActionContext,
-#endif
 #endif
     CoreIPCDateComponents,
 #if !HAVE(WK_SECURE_CODING_NSURLREQUEST)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -74,10 +74,6 @@ static ObjectValue valueFromID(id object)
 #if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
     case IPC::NSType::DDScannerResult:
         return CoreIPCDDScannerResult((DDScannerResult *)object);
-#if PLATFORM(MAC)
-    case IPC::NSType::WKDDActionContext:
-        return CoreIPCDDSecureActionContext((WKDDActionContext *)object);
-#endif
 #endif
     case IPC::NSType::NSDateComponents:
         return CoreIPCDateComponents((NSDateComponents *)object);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
@@ -58,9 +58,6 @@ using WebKit::ObjectValue = Variant<
 #endif
 #if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
     WebKit::CoreIPCDDScannerResult,
-#if PLATFORM(MAC)
-    WebKit::CoreIPCDDSecureActionContext,
-#endif
 #endif
     WebKit::CoreIPCDateComponents,
 #if !HAVE(WK_SECURE_CODING_NSURLREQUEST)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -855,17 +855,19 @@ header: <WebCore/RenderStyleConstants.h>
     WebCore::FloatSize radii().bottomRight();
 }
 
-[AdditionalEncoder=StreamConnectionEncoder] class WebCore::IntRect {
+webkit_platform_headers: <WebCore/IntRect.h>
+
+[AdditionalEncoder=StreamConnectionEncoder, WebKitPlatform] class WebCore::IntRect {
     WebCore::IntPoint location();
     [Validator='WebCore::IntRect { *location, *size }.isValid()'] WebCore::IntSize size();
 }
 
-[AdditionalEncoder=StreamConnectionEncoder] class WebCore::IntPoint {
+[AdditionalEncoder=StreamConnectionEncoder, WebKitPlatform] class WebCore::IntPoint {
     int x();
     int y();
 }
 
-[AdditionalEncoder=StreamConnectionEncoder] class WebCore::IntSize {
+[AdditionalEncoder=StreamConnectionEncoder, WebKitPlatform] class WebCore::IntSize {
     int width();
     int height();
 }

--- a/Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.h
+++ b/Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
+
+#include "WebHitTestResultData.h"
+
+#include <wtf/ArgumentCoder.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+
+OBJC_CLASS DDScannerResult;
+
+namespace WebKit {
+
+struct CoreIPCDDSecureActionContextData {
+    WebCore::IntRect highlightFrame;
+    WebCore::IntRect aimFrame;
+    RetainPtr<NSString> eventTitle;
+    RetainPtr<NSString> leadingText;
+    RetainPtr<NSString> trailingText;
+    RetainPtr<NSString> coreSpotlightUniqueIdentifier;
+    RetainPtr<NSDate> referenceDate;
+    RetainPtr<NSString> hostUUID;
+    RetainPtr<NSString> authorABUUID;
+    RetainPtr<NSString> authorEmailAddress;
+    RetainPtr<NSString> authorName;
+    RetainPtr<NSURL> url;
+    RetainPtr<NSString> matchedString;
+
+    std::optional<Vector<RetainPtr<DDScannerResult>>> allResults;
+    Vector<RetainPtr<DDScannerResult>> groupAllResults;
+    RetainPtr<NSNumber> groupCategory;
+    RetainPtr<NSString> groupTranscript;
+    RetainPtr<NSString> selectionString;
+
+    std::optional<RetainPtr<DDScannerResult>> mainResult;
+
+    bool immediate;
+    bool isRightClick;
+    std::optional<bool> bypassScreentimeContactShield;
+    RetainPtr<NSPersonNameComponents> authorNameComponents;
+};
+
+class CoreIPCDDSecureActionContext {
+    WTF_MAKE_TZONE_ALLOCATED(CoreIPCDDSecureActionContext);
+public:
+    CoreIPCDDSecureActionContext(DDSecureActionContext *);
+    CoreIPCDDSecureActionContext(CoreIPCDDSecureActionContextData&&);
+    RetainPtr<id> toID() const;
+
+private:
+    friend struct IPC::ArgumentCoder<CoreIPCDDSecureActionContext>;
+    CoreIPCDDSecureActionContextData m_data;
+};
+
+
+} // namespace WebKit
+
+#endif // PLATFORM(MAC) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)

--- a/Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.mm
+++ b/Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.mm
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CoreIPCDDSecureActionContext.h"
+
+#import <pal/cocoa/DataDetectorsCoreSoftLink.h>
+#import <pal/mac/DataDetectorsSoftLink.h>
+
+#if PLATFORM(MAC) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
+
+@interface DDSecureActionContext(WKSecureCoding)
+- (NSDictionary *)_webKitPropertyListData;
+- (instancetype)_initWithWebKitPropertyListData:(NSDictionary *)plist;
+@end
+
+namespace WebKit {
+
+CoreIPCDDSecureActionContext::CoreIPCDDSecureActionContext(DDSecureActionContext * object)
+{
+    RetainPtr dictionary = [object _webKitPropertyListData];
+
+    RetainPtr NSRectTypeString = [NSString stringWithCString:@encode(NSRect) encoding:NSASCIIStringEncoding];
+
+    if (auto *highlightFrame = dynamic_objc_cast<NSValue>([dictionary.get() objectForKey:@"highlightFrame"])) {
+        RetainPtr type = [NSString stringWithCString:[highlightFrame objCType] encoding:NSASCIIStringEncoding];
+        if ([type.get() isEqual:NSRectTypeString.get()])
+            m_data.highlightFrame = WebCore::enclosingIntRect([highlightFrame rectValue]);
+    }
+
+    if (auto *aimFrame = dynamic_objc_cast<NSValue>([dictionary.get() objectForKey:@"aimFrame"])) {
+        RetainPtr type = [NSString stringWithCString:[aimFrame objCType] encoding:NSASCIIStringEncoding];
+        if ([type.get() isEqual:NSRectTypeString.get()])
+            m_data.aimFrame = WebCore::enclosingIntRect([aimFrame rectValue]);
+    }
+
+    if (auto *eventTitle = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"eventTitle"]))
+        m_data.eventTitle = eventTitle;
+
+    if (auto *leadingText = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"leadingText"]))
+        m_data.leadingText = leadingText;
+
+    if (auto *trailingText = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"trailingText"]))
+        m_data.trailingText = trailingText;
+
+    if (auto *coreSpotlightUniqueIdentifier = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"coreSpotlightUniqueIdentifier"]))
+        m_data.coreSpotlightUniqueIdentifier = coreSpotlightUniqueIdentifier;
+
+    if (auto *referenceDate = dynamic_objc_cast<NSDate>([dictionary.get() objectForKey:@"referenceDate"]))
+        m_data.referenceDate = referenceDate;
+
+    if (auto *hostUUID = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"hostUUID"]))
+        m_data.hostUUID = hostUUID;
+
+    if (auto *authorABUUID = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"authorABUUID"]))
+        m_data.authorABUUID = authorABUUID;
+
+    if (auto *authorEmailAddress = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"authorEmailAddress"]))
+        m_data.authorEmailAddress = authorEmailAddress;
+
+    if (auto *authorName = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"authorName"]))
+        m_data.authorName = authorName;
+
+    if (auto *url = dynamic_objc_cast<NSURL>([dictionary.get() objectForKey:@"url"]))
+        m_data.url = url;
+
+    if (auto *matchedString = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"matchedString"]))
+        m_data.matchedString = matchedString;
+
+    if (auto *allResults = dynamic_objc_cast<NSArray>([dictionary.get() objectForKey:@"allResults"])) {
+        Vector<RetainPtr<DDScannerResult>> result;
+        result.reserveInitialCapacity(allResults.count);
+        for (id item in allResults) {
+            if ([item isKindOfClass:PAL::getDDScannerResultClassSingleton()])
+                result.append((DDScannerResult *)item);
+        };
+        m_data.allResults = WTFMove(result);
+    }
+
+    if (auto *groupAllResults = dynamic_objc_cast<NSArray>([dictionary.get() objectForKey:@"groupAllResults"])) {
+        Vector<RetainPtr<DDScannerResult>> result;
+        result.reserveInitialCapacity(groupAllResults.count);
+        for (id item in groupAllResults) {
+            if ([item isKindOfClass:PAL::getDDScannerResultClassSingleton()])
+                result.append((DDScannerResult *)item);
+        };
+        m_data.groupAllResults = WTFMove(result);
+    }
+
+    if (auto *groupCategory = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"groupCategory"]))
+        m_data.groupCategory = groupCategory;
+
+    if (auto *groupTranscript = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"groupTranscript"]))
+        m_data.groupTranscript = groupTranscript;
+
+    if (auto *selectionString = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"selectionString"]))
+        m_data.selectionString = selectionString;
+
+    DDScannerResult *mainResult = [dictionary.get() objectForKey:@"mainResult"];
+    if ([mainResult isKindOfClass:PAL::getDDScannerResultClassSingleton()])
+        m_data.mainResult = mainResult;
+
+    if (auto *immediate = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"immediate"]))
+        m_data.immediate = [immediate boolValue];
+
+    if (auto *isRightClick = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"isRightClick"]))
+        m_data.isRightClick = [isRightClick boolValue];
+
+    if (auto *bypassScreentimeContactShield = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"bypassScreentimeContactShield"]))
+        m_data.bypassScreentimeContactShield = [bypassScreentimeContactShield boolValue];
+
+    if (auto *authorNameComponents = dynamic_objc_cast<NSPersonNameComponents>([dictionary.get() objectForKey:@"authorNameComponents"]))
+        m_data.authorNameComponents = authorNameComponents;
+}
+
+CoreIPCDDSecureActionContext::CoreIPCDDSecureActionContext(CoreIPCDDSecureActionContextData&& data)
+: m_data(WTFMove(data)) { }
+
+RetainPtr<id> CoreIPCDDSecureActionContext::toID() const
+{
+    RetainPtr dict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:23]);
+
+    [dict setObject:[NSValue valueWithRect:m_data.highlightFrame] forKey:@"highlightFrame"];
+    [dict setObject:[NSValue valueWithRect:m_data.aimFrame] forKey:@"aimFrame"];
+
+    if (m_data.eventTitle)
+        [dict setObject:m_data.eventTitle.get() forKey:@"eventTitle"];
+    if (m_data.leadingText)
+        [dict setObject:m_data.leadingText.get() forKey:@"leadingText"];
+    if (m_data.trailingText)
+        [dict setObject:m_data.trailingText.get() forKey:@"trailingText"];
+    if (m_data.coreSpotlightUniqueIdentifier)
+        [dict setObject:m_data.coreSpotlightUniqueIdentifier.get() forKey:@"coreSpotlightUniqueIdentifier"];
+    if (m_data.referenceDate)
+        [dict setObject:m_data.referenceDate.get() forKey:@"referenceDate"];
+    if (m_data.hostUUID)
+        [dict setObject:m_data.hostUUID.get() forKey:@"hostUUID"];
+    if (m_data.authorABUUID)
+        [dict setObject:m_data.authorABUUID.get() forKey:@"authorABUUID"];
+    if (m_data.authorEmailAddress)
+        [dict setObject:m_data.authorEmailAddress.get() forKey:@"authorEmailAddress"];
+    if (m_data.authorName)
+        [dict setObject:m_data.authorName.get() forKey:@"authorName"];
+    if (m_data.url)
+        [dict setObject:m_data.url.get() forKey:@"url"];
+    if (m_data.matchedString)
+        [dict setObject:m_data.matchedString.get() forKey:@"matchedString"];
+    if (m_data.allResults) {
+        RetainPtr arr = [NSMutableArray arrayWithCapacity:m_data.allResults->size()];
+        for (auto& element : *m_data.allResults)
+            [arr addObject:element.get()];
+        [dict setObject:arr.get() forKey:@"allResults"];
+    }
+    RetainPtr grpArr = [NSMutableArray arrayWithCapacity:m_data.groupAllResults.size()];
+    for (auto& element : m_data.groupAllResults)
+        [grpArr addObject:element.get()];
+    [dict setObject:grpArr.get() forKey:@"groupAllResults"];
+    if (m_data.groupCategory)
+        [dict setObject:m_data.groupCategory.get() forKey:@"groupCategory"];
+    if (m_data.groupTranscript)
+        [dict setObject:m_data.groupTranscript.get() forKey:@"groupTranscript"];
+    if (m_data.selectionString)
+        [dict setObject:m_data.selectionString.get() forKey:@"selectionString"];
+    if (m_data.mainResult)
+        [dict setObject:m_data.mainResult->get() forKey:@"mainResult"];
+
+    [dict setObject:@(m_data.immediate) forKey:@"immediate"];
+    [dict setObject:@(m_data.isRightClick) forKey:@"isRightClick"];
+    if (m_data.bypassScreentimeContactShield)
+        [dict setObject:@(*m_data.bypassScreentimeContactShield) forKey:@"bypassScreentimeContactShield"];
+
+    if (m_data.authorNameComponents)
+        [dict setObject:m_data.authorNameComponents.get() forKey:@"authorNameComponents"];
+
+    return adoptNS([[PAL::getWKDDActionContextClassSingleton() alloc] _initWithWebKitPropertyListData:dict.get()]);
+}
+
+}
+
+#endif // PLATFORM(MAC) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)

--- a/Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.serialization.in
+++ b/Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.serialization.in
@@ -21,34 +21,39 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if PLATFORM(MAC) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
-secure_coding_header: <pal/mac/DataDetectorsSoftLink.h>
 
-[WebKitSecureCodingClass=PAL::getWKDDActionContextClassSingleton()] webkit_secure_coding DDSecureActionContext {
-    highlightFrame: NSValue
-    aimFrame: NSValue
-    eventTitle: String
-    leadingText: String
-    trailingText: String
-    coreSpotlightUniqueIdentifier: String
-    referenceDate: Date
-    hostUUID: String
-    authorABUUID: String
-    authorEmailAddress: String
-    authorName: String
-    url: URL
-    matchedString: String
+webkit_platform_headers: "CoreIPCDDSecureActionContext.h"
+[WebKitPlatform, CustomHeader] struct WebKit::CoreIPCDDSecureActionContextData {
+    WebCore::IntRect highlightFrame;
+    WebCore::IntRect aimFrame;
+    RetainPtr<NSString> eventTitle;
+    RetainPtr<NSString> leadingText;
+    RetainPtr<NSString> trailingText;
+    RetainPtr<NSString> coreSpotlightUniqueIdentifier;
+    RetainPtr<NSDate> referenceDate;
+    RetainPtr<NSString> hostUUID;
+    RetainPtr<NSString> authorABUUID;
+    RetainPtr<NSString> authorEmailAddress;
+    RetainPtr<NSString> authorName;
+    RetainPtr<NSURL> url;
+    RetainPtr<NSString> matchedString;
 
-    allResults: Array<DDScannerResult>?
-    groupAllResults: Array<DDScannerResult>
-    groupCategory: Number
-    groupTranscript: String
-    selectionString: String
+    std::optional<Vector<RetainPtr<DDScannerResult>>> allResults;
+    Vector<RetainPtr<DDScannerResult>> groupAllResults;
+    RetainPtr<NSNumber> groupCategory;
+    RetainPtr<NSString> groupTranscript;
+    RetainPtr<NSString> selectionString;
 
-    mainResult: DDScannerResult?
+    std::optional<RetainPtr<DDScannerResult>> mainResult;
 
-    immediate: Number
-    isRightClick: Number
-    authorNameComponents: PersonNameComponents
+    bool immediate;
+    bool isRightClick;
+    std::optional<bool> bypassScreentimeContactShield;
+    RetainPtr<NSPersonNameComponents> authorNameComponents;
 }
 
-#endif // PLATFORM(MAC) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
+[WebKitPlatform] class WebKit::CoreIPCDDSecureActionContext {
+    WebKit::CoreIPCDDSecureActionContextData m_data;
+}
+
+#endif

--- a/Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in
+++ b/Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in
@@ -25,7 +25,7 @@ headers: <WebCore/TextIndicator.h>
 #if PLATFORM(MAC)
 header: "WebHitTestResultData.h" <pal/mac/DataDetectorsSoftLink.h>
 [Nested] struct WebKit::WebHitTestResultPlatformData::DetectedDataActionContext {
-    [SecureCodingAllowed=[PAL::getWKDDActionContextClassSingleton()]] RetainPtr<WKDDActionContext> context;
+    RetainPtr<WKDDActionContext> context;
 };
 [CustomHeader] struct WebKit::WebHitTestResultPlatformData {
     Markable<WebKit::WebHitTestResultPlatformData::DetectedDataActionContext> detectedDataActionContext;

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -231,6 +231,7 @@ Shared/mac/SecItemRequestData.cpp
 Shared/mac/WebEventFactory.mm @nonARC
 Shared/mac/WebGestureEvent.cpp
 Shared/mac/WebMemorySampler.mac.mm @nonARC
+Shared/mac/CoreIPCDDSecureActionContext.mm
 
 Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm @nonARC
 Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm @nonARC

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2543,6 +2543,8 @@
 		F4E090952D889D6A00322226 /* WKIdentityDocumentPresentmentDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E090942D889CB800322226 /* WKIdentityDocumentPresentmentDelegate.h */; };
 		F4E090992D88AAC300322226 /* WKIdentityDocumentPresentmentRawRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E090962D88A66F00322226 /* WKIdentityDocumentPresentmentRawRequest.h */; };
 		F4E28A362C923814008120DD /* ScriptTrackingPrivacyFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E28A352C923814008120DD /* ScriptTrackingPrivacyFilter.h */; };
+		F4E2A38E2EBA917100D7A783 /* CoreIPCDDSecureActionContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E2A38C2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.mm */; };
+		F4E2A38F2EBAAA7700D7A783 /* CoreIPCDDSecureActionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E2A38B2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.h */; };
 		F4E44EB72DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E44EB62DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift */; };
 		F4E727232A547F0400CE34FD /* WKTouchEventsGestureRecognizerTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */; };
 		F4EB4AFD269CD7F300D297AE /* OSStateSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EB4AFC269CD23600D297AE /* OSStateSPI.h */; };
@@ -5998,7 +6000,6 @@
 		51AD56812B1A8CF5001A0ECB /* GeneratedWebKitSecureCoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeneratedWebKitSecureCoding.h; sourceTree = "<group>"; };
 		51AD56832B1AA324001A0ECB /* GeneratedWebKitSecureCoding.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GeneratedWebKitSecureCoding.mm; sourceTree = "<group>"; };
 		51AD56882B1ABFC1001A0ECB /* SerializedTypeInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SerializedTypeInfo.mm; sourceTree = "<group>"; };
-		51AD56892B1C3BA1001A0ECB /* CoreIPCDDActionContext.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCDDActionContext.serialization.in; sourceTree = "<group>"; };
 		51AD568D2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPersonNameComponents.h; sourceTree = "<group>"; };
 		51AD568E2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPersonNameComponents.mm; sourceTree = "<group>"; };
 		51AD568F2B1C46F0001A0ECB /* CoreIPCPersonNameComponents.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPersonNameComponents.serialization.in; sourceTree = "<group>"; };
@@ -8717,6 +8718,9 @@
 		F4E28A352C923814008120DD /* ScriptTrackingPrivacyFilter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScriptTrackingPrivacyFilter.h; sourceTree = "<group>"; };
 		F4E28A372C923C71008120DD /* ScriptTrackingPrivacyFilter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ScriptTrackingPrivacyFilter.cpp; sourceTree = "<group>"; };
 		F4E28A382C923C71008120DD /* ScriptTrackingPrivacyFilter.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ScriptTrackingPrivacyFilter.serialization.in; sourceTree = "<group>"; };
+		F4E2A38B2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCDDSecureActionContext.h; sourceTree = "<group>"; };
+		F4E2A38C2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCDDSecureActionContext.mm; sourceTree = "<group>"; };
+		F4E2A38D2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCDDSecureActionContext.serialization.in; sourceTree = "<group>"; };
 		F4E2B44A268FDE1A00327ABC /* TapHandlingResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TapHandlingResult.h; path = ios/TapHandlingResult.h; sourceTree = "<group>"; };
 		F4E44EB62DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift"; sourceTree = "<group>"; };
 		F4E47BB527B5AE5B00813B38 /* CocoaImage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaImage.mm; sourceTree = "<group>"; };
@@ -12873,7 +12877,6 @@
 				5181988E2B7585E30084E292 /* CoreIPCDateComponents.h */,
 				5181988F2B7585E30084E292 /* CoreIPCDateComponents.mm */,
 				5181988D2B7585E30084E292 /* CoreIPCDateComponents.serialization.in */,
-				51AD56892B1C3BA1001A0ECB /* CoreIPCDDActionContext.serialization.in */,
 				51ACFFD52B048804001331A2 /* CoreIPCDDScannerResult.serialization.in */,
 				5197FAD22AFD33B0009180C5 /* CoreIPCDictionary.h */,
 				5187BDED2B005DEE008A6EE5 /* CoreIPCDictionary.mm */,
@@ -15756,6 +15759,9 @@
 			isa = PBXGroup;
 			children = (
 				9F54F88E16488E87007DF81A /* AuxiliaryProcessMac.mm */,
+				F4E2A38B2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.h */,
+				F4E2A38C2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.mm */,
+				F4E2A38D2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.serialization.in */,
 				1AC75A1C1B33695E0056745B /* HangDetectionDisablerMac.mm */,
 				2D50365D1BCC793F00E20BB3 /* NativeWebGestureEventMac.mm */,
 				C02BFF1D1251502E009CCBEA /* NativeWebKeyboardEventMac.mm */,
@@ -17634,6 +17640,7 @@
 				F48C81E42AE0BA8E00073850 /* CoreIPCData.h in Headers */,
 				F49EE2212AE87F41003E3C34 /* CoreIPCDate.h in Headers */,
 				518198902B7585EB0084E292 /* CoreIPCDateComponents.h in Headers */,
+				F4E2A38F2EBAAA7700D7A783 /* CoreIPCDDSecureActionContext.h in Headers */,
 				5197FAEA2AFD33CF009180C5 /* CoreIPCDictionary.h in Headers */,
 				F4ABDB632B018C4B00C5471A /* CoreIPCError.h in Headers */,
 				F4ABDB732B0417AD00C5471A /* CoreIPCLocale.h in Headers */,
@@ -21218,6 +21225,7 @@
 				5157AE032B23C34700C0E095 /* CoreIPCContacts.mm in Sources */,
 				52B060F92B745E4D009B1666 /* CoreIPCCVPixelBufferRef.mm in Sources */,
 				518198912B7585F80084E292 /* CoreIPCDateComponents.mm in Sources */,
+				F4E2A38E2EBA917100D7A783 /* CoreIPCDDSecureActionContext.mm in Sources */,
 				5187BDEE2B005E16008A6EE5 /* CoreIPCDictionary.mm in Sources */,
 				F4ABDB662B01C68F00C5471A /* CoreIPCError.mm in Sources */,
 				F4A30A6D2B08255B004E1F24 /* CoreIPCLocale.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -1748,7 +1748,7 @@ static RetainPtr<DDScannerResult> fakeDataDetectorResultForTesting()
                                  signature:(NSData *)signature;
 @end
 
-TEST(IPCSerialization, SecureCoding)
+TEST(IPCSerialization, DataDetectors)
 {
     // DDScannerResult
     //   - Note: For now, there's no reasonable way to create anything but an empty DDScannerResult object
@@ -1764,7 +1764,10 @@ TEST(IPCSerialization, SecureCoding)
     [actionContext setHighlightFrame:NSMakeRect(1, 2, 3, 4)];
 
     runTestNS({ actionContext.get() });
+}
 
+TEST(IPCSerialization, SecureCoding)
+{
     // PKPaymentMerchantSession
     // This initializer doesn't exercise retryNonce or domain
     RetainPtr<PKPaymentMerchantSession> session = adoptNS([[PAL::getPKPaymentMerchantSessionClassSingleton() alloc]


### PR DESCRIPTION
#### 4a8681f07b140500eba88271dd9c645d88c11416
<pre>
Update WKDDActionContext serialization to use WKSecureCoding interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=301588">https://bugs.webkit.org/show_bug.cgi?id=301588</a>
<a href="https://rdar.apple.com/163590357">rdar://163590357</a>

Reviewed by Alex Christensen.

This patch removes WKKeyedCoder at the IDL layer for serializing WKDDActionContext.

IPCSerialization.mm tests are refactored to split out the Data Detectors test.

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::typeFromObject):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.h: Added.
* Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.mm: Added.
(WebKit::CoreIPCDDSecureActionContext::CoreIPCDDSecureActionContext):
(WebKit::CoreIPCDDSecureActionContext::toID const):
* Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.serialization.in: Renamed from Source/WebKit/Shared/Cocoa/CoreIPCDDActionContext.serialization.in.
* Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, DataDetectors)):
(TEST(IPCSerialization, SecureCoding)):

Canonical link: <a href="https://commits.webkit.org/302731@main">https://commits.webkit.org/302731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c54909b0bca998bdc7da3d55fb9aa5ebe3828591

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137330 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81432 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2cb3a0c7-b609-4d65-a062-7713f105176e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98978 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66787 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7a0c0ae1-fa8e-44ac-85f4-27eeca740aa4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79671 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0a17bed4-b834-4f14-89b9-989ca0494ba8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34498 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80600 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139811 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107483 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107371 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27351 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31190 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54794 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2065 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65434 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1880 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1914 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1988 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->