### PR TITLE
Reduce unsafe buffer usage in WTF

### DIFF
--- a/Source/JavaScriptCore/b3/B3GenericBlockInsertionSet.h
+++ b/Source/JavaScriptCore/b3/B3GenericBlockInsertionSet.h
@@ -83,7 +83,7 @@ public:
         // We allow insertions to be given to us in any order. So, we need to sort them before
         // running WTF::executeInsertions. We strongly prefer a stable sort and we want it to be
         // fast, so we use bubble sort.
-        bubbleSort(m_insertions.begin(), m_insertions.end());
+        bubbleSort(m_insertions.mutableSpan());
         
         executeInsertions(m_blocks, m_insertions);
         

--- a/Source/JavaScriptCore/b3/B3InsertionSet.cpp
+++ b/Source/JavaScriptCore/b3/B3InsertionSet.cpp
@@ -69,7 +69,7 @@ void InsertionSet::execute(BasicBlock* block)
 {
     for (Insertion& insertion : m_insertions)
         insertion.element()->owner = block;
-    bubbleSort(m_insertions.begin(), m_insertions.end());
+    bubbleSort(m_insertions.mutableSpan());
     executeInsertions(block->m_values, m_insertions);
     m_bottomForType = TypeMap<Value*>();
 }

--- a/Source/JavaScriptCore/b3/air/AirInsertionSet.cpp
+++ b/Source/JavaScriptCore/b3/air/AirInsertionSet.cpp
@@ -41,7 +41,7 @@ void InsertionSet::insertInsts(size_t index, Vector<Inst>&& insts)
 
 void InsertionSet::execute(BasicBlock* block)
 {
-    bubbleSort(m_insertions.begin(), m_insertions.end());
+    bubbleSort(m_insertions.mutableSpan());
     executeInsertions(block->m_insts, m_insertions);
 }
 

--- a/Source/JavaScriptCore/b3/air/AirOptimizeBlockOrder.cpp
+++ b/Source/JavaScriptCore/b3/air/AirOptimizeBlockOrder.cpp
@@ -53,7 +53,7 @@ public:
         // We prefer a stable sort, and we don't want it to go off the rails if we see NaN. Also, the number
         // of successors is bounded. In fact, it currently cannot be more than 2. :-)
         bubbleSort(
-            m_successors.begin(), m_successors.end(),
+            m_successors.mutableSpan(),
             [] (BasicBlock* left, BasicBlock* right) {
                 return left->frequency() < right->frequency();
             });

--- a/Source/JavaScriptCore/b3/air/AirPhaseInsertionSet.cpp
+++ b/Source/JavaScriptCore/b3/air/AirPhaseInsertionSet.cpp
@@ -35,7 +35,7 @@ namespace JSC { namespace B3 { namespace Air {
 
 void PhaseInsertionSet::execute(BasicBlock* block)
 {
-    bubbleSort(m_insertions.begin(), m_insertions.end());
+    bubbleSort(m_insertions.mutableSpan());
     executeInsertions(block->m_insts, m_insertions);
 }
 

--- a/Source/JavaScriptCore/bytecode/BytecodeRewriter.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeRewriter.cpp
@@ -54,7 +54,7 @@ void BytecodeRewriter::applyModification()
 
 void BytecodeRewriter::execute()
 {
-    WTF::bubbleSort(m_insertions.begin(), m_insertions.end(), [] (const Insertion& lhs, const Insertion& rhs) {
+    WTF::bubbleSort(m_insertions.mutableSpan(), [] (const Insertion& lhs, const Insertion& rhs) {
         return lhs.index < rhs.index;
     });
 

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -986,7 +986,7 @@ RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
     if (jitCode->m_unlinkedCalls.size()) {
         std::move(m_unlinkedCalls.begin(), m_unlinkedCalls.end(), jitCode->m_unlinkedCalls.begin());
         // It is almost always already sorted.
-        WTF::bubbleSort(jitCode->m_unlinkedCalls.begin(), jitCode->m_unlinkedCalls.end(),
+        WTF::bubbleSort(jitCode->m_unlinkedCalls.mutableSpan(),
             [](const auto& lhs, const auto& rhs) {
                 return lhs.bytecodeIndex < rhs.bytecodeIndex;
             });

--- a/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
@@ -30,6 +30,8 @@
 #include "JSObjectInlines.h"
 #include "StructureInlines.h"
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace JSC {
 
 const ClassInfo ScopedArgumentsTable::s_info = { "ScopedArgumentsTable"_s, nullptr, nullptr, nullptr, CREATE_METHOD_TABLE(ScopedArgumentsTable) };
@@ -141,3 +143,4 @@ Structure* ScopedArgumentsTable::createStructure(VM& vm, JSGlobalObject* globalO
 
 } // namespace JSC
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/AccessibleAddress.h
+++ b/Source/WTF/wtf/AccessibleAddress.h
@@ -27,8 +27,6 @@
 
 #include <wtf/WTFConfig.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 inline uintptr_t lowestAccessibleAddress()
@@ -45,5 +43,3 @@ inline uintptr_t highestAccessibleAddress()
 
 using WTF::lowestAccessibleAddress;
 using WTF::highestAccessibleAddress;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/Atomics.h
+++ b/Source/WTF/wtf/Atomics.h
@@ -29,8 +29,6 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 ALWAYS_INLINE bool hasFence(std::memory_order order)
@@ -441,7 +439,7 @@ public:
     T* consume(T* pointer)
     {
 #if CPU(ARM64) || CPU(ARM)
-        return std::bit_cast<T*>(std::bit_cast<char*>(pointer) + m_value);
+        return addOpaqueZero(pointer, m_value);
 #else
         UNUSED_PARAM(m_value);
         return pointer;
@@ -499,5 +497,3 @@ using WTF::InputAndValue;
 using WTF::inputAndValue;
 using WTF::ensurePointer;
 using WTF::opaqueMixture;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -207,9 +207,7 @@ ALWAYS_INLINE constexpr bool BitSet<bitSetSize, WordType>::concurrentTestAndSet(
 {
     WordType mask = one << (n % wordSize);
     size_t index = n / wordSize;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    WordType* data = dependency.consume(bits.data()) + index;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    WordType* data = dependency.consume(&bits[index]);
     // transactionRelaxed() returns true if the bit was changed. If the bit was changed,
     // then the previous bit must have been false since we're trying to set it. Hence,
     // the result of transactionRelaxed() is the inverse of our expected result.
@@ -228,9 +226,7 @@ ALWAYS_INLINE constexpr bool BitSet<bitSetSize, WordType>::concurrentTestAndClea
 {
     WordType mask = one << (n % wordSize);
     size_t index = n / wordSize;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    WordType* data = dependency.consume(bits.data()) + index;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    WordType* data = dependency.consume(&bits[index]);
     // transactionRelaxed() returns true if the bit was changed. If the bit was changed,
     // then the previous bit must have been true since we're trying to clear it. Hence,
     // the result of transactionRelaxed() matches our expected result.

--- a/Source/WTF/wtf/Brigand.h
+++ b/Source/WTF/wtf/Brigand.h
@@ -48,6 +48,7 @@
 
 #define BRIGAND_NO_BOOST_SUPPORT 1
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -453,13 +454,10 @@ namespace brigand
 {
 namespace detail
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    constexpr std::size_t count_bools(bool const * const begin, bool const * const end,
-        std::size_t n)
+    constexpr std::size_t count_bools(std::span<const bool> data)
     {
-        return begin == end ? n : detail::count_bools(begin + 1, end, n + *begin);
+        return std::ranges::count(data, true);
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     template <bool... Bs>
     struct template_count_bools
@@ -506,20 +504,20 @@ namespace lazy
     template <template<typename...> class S, typename... Ts, typename Pred>
     struct count_if<S<Ts...>, Pred>
     {
-        static constexpr bool s_v[] = { ::brigand::apply<Pred, Ts>::type::value... };
-        using type = brigand::size_t<::brigand::detail::count_bools(s_v, s_v + sizeof...(Ts), 0u)>;
+        static constexpr auto s_v = std::to_array<bool>({ ::brigand::apply<Pred, Ts>::type::value... });
+        using type = brigand::size_t<::brigand::detail::count_bools(s_v)>;
     };
     template <template <typename...> class S, typename... Ts, template <typename...> class F>
     struct count_if<S<Ts...>, bind<F, _1>>
     {
-        static constexpr bool s_v[] = { F<Ts>::value... };
-        using type = brigand::size_t<::brigand::detail::count_bools(s_v, s_v + sizeof...(Ts), 0u)>;
+        static constexpr auto s_v = std::to_array<bool>({ F<Ts>::value... });
+        using type = brigand::size_t<::brigand::detail::count_bools(s_v)>;
     };
     template <template <typename...> class S, typename... Ts, template <typename...> class F>
     struct count_if<S<Ts...>, F<_1>>
     {
-        static constexpr bool s_v[] = { F<Ts>::type::value... };
-        using type = brigand::size_t<::brigand::detail::count_bools(s_v, s_v + sizeof...(Ts), 0u)>;
+        static constexpr auto s_v = std::to_array<bool>({ F<Ts>::type::value... });
+        using type = brigand::size_t<::brigand::detail::count_bools(s_v)>;
     };
 #else
     template <template <typename...> class S, typename... Ts, typename Pred>

--- a/Source/WTF/wtf/BubbleSort.h
+++ b/Source/WTF/wtf/BubbleSort.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 // Why would you want to use bubble sort? When you know that your input is already mostly
@@ -50,46 +48,44 @@ namespace WTF {
 // sorted, the sort must be stable, they are usually already sorted to begin with, and when they
 // are unsorted it's usually because of a few out-of-place elements.
 
-template<typename IteratorType, typename LessThan>
-void bubbleSort(IteratorType begin, IteratorType end, const LessThan& lessThan)
+template<typename T, typename LessThan>
+void bubbleSort(std::span<T> data, const LessThan& lessThan)
 {
     for (;;) {
         bool changed = false;
-        ASSERT(end >= begin);
-        size_t limit = end - begin;
+        size_t limit = data.size();
         for (size_t i = limit; i-- > 1;) {
-            if (lessThan(begin[i], begin[i - 1])) {
-                std::swap(begin[i], begin[i - 1]);
+            if (lessThan(data[i], data[i - 1])) {
+                std::swap(data[i], data[i - 1]);
                 changed = true;
             }
         }
         if (!changed)
             return;
         // After one run, the first element in the list is guaranteed to be the smallest.
-        begin++;
+        skip(data, 1);
 
         // Now go in the other direction. This eliminates most sorting pathologies.
         changed = false;
-        ASSERT(end >= begin);
-        limit = end - begin;
+        limit = data.size();
         for (size_t i = 1; i < limit; ++i) {
-            if (lessThan(begin[i], begin[i - 1])) {
-                std::swap(begin[i], begin[i - 1]);
+            if (lessThan(data[i], data[i - 1])) {
+                std::swap(data[i], data[i - 1]);
                 changed = true;
             }
         }
         if (!changed)
             return;
         // Now the last element is guaranteed to be the largest.
-        end--;
+        dropLast(data);
     }
 }
 
-template<typename IteratorType>
-void bubbleSort(IteratorType begin, IteratorType end)
+template<typename T>
+void bubbleSort(std::span<T> data)
 {
     bubbleSort(
-        begin, end,
+        data,
         [](auto& left, auto& right) {
             return left < right;
         });
@@ -98,5 +94,3 @@ void bubbleSort(IteratorType begin, IteratorType end)
 } // namespace WTF
 
 using WTF::bubbleSort;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/CagedPtr.h
+++ b/Source/WTF/wtf/CagedPtr.h
@@ -36,8 +36,6 @@
 #include <mach/vm_param.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 template<Gigacage::Kind passedKind, typename T, typename PtrTraits = RawPtrTraits<T>>
@@ -78,10 +76,12 @@ public:
         return Gigacage::cagedMayBeNull(kind, ptr);
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // We need the template here so that the type of U is deduced at usage time rather than class time. U should always be T.
     template<typename U = T>
-    typename std::enable_if<!std::is_same<void, U>::value, T>::type&
+    WTF_UNSAFE_BUFFER_USAGE typename std::enable_if<!std::is_same<void, U>::value, T>::type&
     /* T& */ at(size_t index) const { return get()[index]; }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     CagedPtr(CagedPtr& other)
         : m_ptr(other.m_ptr)
@@ -127,8 +127,6 @@ protected:
 };
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 using WTF::CagedPtr;
 

--- a/Source/WTF/wtf/CagedUniquePtr.h
+++ b/Source/WTF/wtf/CagedUniquePtr.h
@@ -49,23 +49,27 @@ public:
     template<typename... Arguments>
     static CagedUniquePtr create(size_t length, Arguments&&... arguments)
     {
-        T* result = static_cast<T*>(Gigacage::malloc(kind, sizeof(T) * length));
+        std::span<T> result = unsafeMakeSpan(
+            static_cast<T*>(
+                Gigacage::malloc(
+                    kind, checkedProduct<size_t>(sizeof(T), length))), length);
         while (length--)
-            new (result + length) T(arguments...);
-        return CagedUniquePtr(result);
+            new (&result[length]) T(arguments...);
+        return CagedUniquePtr(result.data());
     }
 
     template<typename... Arguments>
     static CagedUniquePtr tryCreate(size_t length, Arguments&&... arguments)
     {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        T* result = static_cast<T*>(Gigacage::tryMalloc(kind, sizeof(T) * length));
-        if (!result)
+        std::span<T> result = unsafeMakeSpan(
+            static_cast<T*>(
+                Gigacage::tryMalloc(
+                    kind, checkedProduct<size_t>(sizeof(T), length))), length);
+        if (!result.data())
             return { };
         while (length--)
-            new (result + length) T(arguments...);
-        return CagedUniquePtr(result);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+            new (&result[length]) T(arguments...);
+        return CagedUniquePtr(result.data());
     }
 
     CagedUniquePtr& operator=(CagedUniquePtr&& ptr)

--- a/Source/WTF/wtf/CodePtr.h
+++ b/Source/WTF/wtf/CodePtr.h
@@ -30,8 +30,6 @@
 #include <wtf/HashTraits.h>
 #include <wtf/PtrTag.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 class PrintStream;
@@ -207,11 +205,13 @@ public:
     template<typename T, typename = std::enable_if_t<!std::is_same<T, bool>::value>>
     operator T() = delete;
 
-    CodePtr operator+(size_t sizeInBytes) const { return CodePtr::fromUntaggedPtr(untaggedPtr<uint8_t*>() + sizeInBytes); }
-    CodePtr operator-(size_t sizeInBytes) const { return CodePtr::fromUntaggedPtr(untaggedPtr<uint8_t*>() - sizeInBytes); }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    WTF_UNSAFE_BUFFER_USAGE CodePtr operator+(size_t sizeInBytes) const { return CodePtr::fromUntaggedPtr(untaggedPtr<uint8_t*>() + sizeInBytes); }
+    WTF_UNSAFE_BUFFER_USAGE CodePtr operator-(size_t sizeInBytes) const { return CodePtr::fromUntaggedPtr(untaggedPtr<uint8_t*>() - sizeInBytes); }
 
-    CodePtr& operator+=(size_t sizeInBytes) { return *this = *this + sizeInBytes; }
-    CodePtr& operator-=(size_t sizeInBytes) { return *this = *this - sizeInBytes; }
+    WTF_UNSAFE_BUFFER_USAGE CodePtr& operator+=(size_t sizeInBytes) { return *this = *this + sizeInBytes; }
+    WTF_UNSAFE_BUFFER_USAGE CodePtr& operator-=(size_t sizeInBytes) { return *this = *this - sizeInBytes; }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     void dumpWithName(ASCIILiteral name, PrintStream& out) const
     {
@@ -299,5 +299,3 @@ struct HashTraits<CodePtr<tag, attr>> : public CustomHashTraits<CodePtr<tag, att
 } // namespace WTF
 
 using WTF::CodePtr;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/MetaAllocator.cpp
+++ b/Source/WTF/wtf/MetaAllocator.cpp
@@ -32,6 +32,8 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/WTFConfig.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(MetaAllocatorHandle);
@@ -496,4 +498,4 @@ void MetaAllocator::dumpProfile()
 
 } // namespace WTF
 
-
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1549,6 +1549,19 @@ struct SizedUnsignedTrait<8> {
 template<typename T>
 using SameSizeUnsignedInteger = SizedUnsignedTrait<sizeof(T)>::Type;
 
+// We use this primitive on ARM to express memory ordering efficiently.
+template<typename T>
+inline T* addOpaqueZero(T* pointer, unsigned opaqueZero)
+{
+    ASSERT(!opaqueZero); // Use a debug ASSERT only so the RELEASE compiler doesn't optimize out this function.
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    // This is bounds-safe because opaqueZero is always zero.
+    return std::bit_cast<T*>(std::bit_cast<char*>(pointer) + opaqueZero);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+}
+
+
 } // namespace WTF
 
 #define WTFMove(value) std::move<WTF::CheckMoveParameter>(value)
@@ -1567,6 +1580,7 @@ template<typename T, typename U> constexpr auto forward_like_preserving_const(U&
 using WTF::GB;
 using WTF::KB;
 using WTF::MB;
+using WTF::addOpaqueZero;
 using WTF::approximateBinarySearch;
 using WTF::asBytes;
 using WTF::asByteSpan;


### PR DESCRIPTION
#### 0b50860edfd4388c393278c559686121406f429e
<pre>
Reduce unsafe buffer usage in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=301631">https://bugs.webkit.org/show_bug.cgi?id=301631</a>
<a href="https://rdar.apple.com/163646249">rdar://163646249</a>

Reviewed by Chris Dumez.

* Source/WTF/wtf/Atomics.h:
(WTF::Dependency::consume): Move the unsafe behavior into a helper function in
StdLibExtras to avoid sprinkling unsafe throughout the project and to establish
a self-documenting abstraction that verifies its bounds safety with an ASSERT.

* Source/WTF/wtf/BitSet.h:
(WTF::WordType&gt;::concurrentTestAndSet):
(WTF::WordType&gt;::concurrentTestAndClear): Use operator[] instead of pointer
arithmetic since operator[] is checked.

* Source/WTF/wtf/Brigand.h:
(brigand::detail::count_bools): Use std::array instead of C array, since std::array
is bounds-safe.

* Source/WTF/wtf/BubbleSort.h:
(WTF::bubbleSort): Use span instead of iterators since span is bounds-safe.

* Source/WTF/wtf/CagedPtr.h: Mark our function unsafe so that callers get
labeled unsafe instead of us; we don&apos;t have the information required to make
this behavior safe internally.

* Source/WTF/wtf/CagedUniquePtr.h:
(WTF::CagedUniquePtr::create):
(WTF::CagedUniquePtr::tryCreate): Use span instead of raw pointer because span
is bounds-safe.

* Source/WTF/wtf/CodePtr.h:
(WTF::CodePtr::operator+ const):
(WTF::CodePtr::operator- const):
(WTF::CodePtr::operator+=):
(WTF::CodePtr::operator-=): Mark our function unsafe so that callers get
labeled unsafe instead of us; we don&apos;t have the information required to make
this behavior safe internally.

* Source/WTF/wtf/ConcurrentPtrHashSet.cpp:
(WTF::ConcurrentPtrHashSet::deleteOldTables):
(WTF::ConcurrentPtrHashSet::initialize):
(WTF::ConcurrentPtrHashSet::addSlow):
(WTF::ConcurrentPtrHashSet::containsImplSlow const):
(WTF::ConcurrentPtrHashSet::sizeSlow const):
(WTF::ConcurrentPtrHashSet::resizeIfNecessary):
(WTF::ConcurrentPtrHashSet::Table::create):
(WTF::ConcurrentPtrHashSet::Table::createStub):
(WTF::ConcurrentPtrHashSet::Table::initializeStub): Deleted.
* Source/WTF/wtf/ConcurrentPtrHashSet.h: Use TrailingArray instead of hand-coding
a trailing array. I had to out-of-line the stub table because TrailingArray
must be out of line.
* Source/WTF/wtf/MetaAllocator.cpp:
* Source/WTF/wtf/StdLibExtras.h:
(WTF::addOpaqueZero):

Canonical link: <a href="https://commits.webkit.org/302364@main">https://commits.webkit.org/302364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa553257957d613d39645ee883a50f501815a30b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136257 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4a173096-5c08-4cac-8395-d4a8e5600708) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98114 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8dbc733d-9b9a-48d8-820a-49e324f9db2b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78728 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c9ed39a8-bc9b-43a1-b653-359381f86b84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/752 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33563 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79536 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/120884 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138718 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127333 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/921 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106663 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106474 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/774 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30316 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53404 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20126 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1016 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64326 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160345 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/859 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40020 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/915 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/951 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->