### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for MediaKeySystemClient

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemClient.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemClient.h
@@ -26,16 +26,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class MediaKeySystemClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaKeySystemClient> : std::true_type { };
-}
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -43,10 +34,8 @@ class Document;
 class Page;
 class MediaKeySystemRequest;
 
-class MediaKeySystemClient : public CanMakeWeakPtr<MediaKeySystemClient> {
+class MediaKeySystemClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaKeySystemClient> {
 public:
-    virtual void pageDestroyed() = 0;
-
     virtual void requestMediaKeySystem(MediaKeySystemRequest&) = 0;
     virtual void cancelMediaKeySystemRequest(MediaKeySystemRequest&) = 0;
 
@@ -54,7 +43,7 @@ protected:
     virtual ~MediaKeySystemClient() = default;
 };
 
-WEBCORE_EXPORT void provideMediaKeySystemTo(Page&, MediaKeySystemClient&);
+WEBCORE_EXPORT void provideMediaKeySystemTo(Page&, Ref<MediaKeySystemClient>&&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
@@ -49,20 +49,16 @@ MediaKeySystemController* MediaKeySystemController::from(Page* page)
     return static_cast<MediaKeySystemController*>(Supplement<Page>::from(page, MediaKeySystemController::supplementName()));
 }
 
-MediaKeySystemController::MediaKeySystemController(MediaKeySystemClient& client)
-    : m_client(client)
+MediaKeySystemController::MediaKeySystemController(Ref<MediaKeySystemClient>&& client)
+    : m_client(WTFMove(client))
 {
 }
 
-MediaKeySystemController::~MediaKeySystemController()
-{
-    if (m_client)
-        m_client->pageDestroyed();
-}
+MediaKeySystemController::~MediaKeySystemController() = default;
 
-void provideMediaKeySystemTo(Page& page, MediaKeySystemClient& client)
+void provideMediaKeySystemTo(Page& page, Ref<MediaKeySystemClient>&& client)
 {
-    Supplement<Page>::provideTo(&page, MediaKeySystemController::supplementName(), makeUnique<MediaKeySystemController>(client));
+    Supplement<Page>::provideTo(&page, MediaKeySystemController::supplementName(), makeUnique<MediaKeySystemController>(WTFMove(client)));
 }
 
 void MediaKeySystemController::logRequestMediaKeySystemDenial(Document& document)

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.h
@@ -39,7 +39,7 @@ class MediaKeySystemController : public Supplement<Page> {
     WTF_MAKE_TZONE_ALLOCATED(MediaKeySystemController);
     WTF_MAKE_NONCOPYABLE(MediaKeySystemController);
 public:
-    explicit MediaKeySystemController(MediaKeySystemClient&);
+    explicit MediaKeySystemController(Ref<MediaKeySystemClient>&&);
     ~MediaKeySystemController();
 
     void requestMediaKeySystem(MediaKeySystemRequest&);
@@ -51,19 +51,17 @@ public:
     static MediaKeySystemController* from(Page*);
 
 private:
-    WeakPtr<MediaKeySystemClient> m_client;
+    const Ref<MediaKeySystemClient> m_client;
 };
 
 inline void MediaKeySystemController::requestMediaKeySystem(MediaKeySystemRequest& request)
 {
-    if (m_client)
-        m_client->requestMediaKeySystem(request);
+    m_client->requestMediaKeySystem(request);
 }
 
 inline void MediaKeySystemController::cancelMediaKeySystemRequest(MediaKeySystemRequest& request)
 {
-    if (m_client)
-        m_client->cancelMediaKeySystemRequest(request);
+    m_client->cancelMediaKeySystemRequest(request);
 }
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp
@@ -39,29 +39,26 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebMediaKeySystemClient);
 
+Ref<WebMediaKeySystemClient> WebMediaKeySystemClient::create(WebPage& page)
+{
+    return adoptRef(*new WebMediaKeySystemClient(page));
+}
+
 WebMediaKeySystemClient::WebMediaKeySystemClient(WebPage& page)
     : m_page(page)
 {
 }
 
-void WebMediaKeySystemClient::pageDestroyed()
-{
-    delete this;
-}
-
-Ref<WebPage> WebMediaKeySystemClient::protectedPage() const
-{
-    return m_page.get();
-}
-
 void WebMediaKeySystemClient::requestMediaKeySystem(MediaKeySystemRequest& request)
 {
-    protectedPage()->mediaKeySystemPermissionRequestManager().startMediaKeySystemRequest(request);
+    if (RefPtr page = m_page.get())
+        page->mediaKeySystemPermissionRequestManager().startMediaKeySystemRequest(request);
 }
 
 void WebMediaKeySystemClient::cancelMediaKeySystemRequest(MediaKeySystemRequest& request)
 {
-    protectedPage()->mediaKeySystemPermissionRequestManager().cancelMediaKeySystemRequest(request);
+    if (RefPtr page = m_page.get())
+        page->mediaKeySystemPermissionRequestManager().cancelMediaKeySystemRequest(request);
 }
 
 } // namespace WebKit;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h
@@ -28,26 +28,28 @@
 #if ENABLE(ENCRYPTED_MEDIA)
 
 #include <WebCore/MediaKeySystemClient.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
-class WebMediaKeySystemClient final : public WebCore::MediaKeySystemClient {
+class WebMediaKeySystemClient final : public WebCore::MediaKeySystemClient, public RefCounted<WebMediaKeySystemClient> {
     WTF_MAKE_TZONE_ALLOCATED(WebMediaKeySystemClient);
 public:
-    WebMediaKeySystemClient(WebPage&);
+    static Ref<WebMediaKeySystemClient> create(WebPage&);
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
-    void pageDestroyed() final;
+    explicit WebMediaKeySystemClient(WebPage&);
 
     void requestMediaKeySystem(WebCore::MediaKeySystemRequest&) final;
     void cancelMediaKeySystemRequest(WebCore::MediaKeySystemRequest&) final;
 
-    Ref<WebPage> protectedPage() const;
-
-    WeakRef<WebPage> m_page;
+    WeakPtr<WebPage> m_page;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1026,7 +1026,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     WebCore::provideUserMediaTo(page.ptr(), WebUserMediaClient::create(*this));
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
-    WebCore::provideMediaKeySystemTo(page, *new WebMediaKeySystemClient(*this));
+    WebCore::provideMediaKeySystemTo(page, WebMediaKeySystemClient::create(*this));
 #endif
 
     page->setControlledByAutomation(parameters.controlledByAutomation);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.h
@@ -33,11 +33,13 @@ class WebMediaKeySystemClient final : public WebCore::MediaKeySystemClient {
 public:
     static WebMediaKeySystemClient& singleton();
 
+    // Do nothing since this is a singleton object.
+    void ref() const final { }
+    void deref() const final { }
+
 private:
     friend NeverDestroyed<WebMediaKeySystemClient>;
     WebMediaKeySystemClient() = default;
-
-    void pageDestroyed() override { }
 
     void requestMediaKeySystem(WebCore::MediaKeySystemRequest&) override;
     void cancelMediaKeySystemRequest(WebCore::MediaKeySystemRequest&) override { }


### PR DESCRIPTION
#### a41d7a759282b3468bdcb5f7b094b0561c7bcbfd
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for MediaKeySystemClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=301617">https://bugs.webkit.org/show_bug.cgi?id=301617</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/encryptedmedia/MediaKeySystemClient.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp:
(WebCore::MediaKeySystemController::MediaKeySystemController):
(WebCore::provideMediaKeySystemTo):
(WebCore::MediaKeySystemController::~MediaKeySystemController): Deleted.
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.h:
(WebCore::MediaKeySystemController::requestMediaKeySystem):
(WebCore::MediaKeySystemController::cancelMediaKeySystemRequest):
* Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp:
(WebKit::WebMediaKeySystemClient::create):
(WebKit::WebMediaKeySystemClient::WebMediaKeySystemClient):
(WebKit::WebMediaKeySystemClient::requestMediaKeySystem):
(WebKit::WebMediaKeySystemClient::cancelMediaKeySystemRequest):
(WebKit::WebMediaKeySystemClient::pageDestroyed): Deleted.
(WebKit::WebMediaKeySystemClient::protectedPage const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_toolbarsAreVisible):
* Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.h:

Canonical link: <a href="https://commits.webkit.org/302327@main">https://commits.webkit.org/302327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d992dd6759ecff9d98c942186e10a7e66d7f7ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136004 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80021 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c441c4f0-7e76-4014-be79-a2d15dda4aa5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97908 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65821 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c7a356b9-5029-42f5-b800-77ef3a18f932) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115234 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78525 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8ab562d5-b57c-4823-b534-84c1e675b1c3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33343 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79287 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138457 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106444 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106268 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27080 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/599 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30103 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53064 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/770 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64006 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/637 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/694 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/720 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->