### PR TITLE
[WebXR][GLib] TestWebKitWebXR/permission-request is flaky

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp
@@ -208,8 +208,6 @@ static void testWebKitXRPermissionRequest(WebXRTest* test, gconstpointer)
         return TRUE;
     };
 
-    test->loadHtml("", "https://foo.com/bar");
-    test->waitUntilLoadFinished();
     test->showInWindow();
 
     auto testPermissionRequest = [&](StringView mode, StringView options, Answer answer) {
@@ -226,10 +224,11 @@ static void testWebKitXRPermissionRequest(WebXRTest* test, gconstpointer)
             "start()"_s);
         data.answer = answer;
         data.resetResult();
+        test->loadHtml("", "https://foo.com/bar");
+        test->waitUntilLoadFinished();
         test->runJavaScriptAndWaitUntilFinished(script.utf8().data(), nullptr);
         test->waitUntilTitleChanged();
         data.result.title = String::fromUTF8(webkit_web_view_get_title(test->webView()));
-        test->runJavaScriptAndWaitUntilFinished("document.title = ''", nullptr);
     };
 
     // requestSession is rejected by default without a permission-request callback

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -585,12 +585,5 @@
                 "expected": {"gtk": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/284812"}}
             }
         }
-    },
-    "TestWebKitWebXR": {
-        "subtests": {
-            "/webkit/WebKitWebXR/permission-request": {
-                "expected": {"all": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/301508"}}
-            }
-        }
     }
 }


### PR DESCRIPTION
#### 4eef88235757f0df3ce7a1779ca4d4cfda929b72
<pre>
[WebXR][GLib] TestWebKitWebXR/permission-request is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=301508">https://bugs.webkit.org/show_bug.cgi?id=301508</a>

Reviewed by Adrian Perez de Castro.

TestWebKitWebXR/permission-request test was flaky on the Buildbot, particularly
on EWS. The result window title was &quot;&quot; rather than the expected strings &quot;pass&quot;
or &quot;fail&quot;. This was reproducible on my PC by limiting the CPU affinity with
taskset.
&gt; while WITH_OPENXR_RUNTIME=y taskset 1 ./Tools/Scripts/run-gtk-tests --release WebKitGTK/TestWebKitWebXR; do; done

In the test code, the title was cleared after the test with the following code:
&gt; test-&gt;runJavaScriptAndWaitUntilFinished(&quot;document.title = &apos;&apos;&quot;, nullptr);

The problem was that we didn&apos;t wait the title changed. We should do:
&gt; test-&gt;waitUntilTitleChanged();

Rather than changing the title, this change loads an empty string before the
test run.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp:
(testWebKitXRPermissionRequest):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/302292@main">https://commits.webkit.org/302292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0d373bb49a7ef9ea08254769ffe0ab97ee0b943

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80003 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/731 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97888 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65796 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78504 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/532 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33320 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79264 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108973 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138432 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106423 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106243 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/581 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30082 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53032 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20090 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/746 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/617 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->