### PR TITLE
Fix Webkit.org survey plugin to show survey and results

### DIFF
--- a/Websites/webkit.org/wp-content/plugins/table-of-contents.php
+++ b/Websites/webkit.org/wp-content/plugins/table-of-contents.php
@@ -34,6 +34,7 @@ class WebKitTableOfContents {
 
     public static function hasIndex() {
         $toc = get_post_meta( get_the_ID(), 'toc', true );
+        if (!is_array($toc)) return false;
         array_walk($toc, array('WebKitTableOfContents', 'filterIndex'));
         return ( ! empty(self::$toc) && count(self::$toc) > 2 );
     }

--- a/Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php
+++ b/Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php
@@ -34,7 +34,6 @@ class WebKit_Survey {
     public static function survey_shortcode($atts, $content) {
         $json_string = str_replace(array('“','”'), '"', html_entity_decode(strip_tags($content)));
         $Survey = json_decode($json_string);
-
         // Capture survey settings data when updating the post
         if (self::$post_update) {
             $post_id = get_the_ID();
@@ -53,7 +52,7 @@ class WebKit_Survey {
         include($results_template);
         if ($atts['closed'] == "false" && !self::responded())
             include($survey_template);
-        echo '</div';
+        echo '</div>';
         return ob_get_clean();
     }
 
@@ -158,6 +157,7 @@ class WebKit_Survey {
             return unserialize($cached);
 
         $responses = get_post_custom_values($key);
+        if (!$responses) $responses = [];
         $max = 0;
 
         // Add the tabulated responses to the survey data

--- a/Websites/webkit.org/wp-content/plugins/webkit-survey/results.php
+++ b/Websites/webkit.org/wp-content/plugins/webkit-survey/results.php
@@ -59,10 +59,10 @@
 <?php 
     $SurveyResults = WebKit_Survey::calculate_results();
     foreach ($SurveyResults->survey as $id => $Entry): $total = isset($Entry->scores['total']) ? $Entry->scores['total'] : 1; 
-    
     $results_classes = ['webkit-survey-results'];
-    if ($SurveyResults->status == 'closed' || $SurveyResults->results == 'visible' || WebKit_Survey::responded() || is_admin()) 
+    if ($SurveyResults->status == 'closed' || $SurveyResults->results == 'visible' || WebKit_Survey::responded() || is_admin())
         $results_classes[] = 'visible';
+
 ?>
 <div class="<?php esc_attr_e(join(' ', $results_classes)); ?>">
     <h3><?php echo $Entry->question; ?></h3>
@@ -75,7 +75,7 @@
             $score = isset($Entry->scores[$value]) ? $Entry->scores[$value] : 0; 
             $percentage = $score * 100 / $total;
         ?>
-        <li<?php if ($SurveyResults->winner == $value) echo ' class="winner"'; ?>>
+        <li<?php if (isset($SurveyResults->winner) && $SurveyResults->winner == $value) echo ' class="winner"'; ?>>
             <div class="label">
                 <div class="option" style="min-width: calc(<?php esc_attr_e($percentage); ?>% - 4.8ch);"><?php echo esc_html($option); ?></div>
                 <div class="percentage"><?php echo number_format($percentage, 0); ?>%</div>
@@ -84,5 +84,5 @@
         </li>
     <?php endforeach; ?>
     </ul>
-<?php endforeach; ?>
 </div>
+<?php endforeach; ?>

--- a/Websites/webkit.org/wp-content/plugins/webkit-survey/survey.php
+++ b/Websites/webkit.org/wp-content/plugins/webkit-survey/survey.php
@@ -89,14 +89,16 @@
 
 <form class="webkit-survey-form" method="POST">
 <?php
-wp_nonce_field("webkit_survey-" . get_the_ID(), "_nonce", $true);
+wp_nonce_field("webkit_survey-" . get_the_ID(), "_nonce", true);
 foreach ($Survey->survey as $id => $Entry):
+    
+    $response_count = count($Entry->responses);
 ?>
     <h3><?php echo $Entry->question; ?></h3>
     
     <ul>
     <?php foreach ($Entry->responses as $value => $response): ?>
-        <li><label><input type="radio" name="questions[<?php echo esc_attr($id); ?>]" value="<?php echo esc_attr($value); ?>" required> <span><?php echo esc_html($response); ?></span>
+        <li><label><input type="radio" name="questions[<?php echo esc_attr($id); ?>]" value="<?php echo esc_attr($value); ?>" required <?php echo ($response_count == 1) ? "checked": "" ?>> <?php if($response_count > 1):?> <span><?php echo esc_html($response); ?></span><?php endif; ?>
         <?php if ($response == "Other:"): ?>
             <input type="text" name="other[<?php echo esc_attr($id); ?>]" maxlength="144">
         <?php endif; ?>


### PR DESCRIPTION
#### f43f492aa5da79d173e8c3148d1169acbca47455
<pre>
Fix Webkit.org survey plugin to show survey and results
<a href="https://bugs.webkit.org/show_bug.cgi?id=301635">https://bugs.webkit.org/show_bug.cgi?id=301635</a>

Reviewed by Devin Rousso.

Fixes HTML in the survey results that prevented rendering the results
correctly. This includes a drive-by fix for the table-of-contents plugin
that prevented the page from saving correctly in some cases.

Additional changes enhance how text responses for surveys are taken to make
the experience more inline with expectations.

* Websites/webkit.org/wp-content/plugins/table-of-contents.php:
* Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php:
* Websites/webkit.org/wp-content/plugins/webkit-survey/results.php:
* Websites/webkit.org/wp-content/plugins/webkit-survey/survey.php:

Canonical link: <a href="https://commits.webkit.org/302298@main">https://commits.webkit.org/302298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2d3c302a4a8744d89b83852acf8d81a0cb5e09b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128679 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/39511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/136064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f826a5f5-f867-4f00-bef5-2c16b1790fb1) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/136064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/92bef988-a027-4a04-837c-390285a84289) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131627 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/39511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/136064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2d89720f-0adc-4ff8-a8d0-f5e2d444973b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/39511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/79344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/39511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/138519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/138519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/39511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/138519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/39511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20094 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->