### PR TITLE
[32-bit jsvalues] Allocate all cells out of 32-bit heap on 64-bit.

### DIFF
--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -120,7 +120,7 @@ void* CompleteSubspace::tryAllocateSlow(VM& vm, size_t size, GCDeferralContext* 
 
     if (Allocator allocator = allocatorForNonInline(size, AllocatorForMode::EnsureAllocator))
         return allocator.allocate(vm.heap, allocator.cellSize(), deferralContext, AllocationFailureMode::ReturnNull);
-    
+
     if (size <= Options::preciseAllocationCutoff()
         && size <= MarkedSpace::largeCutoff) {
         dataLog("FATAL: attampting to allocate small object using large allocation.\n");
@@ -210,4 +210,3 @@ void CompleteSubspace::prepareAllAllocators()
 }
 
 } // namespace JSC
-

--- a/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp
@@ -41,6 +41,8 @@ FastMallocAlignedMemoryAllocator::~FastMallocAlignedMemoryAllocator() = default;
 
 void* FastMallocAlignedMemoryAllocator::tryAllocateAlignedMemory(size_t alignment, size_t size)
 {
+    if constexpr (useCompressedHeap && is64Bit())
+        return Gigacage::tryAlignedMalloc(Gigacage::Primitive, alignment, size);
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
     return m_heap.memalign(alignment, size, true);
 #else
@@ -51,6 +53,8 @@ void* FastMallocAlignedMemoryAllocator::tryAllocateAlignedMemory(size_t alignmen
 
 void FastMallocAlignedMemoryAllocator::freeAlignedMemory(void* basePtr)
 {
+    if constexpr (useCompressedHeap && is64Bit())
+        return Gigacage::alignedFree(Gigacage::Primitive, basePtr);
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
     return m_heap.free(basePtr);
 #else
@@ -66,6 +70,8 @@ void FastMallocAlignedMemoryAllocator::dump(PrintStream& out) const
 
 void* FastMallocAlignedMemoryAllocator::tryAllocateMemory(size_t size)
 {
+    if constexpr (useCompressedHeap && is64Bit())
+        return Gigacage::tryMalloc(Gigacage::Primitive, size);
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
     return m_heap.malloc(size);
 #else
@@ -75,6 +81,8 @@ void* FastMallocAlignedMemoryAllocator::tryAllocateMemory(size_t size)
 
 void FastMallocAlignedMemoryAllocator::freeMemory(void* pointer)
 {
+    if constexpr (useCompressedHeap && is64Bit())
+        return Gigacage::free(Gigacage::Primitive, pointer);
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
     return m_heap.free(pointer);
 #else
@@ -84,6 +92,8 @@ void FastMallocAlignedMemoryAllocator::freeMemory(void* pointer)
 
 void* FastMallocAlignedMemoryAllocator::tryReallocateMemory(void* pointer, size_t size)
 {
+    if constexpr (useCompressedHeap && is64Bit())
+        return Gigacage::tryRealloc(Gigacage::Primitive, pointer, size);
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
     return m_heap.realloc(pointer, size);
 #else
@@ -92,4 +102,3 @@ void* FastMallocAlignedMemoryAllocator::tryReallocateMemory(void* pointer, size_
 }
 
 } // namespace JSC
-

--- a/Source/JavaScriptCore/heap/HeapCell.h
+++ b/Source/JavaScriptCore/heap/HeapCell.h
@@ -25,8 +25,10 @@
 
 #pragma once
 
+#include <JavaScriptCore/CPU.h>
 #include <JavaScriptCore/DestructionMode.h>
 #include <JavaScriptCore/EnsureStillAliveHere.h>
+#include <wtf/Gigacage.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -48,7 +50,10 @@ public:
         Auxiliary
     };
     
-    HeapCell() { }
+    HeapCell() {
+        if constexpr (useCompressedHeap && is64Bit())
+            RELEASE_ASSERT(Gigacage::contains(this));
+    }
     
     // We're intentionally only zapping the bits for the structureID and leaving
     // the rest of the cell header bits intact for crash analysis uses.

--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -82,7 +82,7 @@ void* StructureAlignedMemoryAllocator::tryReallocateMemory(void*, size_t)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-#if CPU(ADDRESS64) && !ENABLE(STRUCTURE_ID_WITH_SHIFT)
+#if CPU(ADDRESS64) && !ENABLE(STRUCTURE_ID_WITH_SHIFT) && !USE(COMPRESSED_HEAP)
 #if !USE(SYSTEM_MALLOC)
 
 static const bmalloc_type structureHeapType { BMALLOC_TYPE_INITIALIZER(MarkedBlock::blockSize, MarkedBlock::blockSize, "Structure Heap") };
@@ -98,6 +98,7 @@ public:
         uintptr_t mappedHeapSize = structureHeapAddressSize;
         for (unsigned i = 0; i < 8; ++i) {
             g_jscConfig.startOfStructureHeap = reinterpret_cast<uintptr_t>(OSAllocator::tryReserveUncommittedAligned(mappedHeapSize, structureHeapAddressSize, OSAllocator::FastMallocPages));
+
             if (g_jscConfig.startOfStructureHeap)
                 break;
             mappedHeapSize /= 2;
@@ -231,19 +232,28 @@ void StructureAlignedMemoryAllocator::initializeStructureAddressSpace()
 
 void StructureAlignedMemoryAllocator::initializeStructureAddressSpace()
 {
-    g_jscConfig.startOfStructureHeap = 0;
-    g_jscConfig.sizeOfStructureHeap = UINTPTR_MAX;
+    if constexpr (useCompressedHeap && is64Bit()) {
+        g_jscConfig.startOfStructureHeap = std::bit_cast<uintptr_t>(Gigacage::basePtr(Gigacage::Primitive));
+        g_jscConfig.sizeOfStructureHeap = Gigacage::size(Gigacage::Primitive);
+    }else {
+        g_jscConfig.startOfStructureHeap = 0;
+        g_jscConfig.sizeOfStructureHeap = UINTPTR_MAX;
+    }
 }
 
 void* StructureAlignedMemoryAllocator::tryAllocateAlignedMemory(size_t alignment, size_t size)
 {
     ASSERT_UNUSED(alignment, alignment == MarkedBlock::blockSize);
     ASSERT_UNUSED(size, size == MarkedBlock::blockSize);
+    if constexpr (useCompressedHeap && is64Bit())
+        return Gigacage::tryAlignedMalloc(Gigacage::Primitive, MarkedBlock::blockSize, MarkedBlock::blockSize);
     return tryFastCompactAlignedMalloc(MarkedBlock::blockSize, MarkedBlock::blockSize);
 }
 
 void StructureAlignedMemoryAllocator::freeAlignedMemory(void* block)
 {
+    if constexpr (useCompressedHeap && is64Bit())
+        return Gigacage::alignedFree(Gigacage::Primitive, block);
     fastAlignedFree(block);
 }
 

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -42,6 +42,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/JSStringInlines.h>
 #include <JavaScriptCore/MathCommon.h>
+#include <JavaScriptCore/Scribble.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringImpl.h>
 
@@ -444,11 +445,15 @@ inline JSValue::JSValue(HashTableDeletedValueTag)
 inline JSValue::JSValue(JSCell* ptr)
 {
     u.asInt64 = reinterpret_cast<uintptr_t>(ptr);
+    if constexpr (useCompressedHeap && is64Bit())
+        RELEASE_ASSERT(!u.ptr || u.asInt64 == SCRIBBLE_WORD ||u.ptr == JSCell::seenMultipleCalleeObjects() || Gigacage::contains(u.ptr));
 }
 
 inline JSValue::JSValue(const JSCell* ptr)
 {
     u.asInt64 = reinterpret_cast<uintptr_t>(const_cast<JSCell*>(ptr));
+    if constexpr (useCompressedHeap && is64Bit())
+        RELEASE_ASSERT(!u.ptr || u.asInt64 == SCRIBBLE_WORD ||u.ptr == JSCell::seenMultipleCalleeObjects() || Gigacage::contains(u.ptr));
 }
 
 inline JSValue::operator bool() const
@@ -578,6 +583,8 @@ inline bool JSValue::isNumber() const
 ALWAYS_INLINE JSCell* JSValue::asCell() const
 {
     ASSERT(isCell());
+    if constexpr (useCompressedHeap && is64Bit())
+        RELEASE_ASSERT(!u.ptr || u.asInt64 == SCRIBBLE_WORD ||u.ptr == JSCell::seenMultipleCalleeObjects() || Gigacage::contains(u.ptr));
     return u.ptr;
 }
 

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -1514,8 +1514,6 @@ bool canUseHandlerIC()
 
 bool canUseWasm()
 {
-    if constexpr (useCompressedHeap)
-        return false;
 #if ENABLE(WEBASSEMBLY) && !PLATFORM(WATCHOS)
     return true;
 #else

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -174,7 +174,7 @@ private:
     static unsigned computeNumberOfGCMarkers(unsigned maxNumberOfGCMarkers);
     static unsigned computeNumberOfWorkerThreads(int maxNumberOfWorkerThreads, int minimum = 1);
     static int32_t computePriorityDeltaOfWorkerThreads(int32_t twoCorePriorityDelta, int32_t multiCorePriorityDelta);
-    static constexpr bool jitEnabledByDefault() { return !useCompressedHeap && (is32Bit() || isAddress64Bit()); }
+    static constexpr bool jitEnabledByDefault() { return (is32Bit() || isAddress64Bit()); }
     static constexpr bool ipintEnabledByDefault() { return isARM64() || isARM64E() || isX86_64(); }
 };
 

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -239,12 +239,16 @@ protected:
             }
         }
         previous->fireStructureTransitionWatchpoint(deferred);
+        if constexpr (useCompressedHeap)
+            id(); // Run assertions that this was allocated correctly.
     }
 
     void finishCreation(VM& vm)
     {
         Base::finishCreation(vm);
         ASSERT(m_prototype.get().isEmpty() || isValidPrototype(m_prototype.get()));
+        if constexpr (useCompressedHeap)
+            id(); // Run assertions that this was allocated correctly.
     }
 
 private:

--- a/Source/JavaScriptCore/tools/Integrity.cpp
+++ b/Source/JavaScriptCore/tools/Integrity.cpp
@@ -252,11 +252,14 @@ bool Analyzer::analyzeCell(VM& vm, JSCell* cell, Analyzer::Action action)
         AUDIT_VERIFY(cellIsProperlyAligned,
             "cell %p cell.type %d allocator.cellSize %zu", cell, cell->type(), allocatorCellSize);
     }
-
+    
     JSType cellType = cell->type();
-    if (cell->type() != JSCellButterflyType)
-        AUDIT_VERIFY(!Gigacage::contains(cell), "cell %p cell.type %d", cell, cellType);
 
+    if constexpr (useCompressedHeap && is64Bit())
+        AUDIT_VERIFY(Gigacage::contains(cell), "cell %p cell.type %d", cell, cellType);
+    else
+        AUDIT_VERIFY(cell->type() == JSCellButterflyType || !Gigacage::contains(cell), "cell %p cell.type %d", cell, cellType);
+    
     WeakSet& weakSet = cell->cellContainer().weakSet();
     AUDIT_VERIFY(!weakSet.m_allocator || isSanePointer(weakSet.m_allocator),
         "cell %p cell.type %d weakSet.allocator %p", cell, cell->type(), weakSet.m_allocator);

--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -438,7 +438,7 @@
 
 #if !defined(USE_COMPRESSED_HEAP)
 /* Change run-jsc-stress-tests too. */
-#define USE_COMPRESSED_HEAP 0
+#define USE_COMPRESSED_HEAP 1
 #endif
 
 #if defined(__cplusplus)

--- a/Source/bmalloc/bmalloc/Gigacage.h
+++ b/Source/bmalloc/bmalloc/Gigacage.h
@@ -47,6 +47,8 @@
 #define GIGACAGE_ENABLED 0
 #endif
 
+#define BUSE_COMPRESSED_HEAP 1
+
 
 namespace Gigacage {
 
@@ -62,7 +64,7 @@ BINLINE const char* name(Kind kind)
     return nullptr;
 }
 
-constexpr bool hasCapacityToUseLargeGigacage = BOS_EFFECTIVE_ADDRESS_WIDTH > 36;
+constexpr bool hasCapacityToUseLargeGigacage = BOS_EFFECTIVE_ADDRESS_WIDTH > 36 && !BUSE_COMPRESSED_HEAP;
 
 #if GIGACAGE_ENABLED
 
@@ -73,7 +75,7 @@ constexpr size_t maximumCageSizeReductionForSlide = hasCapacityToUseLargeGigacag
 // In Linux, if `vm.overcommit_memory = 2` is specified, mmap with large size can fail if it exceeds the size of RAM.
 // So we specify GIGACAGE_ALLOCATION_CAN_FAIL = 1.
 #if BOS(LINUX)
-#define GIGACAGE_ALLOCATION_CAN_FAIL 1
+#define GIGACAGE_ALLOCATION_CAN_FAIL !BUSE_COMPRESSED_HEAP
 #else
 #define GIGACAGE_ALLOCATION_CAN_FAIL 0
 #endif


### PR DESCRIPTION
#### 99b2f624ca1d11a89724fb796c684125257cc288
<pre>
[32-bit jsvalues] Allocate all cells out of 32-bit heap on 64-bit.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301601">https://bugs.webkit.org/show_bug.cgi?id=301601</a>

Reviewed by OOPS.

This is the next step to making a 32-bit JSValue mode for 64-bit.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba4e3739b084c4434e7eafc5ab3a64481fa1293e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129489 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136878 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80912 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131360 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98640 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66506 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132436 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1307 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/announcement-notification.html accessibility/area-element-bounding-box.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-controlled-table-row-visibility.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115984 "Found 123 new API test failures: TestWebKitAPI.WebKitLegacy.CloseNewWindowInNavigationPolicyDelegate, TestWebKitAPI.WebKitLegacy.MenuAndButtonForNormalLeftClick, TestWebKitAPI.JavaScriptCore_PropertySlot.VMInquiryReset, TestWebKitAPI.WebKitLegacy.RenderedImageFromDOMRange, TestWebKitAPI.WebKitLegacy.DOMNodeFromJSObject, TestWebKitAPI.WebKitLegacy.MenuAndButtonForCommandMiddleClick, TestWebKitAPI.WebKitLegacy.MenuAndButtonForNormalRightClick, TestWebKitAPI.WebKitLegacy.MenuAndButtonForShiftLeftClick, TestWebKitAPI.WebKitLegacy.AddArrayOfNullImageTypes, TestWebKitAPI.WebKitLegacy.HTMLTableCellElementCellAbove ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79287 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1228 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34115 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/display-contents/aria-grid.html accessibility/display-contents/aria-hidden.html accessibility/display-contents/element-roles.html accessibility/mac/abbr-acronym-tags.html accessibility/mac/accesskey.html accessibility/mac/active-descendant-after-visibility-change.html accessibility/mac/attributed-string/attributed-string-does-not-includes-misspelled-for-non-editable.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80154 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121481 "Found 42 new JSC stress test failures: microbenchmarks/exceptions-simd.js.ftl-no-cjit-validate-sampling-profiler, stress/bigdecimal-identifiers-fail-on-oom.js.bytecode-cache, stress/bigdecimal-identifiers-fail-on-oom.js.default, stress/bigdecimal-identifiers-fail-on-oom.js.ftl-no-cjit-validate-sampling-profiler, stress/bigdecimal-identifiers-fail-on-oom.js.lockdown, stress/bigdecimal-identifiers-fail-on-oom.js.mini-mode, stress/bigdecimal-identifiers-fail-on-oom.js.no-cjit-validate-phases, stress/bigdecimal-identifiers-fail-on-oom.js.no-ftl, stress/bigdecimal-identifiers-fail-on-oom.js.no-llint, stress/disable-gigacage-arrays.js.default ... (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109697 "17 api tests failed or timed out") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34613 "Found 60 new test failures: accessibility/mac/accessibility-make-first-responder.html accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html accessibility/smart-invert.html compositing/backing/backing-store-attachment-scroll.html compositing/backing/backing-store-columns-inside-position-fixed.html compositing/cocoa/clip-fixed-element-to-viewport.html compositing/cocoa/clip-nested-sticky-elements.html compositing/cocoa/clip-sticky-element-to-viewport.html compositing/cocoa/clip-sticky-element-with-overflow-clip-on-root.html compositing/fixed-with-main-thread-scrolling.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139352 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127941 "Found 40 new JSC stress test failures: stress/bigdecimal-identifiers-fail-on-oom.js.bytecode-cache, stress/bigdecimal-identifiers-fail-on-oom.js.default, stress/bigdecimal-identifiers-fail-on-oom.js.eager-jettison-no-cjit, stress/bigdecimal-identifiers-fail-on-oom.js.ftl-no-cjit-no-put-stack-validate, stress/bigdecimal-identifiers-fail-on-oom.js.ftl-no-cjit-small-pool, stress/disable-gigacage-arrays.js.default, stress/disable-gigacage-strings.js.default, stress/disable-gigacage-typed-arrays.js.default, stress/exhaust-gigacage-and-allocate-vm.js.default, stress/get-own-property-descriptors-oom.js.default ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1536 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1474 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html accessibility/custom-elements/autocomplete.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107162 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107003 "Passed tests") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1252 "Found unexpected failure with change (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30843 "Found 60 new test failures: accessibility/mac/accessibility-make-first-responder.html accessibility/smart-invert.html compositing/backing/backing-store-attachment-scroll.html compositing/backing/backing-store-columns-inside-position-fixed.html compositing/cocoa/clip-fixed-element-to-viewport.html compositing/cocoa/clip-nested-sticky-elements.html compositing/cocoa/clip-sticky-element-to-viewport.html compositing/cocoa/clip-sticky-element-with-overflow-clip-on-root.html compositing/fixed-with-main-thread-scrolling.html compositing/iframes/remove-reinsert-webview-with-iframe.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54226 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1607 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64970 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160955 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1427 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40148 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->