### PR TITLE
Web Inspector: use `UniqueRef` for `AgentRegistry`

### DIFF
--- a/Source/JavaScriptCore/inspector/InspectorAgentRegistry.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorAgentRegistry.cpp
@@ -41,7 +41,7 @@ AgentRegistry::~AgentRegistry()
         agent->discardAgent();
 }
 
-void AgentRegistry::append(std::unique_ptr<InspectorAgentBase> agent)
+void AgentRegistry::append(UniqueRef<InspectorAgentBase>&& agent)
 {
     m_agents.append(WTFMove(agent));
 }

--- a/Source/JavaScriptCore/inspector/InspectorAgentRegistry.h
+++ b/Source/JavaScriptCore/inspector/InspectorAgentRegistry.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <JavaScriptCore/JSExportMacros.h>
+#include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -41,7 +42,7 @@ public:
     JS_EXPORT_PRIVATE AgentRegistry();
     JS_EXPORT_PRIVATE ~AgentRegistry();
 
-    JS_EXPORT_PRIVATE void append(std::unique_ptr<InspectorAgentBase>);
+    JS_EXPORT_PRIVATE void append(UniqueRef<InspectorAgentBase>&&);
 
     JS_EXPORT_PRIVATE void didCreateFrontendAndBackend();
     JS_EXPORT_PRIVATE void willDestroyFrontendAndBackend(DisconnectReason);
@@ -53,7 +54,7 @@ private:
     AgentRegistry(const AgentRegistry&) = delete;
     AgentRegistry& operator=(const AgentRegistry&) = delete;
 
-    Vector<std::unique_ptr<InspectorAgentBase>> m_agents;
+    Vector<UniqueRef<InspectorAgentBase>> m_agents;
 };
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -73,8 +73,8 @@ JSGlobalObjectInspectorController::JSGlobalObjectInspectorController(JSGlobalObj
 {
     auto context = jsAgentContext();
 
-    auto consoleAgent = makeUnique<InspectorConsoleAgent>(context);
-    m_consoleAgent = consoleAgent.get();
+    auto consoleAgent = makeUniqueRef<InspectorConsoleAgent>(context);
+    m_consoleAgent = consoleAgent.ptr();
     m_agents.append(WTFMove(consoleAgent));
 
     m_consoleClient = makeUnique<JSGlobalObjectConsoleClient>(m_consoleAgent);
@@ -265,7 +265,7 @@ VM& JSGlobalObjectInspectorController::vm()
 }
 
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
-void JSGlobalObjectInspectorController::registerAlternateAgent(std::unique_ptr<InspectorAgentBase> agent)
+void JSGlobalObjectInspectorController::registerAlternateAgent(UniqueRef<InspectorAgentBase>&& agent)
 {
     // FIXME: change this to notify agents which frontend has connected (by id).
     agent->didCreateFrontendAndBackend();
@@ -278,8 +278,8 @@ InspectorAgent& JSGlobalObjectInspectorController::ensureInspectorAgent()
 {
     if (!m_inspectorAgent) {
         auto context = jsAgentContext();
-        auto inspectorAgent = makeUnique<InspectorAgent>(context);
-        m_inspectorAgent = inspectorAgent.get();
+        auto inspectorAgent = makeUniqueRef<InspectorAgent>(context);
+        m_inspectorAgent = inspectorAgent.ptr();
         m_agents.append(WTFMove(inspectorAgent));
     }
     return *m_inspectorAgent;
@@ -289,8 +289,8 @@ InspectorDebuggerAgent& JSGlobalObjectInspectorController::ensureDebuggerAgent()
 {
     if (!m_debuggerAgent) {
         auto context = jsAgentContext();
-        auto debuggerAgent = makeUnique<JSGlobalObjectDebuggerAgent>(context, m_consoleAgent);
-        m_debuggerAgent = debuggerAgent.get();
+        auto debuggerAgent = makeUniqueRef<JSGlobalObjectDebuggerAgent>(context, m_consoleAgent);
+        m_debuggerAgent = debuggerAgent.ptr();
         m_consoleClient->setDebuggerAgent(m_debuggerAgent);
         m_agents.append(WTFMove(debuggerAgent));
     }
@@ -327,20 +327,20 @@ void JSGlobalObjectInspectorController::createLazyAgents()
 
     ensureInspectorAgent();
 
-    m_agents.append(makeUnique<JSGlobalObjectRuntimeAgent>(context));
+    m_agents.append(makeUniqueRef<JSGlobalObjectRuntimeAgent>(context));
 
     ensureDebuggerAgent();
 
-    auto scriptProfilerAgentPtr = makeUnique<InspectorScriptProfilerAgent>(context);
-    m_consoleClient->setPersistentScriptProfilerAgent(scriptProfilerAgentPtr.get());
-    m_agents.append(WTFMove(scriptProfilerAgentPtr));
+    auto scriptProfilerAgent = makeUniqueRef<InspectorScriptProfilerAgent>(context);
+    m_consoleClient->setPersistentScriptProfilerAgent(scriptProfilerAgent.ptr());
+    m_agents.append(WTFMove(scriptProfilerAgent));
 
-    auto heapAgent = makeUnique<InspectorHeapAgent>(context);
+    auto heapAgent = makeUniqueRef<InspectorHeapAgent>(context);
     if (m_consoleAgent)
-        m_consoleAgent->setHeapAgent(heapAgent.get());
+        m_consoleAgent->setHeapAgent(heapAgent.ptr());
     m_agents.append(WTFMove(heapAgent));
 
-    m_agents.append(makeUnique<JSGlobalObjectAuditAgent>(context));
+    m_agents.append(makeUniqueRef<JSGlobalObjectAuditAgent>(context));
 }
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
@@ -100,7 +100,7 @@ public:
 
     const FrontendRouter& frontendRouter() const final { return m_frontendRouter.get(); }
     BackendDispatcher& backendDispatcher() final { return m_backendDispatcher.get(); }
-    void registerAlternateAgent(std::unique_ptr<InspectorAgentBase>) final;
+    void registerAlternateAgent(UniqueRef<InspectorAgentBase>&&) final;
 #endif
 
 private:

--- a/Source/JavaScriptCore/inspector/augmentable/AugmentableInspectorController.h
+++ b/Source/JavaScriptCore/inspector/augmentable/AugmentableInspectorController.h
@@ -44,7 +44,7 @@ public:
 
     virtual const FrontendRouter& frontendRouter() const = 0;
     virtual BackendDispatcher& backendDispatcher() = 0;
-    virtual void registerAlternateAgent(std::unique_ptr<InspectorAgentBase>) = 0;
+    virtual void registerAlternateAgent(UniqueRef<InspectorAgentBase>&&) = 0;
 
     bool connected() const { return frontendRouter().hasFrontends(); }
 };

--- a/Source/JavaScriptCore/inspector/scripts/codegen/objc_generator_templates.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/objc_generator_templates.py
@@ -144,7 +144,7 @@ ${invocation}
     _${variableNamePrefix}Handler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspector${domainName}BackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<${domainName}BackendDispatcher, Alternate${domainName}BackendDispatcher>>("${domainName}"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<${domainName}BackendDispatcher, Alternate${domainName}BackendDispatcher>>("${domainName}"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/command-targetType-matching-domain-debuggableType.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/command-targetType-matching-domain-debuggableType.json-result
@@ -737,7 +737,7 @@ using namespace Inspector;
     _domainHandler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorDomainBackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<DomainBackendDispatcher, AlternateDomainBackendDispatcher>>("Domain"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<DomainBackendDispatcher, AlternateDomainBackendDispatcher>>("Domain"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
@@ -1208,7 +1208,7 @@ using namespace Inspector;
     _databaseHandler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorDatabaseBackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<DatabaseBackendDispatcher, AlternateDatabaseBackendDispatcher>>("Database"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<DatabaseBackendDispatcher, AlternateDatabaseBackendDispatcher>>("Database"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
@@ -1076,7 +1076,7 @@ using namespace Inspector;
     _databaseHandler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorDatabaseBackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<DatabaseBackendDispatcher, AlternateDatabaseBackendDispatcher>>("Database"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<DatabaseBackendDispatcher, AlternateDatabaseBackendDispatcher>>("Database"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result
@@ -863,7 +863,7 @@ using namespace Inspector;
     _networkHandler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorNetworkBackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<NetworkBackendDispatcher, AlternateNetworkBackendDispatcher>>("Network"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<NetworkBackendDispatcher, AlternateNetworkBackendDispatcher>>("Network"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-debuggableTypes.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-debuggableTypes.json-result
@@ -737,7 +737,7 @@ using namespace Inspector;
     _domainHandler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorDomainBackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<DomainBackendDispatcher, AlternateDomainBackendDispatcher>>("Domain"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<DomainBackendDispatcher, AlternateDomainBackendDispatcher>>("Domain"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
@@ -1240,7 +1240,7 @@ using namespace Inspector;
     _databaseHandler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorDatabaseBackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<DatabaseBackendDispatcher, AlternateDatabaseBackendDispatcher>>("Database"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<DatabaseBackendDispatcher, AlternateDatabaseBackendDispatcher>>("Database"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetType-matching-domain-debuggableType.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetType-matching-domain-debuggableType.json-result
@@ -737,7 +737,7 @@ using namespace Inspector;
     _domainHandler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorDomainBackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<DomainBackendDispatcher, AlternateDomainBackendDispatcher>>("Domain"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<DomainBackendDispatcher, AlternateDomainBackendDispatcher>>("Domain"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetTypes.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetTypes.json-result
@@ -737,7 +737,7 @@ using namespace Inspector;
     _domainHandler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorDomainBackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<DomainBackendDispatcher, AlternateDomainBackendDispatcher>>("Domain"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<DomainBackendDispatcher, AlternateDomainBackendDispatcher>>("Domain"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domains-with-varying-command-sizes.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domains-with-varying-command-sizes.json-result
@@ -1128,7 +1128,7 @@ using namespace Inspector;
     _network1Handler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorNetwork1BackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<Network1BackendDispatcher, AlternateNetwork1BackendDispatcher>>("Network1"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<Network1BackendDispatcher, AlternateNetwork1BackendDispatcher>>("Network1"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 
@@ -1145,7 +1145,7 @@ using namespace Inspector;
     _network3Handler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorNetwork3BackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<Network3BackendDispatcher, AlternateNetwork3BackendDispatcher>>("Network3"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<Network3BackendDispatcher, AlternateNetwork3BackendDispatcher>>("Network3"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
@@ -911,7 +911,7 @@ using namespace Inspector;
     _commandDomainHandler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorCommandDomainBackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<CommandDomainBackendDispatcher, AlternateCommandDomainBackendDispatcher>>("CommandDomain"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<CommandDomainBackendDispatcher, AlternateCommandDomainBackendDispatcher>>("CommandDomain"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/event-targetType-matching-domain-debuggableType.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/event-targetType-matching-domain-debuggableType.json-result
@@ -737,7 +737,7 @@ using namespace Inspector;
     _domainHandler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorDomainBackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<DomainBackendDispatcher, AlternateDomainBackendDispatcher>>("Domain"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<DomainBackendDispatcher, AlternateDomainBackendDispatcher>>("Domain"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result
@@ -819,7 +819,7 @@ using namespace Inspector;
     _network1Handler = handler;
 
     auto alternateDispatcher = makeUnique<ObjCInspectorNetwork1BackendDispatcher>(handler);
-    auto alternateAgent = makeUnique<AlternateDispatchableAgent<Network1BackendDispatcher, AlternateNetwork1BackendDispatcher>>("Network1"_s, *_controller, WTFMove(alternateDispatcher));
+    auto alternateAgent = makeUniqueRef<AlternateDispatchableAgent<Network1BackendDispatcher, AlternateNetwork1BackendDispatcher>>("Network1"_s, *_controller, WTFMove(alternateDispatcher));
     _controller->registerAlternateAgent(WTFMove(alternateAgent));
 }
 

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -108,8 +108,8 @@ InspectorController::InspectorController(Page& page, std::unique_ptr<InspectorBa
 
     auto pageContext = pageAgentContext();
 
-    auto consoleAgent = makeUnique<PageConsoleAgent>(pageContext);
-    m_instrumentingAgents->setWebConsoleAgent(consoleAgent.get());
+    auto consoleAgent = makeUniqueRef<PageConsoleAgent>(pageContext);
+    m_instrumentingAgents->setWebConsoleAgent(consoleAgent.ptr());
     m_agents.append(WTFMove(consoleAgent));
 }
 
@@ -167,34 +167,34 @@ void InspectorController::createLazyAgents()
     ensureInspectorAgent();
     ensurePageAgent();
 
-    m_agents.append(makeUnique<PageRuntimeAgent>(pageContext));
+    m_agents.append(makeUniqueRef<PageRuntimeAgent>(pageContext));
 
-    auto debuggerAgent = makeUnique<PageDebuggerAgent>(pageContext);
-    auto debuggerAgentPtr = debuggerAgent.get();
+    auto debuggerAgent = makeUniqueRef<PageDebuggerAgent>(pageContext);
+    auto debuggerAgentPtr = debuggerAgent.ptr();
     m_agents.append(WTFMove(debuggerAgent));
 
-    m_agents.append(makeUnique<PageNetworkAgent>(pageContext, m_inspectorBackendClient.get()));
-    m_agents.append(makeUnique<InspectorCSSAgent>(pageContext));
+    m_agents.append(makeUniqueRef<PageNetworkAgent>(pageContext, m_inspectorBackendClient.get()));
+    m_agents.append(makeUniqueRef<InspectorCSSAgent>(pageContext));
     ensureDOMAgent();
-    m_agents.append(makeUnique<PageDOMDebuggerAgent>(pageContext, debuggerAgentPtr));
-    m_agents.append(makeUnique<InspectorLayerTreeAgent>(pageContext));
-    m_agents.append(makeUnique<PageWorkerAgent>(pageContext));
-    m_agents.append(makeUnique<InspectorDOMStorageAgent>(pageContext));
-    m_agents.append(makeUnique<InspectorIndexedDBAgent>(pageContext));
+    m_agents.append(makeUniqueRef<PageDOMDebuggerAgent>(pageContext, debuggerAgentPtr));
+    m_agents.append(makeUniqueRef<InspectorLayerTreeAgent>(pageContext));
+    m_agents.append(makeUniqueRef<PageWorkerAgent>(pageContext));
+    m_agents.append(makeUniqueRef<InspectorDOMStorageAgent>(pageContext));
+    m_agents.append(makeUniqueRef<InspectorIndexedDBAgent>(pageContext));
 
-    auto scriptProfilerAgentPtr = makeUnique<InspectorScriptProfilerAgent>(pageContext);
-    m_instrumentingAgents->setPersistentScriptProfilerAgent(scriptProfilerAgentPtr.get());
-    m_agents.append(WTFMove(scriptProfilerAgentPtr));
+    auto scriptProfilerAgent = makeUniqueRef<InspectorScriptProfilerAgent>(pageContext);
+    m_instrumentingAgents->setPersistentScriptProfilerAgent(scriptProfilerAgent.ptr());
+    m_agents.append(WTFMove(scriptProfilerAgent));
 
 #if ENABLE(RESOURCE_USAGE)
-    m_agents.append(makeUnique<InspectorCPUProfilerAgent>(pageContext));
-    m_agents.append(makeUnique<InspectorMemoryAgent>(pageContext));
+    m_agents.append(makeUniqueRef<InspectorCPUProfilerAgent>(pageContext));
+    m_agents.append(makeUniqueRef<InspectorMemoryAgent>(pageContext));
 #endif
-    m_agents.append(makeUnique<PageHeapAgent>(pageContext));
-    m_agents.append(makeUnique<PageAuditAgent>(pageContext));
-    m_agents.append(makeUnique<PageCanvasAgent>(pageContext));
-    m_agents.append(makeUnique<PageTimelineAgent>(pageContext));
-    m_agents.append(makeUnique<InspectorAnimationAgent>(pageContext));
+    m_agents.append(makeUniqueRef<PageHeapAgent>(pageContext));
+    m_agents.append(makeUniqueRef<PageAuditAgent>(pageContext));
+    m_agents.append(makeUniqueRef<PageCanvasAgent>(pageContext));
+    m_agents.append(makeUniqueRef<PageTimelineAgent>(pageContext));
+    m_agents.append(makeUniqueRef<InspectorAnimationAgent>(pageContext));
 
     if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
         commandLineAPIHost->init(m_instrumentingAgents.copyRef());
@@ -452,8 +452,8 @@ InspectorAgent& InspectorController::ensureInspectorAgent()
 {
     if (!m_inspectorAgent) {
         auto pageContext = pageAgentContext();
-        auto inspectorAgent = makeUnique<InspectorAgent>(pageContext);
-        m_inspectorAgent = inspectorAgent.get();
+        auto inspectorAgent = makeUniqueRef<InspectorAgent>(pageContext);
+        m_inspectorAgent = inspectorAgent.ptr();
         m_instrumentingAgents->setPersistentInspectorAgent(m_inspectorAgent);
         m_agents.append(WTFMove(inspectorAgent));
     }
@@ -464,8 +464,8 @@ InspectorDOMAgent& InspectorController::ensureDOMAgent()
 {
     if (!m_domAgent) {
         auto pageContext = pageAgentContext();
-        auto domAgent = makeUnique<InspectorDOMAgent>(pageContext, m_overlay.get());
-        m_domAgent = domAgent.get();
+        auto domAgent = makeUniqueRef<InspectorDOMAgent>(pageContext, m_overlay.get());
+        m_domAgent = domAgent.ptr();
         m_agents.append(WTFMove(domAgent));
     }
     return *m_domAgent;
@@ -475,8 +475,8 @@ InspectorPageAgent& InspectorController::ensurePageAgent()
 {
     if (!m_pageAgent) {
         auto pageContext = pageAgentContext();
-        auto pageAgent = makeUnique<InspectorPageAgent>(pageContext, m_inspectorBackendClient.get(), m_overlay.get());
-        m_pageAgent = pageAgent.get();
+        auto pageAgent = makeUniqueRef<InspectorPageAgent>(pageContext, m_inspectorBackendClient.get(), m_overlay.get());
+        m_pageAgent = pageAgent.ptr();
         m_agents.append(WTFMove(pageAgent));
     }
     return *m_pageAgent;

--- a/Source/WebCore/inspector/WorkerInspectorController.cpp
+++ b/Source/WebCore/inspector/WorkerInspectorController.cpp
@@ -79,8 +79,8 @@ WorkerInspectorController::WorkerInspectorController(WorkerOrWorkletGlobalScope&
 
     auto workerContext = workerAgentContext();
 
-    auto consoleAgent = makeUnique<WorkerConsoleAgent>(workerContext);
-    m_instrumentingAgents->setWebConsoleAgent(consoleAgent.get());
+    auto consoleAgent = makeUniqueRef<WorkerConsoleAgent>(workerContext);
+    m_instrumentingAgents->setWebConsoleAgent(consoleAgent.ptr());
     m_agents.append(WTFMove(consoleAgent));
 }
 
@@ -226,27 +226,27 @@ void WorkerInspectorController::createLazyAgents()
 
     auto workerContext = workerAgentContext();
 
-    m_agents.append(makeUnique<WorkerRuntimeAgent>(workerContext));
+    m_agents.append(makeUniqueRef<WorkerRuntimeAgent>(workerContext));
 
     if (is<ServiceWorkerGlobalScope>(m_globalScope)) {
-        m_agents.append(makeUnique<InspectorAgent>(workerContext));
-        m_agents.append(makeUnique<ServiceWorkerAgent>(workerContext));
-        m_agents.append(makeUnique<WorkerNetworkAgent>(workerContext));
+        m_agents.append(makeUniqueRef<InspectorAgent>(workerContext));
+        m_agents.append(makeUniqueRef<ServiceWorkerAgent>(workerContext));
+        m_agents.append(makeUniqueRef<WorkerNetworkAgent>(workerContext));
     }
 
-    m_agents.append(makeUnique<WebHeapAgent>(workerContext));
+    m_agents.append(makeUniqueRef<WebHeapAgent>(workerContext));
 
     ensureDebuggerAgent();
-    m_agents.append(makeUnique<WorkerDOMDebuggerAgent>(workerContext, m_debuggerAgent.get()));
+    m_agents.append(makeUniqueRef<WorkerDOMDebuggerAgent>(workerContext, m_debuggerAgent.get()));
 
-    m_agents.append(makeUnique<WorkerAuditAgent>(workerContext));
-    m_agents.append(makeUnique<WorkerCanvasAgent>(workerContext));
-    m_agents.append(makeUnique<WorkerTimelineAgent>(workerContext));
-    m_agents.append(makeUnique<WorkerWorkerAgent>(workerContext));
+    m_agents.append(makeUniqueRef<WorkerAuditAgent>(workerContext));
+    m_agents.append(makeUniqueRef<WorkerCanvasAgent>(workerContext));
+    m_agents.append(makeUniqueRef<WorkerTimelineAgent>(workerContext));
+    m_agents.append(makeUniqueRef<WorkerWorkerAgent>(workerContext));
 
-    auto scriptProfilerAgentPtr = makeUnique<InspectorScriptProfilerAgent>(workerContext);
-    m_instrumentingAgents->setPersistentScriptProfilerAgent(scriptProfilerAgentPtr.get());
-    m_agents.append(WTFMove(scriptProfilerAgentPtr));
+    auto scriptProfilerAgent = makeUniqueRef<InspectorScriptProfilerAgent>(workerContext);
+    m_instrumentingAgents->setPersistentScriptProfilerAgent(scriptProfilerAgent.ptr());
+    m_agents.append(WTFMove(scriptProfilerAgent));
 
     if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
         commandLineAPIHost->init(m_instrumentingAgents.copyRef());
@@ -256,8 +256,8 @@ WorkerDebuggerAgent& WorkerInspectorController::ensureDebuggerAgent()
 {
     if (!m_debuggerAgent) {
         auto workerContext = workerAgentContext();
-        auto debuggerAgent = makeUnique<WorkerDebuggerAgent>(workerContext);
-        m_debuggerAgent = debuggerAgent.get();
+        auto debuggerAgent = makeUniqueRef<WorkerDebuggerAgent>(workerContext);
+        m_debuggerAgent = debuggerAgent.ptr();
         m_agents.append(WTFMove(debuggerAgent));
     }
     return *m_debuggerAgent;

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -60,8 +60,8 @@ WebPageInspectorController::WebPageInspectorController(WebPageProxy& inspectedPa
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
     , m_inspectedPage(inspectedPage)
 {
-    auto targetAgent = makeUnique<InspectorTargetAgent>(m_frontendRouter, m_backendDispatcher);
-    m_targetAgent = targetAgent.get();
+    auto targetAgent = makeUniqueRef<InspectorTargetAgent>(m_frontendRouter, m_backendDispatcher);
+    m_targetAgent = targetAgent.ptr();
     m_agents.append(WTFMove(targetAgent));
 }
 
@@ -261,7 +261,7 @@ void WebPageInspectorController::createLazyAgents()
 
     auto webPageContext = webPageAgentContext();
 
-    m_agents.append(makeUnique<InspectorBrowserAgent>(webPageContext));
+    m_agents.append(makeUniqueRef<InspectorBrowserAgent>(webPageContext));
 }
 
 void WebPageInspectorController::addTarget(std::unique_ptr<InspectorTargetProxy>&& target)


### PR DESCRIPTION
#### 07e07d5fd650bcdd7fb526500ed5253010cef6c5
<pre>
Web Inspector: use `UniqueRef` for `AgentRegistry`
<a href="https://bugs.webkit.org/show_bug.cgi?id=301633">https://bugs.webkit.org/show_bug.cgi?id=301633</a>

Reviewed by BJ Burg.

* Source/JavaScriptCore/inspector/InspectorAgentRegistry.h:
* Source/JavaScriptCore/inspector/InspectorAgentRegistry.cpp:
(Inspector::AgentRegistry::append):
It assumes that all agents exist so using `std::unique_ptr` is not ideal as that can be `nullptr`.
As such, `UniqueRef` is better since it cannot be `nullptr`.

* Source/WebCore/inspector/InspectorController.cpp:
(WebCore::InspectorController::InspectorController):
(WebCore::InspectorController::createLazyAgents):
(WebCore::InspectorController::ensureInspectorAgent):
(WebCore::InspectorController::ensureDOMAgent):
(WebCore::InspectorController::ensurePageAgent):
* Source/WebCore/inspector/WorkerInspectorController.cpp:
(WebCore::WorkerInspectorController::WorkerInspectorController):
(WebCore::WorkerInspectorController::createLazyAgents):
(WebCore::WorkerInspectorController::ensureDebuggerAgent):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::WebPageInspectorController):
(WebKit::WebPageInspectorController::createLazyAgents):
* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h:
* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp:
(Inspector::JSGlobalObjectInspectorController::JSGlobalObjectInspectorController):
(Inspector::JSGlobalObjectInspectorController::registerAlternateAgent):
(Inspector::JSGlobalObjectInspectorController::ensureInspectorAgent):
(Inspector::JSGlobalObjectInspectorController::ensureDebuggerAgent):
(Inspector::JSGlobalObjectInspectorController::createLazyAgents):
* Source/JavaScriptCore/inspector/augmentable/AugmentableInspectorController.h:
* Source/JavaScriptCore/inspector/scripts/codegen/objc_generator_templates.py:
Create all agents using `makeUniqueRef` instead.
Also remove unnecessary `.get()` since `UniqueRef` can be converted to a reference.

* Source/JavaScriptCore/inspector/scripts/tests/expected/command-targetType-matching-domain-debuggableType.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-debuggableTypes.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetType-matching-domain-debuggableType.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetTypes.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domains-with-varying-command-sizes.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/event-targetType-matching-domain-debuggableType.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result:

Canonical link: <a href="https://commits.webkit.org/302594@main">https://commits.webkit.org/302594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d65122e2e3165791b97b4b5397d912bb633bb501

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137012 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1758 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116105 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79408 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34236 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80285 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121617 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139491 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128077 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1672 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1593 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107107 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27268 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1370 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30958 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54426 "Hash d65122e2 for PR 53148 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1743 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65106 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161091 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1563 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40178 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->