### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for RTCIceTransportBackendClient

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCIceTransportBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransportBackend.h
@@ -28,22 +28,13 @@
 
 #include "RTCIceGatheringState.h"
 #include "RTCIceTransportState.h"
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class RTCIceTransportBackendClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::RTCIceTransportBackendClient> : std::true_type { };
-}
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
 class RTCIceCandidate;
 
-class RTCIceTransportBackendClient : public CanMakeWeakPtr<RTCIceTransportBackendClient> {
+class RTCIceTransportBackendClient : public AbstractRefCountedAndCanMakeWeakPtr<RTCIceTransportBackendClient> {
 public:
     virtual ~RTCIceTransportBackendClient() = default;
     virtual void onStateChanged(RTCIceTransportState) = 0;


### PR DESCRIPTION
#### f64f6840f2d5b0f631f6baa8d6d2366ff4755370
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for RTCIceTransportBackendClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=301620">https://bugs.webkit.org/show_bug.cgi?id=301620</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/mediastream/RTCIceTransportBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp:
(WebCore::LibWebRTCIceTransportBackendObserver::start):
(WebCore::LibWebRTCIceTransportBackendObserver::onIceTransportStateChanged):
(WebCore::LibWebRTCIceTransportBackendObserver::onGatheringStateChanged):
(WebCore::LibWebRTCIceTransportBackendObserver::processSelectedCandidatePairChanged):

Canonical link: <a href="https://commits.webkit.org/302326@main">https://commits.webkit.org/302326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/359f34a55f838f61227680a51789fcebb73f1edc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80025 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d4fcc25e-1fac-4a51-8c9b-124fcbad1908) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97914 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65836 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/41f9c8ff-4411-446a-80be-262138b2b994) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115239 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78531 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/553 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33348 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79292 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138462 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106449 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106272 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27081 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/602 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30108 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53069 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/775 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64019 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/641 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/699 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->