### PR TITLE
Unreviewed, reverting 302222@main (e417ae6c5c6f)

### DIFF
--- a/LayoutTests/platform/mac-wk2/fast/scrolling/rtl-scrollbars-animation-property-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/scrolling/rtl-scrollbars-animation-property-expected.txt
@@ -1,11 +1,11 @@
-layer at (0,0) size 783x2000
-  RenderView at (0,0) size 783x600
-layer at (0,0) size 783x216
-  RenderBlock {HTML} at (0,0) size 783x216
-    RenderBody {BODY} at (8,8) size 767x200
-layer at (8,8) size 200x200 clip at (25,8) size 183x183 scrollHeight 2000 scrollbarHasRTLLayoutDirection
+layer at (0,0) size 786x2000
+  RenderView at (0,0) size 786x600
+layer at (0,0) size 786x216
+  RenderBlock {HTML} at (0,0) size 786x216
+    RenderBody {BODY} at (8,8) size 770x200
+layer at (8,8) size 200x200 clip at (22,8) size 186x186 scrollHeight 2000 scrollbarHasRTLLayoutDirection
   RenderBlock (relative positioned) {DIV} at (0,0) size 200x200
-layer at (25,8) size 1x2000 backgroundClip at (25,8) size 183x183 clip at (25,8) size 183x183
-  RenderBlock (positioned) {DIV} at (17,0) size 1x2000
+layer at (22,8) size 1x2000 backgroundClip at (22,8) size 186x186 clip at (22,8) size 186x186
+  RenderBlock (positioned) {DIV} at (14,0) size 1x2000
 layer at (0,0) size 1x2000
   RenderBlock (positioned) {DIV} at (0,0) size 1x2000

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -234,7 +234,7 @@ int ScrollbarThemeMac::scrollbarThickness(ScrollbarWidth scrollbarWidth, Scrollb
         return 0;
     NSScrollerImp *scrollerImp = [NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:nsControlSizeFromScrollbarWidth(scrollbarWidth) horizontal:NO replacingScrollerImp:nil];
     [scrollerImp setExpanded:(expansionState == ScrollbarExpansionState::Expanded)];
-    return [[scrollerImp class] scrollerWidth];
+    return [scrollerImp trackBoxWidth];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 


### PR DESCRIPTION
#### 9d69381d1353ade1b34e276d5f64fd56b7454d44
<pre>
Unreviewed, reverting 302222@main (e417ae6c5c6f)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301587">https://bugs.webkit.org/show_bug.cgi?id=301587</a>
<a href="https://rdar.apple.com/163584974">rdar://163584974</a>

REGRESSION(302222@main) [ Tahoe ]: 14 TestWebKitAPI.CSSViewportUnits (api-tests) are constant failures

Reverted change:

    Always-on scrollbars are not symmetrical in the track
    <a href="https://bugs.webkit.org/show_bug.cgi?id=299577">https://bugs.webkit.org/show_bug.cgi?id=299577</a>
    <a href="https://rdar.apple.com/161372025">rdar://161372025</a>
    302222@main (e417ae6c5c6f)

Canonical link: <a href="https://commits.webkit.org/302273@main">https://commits.webkit.org/302273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f3c6df25e3f1fd695104575fc0d5d8961583cb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39410 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/135967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/718 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/135967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131527 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/135967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/33307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/79252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/33789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/138418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/675 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/138418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/722 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/111539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/138418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/30069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20079 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63954 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->