### PR TITLE
Improve script execution context usage in Trusted Types code

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-secondary-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-secondary-document-expected.txt
@@ -1,0 +1,99 @@
+
+PASS HTMLElement innerHTML throws with a plain string
+PASS HTMLElement setHTMLUnsafe throws with a plain string
+PASS ShadowRoot innerHTML throws with a plain string
+PASS ShadowRoot setHTMLUnsafe throws with a plain string
+PASS HTMLIFrameElement srcdoc throws with a plain string
+PASS HTMLScriptElement textContent throws with a plain string
+PASS HTMLScriptElement innerText throws with a plain string
+PASS HTMLScriptElement text throws with a plain string
+PASS Element insertAdjacentHTML throws with a plain string
+PASS Document execCommand throws with a plain string
+PASS Range createContextualFragment throws with a plain string
+PASS HTMLElement innerHTML works with a TrustedHTML
+PASS HTMLElement setHTMLUnsafe works with a TrustedHTML
+PASS ShadowRoot innerHTML works with a TrustedHTML
+PASS ShadowRoot setHTMLUnsafe works with a TrustedHTML
+PASS HTMLIFrameElement srcdoc works with a TrustedHTML
+PASS HTMLScriptElement textContent works with a TrustedScript
+PASS HTMLScriptElement innerText works with a TrustedScript
+PASS HTMLScriptElement text works with a TrustedScript
+PASS Element insertAdjacentHTML works with a TrustedHTML
+PASS Document execCommand works with a TrustedHTML
+PASS Trusted Type assignment required for Range createContextualFragment
+PASS Element.setAttribute throws for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=onclick with a plain string
+PASS Element.setAttribute throws for elementNS=http://www.w3.org/2000/svg, element=g,  attrName=ondblclick with a plain string
+PASS Element.setAttribute throws for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow,  attrName=onmousedown with a plain string
+PASS Element.setAttribute throws for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME,  attrName=srcdoc with a plain string
+PASS Element.setAttribute throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
+PASS Element.setAttribute throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
+PASS Element.setAttributeNS throws for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=onclick with a plain string
+PASS Element.setAttributeNS throws for elementNS=http://www.w3.org/2000/svg, element=g,  attrName=ondblclick with a plain string
+PASS Element.setAttributeNS throws for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow,  attrName=onmousedown with a plain string
+PASS Element.setAttributeNS throws for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME,  attrName=srcdoc with a plain string
+PASS Element.setAttributeNS throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
+PASS Element.setAttributeNS throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
+PASS Element.setAttributeNS throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
+PASS Element.setAttributeNode throws for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=onclick with a plain string
+PASS Element.setAttributeNode throws for elementNS=http://www.w3.org/2000/svg, element=g,  attrName=ondblclick with a plain string
+PASS Element.setAttributeNode throws for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow,  attrName=onmousedown with a plain string
+PASS Element.setAttributeNode throws for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME,  attrName=srcdoc with a plain string
+PASS Element.setAttributeNode throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
+PASS Element.setAttributeNode throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
+PASS Element.setAttributeNode throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
+PASS Element.setAttributeNodeNS throws for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=onclick with a plain string
+PASS Element.setAttributeNodeNS throws for elementNS=http://www.w3.org/2000/svg, element=g,  attrName=ondblclick with a plain string
+PASS Element.setAttributeNodeNS throws for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow,  attrName=onmousedown with a plain string
+PASS Element.setAttributeNodeNS throws for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME,  attrName=srcdoc with a plain string
+PASS Element.setAttributeNodeNS throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
+PASS Element.setAttributeNodeNS throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
+PASS Element.setAttributeNodeNS throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
+PASS NamedNodeMap.setNamedItem throws for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=onclick with a plain string
+PASS NamedNodeMap.setNamedItem throws for elementNS=http://www.w3.org/2000/svg, element=g,  attrName=ondblclick with a plain string
+PASS NamedNodeMap.setNamedItem throws for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow,  attrName=onmousedown with a plain string
+PASS NamedNodeMap.setNamedItem throws for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME,  attrName=srcdoc with a plain string
+PASS NamedNodeMap.setNamedItem throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
+PASS NamedNodeMap.setNamedItem throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
+PASS NamedNodeMap.setNamedItem throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
+PASS NamedNodeMap.setNamedItemNS throws for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=onclick with a plain string
+PASS NamedNodeMap.setNamedItemNS throws for elementNS=http://www.w3.org/2000/svg, element=g,  attrName=ondblclick with a plain string
+PASS NamedNodeMap.setNamedItemNS throws for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow,  attrName=onmousedown with a plain string
+PASS NamedNodeMap.setNamedItemNS throws for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME,  attrName=srcdoc with a plain string
+PASS NamedNodeMap.setNamedItemNS throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
+PASS NamedNodeMap.setNamedItemNS throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
+PASS NamedNodeMap.setNamedItemNS throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
+PASS Attr.value throws for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=onclick with a plain string
+PASS Attr.value throws for elementNS=http://www.w3.org/2000/svg, element=g,  attrName=ondblclick with a plain string
+PASS Attr.value throws for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow,  attrName=onmousedown with a plain string
+PASS Attr.value throws for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME,  attrName=srcdoc with a plain string
+PASS Attr.value throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
+PASS Attr.value throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
+PASS Attr.value throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
+PASS Node.nodeValue throws for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=onclick with a plain string
+PASS Node.nodeValue throws for elementNS=http://www.w3.org/2000/svg, element=g,  attrName=ondblclick with a plain string
+PASS Node.nodeValue throws for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow,  attrName=onmousedown with a plain string
+PASS Node.nodeValue throws for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME,  attrName=srcdoc with a plain string
+PASS Node.nodeValue throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
+PASS Node.nodeValue throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
+PASS Node.nodeValue throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
+PASS Node.textContent throws for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=onclick with a plain string
+PASS Node.textContent throws for elementNS=http://www.w3.org/2000/svg, element=g,  attrName=ondblclick with a plain string
+PASS Node.textContent throws for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow,  attrName=onmousedown with a plain string
+PASS Node.textContent throws for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME,  attrName=srcdoc with a plain string
+PASS Node.textContent throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
+PASS Node.textContent throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
+PASS Node.textContent throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
+PASS Element.setAttribute works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=onclick with a TrustedScript input.
+PASS Element.setAttribute works for elementNS=http://www.w3.org/2000/svg, element=g,  attrName=ondblclick with a TrustedScript input.
+PASS Element.setAttribute works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow,  attrName=onmousedown with a TrustedScript input.
+PASS Element.setAttribute works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME,  attrName=srcdoc with a TrustedHTML input.
+PASS Element.setAttribute works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a TrustedScriptURL input.
+PASS Element.setAttribute works for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a TrustedScriptURL input.
+PASS Element.setAttributeNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=onclick with a TrustedScript input.
+PASS Element.setAttributeNS works for elementNS=http://www.w3.org/2000/svg, element=g,  attrName=ondblclick with a TrustedScript input.
+PASS Element.setAttributeNS works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow,  attrName=onmousedown with a TrustedScript input.
+PASS Element.setAttributeNS works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME,  attrName=srcdoc with a TrustedHTML input.
+PASS Element.setAttributeNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a TrustedScriptURL input.
+PASS Element.setAttributeNS works for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a TrustedScriptURL input.
+PASS Element.setAttributeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a TrustedScriptURL input.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-secondary-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-secondary-document.html
@@ -1,0 +1,340 @@
+<!DOCTYPE html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="support/namespaces.js"></script>
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+</head>
+<body>
+<script>
+const policyWithoutModification =
+  window.trustedTypes.createPolicy('policyWithoutModification', {
+    createHTML: s => s,
+    createScript: s => s,
+    createScriptURL: s => s,
+  });
+
+function createTrustedOutput(type, input) {
+  return type ?
+    policyWithoutModification[type.replace("Trusted", "create")](input) : input;
+}
+
+const secondaryDocument = document.implementation.createHTMLDocument("");
+const testData = [
+    {
+        name: "HTMLElement innerHTML",
+        subject: () => secondaryDocument.createElement("div"),
+        property: "innerHTML",
+        type: "TrustedHTML",
+    },
+    {
+        name: "HTMLElement setHTMLUnsafe",
+        subject: () => secondaryDocument.createElement("div"),
+        method: "setHTMLUnsafe",
+        type: "TrustedHTML",
+    },
+    {
+        name: "ShadowRoot innerHTML",
+        subject: () => {
+            const div = secondaryDocument.createElement("div");
+            return div.attachShadow({mode: 'open'});
+        },
+        property: "innerHTML",
+        type: "TrustedHTML",
+    },
+    {
+        name: "ShadowRoot setHTMLUnsafe",
+        subject: () => {
+            const div = secondaryDocument.createElement("div");
+            return div.attachShadow({mode: 'open'});
+        },
+        method: "setHTMLUnsafe",
+        type: "TrustedHTML",
+    },
+    {
+        name: "HTMLIFrameElement srcdoc",
+        subject: () => secondaryDocument.createElement("iframe"),
+        property: "srcdoc",
+        type: "TrustedHTML",
+    },
+    {
+        name: "HTMLScriptElement textContent",
+        subject: () => secondaryDocument.createElement("script"),
+        property: "textContent",
+        type: "TrustedScript",
+    },
+    {
+        name: "HTMLScriptElement innerText",
+        subject: () => secondaryDocument.createElement("script"),
+        property: "innerText",
+        type: "TrustedScript",
+    },
+    {
+        name: "HTMLScriptElement text",
+        subject: () => secondaryDocument.createElement("script"),
+        property: "text",
+        type: "TrustedScript",
+    },
+];
+
+for (let entry of testData) {
+    test(_ => {
+        const subject = entry.subject();
+        assert_throws_js(TypeError, _ => {
+            if (entry.property)
+                subject[entry.property] = "2+2";
+            else if (entry.method)
+                subject[entry.method]("2+2");
+        });
+    }, entry.name + " throws with a plain string");
+}
+
+test(_ => {
+    assert_throws_js(TypeError, _ => {
+        let element = secondaryDocument.createElement("div");
+        element.insertAdjacentHTML("afterbegin", "2+2");
+    });
+}, "Element insertAdjacentHTML throws with a plain string");
+
+test(_ => {
+    assert_throws_js(TypeError, _ => {
+        secondaryDocument.execCommand("insertHTML", false, "2+2");
+    });
+}, "Document execCommand throws with a plain string");
+
+test(_ => {
+    assert_throws_js(TypeError, _ => {
+        let range = secondaryDocument.createRange();
+        range.selectNodeContents(secondaryDocument.documentElement);
+        range.createContextualFragment("2+2");
+    });
+}, "Range createContextualFragment throws with a plain string");
+
+for (let entry of testData) {
+    test(_ => {
+        const subject = entry.subject();
+        let trustedInput = createTrustedOutput(entry.type, "somevalue");
+        if (entry.property)
+            subject[entry.property] = trustedInput;
+        else if (entry.method)
+            subject[entry.method](trustedInput);
+    }, entry.name + " works with a " + entry.type);
+}
+
+test(_ => {
+    let trustedInput = createTrustedOutput("TrustedHTML", "somevalue");
+    let element = secondaryDocument.createElement("div");
+    element.insertAdjacentHTML("afterbegin", trustedInput);
+}, "Element insertAdjacentHTML works with a TrustedHTML");
+
+test(_ => {
+    let trustedInput = createTrustedOutput("TrustedHTML", "somevalue");
+    secondaryDocument.execCommand("insertHTML", false, trustedInput);
+}, "Document execCommand works with a TrustedHTML");
+
+test(_ => {
+    assert_throws_js(TypeError, _ => {
+        let range = secondaryDocument.createRange();
+        range.selectNodeContents(secondaryDocument.documentElement);
+        range.createContextualFragment("1+1");
+    });
+}, "Trusted Type assignment required for Range createContextualFragment");
+
+const trustedTypeDataForAttribute = [
+    {
+        element: _ => secondaryDocument.createElement("div"),
+        attrNS: null,
+        attrName: "onclick",
+        sink: "Element onclick",
+        type: "TrustedScript"
+    },
+    {
+        element: _ => secondaryDocument.createElementNS(NSURI_SVG, "g"),
+        attrNS: null,
+        attrName: "ondblclick",
+        sink: "Element ondblclick",
+        type: "TrustedScript"
+    },
+    {
+        element: _ => secondaryDocument.createElementNS(NSURI_MATHML, "mrow"),
+        attrNS: null,
+        attrName: "onmousedown",
+        sink: "Element onmousedown",
+        type: "TrustedScript"
+    },
+    {
+        element: _ => secondaryDocument.createElement("iframe"),
+        attrNS: null,
+        attrName: "srcdoc",
+        sink: "HTMLIFrameElement srcdoc",
+        type: "TrustedHTML"
+    },
+    {
+        element: _ => secondaryDocument.createElement("script"),
+        attrNS: null,
+        attrName: "src",
+        sink: "HTMLScriptElement src",
+        type: "TrustedScriptURL"
+    },
+    {
+        element: _ => secondaryDocument.createElementNS(NSURI_SVG, "script"),
+        attrNS: null,
+        attrName: "href",
+        sink: "SVGScriptElement href",
+        type: "TrustedScriptURL"
+    },
+    {
+        element: _ => secondaryDocument.createElementNS(NSURI_SVG, "script"),
+        attrNS: NSURI_XLINK,
+        attrName: "href",
+        sink: "SVGScriptElement href",
+        type: "TrustedScriptURL"
+    },
+];
+
+function findAttribute(element, attrNS, attrName) {
+    for (let i = 0; i < element.attributes.length; i++) {
+        let attr = element.attributes[i];
+        if (attr.namespaceURI === attrNS &&
+            attr.localName === attrName) {
+            return attr;
+        }
+    }
+}
+
+const attributeSetterData = [
+    {
+        api: "Element.setAttribute",
+        acceptNS: false,
+        acceptTrustedTypeArgumentInIDL: true,
+        runSetter: function(element, attrNS, attrName, attrValue) {
+            assert_equals(attrNS, null);
+            this.lastAttributeNode = findAttribute(element, attrNS, attrName);
+            return element.setAttribute(attrName, attrValue);
+        },
+    },
+    {
+        api: "Element.setAttributeNS",
+        acceptNS: true,
+        acceptTrustedTypeArgumentInIDL: true,
+        runSetter: function(element, attrNS, attrName, attrValue) {
+            this.lastAttributeNode = findAttribute(element, attrNS, attrName);
+            return element.setAttributeNS(attrNS, attrName, attrValue);
+        },
+    },
+    {
+        api: "Element.setAttributeNode",
+        acceptNS: true,
+        setterClass: "setAttributeNode",
+        runSetter: function(element, attrNS, attrName, attrValue, type) {
+            this.lastAttributeNode = secondaryDocument.createAttributeNS(attrNS, attrName);
+            this.lastAttributeNode.value = attrValue;
+            return element.setAttributeNode(this.lastAttributeNode);
+        },
+    },
+    {
+        api: "Element.setAttributeNodeNS",
+        acceptNS: true,
+        runSetter: function(element, attrNS, attrName, attrValue, type) {
+            this.lastAttributeNode = document.createAttributeNS(attrNS, attrName);
+            this.lastAttributeNode.value = attrValue;
+            return element.setAttributeNodeNS(this.lastAttributeNode);
+        },
+    },
+    {
+        api: "NamedNodeMap.setNamedItem",
+        acceptNS: true,
+        runSetter: function(element, attrNS, attrName, attrValue, type) {
+            const nodeMap = element.attributes;
+            this.lastAttributeNode = secondaryDocument.createAttributeNS(attrNS, attrName);
+            this.lastAttributeNode.value = attrValue;
+            return nodeMap.setNamedItem(this.lastAttributeNode);
+        },
+    },
+    {
+        api: "NamedNodeMap.setNamedItemNS",
+        acceptNS: true,
+        runSetter: function(element, attrNS, attrName, attrValue, type) {
+            const nodeMap = element.attributes;
+            this.lastAttributeNode = secondaryDocument.createAttributeNS(attrNS, attrName);
+            this.lastAttributeNode.value = attrValue;
+            return nodeMap.setNamedItemNS(this.lastAttributeNode);
+        },
+    },
+    {
+        api:"Attr.value",
+        acceptNS: true,
+        runSetter: function(element, attrNS, attrName, attrValue, type) {
+            element.setAttributeNS(attrNS, attrName, createTrustedOutput(type, ""));
+            this.lastAttributeNode = findAttribute(element, attrNS, attrName);
+            assert_true(!!this.lastAttributeNode);
+            return (this.lastAttributeNode.value = attrValue);
+        },
+    },
+    {
+        api: "Node.nodeValue",
+        acceptNS: true,
+        runSetter: function(element, attrNS, attrName, attrValue, type) {
+            element.setAttributeNS(attrNS, attrName, createTrustedOutput(type, ""));
+            this.lastAttributeNode = findAttribute(element, attrNS, attrName);
+            assert_true(!!this.lastAttributeNode);
+            return (this.lastAttributeNode.nodeValue = attrValue);
+        },
+    },
+    {
+        api: "Node.textContent",
+        acceptNS: true,
+        runSetter: function(element, attrNS, attrName, attrValue, type) {
+            element.setAttributeNS(attrNS, attrName, createTrustedOutput(type, ""));
+            this.lastAttributeNode = findAttribute(element, attrNS, attrName);
+            assert_true(!!this.lastAttributeNode);
+            return (this.lastAttributeNode.textContent = attrValue);
+        },
+    },
+];
+
+// Set an attribute for each testcase of trustedTypeDataForAttribute. The CSP
+// rule and a null default policy will block those corresponding to trusted
+// type sinks.
+attributeSetterData.forEach(setterData => {
+    trustedTypeDataForAttribute.forEach(testData => {
+        if (testData.attrNS && !setterData.acceptNS) return;
+        test(() => {
+            let element = testData.element();
+            // This is a trusted type sink and should be blocked.
+            assert_throws_js(TypeError, () => {
+                setterData.runSetter(element, testData.attrNS, testData.attrName,
+                    "neverset", testData.type);
+            });
+        }, `${setterData.api} throws for \
+elementNS=${testData.element().namespaceURI}, \
+element=${testData.element().tagName}, \
+${testData.attrNS ? 'attrNS='+testData.attrNS+', ' : ''} \
+attrName=${testData.attrName} with a plain string`);
+    });
+});
+
+
+  // For attributes that are trusted type sinks, try setting them to a value
+  // that has the expected trusted type.
+  attributeSetterData.filter(setterData => setterData.acceptTrustedTypeArgumentInIDL).forEach(setterData => {
+    trustedTypeDataForAttribute.forEach(testData => {
+      if (!testData.type) return;
+      if (testData.attrNS && !setterData.acceptNS) return;
+      test(() => {
+        let element = testData.element();
+        let trustedInput = createTrustedOutput(testData.type, "somevalue");
+        // Passing a trusted type should work normally.
+        setterData.runSetter(element, testData.attrNS, testData.attrName,
+                             trustedInput, testData.type);
+        assert_equals(element.getAttributeNS(testData.attrNS,
+                                             testData.attrName), "somevalue");
+      }, `${setterData.api} works for \
+elementNS=${testData.element().namespaceURI}, \
+element=${testData.element().tagName}, \
+${testData.attrNS ? 'attrNS='+testData.attrNS+', ' : ''} \
+attrName=${testData.attrName} with a ${testData.type} input.`);
+    });
+  });
+</script>
+</body>

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -104,11 +104,11 @@ ExceptionOr<void> Attr::setValue(const AtomString& value)
 {
     if (RefPtr element = m_element.get()) {
         auto verifiedValue = value;
-        if (document().requiresTrustedTypes()) {
+        if (document().contextDocument().requiresTrustedTypes()) {
             auto type = trustedTypeForAttribute(element->nodeName(), qualifiedName().localName(),
                 element->namespaceURI(), qualifiedName().namespaceURI());
             if (!type.attributeType.isNull()) {
-                auto compliantValue = trustedTypesCompliantAttributeValue(document(), type.attributeType, value,
+                auto compliantValue = trustedTypesCompliantAttributeValue(document().contextDocument(), type.attributeType, value,
                     type.sink);
                 if (compliantValue.hasException())
                     return compliantValue.releaseException();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1212,7 +1212,7 @@ void Document::setMarkupUnsafe(const String& markup, OptionSet<ParserContentPoli
 
 ExceptionOr<Ref<Document>> Document::parseHTMLUnsafe(Document& context, Variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    auto stringValueHolder = trustedTypeCompliantString(*context.scriptExecutionContext(), WTFMove(html), "Document parseHTMLUnsafe"_s);
+    auto stringValueHolder = trustedTypeCompliantString(context.contextDocument(), WTFMove(html), "Document parseHTMLUnsafe"_s);
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
 
@@ -4525,7 +4525,7 @@ ExceptionOr<void> Document::write(Document* entryDocument, FixedVector<Variant<R
     }
 
     String textString = text.toString();
-    auto stringValueHolder = trustedTypeCompliantString(TrustedType::TrustedHTML, *scriptExecutionContext(), textString, lineFeed.isEmpty() ? "Document write"_s : "Document writeln"_s);
+    auto stringValueHolder = trustedTypeCompliantString(TrustedType::TrustedHTML, contextDocument(), textString, lineFeed.isEmpty() ? "Document write"_s : "Document writeln"_s);
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
     SegmentedString trustedText(stringValueHolder.releaseReturnValue());
@@ -7863,7 +7863,7 @@ ExceptionOr<bool> Document::execCommand(const String& commandName, bool userInte
         [&commandName, this](const String& str) -> ExceptionOr<String> {
             if (commandName != "insertHTML"_s)
                 return String(str);
-            return trustedTypeCompliantString(TrustedType::TrustedHTML, *scriptExecutionContext(), str, "Document execCommand"_s);
+            return trustedTypeCompliantString(TrustedType::TrustedHTML, contextDocument(), str, "Document execCommand"_s);
         },
         [](const RefPtr<TrustedHTML>& trustedHtml) -> ExceptionOr<String> {
             return trustedHtml->toString();

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2142,9 +2142,9 @@ ExceptionOr<void> Element::setAttribute(const AtomString& qualifiedName, const T
         setAttributeInternal(index, name, std::get<AtomString>(value), InSynchronizationOfLazyAttribute::No);
     else {
         AttributeTypeAndSink type;
-        if (document().requiresTrustedTypes())
+        if (document().contextDocument().requiresTrustedTypes())
             type = trustedTypeForAttribute(nodeName(), name.localName().convertToASCIILowercase(), this->namespaceURI(), name.namespaceURI());
-        auto compliantValue = trustedTypesCompliantAttributeValue(document(), type.attributeType, value, type.sink);
+        auto compliantValue = trustedTypesCompliantAttributeValue(document().contextDocument(), type.attributeType, value, type.sink);
 
         if (compliantValue.hasException())
             return compliantValue.releaseException();
@@ -3747,10 +3747,10 @@ ExceptionOr<RefPtr<Attr>> Element::setAttributeNode(Attr& attrNode)
     // before making changes to attrNode's Element connections.
     auto attrNodeValue = attrNode.value();
 
-    if (document().requiresTrustedTypes()) {
+    if (document().contextDocument().requiresTrustedTypes()) {
         auto& name = attrNode.qualifiedName();
         auto type = trustedTypeForAttribute(nodeName(), name.localName().convertToASCIILowercase(), this->namespaceURI(), name.namespaceURI());
-        auto compliantValue = trustedTypesCompliantAttributeValue(document(), type.attributeType, attrNodeValue, type.sink);
+        auto compliantValue = trustedTypesCompliantAttributeValue(document().contextDocument(), type.attributeType, attrNodeValue, type.sink);
 
         if (compliantValue.hasException())
             return compliantValue.releaseException();
@@ -3804,10 +3804,10 @@ ExceptionOr<RefPtr<Attr>> Element::setAttributeNodeNS(Attr& attrNode)
     // before making changes to attrNode's Element connections.
     auto attrNodeValue = attrNode.value();
 
-    if (document().requiresTrustedTypes()) {
+    if (document().contextDocument().requiresTrustedTypes()) {
         auto& name = attrNode.qualifiedName();
         auto type = trustedTypeForAttribute(nodeName(), name.localName(), this->namespaceURI(), name.namespaceURI());
-        auto compliantValue = trustedTypesCompliantAttributeValue(document(), type.attributeType, attrNodeValue, type.sink);
+        auto compliantValue = trustedTypesCompliantAttributeValue(document().contextDocument(), type.attributeType, attrNodeValue, type.sink);
 
         if (compliantValue.hasException())
             return compliantValue.releaseException();
@@ -3899,9 +3899,9 @@ ExceptionOr<void> Element::setAttributeNS(const AtomString& namespaceURI, const 
     else {
         QualifiedName parsedAttributeName = result.returnValue();
         AttributeTypeAndSink type;
-        if (document().requiresTrustedTypes())
+        if (document().contextDocument().requiresTrustedTypes())
             type = trustedTypeForAttribute(nodeName(), parsedAttributeName.localName(), this->namespaceURI(), parsedAttributeName.namespaceURI());
-        auto compliantValue = trustedTypesCompliantAttributeValue(document(), type.attributeType, value, type.sink);
+        auto compliantValue = trustedTypesCompliantAttributeValue(document().contextDocument(), type.attributeType, value, type.sink);
 
         if (compliantValue.hasException())
             return compliantValue.releaseException();
@@ -4353,7 +4353,7 @@ ExceptionOr<void> Element::replaceChildrenWithMarkup(const String& markup, Optio
 
 ExceptionOr<void> Element::setHTMLUnsafe(Variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    auto stringValueHolder = trustedTypeCompliantString(*document().scriptExecutionContext(), WTFMove(html), "Element setHTMLUnsafe"_s);
+    auto stringValueHolder = trustedTypeCompliantString(document().contextDocument(), WTFMove(html), "Element setHTMLUnsafe"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
@@ -4387,7 +4387,7 @@ String Element::outerHTML() const
 
 ExceptionOr<void> Element::setOuterHTML(Variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    auto stringValueHolder = trustedTypeCompliantString(*document().scriptExecutionContext(), WTFMove(html), "Element outerHTML"_s);
+    auto stringValueHolder = trustedTypeCompliantString(document().contextDocument(), WTFMove(html), "Element outerHTML"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
@@ -4428,7 +4428,7 @@ ExceptionOr<void> Element::setOuterHTML(Variant<RefPtr<TrustedHTML>, String>&& h
 
 ExceptionOr<void> Element::setInnerHTML(Variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    auto stringValueHolder = trustedTypeCompliantString(*document().scriptExecutionContext(), WTFMove(html), "Element innerHTML"_s);
+    auto stringValueHolder = trustedTypeCompliantString(document().contextDocument(), WTFMove(html), "Element innerHTML"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
@@ -6013,7 +6013,7 @@ ExceptionOr<void> Element::insertAdjacentHTML(const String& where, const String&
 
 ExceptionOr<void> Element::insertAdjacentHTML(const String& where, Variant<RefPtr<TrustedHTML>, String>&& markup)
 {
-    auto stringValueHolder = trustedTypeCompliantString(*document().scriptExecutionContext(), WTFMove(markup), "Element insertAdjacentHTML"_s);
+    auto stringValueHolder = trustedTypeCompliantString(document().contextDocument(), WTFMove(markup), "Element insertAdjacentHTML"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -743,7 +743,7 @@ String Range::toString() const
 ExceptionOr<Ref<DocumentFragment>> Range::createContextualFragment(Variant<RefPtr<TrustedHTML>, String>&& markup)
 {
     Node& node = startContainer();
-    auto stringValueHolder = trustedTypeCompliantString(*node.document().scriptExecutionContext(), WTFMove(markup), "Range createContextualFragment"_s);
+    auto stringValueHolder = trustedTypeCompliantString(node.document().contextDocument(), WTFMove(markup), "Range createContextualFragment"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -243,7 +243,7 @@ ExceptionOr<void> ShadowRoot::replaceChildrenWithMarkup(const String& markup, Op
 
 ExceptionOr<void> ShadowRoot::setHTMLUnsafe(Variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    auto stringValueHolder = trustedTypeCompliantString(*document().scriptExecutionContext(), WTFMove(html), "ShadowRoot setHTMLUnsafe"_s);
+    auto stringValueHolder = trustedTypeCompliantString(document().contextDocument(), WTFMove(html), "ShadowRoot setHTMLUnsafe"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
@@ -263,7 +263,7 @@ String ShadowRoot::innerHTML() const
 
 ExceptionOr<void> ShadowRoot::setInnerHTML(Variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    auto stringValueHolder = trustedTypeCompliantString(*document().scriptExecutionContext(), WTFMove(html), "ShadowRoot innerHTML"_s);
+    auto stringValueHolder = trustedTypeCompliantString(document().contextDocument(), WTFMove(html), "ShadowRoot innerHTML"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -186,7 +186,7 @@ String HTMLIFrameElement::srcdoc() const
 
 ExceptionOr<void> HTMLIFrameElement::setSrcdoc(Variant<RefPtr<TrustedHTML>, String>&& value, SubstituteData::SessionHistoryVisibility sessionHistoryVisibility)
 {
-    auto stringValueHolder = trustedTypeCompliantString(*protectedDocument()->protectedScriptExecutionContext(), WTFMove(value), "HTMLIFrameElement srcdoc"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protectedDocument()->protectedContextDocument(), WTFMove(value), "HTMLIFrameElement srcdoc"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();

--- a/Source/WebCore/svg/properties/SVGAnimatedString.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimatedString.cpp
@@ -40,7 +40,7 @@ ExceptionOr<void> SVGAnimatedString::setBaseVal(const StringOrTrustedScriptURL& 
         [&](const String& str) -> ExceptionOr<String> {
             SVGElement* el = contextElement();
             if (el && isScriptElement(*el) && m_isHrefProperty == IsHrefProperty::Yes)
-                return trustedTypeCompliantString(TrustedType::TrustedScriptURL, *(contextElement()->document().scriptExecutionContext()), str, "SVGScriptElement href"_s);
+                return trustedTypeCompliantString(TrustedType::TrustedScriptURL, *contextElement()->scriptExecutionContext(), str, "SVGScriptElement href"_s);
             return String(str);
         },
         [](const RefPtr<TrustedScriptURL>& trustedScriptURL) -> ExceptionOr<String> {

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -79,7 +79,7 @@ static inline SharedWorkerObjectConnection* mainThreadConnection()
 
 ExceptionOr<Ref<SharedWorker>> SharedWorker::create(Document& document, Variant<RefPtr<TrustedScriptURL>, String>&& scriptURLString, std::optional<Variant<String, WorkerOptions>>&& maybeOptions)
 {
-    auto compliantScriptURLString = trustedTypeCompliantString(document, WTFMove(scriptURLString), "SharedWorker constructor"_s);
+    auto compliantScriptURLString = trustedTypeCompliantString(document.contextDocument(), WTFMove(scriptURLString), "SharedWorker constructor"_s);
     if (compliantScriptURLString.hasException())
         return compliantScriptURLString.releaseException();
 

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -46,7 +46,7 @@ Ref<DOMParser> DOMParser::create(Document& contextDocument)
 
 ExceptionOr<Ref<Document>> DOMParser::parseFromString(Variant<RefPtr<TrustedHTML>, String>&& string, const AtomString& contentType)
 {
-    auto stringValueHolder = trustedTypeCompliantString(*protectedContextDocument()->protectedScriptExecutionContext().get(), WTFMove(string), "DOMParser parseFromString"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protectedContextDocument()->protectedContextDocument(), WTFMove(string), "DOMParser parseFromString"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();


### PR DESCRIPTION
#### 76ec38e84a6401d83ff18fc5d0a24f71a062bf56
<pre>
Improve script execution context usage in Trusted Types code
<a href="https://bugs.webkit.org/show_bug.cgi?id=301625">https://bugs.webkit.org/show_bug.cgi?id=301625</a>

Reviewed by Darin Adler.

The existing usage of document() rather than document().contextDocument() can cause situations where
objects created within secondary documents (e.g. createHTMLDocument()) would not be protected by Trusted Types.

Test: imported/w3c/web-platform-tests/trusted-types/trusted-types-secondary-document.html
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-secondary-document-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-secondary-document.html: Added.
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::setValue):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::parseHTMLUnsafe):
(WebCore::Document::write):
(WebCore::Document::execCommand):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setAttribute):
(WebCore::Element::setAttributeNode):
(WebCore::Element::setAttributeNodeNS):
(WebCore::Element::setAttributeNS):
(WebCore::Element::setHTMLUnsafe):
(WebCore::Element::setOuterHTML):
(WebCore::Element::setInnerHTML):
(WebCore::Element::insertAdjacentHTML):
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::createContextualFragment):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::setHTMLUnsafe):
(WebCore::ShadowRoot::setInnerHTML):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::setSrcdoc):
* Source/WebCore/svg/properties/SVGAnimatedString.cpp:
(WebCore::SVGAnimatedString::setBaseVal):
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::create):
* Source/WebCore/xml/DOMParser.cpp:
(WebCore::DOMParser::parseFromString):

Canonical link: <a href="https://commits.webkit.org/302412@main">https://commits.webkit.org/302412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a29ebc892a3ed8b191a1fbd9d28de57c8ce471d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80231 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98103 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66050 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115435 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78715 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33546 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138707 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106641 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111769 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106452 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/761 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30301 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53393 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20144 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1005 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64314 "Found 158 new failures in WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm, workers/shared/SharedWorker.cpp, WebProcess/InjectedBundle/API/c/WKBundlePage.cpp, WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm, WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm ...") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/850 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/906 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/941 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->