### PR TITLE
REGRESSION(302102@main): daringfireball.net layout is broken at wider window widths when zooming

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/float-rewind-parallel-flow-3-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/float-rewind-parallel-flow-3-crash.html
@@ -1,5 +1,3 @@
-<!-- webkit-test-runner [ EvaluationTimeZoomEnabled=false ] -->
-<!-- FIXME: https://bugs.webkit.org/show_bug.cgi?id=301363 -->
 <!DOCTYPE html>
 <link rel="help" href="https://crbug.com/1520442">
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/abspos-static-position-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/abspos-static-position-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<style>
+body {
+  margin: 0;
+}
+.parent {
+    margin-top: 100px;
+    margin-left: 25%;
+    height: 200px;
+    outline: 4px solid black;
+}
+
+.abspos {
+    position: absolute;
+    width: 200px;
+    height: 200px;
+    background-color: green;
+}
+</style>
+<body>
+<div class="parent">
+    <div class="abspos"></div>
+</div>
+    

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/abspos-static-position.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/abspos-static-position.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="match" href="abspos-static-position.html">
+<style>
+body {
+    margin: 0;
+    zoom: 2;
+}
+.parent {
+    margin-top: 50px;
+    margin-left: 25%;
+    height: 100px;
+    outline: 2px solid black;
+}
+
+.abspos {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="parent">
+    <div class="abspos"></div>
+</div>
+    


### PR DESCRIPTION
#### 5d5ab2203d17fc9ba78c8fc31da123b4fe7ba372
<pre>
REGRESSION(302102@main): daringfireball.net layout is broken at wider window widths when zooming
<a href="https://bugs.webkit.org/show_bug.cgi?id=301641">https://bugs.webkit.org/show_bug.cgi?id=301641</a>
<a href="https://rdar.apple.com/163643492">rdar://163643492</a>

Reviewed by Alan Baradlay.

When we compute the static position for an OOF box we walk up the
ancestor renderers and check their geometry. Since this process we check
the used value of the renderers, we end up getting the values with zoom
applied.

The problem is that when we take these values and then put them inside of
an Style::InsetEdge as a fixed value we end up applying zoom again when
evaluting this value. This happens when we call PositionedLayoutConstraints::inset{Before, After}
which is done after we compute the static position to modify the inset
modified containing range&apos;s position. This position is then used to
resolve the location of the OOF box in PositionedLayoutConstrains::resolvePosition.

The fix is to divide out the used zoom before we set these values on the
InsetEdges. Note that we need to use usedValueForLength()&apos;s value
because directly calling usedZoom() would result in incorrect behavior
with EvaluationTimeZoom disabled.

* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/float-rewind-parallel-flow-3-crash.html:
This test was marked to disable EvaluationTimeZoomEnabled in 302102@main
but is now passing with the changes in this patch.

Canonical link: <a href="https://commits.webkit.org/302331@main">https://commits.webkit.org/302331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80b28f514db4af9aa44e6f3565d3eb397ef57a15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80115 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5e2b3ff9-90dc-4f78-8623-cc0195f3d84d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/869 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98000 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65909 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b6ce9142-fe35-4465-bd74-23f5ec3730f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131682 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/698 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78614 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/647 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33440 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79396 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109076 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Running run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33922 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138573 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/807 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/820 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106537 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111666 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106354 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; 1 api test failed or timed out; Running compile-webkit-without-change") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27084 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/668 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30194 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53200 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/877 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64172 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/730 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/786 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Running compile-webkit") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/820 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
<!--EWS-Status-Bubble-End-->