### PR TITLE
Web Inspector: REGRESSION(?): cannot stop Timeline recording after submitting a form

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
@@ -41,7 +41,6 @@ WI.TimelineManager = class TimelineManager extends WI.Object
         this._enabledTimelineTypesSetting = new WI.Setting("enabled-instrument-types", WI.TimelineManager.defaultTimelineTypes());
 
         this._capturingState = TimelineManager.CapturingState.Inactive;
-        this._capturingInstrumentCount = 0;
         this._capturingStartTime = NaN;
         this._capturingEndTime = NaN;
 
@@ -396,11 +395,6 @@ WI.TimelineManager = class TimelineManager extends WI.Object
             this._activeRecording.initializeTimeBoundsIfNecessary(startTime);
         }
 
-        this._capturingInstrumentCount++;
-        console.assert(this._capturingInstrumentCount);
-        if (this._capturingInstrumentCount > 1)
-            return;
-
         if (this._capturingState === TimelineManager.CapturingState.Active)
             return;
 
@@ -437,11 +431,6 @@ WI.TimelineManager = class TimelineManager extends WI.Object
             if (isNaN(this._capturingEndTime) || endTime > this._capturingEndTime)
                 this._capturingEndTime = endTime;
         }
-
-        this._capturingInstrumentCount--;
-        console.assert(this._capturingInstrumentCount >= 0);
-        if (this._capturingInstrumentCount)
-            return;
 
         if (this._capturingState === TimelineManager.CapturingState.Inactive)
             return;


### PR DESCRIPTION
#### 65da45bdad2c438b8ae81c6632302267a654c74f
<pre>
Web Inspector: REGRESSION(?): cannot stop Timeline recording after submitting a form
<a href="https://bugs.webkit.org/show_bug.cgi?id=301643">https://bugs.webkit.org/show_bug.cgi?id=301643</a>

Reviewed by Darin Adler.

In the case of a cross-origin form submission, the old page is destroyed so all of the timeline instruments are gone and won&apos;t notify Web Inspector that they&apos;re no longer recording.

We effectively should reset the count of active timeline instruments, but it&apos;s not even really necessary to have that value in the first place when we already have a `WI.TimelineManager.CapturingState`.

* Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js:
(WI.TimelineManager):
(WI.TimelineManager.prototype.capturingStarted):
(WI.TimelineManager.prototype.capturingStopped):

Canonical link: <a href="https://commits.webkit.org/302776@main">https://commits.webkit.org/302776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8b0ef7a50d2623c42b5ed4079699b223ca8cc08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80087 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97974 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65885 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131644 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/699 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115300 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78586 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/633 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33411 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79358 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109053 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138533 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106507 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106326 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27377 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/649 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53159 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/842 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64099 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/703 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/759 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->