### PR TITLE
REGRESSION(IOS26): TestWebKitAPI.WKWebView.GetContentsShouldReturnAttributedString.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
@@ -124,12 +124,7 @@ TEST(WKWebView, GetContentsOfAllFramesShouldReturnString)
     Util::run(&finished);
 }
 
-// FIXME: rdar://163666375 (REGRESSION(IOS26): TestWebKitAPI.WKWebView.GetContentsShouldReturnAttributedString (301652))
-#if PLATFORM(IOS)
-TEST(WKWebView, DISABLED_GetContentsShouldReturnAttributedString)
-#else
 TEST(WKWebView, GetContentsShouldReturnAttributedString)
-#endif
 {
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
@@ -169,7 +164,7 @@ TEST(WKWebView, GetContentsShouldReturnAttributedString)
 #if USE(APPKIT)
         EXPECT_WK_STREQ(@"sRGB IEC61966-2.1 colorspace 1 0 0 1", dynamic_objc_cast<NSColor>(documentAttributes[NSBackgroundColorDocumentAttribute]).description);
 #else
-        EXPECT_WK_STREQ(@"kCGColorSpaceModelRGB 1 0 0 1 ", dynamic_objc_cast<UIColor>(documentAttributes[NSBackgroundColorDocumentAttribute]).description);
+        EXPECT_WK_STREQ(@"kCGColorSpaceModelRGB 1 0 0 1", dynamic_objc_cast<UIColor>(documentAttributes[NSBackgroundColorDocumentAttribute]).description);
 #endif
 
         finished = true;


### PR DESCRIPTION
#### fda2bd1b4d70264a787511e2fc2d663f15828d81
<pre>
REGRESSION(IOS26): TestWebKitAPI.WKWebView.GetContentsShouldReturnAttributedString.
<a href="https://webkit.org/b/301652">https://webkit.org/b/301652</a>
<a href="https://rdar.apple.com/problem/163666375">rdar://problem/163666375</a>

Unreviewed test gardening.

Update the expected results to remove training whitespace, since UIColor changed in iOS 26.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:
(TestWebKitAPI::TEST(WKWebView, GetContentsShouldReturnAttributedString)):

Canonical link: <a href="https://commits.webkit.org/302359@main">https://commits.webkit.org/302359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0760e492ca3eeb0e17b318d594ece051b1068795

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80133 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/70227fcd-1483-4a57-b2ee-42ff20352923) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98018 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65918 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/72ecbf76-b7ef-42af-90a0-77be610762ee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78626 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dd4803d4-cde3-4c34-8f3b-6f03d1716add) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33452 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79416 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138596 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/807 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106558 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106366 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30208 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53242 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20123 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/898 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/749 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/840 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->