### PR TITLE
Add Experimental Caption Display Settings menu

### DIFF
--- a/LayoutTests/media/track/text-track-caption-style-menu-expected.txt
+++ b/LayoutTests/media/track/text-track-caption-style-menu-expected.txt
@@ -1,0 +1,19 @@
+
+RUN(video.textTracks[0].mode = "showing")
+EXPECTED (allCueElements().length == '1') OK
+EXPECTED (firstCueElement().textContent == 'Lorem') OK
+
+Pretend to show the subtitle style menu:
+RUN(internals.showCaptionDisplaySettingsPreviewForMediaElement(video))
+EXPECTED (allCueElements().length == '1') OK
+EXPECTED (firstCueElement().textContent == 'This is a preview') OK
+
+Ensure that activeCues does not change:
+EXPECTED (video.textTracks[0].activeCues[0].text == 'Lorem') OK
+
+Pretend to hide the subtitle style menu:
+RUN(internals.hideCaptionDisplaySettingsPreviewForMediaElement(video))
+EXPECTED (allCueElements().length == '1') OK
+EXPECTED (firstCueElement().textContent == 'Lorem') OK
+END OF TEST
+

--- a/LayoutTests/media/track/text-track-caption-style-menu.html
+++ b/LayoutTests/media/track/text-track-caption-style-menu.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+    <script src=../video-test.js></script>
+    <script src=../media-file.js></script>
+    <script>
+        function allCueElements() {
+            return internals.shadowRoot(video).querySelectorAll('[useragentpart="-internal-cue-background"]');
+        }
+
+        function firstCueElement() {
+            return internals.shadowRoot(video).querySelector('[useragentpart="-internal-cue-background"]');
+        }
+
+        async function runTest() {
+            findMediaElement();
+
+            video.src = findMediaFile('video', '../content/test') + '#t=0.5';
+
+            run('video.textTracks[0].mode = "showing"');
+            await testExpectedEventually('allCueElements().length', 1);
+            testExpected('firstCueElement().textContent', 'Lorem');
+
+            consoleWrite('');
+            consoleWrite('Pretend to show the subtitle style menu:');
+            run('internals.showCaptionDisplaySettingsPreviewForMediaElement(video)');
+            await testExpectedEventually('allCueElements().length', 1);
+            testExpected('firstCueElement().textContent', 'This is a preview');
+
+            consoleWrite('');
+            consoleWrite('Ensure that activeCues does not change:');
+            testExpected('video.textTracks[0].activeCues[0].text', "Lorem")
+
+            consoleWrite('');
+            consoleWrite('Pretend to hide the subtitle style menu:');
+            run('internals.hideCaptionDisplaySettingsPreviewForMediaElement(video)');
+            await testExpectedEventually('allCueElements().length', 1);
+            testExpected('firstCueElement().textContent', 'Lorem');
+        }
+
+
+        window.addEventListener('load', event => {
+            runTest().then(endTest).catch(failTest);
+        })
+    </script>
+</head>
+<body>
+    <video>
+        <track src="captions-webvtt/captions.vtt" kind="captions" default>
+    </video>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1770,6 +1770,21 @@ CanvasUsesAcceleratedDrawing:
     WebCore:
       default: false
 
+CaptionDisplaySettingsEnabled:
+  type: bool
+  status: unstable
+  category: media
+  humanReadableName: "Caption Display Settings API"
+  humanReadableDescription: "Enable Caption Display Settings API"
+  condition: ENABLE(VIDEO)
+  defaultValue:
+    WebKit:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebCore:
+      default: false
+
 CaptureAudioInGPUProcessEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -38,6 +38,7 @@ namespace WebCore {
 
 class AudioTrack;
 class AudioTrackList;
+class DOMPromise;
 class Element;
 class WeakPtrImplWithEventTargetData;
 class HTMLElement;
@@ -105,6 +106,7 @@ public:
     bool needsChromeMediaControlsPseudoElement() const;
     bool isMediaControlsMacInlineSizeSpecsEnabled() const;
 
+    void captionPreferencesChanged();
     enum class ForceUpdate : bool { No, Yes };
     void updateCaptionDisplaySizes(ForceUpdate = ForceUpdate::No);
     void updateTextTrackRepresentationImageIfNeeded();
@@ -126,6 +128,8 @@ public:
     static String base64StringForIconNameAndType(const String& iconName, const String& iconType);
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
     bool showMediaControlsContextMenu(HTMLElement&, String&& optionsJSONString, Ref<VoidCallback>&&);
+    void showCaptionDisplaySettingsPreview();
+    void hideCaptionDisplaySettingsPreview();
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
 
     using SourceType = HTMLMediaElementSourceType;
@@ -143,6 +147,8 @@ public:
 private:
     void savePreviouslySelectedTextTrackIfNecessary();
     void restorePreviouslySelectedTextTrackIfNecessary();
+
+    MediaControlTextTrackContainerElement* ensureTextTrackContainer();
 
 #if ENABLE(MEDIA_SESSION)
     RefPtr<MediaSession> mediaSession() const;

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1114,6 +1114,9 @@
 /* Menu item label for the track that represents disabling closed captions. */
 "Off (text track)" = "Off";
 
+/* Menu item label for the track that represents enabling closed captions. */
+"On (text track)" = "On";
+
 /* Title for Open Link action button */
 "Open" = "Open";
 
@@ -1560,6 +1563,9 @@
 
 /* text that appears at the start of nearly-obsolete web pages in the form of a 'searchable index' */
 "This is a searchable index. Enter search keywords: " = "This is a searchable index. Enter search keywords: ";
+
+/* This is the %s subtitle style (Caption User Preferences) */
+"This is the %s subtitle style" = "This is the %s subtitle style";
 
 /* Not Secure Connection warning text */
 "This website does not support connecting securely over HTTPS. The information you see and enter on this website, including credit cards, phone numbers, and passwords, can be read and altered by other people." = "This website does not support connecting securely over HTTPS. The information you see and enter on this website, including credit cards, phone numbers, and passwords, can be read and altered by other people.";

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7830,6 +7830,22 @@ void HTMLMediaElement::updateTextTrackRepresentationImageIfNeeded()
         m_mediaControlsHost->updateTextTrackRepresentationImageIfNeeded();
 }
 
+void HTMLMediaElement::showCaptionDisplaySettingsPreview()
+{
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    if (RefPtr mediaControlsHost = m_mediaControlsHost.get())
+        mediaControlsHost->showCaptionDisplaySettingsPreview();
+#endif
+}
+
+void HTMLMediaElement::hideCaptionDisplaySettingsPreview()
+{
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    if (RefPtr mediaControlsHost = m_mediaControlsHost.get())
+        mediaControlsHost->hideCaptionDisplaySettingsPreview();
+#endif
+}
+
 void HTMLMediaElement::setClosedCaptionsVisible(bool closedCaptionVisible)
 {
     ALWAYS_LOG(LOGIDENTIFIER, closedCaptionVisible);
@@ -7973,7 +7989,7 @@ void HTMLMediaElement::captionPreferencesChanged()
         return;
 
     if (RefPtr mediaControlsHost = m_mediaControlsHost.get())
-        mediaControlsHost->updateCaptionDisplaySizes(MediaControlsHost::ForceUpdate::Yes);
+        mediaControlsHost->captionPreferencesChanged();
 
     if (RefPtr player = m_player)
         player->tracksChanged();

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -472,6 +472,9 @@ public:
     void textTrackReadyStateChanged(TextTrack*);
     void updateTextTrackRepresentationImageIfNeeded();
 
+    WEBCORE_EXPORT void showCaptionDisplaySettingsPreview();
+    WEBCORE_EXPORT void hideCaptionDisplaySettingsPreview();
+
     WEBCORE_EXPORT bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) override;
     WEBCORE_EXPORT bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) override;
 

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
@@ -34,14 +34,21 @@
 #include "HTMLDivElement.h"
 #include "IntRect.h"
 #include "MediaControllerInterface.h"
+#include "PODInterval.h"
 #include "TextTrackRepresentation.h"
 #include <wtf/LoggerHelper.h>
+#include <wtf/MediaTime.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class HTMLMediaElement;
+class TextTrack;
+class TextTrackCue;
 class VTTCue;
+
+using CueInterval = PODInterval<MediaTime, TextTrackCue*>;
+using CueList = Vector<CueInterval>;
 
 class MediaControlTextTrackContainerElement final
     : public HTMLDivElement
@@ -54,7 +61,9 @@ class MediaControlTextTrackContainerElement final
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaControlTextTrackContainerElement);
 public:
     static Ref<MediaControlTextTrackContainerElement> create(Document&, HTMLMediaElement&);
+    ~MediaControlTextTrackContainerElement();
 
+    void captionPreferencesChanged();
     enum class ForceUpdate : bool { No, Yes };
     void updateSizes(ForceUpdate force = ForceUpdate::No);
     void updateDisplay();
@@ -65,6 +74,9 @@ public:
 
     void enteredFullscreen();
     void exitedFullscreen();
+
+    void showCaptionDisplaySettingsPreview();
+    void hideCaptionDisplaySettingsPreview();
 
 private:
     explicit MediaControlTextTrackContainerElement(Document&, HTMLMediaElement&);
@@ -89,6 +101,9 @@ private:
     void show();
     bool isShowing() const;
 
+    CueList currentlyActiveCues() const;
+    VTTCue& ensurePreviewCue() const;
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final;
     uint64_t logIdentifier() const final;
@@ -105,6 +120,10 @@ private:
     int m_fontSize { 0 };
     bool m_fontSizeIsImportant { false };
     bool m_needsToGenerateTextTrackRepresentation { false };
+    bool m_shouldShowCaptionPreviewCue { false };
+
+    mutable RefPtr<TextTrack> m_previewTrack;
+    mutable RefPtr<VTTCue> m_previewCue;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -83,6 +83,12 @@ TextTrack& TextTrack::captionMenuOffItem()
     return off;
 }
 
+TextTrack& TextTrack::captionMenuOnItem()
+{
+    static TextTrack& on = TextTrack::create(nullptr, "on menu item"_s, emptyAtom(), emptyAtom(), emptyAtom()).leakRef();
+    return on;
+}
+
 TextTrack& TextTrack::captionMenuAutomaticItem()
 {
     static TextTrack& automatic = TextTrack::create(nullptr, "automatic menu item"_s, emptyAtom(), emptyAtom(), emptyAtom()).leakRef();

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -56,6 +56,7 @@ public:
     void didMoveToNewDocument(Document& newDocument) final;
 
     static TextTrack& captionMenuOffItem();
+    static TextTrack& captionMenuOnItem();
     static TextTrack& captionMenuAutomaticItem();
 
     static bool isValidKindKeyword(const AtomString&);

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -215,6 +215,8 @@ static String trackDisplayName(TextTrack* track)
 {
     if (track == &TextTrack::captionMenuOffItem())
         return textTrackOffMenuItemText();
+    if (track == &TextTrack::captionMenuOnItem())
+        return textTrackOnMenuItemText();
     if (track == &TextTrack::captionMenuAutomaticItem())
         return textTrackAutomaticMenuItemText();
 
@@ -456,6 +458,14 @@ String CaptionUserPreferences::primaryAudioTrackLanguageOverride() const
     if (!m_primaryAudioTrackLanguageOverride.isEmpty())
         return m_primaryAudioTrackLanguageOverride;
     return defaultLanguage(ShouldMinimizeLanguages::No);
+}
+
+String CaptionUserPreferences::captionPreviewTitle() const
+{
+    if (testingMode())
+        return "This is a preview"_s;
+
+    return WEB_UI_STRING_KEY("This is a preview style", "This is a preview style (Caption User Preferences)", "Caption Style Preview String");
 }
 
 PageGroup& CaptionUserPreferences::pageGroup() const

--- a/Source/WebCore/page/CaptionUserPreferences.h
+++ b/Source/WebCore/page/CaptionUserPreferences.h
@@ -108,7 +108,9 @@ public:
 
     friend class CaptionUserPreferencesTestingModeToken;
     WEBCORE_EXPORT UniqueRef<CaptionUserPreferencesTestingModeToken> createTestingModeToken();
-    
+
+    virtual String captionPreviewTitle() const;
+
     PageGroup& pageGroup() const;
 
 protected:

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -758,6 +758,8 @@ static String trackDisplayName(const TrackBase& track, const Vector<String>& pre
 {
     if (&track == &TextTrack::captionMenuOffItem())
         return textTrackOffMenuItemText();
+    if (&track == &TextTrack::captionMenuOnItem())
+        return textTrackOnMenuItemText();
     if (&track == &TextTrack::captionMenuAutomaticItem())
         return textTrackAutomaticMenuItemText();
 
@@ -1050,6 +1052,19 @@ String CaptionUserPreferencesMediaAF::nameForProfileID(const String& profileID)
     RetainPtr cfProfileID = profileID.createCFString();
     RetainPtr cfProfileName = adoptCF(MACaptionAppearanceCopyProfileName(cfProfileID.get()));
     return cfProfileName.get();
+}
+
+String CaptionUserPreferencesMediaAF::captionPreviewTitle() const
+{
+    if (testingMode())
+        return CaptionUserPreferences::captionPreviewTitle();
+
+    String activeProfileID = platformActiveProfileID();
+    String activeProfileName = nameForProfileID(activeProfileID);
+    if (activeProfileName.isEmpty())
+        return CaptionUserPreferences::captionPreviewTitle();
+
+    return WEB_UI_FORMAT_STRING("This is the %s subtitle style", "This is the %s subtitle style (Caption User Preferences)", activeProfileName.utf8().data());
 }
 
 }

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
@@ -99,6 +99,7 @@ public:
     Vector<RefPtr<TextTrack>> sortedTrackListForMenu(TextTrackList*, HashSet<TextTrack::Kind>) override;
     String displayNameForTrack(AudioTrack*) const override;
     String displayNameForTrack(TextTrack*) const override;
+    String captionPreviewTitle() const override;
 
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
     WEBCORE_EXPORT String captionsWindowCSS() const;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -698,7 +698,7 @@ public:
     virtual bool needsScrollGeometryUpdates() const { return false; }
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
-    virtual void showMediaControlsContextMenu(FloatRect&&, Vector<MediaControlsContextMenuItem>&&, CompletionHandler<void(MediaControlsContextMenuItem::ID)>&& completionHandler) { completionHandler(MediaControlsContextMenuItem::invalidID); }
+    virtual void showMediaControlsContextMenu(FloatRect&&, Vector<MediaControlsContextMenuItem>&&, HTMLMediaElement&,  CompletionHandler<void(MediaControlsContextMenuItem::ID)>&& completionHandler) { completionHandler(MediaControlsContextMenuItem::invalidID); }
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
 #if ENABLE(WEBXR)
@@ -775,6 +775,10 @@ public:
 #endif
 
     virtual bool usePluginRendererScrollableArea(LocalFrame&) const { return true; }
+
+#if ENABLE(VIDEO)
+    virtual void showCaptionDisplaySettings(CompletionHandler<void(bool)>&& callback) { callback(false); }
+#endif
 
     WEBCORE_EXPORT virtual ~ChromeClient();
 

--- a/Source/WebCore/page/ContextMenuContext.h
+++ b/Source/WebCore/page/ContextMenuContext.h
@@ -28,6 +28,7 @@
 
 #if ENABLE(CONTEXT_MENUS)
 
+#include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/HitTestResult.h>
 #include <WebCore/Image.h>
 
@@ -81,6 +82,11 @@ public:
     Image* potentialQRCodeViewportSnapshotImage() const { return m_potentialQRCodeViewportSnapshotImage.get(); }
 #endif
 
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    void setMediaElementIdentifier(HTMLMediaElementIdentifier identifier) { m_mediaElementIdentifier = identifier; }
+    std::optional<HTMLMediaElementIdentifier> mediaElementIdentifier() const { return m_mediaElementIdentifier; }
+#endif
+
 private:
     Type m_type { Type::ContextMenu };
     HitTestResult m_hitTestResult;
@@ -97,6 +103,10 @@ private:
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
     RefPtr<Image> m_potentialQRCodeNodeSnapshotImage;
     RefPtr<Image> m_potentialQRCodeViewportSnapshotImage;
+#endif
+
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    Markable<HTMLMediaElementIdentifier> m_mediaElementIdentifier;
 #endif
 };
 

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -247,7 +247,10 @@ std::unique_ptr<ContextMenu> ContextMenuController::maybeCreateContextMenu(Event
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
     prepareContextForQRCode(m_context);
 #endif
-    
+
+    if (RefPtr menuProvider = m_menuProvider)
+        menuProvider->prepareContext(m_context);
+
     return makeUnique<ContextMenu>();
 }
 
@@ -1863,6 +1866,10 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
         case ContextMenuItemTagRewrite:
         case ContextMenuItemTagSummarize:
             break;
+#if ENABLE(VIDEO)
+        case ContextMenuItemCaptionDisplayStyleSubmenu:
+            break;
+#endif
     }
 
     item.setChecked(shouldCheck);

--- a/Source/WebCore/page/ContextMenuProvider.h
+++ b/Source/WebCore/page/ContextMenuProvider.h
@@ -39,6 +39,7 @@
 namespace WebCore {
 
 class ContextMenu;
+class ContextMenuContext;
 
 class ContextMenuProvider : public RefCounted<ContextMenuProvider> {
 public:
@@ -49,6 +50,7 @@ public:
     virtual void contextMenuItemSelected(ContextMenuAction, const String& title) = 0;
     virtual void contextMenuCleared() = 0;
     virtual ContextMenuContext::Type contextMenuContextType() { return ContextMenuContext::Type::ContextMenu; };
+    virtual void prepareContext(ContextMenuContext&) { }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ContextMenuItem.cpp
+++ b/Source/WebCore/platform/ContextMenuItem.cpp
@@ -274,6 +274,7 @@ static bool isValidContextMenuAction(WebCore::ContextMenuAction action)
     case ContextMenuAction::ContextMenuItemTagProofread:
     case ContextMenuAction::ContextMenuItemTagRewrite:
     case ContextMenuAction::ContextMenuItemTagSummarize:
+    case ContextMenuAction::ContextMenuItemCaptionDisplayStyleSubmenu:
     case ContextMenuAction::ContextMenuItemBaseCustomTag:
     case ContextMenuAction::ContextMenuItemLastCustomTag:
     case ContextMenuAction::ContextMenuItemBaseApplicationTag:

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -169,11 +169,12 @@ enum ContextMenuAction {
     ContextMenuItemTagProofread,
     ContextMenuItemTagRewrite,
     ContextMenuItemTagSummarize,
+    ContextMenuItemCaptionDisplayStyleSubmenu,
 #if PLATFORM(COCOA)
     ContextMenuItemTagSmartLists,
     ContextMenuItemLastNonCustomTag = ContextMenuItemTagSmartLists,
 #else
-    ContextMenuItemLastNonCustomTag = ContextMenuItemTagSummarize,
+    ContextMenuItemLastNonCustomTag = ContextMenuItemCaptionDisplayStyleSubmenu,
 #endif
     ContextMenuItemBaseCustomTag = 5000,
     ContextMenuItemLastCustomTag = 5999,

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -1349,6 +1349,11 @@ String textTrackOffMenuItemText()
     return WEB_UI_STRING_KEY("Off", "Off (text track)", "Menu item label for the track that represents disabling closed captions.");
 }
 
+String textTrackOnMenuItemText()
+{
+    return WEB_UI_STRING_KEY("On", "On (text track)", "Menu item label for the track that represents enabling closed captions.");
+}
+
 String textTrackAutomaticMenuItemText()
 {
     return WEB_UI_STRING_KEY("Auto (Recommended)", "Auto (Recommended) (text track)", "Menu item label for automatic track selection behavior.");

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -355,6 +355,7 @@ namespace WebCore {
 #if ENABLE(VIDEO)
     String trackNoLabelText();
     String textTrackOffMenuItemText();
+    String textTrackOnMenuItemText();
     String textTrackAutomaticMenuItemText();
 #if PLATFORM(COCOA)
     String addTrackLabelAsSuffix(const String&, const String&);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4837,6 +4837,16 @@ double Internals::closestTimeToTimeRanges(double time, TimeRanges& ranges)
     return ranges.nearest(time);
 }
 
+void Internals::showCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement& element)
+{
+    element.showCaptionDisplaySettingsPreview();
+}
+
+void Internals::hideCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement& element)
+{
+    element.hideCaptionDisplaySettingsPreview();
+}
+
 #endif
 
 ExceptionOr<Ref<DOMRect>> Internals::selectionBounds()

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -836,6 +836,10 @@ public:
     ExceptionOr<String> textTrackBCP47Language(TextTrack&);
     Ref<TimeRanges> createTimeRanges(Float32Array& startTimes, Float32Array& endTimes);
     double closestTimeToTimeRanges(double time, TimeRanges&);
+
+    void showCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement&);
+    void hideCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement&);
+
 #endif
 
     ExceptionOr<Ref<DOMRect>> selectionBounds();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1023,6 +1023,9 @@ enum ContentsFormat {
      endTimes);
     [Conditional=VIDEO] unrestricted double closestTimeToTimeRanges(unrestricted double time, TimeRanges ranges);
 
+    [Conditional=VIDEO] undefined showCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement element);
+    [Conditional=VIDEO] undefined hideCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement element);
+
     boolean isSelectPopupVisible(HTMLSelectElement element);
 
     DOMRect selectionBounds();

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -371,6 +371,8 @@ static std::optional<SymbolNameWithType> symbolNameWithTypeForAction(const WebCo
         return { { SymbolType::Public, "translate"_s } };
     case WebCore::ContextMenuItemTagUnderline:
         return { { SymbolType::Public, "underline"_s } };
+    case WebCore::ContextMenuItemCaptionDisplayStyleSubmenu:
+        return { };
     }
 
     return { };

--- a/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
+++ b/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
@@ -138,6 +138,7 @@ enum {
     kWKContextMenuItemTagProofread,
     kWKContextMenuItemTagRewrite,
     kWKContextMenuItemTagSummarize,
+    kWKContextMenuItemCaptionDisplayStyleSubmenu,
     kWKContextMenuItemBaseApplicationTag = 10000
 };
 typedef uint32_t WKContextMenuItemTag;

--- a/Source/WebKit/Shared/ContextMenuContextData.cpp
+++ b/Source/WebKit/Shared/ContextMenuContextData.cpp
@@ -70,6 +70,11 @@ ContextMenuContextData::ContextMenuContextData(const IntPoint& menuLocation, con
     if (RefPtr image = context.potentialQRCodeViewportSnapshotImage())
         setPotentialQRCodeViewportSnapshotImage(*image);
 #endif
+
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    if (auto identifier = context.mediaElementIdentifier())
+        setMediaElementIdentifier(*identifier);
+#endif
 }
 
 #if ENABLE(SERVICE_CONTROLS)
@@ -159,6 +164,9 @@ ContextMenuContextData::ContextMenuContextData(WebCore::ContextMenuContext::Type
     , bool hasEntireImage
     , bool allowsFollowingLink
     , bool allowsFollowingImageURL
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    , std::optional<WebCore::HTMLMediaElementIdentifier> mediaElementIdentifier
+#endif
 )
     : m_type(type)
     , m_menuLocation(WTFMove(menuLocation))
@@ -176,6 +184,9 @@ ContextMenuContextData::ContextMenuContextData(WebCore::ContextMenuContext::Type
     , m_controlledImageAttachmentID(WTFMove(controlledImageAttachmentID))
     , m_controlledImageElementContext(WTFMove(controlledImageElementContext))
     , m_controlledImageMIMEType(WTFMove(controlledImageMIMEType))
+#endif
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    , m_mediaElementIdentifier(WTFMove(mediaElementIdentifier))
 #endif
 {
 #if ENABLE(SERVICE_CONTROLS)

--- a/Source/WebKit/Shared/ContextMenuContextData.h
+++ b/Source/WebKit/Shared/ContextMenuContextData.h
@@ -73,6 +73,9 @@ public:
         , bool hasEntireImage
         , bool allowsFollowingLink
         , bool allowsFollowingImageURL
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+        , std::optional<WebCore::HTMLMediaElementIdentifier> mediaElementIdentifier
+#endif
     );
 
     Type type() const { return m_type; }
@@ -135,6 +138,11 @@ public:
     void setQRCodePayloadString(const String& string) { m_qrCodePayloadString = string; }
 #endif
 
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    void setMediaElementIdentifier(WebCore::HTMLMediaElementIdentifier identifier) { m_mediaElementIdentifier = identifier; }
+    std::optional<WebCore::HTMLMediaElementIdentifier> mediaElementIdentifier() const { return m_mediaElementIdentifier; }
+#endif
+
 private:
     Type m_type;
 
@@ -168,6 +176,10 @@ private:
     RefPtr<WebCore::ShareableBitmap> m_potentialQRCodeViewportSnapshotImage;
 
     String m_qrCodePayloadString;
+#endif
+
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    Markable<WebCore::HTMLMediaElementIdentifier> m_mediaElementIdentifier;
 #endif
 };
 

--- a/Source/WebKit/Shared/ContextMenuContextData.serialization.in
+++ b/Source/WebKit/Shared/ContextMenuContextData.serialization.in
@@ -45,6 +45,10 @@ class WebKit::ContextMenuContextData {
     bool hasEntireImage();
     bool allowsFollowingLink();
     bool allowsFollowingImageURL();
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    std::optional<WebCore::MediaPlayerClientIdentifier> mediaElementIdentifier();
+#endif
+
 };
 
 #endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -119,6 +119,7 @@ template: struct WebCore::BackForwardFrameItemIdentifierType
 template: struct WebCore::BackForwardItemIdentifierType
 template: struct WebCore::DictationContextType
 template: struct WebCore::FrameIdentifierType
+template: struct WebCore::HTMLMediaElementType
 template: struct WebCore::MediaKeySystemRequestIdentifierType
 template: struct WebCore::MediaPlayerIdentifierType
 template: struct WebCore::MediaPlayerClientIdentifierType

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -44,6 +44,7 @@
 #include <WebCore/ExceptionData.h>
 #include <WebCore/FocusDirection.h>
 #include <WebCore/FrameIdentifier.h>
+#include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/InputMode.h>
 #include <WebCore/MediaControlsContextMenuItem.h>
 #include <WebCore/ScrollTypes.h>
@@ -677,7 +678,7 @@ public:
 #endif
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
-    virtual void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&& completionHandler) { completionHandler(WebCore::MediaControlsContextMenuItem::invalidID); }
+    virtual void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, const FrameInfoData&, WebCore::HTMLMediaElementIdentifier, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&& completionHandler) { completionHandler(WebCore::MediaControlsContextMenuItem::invalidID); }
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
     
 #if PLATFORM(MAC)
@@ -840,6 +841,10 @@ public:
 #if ENABLE(POINTER_LOCK)
     virtual void beginPointerLockMouseTracking() { }
     virtual void endPointerLockMouseTracking() { }
+#endif
+
+#if ENABLE(VIDEO)
+    virtual void showCaptionDisplaySettings(CompletionHandler<void(bool)>&& callback) { callback(false); }
 #endif
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1481,6 +1481,29 @@ void WebPageProxy::setBrowsingContextGroup(BrowsingContextGroup& browsingContext
     m_browsingContextGroup = browsingContextGroup;
 }
 
+#if ENABLE(VIDEO)
+void WebPageProxy::showCaptionDisplaySettings(CompletionHandler<void(bool)>&& callback)
+{
+    if (RefPtr pageClient = this->pageClient()) {
+        pageClient->showCaptionDisplaySettings(WTFMove(callback));
+        return;
+    }
+
+    callback(false);
+}
+
+void WebPageProxy::showCaptionDisplaySettingsPreview(const FrameInfoData& frameInfo, WebCore::HTMLMediaElementIdentifier identifier)
+{
+    sendToProcessContainingFrame(frameInfo.frameID, Messages::WebPage::ShowCaptionDisplaySettingsPreview(identifier));
+}
+
+void WebPageProxy::hideCaptionDisplaySettingsPreview(const FrameInfoData& frameInfo, WebCore::HTMLMediaElementIdentifier identifier)
+{
+    sendToProcessContainingFrame(frameInfo.frameID, Messages::WebPage::HideCaptionDisplaySettingsPreview(identifier));
+}
+
+#endif
+
 void WebPageProxy::swapToProvisionalPage(Ref<ProvisionalPageProxy>&& provisionalPage)
 {
     ASSERT(!m_isClosed);
@@ -12998,12 +13021,11 @@ Ref<MediaKeySystemPermissionRequestManagerProxy> WebPageProxy::protectedMediaKey
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
-void WebPageProxy::showMediaControlsContextMenu(FloatRect&& targetFrame, Vector<MediaControlsContextMenuItem>&& items, CompletionHandler<void(MediaControlsContextMenuItem::ID)>&& completionHandler)
+void WebPageProxy::showMediaControlsContextMenu(FloatRect&& targetFrame, Vector<MediaControlsContextMenuItem>&& items, const FrameInfoData& frameInfo, HTMLMediaElementIdentifier identifier, CompletionHandler<void(MediaControlsContextMenuItem::ID)>&& completionHandler)
 {
     if (RefPtr pageClient = this->pageClient())
-        pageClient->showMediaControlsContextMenu(WTFMove(targetFrame), WTFMove(items), WTFMove(completionHandler));
+        pageClient->showMediaControlsContextMenu(WTFMove(targetFrame), WTFMove(items), frameInfo, identifier, WTFMove(completionHandler));
 }
-
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
 #if ENABLE(NOTIFICATIONS)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2188,7 +2188,7 @@ public:
 #endif
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
-    void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, CompletionHandler<void(WebCore::MediaControlsContextMenuItemID)>&&);
+    void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, const FrameInfoData&,  WebCore::HTMLMediaElementIdentifier, CompletionHandler<void(WebCore::MediaControlsContextMenuItemID)>&&);
 #endif
 
     static RefPtr<WebPageProxy> nonEphemeralWebPageProxy();
@@ -2844,6 +2844,11 @@ public:
     Vector<RendererBufferFormat> preferredBufferFormats() const;
 #endif
 
+#if ENABLE(VIDEO)
+    void showCaptionDisplaySettingsPreview(const FrameInfoData&, WebCore::HTMLMediaElementIdentifier);
+    void hideCaptionDisplaySettingsPreview(const FrameInfoData&, WebCore::HTMLMediaElementIdentifier);
+#endif
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
@@ -3448,6 +3453,10 @@ private:
 
     void setAllowsLayoutViewportHeightExpansion(bool);
     void setBrowsingContextGroup(BrowsingContextGroup&);
+
+#if ENABLE(VIDEO)
+    void showCaptionDisplaySettings(CompletionHandler<void(bool)>&&);
+#endif
 
     struct Internals;
     Internals& internals() { return m_internals; }

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -255,7 +255,7 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
-    [EnabledBy=MediaControlsContextMenusEnabled] ShowMediaControlsContextMenu(WebCore::FloatRect targetFrame, Vector<WebCore::MediaControlsContextMenuItem> items) -> (WebCore::MediaControlsContextMenuItem::ID selectedItemID)
+    [EnabledBy=MediaControlsContextMenusEnabled] ShowMediaControlsContextMenu(WebCore::FloatRect targetFrame, Vector<WebCore::MediaControlsContextMenuItem> items, struct WebKit::FrameInfoData frameInfoData, WebCore::MediaPlayerClientIdentifier identifier) -> (WebCore::MediaControlsContextMenuItem::ID selectedItemID)
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
 #if HAVE(TOUCH_BAR)
@@ -669,4 +669,8 @@ messages -> WebPageProxy {
     HasActiveNowPlayingSessionChanged(bool hasActiveNowPlayingSessionChanged)
 
     SetAllowsLayoutViewportHeightExpansion(bool newValue)
+
+#if ENABLE(VIDEO)
+    ShowCaptionDisplaySettings() -> (bool success)
+#endif
 }

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -312,7 +312,7 @@ private:
     void setMouseEventPolicy(WebCore::MouseEventPolicy) final;
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
-    void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&) final;
+    void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, const FrameInfoData&, WebCore::HTMLMediaElementIdentifier,  CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&) final;
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1185,9 +1185,9 @@ void PageClientImpl::setMouseEventPolicy(WebCore::MouseEventPolicy policy)
 }
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
-void PageClientImpl::showMediaControlsContextMenu(FloatRect&& targetFrame, Vector<MediaControlsContextMenuItem>&& items, CompletionHandler<void(MediaControlsContextMenuItem::ID)>&& completionHandler)
+void PageClientImpl::showMediaControlsContextMenu(FloatRect&& targetFrame, Vector<MediaControlsContextMenuItem>&& items, const FrameInfoData& frameInfo, HTMLMediaElementIdentifier identifier, CompletionHandler<void(MediaControlsContextMenuItem::ID)>&& completionHandler)
 {
-    [contentView() _showMediaControlsContextMenu:WTFMove(targetFrame) items:WTFMove(items) completionHandler:WTFMove(completionHandler)];
+    [contentView() _showMediaControlsContextMenu:WTFMove(targetFrame) items:WTFMove(items) frameInfo:frameInfo identifier:identifier completionHandler:WTFMove(completionHandler)];
 }
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h
@@ -29,6 +29,7 @@
 #import "WKActionSheet.h"
 #import <UIKit/UIPopoverController.h>
 #import <WebCore/ElementContext.h>
+#import <WebCore/HTMLMediaElementIdentifier.h>
 #import <WebCore/MediaControlsContextMenuItem.h>
 #import <pal/spi/ios/DataDetectorsUISPI.h>
 #import <wtf/Forward.h>
@@ -95,6 +96,10 @@ typedef NS_ENUM(NSInteger, _WKElementActionType);
 - (void)_actionSheetAssistant:(WKActionSheetAssistant *)assistant performAction:(WebKit::SheetAction)action onElements:(Vector<WebCore::ElementContext>&&)elements;
 #endif
 - (NSArray<UIMenuElement *> *)additionalMediaControlsContextMenuItemsForActionSheetAssistant:(WKActionSheetAssistant *)assistant;
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
+- (void)captionStyleMenuWillOpenWithFrameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier;
+- (void)captionStyleMenuDidCloseWithFrameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier;
+#endif
 @end
 
 #if USE(UICONTEXTMENU)
@@ -114,7 +119,7 @@ UIContextMenuInteractionDelegate>
 - (void)showImageSheet;
 - (void)showDataDetectorsUIForPositionInformation:(const WebKit::InteractionInformationAtPosition&)positionInformation;
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
-- (void)showMediaControlsContextMenu:(WebCore::FloatRect&&)targetFrame items:(Vector<WebCore::MediaControlsContextMenuItem>&&)items completionHandler:(CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&)completionHandler;
+- (void)showMediaControlsContextMenu:(WebCore::FloatRect&&)targetFrame items:(Vector<WebCore::MediaControlsContextMenuItem>&&)items frameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier completionHandler:(CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&)completionHandler;
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 - (void)cleanupSheet;
 - (void)updateSheetPosition;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -102,6 +102,7 @@ class SelectionRect;
 struct ContactInfo;
 struct ContactsRequestData;
 struct DigitalCredentialsRequestData;
+struct MediaPlayerClientIdentifierType;
 struct PromisedAttachmentInfo;
 struct ShareDataWithParsedURL;
 struct TextRecognitionResult;
@@ -118,6 +119,8 @@ struct DragItem;
 #endif
 
 using NodeIdentifier = ObjectIdentifier<NodeIdentifierType>;
+using HTMLMediaElementIdentifier = ObjectIdentifier<MediaPlayerClientIdentifierType>;
+
 }
 
 namespace WebKit {
@@ -969,7 +972,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 #endif
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
-- (void)_showMediaControlsContextMenu:(WebCore::FloatRect&&)targetFrame items:(Vector<WebCore::MediaControlsContextMenuItem>&&)items completionHandler:(CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&)completionHandler;
+- (void)_showMediaControlsContextMenu:(WebCore::FloatRect&&)targetFrame items:(Vector<WebCore::MediaControlsContextMenuItem>&&)items frameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier completionHandler:(CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&)completionHandler;
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
 - (BOOL)_formControlRefreshEnabled;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12259,11 +12259,20 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
-- (void)_showMediaControlsContextMenu:(WebCore::FloatRect&&)targetFrame items:(Vector<WebCore::MediaControlsContextMenuItem>&&)items completionHandler:(CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&)completionHandler
+- (void)_showMediaControlsContextMenu:(WebCore::FloatRect&&)targetFrame items:(Vector<WebCore::MediaControlsContextMenuItem>&&)items frameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier completionHandler:(CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&)completionHandler
 {
-    [_actionSheetAssistant showMediaControlsContextMenu:WTFMove(targetFrame) items:WTFMove(items) completionHandler:WTFMove(completionHandler)];
+    [_actionSheetAssistant showMediaControlsContextMenu:WTFMove(targetFrame) items:WTFMove(items) frameInfo:frameInfo identifier:identifier completionHandler:WTFMove(completionHandler)];
 }
 
+- (void)captionStyleMenuWillOpenWithFrameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier
+{
+    _page->showCaptionDisplaySettingsPreview(frameInfo, identifier);
+}
+
+- (void)captionStyleMenuDidCloseWithFrameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier
+{
+    _page->hideCaptionDisplaySettingsPreview(frameInfo, identifier);
+}
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
 #if HAVE(UI_POINTER_INTERACTION)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -326,6 +326,10 @@ private:
     void didCleanupFullscreen() final { }
 #endif
 
+#if ENABLE(VIDEO)
+    void showCaptionDisplaySettings(CompletionHandler<void(bool)>&&) final;
+#endif
+
     CheckedPtr<WebViewImpl> checkedImpl() const { return m_impl.get(); }
 
     bool isViewVisible(NSView *, NSWindow *);

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1182,6 +1182,11 @@ void PageClientImpl::didChangeLocalInspectorAttachment()
 #endif
 }
 
+void PageClientImpl::showCaptionDisplaySettings(CompletionHandler<void(bool)>&& callback)
+{
+    checkedImpl()->showCaptionDisplaySettings(WTFMove(callback));
+}
+
 RetainPtr<NSView> PageClient::protectedViewForPresentingRevealPopover() const
 {
     return viewForPresentingRevealPopover();

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
@@ -36,6 +36,7 @@ OBJC_CLASS NSMenu;
 OBJC_CLASS NSMenuItem;
 OBJC_CLASS NSView;
 OBJC_CLASS NSWindow;
+OBJC_CLASS WKCaptionStyleMenuController;
 OBJC_CLASS WKMenuDelegate;
 
 #if ENABLE(WRITING_TOOLS)
@@ -75,6 +76,9 @@ public:
     RetainPtr<CGImageRef> imageForCopySubject() const final { return m_copySubjectResult; }
 #endif
 
+    void captionStyleMenuWillOpen();
+    void captionStyleMenuDidClose();
+
 private:
     WebContextMenuProxyMac(NSView *, WebPageProxy&, FrameInfoData&&, ContextMenuContextData&&, const UserData&);
 
@@ -99,11 +103,20 @@ private:
     NSMenu *platformMenu() const override;
     RetainPtr<NSArray> platformData() const override;
 
+#if ENABLE(VIDEO)
+    WKCaptionStyleMenuController *captionStyleMenuController();
+#endif
+
+    WKMenuDelegate *menuDelegate();
+
     RetainPtr<NSMenu> m_menu;
     RetainPtr<WKMenuDelegate> m_menuDelegate;
     WeakObjCPtr<NSView> m_webView;
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
     RetainPtr<CGImageRef> m_copySubjectResult;
+#endif
+#if ENABLE(VIDEO)
+    RetainPtr<WKCaptionStyleMenuController> m_captionStyleMenuController;
 #endif
     const FrameInfoData m_frameInfo;
 };

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -815,6 +815,10 @@ public:
     void setClientImplicitlyRequestedTopScrollPocket();
 #endif
 
+#if ENABLE(VIDEO)
+    void showCaptionDisplaySettings(CompletionHandler<void(bool)>&&);
+#endif
+
 private:
 #if HAVE(TOUCH_BAR)
     void setUpTextTouchBar(NSTouchBar *);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -81,6 +81,7 @@
 #import "WebPageProxy.h"
 #import "WebProcessPool.h"
 #import "WebProcessProxy.h"
+#import "_WKCaptionStyleMenuController.h"
 #import "_WKDragActionsInternal.h"
 #import "_WKRemoteObjectRegistryInternal.h"
 #import "_WKThumbnailViewInternal.h"
@@ -7300,6 +7301,15 @@ void WebViewImpl::unregisterViewAboveScrollPocket(NSView *containerView)
 }
 
 #endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
+#if ENABLE(VIDEO)
+void WebViewImpl::showCaptionDisplaySettings(CompletionHandler<void(bool)>&& callback)
+{
+    RetainPtr controller = adoptNS([[WKCaptionStyleMenuController alloc] init]);
+    NSMenu *menu = [controller captionStyleMenu];
+    callback([menu popUpMenuPositioningItem:nil atLocation:NSMakePoint(0, 0) inView:[protectedWindow() contentView]]);
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -2159,10 +2159,10 @@ double WebChromeClient::baseViewportLayoutSizeScaleFactor() const
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
-void WebChromeClient::showMediaControlsContextMenu(FloatRect&& targetFrame, Vector<MediaControlsContextMenuItem>&& items, CompletionHandler<void(MediaControlsContextMenuItem::ID)>&& completionHandler)
+void WebChromeClient::showMediaControlsContextMenu(FloatRect&& targetFrame, Vector<MediaControlsContextMenuItem>&& items, HTMLMediaElement& element, CompletionHandler<void(MediaControlsContextMenuItem::ID)>&& completionHandler)
 {
     if (RefPtr page = m_page.get())
-        page->showMediaControlsContextMenu(WTFMove(targetFrame), WTFMove(items), WTFMove(completionHandler));
+        page->showMediaControlsContextMenu(WTFMove(targetFrame), WTFMove(items), element.identifier(), WTFMove(completionHandler));
     else
         completionHandler({ });
 }
@@ -2402,6 +2402,17 @@ bool WebChromeClient::usePluginRendererScrollableArea(LocalFrame& frame) const
         return !pluginView->pluginDelegatesScrollingToMainFrame();
 #endif
     return true;
+}
+
+void WebChromeClient::showCaptionDisplaySettings(CompletionHandler<void(bool)>&& callback)
+{
+    RefPtr page = m_page.get();
+    if (!page) {
+        callback(false);
+        return;
+    }
+
+    page->sendWithAsyncReply(Messages::WebPageProxy::ShowCaptionDisplaySettings(), WTFMove(callback));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -499,7 +499,7 @@ private:
     URL allowedQueryParametersForAdvancedPrivacyProtections(const URL&) const final;
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
-    void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&) final;
+    void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, WebCore::HTMLMediaElement&, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&) final;
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
 #if ENABLE(WEBXR)
@@ -575,6 +575,10 @@ private:
     void setNeedsFixedContainerEdgesUpdate() final;
 
     bool usePluginRendererScrollableArea(WebCore::LocalFrame&) const final;
+
+#if ENABLE(VIDEO)
+    void showCaptionDisplaySettings(CompletionHandler<void(bool)>&&) final;
+#endif
 
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -307,6 +307,7 @@ struct InteractionRegion;
 struct KeypressCommand;
 struct MarkupExclusionRule;
 struct MediaDeviceHashSalts;
+struct MediaPlayerClientIdentifierType;
 struct MediaUsageInfo;
 struct MessageWithMessagePorts;
 struct NavigationIdentifierType;
@@ -343,6 +344,7 @@ struct OpenID4VPRequest;
 
 using BackForwardItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardItemIdentifierType>>;
 using DictationContext = ObjectIdentifier<DictationContextType>;
+using HTMLMediaElementIdentifier = ObjectIdentifier<MediaPlayerClientIdentifierType>;
 using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
 using MediaProducerMutedStateFlags = OptionSet<MediaProducerMutedState>;
 using NavigationIdentifier = ObjectIdentifier<NavigationIdentifierType, uint64_t>;
@@ -1858,7 +1860,7 @@ public:
 #endif
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
-    void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&);
+    void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, WebCore::HTMLMediaElementIdentifier, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&);
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
 #if USE(GRAPHICS_LAYER_TEXTURE_MAPPER) || USE(GRAPHICS_LAYER_WC)
@@ -2105,6 +2107,11 @@ public:
     RefPtr<WebCore::ShareableBitmap> shareableBitmapSnapshotForNode(WebCore::Node&);
 
     void paintRemoteFrameContents(WebCore::FrameIdentifier, const WebCore::IntRect&, WebCore::GraphicsContext&);
+
+#if ENABLE(VIDEO)
+    void showCaptionDisplaySettingsPreview(WebCore::HTMLMediaElementIdentifier);
+    void hideCaptionDisplaySettingsPreview(WebCore::HTMLMediaElementIdentifier);
+#endif
 
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -919,4 +919,9 @@ messages -> WebPage WantsAsyncDispatchMessage {
     WillBeginContextMenuInteraction()
     DidEndContextMenuInteraction()
 #endif
+
+#if ENABLE(VIDEO)
+    ShowCaptionDisplaySettingsPreview(WebCore::MediaPlayerClientIdentifier identifier)
+    HideCaptionDisplaySettingsPreview(WebCore::MediaPlayerClientIdentifier identifier)
+#endif
 }


### PR DESCRIPTION
#### cef383eee99194c1d8a6dcd122cd0d3c040f9e8b
<pre>
Add Experimental Caption Display Settings menu
<a href="https://rdar.apple.com/163663431">rdar://163663431</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301650">https://bugs.webkit.org/show_bug.cgi?id=301650</a>

Reviewed by Andy Estes.

Hook up the experimental CaptionDisplaySettings menus to the default
media controls.

When this experimental feature flag is enabled, the Subtitle menu
will have a new &quot;Settings&quot; submenu, and when those entries are selected,
the system&apos;s subtitle settings will change. When the Settings menu
is visible, send a message back to the media element which is showing
the menu and enable a preview of the style selection, by adding a
synthetic VTTCue and hiding any existing subtitles.

Because the messages need to flow back to the correct media element,
many existing methods need to take a HTMLMediaElementIdentifier and
this identifier needs to be stored by the context menu.

Test: media/track/text-track-caption-style-menu.html

* LayoutTests/media/track/text-track-caption-style-menu-expected.txt: Added.
* LayoutTests/media/track/text-track-caption-style-menu.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::ensureTextTrackContainer):
(WebCore::MediaControlsHost::textTrackContainer):
(WebCore::MediaControlsHost::captionPreferencesChanged):
(WebCore::MediaControlsHost::showMediaControlsContextMenu):
(WebCore::MediaControlsHost::showCaptionDisplaySettingsPreview):
(WebCore::MediaControlsHost::hideCaptionDisplaySettingsPreview):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::showCaptionDisplaySettingsPreview):
(WebCore::HTMLMediaElement::hideCaptionDisplaySettingsPreview):
(WebCore::HTMLMediaElement::captionPreferencesChanged):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateDisplay):
(WebCore::MediaControlTextTrackContainerElement::updateTextStrokeStyle):
(WebCore::MediaControlTextTrackContainerElement::showCaptionDisplaySettingsPreview):
(WebCore::MediaControlTextTrackContainerElement::hideCaptionDisplaySettingsPreview):
(WebCore::MediaControlTextTrackContainerElement::captionPreferencesChanged):
(WebCore::MediaControlTextTrackContainerElement::updateSizes):
(WebCore::MediaControlTextTrackContainerElement::currentlyActiveCues const):
(WebCore::MediaControlTextTrackContainerElement::ensurePreviewCue const):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h:
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::captionMenuOnItem):
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::trackDisplayName):
(WebCore::CaptionUserPreferences::captionPreviewTitle const):
* Source/WebCore/page/CaptionUserPreferences.h:
* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::trackDisplayName):
(WebCore::CaptionUserPreferencesMediaAF::captionPreviewTitle const):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::showMediaControlsContextMenu):
(WebCore::ChromeClient::showCaptionDisplaySettings):
* Source/WebCore/page/ContextMenuContext.h:
(WebCore::ContextMenuContext::setMediaElementIdentifier):
(WebCore::ContextMenuContext::mediaElementIdentifier const):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::maybeCreateContextMenu):
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/page/ContextMenuProvider.h:
(WebCore::ContextMenuProvider::prepareContext):
* Source/WebCore/platform/ContextMenuItem.cpp:
(WebCore::isValidContextMenuAction):
* Source/WebCore/platform/ContextMenuItem.h:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::textTrackOnMenuItemText):
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::captionStyleMenuWillOpenForMediaElement):
(WebCore::Internals::captionStyleMenuDidCloseForMediaElement):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::symbolNameWithTypeForAction):
* Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h:
* Source/WebKit/Shared/ContextMenuContextData.cpp:
(WebKit::m_selectionIsEditable):
(WebKit::ContextMenuContextData::ContextMenuContextData):
* Source/WebKit/Shared/ContextMenuContextData.h:
(WebKit::ContextMenuContextData::setMediaElementIdentifier):
(WebKit::ContextMenuContextData::mediaElementIdentifier const):
* Source/WebKit/Shared/ContextMenuContextData.serialization.in:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::showMediaControlsContextMenu):
(WebKit::PageClient::showCaptionDisplaySettings):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::showCaptionDisplaySettings):
(WebKit::WebPageProxy::showCaptionDisplaySettingsPreview):
(WebKit::WebPageProxy::hideCaptionDisplaySettingsPreview):
(WebKit::WebPageProxy::showMediaControlsContextMenu):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::showMediaControlsContextMenu):
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h:
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant _uiMenuElementsForMediaControlContextMenuItems:]):
(-[WKActionSheetAssistant showMediaControlsContextMenu:items:frameInfo:identifier:completionHandler:]):
(-[WKActionSheetAssistant captionStyleMenuWillOpen:]):
(-[WKActionSheetAssistant captionStyleMenuDidClose:]):
(-[WKActionSheetAssistant showMediaControlsContextMenu:items:completionHandler:]): Deleted.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _showMediaControlsContextMenu:items:frameInfo:identifier:completionHandler:]):
(-[WKContentView captionStyleMenuWillOpenWithFrameInfo:identifier:]):
(-[WKContentView captionStyleMenuDidCloseWithFrameInfo:identifier:]):
(-[WKContentView _showMediaControlsContextMenu:items:completionHandler:]): Deleted.
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::showCaptionDisplaySettings):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(-[WKMenuDelegate captionStyleMenuWillOpen:]):
(-[WKMenuDelegate captionStyleMenuDidClose:]):
(WebKit::WebContextMenuProxyMac::getContextMenuItem):
(WebKit::WebContextMenuProxyMac::useContextMenuItems):
(WebKit::WebContextMenuProxyMac::captionStyleMenuController):
(WebKit::WebContextMenuProxyMac::menuDelegate):
(WebKit::WebContextMenuProxyMac::captionStyleMenuWillOpen):
(WebKit::WebContextMenuProxyMac::captionStyleMenuDidClose):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::showCaptionDisplaySettings):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::showMediaControlsContextMenu):
(WebKit::WebChromeClient::showCaptionDisplaySettings):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::showMediaControlsContextMenu):
(WebKit::WebPage::showCaptionDisplaySettingsPreview):
(WebKit::WebPage::hideCaptionDisplaySettingsPreview):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/302688@main">https://commits.webkit.org/302688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e19efc4980df93505d5ec1f9da4cd60d011a077

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/2181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137313 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/da46a64d-ab2d-4027-84fb-e326407bfee2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2072 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/886783a9-4c02-47be-8a04-2264b81b933e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132867 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/116358 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79658 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c1fa117-76b3-48a4-b70c-b56486daed47) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/34485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80583 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121912 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/34993 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139794 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128372 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/1975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/107468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107356 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27326 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/1577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2048 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/65417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161386 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/1862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40221 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1971 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->