### PR TITLE
[GTK][WPE] Add rendering and buffer formats information to webkit://gpu

### DIFF
--- a/Source/WebKit/Shared/glib/RenderProcessInfo.h
+++ b/Source/WebKit/Shared/glib/RenderProcessInfo.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "RendererBufferFormat.h"
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -40,6 +41,10 @@ struct RenderProcessInfo {
     String eglVersion;
     String eglVendor;
     String eglExtensions;
+    unsigned cpuPaintingThreadsCount { 0 };
+    unsigned gpuPaintingThreadsCount { 0 };
+    unsigned msaaSampleCount { 0 };
+    Vector<RendererBufferFormat::Format> supportedBufferFormats;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/glib/RenderProcessInfo.serialization.in
+++ b/Source/WebKit/Shared/glib/RenderProcessInfo.serialization.in
@@ -31,4 +31,8 @@ struct WebKit::RenderProcessInfo {
     String eglVersion;
     String eglVendor;
     String eglExtensions;
+    unsigned cpuPaintingThreadsCount;
+    unsigned gpuPaintingThreadsCount;
+    unsigned msaaSampleCount;
+    Vector<WebKit::RendererBufferFormat::Format> supportedBufferFormats;
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2837,6 +2837,10 @@ public:
     bool toolbarsAreVisible() const { return m_toolbarsAreVisible; }
     void setToolbarsAreVisible(bool);
 
+#if USE(GBM) && (PLATFORM(GTK) || PLATFORM(WPE))
+    Vector<RendererBufferFormat> preferredBufferFormats() const;
+#endif
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
@@ -3089,9 +3093,6 @@ private:
 #if PLATFORM(GTK) || PLATFORM(WPE)
     void bindAccessibilityTree(const String&);
     OptionSet<WebCore::PlatformEventModifier> currentStateOfModifierKeys();
-#if USE(GBM)
-    Vector<RendererBufferFormat> preferredBufferFormats() const;
-#endif
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -32,6 +32,7 @@
 #if USE(COORDINATED_GRAPHICS)
 #include "CoordinatedSceneState.h"
 #include "DrawingArea.h"
+#include "RenderProcessInfo.h"
 #include "WebPageInlines.h"
 #include "WebPageProxyMessages.h"
 #include "WebProcess.h"
@@ -619,6 +620,10 @@ void LayerTreeHost::foreachRegionInDamageHistoryForTesting(Function<void(const R
 
 void LayerTreeHost::fillGLInformation(RenderProcessInfo&& info, CompletionHandler<void(RenderProcessInfo&&)>&& completionHandler)
 {
+#if USE(SKIA)
+    info.cpuPaintingThreadsCount = SkiaPaintingEngine::numberOfCPUPaintingThreads();
+    info.gpuPaintingThreadsCount = SkiaPaintingEngine::numberOfGPUPaintingThreads();
+#endif
     m_compositor->fillGLInformation(WTFMove(info), WTFMove(completionHandler));
 }
 

--- a/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
@@ -287,6 +287,16 @@ void WebPage::getRenderProcessInfo(CompletionHandler<void(RenderProcessInfo&&)>&
         break;
     }
 
+#if USE(SKIA)
+    info.msaaSampleCount = display->msaaSampleCount();
+#endif
+
+    if (info.platform != "WPE"_s) {
+        info.supportedBufferFormats = display->bufferFormats().map([](const auto& format) -> RendererBufferFormat::Format {
+            return { format.fourcc.value, format.modifiers };
+        });
+    }
+
     static_cast<DrawingAreaCoordinatedGraphics*>(m_drawingArea.get())->fillGLInformation(WTFMove(info), WTFMove(completionHandler));
 }
 


### PR DESCRIPTION
#### e36b742a17b74dd86287584684457d32e4dcf332
<pre>
[GTK][WPE] Add rendering and buffer formats information to webkit://gpu
<a href="https://bugs.webkit.org/show_bug.cgi?id=301623">https://bugs.webkit.org/show_bug.cgi?id=301623</a>

Reviewed by Adrian Perez de Castro.

Add information about threaded rendering, MSAA, preferred buffer formats
and supported buffer formats. This patch laso fixes the JSON output
that I broke in 302185@main.

Canonical link: <a href="https://commits.webkit.org/302293@main">https://commits.webkit.org/302293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f3682267d4fe0142b7ca1fac962f0c0b8f3fea8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136033 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80047 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97931 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65845 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78550 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/127995 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/571 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79314 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138486 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/738 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/702 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106467 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106290 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/622 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30130 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53105 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20091 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/798 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64044 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/664 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/747 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->