### PR TITLE
[visionOS] Upstream the `isLookToScrollEnabled` API

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.h
@@ -98,6 +98,11 @@ typedef NS_ENUM(NSInteger, WKInactiveSchedulingPolicy) {
  */
 @property (nonatomic) WKInactiveSchedulingPolicy inactiveSchedulingPolicy WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
+/*! @abstract A Boolean value indicating whether LookToScroll is enabled.
+    @discussion The default value is `NO`.
+    */
+@property (nonatomic) BOOL isLookToScrollEnabled WK_API_AVAILABLE(visionos(26.0)) WK_API_UNAVAILABLE(macos, ios, macCatalyst, tvos, watchos);
+
 @end
 
 @interface WKPreferences (WKDeprecated)
@@ -108,9 +113,5 @@ typedef NS_ENUM(NSInteger, WKInactiveSchedulingPolicy) {
 #endif
 
 @property (nonatomic) BOOL javaScriptEnabled WK_API_DEPRECATED("Use WKWebpagePreferences.allowsContentJavaScript to disable content JavaScript on a per-navigation basis", macos(10.10, 11.0), ios(8.0, 14.0));
-
-#if 0 // API_WEBKIT_ADDITIONS_REPLACEMENT
-#import <WebKitAdditions/WKPreferencesAdditions.h>
-#endif
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -239,6 +239,26 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return *_preferences;
 }
 
+#if PLATFORM(VISION)
+- (void)setIsLookToScrollEnabled:(BOOL)enabled
+{
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    protectedPreferences(self)->setOverlayRegionsEnabled(enabled);
+#else
+    UNUSED_PARAM(enabled);
+#endif
+}
+
+- (BOOL)isLookToScrollEnabled
+{
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    return protectedPreferences(self)->overlayRegionsEnabled();
+#else
+    return NO;
+#endif
+}
+#endif
+
 @end
 
 @implementation WKPreferences (WKPrivate)
@@ -1933,9 +1953,5 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 {
     WebKit::WebPreferences::forceSiteIsolationAlwaysOnForTesting();
 }
-
-#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WKPreferencesAdditions.mm>)
-#import <WebKitAdditions/WKPreferencesAdditions.mm>
-#endif
 
 @end


### PR DESCRIPTION
#### a15efb377c26295f6b6235dfb8b983c4417868d4
<pre>
[visionOS] Upstream the `isLookToScrollEnabled` API
<a href="https://bugs.webkit.org/show_bug.cgi?id=301636">https://bugs.webkit.org/show_bug.cgi?id=301636</a>
&lt;<a href="https://rdar.apple.com/163596987">rdar://163596987</a>&gt;

Reviewed by Tim Horton.

Moving this property from the internal repository since it has shipped.

* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences setIsLookToScrollEnabled:]):
(-[WKPreferences isLookToScrollEnabled]):

Canonical link: <a href="https://commits.webkit.org/302348@main">https://commits.webkit.org/302348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4a8da331410752dd5db13702f6bff32c8d0cebd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136066 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80078 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/68f57f7d-ad98-43d5-95d2-f8e4097acb72) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97957 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65871 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/48b5b4da-a48b-4d9a-aebb-f878991706e8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78575 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aaeef37c-4986-4a17-915b-fe0289513e2f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/597 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79346 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138521 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106492 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106315 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27098 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/642 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30153 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53148 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/831 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64086 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/694 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/749 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/778 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->