### PR TITLE
Web Inspector: don't increase the lifetime of `InstrumentingAgents`

### DIFF
--- a/Source/WebCore/inspector/CommandLineAPIHost.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIHost.cpp
@@ -84,11 +84,10 @@ void CommandLineAPIHost::disconnect()
 
 void CommandLineAPIHost::inspect(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue object, JSC::JSValue hints)
 {
-    RefPtr agents = m_instrumentingAgents.get();
-    if (!agents)
+    if (!m_instrumentingAgents)
         return;
 
-    auto* inspectorAgent = agents->persistentInspectorAgent();
+    auto* inspectorAgent = m_instrumentingAgents->persistentInspectorAgent();
     if (!inspectorAgent)
         return;
 

--- a/Source/WebCore/inspector/CommandLineAPIHost.h
+++ b/Source/WebCore/inspector/CommandLineAPIHost.h
@@ -58,9 +58,9 @@ public:
     static Ref<CommandLineAPIHost> create();
     ~CommandLineAPIHost();
 
-    void init(RefPtr<InstrumentingAgents> instrumentingAgents)
+    void init(InstrumentingAgents& instrumentingAgents)
     {
-        m_instrumentingAgents = instrumentingAgents;
+        m_instrumentingAgents = &instrumentingAgents;
     }
 
     void disconnect();
@@ -99,7 +99,7 @@ public:
 private:
     CommandLineAPIHost();
 
-    RefPtr<InstrumentingAgents> m_instrumentingAgents;
+    CheckedPtr<InstrumentingAgents> m_instrumentingAgents;
     std::unique_ptr<InspectableObject> m_inspectedObject; // $0
     Inspector::PerGlobalObjectWrapperWorld m_wrappers;
 };

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -93,7 +93,7 @@ FrameAgentContext FrameInspectorController::frameAgentContext()
     };
     WebAgentContext webContext = {
         baseContext,
-        m_instrumentingAgents.get()
+        m_instrumentingAgents
     };
     return {
         webContext,
@@ -110,7 +110,7 @@ void FrameInspectorController::createLazyAgents()
 
     m_injectedScriptManager->connect();
     if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
-        commandLineAPIHost->init(m_instrumentingAgents.copyRef());
+        commandLineAPIHost->init(m_instrumentingAgents);
 }
 
 void FrameInspectorController::connectFrontend(Inspector::FrontendChannel& frontendChannel, bool isAutomaticInspection, bool immediatelyPause)
@@ -129,7 +129,7 @@ void FrameInspectorController::connectFrontend(Inspector::FrontendChannel& front
 
     if (connectedFirstFrontend) {
         m_agents.didCreateFrontendAndBackend();
-        InspectorInstrumentation::registerInstrumentingAgents(m_instrumentingAgents.get());
+        InspectorInstrumentation::registerInstrumentingAgents(m_instrumentingAgents);
     }
 }
 
@@ -140,7 +140,7 @@ void FrameInspectorController::disconnectFrontend(Inspector::FrontendChannel& fr
 
     bool disconnectedLastFrontend = !m_frontendRouter->hasFrontends();
     if (disconnectedLastFrontend) {
-        InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents.get());
+        InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents);
         m_agents.willDestroyFrontendAndBackend(DisconnectReason::InspectorDestroyed);
         m_injectedScriptManager->discardInjectedScripts();
     }
@@ -154,7 +154,7 @@ void FrameInspectorController::inspectedFrameDestroyed()
     for (unsigned i = 0; i < m_frontendRouter->frontendCount(); ++i)
         InspectorInstrumentation::frontendDeleted();
 
-    InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents.get());
+    InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents);
     m_agents.willDestroyFrontendAndBackend(DisconnectReason::InspectedTargetDestroyed);
 
     m_injectedScriptManager->disconnect();

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -88,7 +88,7 @@ private:
     void createLazyAgents();
 
     WeakRef<LocalFrame> m_frame;
-    const Ref<InstrumentingAgents> m_instrumentingAgents;
+    const UniqueRef<InstrumentingAgents> m_instrumentingAgents;
     const UniqueRef<WebInjectedScriptManager> m_injectedScriptManager;
     const Ref<Inspector::FrontendRouter> m_frontendRouter;
     const Ref<Inspector::BackendDispatcher> m_backendDispatcher;

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -140,7 +140,7 @@ PageAgentContext InspectorController::pageAgentContext()
 
     WebAgentContext webContext = {
         baseContext,
-        m_instrumentingAgents.get()
+        m_instrumentingAgents
     };
 
     PageAgentContext pageContext = {
@@ -197,7 +197,7 @@ void InspectorController::createLazyAgents()
     m_agents.append(makeUnique<InspectorAnimationAgent>(pageContext));
 
     if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
-        commandLineAPIHost->init(m_instrumentingAgents.copyRef());
+        commandLineAPIHost->init(m_instrumentingAgents);
 }
 
 void InspectorController::inspectedPageDestroyed()
@@ -266,7 +266,7 @@ void InspectorController::connectFrontend(Inspector::FrontendChannel& frontendCh
     InspectorInstrumentation::frontendCreated();
 
     if (connectedFirstFrontend) {
-        InspectorInstrumentation::registerInstrumentingAgents(m_instrumentingAgents.get());
+        InspectorInstrumentation::registerInstrumentingAgents(m_instrumentingAgents);
         m_agents.didCreateFrontendAndBackend();
     }
 
@@ -296,7 +296,7 @@ void InspectorController::disconnectFrontend(FrontendChannel& frontendChannel)
         m_injectedScriptManager->discardInjectedScripts();
 
         // Unplug all instrumentations since they aren't needed now.
-        InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents.get());
+        InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents);
     }
 
     m_inspectorBackendClient->frontendCountChanged(m_frontendRouter->frontendCount());
@@ -323,7 +323,7 @@ void InspectorController::disconnectAllFrontends()
         InspectorInstrumentation::frontendDeleted();
 
     // Unplug all instrumentations to prevent further agent callbacks.
-    InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents.get());
+    InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents);
 
     // Notify agents first, since they may need to use InspectorBackendClient.
     m_agents.willDestroyFrontendAndBackend(DisconnectReason::InspectedTargetDestroyed);

--- a/Source/WebCore/inspector/InspectorController.h
+++ b/Source/WebCore/inspector/InspectorController.h
@@ -118,8 +118,8 @@ public:
     InspectorBackendClient* inspectorBackendClient() const { return m_inspectorBackendClient.get(); }
     InspectorFrontendClient* inspectorFrontendClient() const { return m_inspectorFrontendClient; }
 
-    InstrumentingAgents& instrumentingAgents() const { return m_instrumentingAgents.get(); }
-    Inspector::BackendDispatcher& backendDispatcher() const { return m_backendDispatcher.get(); }
+    InstrumentingAgents& instrumentingAgents() const { return m_instrumentingAgents; }
+    Inspector::BackendDispatcher& backendDispatcher() const { return m_backendDispatcher; }
 
     Inspector::InspectorAgent& ensureInspectorAgent();
     InspectorDOMAgent& ensureDOMAgent();
@@ -142,7 +142,7 @@ private:
     void createLazyAgents();
 
     WeakRef<Page> m_page;
-    const Ref<InstrumentingAgents> m_instrumentingAgents;
+    const UniqueRef<InstrumentingAgents> m_instrumentingAgents;
     const UniqueRef<WebInjectedScriptManager> m_injectedScriptManager;
     const Ref<Inspector::FrontendRouter> m_frontendRouter;
     const Ref<Inspector::BackendDispatcher> m_backendDispatcher;

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1133,7 +1133,7 @@ void InspectorInstrumentation::didEnableExtensionImpl(InstrumentingAgents& instr
 void InspectorInstrumentation::willDestroyWebGLProgram(WebGLProgram& program)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (RefPtr agents = instrumentingAgents(program.protectedScriptExecutionContext().get()))
+    if (CheckedPtr agents = instrumentingAgents(program.protectedScriptExecutionContext().get()))
         willDestroyWebGLProgramImpl(*agents, program);
 }
 
@@ -1340,7 +1340,7 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(const LocalFr
 
 InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(const LocalFrame& frame)
 {
-    return frame.inspectorController().m_instrumentingAgents.get();
+    return frame.inspectorController().m_instrumentingAgents;
 }
 
 InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(Document& document)
@@ -1354,7 +1354,7 @@ InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(Document& doc
 InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(Page& page)
 {
     ASSERT(isMainThread());
-    return page.inspectorController().m_instrumentingAgents.get();
+    return page.inspectorController().m_instrumentingAgents;
 }
 
 InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(ScriptExecutionContext& context)

--- a/Source/WebCore/inspector/InspectorWebAgentBase.h
+++ b/Source/WebCore/inspector/InspectorWebAgentBase.h
@@ -31,6 +31,7 @@
 #include <WebCore/LocalFrame.h>
 #include <WebCore/Page.h>
 #include <WebCore/WorkerOrWorkletGlobalScope.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
@@ -86,7 +87,7 @@ protected:
     {
     }
 
-    WeakRef<InstrumentingAgents> m_instrumentingAgents;
+    const CheckedRef<InstrumentingAgents> m_instrumentingAgents;
     Inspector::InspectorEnvironment& m_environment;
 };
     

--- a/Source/WebCore/inspector/InstrumentingAgents.cpp
+++ b/Source/WebCore/inspector/InstrumentingAgents.cpp
@@ -36,14 +36,14 @@ namespace WebCore {
 
 using namespace Inspector;
 
-Ref<InstrumentingAgents> InstrumentingAgents::create(Inspector::InspectorEnvironment& environment)
+UniqueRef<InstrumentingAgents> InstrumentingAgents::create(Inspector::InspectorEnvironment& environment)
 {
-    return adoptRef(*new InstrumentingAgents(environment, nullptr));
+    return makeUniqueRef<InstrumentingAgents>(environment, nullptr);
 }
 
-Ref<InstrumentingAgents> InstrumentingAgents::create(Inspector::InspectorEnvironment& environment, InstrumentingAgents& fallbackAgents)
+UniqueRef<InstrumentingAgents> InstrumentingAgents::create(Inspector::InspectorEnvironment& environment, InstrumentingAgents& fallbackAgents)
 {
-    return adoptRef(*new InstrumentingAgents(environment, &fallbackAgents));
+    return makeUniqueRef<InstrumentingAgents>(environment, &fallbackAgents);
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(InstrumentingAgents);
@@ -71,8 +71,8 @@ Class* InstrumentingAgents::Getter##Name() const \
 { \
     if (m_##Getter##Name) \
         return m_##Getter##Name; \
-    if (RefPtr fallbackAgents = m_fallbackAgents.get()) \
-        return fallbackAgents->Getter##Name(); \
+    if (m_fallbackAgents) \
+        return m_fallbackAgents->Getter##Name(); \
     return nullptr; \
 } \
 void InstrumentingAgents::set##Setter##Name(Class* agent) \

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -32,10 +32,11 @@
 #pragma once
 
 #include <JavaScriptCore/InspectorEnvironment.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/UniqueRef.h>
 
 namespace Inspector {
 class InspectorAgent;
@@ -139,12 +140,13 @@ class WebHeapAgent;
     DEFINE_TRACKING_INSPECTOR_AGENT(macro, Timeline) \
     DEFINE_TRACKING_INSPECTOR_AGENT(macro, Timeline_Page) \
 
-class InstrumentingAgents : public WTF::RefCountedAndCanMakeWeakPtr<InstrumentingAgents> {
+class InstrumentingAgents : public CanMakeCheckedPtr<InstrumentingAgents> {
     WTF_MAKE_NONCOPYABLE(InstrumentingAgents);
     WTF_MAKE_TZONE_ALLOCATED(InstrumentingAgents);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InstrumentingAgents);
 public:
-    static Ref<InstrumentingAgents> create(Inspector::InspectorEnvironment&);
-    static Ref<InstrumentingAgents> create(Inspector::InspectorEnvironment&, InstrumentingAgents& fallbackAgents);
+    static UniqueRef<InstrumentingAgents> create(Inspector::InspectorEnvironment&);
+    static UniqueRef<InstrumentingAgents> create(Inspector::InspectorEnvironment&, InstrumentingAgents& fallbackAgents);
 
     ~InstrumentingAgents() = default;
     void reset();
@@ -159,10 +161,11 @@ FOR_EACH_INSPECTOR_AGENT(DECLARE_GETTER_SETTER_FOR_INSPECTOR_AGENT)
 #undef DECLARE_GETTER_SETTER_FOR_INSPECTOR_AGENT
 
 private:
+    template<typename T, class... Args> friend WTF::UniqueRef<T> WTF::makeUniqueRefWithoutFastMallocCheck(Args&&...);
     InstrumentingAgents(Inspector::InspectorEnvironment&, InstrumentingAgents* fallbackAgents);
 
     Inspector::InspectorEnvironment& m_environment;
-    const WeakPtr<InstrumentingAgents> m_fallbackAgents;
+    const InstrumentingAgents* m_fallbackAgents;
 
 #define DECLARE_MEMBER_VARIABLE_FOR_INSPECTOR_AGENT(Class, Name, Getter, Setter) \
     Class* m_##Getter##Name { nullptr }; \

--- a/Source/WebCore/inspector/WorkerInspectorController.cpp
+++ b/Source/WebCore/inspector/WorkerInspectorController.cpp
@@ -202,7 +202,7 @@ WorkerAgentContext WorkerInspectorController::workerAgentContext()
 
     WebAgentContext webContext = {
         baseContext,
-        m_instrumentingAgents.get(),
+        m_instrumentingAgents,
     };
 
     WorkerAgentContext workerContext = {
@@ -249,7 +249,7 @@ void WorkerInspectorController::createLazyAgents()
     m_agents.append(WTFMove(scriptProfilerAgentPtr));
 
     if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
-        commandLineAPIHost->init(m_instrumentingAgents.copyRef());
+        commandLineAPIHost->init(m_instrumentingAgents);
 }
 
 WorkerDebuggerAgent& WorkerInspectorController::ensureDebuggerAgent()

--- a/Source/WebCore/inspector/WorkerInspectorController.h
+++ b/Source/WebCore/inspector/WorkerInspectorController.h
@@ -29,6 +29,7 @@
 #include "WorkerOrWorkletGlobalScope.h"
 #include <JavaScriptCore/InspectorAgentRegistry.h>
 #include <JavaScriptCore/InspectorEnvironment.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Stopwatch.h>
@@ -79,7 +80,7 @@ private:
 
     void updateServiceWorkerPageFrontendCount();
 
-    const Ref<InstrumentingAgents> m_instrumentingAgents;
+    const UniqueRef<InstrumentingAgents> m_instrumentingAgents;
     const UniqueRef<WebInjectedScriptManager> m_injectedScriptManager;
     const Ref<Inspector::FrontendRouter> m_frontendRouter;
     const Ref<Inspector::BackendDispatcher> m_backendDispatcher;

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -263,9 +263,8 @@ InspectorAnimationAgent::~InspectorAnimationAgent() = default;
 
 void InspectorAnimationAgent::didCreateFrontendAndBackend()
 {
-    Ref agents = m_instrumentingAgents.get();
-    ASSERT(agents->persistentAnimationAgent() != this);
-    agents->setPersistentAnimationAgent(this);
+    ASSERT(m_instrumentingAgents->persistentAnimationAgent() != this);
+    m_instrumentingAgents->setPersistentAnimationAgent(this);
 }
 
 void InspectorAnimationAgent::willDestroyFrontendAndBackend(DisconnectReason)
@@ -273,18 +272,16 @@ void InspectorAnimationAgent::willDestroyFrontendAndBackend(DisconnectReason)
     stopTracking();
     disable();
 
-    Ref agents = m_instrumentingAgents.get();
-    ASSERT(agents->persistentAnimationAgent() == this);
-    agents->setPersistentAnimationAgent(nullptr);
+    ASSERT(m_instrumentingAgents->persistentAnimationAgent() == this);
+    m_instrumentingAgents->setPersistentAnimationAgent(nullptr);
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::enable()
 {
-    Ref agents = m_instrumentingAgents.get();
-    if (agents->enabledAnimationAgent() == this)
+    if (m_instrumentingAgents->enabledAnimationAgent() == this)
         return makeUnexpected("Animation domain already enabled"_s);
 
-    agents->setEnabledAnimationAgent(this);
+    m_instrumentingAgents->setEnabledAnimationAgent(this);
 
     const auto existsInCurrentPage = [&] (ScriptExecutionContext* scriptExecutionContext) {
         // FIXME: <https://webkit.org/b/168475> Web Inspector: Correctly display iframe's WebSockets
@@ -304,7 +301,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::enable()
 
 Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::disable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledAnimationAgent(nullptr);
+    m_instrumentingAgents->setEnabledAnimationAgent(nullptr);
 
     reset();
 
@@ -338,8 +335,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::Styleable>> Ins
 
     m_animationsIgnoringTargetChanges.remove(*animation);
 
-    Ref agents = m_instrumentingAgents.get();
-    auto* domAgent = agents->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 
@@ -388,11 +384,10 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObjec
 
 Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::startTracking()
 {
-    Ref agents = m_instrumentingAgents.get();
-    if (agents->trackingAnimationAgent() == this)
+    if (m_instrumentingAgents->trackingAnimationAgent() == this)
         return { };
 
-    agents->setTrackingAnimationAgent(this);
+    m_instrumentingAgents->setTrackingAnimationAgent(this);
 
     ASSERT(m_trackedStyleOriginatedAnimationData.isEmpty());
 
@@ -403,11 +398,10 @@ Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::startTracking(
 
 Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::stopTracking()
 {
-    Ref agents = m_instrumentingAgents.get();
-    if (agents->trackingAnimationAgent() != this)
+    if (m_instrumentingAgents->trackingAnimationAgent() != this)
         return { };
 
-    agents->setTrackingAnimationAgent(nullptr);
+    m_instrumentingAgents->setTrackingAnimationAgent(nullptr);
 
     m_trackedStyleOriginatedAnimationData.clear();
 
@@ -473,7 +467,7 @@ void InspectorAnimationAgent::willApplyKeyframeEffect(const Styleable& target, K
         .release();
 
     if (ensureResult.isNewEntry) {
-        if (auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent()) {
+        if (auto* domAgent = m_instrumentingAgents->persistentDOMAgent()) {
             if (auto nodeId = domAgent->pushStyleableElementToFrontend(target))
                 event->setNodeId(nodeId);
         }

--- a/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
@@ -51,14 +51,14 @@ InspectorCPUProfilerAgent::~InspectorCPUProfilerAgent() = default;
 
 void InspectorCPUProfilerAgent::didCreateFrontendAndBackend()
 {
-    Ref { m_instrumentingAgents.get() }->setPersistentCPUProfilerAgent(this);
+    m_instrumentingAgents->setPersistentCPUProfilerAgent(this);
 }
 
 void InspectorCPUProfilerAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
     stopTracking();
 
-    Ref { m_instrumentingAgents.get() }->setPersistentCPUProfilerAgent(nullptr);
+    m_instrumentingAgents->setPersistentCPUProfilerAgent(nullptr);
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorCPUProfilerAgent::startTracking()

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -320,13 +320,12 @@ void InspectorCSSAgent::reset()
 
 Inspector::Protocol::ErrorStringOr<void> InspectorCSSAgent::enable()
 {
-    Ref agents = m_instrumentingAgents.get();
-    if (agents->enabledCSSAgent() == this)
+    if (m_instrumentingAgents->enabledCSSAgent() == this)
         return { };
 
-    agents->setEnabledCSSAgent(this);
+    m_instrumentingAgents->setEnabledCSSAgent(this);
 
-    if (auto* domAgent = agents->persistentDOMAgent()) {
+    if (auto* domAgent = m_instrumentingAgents->persistentDOMAgent()) {
         for (auto* document : domAgent->documents())
             activeStyleSheetsUpdated(*document);
     }
@@ -336,7 +335,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCSSAgent::enable()
 
 Inspector::Protocol::ErrorStringOr<void> InspectorCSSAgent::disable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledCSSAgent(nullptr);
+    m_instrumentingAgents->setEnabledCSSAgent(nullptr);
 
     reset();
 
@@ -403,7 +402,7 @@ bool InspectorCSSAgent::forcePseudoState(const Element& element, CSSSelector::Ps
     if (m_nodeIdToForcedPseudoState.isEmpty())
         return false;
 
-    auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent)
         return false;
 
@@ -644,7 +643,7 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::C
 void InspectorCSSAgent::collectAllStyleSheets(Vector<InspectorStyleSheet*>& result)
 {
     Vector<CSSStyleSheet*> cssStyleSheets;
-    if (auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent()) {
+    if (auto* domAgent = m_instrumentingAgents->persistentDOMAgent()) {
         for (auto* document : domAgent->documents())
             collectAllDocumentStyleSheets(*document, cssStyleSheets);
     }
@@ -710,7 +709,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCSSAgent::setStyleSheetText(co
     if (!inspectorStyleSheet)
         return makeUnexpected(errorString);
 
-    auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 
@@ -732,7 +731,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::CSSStyle>> Insp
     if (!inspectorStyleSheet)
         return makeUnexpected(errorString);
 
-    auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 
@@ -754,7 +753,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::CSSRule>> Inspe
     if (!inspectorStyleSheet)
         return makeUnexpected(errorString);
 
-    auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 
@@ -780,7 +779,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::Grouping>> Insp
     if (!inspectorStyleSheet)
         return makeUnexpected(errorString);
 
-    auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 
@@ -800,7 +799,7 @@ Inspector::Protocol::ErrorStringOr<Inspector::Protocol::CSS::StyleSheetId> Inspe
 {
     Inspector::Protocol::ErrorString errorString;
 
-    auto* pageAgent = Ref { m_instrumentingAgents.get() }->enabledPageAgent();
+    auto* pageAgent = m_instrumentingAgents->enabledPageAgent();
     if (!pageAgent)
         return makeUnexpected("Page domain must be enabled"_s);
 
@@ -868,7 +867,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::CSSRule>> Inspe
     if (!inspectorStyleSheet)
         return makeUnexpected(errorString);
 
-    auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 
@@ -953,7 +952,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCSSAgent::forcePseudoState(Ins
 {
     Inspector::Protocol::ErrorString errorString;
 
-    auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 
@@ -1151,8 +1150,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCSSAgent::setLayoutContextType
     m_layoutContextTypeChangedMode = mode;
     
     if (mode == Inspector::Protocol::CSS::LayoutContextTypeChangedMode::All) {
-        Ref agents = m_instrumentingAgents.get();
-    auto* domAgent = agents->persistentDOMAgent();
+        auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
         if (!domAgent)
             return makeUnexpected("DOM domain must be enabled"_s);
 
@@ -1199,8 +1197,7 @@ void InspectorCSSAgent::nodeHasLayoutFlagsChange(Node& node)
 
 void InspectorCSSAgent::nodesWithPendingLayoutFlagsChangeDispatchTimerFired()
 {
-    Ref agents = m_instrumentingAgents.get();
-    auto* domAgent = agents->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent)
         return;
 
@@ -1230,7 +1227,7 @@ InspectorStyleSheetForInlineStyle& InspectorCSSAgent::asInspectorStyleSheet(Styl
 {
     return m_nodeToInspectorStyleSheet.ensure(&element, [this, &element] {
         String newStyleSheetId = String::number(m_lastStyleSheetId++);
-        auto inspectorStyleSheet = InspectorStyleSheetForInlineStyle::create(Ref { m_instrumentingAgents.get() }->enabledPageAgent(), newStyleSheetId, element, Inspector::Protocol::CSS::StyleSheetOrigin::Author, this);
+        auto inspectorStyleSheet = InspectorStyleSheetForInlineStyle::create(m_instrumentingAgents->enabledPageAgent(), newStyleSheetId, element, Inspector::Protocol::CSS::StyleSheetOrigin::Author, this);
         m_idToInspectorStyleSheet.set(newStyleSheetId, inspectorStyleSheet.copyRef());
         return inspectorStyleSheet;
     }).iterator->value;
@@ -1238,8 +1235,7 @@ InspectorStyleSheetForInlineStyle& InspectorCSSAgent::asInspectorStyleSheet(Styl
 
 Element* InspectorCSSAgent::elementForId(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Ref agents = m_instrumentingAgents.get();
-    auto* domAgent = agents->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent) {
         errorString = "DOM domain must be enabled"_s;
         return nullptr;
@@ -1250,8 +1246,7 @@ Element* InspectorCSSAgent::elementForId(Inspector::Protocol::ErrorString& error
 
 Node* InspectorCSSAgent::nodeForId(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Ref agents = m_instrumentingAgents.get();
-    auto* domAgent = agents->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent) {
         errorString = "DOM domain must be enabled"_s;
         return nullptr;
@@ -1275,7 +1270,7 @@ InspectorStyleSheet* InspectorCSSAgent::bindStyleSheet(CSSStyleSheet* styleSheet
     if (!inspectorStyleSheet) {
         String id = String::number(m_lastStyleSheetId++);
         Document* document = styleSheet->ownerDocument();
-        inspectorStyleSheet = InspectorStyleSheet::create(Ref { m_instrumentingAgents.get() }->enabledPageAgent(), id, styleSheet, detectOrigin(styleSheet, document), InspectorDOMAgent::documentURLString(document), this);
+        inspectorStyleSheet = InspectorStyleSheet::create(m_instrumentingAgents->enabledPageAgent(), id, styleSheet, detectOrigin(styleSheet, document), InspectorDOMAgent::documentURLString(document), this);
         m_idToInspectorStyleSheet.set(id, inspectorStyleSheet);
         m_cssStyleSheetToInspectorStyleSheet.set(styleSheet, inspectorStyleSheet);
         if (m_creatingViaInspectorStyleSheet) {

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -138,14 +138,14 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::disable()
 
 bool InspectorCanvasAgent::enabled() const
 {
-    return Ref { m_instrumentingAgents.get() }->enabledCanvasAgent() == this;
+    return m_instrumentingAgents->enabledCanvasAgent() == this;
 }
 
 void InspectorCanvasAgent::internalEnable()
 {
     ASSERT(!enabled());
 
-    Ref { m_instrumentingAgents.get() }->setEnabledCanvasAgent(this);
+    m_instrumentingAgents->setEnabledCanvasAgent(this);
 
     {
         Locker locker { CanvasRenderingContext::instancesLock() };
@@ -180,7 +180,7 @@ void InspectorCanvasAgent::internalEnable()
 
 void InspectorCanvasAgent::internalDisable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledCanvasAgent(nullptr);
+    m_instrumentingAgents->setEnabledCanvasAgent(nullptr);
 
     reset();
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -335,7 +335,7 @@ void InspectorDOMAgent::didCreateFrontendAndBackend()
     m_history = makeUnique<InspectorHistory>();
     m_domEditor = makeUnique<DOMEditor>(*m_history);
 
-    Ref { m_instrumentingAgents.get() }->setPersistentDOMAgent(this);
+    m_instrumentingAgents->setPersistentDOMAgent(this);
     m_document = m_inspectedPage->localTopDocument();
 
     // Force a layout so that we can collect additional information from the layout process.
@@ -366,7 +366,7 @@ void InspectorDOMAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReaso
     overlay->clearAllGridOverlays();
     overlay->clearAllFlexOverlays();
 
-    Ref { m_instrumentingAgents.get() }->setPersistentDOMAgent(nullptr);
+    m_instrumentingAgents->setPersistentDOMAgent(nullptr);
     m_documentRequested = false;
     reset();
 }
@@ -463,7 +463,7 @@ void InspectorDOMAgent::unbind(Node& node)
             unbind(*afterElement);
     }
 
-    if (auto* cssAgent = Ref { m_instrumentingAgents.get() }->enabledCSSAgent())
+    if (auto* cssAgent = m_instrumentingAgents->enabledCSSAgent())
         cssAgent->didRemoveDOMNode(node, id);
 
     if (m_childrenRequested.remove(id)) {
@@ -1513,8 +1513,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(co
     RefPtr<Document> document;
 
     if (!!frameId) {
-        Ref agents = m_instrumentingAgents.get();
-        auto* pageAgent = agents->enabledPageAgent();
+        auto* pageAgent = m_instrumentingAgents->enabledPageAgent();
         if (!pageAgent)
             return makeUnexpected("Page domain must be enabled"_s);
 
@@ -1689,8 +1688,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightFrame(const
 {
     Inspector::Protocol::ErrorString errorString;
 
-    Ref agents = m_instrumentingAgents.get();
-    auto* pageAgent = agents->enabledPageAgent();
+    auto* pageAgent = m_instrumentingAgents->enabledPageAgent();
     if (!pageAgent)
         return makeUnexpected("Page domain must be enabled"_s);
 
@@ -2021,13 +2019,12 @@ Ref<Inspector::Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* 
             value->setChildren(WTFMove(children));
     }
 
-    Ref agents = m_instrumentingAgents.get();
-    if (auto* cssAgent = agents->enabledCSSAgent()) {
+    if (auto* cssAgent = m_instrumentingAgents->enabledCSSAgent()) {
         if (auto layoutFlags = cssAgent->protocolLayoutFlagsForNode(*node))
             value->setLayoutFlags(layoutFlags.releaseNonNull());
     }
 
-    auto* pageAgent = agents->enabledPageAgent();
+    auto* pageAgent = m_instrumentingAgents->enabledPageAgent();
     if (pageAgent) {
         if (auto* frameView = node->document().view())
             value->setFrameId(pageAgent->frameId(&frameView->frame()));
@@ -2757,7 +2754,7 @@ void InspectorDOMAgent::willDestroyDOMNode(Node& node)
     m_idToNode.remove(nodeId);
     m_childrenRequested.remove(nodeId);
 
-    if (auto* cssAgent = Ref { m_instrumentingAgents.get() }->enabledCSSAgent())
+    if (auto* cssAgent = m_instrumentingAgents->enabledCSSAgent())
         cssAgent->didRemoveDOMNode(node, nodeId);
 
     // This can be called in response to GC. Due to the single-process model used in WebKit1, the
@@ -2805,7 +2802,7 @@ void InspectorDOMAgent::didModifyDOMAttr(Element& element, const AtomString& nam
     if (!id)
         return;
 
-    if (auto* cssAgent = Ref { m_instrumentingAgents.get() }->enabledCSSAgent())
+    if (auto* cssAgent = m_instrumentingAgents->enabledCSSAgent())
         cssAgent->didModifyDOMAttr(element);
 
     m_frontendDispatcher->attributeModified(id, name, value);
@@ -2817,7 +2814,7 @@ void InspectorDOMAgent::didRemoveDOMAttr(Element& element, const AtomString& nam
     if (!id)
         return;
 
-    if (auto* cssAgent = Ref { m_instrumentingAgents.get() }->enabledCSSAgent())
+    if (auto* cssAgent = m_instrumentingAgents->enabledCSSAgent())
         cssAgent->didModifyDOMAttr(element);
 
     m_frontendDispatcher->attributeRemoved(id, name);
@@ -2826,13 +2823,12 @@ void InspectorDOMAgent::didRemoveDOMAttr(Element& element, const AtomString& nam
 void InspectorDOMAgent::styleAttributeInvalidated(const Vector<Element*>& elements)
 {
     auto nodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
-    Ref agents = m_instrumentingAgents.get();
     for (auto& element : elements) {
         auto id = boundNodeId(element);
         if (!id)
             continue;
 
-        if (auto* cssAgent = agents->enabledCSSAgent())
+        if (auto* cssAgent = m_instrumentingAgents->enabledCSSAgent())
             cssAgent->didModifyDOMAttr(*element);
 
         nodeIds->addItem(id);

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
@@ -70,17 +70,17 @@ InspectorDOMDebuggerAgent::~InspectorDOMDebuggerAgent() = default;
 
 bool InspectorDOMDebuggerAgent::enabled() const
 {
-    return Ref { m_instrumentingAgents.get() }->enabledDOMDebuggerAgent() == this;
+    return m_instrumentingAgents->enabledDOMDebuggerAgent() == this;
 }
 
 void InspectorDOMDebuggerAgent::enable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledDOMDebuggerAgent(this);
+    m_instrumentingAgents->setEnabledDOMDebuggerAgent(this);
 }
 
 void InspectorDOMDebuggerAgent::disable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledDOMDebuggerAgent(nullptr);
+    m_instrumentingAgents->setEnabledDOMDebuggerAgent(nullptr);
 
     m_listenerBreakpoints.clear();
     m_pauseOnAllIntervalsBreakpoint = nullptr;
@@ -288,8 +288,7 @@ void InspectorDOMDebuggerAgent::willHandleEvent(ScriptExecutionContext& scriptEx
     if (!m_debuggerAgent->breakpointsActive())
         return;
 
-    Ref agents = m_instrumentingAgents.get();
-    auto* domAgent = agents->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
 
     auto breakpoint = m_pauseOnAllListenersBreakpoint;
     if (!breakpoint) {
@@ -348,8 +347,7 @@ void InspectorDOMDebuggerAgent::didHandleEvent(ScriptExecutionContext& scriptExe
         }
     }
     if (!breakpoint) {
-        Ref agents = m_instrumentingAgents.get();
-        if (auto* domAgent = agents->persistentDOMAgent())
+        if (auto* domAgent = m_instrumentingAgents->persistentDOMAgent())
             breakpoint = domAgent->breakpointForEventListener(*event.currentTarget(), event.type(), registeredEventListener.callback(), registeredEventListener.useCapture());
     }
     if (!breakpoint)

--- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
@@ -79,22 +79,20 @@ void InspectorDOMStorageAgent::willDestroyFrontendAndBackend(Inspector::Disconne
 
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::enable()
 {
-    Ref agents = m_instrumentingAgents.get();
-    if (agents->enabledDOMStorageAgent() == this)
+    if (m_instrumentingAgents->enabledDOMStorageAgent() == this)
         return makeUnexpected("DOMStorage domain already enabled"_s);
 
-    agents->setEnabledDOMStorageAgent(this);
+    m_instrumentingAgents->setEnabledDOMStorageAgent(this);
 
     return { };
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::disable()
 {
-    Ref agents = m_instrumentingAgents.get();
-    if (agents->enabledDOMStorageAgent() != this)
+    if (m_instrumentingAgents->enabledDOMStorageAgent() != this)
         return makeUnexpected("DOMStorage domain already disabled"_s);
 
-    agents->setEnabledDOMStorageAgent(nullptr);
+    m_instrumentingAgents->setEnabledDOMStorageAgent(nullptr);
 
     return { };
 }

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
@@ -81,14 +81,14 @@ void InspectorLayerTreeAgent::reset()
 
 Inspector::Protocol::ErrorStringOr<void> InspectorLayerTreeAgent::enable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledLayerTreeAgent(this);
+    m_instrumentingAgents->setEnabledLayerTreeAgent(this);
 
     return { };
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorLayerTreeAgent::disable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledLayerTreeAgent(nullptr);
+    m_instrumentingAgents->setEnabledLayerTreeAgent(nullptr);
 
     reset();
 
@@ -117,7 +117,7 @@ void InspectorLayerTreeAgent::pseudoElementDestroyed(PseudoElement& pseudoElemen
 
 Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::LayerTree::Layer>>> InspectorLayerTreeAgent::layersForNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    auto* node = Ref { m_instrumentingAgents.get() }->persistentDOMAgent()->nodeForId(nodeId);
+    auto* node = m_instrumentingAgents->persistentDOMAgent()->nodeForId(nodeId);
     if (!node)
         return makeUnexpected("Missing node for given nodeId"_s);
 
@@ -221,8 +221,7 @@ Inspector::Protocol::DOM::NodeId InspectorLayerTreeAgent::idForNode(Node* node)
     if (!node)
         return 0;
 
-    Ref agents = m_instrumentingAgents.get();
-    InspectorDOMAgent* domAgent = agents->persistentDOMAgent();
+    InspectorDOMAgent* domAgent = m_instrumentingAgents->persistentDOMAgent();
     
     auto nodeId = domAgent->boundNodeId(node);
     if (!nodeId) {

--- a/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
@@ -52,34 +52,32 @@ InspectorMemoryAgent::~InspectorMemoryAgent() = default;
 
 void InspectorMemoryAgent::didCreateFrontendAndBackend()
 {
-    Ref { m_instrumentingAgents.get() }->setPersistentMemoryAgent(this);
+    m_instrumentingAgents->setPersistentMemoryAgent(this);
 }
 
 void InspectorMemoryAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
     disable();
 
-    Ref { m_instrumentingAgents.get() }->setPersistentMemoryAgent(nullptr);
+    m_instrumentingAgents->setPersistentMemoryAgent(nullptr);
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::enable()
 {
-    Ref agents = m_instrumentingAgents.get();
-    if (agents->enabledMemoryAgent() == this)
+    if (m_instrumentingAgents->enabledMemoryAgent() == this)
         return makeUnexpected("Memory domain already enabled"_s);
 
-    agents->setEnabledMemoryAgent(this);
+    m_instrumentingAgents->setEnabledMemoryAgent(this);
 
     return { };
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::disable()
 {
-    Ref agents = m_instrumentingAgents.get();
-    if (agents->enabledMemoryAgent() != this)
+    if (m_instrumentingAgents->enabledMemoryAgent() != this)
         return makeUnexpected("Memory domain already disabled"_s);
 
-    agents->setEnabledMemoryAgent(nullptr);
+    m_instrumentingAgents->setEnabledMemoryAgent(nullptr);
 
     m_tracking = false;
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -733,7 +733,7 @@ Ref<Inspector::Protocol::Network::Initiator> InspectorNetworkAgent::buildInitiat
         initiatorObject->setLineNumber(document->scriptableDocumentParser()->textPosition().m_line.oneBasedInt());
     }
 
-    auto domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    auto domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (domAgent && resourceRequest) {
         if (auto inspectorInitiatorNodeIdentifier = resourceRequest->inspectorInitiatorNodeIdentifier()) {
             if (!initiatorObject) {
@@ -802,7 +802,7 @@ void InspectorNetworkAgent::didReceiveWebSocketFrameError(WebSocketChannelIdenti
 Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::enable()
 {
     m_enabled = true;
-    Ref { m_instrumentingAgents.get() }->setEnabledNetworkAgent(this);
+    m_instrumentingAgents->setEnabledNetworkAgent(this);
 
     {
         Locker locker { WebSocket::allActiveWebSocketsLock() };
@@ -840,7 +840,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::disable()
     m_enabled = false;
     m_interceptionEnabled = false;
     m_intercepts.clear();
-    Ref { m_instrumentingAgents.get() }->setEnabledNetworkAgent(nullptr);
+    m_instrumentingAgents->setEnabledNetworkAgent(nullptr);
     m_resourcesData->clear();
     m_extraRequestHeaders.clear();
 

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -127,11 +127,10 @@ void InspectorPageAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReas
 
 Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::enable()
 {
-    Ref agents = m_instrumentingAgents.get();
-    if (agents->enabledPageAgent() == this)
+    if (m_instrumentingAgents->enabledPageAgent() == this)
         return makeUnexpected("Page domain already enabled"_s);
 
-    agents->setEnabledPageAgent(this);
+    m_instrumentingAgents->setEnabledPageAgent(this);
 
     auto& stopwatch = m_environment.executionStopwatch();
     stopwatch.reset();
@@ -144,7 +143,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::enable()
 
 Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::disable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledPageAgent(nullptr);
+    m_instrumentingAgents->setEnabledPageAgent(nullptr);
 
     setShowPaintRects(false);
 #if !PLATFORM(IOS_FAMILY)
@@ -585,7 +584,7 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Generi
     Inspector::Protocol::ErrorString errorString;
 
     if (!!requestId) {
-        if (auto* networkAgent = Ref { m_instrumentingAgents.get() }->enabledNetworkAgent()) {
+        if (auto* networkAgent = m_instrumentingAgents->enabledNetworkAgent()) {
             RefPtr<JSON::ArrayOf<Inspector::Protocol::GenericTypes::SearchMatch>> result;
             networkAgent->searchInRequest(errorString, requestId, query, caseSensitive && *caseSensitive, isRegex && *isRegex, result);
             if (!result)
@@ -655,7 +654,7 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Page::
         }
     }
 
-    if (auto* networkAgent = Ref { m_instrumentingAgents.get() }->enabledNetworkAgent())
+    if (auto* networkAgent = m_instrumentingAgents->enabledNetworkAgent())
         networkAgent->searchOtherRequests(regex, result);
 
     return result;
@@ -948,7 +947,7 @@ Inspector::Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotNode(Insp
 {
     Inspector::Protocol::ErrorString errorString;
 
-    InspectorDOMAgent* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    InspectorDOMAgent* domAgent = m_instrumentingAgents->persistentDOMAgent();
     ASSERT(domAgent);
     Node* node = domAgent->assertNode(errorString, nodeId);
     if (!node)

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -143,19 +143,19 @@ Inspector::Protocol::ErrorStringOr<void> InspectorTimelineAgent::setInstruments(
 
 bool InspectorTimelineAgent::enabled() const
 {
-    return Ref { m_instrumentingAgents.get() }->enabledTimelineAgent() == this;
+    return m_instrumentingAgents->enabledTimelineAgent() == this;
 }
 
 void InspectorTimelineAgent::internalEnable()
 {
     ASSERT(!enabled());
 
-    Ref { m_instrumentingAgents.get() }->setEnabledTimelineAgent(this);
+    m_instrumentingAgents->setEnabledTimelineAgent(this);
 }
 
 void InspectorTimelineAgent::internalDisable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledTimelineAgent(nullptr);
+    m_instrumentingAgents->setEnabledTimelineAgent(nullptr);
 
     stop();
 
@@ -164,7 +164,7 @@ void InspectorTimelineAgent::internalDisable()
 
 bool InspectorTimelineAgent::tracking() const
 {
-    return Ref { m_instrumentingAgents.get() }->trackingTimelineAgent() == this;
+    return m_instrumentingAgents->trackingTimelineAgent() == this;
 }
 
 void InspectorTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
@@ -176,7 +176,7 @@ void InspectorTimelineAgent::internalStart(std::optional<int>&& maxCallStackDept
     else
         m_maxCallStackDepth = 5;
 
-    Ref { m_instrumentingAgents.get() }->setTrackingTimelineAgent(this);
+    m_instrumentingAgents->setTrackingTimelineAgent(this);
 
     m_environment.debugger()->addObserver(*this);
 
@@ -185,7 +185,7 @@ void InspectorTimelineAgent::internalStart(std::optional<int>&& maxCallStackDept
 
 void InspectorTimelineAgent::internalStop()
 {
-    Ref { m_instrumentingAgents.get() }->setTrackingTimelineAgent(nullptr);
+    m_instrumentingAgents->setTrackingTimelineAgent(nullptr);
 
     m_environment.debugger()->removeObserver(*this, true);
 
@@ -223,7 +223,7 @@ void InspectorTimelineAgent::startFromConsole(const String& title)
         for (const TimelineRecordEntry& record : m_pendingConsoleProfileRecords) {
             auto recordTitle = record.data->getString("title"_s);
             if (recordTitle == title) {
-                if (auto* consoleAgent = Ref { m_instrumentingAgents.get() } -> webConsoleAgent()) {
+                if (auto* consoleAgent = m_instrumentingAgents -> webConsoleAgent()) {
                     // FIXME: Send an enum to the frontend for localization?
                     String warning = title.isEmpty() ? "Unnamed Profile already exists"_s : makeString("Profile \""_s, ScriptArguments::truncateStringForConsoleMessage(title), "\" already exists"_s);
                     consoleAgent->addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Profile, MessageLevel::Warning, warning));
@@ -258,7 +258,7 @@ void InspectorTimelineAgent::stopFromConsole(const String& title)
         }
     }
 
-    if (auto* consoleAgent = Ref { m_instrumentingAgents.get() }->webConsoleAgent()) {
+    if (auto* consoleAgent = m_instrumentingAgents->webConsoleAgent()) {
         // FIXME: Send an enum to the frontend for localization?
         String warning = title.isEmpty() ? "No profiles exist"_s : makeString("Profile \""_s, ScriptArguments::truncateStringForConsoleMessage(title), "\" does not exist"_s);
         consoleAgent->addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::ProfileEnd, MessageLevel::Warning, warning));
@@ -356,7 +356,7 @@ void InspectorTimelineAgent::didEnqueueFirstContentfulPaint()
 void InspectorTimelineAgent::didEnqueueLargestContentfulPaint(Element* element, unsigned area)
 {
     Inspector::Protocol::DOM::NodeId nodeID = 0;
-    if (auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent())
+    if (auto* domAgent = m_instrumentingAgents->persistentDOMAgent())
         nodeID = domAgent->pushNodeToFrontend(element);
 
     appendRecord(TimelineRecordFactory::createLargestContentfulPaintData(nodeID, area), TimelineRecordType::LargestContentfulPaint, false);
@@ -367,7 +367,7 @@ void InspectorTimelineAgent::startProgrammaticCapture()
     ASSERT(!tracking());
 
     // Disable breakpoints during programmatic capture.
-    if (auto* webDebuggerAgent = Ref { m_instrumentingAgents.get() }->enabledWebDebuggerAgent()) {
+    if (auto* webDebuggerAgent = m_instrumentingAgents->enabledWebDebuggerAgent()) {
         m_programmaticCaptureRestoreBreakpointActiveValue = webDebuggerAgent->breakpointsActive();
         if (m_programmaticCaptureRestoreBreakpointActiveValue)
             webDebuggerAgent->setBreakpointsActive(false);
@@ -390,7 +390,7 @@ void InspectorTimelineAgent::stopProgrammaticCapture()
 
     // Re-enable breakpoints if they were enabled.
     if (m_programmaticCaptureRestoreBreakpointActiveValue) {
-        if (auto* webDebuggerAgent = Ref { m_instrumentingAgents.get() }->enabledWebDebuggerAgent())
+        if (auto* webDebuggerAgent = m_instrumentingAgents->enabledWebDebuggerAgent())
             webDebuggerAgent->setBreakpointsActive(true);
     }
 }
@@ -430,7 +430,7 @@ void InspectorTimelineAgent::toggleInstruments(InstrumentState state)
 
 void InspectorTimelineAgent::toggleScriptProfilerInstrument(InstrumentState state)
 {
-    if (auto* scriptProfilerAgent = Ref { m_instrumentingAgents.get() }->persistentScriptProfilerAgent()) {
+    if (auto* scriptProfilerAgent = m_instrumentingAgents->persistentScriptProfilerAgent()) {
         if (state == InstrumentState::Start)
             scriptProfilerAgent->startTracking(true);
         else
@@ -440,7 +440,7 @@ void InspectorTimelineAgent::toggleScriptProfilerInstrument(InstrumentState stat
 
 void InspectorTimelineAgent::toggleHeapInstrument(InstrumentState state)
 {
-    if (auto* heapAgent = Ref { m_instrumentingAgents.get() }->persistentWebHeapAgent()) {
+    if (auto* heapAgent = m_instrumentingAgents->persistentWebHeapAgent()) {
         if (state == InstrumentState::Start) {
             if (shouldStartHeapInstrument())
                 heapAgent->startTracking();
@@ -452,7 +452,7 @@ void InspectorTimelineAgent::toggleHeapInstrument(InstrumentState state)
 void InspectorTimelineAgent::toggleCPUInstrument(InstrumentState state)
 {
 #if ENABLE(RESOURCE_USAGE)
-    if (auto* cpuProfilerAgent = Ref { m_instrumentingAgents.get() }->persistentCPUProfilerAgent()) {
+    if (auto* cpuProfilerAgent = m_instrumentingAgents->persistentCPUProfilerAgent()) {
         if (state == InstrumentState::Start)
             cpuProfilerAgent->startTracking();
         else
@@ -466,7 +466,7 @@ void InspectorTimelineAgent::toggleCPUInstrument(InstrumentState state)
 void InspectorTimelineAgent::toggleMemoryInstrument(InstrumentState state)
 {
 #if ENABLE(RESOURCE_USAGE)
-    if (auto* memoryAgent = Ref { m_instrumentingAgents.get() }->persistentMemoryAgent()) {
+    if (auto* memoryAgent = m_instrumentingAgents->persistentMemoryAgent()) {
         if (state == InstrumentState::Start)
             memoryAgent->startTracking();
         else
@@ -490,7 +490,7 @@ void InspectorTimelineAgent::toggleTimelineInstrument(InstrumentState state)
 
 void InspectorTimelineAgent::toggleAnimationInstrument(InstrumentState state)
 {
-    if (auto* animationAgent = Ref { m_instrumentingAgents.get() }->persistentAnimationAgent()) {
+    if (auto* animationAgent = m_instrumentingAgents->persistentAnimationAgent()) {
         if (state == InstrumentState::Start)
             animationAgent->startTracking();
         else

--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
@@ -51,12 +51,12 @@ InspectorWorkerAgent::~InspectorWorkerAgent()
 
 void InspectorWorkerAgent::didCreateFrontendAndBackend()
 {
-    Ref { m_instrumentingAgents.get() }->setPersistentWorkerAgent(this);
+    m_instrumentingAgents->setPersistentWorkerAgent(this);
 }
 
 void InspectorWorkerAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    Ref { m_instrumentingAgents.get() }->setPersistentWorkerAgent(nullptr);
+    m_instrumentingAgents->setPersistentWorkerAgent(nullptr);
 
     disable();
 }

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
@@ -49,19 +49,19 @@ WebDebuggerAgent::~WebDebuggerAgent() = default;
 
 bool WebDebuggerAgent::enabled() const
 {
-    return Ref { m_instrumentingAgents.get() }->enabledWebDebuggerAgent() == this && InspectorDebuggerAgent::enabled();
+    return m_instrumentingAgents->enabledWebDebuggerAgent() == this && InspectorDebuggerAgent::enabled();
 }
 
 void WebDebuggerAgent::internalEnable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledWebDebuggerAgent(this);
+    m_instrumentingAgents->setEnabledWebDebuggerAgent(this);
 
     InspectorDebuggerAgent::internalEnable();
 }
 
 void WebDebuggerAgent::internalDisable(bool isBeingDestroyed)
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledWebDebuggerAgent(nullptr);
+    m_instrumentingAgents->setEnabledWebDebuggerAgent(nullptr);
 
     InspectorDebuggerAgent::internalDisable(isBeingDestroyed);
 }

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.h
@@ -27,8 +27,8 @@
 
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorDebuggerAgent.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -67,7 +67,7 @@ protected:
 
     void didClearAsyncStackTraceData() final;
 
-    WeakRef<InstrumentingAgents> m_instrumentingAgents;
+    const CheckedRef<InstrumentingAgents> m_instrumentingAgents;
 
 private:
     HashMap<const RegisteredEventListener*, int> m_registeredEventListeners;

--- a/Source/WebCore/inspector/agents/WebHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.cpp
@@ -115,25 +115,23 @@ void WebHeapAgent::didCreateFrontendAndBackend()
 {
     InspectorHeapAgent::didCreateFrontendAndBackend();
 
-    Ref agents = m_instrumentingAgents.get();
-    ASSERT(agents->persistentWebHeapAgent() != this);
-    agents->setPersistentWebHeapAgent(this);
+    ASSERT(m_instrumentingAgents->persistentWebHeapAgent() != this);
+    m_instrumentingAgents->setPersistentWebHeapAgent(this);
 }
 
 void WebHeapAgent::willDestroyFrontendAndBackend(DisconnectReason reason)
 {
     InspectorHeapAgent::willDestroyFrontendAndBackend(reason);
 
-    Ref agents = m_instrumentingAgents.get();
-    ASSERT(agents->persistentWebHeapAgent() == this);
-    agents->setPersistentWebHeapAgent(nullptr);
+    ASSERT(m_instrumentingAgents->persistentWebHeapAgent() == this);
+    m_instrumentingAgents->setPersistentWebHeapAgent(nullptr);
 }
 
 Inspector::Protocol::ErrorStringOr<void> WebHeapAgent::enable()
 {
     auto result = InspectorHeapAgent::enable();
 
-    if (auto* consoleAgent = Ref { m_instrumentingAgents.get() }->webConsoleAgent())
+    if (auto* consoleAgent = m_instrumentingAgents->webConsoleAgent())
         consoleAgent->setHeapAgent(this);
 
     return result;
@@ -143,7 +141,7 @@ Inspector::Protocol::ErrorStringOr<void> WebHeapAgent::disable()
 {
     m_sendGarbageCollectionEventsTask->reset();
 
-    if (auto* consoleAgent = Ref { m_instrumentingAgents.get() }->webConsoleAgent())
+    if (auto* consoleAgent = m_instrumentingAgents->webConsoleAgent())
         consoleAgent->setHeapAgent(nullptr);
 
     return InspectorHeapAgent::disable();

--- a/Source/WebCore/inspector/agents/WebHeapAgent.h
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.h
@@ -27,9 +27,9 @@
 
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorHeapAgent.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -57,7 +57,7 @@ protected:
     void dispatchGarbageCollectedEvent(Inspector::Protocol::Heap::GarbageCollection::Type, Seconds startTime, Seconds endTime) final;
     void dispatchGarbageCollectionEventsAfterDelay(Vector<GarbageCollectionData>&& collections);
 
-    WeakRef<InstrumentingAgents> m_instrumentingAgents;
+    const CheckedRef<InstrumentingAgents> m_instrumentingAgents;
 
     const UniqueRef<SendGarbageCollectionEventsTask> m_sendGarbageCollectionEventsTask;
 };

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
@@ -67,19 +67,19 @@ PageCanvasAgent::~PageCanvasAgent() = default;
 
 bool PageCanvasAgent::enabled() const
 {
-    return Ref { m_instrumentingAgents.get() }->enabledPageCanvasAgent() == this && InspectorCanvasAgent::enabled();
+    return m_instrumentingAgents->enabledPageCanvasAgent() == this && InspectorCanvasAgent::enabled();
 }
 
 void PageCanvasAgent::internalEnable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledPageCanvasAgent(this);
+    m_instrumentingAgents->setEnabledPageCanvasAgent(this);
 
     InspectorCanvasAgent::internalEnable();
 }
 
 void PageCanvasAgent::internalDisable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledPageCanvasAgent(nullptr);
+    m_instrumentingAgents->setEnabledPageCanvasAgent(nullptr);
 
     InspectorCanvasAgent::internalDisable();
 }
@@ -97,19 +97,18 @@ Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> PageCanvasA
         return makeUnexpected("Missing element of canvas for given canvasId"_s);
 
     // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
-    Ref agents = m_instrumentingAgents.get();
-    int documentNodeId = agents->persistentDOMAgent()->boundNodeId(&node->document());
+    int documentNodeId = m_instrumentingAgents->persistentDOMAgent()->boundNodeId(&node->document());
     if (!documentNodeId)
         return makeUnexpected("Document must have been requested"_s);
 
-    return agents->persistentDOMAgent()->pushNodeToFrontend(errorString, documentNodeId, node);
+    return m_instrumentingAgents->persistentDOMAgent()->pushNodeToFrontend(errorString, documentNodeId, node);
 }
 
 Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> PageCanvasAgent::requestClientNodes(const Inspector::Protocol::Canvas::CanvasId& canvasId)
 {
     Inspector::Protocol::ErrorString errorString;
 
-    auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 

--- a/Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp
@@ -45,19 +45,19 @@ PageDOMDebuggerAgent::~PageDOMDebuggerAgent() = default;
 
 bool PageDOMDebuggerAgent::enabled() const
 {
-    return Ref { m_instrumentingAgents.get() }->enabledPageDOMDebuggerAgent() == this && InspectorDOMDebuggerAgent::enabled();
+    return m_instrumentingAgents->enabledPageDOMDebuggerAgent() == this && InspectorDOMDebuggerAgent::enabled();
 }
 
 void PageDOMDebuggerAgent::enable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledPageDOMDebuggerAgent(this);
+    m_instrumentingAgents->setEnabledPageDOMDebuggerAgent(this);
 
     InspectorDOMDebuggerAgent::enable();
 }
 
 void PageDOMDebuggerAgent::disable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledPageDOMDebuggerAgent(nullptr);
+    m_instrumentingAgents->setEnabledPageDOMDebuggerAgent(nullptr);
 
     m_domSubtreeModifiedBreakpoints.clear();
     m_domAttributeModifiedBreakpoints.clear();
@@ -70,7 +70,7 @@ Inspector::Protocol::ErrorStringOr<void> PageDOMDebuggerAgent::setDOMBreakpoint(
 {
     Inspector::Protocol::ErrorString errorString;
 
-    auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 
@@ -107,7 +107,7 @@ Inspector::Protocol::ErrorStringOr<void> PageDOMDebuggerAgent::removeDOMBreakpoi
 {
     Inspector::Protocol::ErrorString errorString;
 
-    auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    auto* domAgent = m_instrumentingAgents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 
@@ -252,7 +252,7 @@ void PageDOMDebuggerAgent::willRemoveDOMNode(Node& node)
     ASSERT(closestBreakpointOwner);
 
     auto pauseData = buildPauseDataForDOMBreakpoint(*closestBreakpointType, *closestBreakpointOwner);
-    if (auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent()) {
+    if (auto* domAgent = m_instrumentingAgents->persistentDOMAgent()) {
         if (&node != closestBreakpointOwner) {
             if (auto targetNodeId = domAgent->pushNodeToFrontend(&node))
                 pauseData->setInteger("targetNodeId"_s, targetNodeId);
@@ -311,7 +311,7 @@ Ref<JSON::Object> PageDOMDebuggerAgent::buildPauseDataForDOMBreakpoint(Inspector
 
     auto pauseData = JSON::Object::create();
     pauseData->setString("type"_s, Inspector::Protocol::Helpers::getEnumConstantValue(breakpointType));
-    if (auto* domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent()) {
+    if (auto* domAgent = m_instrumentingAgents->persistentDOMAgent()) {
         if (auto breakpointOwnerNodeId = domAgent->pushNodeToFrontend(&breakpointOwner))
             pauseData->setInteger("nodeId"_s, breakpointOwnerNodeId);
     }

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
@@ -68,7 +68,7 @@ PageDebuggerAgent::~PageDebuggerAgent() = default;
 
 bool PageDebuggerAgent::enabled() const
 {
-    return Ref { m_instrumentingAgents.get() }->enabledPageDebuggerAgent() == this && WebDebuggerAgent::enabled();
+    return m_instrumentingAgents->enabledPageDebuggerAgent() == this && WebDebuggerAgent::enabled();
 }
 
 Inspector::Protocol::ErrorStringOr<std::tuple<Ref<Inspector::Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> PageDebuggerAgent::evaluateOnCallFrame(const Inspector::Protocol::Debugger::CallFrameId& callFrameId, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture)
@@ -83,14 +83,14 @@ Inspector::Protocol::ErrorStringOr<std::tuple<Ref<Inspector::Protocol::Runtime::
 
 void PageDebuggerAgent::internalEnable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledPageDebuggerAgent(this);
+    m_instrumentingAgents->setEnabledPageDebuggerAgent(this);
 
     WebDebuggerAgent::internalEnable();
 }
 
 void PageDebuggerAgent::internalDisable(bool isBeingDestroyed)
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledPageDebuggerAgent(nullptr);
+    m_instrumentingAgents->setEnabledPageDebuggerAgent(nullptr);
 
     WebDebuggerAgent::internalDisable(isBeingDestroyed);
 }

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
@@ -50,14 +50,14 @@ Inspector::Protocol::ErrorStringOr<void> PageHeapAgent::enable()
 {
     auto result = WebHeapAgent::enable();
 
-    Ref { m_instrumentingAgents.get() }->setEnabledPageHeapAgent(this);
+    m_instrumentingAgents->setEnabledPageHeapAgent(this);
 
     return result;
 }
 
 Inspector::Protocol::ErrorStringOr<void> PageHeapAgent::disable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledPageHeapAgent(nullptr);
+    m_instrumentingAgents->setEnabledPageHeapAgent(nullptr);
 
     return WebHeapAgent::disable();
 }

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.h
@@ -28,8 +28,8 @@
 #include "InspectorWebAgentBase.h"
 #include "InstrumentingAgents.h"
 #include "WebHeapAgent.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -53,7 +53,7 @@ public:
     void mainFrameNavigated();
 
 private:
-    WeakRef<InstrumentingAgents> m_instrumentingAgents;
+    const CheckedRef<InstrumentingAgents> m_instrumentingAgents;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -61,7 +61,7 @@ PageNetworkAgent::~PageNetworkAgent() = default;
 Inspector::Protocol::Network::LoaderId PageNetworkAgent::loaderIdentifier(DocumentLoader* loader)
 {
     if (loader) {
-        if (auto* pageAgent = Ref { m_instrumentingAgents.get() }->enabledPageAgent())
+        if (auto* pageAgent = m_instrumentingAgents->enabledPageAgent())
             return pageAgent->loaderId(loader);
     }
     return { };
@@ -70,7 +70,7 @@ Inspector::Protocol::Network::LoaderId PageNetworkAgent::loaderIdentifier(Docume
 Inspector::Protocol::Network::FrameId PageNetworkAgent::frameIdentifier(DocumentLoader* loader)
 {
     if (loader) {
-        if (auto* pageAgent = Ref { m_instrumentingAgents.get() }->enabledPageAgent())
+        if (auto* pageAgent = m_instrumentingAgents->enabledPageAgent())
             return pageAgent->frameId(loader->frame());
     }
     return { };
@@ -118,7 +118,7 @@ bool PageNetworkAgent::setEmulatedConditionsInternal(std::optional<int>&& bytesP
 
 ScriptExecutionContext* PageNetworkAgent::scriptExecutionContext(Inspector::Protocol::ErrorString& errorString, const Inspector::Protocol::Network::FrameId& frameId)
 {
-    auto* pageAgent = Ref { m_instrumentingAgents.get() }->enabledPageAgent();
+    auto* pageAgent = m_instrumentingAgents->enabledPageAgent();
     if (!pageAgent) {
         errorString = "Page domain must be enabled"_s;
         return nullptr;

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
@@ -68,8 +68,7 @@ PageRuntimeAgent::~PageRuntimeAgent() = default;
 
 Inspector::Protocol::ErrorStringOr<void> PageRuntimeAgent::enable()
 {
-    Ref agents = m_instrumentingAgents.get();
-    if (agents->enabledPageRuntimeAgent() == this)
+    if (m_instrumentingAgents->enabledPageRuntimeAgent() == this)
         return { };
 
     auto result = InspectorRuntimeAgent::enable();
@@ -80,14 +79,14 @@ Inspector::Protocol::ErrorStringOr<void> PageRuntimeAgent::enable()
     // can force creation of script state which could result in duplicate notifications.
     reportExecutionContextCreation();
 
-    agents->setEnabledPageRuntimeAgent(this);
+    m_instrumentingAgents->setEnabledPageRuntimeAgent(this);
 
     return result;
 }
 
 Inspector::Protocol::ErrorStringOr<void> PageRuntimeAgent::disable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledPageRuntimeAgent(nullptr);
+    m_instrumentingAgents->setEnabledPageRuntimeAgent(nullptr);
 
     return InspectorRuntimeAgent::disable();
 }
@@ -100,7 +99,7 @@ void PageRuntimeAgent::frameNavigated(LocalFrame& frame)
 
 void PageRuntimeAgent::didClearWindowObjectInWorld(LocalFrame& frame, DOMWrapperWorld& world)
 {
-    auto* pageAgent = Ref { m_instrumentingAgents.get() }->enabledPageAgent();
+    auto* pageAgent = m_instrumentingAgents->enabledPageAgent();
     if (!pageAgent)
         return;
 
@@ -138,7 +137,7 @@ void PageRuntimeAgent::unmuteConsole()
 
 void PageRuntimeAgent::reportExecutionContextCreation()
 {
-    auto* pageAgent = Ref { m_instrumentingAgents.get() }->enabledPageAgent();
+    auto* pageAgent = m_instrumentingAgents->enabledPageAgent();
     if (!pageAgent)
         return;
 

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
@@ -34,6 +34,7 @@
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <JavaScriptCore/InspectorRuntimeAgent.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
@@ -75,7 +76,7 @@ private:
     const UniqueRef<Inspector::RuntimeFrontendDispatcher> m_frontendDispatcher;
     const Ref<Inspector::RuntimeBackendDispatcher> m_backendDispatcher;
 
-    WeakRef<InstrumentingAgents> m_instrumentingAgents;
+    const CheckedRef<InstrumentingAgents> m_instrumentingAgents;
 
     WeakRef<Page> m_inspectedPage;
 };

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -81,19 +81,19 @@ PageTimelineAgent::~PageTimelineAgent() = default;
 
 bool PageTimelineAgent::enabled() const
 {
-    return Ref { m_instrumentingAgents.get() }->enabledPageTimelineAgent() == this && InspectorTimelineAgent::enabled();
+    return m_instrumentingAgents->enabledPageTimelineAgent() == this && InspectorTimelineAgent::enabled();
 }
 
 void PageTimelineAgent::internalEnable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledPageTimelineAgent(this);
+    m_instrumentingAgents->setEnabledPageTimelineAgent(this);
 
     InspectorTimelineAgent::internalEnable();
 }
 
 void PageTimelineAgent::internalDisable()
 {
-    Ref { m_instrumentingAgents.get() }->setEnabledPageTimelineAgent(nullptr);
+    m_instrumentingAgents->setEnabledPageTimelineAgent(nullptr);
 
     m_autoCaptureEnabled = false;
 
@@ -102,12 +102,12 @@ void PageTimelineAgent::internalDisable()
 
 bool PageTimelineAgent::tracking() const
 {
-    return Ref { m_instrumentingAgents.get() }->trackingPageTimelineAgent() == this && InspectorTimelineAgent::tracking();
+    return m_instrumentingAgents->trackingPageTimelineAgent() == this && InspectorTimelineAgent::tracking();
 }
 
 void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
 {
-    Ref { m_instrumentingAgents.get() }->setTrackingPageTimelineAgent(this);
+    m_instrumentingAgents->setTrackingPageTimelineAgent(this);
 
     // FIXME: Abstract away platform-specific code once https://bugs.webkit.org/show_bug.cgi?id=142748 is fixed.
 
@@ -161,7 +161,7 @@ void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
 
 void PageTimelineAgent::internalStop()
 {
-    Ref { m_instrumentingAgents.get() }->setTrackingPageTimelineAgent(nullptr);
+    m_instrumentingAgents->setTrackingPageTimelineAgent(nullptr);
 
     m_autoCapturePhase = AutoCapturePhase::None;
 
@@ -278,7 +278,7 @@ void PageTimelineAgent::mainFrameStartedLoading()
     m_autoCapturePhase = AutoCapturePhase::BeforeLoad;
 
     // Pre-emptively disable breakpoints. The frontend must re-enable them.
-    if (auto* webDebuggerAgent = Ref { m_instrumentingAgents.get() }->enabledWebDebuggerAgent())
+    if (auto* webDebuggerAgent = m_instrumentingAgents->enabledWebDebuggerAgent())
         webDebuggerAgent->setBreakpointsActive(false);
 
     // Inform the frontend we started an auto capture. The frontend must stop capture.


### PR DESCRIPTION
#### 2f9a571588be6483ed5484e06548ec7b7589cd80
<pre>
Web Inspector: don&apos;t increase the lifetime of `InstrumentingAgents`
<a href="https://bugs.webkit.org/show_bug.cgi?id=301632">https://bugs.webkit.org/show_bug.cgi?id=301632</a>

Reviewed by NOBODY (OOPS!).

`InstrumentingAgents` will have the same lifetime as all of the agents that reference it, as all of them are created and destroyed at the same time by the same `InspectorController`.

As such, use `CheckedRef` instead of `WeakRef` (which also has the benefit of not needing to be converted to a `Ref` when used).

* Source/WebCore/inspector/InstrumentingAgents.h:
* Source/WebCore/inspector/InstrumentingAgents.cpp:
(WebCore::InstrumentingAgents::create):
* Source/WebCore/inspector/InspectorController.h:
* Source/WebCore/inspector/InspectorController.cpp:
(WebCore::InspectorController::pageAgentContext):
(WebCore::InspectorController::createLazyAgents):
(WebCore::InspectorController::connectFrontend):
(WebCore::InspectorController::disconnectFrontend):
(WebCore::InspectorController::disconnectAllFrontends):
* Source/WebCore/inspector/FrameInspectorController.h:
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::frameAgentContext):
(WebCore::FrameInspectorController::createLazyAgents):
(WebCore::FrameInspectorController::connectFrontend):
(WebCore::FrameInspectorController::disconnectFrontend):
(WebCore::FrameInspectorController::inspectedFrameDestroyed):
* Source/WebCore/inspector/WorkerInspectorController.h:
* Source/WebCore/inspector/WorkerInspectorController.cpp:
(WebCore::WorkerInspectorController::workerAgentContext):
(WebCore::WorkerInspectorController::createLazyAgents):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::willDestroyWebGLProgram):
(WebCore::InspectorInstrumentation::instrumentingAgents):
Hold the `InstrumentingAgents` with a `UniqueRef` since it&apos;s never invalidated.
Also, `CheckedRef` can automatically be converted to a reference so remove unnecessary `.get()`.

* Source/WebCore/inspector/InspectorWebAgentBase.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::InspectorAnimationAgent::didCreateFrontendAndBackend):
(WebCore::InspectorAnimationAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorAnimationAgent::enable):
(WebCore::InspectorAnimationAgent::disable):
(WebCore::InspectorAnimationAgent::requestEffectTarget):
(WebCore::InspectorAnimationAgent::startTracking):
(WebCore::InspectorAnimationAgent::stopTracking):
(WebCore::InspectorAnimationAgent::willApplyKeyframeEffect):
* Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp:
(WebCore::InspectorCPUProfilerAgent::didCreateFrontendAndBackend):
(WebCore::InspectorCPUProfilerAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::enable):
(WebCore::InspectorCSSAgent::disable):
(WebCore::InspectorCSSAgent::forcePseudoState):
(WebCore::InspectorCSSAgent::collectAllStyleSheets):
(WebCore::InspectorCSSAgent::setStyleSheetText):
(WebCore::InspectorCSSAgent::setStyleText):
(WebCore::InspectorCSSAgent::setRuleSelector):
(WebCore::InspectorCSSAgent::setGroupingHeaderText):
(WebCore::InspectorCSSAgent::createStyleSheet):
(WebCore::InspectorCSSAgent::addRule):
(WebCore::InspectorCSSAgent::setLayoutContextTypeChangedMode):
(WebCore::InspectorCSSAgent::nodesWithPendingLayoutFlagsChangeDispatchTimerFired):
(WebCore::InspectorCSSAgent::asInspectorStyleSheet):
(WebCore::InspectorCSSAgent::elementForId):
(WebCore::InspectorCSSAgent::nodeForId):
(WebCore::InspectorCSSAgent::bindStyleSheet):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::enabled const):
(WebCore::InspectorCanvasAgent::internalEnable):
(WebCore::InspectorCanvasAgent::internalDisable):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::didCreateFrontendAndBackend):
(WebCore::InspectorDOMAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorDOMAgent::unbind):
(WebCore::InspectorDOMAgent::highlightSelector):
(WebCore::InspectorDOMAgent::highlightFrame):
(WebCore::InspectorDOMAgent::buildObjectForNode):
(WebCore::InspectorDOMAgent::willDestroyDOMNode):
(WebCore::InspectorDOMAgent::didModifyDOMAttr):
(WebCore::InspectorDOMAgent::didRemoveDOMAttr):
(WebCore::InspectorDOMAgent::styleAttributeInvalidated):
* Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp:
(WebCore::InspectorDOMDebuggerAgent::enabled const):
(WebCore::InspectorDOMDebuggerAgent::enable):
(WebCore::InspectorDOMDebuggerAgent::disable):
(WebCore::InspectorDOMDebuggerAgent::willHandleEvent):
(WebCore::InspectorDOMDebuggerAgent::didHandleEvent):
* Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp:
(WebCore::InspectorDOMStorageAgent::enable):
(WebCore::InspectorDOMStorageAgent::disable):
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp:
(WebCore::InspectorLayerTreeAgent::enable):
(WebCore::InspectorLayerTreeAgent::disable):
(WebCore::InspectorLayerTreeAgent::layersForNode):
(WebCore::InspectorLayerTreeAgent::idForNode):
* Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp:
(WebCore::InspectorMemoryAgent::didCreateFrontendAndBackend):
(WebCore::InspectorMemoryAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorMemoryAgent::enable):
(WebCore::InspectorMemoryAgent::disable):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::buildInitiatorObject):
(WebCore::InspectorNetworkAgent::enable):
(WebCore::InspectorNetworkAgent::disable):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::enable):
(WebCore::InspectorPageAgent::disable):
(WebCore::InspectorPageAgent::searchInResource):
(WebCore::InspectorPageAgent::searchInResources):
(WebCore::InspectorPageAgent::snapshotNode):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::enabled const):
(WebCore::InspectorTimelineAgent::internalEnable):
(WebCore::InspectorTimelineAgent::internalDisable):
(WebCore::InspectorTimelineAgent::tracking const):
(WebCore::InspectorTimelineAgent::internalStart):
(WebCore::InspectorTimelineAgent::internalStop):
(WebCore::InspectorTimelineAgent::startFromConsole):
(WebCore::InspectorTimelineAgent::stopFromConsole):
(WebCore::InspectorTimelineAgent::didEnqueueLargestContentfulPaint):
(WebCore::InspectorTimelineAgent::startProgrammaticCapture):
(WebCore::InspectorTimelineAgent::stopProgrammaticCapture):
(WebCore::InspectorTimelineAgent::toggleScriptProfilerInstrument):
(WebCore::InspectorTimelineAgent::toggleHeapInstrument):
(WebCore::InspectorTimelineAgent::toggleCPUInstrument):
(WebCore::InspectorTimelineAgent::toggleMemoryInstrument):
(WebCore::InspectorTimelineAgent::toggleAnimationInstrument):
* Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp:
(WebCore::InspectorWorkerAgent::didCreateFrontendAndBackend):
(WebCore::InspectorWorkerAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/WebDebuggerAgent.h:
* Source/WebCore/inspector/agents/WebDebuggerAgent.cpp:
(WebCore::WebDebuggerAgent::enabled const):
(WebCore::WebDebuggerAgent::internalEnable):
(WebCore::WebDebuggerAgent::internalDisable):
* Source/WebCore/inspector/agents/WebHeapAgent.h:
* Source/WebCore/inspector/agents/WebHeapAgent.cpp:
(WebCore::WebHeapAgent::didCreateFrontendAndBackend):
(WebCore::WebHeapAgent::willDestroyFrontendAndBackend):
(WebCore::WebHeapAgent::enable):
(WebCore::WebHeapAgent::disable):
* Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp:
(WebCore::PageCanvasAgent::enabled const):
(WebCore::PageCanvasAgent::internalEnable):
(WebCore::PageCanvasAgent::internalDisable):
(WebCore::PageCanvasAgent::requestNode):
(WebCore::PageCanvasAgent::requestClientNodes):
* Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp:
(WebCore::PageDOMDebuggerAgent::enabled const):
(WebCore::PageDOMDebuggerAgent::enable):
(WebCore::PageDOMDebuggerAgent::disable):
(WebCore::PageDOMDebuggerAgent::setDOMBreakpoint):
(WebCore::PageDOMDebuggerAgent::removeDOMBreakpoint):
(WebCore::PageDOMDebuggerAgent::willRemoveDOMNode):
(WebCore::PageDOMDebuggerAgent::buildPauseDataForDOMBreakpoint):
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp:
(WebCore::PageDebuggerAgent::enabled const):
(WebCore::PageDebuggerAgent::internalEnable):
(WebCore::PageDebuggerAgent::internalDisable):
* Source/WebCore/inspector/agents/page/PageHeapAgent.h:
* Source/WebCore/inspector/agents/page/PageHeapAgent.cpp:
(WebCore::PageHeapAgent::enable):
(WebCore::PageHeapAgent::disable):
* Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp:
(WebCore::PageNetworkAgent::loaderIdentifier):
(WebCore::PageNetworkAgent::frameIdentifier):
(WebCore::PageNetworkAgent::scriptExecutionContext):
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.h:
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp:
(WebCore::PageRuntimeAgent::enable):
(WebCore::PageRuntimeAgent::disable):
(WebCore::PageRuntimeAgent::didClearWindowObjectInWorld):
(WebCore::PageRuntimeAgent::reportExecutionContextCreation):
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
(WebCore::PageTimelineAgent::enabled const):
(WebCore::PageTimelineAgent::internalEnable):
(WebCore::PageTimelineAgent::internalDisable):
(WebCore::PageTimelineAgent::tracking const):
(WebCore::PageTimelineAgent::internalStart):
(WebCore::PageTimelineAgent::internalStop):
(WebCore::PageTimelineAgent::mainFrameStartedLoading):
* Source/WebCore/inspector/CommandLineAPIHost.h:
(WebCore::CommandLineAPIHost::init):
* Source/WebCore/inspector/CommandLineAPIHost.cpp:
(WebCore::CommandLineAPIHost::inspect):
Remove the `WeakRef`-&gt;`Ref` temporary since all inspector agents now just directly hold a `CheckedRef`.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f9a571588be6483ed5484e06548ec7b7589cd80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98089 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66000 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/724 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33531 "Found 3 new test failures: inspector/animation/lifecycle-css-transition.html inspector/page/hidpi-snapshot-size.html webaudio/audiobuffersource-not-gced-until-ended.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79502 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109165 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138683 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106630 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106442 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/750 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30286 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53364 "Hash 2f9a5715 for PR 53147 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/981 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64277 "Found 23 new failures in WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp, WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm, WebDriverBidiProtocolObjects.h, WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp, inspector/CommandLineAPIHost.cpp, inspector/InspectorWebAgentBase.h, AutomationProtocolObjects.h and found 2 fixed files: inspector/InspectorWebAgentBase.h, inspector/InspectorCanvasCallTracer.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/832 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->