### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for MediaSessionCoordinatorClient

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinatorPrivate.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinatorPrivate.h
@@ -32,17 +32,9 @@
 #include <WebCore/MediaSessionCoordinatorState.h>
 #include <WebCore/MediaSessionPlaybackState.h>
 #include <WebCore/MediaSessionReadyState.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class MediaSessionCoordinatorClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaSessionCoordinatorClient> : std::true_type { };
-}
 
 namespace WTF {
 class Logger;
@@ -50,7 +42,7 @@ class Logger;
 
 namespace WebCore {
 
-class MediaSessionCoordinatorClient : public CanMakeWeakPtr<MediaSessionCoordinatorClient> {
+class MediaSessionCoordinatorClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaSessionCoordinatorClient> {
 public:
     virtual ~MediaSessionCoordinatorClient() = default;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -745,6 +745,9 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
         USING_CAN_MAKE_WEAKPTR(WebCore::MediaSessionCoordinatorClient);
 
+        void ref() const final { WebKit::MediaSessionCoordinatorProxyPrivate::ref(); }
+        void deref() const final { WebKit::MediaSessionCoordinatorProxyPrivate::deref(); }
+
     private:
         explicit WKMediaSessionCoordinatorForTesting(id <_WKMediaSessionCoordinator> clientCoordinator)
             : WebKit::MediaSessionCoordinatorProxyPrivate()
@@ -756,7 +759,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
         void seekSessionToTime(double time, CompletionHandler<void(bool)>&& callback) final
         {
-            if (auto coordinatorClient = client())
+            if (RefPtr coordinatorClient = client())
                 coordinatorClient->seekSessionToTime(time, WTFMove(callback));
             else
                 callback(false);
@@ -764,7 +767,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
         void playSession(std::optional<double> atTime, std::optional<MonotonicTime> hostTime, CompletionHandler<void(bool)>&& callback) final
         {
-            if (auto coordinatorClient = client())
+            if (RefPtr coordinatorClient = client())
                 coordinatorClient->playSession(WTFMove(atTime), WTFMove(hostTime), WTFMove(callback));
             else
                 callback(false);
@@ -772,7 +775,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
         void pauseSession(CompletionHandler<void(bool)>&& callback) final
         {
-            if (auto coordinatorClient = client())
+            if (RefPtr coordinatorClient = client())
                 coordinatorClient->pauseSession(WTFMove(callback));
             else
                 callback(false);
@@ -780,7 +783,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
         void setSessionTrack(const String& trackIdentifier, CompletionHandler<void(bool)>&& callback) final
         {
-            if (auto coordinatorClient = client())
+            if (RefPtr coordinatorClient = client())
                 coordinatorClient->setSessionTrack(trackIdentifier, WTFMove(callback));
             else
                 callback(false);
@@ -788,7 +791,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
         void coordinatorStateChanged(WebCore::MediaSessionCoordinatorState state) final
         {
-            if (auto coordinatorClient = client())
+            if (RefPtr coordinatorClient = client())
                 coordinatorClient->coordinatorStateChanged(state);
         }
 
@@ -1161,22 +1164,22 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (void)seekSessionToTime:(double)time withCompletion:(void(^)(BOOL))completionHandler
 {
-    m_coordinatorClient->seekSessionToTime(time, makeBlockPtr(completionHandler));
+    Ref { *m_coordinatorClient }->seekSessionToTime(time, makeBlockPtr(completionHandler));
 }
 
 - (void)playSessionWithCompletion:(void(^)(BOOL))completionHandler
 {
-    m_coordinatorClient->playSession({ }, std::optional<MonotonicTime>(), makeBlockPtr(completionHandler));
+    Ref { *m_coordinatorClient }->playSession({ }, std::optional<MonotonicTime>(), makeBlockPtr(completionHandler));
 }
 
 - (void)pauseSessionWithCompletion:(void(^)(BOOL))completionHandler
 {
-    m_coordinatorClient->pauseSession(makeBlockPtr(completionHandler));
+    Ref { *m_coordinatorClient }->pauseSession(makeBlockPtr(completionHandler));
 }
 
 - (void)setSessionTrack:(NSString*)trackIdentifier withCompletion:(void(^)(BOOL))completionHandler
 {
-    m_coordinatorClient->setSessionTrack(trackIdentifier, makeBlockPtr(completionHandler));
+    Ref { *m_coordinatorClient }->setSessionTrack(trackIdentifier, makeBlockPtr(completionHandler));
 }
 
 - (void)coordinatorStateChanged:(_WKMediaSessionCoordinatorState)state
@@ -1185,7 +1188,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     static_assert(static_cast<size_t>(WebCore::MediaSessionCoordinatorState::Joined) == static_cast<size_t>(WKMediaSessionCoordinatorStateJoined), "WKMediaSessionCoordinatorStateJoined does not match WebKit value");
     static_assert(static_cast<size_t>(WebCore::MediaSessionCoordinatorState::Closed) == static_cast<size_t>(WKMediaSessionCoordinatorStateClosed), "WKMediaSessionCoordinatorStateClosed does not match WebKit value");
 
-    m_coordinatorClient->coordinatorStateChanged(static_cast<WebCore::MediaSessionCoordinatorState>(state));
+    Ref { *m_coordinatorClient }->coordinatorStateChanged(static_cast<WebCore::MediaSessionCoordinatorState>(state));
 }
 
 @end

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
@@ -152,13 +152,14 @@ GroupActivitiesCoordinator::~GroupActivitiesCoordinator()
 
 void GroupActivitiesCoordinator::sessionStateChanged(const GroupActivitiesSession& session, GroupActivitiesSession::State state)
 {
-    if (!client())
+    RefPtr client = this->client();
+    if (!client)
         return;
 
     static_assert(static_cast<size_t>(MediaSessionCoordinatorState::Waiting) == static_cast<size_t>(GroupActivitiesSession::State::Waiting), "MediaSessionCoordinatorState::Waiting != WKGroupSessionStateWaiting");
     static_assert(static_cast<size_t>(MediaSessionCoordinatorState::Joined) == static_cast<size_t>(GroupActivitiesSession::State::Joined), "MediaSessionCoordinatorState::Joined != WKGroupSessionStateJoined");
     static_assert(static_cast<size_t>(MediaSessionCoordinatorState::Closed) == static_cast<size_t>(GroupActivitiesSession::State::Invalidated), "MediaSessionCoordinatorState::Closed != WKGroupSessionStateInvalidated");
-    client()->coordinatorStateChanged(static_cast<MediaSessionCoordinatorState>(state));
+    client->coordinatorStateChanged(static_cast<MediaSessionCoordinatorState>(state));
 }
 
 String GroupActivitiesCoordinator::identifier() const
@@ -229,7 +230,8 @@ void GroupActivitiesCoordinator::trackIdentifierChanged(const String& identifier
 
 void GroupActivitiesCoordinator::issuePlayCommand(AVDelegatingPlaybackCoordinatorPlayCommand *playCommand, CommandCompletionHandler&& callback)
 {
-    if (!client()) {
+    RefPtr client = this->client();
+    if (!client) {
         callback();
         return;
     }
@@ -241,26 +243,28 @@ void GroupActivitiesCoordinator::issuePlayCommand(AVDelegatingPlaybackCoordinato
     if (CMTIME_IS_NUMERIC(playCommand.hostClockTime))
         hostTime = MonotonicTime::fromMachAbsoluteTime(PAL::CMClockConvertHostTimeToSystemUnits(playCommand.hostClockTime));
 
-    client()->playSession(itemTime, hostTime, [callback = WTFMove(callback)] (bool) {
+    client->playSession(itemTime, hostTime, [callback = WTFMove(callback)] (bool) {
         callback();
     });
 }
 
 void GroupActivitiesCoordinator::issuePauseCommand(AVDelegatingPlaybackCoordinatorPauseCommand *pauseCommand, CommandCompletionHandler&& callback)
 {
-    if (!client()) {
+    RefPtr client = this->client();
+    if (!client) {
         callback();
         return;
     }
 
-    client()->pauseSession([callback = WTFMove(callback)] (bool) {
+    client->pauseSession([callback = WTFMove(callback)] (bool) {
         callback();
     });
 }
 
 void GroupActivitiesCoordinator::issueSeekCommand(AVDelegatingPlaybackCoordinatorSeekCommand *seekCommand, CommandCompletionHandler&& callback)
 {
-    if (!client()) {
+    RefPtr client = this->client();
+    if (!client) {
         callback();
         return;
     }
@@ -271,7 +275,7 @@ void GroupActivitiesCoordinator::issueSeekCommand(AVDelegatingPlaybackCoordinato
         return;
     }
 
-    client()->seekSessionToTime(PAL::CMTimeGetSeconds(seekCommand.itemTime), [callback = WTFMove(callback)] (bool) mutable {
+    client->seekSessionToTime(PAL::CMTimeGetSeconds(seekCommand.itemTime), [callback = WTFMove(callback)] (bool) mutable {
         callback();
     });
 }

--- a/Source/WebKit/UIProcess/Media/MediaSessionCoordinatorProxyPrivate.h
+++ b/Source/WebKit/UIProcess/Media/MediaSessionCoordinatorProxyPrivate.h
@@ -65,7 +65,7 @@ public:
 protected:
     explicit MediaSessionCoordinatorProxyPrivate() = default;
 
-    WeakPtr<WebCore::MediaSessionCoordinatorClient> client() const { return m_client; }
+    WebCore::MediaSessionCoordinatorClient* client() const { return m_client.get(); }
 
 private:
     WeakPtr<WebCore::MediaSessionCoordinatorClient> m_client;


### PR DESCRIPTION
#### ae1cc766a3fbc16e36b0080618e6405bb70f02c1
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for MediaSessionCoordinatorClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=301618">https://bugs.webkit.org/show_bug.cgi?id=301618</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/mediasession/MediaSessionCoordinatorPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _createMediaSessionCoordinatorForTesting:completionHandler:]):
(-[WKMediaSessionCoordinatorHelper seekSessionToTime:withCompletion:]):
(-[WKMediaSessionCoordinatorHelper playSessionWithCompletion:]):
(-[WKMediaSessionCoordinatorHelper pauseSessionWithCompletion:]):
(-[WKMediaSessionCoordinatorHelper setSessionTrack:withCompletion:]):
(-[WKMediaSessionCoordinatorHelper coordinatorStateChanged:]):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm:
(WebKit::GroupActivitiesCoordinator::sessionStateChanged):
(WebKit::GroupActivitiesCoordinator::issuePlayCommand):
(WebKit::GroupActivitiesCoordinator::issuePauseCommand):
(WebKit::GroupActivitiesCoordinator::issueSeekCommand):
* Source/WebKit/UIProcess/Media/MediaSessionCoordinatorProxyPrivate.h:
(WebKit::MediaSessionCoordinatorProxyPrivate::client const):

Canonical link: <a href="https://commits.webkit.org/302329@main">https://commits.webkit.org/302329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3739dcd03800e5cbbfdbd56252cd92ec2d0d452e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136139 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80135 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aae86a29-67e3-431b-bc91-90a0be229017) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98019 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3e52edcd-63e4-43f5-9a6a-f75e4f788c37) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78627 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/94853bf7-2501-4dd0-9b75-bda00a6b8621) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33456 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79418 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109089 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138598 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106559 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106367 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27085 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/678 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53244 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/900 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64188 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/751 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/807 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/842 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->