### PR TITLE
Get overview of test failures with Site Isolation enabled

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -121,6 +121,8 @@ overlay-region [ Skip ]
 pdf [ Skip ]
 ipc/mac [ Skip ]
 ipc/restrictedendpoints/mac [ Skip ]
+inspector [ Skip ]
+http/tests/inspector [ Skip ]
 
 # Requires async overflow scrolling
 compositing/shared-backing/overflow-scroll [ Skip ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7459,17 +7459,17 @@ SidewaysWritingModesEnabled:
 
 SiteIsolationEnabled:
   type: bool
-  status: unstable
+  status: internal
   category: security
   humanReadableName: "Site Isolation"
   humanReadableDescription: "Put cross-origin iframes in a different process"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
   sharedPreferenceForWebProcess: true
 
 SiteIsolationSharedProcessEnabled:

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1371,7 +1371,6 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
 
         if (enableAllExperimentalFeatures) {
             WKPreferencesEnableAllExperimentalFeatures(preferences);
-            WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("SiteIsolationEnabled").get());
             WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("VerifyWindowOpenUserGestureFromUIProcess").get());
             WKPreferencesSetExperimentalFeatureForKey(preferences, true, toWK("WebGPUEnabled").get());
             WKPreferencesSetExperimentalFeatureForKey(preferences, true, toWK("ModelElementEnabled").get());


### PR DESCRIPTION
#### 0d8240c4b6f763c401884a69d653fc57a79df9a6
<pre>
Get overview of test failures with Site Isolation enabled
<a href="https://rdar.apple.com/163603711">rdar://163603711</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301604">https://bugs.webkit.org/show_bug.cgi?id=301604</a>

WIP.

* LayoutTests/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetPreferencesToConsistentValues):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d8240c4b6f763c401884a69d653fc57a79df9a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135984 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80006 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/73034722-ae58-4030-a71e-2a0c3e4051b0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/756 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97891 "Failure limit exceed. At least found 255 new test failures: animations/no-cancelation-when-entering-page-cache.html compositing/page-cache-back-crash.html compositing/show-composited-iframe-on-back-button.html fast/canvas/webgl/canvas-webgl-page-cache.html fast/dom/Window/a-rel-noopener.html fast/dom/Window/area-rel-noopener.html fast/dom/crash-with-bad-url.html fast/dom/navigation-type-back-forward.html fast/dom/window-domurl-crash.html fast/dom/window-load-crash.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65804 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/970296e1-fb3c-4722-a12b-a25dcb343623) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131543 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/651 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (failure); Uploaded test results; Compiled WebKit (warnings); layout-tests (cancelled)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115409 "Found 50 new API test failures: TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOriginAllowPopup3, TestWebKitAPI.ResourceLoadStatistics.StorageAccessOnRedirectSitesWithQuirk, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOriginAllowPopup2, TestWebKitAPI.ResourceLoadStatistics.StorageAccessGrantMultipleSubFrameDomains, TestWebKitAPI.ProcessSwap.NavigationWithLockedHistoryWithoutPSON, TestWebKitAPI.ProcessSwap.NavigatingSameOriginFromCOOPSameOrigin2, TestWebKitAPI.ProcessSwap.UseWebProcessCacheForLoadInNewView, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOrigin2, TestWebKitAPI.ProcessSwap.NavigateCrossOriginWithOpenerWithRestrictedOpenerTypeNoOpener ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78507 "Found 9 new API test failures: TestWebKit:WebKit.PendingAPIRequestURL, WPE/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/navigation-policy, WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, WPE/TestWebKitWebContext:/webkit/WebKitSecurityManager/file-xhr, WPE/TestWebKitWebView:/webkit/WebKitWebView/fullscreen, WPE/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/page-id, WPE/TestUIClient:/webkit/WebKitWebView/geolocation-permission-requests, WPE/TestFrame:/webkit/WebKitFrame/subframe, WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/368df7b0-d90b-4c18-be5d-e52b5d1008d4) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/676 "295 new passes 2 flakes 12 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33520 "Too many flaky failures: animations/3d/animate-to-transform-perpective-to-none.html, animations/no-cancelation-when-entering-page-cache.html, animations/resume-after-page-cache.html, compositing/accelerated-layers-after-back.html, compositing/backgrounds/fixed-background-on-descendant.html, compositing/blend-mode/non-separable-blend-modes.html, compositing/filters/drop-shadow-large-blur-radius.html, compositing/iframes/page-cache-layer-tree.html, compositing/page-cache-back-crash.html, compositing/show-composited-iframe-on-back-button.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79268 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120608 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109033 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; 51 api tests failed or timed out; re-run-api-tests (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/34014 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138498 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127055 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/690 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/678 "Too many flaky failures: http/tests/inspector/console/message-from-iframe.html, http/tests/inspector/console/message-from-worker.html, http/tests/inspector/dom/cross-domain-inspected-node-access.html, inspector/canvas/console-record-offscreen-bitmaprenderer.html, inspector/canvas/recording-html-2d.html, inspector/css/getMatchedStylesForNodeLargeSelectors.html, inspector/css/getMatchedStylesForNodeMarkerPseudoId.html, inspector/css/getMatchedStylesForNodeScopeGrouping.html, inspector/css/getMatchedStylesForNodeStartingStyleGrouping.html, inspector/css/node-styles-refreshed.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106476 "127 new passes 1087 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/737 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111744 "layout-tests (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106299 "Found 8 new API test failures: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default, TestWebKit:WebKit.PendingAPIRequestURL, WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/page-id, WebKitGTK/TestFrame:/webkit/WebKitFrame/subframe, WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/navigation-policy, WebKitGTK/TestWebKitWebContext:/webkit/WebKitSecurityManager/file-xhr, WebKitGTK/TestUIClient:/webkit/WebKitWebView/geolocation-permission-requests, WebKitGTK/TestLoaderClient:/webkit/WebKitURIResponse/http-headers (failure)") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/585 "Too many flaky failures: fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode.html, fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode.html, fast/forms/form-control-refresh/autofilled-and-obscured-text-input-dark-mode.html, fast/forms/form-control-refresh/autofilled-and-obscured-text-input-light-mode.html, fast/forms/form-control-refresh/autofilled-text-input-dark-mode.html, fast/forms/form-control-refresh/autofilled-text-input-light-mode.html, fast/forms/form-control-refresh/submit-button-appearance-matches-button-window-inactive.html, http/tests/iframe-monitor/eligibility.html, http/tests/iframe-monitor/iframe-unload.html, http/tests/iframe-monitor/throttler.html (failure)") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/30275 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53037 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/750 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63977 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160073 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/620 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39978 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/679 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/700 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->