### PR TITLE
[GLib] Make IconDatabase handle multiple per-page icons

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.h
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.h
@@ -24,6 +24,7 @@
 #include <WebCore/SQLiteStatement.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
+#include <wtf/ListHashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WorkQueue.h>
@@ -44,8 +45,8 @@ public:
     void invalidate();
 
     void checkIconURLAndSetPageURLIfNeeded(const String& iconURL, const String& pageURL, AllowDatabaseWrite, CompletionHandler<void(bool, bool)>&&);
-    void loadIconForPageURL(const String&, AllowDatabaseWrite, CompletionHandler<void(WebCore::PlatformImagePtr&&)>&&);
-    String iconURLForPageURL(const String&);
+    void loadIconsForPageURL(const String&, AllowDatabaseWrite, CompletionHandler<void(Vector<WebCore::PlatformImagePtr>&&)>&&);
+    ListHashSet<String> iconURLsForPageURL(const String&);
     void setIconForPageURL(const String& iconURL, std::span<const uint8_t>, const String& pageURL, AllowDatabaseWrite, CompletionHandler<void(bool)>&&);
     void clear(CompletionHandler<void()>&&);
 
@@ -53,7 +54,7 @@ private:
     IconDatabase(const String&, AllowDatabaseWrite);
 
     bool createTablesIfNeeded();
-    void populatePageURLToIconURLMap();
+    void populatePageURLToIconURLsMap();
     void pruneTimerFired();
     void startPruneTimer();
     void clearStatements();
@@ -69,7 +70,7 @@ private:
     Ref<WorkQueue> m_workQueue;
     AllowDatabaseWrite m_allowDatabaseWrite { AllowDatabaseWrite::Yes };
     WebCore::SQLiteDatabase m_db;
-    HashMap<String, String> m_pageURLToIconURLMap;
+    HashMap<String, ListHashSet<String>> m_pageURLToIconURLMap;
     Lock m_pageURLToIconURLMapLock;
     HashMap<String, std::pair<WebCore::PlatformImagePtr, MonotonicTime>> m_loadedIcons WTF_GUARDED_BY_LOCK(m_loadedIconsLock);
     Lock m_loadedIconsLock;


### PR DESCRIPTION
#### a388e15a572556156249eb1b97bcdf34327fe43b
<pre>
[GLib] Make IconDatabase handle multiple per-page icons
<a href="https://bugs.webkit.org/show_bug.cgi?id=301088">https://bugs.webkit.org/show_bug.cgi?id=301088</a>

Reviewed by Carlos Garcia Campos.

The existing database schema was already able to store multiple icons
per page URL, so it was left unchanged. The pageURL-&gt;iconURL map was
being filled with the icon from the last row read from the database. The
main change was having the map use a ListHashSet to store the multiple
icon URLs for each page, then apply the needed edits in the rest of the
code that touches it to accomodate the change. Using a ListHashSet
allows keeping the order in which icon URLs were loaded from the
database to make WebKitFaviconDatabase take the last one, thus
preserving previous behaviour (for now).

* Source/WebKit/UIProcess/API/glib/IconDatabase.cpp:
(WebKit::IconDatabase::IconDatabase):
(WebKit::IconDatabase::populatePageURLToIconURLsMap): Load all fetched
rows from the database into the map.
(WebKit::IconDatabase::pruneTimerFired): Fix typo FaviconDatabse typo
in logging statement.
(WebKit::IconDatabase::iconIDForIconURL): Ditto.
(WebKit::IconDatabase::setIconIDForPageURL):
(WebKit::IconDatabase::iconData):
(WebKit::IconDatabase::addIcon):
(WebKit::IconDatabase::updateIconTimestamp):
(WebKit::IconDatabase::deleteIcon):
(WebKit::IconDatabase::checkIconURLAndSetPageURLIfNeeded): Accomodate
to handle multiple URLs in the pageURL-&gt;iconURLs map.
(WebKit::IconDatabase::loadIconsForPageURL): Accomodate to load the
data for all the icons associated with the given pageURL.
(WebKit::IconDatabase::iconURLsForPageURL): Accomodate to handle
multiple URLs in the pageURL-&gt;iconURLs map.
(WebKit::IconDatabase::setIconForPageURL):
(WebKit::IconDatabase::populatePageURLToIconURLMap): Renamed to
populatePageURLToIconURLsMap.
(WebKit::IconDatabase::loadIconForPageURL): Renamed to
loadIconsForPageURL.
(WebKit::IconDatabase::iconURLForPageURL): Renamed to
iconURLsForPageURL.
* Source/WebKit/UIProcess/API/glib/IconDatabase.h: Use a ListHashSet
to store the pageURL-&gt;iconURLs map.
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(webkitFaviconDatabaseGetFaviconInternal): Now that the IconDatabase
returns multiple icons for a page URL, pick and return only the last
one, to preserve existing behaviour.
(webkit_favicon_database_get_favicon_uri): Ditto.

Canonical link: <a href="https://commits.webkit.org/302307@main">https://commits.webkit.org/302307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0f76fdf7a969453ebb6ff68d46262e1eb44d397

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136051 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80064 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97944 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65863 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115272 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78562 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/583 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79332 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138506 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106479 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106302 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27076 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/633 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30141 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53134 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/816 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64071 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/680 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/735 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->