### PR TITLE
Fix editing/pasteboard/paste-noscript.html crash under Site Isolation

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -255,11 +255,11 @@ static void collectFrameWebArchives(WebCore::FrameIdentifier frameIdentifier, Ha
     if (!webFrame)
         return;
 
-    RefPtr frame = webFrame->coreFrame();
-    if (!frame)
+    RefPtr rootFrame = webFrame->coreFrame();
+    if (!rootFrame)
         return;
 
-    for (; frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = rootFrame; frame; frame = frame->tree().traverseNext(rootFrame.get())) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame) {
             remoteFrameIdentifiers.append(frame->frameID());


### PR DESCRIPTION
#### 15cade05e54f40feb0b64a3b5b815ed1e1f92dcb
<pre>
Fix editing/pasteboard/paste-noscript.html crash under Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=301610">https://bugs.webkit.org/show_bug.cgi?id=301610</a>

Reviewed by Ryosuke Niwa.

When running editing/pasteboard/paste-noscript.html with site isolation on, the assertion in collectFrameWebArchives
(`RELEASE_ASSERT(result.isNewEntry)`) fails as an iframe is being visited twice. This is because the frame traveral
does not stay within target frame -- `collectFrameWebArchives` should only collect archives for descendants of target
frame (including the target frame).

* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::collectFrameWebArchives):

Canonical link: <a href="https://commits.webkit.org/302316@main">https://commits.webkit.org/302316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35d5351bdf144d81944d0b1e5883ac770dc63310

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135982 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80004 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1df4af4c-5708-4613-b071-ab48effd222a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97889 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65795 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/429a1870-f66c-4b5d-b16c-15a47cf8fcea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115214 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78505 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5936eff3-defa-41df-bcfc-3e1a81314ae6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/534 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79266 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138434 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/656 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111554 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27077 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/582 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30084 "Found 1 new test failure: fast/images/page-wide-animation-toggle.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53035 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/748 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63975 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/618 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/677 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/698 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->