### PR TITLE
Unreviewed, reverting 302296@main (4dad7ec75d90)

### DIFF
--- a/Source/WebKit/Scripts/generate-swift-availability-macros
+++ b/Source/WebKit/Scripts/generate-swift-availability-macros
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 for search_path in "${BUILT_PRODUCTS_DIR}" "${SDKROOT}"; do
     candidate="${search_path}/usr/local/include/WebKitAdditions/Scripts/postprocess-framework-headers-definitions"
@@ -12,27 +12,27 @@ done
 
 if [[ "${WK_PLATFORM_NAME}" == "macosx" ]]; then
     [[ -n ${OSX_VERSION} ]] || OSX_VERSION=${MACOSX_DEPLOYMENT_TARGET}
+    [[ -n ${XROS_VERSION} ]] || XROS_VERSION="9999"
+    [[ -n ${IOS_VERSION} ]] || IOS_VERSION="9999"
 elif [[ "${WK_PLATFORM_NAME}" == "maccatalyst" ]]; then
     # On Mac Catalyst `LLVM_TARGET_TRIPLE_OS_VERSION` will be in the format `ios{major}.{minor}`.
     [[ -n ${IOS_VERSION} ]] || IOS_VERSION=${LLVM_TARGET_TRIPLE_OS_VERSION#ios}
+    [[ -n ${XROS_VERSION} ]] || XROS_VERSION="9999"
+    [[ -n ${OSX_VERSION} ]] || OSX_VERSION="9999"
 elif [[ "${WK_PLATFORM_NAME}" =~ "iphone" ]]; then
     [[ -n ${IOS_VERSION} ]] || IOS_VERSION=${IPHONEOS_DEPLOYMENT_TARGET}
+    [[ -n ${XROS_VERSION} ]] || XROS_VERSION="9999"
+    [[ -n ${OSX_VERSION} ]] || OSX_VERSION="9999"
 elif [[ "${PLATFORM_NAME}" == xr* ]]; then
     [[ -n ${XROS_VERSION} ]] || XROS_VERSION=${XROS_DEPLOYMENT_TARGET}
-elif [[ "${PLATFORM_NAME}" == watch* ]]; then
-    [[ -n ${WATCHOS_VERSION} ]] || WATCHOS_VERSION=${WATCHOS_DEPLOYMENT_TARGET}
-elif [[ "${PLATFORM_NAME}" == appletv* ]]; then
-    [[ -n ${TVOS_VERSION} ]] | TVOS_VERSION=${TVOS_DEPLOYMENT_TARGET}
+    [[ -n ${IOS_VERSION} ]] || IOS_VERSION="9999"
+    [[ -n ${OSX_VERSION} ]] || OSX_VERSION="9999"
+else
+    [[ -n ${OSX_VERSION} ]] || OSX_VERSION="9999"
+    [[ -n ${XROS_VERSION} ]] || XROS_VERSION="9999"
+    [[ -n ${IOS_VERSION} ]] || IOS_VERSION="9999"
 fi
-
-[[ -n ${OSX_VERSION} ]] || OSX_VERSION="9999"
-[[ -n ${IOS_VERSION} ]] || IOS_VERSION="9999"
-[[ -n ${XROS_VERSION} ]] || XROS_VERSION="9999"
-[[ -n ${WATCHOS_VERSION} ]] || WATCHOS_VERSION="9999"
-[[ -n ${TVOS_VERSION} ]] || TVOS_VERSION="9999"
 
 echo "-Xfrontend -define-availability -Xfrontend \"WK_IOS_TBA:iOS ${IOS_VERSION}\"" \
     "-Xfrontend -define-availability -Xfrontend \"WK_MAC_TBA:macOS ${OSX_VERSION}\"" \
-    "-Xfrontend -define-availability -Xfrontend \"WK_XROS_TBA:visionOS ${XROS_VERSION}\"" \
-    "-Xfrontend -define-availability -Xfrontend \"WK_WATCHOS_TBA:watchOS ${WATCHOS_VERSION}\"" \
-    "-Xfrontend -define-availability -Xfrontend \"WK_TVOS_TBA:tvOS ${TVOS_VERSION}\"" | tee "${SCRIPT_OUTPUT_FILE_0}"
+    "-Xfrontend -define-availability -Xfrontend \"WK_XROS_TBA:visionOS ${XROS_VERSION}\"" | tee "${SCRIPT_OUTPUT_FILE_0}"

--- a/Source/WebKit/Scripts/postprocess-header-rule
+++ b/Source/WebKit/Scripts/postprocess-header-rule
@@ -40,23 +40,22 @@ done
 if [[ "${WK_FRAMEWORK_HEADER_POSTPROCESSING_DISABLED}" != "YES" ]]; then
     if [[ "${WK_PLATFORM_NAME}" == "macosx" ]]; then
         [[ -n ${OSX_VERSION} ]] || OSX_VERSION=${MACOSX_DEPLOYMENT_TARGET}
+        [[ -n ${XROS_VERSION} ]] || XROS_VERSION="NA"
+        [[ -n ${IOS_VERSION} ]] || IOS_VERSION="NA"
     elif [[ "${WK_PLATFORM_NAME}" == "maccatalyst" ]]; then
         # On Mac Catalyst `LLVM_TARGET_TRIPLE_OS_VERSION` will be in the format `ios{major}.{minor}`.
         [[ -n ${IOS_VERSION} ]] || IOS_VERSION=${LLVM_TARGET_TRIPLE_OS_VERSION#ios}
+        [[ -n ${XROS_VERSION} ]] || XROS_VERSION="NA"
+        [[ -n ${OSX_VERSION} ]] || OSX_VERSION="NA"
     elif [[ "${WK_PLATFORM_NAME}" =~ "iphone" ]]; then
         [[ -n ${IOS_VERSION} ]] || IOS_VERSION=${IPHONEOS_DEPLOYMENT_TARGET}
+        [[ -n ${XROS_VERSION} ]] || XROS_VERSION="NA"
+        [[ -n ${OSX_VERSION} ]] || OSX_VERSION="NA"
     elif [[ "${PLATFORM_NAME}" == xr* ]]; then
         [[ -n ${XROS_VERSION} ]] || XROS_VERSION=${XROS_DEPLOYMENT_TARGET}
-    elif [[ "${PLATFORM_NAME}" == watch* ]]; then
-        [[ -n ${WATCHOS_VERSION} ]] || WATCHOS_VERSION=${WATCHOS_DEPLOYMENT_TARGET}
-    elif [[ "${PLATFORM_NAME}" == appletv* ]]; then
-        [[ -n ${TVOS_VERSION} ]] | TVOS_VERSION=${TVOS_DEPLOYMENT_TARGET}
+        [[ -n ${IOS_VERSION} ]] || IOS_VERSION="NA"
+        [[ -n ${OSX_VERSION} ]] || OSX_VERSION="NA"
     fi
-    [[ -n ${OSX_VERSION} ]] || OSX_VERSION="NA"
-    [[ -n ${XROS_VERSION} ]] || XROS_VERSION="NA"
-    [[ -n ${IOS_VERSION} ]] || IOS_VERSION="NA"
-    [[ -n ${WATCHOS_VERSION} ]] || WATCHOS_VERSION="NA"
-    [[ -n ${TVOS_VERSION} ]] || TVOS_VERSION="NA"
 
     SED_OPTIONS=()
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
@@ -23,7 +23,7 @@
 
 // FIXME: Eliminate this file since the refined API can now just go with the rest of the normal API where it belongs.
 
-#if USE_APPLE_INTERNAL_SDK || (!os(tvOS) && !os(watchOS))
+#if !os(tvOS) && !os(watchOS)
 
 // Older versions of the Swift compiler fail to import WebKit_Private. Can be
 // removed when WebKit drops support for macOS Sonoma.
@@ -32,7 +32,6 @@ internal import WebKit_Private.WKWebExtensionPrivate
 #endif
 
 @available(iOS 14.0, macOS 10.16, *)
-@_spi_available(WK_WATCHOS_TBA, WK_TVOS_TBA, *)
 extension WKPDFConfiguration {
     // This is pre-existing API whose documentation does not use the source code.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -43,7 +42,6 @@ extension WKPDFConfiguration {
 }
 
 @available(iOS 14.0, macOS 10.16, *)
-@_spi_available(WK_WATCHOS_TBA, WK_TVOS_TBA, *)
 extension WKWebView {
     // This is pre-existing API whose documentation does not use the source code.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -102,7 +100,6 @@ extension WKWebView {
 }
 
 @available(iOS 15.0, macOS 12.0, *)
-@_spi_available(WK_WATCHOS_TBA, WK_TVOS_TBA, *)
 extension WKWebView {
     // This is pre-existing API whose documentation does not use the source code.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h
@@ -22,7 +22,6 @@ typedef NS_ENUM(NSInteger, _WKWebExtensionBookmarkType) {
 
 /*! @abstract A class conforming to the ``_WKWebExtensionBookmark`` protocol represents a single bookmark node (a bookmark or folder) to web extensions. */
 WK_SWIFT_UI_ACTOR
-WK_API_UNAVAILABLE(watchos, tvos)
 @protocol _WKWebExtensionBookmark <NSObject>
 @optional
 


### PR DESCRIPTION
#### 2ee1ab094c04bf6509c764cc6e9084e7b7a66cab
<pre>
Unreviewed, reverting 302296@main (4dad7ec75d90)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301644">https://bugs.webkit.org/show_bug.cgi?id=301644</a>
<a href="https://rdar.apple.com/163657446">rdar://163657446</a>

REGRESSION(302296@main): Broke Internal watchOS builds

Reverted change:

    Enable WebKitSwiftOverlay on internal watchOS and tvOS builds
    <a href="https://bugs.webkit.org/show_bug.cgi?id=300338">https://bugs.webkit.org/show_bug.cgi?id=300338</a>
    <a href="https://rdar.apple.com/161606521">rdar://161606521</a>
    302296@main (4dad7ec75d90)

Canonical link: <a href="https://commits.webkit.org/302303@main">https://commits.webkit.org/302303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/226410258287c1157f9451f84da502d7e9dd4969

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128701 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39530 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/136083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/136083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131649 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/136083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/128052 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79363 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/33892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138539 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/111642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/106332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/30173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20096 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/64103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->