### PR TITLE
StabilityTracer: com.apple.WebKit.WebContent at WebCore::Navigation::initializeForNewWindow

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -881,7 +881,7 @@ void FrameLoader::didBeginDocument(bool dispatch, LocalDOMWindow* previousWindow
         if (auto integrityPolicyReportOnly = documentLoader->integrityPolicyReportOnly())
             document->setIntegrityPolicyReportOnly(WTFMove(integrityPolicyReportOnly));
 
-        navigationType = m_documentLoader->triggeringAction().navigationAPIType();
+        navigationType = documentLoader->triggeringAction().navigationAPIType();
     }
 
     if (document->settings().navigationAPIEnabled() && document->window() && !document->protectedSecurityOrigin()->isOpaque())

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -169,11 +169,10 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
                     m_entries[*previousNavigation->m_currentEntryIndex] = NavigationHistoryEntry::create(*this, *currentItem);
 
                 m_currentEntryIndex = getEntryIndexOfHistoryItem(m_entries, *currentItem);
-
-                ASSERT(navigationType);
-                m_activation = NavigationActivation::create(*navigationType, *currentEntry(), WTFMove(previousEntry));
-
-                return;
+                if (m_currentEntryIndex) {
+                    m_activation = NavigationActivation::create(*navigationType, *currentEntry(), WTFMove(previousEntry));
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
#### c69ce8c4652b44accf6932761ae7837864f11151
<pre>
StabilityTracer: com.apple.WebKit.WebContent at WebCore::Navigation::initializeForNewWindow
<a href="https://bugs.webkit.org/show_bug.cgi?id=301593">https://bugs.webkit.org/show_bug.cgi?id=301593</a>
<a href="https://rdar.apple.com/163496995">rdar://163496995</a>

Reviewed by Chris Dumez.

The crash appears to be caused by dereferncing / trying to Ref a nullptr
returned by Navigation::currentEntry() on this line:

&quot;m_activation = NavigationActivation::create(*navigationType, *currentEntry(), WTFMove(previousEntry));&quot;

Navigation::currentEntry() returns a nullptr in one of two cases:
1. hasEntriesAndEventsDisabled() is true
2. m_currentEntryIndex is null

Earlier on in Navigation::initializeForNewWindow(), there is a check for
hasEntriesAndEventsDisabled(). So it&apos;s likely that m_currentEntryIndex is null.

m_currentEntryIndex is obtained right before the crashing line. We can see from
this line that it being null means the currentItem is not in m_entries. This else
clause is reachable only if the navigationType is Replace, Reload, or null.

1. If the navigation type is Replace, the currentItem would have been put into
   m_entries in the if clause right before m_currentEntryIndex is obtained.
   So we are likely not in this scenario.
2. If the navigation type is Reload, we expect that the currentItem is already
   in m_entries. In theory it&apos;s possible that in some code path, a new item is
   made for Reload, and so currentItem wouldn&apos;t be in m_entries.
   (It&apos;s not clear why a new item would be made).
3. If the navigation type is null, currentItem would not be in m_entries.
   (It&apos;s not clear why the navigation type would be null).

Situation 2 and more likely 3 are both possible. However, it is not clear how we
would end up in either scenario. So we make a speculative fix:

If the currentItem is not in m_entries (m_currentEntryIndex is null), don&apos;t
create NavigationAction and return, rather fall back to the regular code path
below where the item is added to m_entries and setActivation() is called.

We don&apos;t need the ASSERT to check the navigationType since dereferencing an
optional already has such an assert. Also, we make a small drive-by fix to use the
protected documentLoader.

No new tests since this is a stability tracer crash and we have no reproduction
case and no clear idea on how we end up in this crash scenario as explained above.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didBeginDocument):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):

Canonical link: <a href="https://commits.webkit.org/302279@main">https://commits.webkit.org/302279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed2b42a3770eeab23d4f84606601829e22470d76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79991 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97872 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65787 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c320205-c15c-48eb-aaf0-7b6b50096e74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115193 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78488 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bd72f876-51d7-4e5d-904a-d27ee6402928) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33301 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79244 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138411 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106408 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/715 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106225 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/563 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30063 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53006 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20082 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/727 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63945 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/602 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/662 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->