### PR TITLE
[GTK] Enable MSAA for GPU rendering

### DIFF
--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -39,8 +39,11 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/gl/GrGLInterface.h>
 
 #if USE(LIBEPOXY)
+#include <epoxy/egl.h>
 #include <skia/gpu/ganesh/gl/epoxy/GrGLMakeEpoxyEGLInterface.h>
 #else
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
 #include <skia/gpu/ganesh/gl/egl/GrGLMakeEGLInterface.h>
 #endif
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -49,9 +52,16 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
+#if USE(LIBDRM)
+#include <fcntl.h>
+#include <unistd.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+#include <xf86drm.h>
+#endif
+
 namespace WebCore {
 
-#if PLATFORM(WPE)
+#if PLATFORM(GTK) || PLATFORM(WPE)
 #if CPU(X86) || CPU(X86_64)
 // On x86 ot x86_64 we need at least 8 samples for the antialiasing result to be similar
 // to non MSAA.
@@ -82,7 +92,111 @@ static sk_sp<const GrGLInterface> skiaGLInterface()
 
 static thread_local RefPtr<SkiaGLContext> s_skiaGLContext;
 
-unsigned initializeMSAASampleCount(GrDirectContext* grContext)
+#if USE(LIBDRM)
+static inline bool isNewIntelDevice()
+{
+    auto eglDisplay = eglGetCurrentDisplay();
+    if (eglDisplay == EGL_NO_DISPLAY)
+        return false;
+
+    if (!GLContext::isExtensionSupported(eglQueryString(nullptr, EGL_EXTENSIONS), "EGL_EXT_device_query"))
+        return false;
+
+    EGLDeviceEXT eglDevice;
+    if (!eglQueryDisplayAttribEXT(eglDisplay, EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&eglDevice)))
+        return false;
+
+    if (!GLContext::isExtensionSupported(eglQueryDeviceStringEXT(eglDevice, EGL_EXTENSIONS), "EGL_EXT_device_drm"))
+        return false;
+
+    const char* device = eglQueryDeviceStringEXT(eglDevice, EGL_DRM_DEVICE_FILE_EXT);
+    if (!device || !*device)
+        return false;
+
+    auto fd = UnixFileDescriptor { open(device, O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
+    if (!fd)
+        return false;
+
+    drmDevicePtr drmDevice;
+    if (drmGetDevice2(fd.value(), 0, &drmDevice))
+        return false;
+
+    if (drmDevice->bustype != DRM_BUS_PCI) {
+        drmFreeDevice(&drmDevice);
+        return false;
+    }
+
+    auto vendorID = drmDevice->deviceinfo.pci->vendor_id;
+    auto deviceID = drmDevice->deviceinfo.pci->device_id;
+    drmFreeDevice(&drmDevice);
+
+    static constexpr uint32_t intelVendorID = 0x8086;
+    if (vendorID != intelVendorID)
+        return false;
+
+    // On pre-Ice Lake Intel GPUs MSAA performance is not acceptable.
+    uint32_t maskedDeviceID = deviceID & 0xFF00;
+    switch (maskedDeviceID) {
+    case 0x2900: // Broadwater
+    case 0x2A00: // Broadwater or Eaglelake
+    case 0x2E00: // Eaglelake
+    case 0x0000: // Ironlake
+    case 0x0100: // Ivybridge, Baytrail or Sandybridge
+    case 0x0F00: // Baytrail
+    case 0x0A00: // Apollolake or Haswell
+    case 0x0400: // Haswell
+    case 0x0C00: // Haswell
+    case 0x0D00: // Haswell
+    case 0x2200: // Cherrytrail
+    case 0x1600: // Broadwell
+    case 0x5A00: // Apollolake or Cannonlake
+    case 0x1900: // Skylake
+    case 0x1A00: // Apollolake
+    case 0x3100: // Geminilake
+    case 0x5900: // Amberlake or Kabylake
+    case 0x8700: // Kabylake or Coffeelake
+    case 0x3E00: // Whiskeylake or Coffeelake
+    case 0x9B00: // Cometlake
+        return false;
+    case 0x8A00: // Icelake
+    case 0x4500: // Elkhartlake
+    case 0x4E00: // Jasperlake
+    case 0x9A00: // Tigerlake
+    case 0x4c00: // Rocketlake
+    case 0x4900: // DG1
+    case 0x4600: // Alderlake
+    case 0x4F00: // Alchemist
+    case 0x5600: // Alchemist
+    case 0xA700: // Raptorlake
+    case 0x7D00: // Arrowlake or Meteorlake
+    case 0xB600: // Arrowlake or Meteorlake
+    case 0x6400: // Lunarlake
+    case 0xE200: // Battlemage
+    case 0xB000: // Pantherlake
+        return true;
+    default:
+        break;
+    }
+
+    return false;
+}
+#endif
+
+static bool shouldAllowMSAAOnNewIntel()
+{
+#if USE(LIBDRM)
+    static std::once_flag onceFlag;
+    static bool allowMSAAOnNewIntel;
+    std::call_once(onceFlag, [] {
+        allowMSAAOnNewIntel = isNewIntelDevice();
+    });
+    return allowMSAAOnNewIntel;
+#else
+    return false;
+#endif
+}
+
+static unsigned initializeMSAASampleCount(GrDirectContext* grContext)
 {
     static std::once_flag onceFlag;
     static int sampleCount = s_defaultSampleCount;
@@ -148,7 +262,9 @@ private:
             return;
 
         // FIXME: add GrContextOptions, shader cache, etc.
-        if (auto grContext = GrDirectContexts::MakeGL(skiaGLInterface())) {
+        GrContextOptions options;
+        options.fAllowMSAAOnNewIntel = shouldAllowMSAAOnNewIntel();
+        if (auto grContext = GrDirectContexts::MakeGL(skiaGLInterface(), options)) {
             m_skiaGLContext = WTFMove(glContext);
             m_skiaGrContext = WTFMove(grContext);
             m_sampleCount = initializeMSAASampleCount(m_skiaGrContext.get());


### PR DESCRIPTION
#### 051a94b0bc868b5d04a3e8c78063fc9f0afe3359
<pre>
[GTK] Enable MSAA for GPU rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=301273">https://bugs.webkit.org/show_bug.cgi?id=301273</a>

Reviewed by Miguel Gomez

Only keep it disabled for old intel chips where MSAA performance is not
good enough. Also disable dynamic MSAA for other ports, since results
in embedded are not that good, but adding an env var so that it can be
enabled or disabled in any port.

Canonical link: <a href="https://commits.webkit.org/302289@main">https://commits.webkit.org/302289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c026371a7f54016ec7d5fb9f0b227dfe80f06cb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136011 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/764 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131571 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/78529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/33350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/79294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/33831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/138464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/717 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/138464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/764 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/111581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/138464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/30110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53071 "Failed to checkout and rebase branch from PR 53130") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20088 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/777 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64014 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/643 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->