### PR TITLE
Address Safer CPP failures in WebProcess/WebPage

### DIFF
--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -113,7 +113,7 @@ public:
     Ref<LocalFrame> protectedFrame() const;
 
     WEBCORE_EXPORT RenderView* renderView() const;
-    CheckedPtr<RenderView> checkedRenderView() const;
+    WEBCORE_EXPORT CheckedPtr<RenderView> checkedRenderView() const;
 
     int mapFromLayoutToCSSUnits(LayoutUnit) const;
     LayoutUnit mapFromCSSToLayoutUnits(int) const;

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -147,6 +147,11 @@ ScrollingStateTree& AsyncScrollingCoordinator::ensureScrollingStateTreeForRootFr
     });
 }
 
+CheckedRef<ScrollingStateTree> AsyncScrollingCoordinator::ensureCheckedScrollingStateTreeForRootFrameID(FrameIdentifier rootFrameID)
+{
+    return ensureScrollingStateTreeForRootFrameID(rootFrameID);
+}
+
 const ScrollingStateTree* AsyncScrollingCoordinator::existingScrollingStateTreeForRootFrameID(std::optional<FrameIdentifier> rootFrameID) const
 {
     auto* result = rootFrameID ? m_scrollingStateTrees.get(*rootFrameID) : nullptr;

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -86,6 +86,7 @@ public:
     LocalFrameView* frameViewForScrollingNode(LocalFrame& localMainFrame, std::optional<ScrollingNodeID>) const;
 
     WEBCORE_EXPORT ScrollingStateTree& ensureScrollingStateTreeForRootFrameID(FrameIdentifier);
+    WEBCORE_EXPORT CheckedRef<ScrollingStateTree> ensureCheckedScrollingStateTreeForRootFrameID(FrameIdentifier);
     const ScrollingStateTree* existingScrollingStateTreeForRootFrameID(std::optional<FrameIdentifier>) const;
     ScrollingStateTree* stateTreeForNodeID(std::optional<ScrollingNodeID>) const;
     std::unique_ptr<ScrollingStateTree> commitTreeStateForRootFrameID(FrameIdentifier, LayerRepresentation::Type);

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h
@@ -39,9 +39,9 @@ typedef CAAnimation* PlatformAnimationRef;
 
 namespace WebCore {
 
-WEBCORE_EXPORT NSString* toCAFillModeType(PlatformCAAnimation::FillModeType);
-WEBCORE_EXPORT NSString* toCAValueFunctionType(PlatformCAAnimation::ValueFunctionType);
-WEBCORE_EXPORT CAMediaTimingFunction* toCAMediaTimingFunction(const TimingFunction&, bool reverse);
+WEBCORE_EXPORT RetainPtr<NSString> toCAFillModeType(PlatformCAAnimation::FillModeType);
+WEBCORE_EXPORT RetainPtr<NSString> toCAValueFunctionType(PlatformCAAnimation::ValueFunctionType);
+WEBCORE_EXPORT RetainPtr<CAMediaTimingFunction> toCAMediaTimingFunction(const TimingFunction&, bool reverse);
 
 bool hasExplicitBeginTime(CAAnimation *);
 void setHasExplicitBeginTime(CAAnimation *, bool);

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
@@ -48,7 +48,7 @@ void setHasExplicitBeginTime(CAAnimation *animation, bool value)
     [animation setValue:[NSNumber numberWithBool:value] forKey:WKExplicitBeginTimeFlag];
 }
     
-NSString* toCAFillModeType(PlatformCAAnimation::FillModeType type)
+RetainPtr<NSString> toCAFillModeType(PlatformCAAnimation::FillModeType type)
 {
     switch (type) {
     case PlatformCAAnimation::FillModeType::NoFillMode:
@@ -70,7 +70,7 @@ static PlatformCAAnimation::FillModeType fromCAFillModeType(NSString* string)
     return PlatformCAAnimation::FillModeType::Forwards;
 }
 
-NSString* toCAValueFunctionType(PlatformCAAnimation::ValueFunctionType type)
+RetainPtr<NSString> toCAValueFunctionType(PlatformCAAnimation::ValueFunctionType type)
 {
     switch (type) {
     case PlatformCAAnimation::ValueFunctionType::NoValueFunction: return @"";
@@ -127,7 +127,7 @@ static PlatformCAAnimation::ValueFunctionType fromCAValueFunctionType(NSString* 
     return PlatformCAAnimation::ValueFunctionType::NoValueFunction;
 }
 
-CAMediaTimingFunction* toCAMediaTimingFunction(const TimingFunction& timingFunction, bool reverse)
+RetainPtr<CAMediaTimingFunction> toCAMediaTimingFunction(const TimingFunction& timingFunction, bool reverse)
 {
     if (auto* cubic = dynamicDowncast<CubicBezierTimingFunction>(timingFunction)) {
         RefPtr<CubicBezierTimingFunction> reversed;
@@ -322,7 +322,7 @@ PlatformCAAnimation::FillModeType PlatformCAAnimationCocoa::fillMode() const
 
 void PlatformCAAnimationCocoa::setFillMode(FillModeType value)
 {
-    [m_animation setFillMode:toCAFillModeType(value)];
+    [m_animation setFillMode:toCAFillModeType(value).get()];
 }
 
 void PlatformCAAnimationCocoa::setTimingFunction(const TimingFunction* timingFunction, bool reverse)
@@ -331,7 +331,7 @@ void PlatformCAAnimationCocoa::setTimingFunction(const TimingFunction* timingFun
     switch (animationType()) {
     case AnimationType::Basic:
     case AnimationType::Keyframe:
-        [m_animation setTimingFunction:toCAMediaTimingFunction(*timingFunction, reverse)];
+        [m_animation setTimingFunction:toCAMediaTimingFunction(*timingFunction, reverse).get()];
         break;
     case AnimationType::Spring:
         if (timingFunction->isSpringTimingFunction()) {
@@ -397,7 +397,7 @@ void PlatformCAAnimationCocoa::setValueFunction(ValueFunctionType value)
         return;
 
     ASSERT([static_cast<CAAnimation *>(m_animation.get()) isKindOfClass:[CAPropertyAnimation class]]);
-    return [static_cast<CAPropertyAnimation *>(m_animation.get()) setValueFunction:[CAValueFunction functionWithName:toCAValueFunctionType(value)]];
+    return [static_cast<CAPropertyAnimation *>(m_animation.get()) setValueFunction:[CAValueFunction functionWithName:toCAValueFunctionType(value).get()]];
 }
 
 void PlatformCAAnimationCocoa::setFromValue(float value)
@@ -565,7 +565,7 @@ void PlatformCAAnimationCocoa::copyKeyTimesFrom(const PlatformCAAnimation& value
 void PlatformCAAnimationCocoa::setTimingFunctions(const Vector<Ref<const TimingFunction>>& timingFunctions, bool reverse)
 {
     [static_cast<CAKeyframeAnimation *>(m_animation.get()) setTimingFunctions:createNSArray(timingFunctions, [&] (auto& function) {
-        return toCAMediaTimingFunction(function.get(), reverse);
+        return toCAMediaTimingFunction(function.get(), reverse).autorelease();
     }).get()];
 }
 

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -16,7 +16,6 @@ Platform/IPC/ArgumentCoders.h
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
 WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
-WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
 WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
 WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
 WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
@@ -26,13 +25,9 @@ WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
 WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
 WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
 WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
-WebProcess/Network/WebLoaderStrategy.cpp
-WebProcess/Network/WebResourceLoader.cpp
 [ iOS ] WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
-WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
 [ iOS ] WebProcess/WebPage/WebFoundTextRangeController.cpp
 WebProcess/WebPage/WebFrame.cpp
 [ iOS ] WebProcess/WebPage/ios/FindControllerIOS.mm
 [ iOS ] WebProcess/WebPage/ios/WebPageIOS.mm
-[ Mac ] WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -1,5 +1,3 @@
-WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
-WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 [ iOS ] NetworkProcess/cocoa/NetworkSessionCocoa.mm
 [ iOS ] NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
 [ iOS ] UIProcess/API/ios/WKWebViewIOS.mm
@@ -9,6 +7,7 @@ WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 [ iOS ] UIProcess/ios/WKContentView.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 [ iOS ] WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
 [ iOS ] WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 [ iOS ] WebProcess/WebPage/ViewGestureGeometryCollector.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -74,7 +74,6 @@ WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
 WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
 WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp
-WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
 WebProcess/InjectedBundle/API/c/mac/WKBundleMac.mm
 [ Mac ] WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
 WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
@@ -98,7 +97,4 @@ WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
 [ iOS ] WebProcess/WebPage/ios/FindControllerIOS.mm
 [ iOS ] WebProcess/WebPage/ios/WebPageIOS.mm
 [ Mac ] WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
-[ Mac ] WebProcess/WebPage/mac/TiledCoreAnimationScrollingCoordinator.mm
-WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
-[ Mac ] WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
 [ iOS ] WebProcess/WebProcess.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,5 +1,3 @@
-WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
-WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 [ iOS ] GPUProcess/media/RemoteAudioSessionProxyManager.cpp
 [ iOS ] NetworkProcess/cocoa/NetworkSessionCocoa.mm
 [ iOS ] Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
@@ -27,6 +25,7 @@ WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
 [ iOS ] WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 [ iOS ] WebProcess/Network/NetworkProcessConnection.cpp
 [ iOS ] WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
 [ iOS ] WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,16 +1,3 @@
-WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
-WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
-WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
-WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
-WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
-WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
-WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
-WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
-WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
-WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
-WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
-[ Mac ] WebProcess/WebPage/mac/PageBannerMac.mm
-[ Mac ] WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 [ iOS ] NetworkProcess/cocoa/NetworkSessionCocoa.mm
 [ iOS ] NetworkProcess/cocoa/NetworkTaskCocoa.mm
 [ iOS ] NetworkProcess/ios/NetworkProcessIOS.mm
@@ -77,6 +64,15 @@ WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
 [ iOS ] UIProcess/ios/forms/WKFormSelectPopover.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
+WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
+WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
+WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
+WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
 [ iOS ] WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 [ iOS ] WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm
 [ iOS ] WebProcess/WebPage/ios/WebPageIOS.mm

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -86,7 +86,7 @@ WKTypeID WKBundlePageGetTypeID()
 void WKBundlePageSetContextMenuClient(WKBundlePageRef pageRef, WKBundlePageContextMenuClientBase* wkClient)
 {
 #if ENABLE(CONTEXT_MENUS)
-    WebKit::toImpl(pageRef)->setInjectedBundleContextMenuClient(makeUnique<WebKit::InjectedBundlePageContextMenuClient>(wkClient));
+    WebKit::toProtectedImpl(pageRef)->setInjectedBundleContextMenuClient(makeUnique<WebKit::InjectedBundlePageContextMenuClient>(wkClient));
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(wkClient);
@@ -95,22 +95,22 @@ void WKBundlePageSetContextMenuClient(WKBundlePageRef pageRef, WKBundlePageConte
 
 void WKBundlePageSetEditorClient(WKBundlePageRef pageRef, WKBundlePageEditorClientBase* wkClient)
 {
-    WebKit::toImpl(pageRef)->setInjectedBundleEditorClient(wkClient ? makeUnique<WebKit::InjectedBundlePageEditorClient>(*wkClient) : makeUnique<API::InjectedBundle::EditorClient>());
+    WebKit::toProtectedImpl(pageRef)->setInjectedBundleEditorClient(wkClient ? makeUnique<WebKit::InjectedBundlePageEditorClient>(*wkClient) : makeUnique<API::InjectedBundle::EditorClient>());
 }
 
 void WKBundlePageSetFormClient(WKBundlePageRef pageRef, WKBundlePageFormClientBase* wkClient)
 {
-    WebKit::toImpl(pageRef)->setInjectedBundleFormClient(makeUnique<WebKit::InjectedBundlePageFormClient>(wkClient));
+    WebKit::toProtectedImpl(pageRef)->setInjectedBundleFormClient(makeUnique<WebKit::InjectedBundlePageFormClient>(wkClient));
 }
 
 void WKBundlePageSetPageLoaderClient(WKBundlePageRef pageRef, WKBundlePageLoaderClientBase* wkClient)
 {
-    WebKit::toImpl(pageRef)->setInjectedBundlePageLoaderClient(makeUnique<WebKit::InjectedBundlePageLoaderClient>(wkClient));
+    WebKit::toProtectedImpl(pageRef)->setInjectedBundlePageLoaderClient(makeUnique<WebKit::InjectedBundlePageLoaderClient>(wkClient));
 }
 
 void WKBundlePageSetResourceLoadClient(WKBundlePageRef pageRef, WKBundlePageResourceLoadClientBase* wkClient)
 {
-    WebKit::toImpl(pageRef)->setInjectedBundleResourceLoadClient(makeUnique<WebKit::InjectedBundlePageResourceLoadClient>(wkClient));
+    WebKit::toProtectedImpl(pageRef)->setInjectedBundleResourceLoadClient(makeUnique<WebKit::InjectedBundlePageResourceLoadClient>(wkClient));
 }
 
 void WKBundlePageSetPolicyClient(WKBundlePageRef, WKBundlePagePolicyClientBase*)
@@ -119,7 +119,7 @@ void WKBundlePageSetPolicyClient(WKBundlePageRef, WKBundlePagePolicyClientBase*)
 
 void WKBundlePageSetUIClient(WKBundlePageRef pageRef, WKBundlePageUIClientBase* wkClient)
 {
-    WebKit::toImpl(pageRef)->setInjectedBundleUIClient(makeUnique<WebKit::InjectedBundlePageUIClient>(wkClient));
+    WebKit::toProtectedImpl(pageRef)->setInjectedBundleUIClient(makeUnique<WebKit::InjectedBundlePageUIClient>(wkClient));
 }
 
 WKBundleFrameRef WKBundlePageGetMainFrame(WKBundlePageRef pageRef)
@@ -129,13 +129,13 @@ WKBundleFrameRef WKBundlePageGetMainFrame(WKBundlePageRef pageRef)
 
 WKFrameHandleRef WKBundleFrameCreateFrameHandle(WKBundleFrameRef bundleFrameRef)
 {
-    return WebKit::toAPI(&API::FrameHandle::create(WebKit::toImpl(bundleFrameRef)->frameID()).leakRef());
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&API::FrameHandle::create(WebKit::toImpl(bundleFrameRef)->frameID()).leakRef());
 }
 
 void WKBundlePageClickMenuItem(WKBundlePageRef pageRef, WKContextMenuItemRef item)
 {
 #if ENABLE(CONTEXT_MENUS)
-    WebKit::toImpl(pageRef)->contextMenu().itemSelected(WebKit::toImpl(item)->data());
+    WebKit::toProtectedImpl(pageRef)->protectedContextMenu()->itemSelected(WebKit::toImpl(item)->data());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(item);
@@ -155,9 +155,9 @@ static Ref<API::Array> contextMenuItems(const WebKit::WebContextMenu& contextMen
 WKArrayRef WKBundlePageCopyContextMenuItems(WKBundlePageRef pageRef)
 {
 #if ENABLE(CONTEXT_MENUS)
-    Ref contextMenu = WebKit::toImpl(pageRef)->contextMenu();
+    Ref contextMenu = WebKit::toProtectedImpl(pageRef)->contextMenu();
 
-    return WebKit::toAPI(&contextMenuItems(contextMenu.get()).leakRef());
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&contextMenuItems(contextMenu.get()).leakRef());
 #else
     UNUSED_PARAM(pageRef);
     return nullptr;
@@ -171,11 +171,11 @@ WKArrayRef WKBundlePageCopyContextMenuAtPointInWindow(WKBundlePageRef pageRef, W
     if (!page)
         return nullptr;
 
-    RefPtr contextMenu = WebKit::toImpl(pageRef)->contextMenuAtPointInWindow(page->mainFrame().frameID(), WebKit::toIntPoint(point));
+    RefPtr contextMenu = WebKit::toProtectedImpl(pageRef)->contextMenuAtPointInWindow(page->mainFrame().frameID(), WebKit::toIntPoint(point));
     if (!contextMenu)
         return nullptr;
 
-    return WebKit::toAPI(&contextMenuItems(*contextMenu).leakRef());
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&contextMenuItems(*contextMenu).leakRef());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(point);
@@ -185,7 +185,7 @@ WKArrayRef WKBundlePageCopyContextMenuAtPointInWindow(WKBundlePageRef pageRef, W
 
 void WKBundlePageInsertNewlineInQuotedContent(WKBundlePageRef pageRef)
 {
-    WebKit::toImpl(pageRef)->insertNewlineInQuotedContent();
+    WebKit::toProtectedImpl(pageRef)->insertNewlineInQuotedContent();
 }
 
 void WKAccessibilityTestingInjectPreference(WKBundlePageRef pageRef, WKStringRef domain, WKStringRef key, WKStringRef encodedValue)
@@ -221,7 +221,7 @@ void* WKAccessibilityFocusedObject(WKBundlePageRef pageRef)
 
     WebCore::AXObjectCache::enableAccessibility();
 
-    auto* axObjectCache = focusedDocument->axObjectCache();
+    CheckedPtr axObjectCache = focusedDocument->axObjectCache();
     if (!axObjectCache)
         return nullptr;
 
@@ -255,7 +255,7 @@ void WKAccessibilityAnnounce(WKBundlePageRef pageRef, WKStringRef message)
     if (!core->document())
         return;
 
-    if (auto* cache = core->document()->axObjectCache())
+    if (CheckedPtr cache = core->protectedDocument()->axObjectCache())
         cache->announce(WebKit::toWTFString(message));
 }
 
@@ -281,8 +281,8 @@ void WKAccessibilitySetForceInitialFrameCaching(bool shouldForce)
 
 void WKBundlePageSetEditable(WKBundlePageRef pageRef, bool isEditable)
 {
-    WebKit::WebPage* webPage = WebKit::toImpl(pageRef);
-    if (WebCore::Page* page = webPage ? webPage->corePage() : nullptr)
+    RefPtr webPage = WebKit::toImpl(pageRef);
+    if (RefPtr page = webPage ? webPage->corePage() : nullptr)
         page->setEditable(isEditable);
 }
 
@@ -293,32 +293,32 @@ void WKBundlePageSetDefersLoading(WKBundlePageRef, bool)
 WKStringRef WKBundlePageCopyRenderTreeExternalRepresentation(WKBundlePageRef pageRef, RenderTreeExternalRepresentationBehavior options)
 {
     // Convert to webcore options.
-    return WebKit::toCopiedAPI(WebKit::toImpl(pageRef)->renderTreeExternalRepresentation(options));
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(pageRef)->renderTreeExternalRepresentation(options));
 }
 
 WKStringRef WKBundlePageCopyRenderTreeExternalRepresentationForPrinting(WKBundlePageRef pageRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(pageRef)->renderTreeExternalRepresentationForPrinting());
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(pageRef)->renderTreeExternalRepresentationForPrinting());
 }
 
 void WKBundlePageClose(WKBundlePageRef pageRef)
 {
-    WebKit::toImpl(pageRef)->sendClose();
+    WebKit::toProtectedImpl(pageRef)->sendClose();
 }
 
 double WKBundlePageGetTextZoomFactor(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->textZoomFactor();
+    return WebKit::toProtectedImpl(pageRef)->textZoomFactor();
 }
 
 double WKBundlePageGetPageZoomFactor(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->pageZoomFactor();
+    return WebKit::toProtectedImpl(pageRef)->pageZoomFactor();
 }
 
 WKStringRef WKBundlePageDumpHistoryForTesting(WKBundlePageRef page, WKStringRef directory)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(page)->dumpHistoryForTesting(WebKit::toWTFString(directory)));
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(page)->dumpHistoryForTesting(WebKit::toWTFString(directory)));
 }
 
 WKBundleBackForwardListRef WKBundlePageGetBackForwardList(WKBundlePageRef pageRef)
@@ -328,28 +328,28 @@ WKBundleBackForwardListRef WKBundlePageGetBackForwardList(WKBundlePageRef pageRe
 
 void WKBundlePageInstallPageOverlay(WKBundlePageRef pageRef, WKBundlePageOverlayRef pageOverlayRef)
 {
-    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().installPageOverlay(*WebKit::toImpl(pageOverlayRef)->coreOverlay(), WebCore::PageOverlay::FadeMode::DoNotFade);
+    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().installPageOverlay(*WebKit::toImpl(pageOverlayRef)->protectedCoreOverlay(), WebCore::PageOverlay::FadeMode::DoNotFade);
 }
 
 void WKBundlePageUninstallPageOverlay(WKBundlePageRef pageRef, WKBundlePageOverlayRef pageOverlayRef)
 {
-    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().uninstallPageOverlay(*WebKit::toImpl(pageOverlayRef)->coreOverlay(), WebCore::PageOverlay::FadeMode::DoNotFade);
+    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().uninstallPageOverlay(*WebKit::toImpl(pageOverlayRef)->protectedCoreOverlay(), WebCore::PageOverlay::FadeMode::DoNotFade);
 }
 
 void WKBundlePageInstallPageOverlayWithAnimation(WKBundlePageRef pageRef, WKBundlePageOverlayRef pageOverlayRef)
 {
-    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().installPageOverlay(*WebKit::toImpl(pageOverlayRef)->coreOverlay(), WebCore::PageOverlay::FadeMode::Fade);
+    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().installPageOverlay(*WebKit::toImpl(pageOverlayRef)->protectedCoreOverlay(), WebCore::PageOverlay::FadeMode::Fade);
 }
 
 void WKBundlePageUninstallPageOverlayWithAnimation(WKBundlePageRef pageRef, WKBundlePageOverlayRef pageOverlayRef)
 {
-    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().uninstallPageOverlay(*WebKit::toImpl(pageOverlayRef)->coreOverlay(), WebCore::PageOverlay::FadeMode::Fade);
+    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().uninstallPageOverlay(*WebKit::toImpl(pageOverlayRef)->protectedCoreOverlay(), WebCore::PageOverlay::FadeMode::Fade);
 }
 
 void WKBundlePageSetTopOverhangImage(WKBundlePageRef pageRef, WKImageRef imageRef)
 {
 #if PLATFORM(MAC)
-    WebKit::toImpl(pageRef)->setTopOverhangImage(WebKit::toImpl(imageRef));
+    WebKit::toProtectedImpl(pageRef)->setTopOverhangImage(WebKit::toProtectedImpl(imageRef).get());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(imageRef);
@@ -359,7 +359,7 @@ void WKBundlePageSetTopOverhangImage(WKBundlePageRef pageRef, WKImageRef imageRe
 void WKBundlePageSetBottomOverhangImage(WKBundlePageRef pageRef, WKImageRef imageRef)
 {
 #if PLATFORM(MAC)
-    WebKit::toImpl(pageRef)->setBottomOverhangImage(WebKit::toImpl(imageRef));
+    WebKit::toProtectedImpl(pageRef)->setBottomOverhangImage(WebKit::toProtectedImpl(imageRef).get());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(imageRef);
@@ -369,18 +369,18 @@ void WKBundlePageSetBottomOverhangImage(WKBundlePageRef pageRef, WKImageRef imag
 #if !PLATFORM(IOS_FAMILY)
 void WKBundlePageSetHeaderBanner(WKBundlePageRef pageRef, WKBundlePageBannerRef bannerRef)
 {
-    WebKit::toImpl(pageRef)->setHeaderPageBanner(WebKit::toImpl(bannerRef));
+    WebKit::toProtectedImpl(pageRef)->setHeaderPageBanner(WebKit::toProtectedImpl(bannerRef).get());
 }
 
 void WKBundlePageSetFooterBanner(WKBundlePageRef pageRef, WKBundlePageBannerRef bannerRef)
 {
-    WebKit::toImpl(pageRef)->setFooterPageBanner(WebKit::toImpl(bannerRef));
+    WebKit::toProtectedImpl(pageRef)->setFooterPageBanner(WebKit::toProtectedImpl(bannerRef).get());
 }
 #endif // !PLATFORM(IOS_FAMILY)
 
 bool WKBundlePageHasLocalDataForURL(WKBundlePageRef pageRef, WKURLRef urlRef)
 {
-    return WebKit::toImpl(pageRef)->corePage()->hasLocalDataForURL(URL { WebKit::toWTFString(urlRef) });
+    return WebKit::toProtectedImpl(pageRef)->protectedCorePage()->hasLocalDataForURL(URL { WebKit::toWTFString(urlRef) });
 }
 
 bool WKBundlePageCanHandleRequest(WKURLRequestRef requestRef)
@@ -402,68 +402,68 @@ void WKBundlePageReplaceStringMatches(WKBundlePageRef pageRef, WKArrayRef matchI
         if (RefPtr indexAsObject = matchIndices->at<API::UInt64>(i))
             indices.append(indexAsObject->value());
     }
-    WebKit::toImpl(pageRef)->replaceStringMatchesFromInjectedBundle(indices, WebKit::toWTFString(replacementText), selectionOnly);
+    WebKit::toProtectedImpl(pageRef)->replaceStringMatchesFromInjectedBundle(indices, WebKit::toWTFString(replacementText), selectionOnly);
 }
 
 WKImageRef WKBundlePageCreateSnapshotWithOptions(WKBundlePageRef pageRef, WKRect rect, WKSnapshotOptions options)
 {
-    RefPtr<WebKit::WebImage> webImage = WebKit::toImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::toSnapshotOptions(options));
-    return toAPI(webImage.leakRef());
+    RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::toSnapshotOptions(options));
+    SUPPRESS_UNCOUNTED_ARG return toAPI(webImage.leakRef());
 }
 
 WKImageRef WKBundlePageCreateSnapshotInViewCoordinates(WKBundlePageRef pageRef, WKRect rect, WKImageOptions options)
 {
     auto snapshotOptions = WebKit::snapshotOptionsFromImageOptions(options);
     snapshotOptions.add(WebKit::SnapshotOption::InViewCoordinates);
-    RefPtr<WebKit::WebImage> webImage = WebKit::toImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, snapshotOptions);
-    return toAPI(webImage.leakRef());
+    RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, snapshotOptions);
+    SUPPRESS_UNCOUNTED_ARG return toAPI(webImage.leakRef());
 }
 
 WKImageRef WKBundlePageCreateSnapshotInDocumentCoordinates(WKBundlePageRef pageRef, WKRect rect, WKImageOptions options)
 {
-    RefPtr<WebKit::WebImage> webImage = WebKit::toImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::snapshotOptionsFromImageOptions(options));
-    return toAPI(webImage.leakRef());
+    RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::snapshotOptionsFromImageOptions(options));
+    SUPPRESS_UNCOUNTED_ARG return toAPI(webImage.leakRef());
 }
 
 WKImageRef WKBundlePageCreateScaledSnapshotInDocumentCoordinates(WKBundlePageRef pageRef, WKRect rect, double scaleFactor, WKImageOptions options)
 {
-    RefPtr<WebKit::WebImage> webImage = WebKit::toImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), scaleFactor, WebKit::snapshotOptionsFromImageOptions(options));
-    return toAPI(webImage.leakRef());
+    RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), scaleFactor, WebKit::snapshotOptionsFromImageOptions(options));
+    SUPPRESS_UNCOUNTED_ARG return toAPI(webImage.leakRef());
 }
 
 double WKBundlePageGetBackingScaleFactor(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->deviceScaleFactor();
+    return WebKit::toProtectedImpl(pageRef)->deviceScaleFactor();
 }
 
 void WKBundlePageListenForLayoutMilestones(WKBundlePageRef pageRef, WKLayoutMilestones milestones)
 {
-    WebKit::toImpl(pageRef)->listenForLayoutMilestones(WebKit::toLayoutMilestones(milestones));
+    WebKit::toProtectedImpl(pageRef)->listenForLayoutMilestones(WebKit::toLayoutMilestones(milestones));
 }
 
 void WKBundlePageCloseInspectorForTest(WKBundlePageRef page)
 {
-    WebKit::toImpl(page)->inspector()->close();
+    WebKit::toProtectedImpl(page)->protectedInspector()->close();
 }
 
 void WKBundlePageEvaluateScriptInInspectorForTest(WKBundlePageRef page, WKStringRef script)
 {
-    WebKit::toImpl(page)->inspector()->evaluateScriptForTest(WebKit::toWTFString(script));
+    WebKit::toProtectedImpl(page)->protectedInspector()->evaluateScriptForTest(WebKit::toWTFString(script));
 }
 
 void WKBundlePageForceRepaint(WKBundlePageRef page)
 {
-    WebKit::toImpl(page)->updateRenderingWithForcedRepaintWithoutCallback();
+    WebKit::toProtectedImpl(page)->updateRenderingWithForcedRepaintWithoutCallback();
 }
 
 void WKBundlePageFlushPendingEditorStateUpdate(WKBundlePageRef page)
 {
-    WebKit::toImpl(page)->flushPendingEditorStateUpdate();
+    WebKit::toProtectedImpl(page)->flushPendingEditorStateUpdate();
 }
 
 uint64_t WKBundlePageGetRenderTreeSize(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->renderTreeSize();
+    return WebKit::toProtectedImpl(pageRef)->renderTreeSize();
 }
 
 // This function should be kept around for compatibility with SafariForWebKitDevelopment.
@@ -484,12 +484,12 @@ void WKBundlePageSetPaintedObjectsCounterThreshold(WKBundlePageRef, uint64_t)
 
 bool WKBundlePageIsTrackingRepaints(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->isTrackingRepaints();
+    return WebKit::toProtectedImpl(pageRef)->isTrackingRepaints();
 }
 
 WKArrayRef WKBundlePageCopyTrackedRepaintRects(WKBundlePageRef pageRef)
 {
-    return WebKit::toAPI(&WebKit::toImpl(pageRef)->trackedRepaintRects().leakRef());
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&WebKit::toProtectedImpl(pageRef)->trackedRepaintRects().leakRef());
 }
 
 void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int from, int length, bool suppressUnderline, WKArrayRef highlightData, WKArrayRef annotationData)
@@ -525,7 +525,7 @@ void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int f
             for (RefPtr dictionary : annotationDataArray->elementsOfType<API::Dictionary>()) {
                 auto location = downcast<API::UInt64>(dictionary->get("from"_s))->value();
                 auto length = downcast<API::UInt64>(dictionary->get("length"_s))->value();
-                auto name = downcast<API::String>(dictionary->get("annotation"_s))->string();
+                auto name = Ref { *downcast<API::String>(dictionary->get("annotation"_s)) }->string();
 
                 auto it = annotations.find(name);
                 if (it == annotations.end())
@@ -536,22 +536,22 @@ void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int f
         }
     }
 
-    WebKit::toImpl(pageRef)->setCompositionForTesting(WebKit::toWTFString(text), from, length, suppressUnderline, highlights, annotations);
+    WebKit::toProtectedImpl(pageRef)->setCompositionForTesting(WebKit::toWTFString(text), from, length, suppressUnderline, highlights, annotations);
 }
 
 bool WKBundlePageHasComposition(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->hasCompositionForTesting();
+    return WebKit::toProtectedImpl(pageRef)->hasCompositionForTesting();
 }
 
 void WKBundlePageConfirmComposition(WKBundlePageRef pageRef)
 {
-    WebKit::toImpl(pageRef)->confirmCompositionForTesting(String());
+    WebKit::toProtectedImpl(pageRef)->confirmCompositionForTesting(String());
 }
 
 void WKBundlePageConfirmCompositionWithText(WKBundlePageRef pageRef, WKStringRef text)
 {
-    WebKit::toImpl(pageRef)->confirmCompositionForTesting(WebKit::toWTFString(text));
+    WebKit::toProtectedImpl(pageRef)->confirmCompositionForTesting(WebKit::toWTFString(text));
 }
 
 void WKBundlePageSetUseDarkAppearance(WKBundlePageRef pageRef, bool useDarkAppearance)
@@ -571,27 +571,27 @@ bool WKBundlePageIsUsingDarkAppearance(WKBundlePageRef pageRef)
 
 bool WKBundlePageCanShowMIMEType(WKBundlePageRef pageRef, WKStringRef mimeTypeRef)
 {
-    return WebKit::toImpl(pageRef)->canShowMIMEType(WebKit::toWTFString(mimeTypeRef));
+    return WebKit::toProtectedImpl(pageRef)->canShowMIMEType(WebKit::toWTFString(mimeTypeRef));
 }
 
 WKRenderingSuppressionToken WKBundlePageExtendIncrementalRenderingSuppression(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->extendIncrementalRenderingSuppression();
+    return WebKit::toProtectedImpl(pageRef)->extendIncrementalRenderingSuppression();
 }
 
 void WKBundlePageStopExtendingIncrementalRenderingSuppression(WKBundlePageRef pageRef, WKRenderingSuppressionToken token)
 {
-    WebKit::toImpl(pageRef)->stopExtendingIncrementalRenderingSuppression(token);
+    WebKit::toProtectedImpl(pageRef)->stopExtendingIncrementalRenderingSuppression(token);
 }
 
 bool WKBundlePageIsUsingEphemeralSession(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->usesEphemeralSession();
+    return WebKit::toProtectedImpl(pageRef)->usesEphemeralSession();
 }
 
 bool WKBundlePageIsControlledByAutomation(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->isControlledByAutomation();
+    return WebKit::toProtectedImpl(pageRef)->isControlledByAutomation();
 }
 
 #if TARGET_OS_IPHONE
@@ -657,25 +657,25 @@ void WKBundlePageCallAfterTasksAndTimers(WKBundlePageRef pageRef, WKBundlePageTe
 
 void WKBundlePageFlushDeferredDidReceiveMouseEventForTesting(WKBundlePageRef page)
 {
-    WebKit::toImpl(page)->flushDeferredDidReceiveMouseEvent();
+    WebKit::toProtectedImpl(page)->flushDeferredDidReceiveMouseEvent();
 }
 
 void WKBundlePagePostMessage(WKBundlePageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
-    WebKit::toImpl(pageRef)->postMessage(WebKit::toWTFString(messageNameRef), WebKit::toImpl(messageBodyRef));
+    WebKit::toProtectedImpl(pageRef)->postMessage(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get());
 }
 
 void WKBundlePagePostMessageIgnoringFullySynchronousMode(WKBundlePageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
-    WebKit::toImpl(pageRef)->postMessageIgnoringFullySynchronousMode(WebKit::toWTFString(messageNameRef), WebKit::toImpl(messageBodyRef));
+    WebKit::toProtectedImpl(pageRef)->postMessageIgnoringFullySynchronousMode(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get());
 }
 
 void WKBundlePagePostSynchronousMessageForTesting(WKBundlePageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef, WKTypeRef* returnRetainedDataRef)
 {
     RefPtr<API::Object> returnData;
-    WebKit::toImpl(pageRef)->postSynchronousMessageForTesting(WebKit::toWTFString(messageNameRef), WebKit::toImpl(messageBodyRef), returnData);
+    WebKit::toProtectedImpl(pageRef)->postSynchronousMessageForTesting(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get(), returnData);
     if (returnRetainedDataRef)
-        *returnRetainedDataRef = WebKit::toAPI(returnData.leakRef());
+        SUPPRESS_UNCOUNTED_ARG *returnRetainedDataRef = WebKit::toAPI(returnData.leakRef());
 }
 
 bool WKBundlePageIsSuspended(WKBundlePageRef pageRef)
@@ -685,22 +685,22 @@ bool WKBundlePageIsSuspended(WKBundlePageRef pageRef)
 
 void WKBundlePageAddUserScript(WKBundlePageRef pageRef, WKStringRef source, _WKUserScriptInjectionTime injectionTime, WKUserContentInjectedFrames injectedFrames)
 {
-    WebKit::toImpl(pageRef)->addUserScript(WebKit::toWTFString(source), WebKit::InjectedBundleScriptWorld::normalWorldSingleton(), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
+    WebKit::toProtectedImpl(pageRef)->addUserScript(WebKit::toWTFString(source), WebKit::InjectedBundleScriptWorld::normalWorldSingleton(), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
 }
 
 void WKBundlePageAddUserScriptInWorld(WKBundlePageRef page, WKStringRef source, WKBundleScriptWorldRef scriptWorld, _WKUserScriptInjectionTime injectionTime, WKUserContentInjectedFrames injectedFrames)
 {
-    WebKit::toImpl(page)->addUserScript(WebKit::toWTFString(source), *WebKit::toImpl(scriptWorld), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
+    WebKit::toProtectedImpl(page)->addUserScript(WebKit::toWTFString(source), *WebKit::toProtectedImpl(scriptWorld), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
 }
 
 void WKBundlePageAddUserStyleSheet(WKBundlePageRef pageRef, WKStringRef source, WKUserContentInjectedFrames injectedFrames)
 {
-    WebKit::toImpl(pageRef)->addUserStyleSheet(WebKit::toWTFString(source), WebKit::toUserContentInjectedFrames(injectedFrames));
+    WebKit::toProtectedImpl(pageRef)->addUserStyleSheet(WebKit::toWTFString(source), WebKit::toUserContentInjectedFrames(injectedFrames));
 }
 
 void WKBundlePageRemoveAllUserContent(WKBundlePageRef pageRef)
 {
-    WebKit::toImpl(pageRef)->removeAllUserContent();
+    WebKit::toProtectedImpl(pageRef)->removeAllUserContent();
 }
 
 WKStringRef WKBundlePageCopyGroupIdentifier(WKBundlePageRef pageRef)
@@ -711,7 +711,7 @@ WKStringRef WKBundlePageCopyGroupIdentifier(WKBundlePageRef pageRef)
 void WKBundlePageSetCaptionDisplayMode(WKBundlePageRef page, WKStringRef mode)
 {
 #if ENABLE(VIDEO)
-    Ref captionPreferences = WebKit::toImpl(page)->corePage()->group().ensureCaptionPreferences();
+    Ref captionPreferences = WebKit::toProtectedImpl(page)->protectedCorePage()->checkedGroup()->ensureCaptionPreferences();
     auto displayMode = WTF::EnumTraits<WebCore::CaptionUserPreferences::CaptionDisplayMode>::fromString(WebKit::toWTFString(mode));
     if (displayMode.has_value())
         captionPreferences->setCaptionDisplayMode(displayMode.value());
@@ -724,8 +724,8 @@ void WKBundlePageSetCaptionDisplayMode(WKBundlePageRef page, WKStringRef mode)
 WKCaptionUserPreferencesTestingModeTokenRef WKBundlePageCreateCaptionUserPreferencesTestingModeToken(WKBundlePageRef page)
 {
 #if ENABLE(VIDEO)
-    Ref captionPreferences = WebKit::toImpl(page)->corePage()->group().ensureCaptionPreferences();
-    return WebKit::toAPI(&API::CaptionUserPreferencesTestingModeToken::create(captionPreferences.get()).leakRef());
+    Ref captionPreferences = WebKit::toProtectedImpl(page)->protectedCorePage()->checkedGroup()->ensureCaptionPreferences();
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&API::CaptionUserPreferencesTestingModeToken::create(captionPreferences.get()).leakRef());
 #else
     UNUSED_PARAM(page);
     return { };
@@ -734,7 +734,7 @@ WKCaptionUserPreferencesTestingModeTokenRef WKBundlePageCreateCaptionUserPrefere
 
 void WKBundlePageLayoutIfNeeded(WKBundlePageRef page)
 {
-    WebKit::toImpl(page)->layoutIfNeeded();
+    WebKit::toProtectedImpl(page)->layoutIfNeeded();
 }
 
 void WKBundlePageSetSkipDecidePolicyForResponseIfPossible(WKBundlePageRef page, bool skip)
@@ -744,5 +744,5 @@ void WKBundlePageSetSkipDecidePolicyForResponseIfPossible(WKBundlePageRef page, 
 
 WKStringRef WKBundlePageCopyFrameTextForTesting(WKBundlePageRef page, bool includeSubframes)
 {
-    return WebKit::toAPI(&API::String::create(WebKit::toImpl(page)->frameTextForTestingIncludingSubframes(includeSubframes)).leakRef());
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&API::String::create(WebKit::toProtectedImpl(page)->frameTextForTestingIncludingSubframes(includeSubframes)).leakRef());
 }

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -870,7 +870,7 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
     if (!sendResult.succeeded()) {
         WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG_ERROR("loadResourceSynchronously: failed sending synchronous network process message %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()).characters());
         if (page)
-            page->diagnosticLoggingClient().logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::synchronousMessageFailedKey(), WebCore::ShouldSample::No);
+            page->checkedDiagnosticLoggingClient()->logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::synchronousMessageFailedKey(), WebCore::ShouldSample::No);
         response = ResourceResponse();
         error = internalError(request.url());
     } else

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -369,7 +369,7 @@ void WebResourceLoader::didReceiveResource(ShareableResource::Handle&& handle)
         WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESOURCE_UNABLE_TO_CREATE_FRAGMENTEDSHAREDBUFFER);
         if (RefPtr frame = coreLoader->frame()) {
             if (RefPtr page = frame->page())
-                page->diagnosticLoggingClient().logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::createSharedBufferFailedKey(), WebCore::ShouldSample::No);
+                page->checkedDiagnosticLoggingClient()->logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::createSharedBufferFailedKey(), WebCore::ShouldSample::No);
         }
         coreLoader->didFail(internalError(coreLoader->request().url()));
         return;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -397,8 +397,9 @@ void TextAnimationController::clearAnimationsForActiveWritingToolsSession()
 
     auto textAnimationRanges = std::exchange(m_textAnimationRanges, { });
 
+    RefPtr page = m_webPage.get();
     for (auto textAnimationRange : textAnimationRanges)
-        protectedWebPage()->removeTextAnimationForAnimationID(textAnimationRange.animationUUID);
+        page->removeTextAnimationForAnimationID(textAnimationRange.animationUUID);
 
     if (auto finalReplaceHander = std::exchange(m_finalReplaceHandler, std::nullopt))
         (*finalReplaceHander)(WebCore::TextAnimationRunMode::DoNotRun);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
@@ -506,7 +506,7 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
         }
 
         if (properties.timingFunctions.size())
-            [basicAnimation setTimingFunction:toCAMediaTimingFunction(properties.timingFunctions[0].get(), properties.reverseTimingFunctions)];
+            [basicAnimation setTimingFunction:toCAMediaTimingFunction(properties.timingFunctions[0].get(), properties.reverseTimingFunctions).get()];
 
         caAnimation = WTFMove(basicAnimation);
         break;
@@ -542,11 +542,11 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
         }
 
         if (properties.timingFunction)
-            [keyframeAnimation setTimingFunction:toCAMediaTimingFunction(Ref { *properties.timingFunction }, false)]; // FIXME: handle reverse.
+            [keyframeAnimation setTimingFunction:toCAMediaTimingFunction(Ref { *properties.timingFunction }, false).get()]; // FIXME: handle reverse.
 
         if (properties.timingFunctions.size()) {
             [keyframeAnimation setTimingFunctions:createNSArray(properties.timingFunctions, [&] (auto& function) {
-                return toCAMediaTimingFunction(function.get(), properties.reverseTimingFunctions);
+                return toCAMediaTimingFunction(function.get(), properties.reverseTimingFunctions).autorelease();
             }).get()];
         }
 
@@ -587,11 +587,11 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
     if ([caAnimation isKindOfClass:[CAPropertyAnimation class]]) {
         [(CAPropertyAnimation *)caAnimation setAdditive:properties.additive];
         if (properties.valueFunction != PlatformCAAnimation::ValueFunctionType::NoValueFunction)
-            [(CAPropertyAnimation *)caAnimation setValueFunction:[CAValueFunction functionWithName:toCAValueFunctionType(properties.valueFunction)]];
+            [(CAPropertyAnimation *)caAnimation setValueFunction:[CAValueFunction functionWithName:toCAValueFunctionType(properties.valueFunction).get()]];
     }
 
     if (properties.fillMode != PlatformCAAnimation::FillModeType::NoFillMode)
-        [caAnimation setFillMode:toCAFillModeType(properties.fillMode)];
+        [caAnimation setFillMode:toCAFillModeType(properties.fillMode).get()];
 
     if (properties.hasExplicitBeginTime)
         [caAnimation setValue:@YES forKey:WKExplicitBeginTimeFlag];

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h
@@ -81,7 +81,7 @@ private:
 
     bool m_hasVideo { false };
     std::unique_ptr<LayerHostingContext> m_layerHostingContext;
-    RetainPtr<PlatformLayer> m_platformLayer;
+    const RetainPtr<PlatformLayer> m_platformLayer;
 #if ENABLE(MODEL_PROCESS)
     RefPtr<WebCore::ModelContext> m_modelContext;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
@@ -106,7 +106,7 @@ PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom(LayerType layerType, Pl
     m_layerHostingContext->setRootLayer(customLayer);
     [customLayer setValue:[NSValue valueWithPointer:this] forKey:platformCALayerPointer];
 
-    m_platformLayer = customLayer;
+    lazyInitialize(m_platformLayer, RetainPtr { customLayer });
     [customLayer web_disableAllActions];
 
     properties().position = FloatPoint3D(customLayer.position.x, customLayer.position.y, customLayer.zPosition);
@@ -154,7 +154,7 @@ Ref<WebCore::PlatformCALayer> PlatformCALayerRemoteCustom::clone(PlatformCALayer
 
     if (layerType() == PlatformCALayer::LayerType::LayerTypeAVPlayerLayer) {
         
-        if (PAL::isAVFoundationFrameworkAvailable() && [platformLayer() isKindOfClass:PAL::getAVPlayerLayerClassSingleton()]) {
+        if (PAL::isAVFoundationFrameworkAvailable() && [m_platformLayer isKindOfClass:PAL::getAVPlayerLayerClassSingleton()]) {
             clonedLayer = adoptNS([PAL::allocAVPlayerLayerInstance() init]);
 
             RetainPtr destinationPlayerLayer = static_cast<AVPlayerLayer *>(clonedLayer.get());

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -113,7 +113,7 @@ RemoteScrollingCoordinatorTransaction RemoteScrollingCoordinator::buildTransacti
     willCommitTree(rootFrameID);
 
     return {
-        ensureScrollingStateTreeForRootFrameID(rootFrameID).commit(LayerRepresentation::PlatformLayerIDRepresentation),
+        ensureCheckedScrollingStateTreeForRootFrameID(rootFrameID)->commit(LayerRepresentation::PlatformLayerIDRepresentation),
         std::exchange(m_clearScrollLatchingInNextTransaction, false),
         { },
         RemoteScrollingCoordinatorTransaction::FromDeserialization::No

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -864,7 +864,7 @@ String WebFrame::layerTreeAsText() const
     if (!localFrame)
         return emptyString();
 
-    return localFrame->contentRenderer()->compositor().layerTreeAsText();
+    return localFrame->contentRenderer()->checkedCompositor()->layerTreeAsText();
 }
 
 unsigned WebFrame::pendingUnloadCount() const
@@ -933,7 +933,7 @@ void WebFrame::setAccessibleName(const AtomString& accessibleName)
     RefPtr document = localFrame->document();
     if (!document)
         return;
-    
+
     RefPtr rootObject = document->checkedAXObjectCache()->rootObjectForFrame(*localFrame);
     if (!rootObject)
         return;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6919,6 +6919,11 @@ LocalFrameView* WebPage::localMainFrameView() const
     return dynamicDowncast<LocalFrameView>(mainFrameView());
 }
 
+CheckedPtr<WebCore::LocalFrameView> WebPage::checkedLocalMainFrameView() const
+{
+    return localMainFrameView();
+}
+
 bool WebPage::shouldUseCustomContentProviderForResponse(const ResourceResponse& response)
 {
     auto& mimeType = response.mimeType();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -793,9 +793,10 @@ public:
 
     WebFrame& mainWebFrame() const { return m_mainFrame; }
 
-    WebCore::Frame* mainFrame() const; // May return nullptr.
-    WebCore::FrameView* mainFrameView() const; // May return nullptr.
-    WebCore::LocalFrameView* localMainFrameView() const; // May return nullptr.
+    WebCore::Frame* mainFrame() const;
+    WebCore::FrameView* mainFrameView() const;
+    WebCore::LocalFrameView* localMainFrameView() const;
+    CheckedPtr<WebCore::LocalFrameView> checkedLocalMainFrameView() const;
     RefPtr<WebCore::LocalFrame> localMainFrame() const;
     RefPtr<WebCore::Document> localTopDocument() const;
 

--- a/Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm
@@ -74,7 +74,7 @@ void PageBanner::didAddParentLayer(GraphicsLayer* parentLayer)
         return;
 
     m_layer.get().bounds = CGRectMake(0, 0, parentLayer->size().width(), parentLayer->size().height());
-    [parentLayer->platformLayer() addSublayer:m_layer.get()];
+    [parentLayer->protectedPlatformLayer() addSublayer:m_layer.get()];
 }
 
 void PageBanner::detachFromPage()

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -129,6 +129,7 @@ private:
     void commitTransientZoom(double scale, WebCore::FloatPoint origin, CompletionHandler<void()>&&) override;
     void applyTransientZoomToPage(double scale, WebCore::FloatPoint origin);
     WebCore::PlatformCALayer* layerForTransientZoom() const;
+    RefPtr<WebCore::PlatformCALayer> protectedLayerForTransientZoom() const;
     WebCore::PlatformCALayer* shadowLayerForTransientZoom() const;
 
     void applyTransientZoomToLayers(double scale, WebCore::FloatPoint origin);

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationScrollingCoordinator.mm
@@ -48,11 +48,12 @@ void TiledCoreAnimationScrollingCoordinator::pageDestroyed()
 
 void TiledCoreAnimationScrollingCoordinator::hasNodeWithAnimatedScrollChanged(bool haveAnimatedScrollingNodes)
 {
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
 
     ScrollingCoordinatorMac::hasNodeWithAnimatedScrollChanged(haveAnimatedScrollingNodes);
-    m_page->setHasActiveAnimatedScrolls(haveAnimatedScrollingNodes);
+    page->setHasActiveAnimatedScrolls(haveAnimatedScrollingNodes);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -80,6 +80,7 @@ class AXIsolatedTree;
 - (id)accessibilityFocusedUIElement;
 - (WebCore::IntPoint)accessibilityRemoteFrameOffset;
 - (WebCore::LocalFrame *)focusedLocalFrame;
+- (RefPtr<WebCore::LocalFrame>)protectedFocusedLocalFrame;
 - (NSUInteger)remoteTokenHash;
 
 - (BOOL)shouldFallbackToWebContentAXObjectForMainFramePlugin;


### PR DESCRIPTION
#### dcc3f273a7f6becdfdd62b65d7fcb043e1c3b028
<pre>
Address Safer CPP failures in WebProcess/WebPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=301614">https://bugs.webkit.org/show_bug.cgi?id=301614</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::ensureCheckedScrollingStateTreeForRootFrameID):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm:
(WebCore::toCAFillModeType):
(WebCore::toCAValueFunctionType):
(WebCore::toCAMediaTimingFunction):
(WebCore::PlatformCAAnimationCocoa::setFillMode):
(WebCore::PlatformCAAnimationCocoa::setTimingFunction):
(WebCore::PlatformCAAnimationCocoa::setValueFunction):
(WebCore::PlatformCAAnimationCocoa::setTimingFunctions):
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageSetContextMenuClient):
(WKBundlePageSetEditorClient):
(WKBundlePageSetFormClient):
(WKBundlePageSetPageLoaderClient):
(WKBundlePageSetResourceLoadClient):
(WKBundlePageSetUIClient):
(WKBundleFrameCreateFrameHandle):
(WKBundlePageClickMenuItem):
(WKBundlePageCopyContextMenuItems):
(WKBundlePageCopyContextMenuAtPointInWindow):
(WKBundlePageInsertNewlineInQuotedContent):
(WKAccessibilityFocusedObject):
(WKAccessibilityAnnounce):
(WKBundlePageSetEditable):
(WKBundlePageCopyRenderTreeExternalRepresentation):
(WKBundlePageCopyRenderTreeExternalRepresentationForPrinting):
(WKBundlePageClose):
(WKBundlePageGetTextZoomFactor):
(WKBundlePageGetPageZoomFactor):
(WKBundlePageDumpHistoryForTesting):
(WKBundlePageInstallPageOverlay):
(WKBundlePageUninstallPageOverlay):
(WKBundlePageInstallPageOverlayWithAnimation):
(WKBundlePageUninstallPageOverlayWithAnimation):
(WKBundlePageSetTopOverhangImage):
(WKBundlePageSetBottomOverhangImage):
(WKBundlePageSetHeaderBanner):
(WKBundlePageSetFooterBanner):
(WKBundlePageHasLocalDataForURL):
(WKBundlePageReplaceStringMatches):
(WKBundlePageCreateSnapshotWithOptions):
(WKBundlePageCreateSnapshotInViewCoordinates):
(WKBundlePageCreateSnapshotInDocumentCoordinates):
(WKBundlePageCreateScaledSnapshotInDocumentCoordinates):
(WKBundlePageGetBackingScaleFactor):
(WKBundlePageListenForLayoutMilestones):
(WKBundlePageCloseInspectorForTest):
(WKBundlePageEvaluateScriptInInspectorForTest):
(WKBundlePageForceRepaint):
(WKBundlePageFlushPendingEditorStateUpdate):
(WKBundlePageGetRenderTreeSize):
(WKBundlePageIsTrackingRepaints):
(WKBundlePageCopyTrackedRepaintRects):
(WKBundlePageSetComposition):
(WKBundlePageHasComposition):
(WKBundlePageConfirmComposition):
(WKBundlePageConfirmCompositionWithText):
(WKBundlePageCanShowMIMEType):
(WKBundlePageExtendIncrementalRenderingSuppression):
(WKBundlePageStopExtendingIncrementalRenderingSuppression):
(WKBundlePageIsUsingEphemeralSession):
(WKBundlePageIsControlledByAutomation):
(WKBundlePageFlushDeferredDidReceiveMouseEventForTesting):
(WKBundlePagePostMessage):
(WKBundlePagePostMessageIgnoringFullySynchronousMode):
(WKBundlePagePostSynchronousMessageForTesting):
(WKBundlePageAddUserScript):
(WKBundlePageAddUserScriptInWorld):
(WKBundlePageAddUserStyleSheet):
(WKBundlePageRemoveAllUserContent):
(WKBundlePageSetCaptionDisplayMode):
(WKBundlePageCreateCaptionUserPreferencesTestingModeToken):
(WKBundlePageLayoutIfNeeded):
(WKBundlePageCopyFrameTextForTesting):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::didReceiveResource):
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::TextAnimationController::clearAnimationsForActiveWritingToolsSession):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm:
(WebKit::createAnimation):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm:
(WebKit::PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom):
(WebKit::PlatformCALayerRemoteCustom::clone const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::buildTransaction):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::layerTreeAsText const):
(WebKit::WebFrame::setAccessibleName):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::checkedLocalMainFrameView const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm:
(WebKit::PageBanner::didAddParentLayer):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::registerScrollingTree):
(WebKit::TiledCoreAnimationDrawingArea::unregisterScrollingTree):
(WebKit::TiledCoreAnimationDrawingArea::updateRenderingWithForcedRepaint):
(WebKit::TiledCoreAnimationDrawingArea::updateRenderingWithForcedRepaintAsync):
(WebKit::TiledCoreAnimationDrawingArea::updatePreferences):
(WebKit::TiledCoreAnimationDrawingArea::updateRootLayers):
(WebKit::TiledCoreAnimationDrawingArea::dispatchAfterEnsuringUpdatedScrollPosition):
(WebKit::TiledCoreAnimationDrawingArea::updateRendering):
(WebKit::TiledCoreAnimationDrawingArea::setViewExposedRect):
(WebKit::TiledCoreAnimationDrawingArea::setColorSpace):
(WebKit::TiledCoreAnimationDrawingArea::layerForTransientZoom const):
(WebKit::TiledCoreAnimationDrawingArea::protectedLayerForTransientZoom const):
(WebKit::TiledCoreAnimationDrawingArea::shadowLayerForTransientZoom const):
(WebKit::shadowLayerBoundsForFrame):
(WebKit::TiledCoreAnimationDrawingArea::applyTransientZoomToLayers):
(WebKit::TiledCoreAnimationDrawingArea::applyTransientZoomToPage):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationScrollingCoordinator.mm:
(WebKit::TiledCoreAnimationScrollingCoordinator::hasNodeWithAnimatedScrollChanged):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase enableAccessibilityForAllProcesses]):
(-[WKAccessibilityWebPageObjectBase accessibilityRootObjectWrapper]):
(-[WKAccessibilityWebPageObjectBase setWebPage:]):
(-[WKAccessibilityWebPageObjectBase setIsolatedTree:]):
(-[WKAccessibilityWebPageObjectBase accessibilityFocusedUIElement]):
(-[WKAccessibilityWebPageObjectBase focusedLocalFrame]):
(-[WKAccessibilityWebPageObjectBase protectedFocusedLocalFrame]):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject convertScreenPointToRootView:]):
(-[WKAccessibilityWebPageObject accessibilityChildren]):
(-[WKAccessibilityWebPageObject accessibilityHitTest:]):

Canonical link: <a href="https://commits.webkit.org/302366@main">https://commits.webkit.org/302366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7247ddf86db7bd910d287eaf71dc8dc9e473a5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80157 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98043 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65956 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115368 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78651 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33482 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79448 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138626 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106583 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106390 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27104 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/706 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30237 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53278 "Hash e7247ddf for PR 53129 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/928 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64216 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/779 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/835 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/870 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->