### PR TITLE
REGRESSION (Safari 26): Live HLS ID3 timed metadata cues mapped with endTime = Infinity cause TextTrack.activeCues to include all past cues indefinitely

### DIFF
--- a/LayoutTests/http/tests/media/hls/track-in-band-hls-metadata-cue-duration.html
+++ b/LayoutTests/http/tests/media/hls/track-in-band-hls-metadata-cue-duration.html
@@ -7,6 +7,7 @@
         <script src=../../../media-resources/media-file.js></script>
 
         <script>
+            const cueCount = 5;
             let cuechangeCount = 0;
 
             async function start()
@@ -23,14 +24,15 @@
                     run('track = video.textTracks[0]');
                     run('track.mode = "hidden"');
                     track.addEventListener('cuechange', evt => {
-                        if (++cuechangeCount != 6)
+                        if (++cuechangeCount != cueCount)
                             return;
 
-                        for (var i = 0; i < 6; i++) {
-                            cue = track.cues[i];
-                            consoleWrite(`<br>cue ${i + 1}`);
-                            testExpected('cue.startTime', Number.POSITIVE_INFINITY, "!=");
-                            testExpected('cue.endTime', Number.POSITIVE_INFINITY, "!=");
+                        for (var i = 0; i < cueCount; i++) {
+                            consoleWrite(``);
+                            testExpected(`track.cues[${i}].startTime`, Number.POSITIVE_INFINITY, '!=');
+                            testExpected(`track.cues[${i}].endTime`, Number.POSITIVE_INFINITY, '!=');
+                            if (i > 0)
+                                testExpected(`track.cues[${i}].endTime > track.cues[${i - 1}].endTime`, true);
                         }
 
                         consoleWrite('');

--- a/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
+++ b/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
@@ -132,7 +132,7 @@ bool SerializedPlatformDataCueValue::Data::operator==(const Data& other) const
 {
     return type == other.type
         && otherAttributes == other.otherAttributes
-        && [locale isEqual:other.locale.get()]
+        && ((!locale && !other.locale) || [locale isEqual:other.locale.get()])
         && key == other.key
         && value.index() == other.value.index()
         && WTF::switchOn(value, [] (std::nullptr_t) {


### PR DESCRIPTION
#### 01952a527b502259aab2eb9e3339a851fe50f613
<pre>
REGRESSION (Safari 26): Live HLS ID3 timed metadata cues mapped with endTime = Infinity cause TextTrack.activeCues to include all past cues indefinitely
<a href="https://bugs.webkit.org/show_bug.cgi?id=299853">https://bugs.webkit.org/show_bug.cgi?id=299853</a>
<a href="https://rdar.apple.com/161687917">rdar://161687917</a>

Reviewed by Jer Noble.

274146@main changed the way SerializedPlatformDataCueValue objects are compared so instead
of creating the native NSObjects and comparing them, every field in the internal Data struct
is compared directly. The `locale` field is an NSLocale, so values are compared with `isEqual:`,
but because any message to a nil NSObject returns a falsy value,
`SerializedPlatformDataCueValue::Data::operator==` always returns false if the data cue
doesn&apos;t have a locale.

track-in-band-hls-metadata-cue-duration.html was updated for this fix.

* LayoutTests/http/tests/media/hls/track-in-band-hls-metadata-cue-duration.html:
* Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm:
(WebCore::SerializedPlatformDataCueValue::Data::operator== const):

Canonical link: <a href="https://commits.webkit.org/302395@main">https://commits.webkit.org/302395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc604ff994da5c9cb714f652091f936bfc9702ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80056 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/139b6428-8a45-47d0-9a10-ab45ecad17ce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/794 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97940 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65856 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a1ce9912-ada5-48b0-bfad-19e4427dfcdb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78559 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f8dc0674-2211-49d8-8ae3-46ec3a2aec80) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/576 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33376 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79323 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138495 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106474 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106297 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27126 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/627 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30135 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53122 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/807 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64054 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/673 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/729 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/756 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->