### PR TITLE
RELEASE_ASSERT in toJSNewlyCreated() to SVGPathElement

### DIFF
--- a/LayoutTests/fast/svg/SVGPathElement-toJS-crash-expected.txt
+++ b/LayoutTests/fast/svg/SVGPathElement-toJS-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash.
+
+

--- a/LayoutTests/fast/svg/SVGPathElement-toJS-crash.html
+++ b/LayoutTests/fast/svg/SVGPathElement-toJS-crash.html
@@ -1,0 +1,11 @@
+<script>
+testRunner?.dumpAsText();
+function main() {
+    var v75 = x51.targetElement;
+}
+</script>
+<body onload="main()">
+<p>This test passes if it doesn't crash.</p>
+<svg id="x11" xmlns="http://www.w3.org/2000/svg" color-rendering="optimizeSpeed" baseProfile="basic" filter="opacity(1) invert(0.67)" mask="radial-gradient(circle at right 100% bottom 0.18em,rgb(165,68,80)) stroke-box subtract luminance" onzoom="f1()" overflow="hidden" onabort="f2()" height="23%" color-interpolation="linearRGB">
+<path id="x26" stroke-dasharray="0px" onclick="f0()" pathLength="1" stroke-dashoffset="15em" class="class0" image-rendering="optimizeQuality" tabindex="-1" onactivate="f3()" clip-rule="inherit" fill-opacity="100%">
+<set id="x51" attributeName="mask" repeatDur="indefinite" max="0ms" repeatCount="indefinite" fill="freeze" dur="2s" restart="whenNotActive" onbegin="f4()">

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -4180,7 +4180,6 @@ sub GetGnuVTableOffsetForType
         || $typename eq "SVGGElement"
         || $typename eq "SVGImageElement"
         || $typename eq "SVGLineElement"
-        || $typename eq "SVGPathElement"
         || $typename eq "SVGPolyElement"
         || $typename eq "SVGPolygonElement"
         || $typename eq "SVGPolylineElement"


### PR DESCRIPTION
#### bc93fb064a1ac98ade6e69f44b5342599b8c68da
<pre>
RELEASE_ASSERT in toJSNewlyCreated() to SVGPathElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=301605">https://bugs.webkit.org/show_bug.cgi?id=301605</a>
<a href="https://rdar.apple.com/163020232">rdar://163020232</a>

Reviewed by Darin Adler.

The vtable validation generated in toJSNewlyCreated() was using an offset
that doesn&apos;t match our actual implementation. Fix the offset used in the
bindings generator to address the assertion failure.

Test: fast/svg/SVGPathElement-toJS-crash.html

* LayoutTests/fast/svg/SVGPathElement-toJS-crash-expected.txt: Added.
* LayoutTests/fast/svg/SVGPathElement-toJS-crash.html: Added.
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GetGnuVTableOffsetForType):

Canonical link: <a href="https://commits.webkit.org/302286@main">https://commits.webkit.org/302286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d2e51b84ad630ce5aab3c976d475af07b6c6587

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79994 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b72b5f4d-cb6c-47c5-b341-922587488d38) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97876 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65790 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/34f1f45e-1c8a-477f-8306-ab9df2bac186) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78492 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d24204c1-a017-431b-9dea-629f304149b4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33305 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79250 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138416 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/641 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106412 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111537 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106229 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/dom-cache (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27065 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/568 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30067 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53011 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/732 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63955 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/607 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/666 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/684 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->