### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for RTCDtlsTransportBackendClient

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransportBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransportBackend.h
@@ -27,16 +27,8 @@
 #if ENABLE(WEB_RTC)
 
 #include "RTCDtlsTransportState.h"
-#include <wtf/WeakPtr.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
-namespace WebCore {
-class RTCDtlsTransportBackendClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::RTCDtlsTransportBackendClient> : std::true_type { };
-}
 namespace JSC {
 class ArrayBuffer;
 }
@@ -45,7 +37,7 @@ namespace WebCore {
 
 class RTCIceTransportBackend;
 
-class RTCDtlsTransportBackendClient : public CanMakeWeakPtr<RTCDtlsTransportBackendClient> {
+class RTCDtlsTransportBackendClient : public AbstractRefCountedAndCanMakeWeakPtr<RTCDtlsTransportBackendClient> {
 public:
     virtual ~RTCDtlsTransportBackendClient() = default;
     virtual void onStateChanged(RTCDtlsTransportState, Vector<Ref<JSC::ArrayBuffer>>&&) = 0;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.cpp
@@ -82,7 +82,8 @@ LibWebRTCDtlsTransportBackendObserver::LibWebRTCDtlsTransportBackendObserver(RTC
 
 void LibWebRTCDtlsTransportBackendObserver::updateState(webrtc::DtlsTransportInformation&& info)
 {
-    if (!m_client)
+    RefPtr client = m_client.get();
+    if (!client)
         return;
 
     Vector<webrtc::Buffer> certificates;
@@ -93,7 +94,7 @@ void LibWebRTCDtlsTransportBackendObserver::updateState(webrtc::DtlsTransportInf
             certificates.append(WTFMove(certificate));
         }
     }
-    m_client->onStateChanged(toRTCDtlsTransportState(info.state()), map(certificates, [](auto& certificate) -> Ref<JSC::ArrayBuffer> {
+    client->onStateChanged(toRTCDtlsTransportState(info.state()), map(certificates, [](auto& certificate) -> Ref<JSC::ArrayBuffer> {
         return JSC::ArrayBuffer::create(certificate);
     }));
 }
@@ -126,8 +127,8 @@ void LibWebRTCDtlsTransportBackendObserver::OnStateChange(webrtc::DtlsTransportI
 void LibWebRTCDtlsTransportBackendObserver::OnError(webrtc::RTCError)
 {
     callOnMainThread([protectedThis = Ref { *this }] {
-        if (protectedThis->m_client)
-            protectedThis->m_client->onError();
+        if (RefPtr client = protectedThis->m_client.get())
+            client->onError();
     });
 }
 


### PR DESCRIPTION
#### c6341ce649dc8b214d99ff893938d82b9eecad58
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for RTCDtlsTransportBackendClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=301622">https://bugs.webkit.org/show_bug.cgi?id=301622</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/mediastream/RTCDtlsTransportBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.cpp:
(WebCore::LibWebRTCDtlsTransportBackendObserver::updateState):
(WebCore::LibWebRTCDtlsTransportBackendObserver::OnError):

Canonical link: <a href="https://commits.webkit.org/302325@main">https://commits.webkit.org/302325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d0a61195b888d0bb451c1c025b9547417c0c6dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80033 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97918 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65831 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78535 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33353 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79300 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138470 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106453 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/770 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106276 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27082 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/612 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30113 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53079 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/783 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64023 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/649 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/732 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->