### PR TITLE
REGRESSION (299407@main): Google AI page renders incorrectly

### DIFF
--- a/LayoutTests/fast/backgrounds/background-image-style-update-by-custom-property-animation-expected.txt
+++ b/LayoutTests/fast/backgrounds/background-image-style-update-by-custom-property-animation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS 'background-clip' stays set after animation style has been applied
+

--- a/LayoutTests/fast/backgrounds/background-image-style-update-by-custom-property-animation.html
+++ b/LayoutTests/fast/backgrounds/background-image-style-update-by-custom-property-animation.html
@@ -1,0 +1,30 @@
+<!doctype html>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<style>
+@property --angle {
+    syntax: "<angle>";
+    initial-value: 0deg;
+    inherits: false;
+}
+
+#target {
+    background-image: linear-gradient(var(--angle),red,green,blue);
+    background-clip: text;
+}
+</style>
+<div id="target"></div>
+<script>
+  test(function() {
+    let target = document.getElementById("target");
+    assert_equals(getComputedStyle(target)['background-clip'], "text");
+
+    const animation = target.animate({ "--angle": "360deg" }, 100);
+    animation.pause();
+    animation.currentTime = 10;
+
+    assert_equals(getComputedStyle(target)['background-clip'], "text");
+  }, "'background-clip' stays set after animation style has been applied");
+</script>

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -82,6 +82,7 @@ rendering/svg/RenderSVGText.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
 rendering/svg/legacy/SVGResourcesCycleSolver.cpp
 rendering/updating/RenderTreeUpdater.cpp
+style/StyleBuilderCustom.h
 style/StyleCustomProperty.cpp
 style/Styleable.cpp
 style/values/StyleValueTypes.h

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -4077,7 +4077,7 @@ class GenerateStyleBuilderGenerated:
                 return "&fromCSSValueDeducingType"
 
         if property.codegen_properties.fill_layer_primary:
-            to.write(f"applyValuePrimaryFillLayerProperty<&RenderStyle::{property.method_name_for_set_layers}, {converter(property)}, {property.type_name_for_layers}>(builderState, value);")
+            to.write(f"applyValuePrimaryFillLayerProperty<&RenderStyle::{property.method_name_for_ensure_layers}, &RenderStyle::{property.method_name_for_set_layers},  &{property.type_name_for_layers}::Layer::{property.codegen_properties.fill_layer_setter}, &{property.type_name_for_layers}::Layer::{property.codegen_properties.fill_layer_getter}, &{property.type_name_for_layers}::Layer::{property.codegen_properties.fill_layer_initial}, {converter(property)}, {property.type_name_for_layers}>(builderState, value);")
         else:
             to.write(f"applyValueSecondaryFillLayerProperty<&RenderStyle::{property.method_name_for_ensure_layers}, &{property.type_name_for_layers}::Layer::{property.codegen_properties.fill_layer_setter}, &{property.type_name_for_layers}::Layer::{property.codegen_properties.fill_layer_getter}, &{property.type_name_for_layers}::Layer::{property.codegen_properties.fill_layer_initial}, {converter(property)}>(builderState, value);")
 

--- a/Source/WebCore/style/values/backgrounds/StyleFillLayers.h
+++ b/Source/WebCore/style/values/backgrounds/StyleFillLayers.h
@@ -93,6 +93,8 @@ template<typename T> struct FillLayers {
         return *this;
     }
 
+    bool isNone() const { return isEmpty() || (size() == 1 && first().image().isNone()); }
+
     void computeClipMax() const;
 
     bool imagesAreLoaded(const RenderElement*) const;


### PR DESCRIPTION
#### 9b938cd84e6c5f652b5af964839d613b879cf553
<pre>
REGRESSION (299407@main): Google AI page renders incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=301429">https://bugs.webkit.org/show_bug.cgi?id=301429</a>

Reviewed by Antti Koivisto.

Bandaid fix to allow custom property animations that update background-image
or mask-image to work by updating the FillLayers list rather than replacing
it. A better long term fix is to use CoordinatedValueList, like `animation`
and `transition`. That is tracked in <a href="https://webkit.org/b/301581.">https://webkit.org/b/301581.</a>

Test: fast/backgrounds/background-image-style-update-by-custom-property-animation.html
* LayoutTests/fast/backgrounds/background-image-style-update-by-custom-property-animation-expected.txt: Added.
* LayoutTests/fast/backgrounds/background-image-style-update-by-custom-property-animation.html: Added.
* Source/WebCore/css/scripts/process-css-properties.py:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/values/backgrounds/StyleFillLayers.h:

Canonical link: <a href="https://commits.webkit.org/302305@main">https://commits.webkit.org/302305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f296f40a4064b035eebdab2427315103ef81545

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80066 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97947 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65865 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78565 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/588 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33385 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79334 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138508 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106483 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106306 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27074 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/635 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30144 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53136 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/818 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64069 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/737 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->