### PR TITLE
Move CoreIPCError away from using an opaque Dictionary to serialize properties

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.h
@@ -28,6 +28,7 @@
 #if PLATFORM(COCOA)
 
 #import <CoreFoundation/CoreFoundation.h>
+#import <wtf/ArgumentCoder.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/text/WTFString.h>
 
@@ -38,49 +39,66 @@ namespace WebKit {
 class CoreIPCError {
     WTF_MAKE_TZONE_ALLOCATED(CoreIPCError);
 public:
-    static bool hasValidUserInfo(const RetainPtr<CFDictionaryRef>&);
-
     CoreIPCError(CoreIPCError&&) = default;
     CoreIPCError& operator=(CoreIPCError&&) = default;
 
     CoreIPCError(NSError *);
-    CoreIPCError(String&& domain, int64_t code, RetainPtr<CFDictionaryRef>&& userInfo, std::unique_ptr<CoreIPCError>&& underlyingError)
+    CoreIPCError(String&& domain, int64_t code, std::unique_ptr<CoreIPCError>&& underlyingError, std::optional<Vector<RetainPtr<SecCertificateRef>>>&& clientCertificateChain, std::optional<Vector<RetainPtr<SecCertificateRef>>>&& peerCertificateChain, String&& localizedDescription, String&& localizedFailureReasonError, String&& localizedRecoverySuggestionError, std::optional<Vector<String>>&& localizedRecoveryOptionsError, String&& localizedFailureError, String&& helpAnchorError, String&& debugDescriptionError, RetainPtr<NSNumber>&& stringEncodingError, RetainPtr<SecTrustRef>&& failingURLPeerTrustError, RetainPtr<NSURL>&& urlError, RetainPtr<NSURL>&& failingURLError, String&& filePathError, String&& networkTaskDescription, String&& networkTaskMetricsPrivacyStance, String&& description)
         : m_domain(WTFMove(domain))
         , m_code(WTFMove(code))
-        , m_userInfo(WTFMove(userInfo))
         , m_underlyingError(WTFMove(underlyingError))
+        , m_clientCertificateChain(WTFMove(clientCertificateChain))
+        , m_peerCertificateChain(WTFMove(peerCertificateChain))
+        , m_localizedDescription(WTFMove(localizedDescription))
+        , m_localizedFailureReasonError(WTFMove(localizedFailureReasonError))
+        , m_localizedRecoverySuggestionError(WTFMove(localizedRecoverySuggestionError))
+        , m_localizedRecoveryOptionsError(WTFMove(localizedRecoveryOptionsError))
+        , m_localizedFailureError(WTFMove(localizedFailureError))
+        , m_helpAnchorError(WTFMove(helpAnchorError))
+        , m_debugDescriptionError(WTFMove(debugDescriptionError))
+        , m_stringEncodingError(WTFMove(stringEncodingError))
+        , m_failingURLPeerTrustError(WTFMove(failingURLPeerTrustError))
+        , m_urlError(WTFMove(urlError))
+        , m_failingURLError(WTFMove(failingURLError))
+        , m_filePathError(WTFMove(filePathError))
+        , m_networkTaskDescription(WTFMove(networkTaskDescription))
+        , m_networkTaskMetricsPrivacyStance(WTFMove(networkTaskMetricsPrivacyStance))
+        , m_description(WTFMove(description))
     {
     }
 
     RetainPtr<id> toID() const;
 
-    String domain() const
-    {
-        return m_domain;
-    }
-
-    int64_t code() const
-    {
-        return m_code;
-    }
-
-    RetainPtr<CFDictionaryRef> userInfo() const
-    {
-        return m_userInfo;
-    }
-
-    const std::unique_ptr<CoreIPCError>& underlyingError() const
-    {
-        return m_underlyingError;
-    }
-
 private:
-    bool isSafeToEncodeUserInfo(id value);
+    friend struct IPC::ArgumentCoder<CoreIPCError>;
 
     String m_domain;
     int64_t m_code;
-    RetainPtr<CFDictionaryRef> m_userInfo;
     std::unique_ptr<CoreIPCError> m_underlyingError;
+
+    std::optional<Vector<RetainPtr<SecCertificateRef>>> m_clientCertificateChain;
+    std::optional<Vector<RetainPtr<SecCertificateRef>>> m_peerCertificateChain;
+    String m_localizedDescription;
+    String m_localizedFailureReasonError;
+    String m_localizedRecoverySuggestionError;
+    std::optional<Vector<String>> m_localizedRecoveryOptionsError;
+    String m_localizedFailureError;
+
+    String m_helpAnchorError;
+    String m_debugDescriptionError;
+
+    RetainPtr<NSNumber> m_stringEncodingError;
+
+    RetainPtr<SecTrustRef> m_failingURLPeerTrustError;
+    RetainPtr<NSURL> m_urlError;
+    RetainPtr<NSURL> m_failingURLError;
+
+    String m_filePathError;
+
+    String m_networkTaskDescription;
+    String m_networkTaskMetricsPrivacyStance;
+
+    String m_description;
 };
 
 }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.serialization.in
@@ -24,11 +24,35 @@
 
 webkit_platform_headers: "CoreIPCError.h"
 
-[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCError {
-    String domain();
-    int64_t code();
-    [Validator='WebKit::CoreIPCError::hasValidUserInfo(*userInfo)'] RetainPtr<CFDictionaryRef> userInfo();
-    std::unique_ptr<WebKit::CoreIPCError> underlyingError();
+[WebKitPlatform] class WebKit::CoreIPCError {
+    String m_domain;
+    int64_t m_code;
+    std::unique_ptr<WebKit::CoreIPCError> m_underlyingError;
+
+    std::optional<Vector<RetainPtr<SecCertificateRef>>> m_clientCertificateChain;
+    std::optional<Vector<RetainPtr<SecCertificateRef>>> m_peerCertificateChain;
+
+    String m_localizedDescription;
+    String m_localizedFailureReasonError;
+    String m_localizedRecoverySuggestionError;
+    std::optional<Vector<String>> m_localizedRecoveryOptionsError;
+    String m_localizedFailureError;
+
+    String m_helpAnchorError;
+    String m_debugDescriptionError;
+
+    RetainPtr<NSNumber> m_stringEncodingError;
+
+    RetainPtr<SecTrustRef> m_failingURLPeerTrustError;
+    RetainPtr<NSURL> m_urlError;
+    RetainPtr<NSURL> m_failingURLError;
+
+    String m_filePathError;
+    
+    String m_networkTaskDescription;
+    String m_networkTaskMetricsPrivacyStance;
+
+    String m_description;
 }
 
 #endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### cbba5e3542f52dcad12f6f2d849b4ae0e217ba7b
<pre>
Move CoreIPCError away from using an opaque Dictionary to serialize properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=301576">https://bugs.webkit.org/show_bug.cgi?id=301576</a>
<a href="https://rdar.apple.com/163640507">rdar://163640507</a>

Reviewed by Alex Christensen.

Moves CoreIPCError away from using opaque dictionaries to serialized properties.
Instead, we break all critical properties out into explicitly typed fields.

* Source/WebKit/Shared/Cocoa/CoreIPCError.h:
(WebKit::CoreIPCError::CoreIPCError):
(WebKit::CoreIPCError::domain const): Deleted.
(WebKit::CoreIPCError::code const): Deleted.
(WebKit::CoreIPCError::userInfo const): Deleted.
(WebKit::CoreIPCError::underlyingError const): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCError.mm:
(WebKit::CoreIPCError::toID const):
(WebKit::CoreIPCError::CoreIPCError):
(WebKit::CoreIPCError::hasValidUserInfo): Deleted.
(WebKit::CoreIPCError::isSafeToEncodeUserInfo): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCError.serialization.in:

Canonical link: <a href="https://commits.webkit.org/302861@main">https://commits.webkit.org/302861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6640caa9accfac07f1c147daea2fefad75e35393

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137860 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82036 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/93ea5025-c14b-4fdf-a568-6efff0bcc14a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99381 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b9f00cc5-a761-4552-b68b-0c737a8265e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80079 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1911 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81119 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140338 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107897 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107800 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27441 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31589 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55466 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2573 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65961 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2391 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2594 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2499 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->