### PR TITLE
Event timing: implement targetSelector

### DIFF
--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -66,6 +66,7 @@
 #include "DocumentWindow.h"
 #include "Editor.h"
 #include "Element.h"
+#include "ElementInlines.h"
 #include "EventCounts.h"
 #include "EventHandler.h"
 #include "EventListener.h"
@@ -2518,27 +2519,34 @@ EventTimingInteractionID LocalDOMWindow::computeInteractionID(Event& event, Even
         if (keyboardEvent->isComposing())
             return { };
 
-        auto it = m_pendingKeyDowns.find(keyboardEvent->keyCode());
-        if (it == m_pendingKeyDowns.end())
+        auto index = m_pendingKeys.find(keyboardEvent->keyCode());
+        if (index == WTF::notFound)
             return { };
 
-        auto interactionID = it->value.keyDown.interactionID.isUnassigned() ? generateInteractionID() : it->value.keyDown.interactionID;
-        it->value.keyDown.interactionID = interactionID;
-        m_performanceEventTimingCandidates.append(it->value.keyDown);
-        if (it->value.keyPress) {
-            it->value.keyPress->interactionID = interactionID;
-            m_performanceEventTimingCandidates.append(*it->value.keyPress);
+        auto& keyPressData = m_pendingKeyDowns[index];
+        auto interactionID = keyPressData.keyDown.interactionID.isUnassigned() ? generateInteractionID() : keyPressData.keyDown.interactionID;
+        keyPressData.keyDown.interactionID = interactionID;
+        m_performanceEventTimingCandidates.append(keyPressData.keyDown);
+        if (keyPressData.keyPress) {
+            keyPressData.keyPress->interactionID = interactionID;
+            m_performanceEventTimingCandidates.append(*keyPressData.keyPress);
         }
-        m_pendingKeyDowns.remove(it);
+        m_pendingKeys[index] = m_pendingKeys.last();
+        m_pendingKeyDowns[index] = m_pendingKeyDowns.last();
+        m_pendingKeys.removeLast();
+        m_pendingKeyDowns.removeLast();
+
         keyboardEvent->setInteractionID(interactionID);
         return interactionID;
     }
     case EventType::compositionstart: {
         for (auto& pendingEntry : m_pendingKeyDowns) {
-            m_performanceEventTimingCandidates.append(pendingEntry.value.keyDown);
-            if (pendingEntry.value.keyPress)
-                m_performanceEventTimingCandidates.append(*pendingEntry.value.keyPress);
+            m_performanceEventTimingCandidates.append(pendingEntry.keyDown);
+            if (pendingEntry.keyPress)
+                m_performanceEventTimingCandidates.append(*pendingEntry.keyPress);
         }
+
+        m_pendingKeys.clear();
         m_pendingKeyDowns.clear();
         return { };
     }
@@ -2628,6 +2636,27 @@ EventTimingInteractionID LocalDOMWindow::generateInteractionIDWithoutIncreasingI
     return ensureUserInteractionValue();
 }
 
+String LocalDOMWindow::generateCSSSelector(EventTarget& target)
+{
+    if (!target.isNode())
+        return ""_s;
+
+    auto node = downcast<Node>(&target);
+
+    if (!node->isElementNode())
+        return node->nodeName();
+
+    auto element = downcast<Element>(node);
+    if (element->elementData() && element->elementData()->hasID())
+        return makeString(node->nodeName(), ", #"_s, element->elementData()->idForStyleResolution().string());
+
+    auto& src = element->attributeWithoutSynchronization(HTMLNames::srcAttr);
+    if (!src.isNull())
+        return makeString(node->nodeName(), "[src="_s, src , "]"_s);
+
+    return node->nodeName();
+}
+
 PerformanceEventTimingCandidate LocalDOMWindow::initializeEventTimingEntry(Event& event, EventType type)
 {
     auto startTime = performance().relativeTimeFromTimeOriginInReducedResolutionSeconds(event.timeStamp());
@@ -2644,6 +2673,7 @@ PerformanceEventTimingCandidate LocalDOMWindow::initializeEventTimingEntry(Event
         .processingEnd = { },
         .duration = { },
         .target = { },
+        .targetSelector = { },
         .interactionID = computeInteractionID(event, type)
     };
 }
@@ -2653,6 +2683,8 @@ void LocalDOMWindow::finalizeEventTimingEntry(PerformanceEventTimingCandidate& e
     auto processingEnd = performance().nowInReducedResolutionSeconds();
     entry.processingEnd = processingEnd;
     entry.target = event.target();
+    if (entry.target)
+        entry.targetSelector = generateCSSSelector(*entry.target);
 
     switch (type) {
     case EventType::pointerdown: {
@@ -2683,18 +2715,22 @@ void LocalDOMWindow::finalizeEventTimingEntry(PerformanceEventTimingCandidate& e
             m_performanceEventTimingCandidates.append(entry);
             return;
         }
-        auto it = m_pendingKeyDowns.find(keyCode);
-        if (it != m_pendingKeyDowns.end()) {
-            it->value.keyDown.interactionID = generateInteractionIDWithoutIncreasingInteractionCount();
-            m_performanceEventTimingCandidates.append(it->value.keyDown);
-            if (it->value.keyPress) {
-                it->value.keyPress->interactionID = it->value.keyDown.interactionID;
-                m_performanceEventTimingCandidates.append(*it->value.keyPress);
+
+        auto index = m_pendingKeys.find(keyCode);
+        if (index != WTF::notFound) {
+            auto& pendingKeyDownState = m_pendingKeyDowns[index];
+            pendingKeyDownState.keyDown.interactionID = generateInteractionIDWithoutIncreasingInteractionCount();
+            m_performanceEventTimingCandidates.append(WTFMove(pendingKeyDownState.keyDown));
+            if (pendingKeyDownState.keyPress) {
+                pendingKeyDownState.keyPress->interactionID = pendingKeyDownState.keyDown.interactionID;
+                m_performanceEventTimingCandidates.append(WTFMove(*pendingKeyDownState.keyPress));
             }
-            it->value = { .keyDown = entry };
+            pendingKeyDownState = { .keyDown = entry };
             return;
         }
-        m_pendingKeyDowns.set(keyCode, PendingKeyDownState { .keyDown = entry });
+
+        m_pendingKeys.append(keyCode);
+        m_pendingKeyDowns.append({ .keyDown = entry });
         return;
     }
     case EventType::keypress: {
@@ -2704,12 +2740,12 @@ void LocalDOMWindow::finalizeEventTimingEntry(PerformanceEventTimingCandidate& e
             return;
         }
         auto keyCode = keyboardEvent->keyCodeForKeyDown();
-        auto it = m_pendingKeyDowns.find(keyCode);
-        if (it == m_pendingKeyDowns.end()) {
+        auto index = m_pendingKeys.find(keyCode);
+        if (index != WTF::notFound) {
             m_performanceEventTimingCandidates.append(entry);
             return;
         }
-        it->value.keyPress = entry;
+        m_pendingKeyDowns[index].keyPress = entry;
         return;
     }
     default:
@@ -2724,11 +2760,11 @@ void LocalDOMWindow::dispatchPendingEventTimingEntries()
         m_pendingPointerDown->duration = std::max(renderingTime - m_pendingPointerDown->startTime, Seconds::fromMilliseconds(1));
 
     for (auto& keydownEntry : m_pendingKeyDowns) {
-        if (!keydownEntry.value.keyDown.duration)
-            keydownEntry.value.keyDown.duration = std::max(renderingTime - keydownEntry.value.keyDown.startTime, Seconds::fromMilliseconds(1));
+        if (!keydownEntry.keyDown.duration)
+            keydownEntry.keyDown.duration = std::max(renderingTime - keydownEntry.keyDown.startTime, Seconds::fromMilliseconds(1));
 
-        if (keydownEntry.value.keyPress && !keydownEntry.value.keyPress->duration)
-            keydownEntry.value.keyPress->duration = std::max(renderingTime - keydownEntry.value.keyPress->startTime, Seconds::fromMilliseconds(1));
+        if (keydownEntry.keyPress && !keydownEntry.keyPress->duration)
+            keydownEntry.keyPress->duration = std::max(renderingTime - keydownEntry.keyPress->startTime, Seconds::fromMilliseconds(1));
     }
 
     if (m_performanceEventTimingCandidates.isEmpty())

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -286,6 +286,7 @@ public:
     PerformanceEventTimingCandidate initializeEventTimingEntry(Event&, EventType);
     void finalizeEventTimingEntry(PerformanceEventTimingCandidate&, const Event&, EventType);
     void dispatchPendingEventTimingEntries();
+    String generateCSSSelector(EventTarget&);
     uint64_t interactionCount() { return m_interactionCount; }
     // Misleading function names that mirror the spec; see https://github.com/w3c/event-timing/issues/158 :
     bool hasDispatchedInputEvent() const { return m_hasDispatchedInputEvent; }
@@ -464,7 +465,9 @@ private:
         PerformanceEventTimingCandidate keyDown;
         std::optional<PerformanceEventTimingCandidate> keyPress { std::nullopt };
     };
-    HashMap<int64_t, PendingKeyDownState, IntHash<int64_t>, WTF::SignedWithZeroKeyHashTraits<int64_t>> m_pendingKeyDowns;
+
+    Vector<int64_t, 8> m_pendingKeys;
+    Vector<PendingKeyDownState> m_pendingKeyDowns;
 
     EventTimingInteractionID m_userInteractionValue;
     uint64_t m_interactionCount { 0 };

--- a/Source/WebCore/page/PerformanceEventTiming.cpp
+++ b/Source/WebCore/page/PerformanceEventTiming.cpp
@@ -48,6 +48,7 @@ PerformanceEventTiming::PerformanceEventTiming(const PerformanceEventTimingCandi
     , m_processingEnd(candidate.processingEnd)
     , m_interactionID(candidate.interactionID)
     , m_target(candidate.target)
+    , m_targetSelector(candidate.targetSelector)
 { }
 
 PerformanceEventTiming::~PerformanceEventTiming() = default;

--- a/Source/WebCore/page/PerformanceEventTiming.h
+++ b/Source/WebCore/page/PerformanceEventTiming.h
@@ -46,6 +46,7 @@ public:
     DOMHighResTimeStamp processingEnd() const { return m_processingEnd.milliseconds(); }
     bool cancelable() const { return m_cancelable; }
     Node* target() const;
+    String targetSelector() const { return m_targetSelector; }
     uint64_t interactionId() const;
 
     Type performanceEntryType() const final;
@@ -65,6 +66,7 @@ private:
     Seconds m_processingEnd;
     EventTimingInteractionID m_interactionID;
     WeakPtr<EventTarget, EventTarget::WeakPtrImplType> m_target;
+    String m_targetSelector;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/PerformanceEventTiming.idl
+++ b/Source/WebCore/page/PerformanceEventTiming.idl
@@ -35,6 +35,7 @@ typedef double DOMHighResTimeStamp;
     readonly attribute DOMHighResTimeStamp processingEnd;
     readonly attribute boolean cancelable;
     readonly attribute Node? target;
+    readonly attribute DOMString targetSelector;
     readonly attribute unsigned long long interactionId;
     [Default] object toJSON();
 };

--- a/Source/WebCore/page/PerformanceEventTimingCandidate.h
+++ b/Source/WebCore/page/PerformanceEventTimingCandidate.h
@@ -28,6 +28,7 @@
 #include <WebCore/EventTarget.h>
 #include <WebCore/EventTimingInteractionID.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -41,6 +42,7 @@ struct PerformanceEventTimingCandidate {
     Seconds processingEnd;
     Seconds duration;
     WeakPtr<EventTarget, EventTarget::WeakPtrImplType> target;
+    String targetSelector;
     EventTimingInteractionID interactionID;
 };
 


### PR DESCRIPTION
#### 947e2e97f321760a8a2cbbc01c08d3e1c4f64ec4
<pre>
Event timing: implement targetSelector
<a href="https://bugs.webkit.org/show_bug.cgi?id=301597">https://bugs.webkit.org/show_bug.cgi?id=301597</a>
<a href="https://rdar.apple.com/163598158">rdar://163598158</a>

Reviewed by NOBODY (OOPS!).

Implements the feature as described by the current spec draft: a string
that is similar to a CSS selector is stored inside the Event Timing
entry generated when finalizeEventTimingEntry() is called.

Adding one extra data member to PerformanceEventTimingCandidate made
it too large for a HashMap, so it was necessary to change how
m_pendingKeyDowns is stored: we now have two separate Vector, one
for keys (m_pendingKeys) and one for values (m_pendingKeyDowns). This
causes lookup to be O(n), but the map is so small that this isn&apos;t a
problem - the map contains currently pressed keyboard keys.

No new tests (OOPS!).

* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::computeInteractionID):
(WebCore::LocalDOMWindow::generateCSSSelector):
(WebCore::LocalDOMWindow::initializeEventTimingEntry):
(WebCore::LocalDOMWindow::finalizeEventTimingEntry):
(WebCore::LocalDOMWindow::dispatchPendingEventTimingEntries):
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/PerformanceEventTiming.cpp:
(WebCore::PerformanceEventTiming::PerformanceEventTiming):
* Source/WebCore/page/PerformanceEventTiming.h:
* Source/WebCore/page/PerformanceEventTiming.idl:
* Source/WebCore/page/PerformanceEventTimingCandidate.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/947e2e97f321760a8a2cbbc01c08d3e1c4f64ec4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135944 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79978 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/694 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97864 "Found 1 new test failure: imported/w3c/web-platform-tests/event-timing/interactionid-keypress.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65779 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/501 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33292 "Found 1 new test failure: editing/mac/input/hangul-enter-confirms-and-sends-keypress.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79228 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108932 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33774 "Found 1 new test failure: imported/w3c/web-platform-tests/event-timing/interactionid-keypress.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138394 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/654 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/622 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/backdrop-filter-animated.html imported/w3c/web-platform-tests/event-timing/interactionid-keypress.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106399 "Found 1 new test failure: imported/w3c/web-platform-tests/event-timing/interactionid-keypress.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106216 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/548 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30055 "Found 1 new test failure: imported/w3c/web-platform-tests/event-timing/interactionid-keypress.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52992 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/711 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63924 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/589 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/649 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->