### PR TITLE
[GTK] [2.51.1] Fails to build on i386: redefinition of 'a' with a different type: 'const char *' vs 'const Latin1Character *' (aka 'const unsigned char *')

### DIFF
--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -246,24 +246,24 @@ ALWAYS_INLINE bool equal(const Latin1Character* a, std::span<const Latin1Charact
     ASSERT(b.size() <= std::numeric_limits<unsigned>::max());
     unsigned length = b.size();
 
-    const char* a = byteCast<char>(a);
-    const char* b = byteCast<char>(b.data());
+    const char* aString = byteCast<char>(a);
+    const char* bString = byteCast<char>(b.data());
 
     unsigned wordLength = length >> 2;
     for (unsigned i = 0; i != wordLength; ++i) {
-        if (unalignedLoad<uint32_t>(a) != unalignedLoad<uint32_t>(b))
+        if (unalignedLoad<uint32_t>(aString) != unalignedLoad<uint32_t>(bString))
             return false;
-        a += sizeof(uint32_t);
-        b += sizeof(uint32_t);
+        aString += sizeof(uint32_t);
+        bString += sizeof(uint32_t);
     }
 
     length &= 3;
 
     if (length) {
-        const Latin1Character* aRemainder = byteCast<Latin1Character>(a);
-        const Latin1Character* bRemainder = byteCast<Latin1Character>(b);
+        const Latin1Character* aRemainder = byteCast<Latin1Character>(aString);
+        const Latin1Character* bRemainder = byteCast<Latin1Character>(bString);
 
-        for (unsigned i = 0; i <  length; ++i) {
+        for (unsigned i = 0; i < length; ++i) {
             if (aRemainder[i] != bRemainder[i])
                 return false;
         }
@@ -277,18 +277,18 @@ ALWAYS_INLINE bool equal(const char16_t* a, std::span<const char16_t> b)
     ASSERT(b.size() <= std::numeric_limits<unsigned>::max());
     unsigned length = b.size();
 
-    const char* a = reinterpret_cast<const char*>(a);
-    const char* b = reinterpret_cast<const char*>(b.data());
+    const char* aString = reinterpret_cast<const char*>(a);
+    const char* bString = reinterpret_cast<const char*>(b.data());
 
     unsigned wordLength = length >> 1;
     for (unsigned i = 0; i != wordLength; ++i) {
-        if (unalignedLoad<uint32_t>(a) != unalignedLoad<uint32_t>(b))
+        if (unalignedLoad<uint32_t>(aString) != unalignedLoad<uint32_t>(bString))
             return false;
-        a += sizeof(uint32_t);
-        b += sizeof(uint32_t);
+        aString += sizeof(uint32_t);
+        bString += sizeof(uint32_t);
     }
 
-    if (length & 1 && *reinterpret_cast<const char16_t*>(a) != *reinterpret_cast<const char16_t*>(b))
+    if (length & 1 && *reinterpret_cast<const char16_t*>(aString) != *reinterpret_cast<const char16_t*>(bString))
         return false;
 
     return true;


### PR DESCRIPTION
#### 2a2707faa14a2769f7b9879056e4f15f9bc5a49e
<pre>
[GTK] [2.51.1] Fails to build on i386: redefinition of &apos;a&apos; with a different type: &apos;const char *&apos; vs &apos;const Latin1Character *&apos; (aka &apos;const unsigned char *&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301512">https://bugs.webkit.org/show_bug.cgi?id=301512</a>

Unreviewed build fix.

Unfortunately I renamed the parameters to exactly the same names as the
local variables. I prefer to not rename the parameters again, since
these are the best names for the other architectures, so let&apos;s change
the locals instead.

Canonical link: <a href="https://commits.webkit.org/302344@main">https://commits.webkit.org/302344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91b8047d933040b791e7925059233ac467cabc6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136091 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80100 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97983 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80100 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78598 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33421 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79370 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120719 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138548 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127168 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/750 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106519 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106339 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27095 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/656 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30178 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53218 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64118 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160180 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/712 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39996 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->