### PR TITLE
[WebXR] WebGLRenderingContextBase::makeXRCompatible doesn't request extensions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https-expected.txt
@@ -1,4 +1,6 @@
 
+PASS Ensure that the framebuffer given by the WebGL layer works with stencil for non-immersive - webgl
+PASS Ensure that the framebuffer given by the WebGL layer works with stencil for non-immersive - webgl2
 PASS Ensure that the framebuffer given by the WebGL layer works with stencil for immersive - webgl
 PASS Ensure that the framebuffer given by the WebGL layer works with stencil for immersive - webgl2
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -98,10 +98,6 @@ webkit.org/b/254733 inspector/canvas/shaderProgram-add-remove-webgl.html [ Failu
 # Crash on EWS bot.
 webrtc/vp8-then-h264-gpu-process-crash.html [ Skip ]
 
-# WebXR
-webkit.org/b/301551 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https.html [ Failure ]
-webkit.org/b/301494 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html [ Failure ]
-
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End of Triaged Expectations
 # Legacy Expectations sections below

--- a/LayoutTests/platform/visionos/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https-expected.txt
+++ b/LayoutTests/platform/visionos/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Ensure that the framebuffer given by the WebGL layer works with stencil for immersive - webgl
+PASS Ensure that the framebuffer given by the WebGL layer works with stencil for immersive - webgl2
+

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -246,8 +246,6 @@ imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpir
 # WebXR
 
 webkit.org/b/299366 imported/w3c/web-platform-tests/webxr/xrSession_visibilityState_inline.https.html [ Skip ] # Timeout
-webkit.org/b/301551 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https.html [ Failure ]
-webkit.org/b/301493 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html [ Failure ]
 
 # WTR window size handling
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https-expected.txt
@@ -1,6 +1,0 @@
-
-FAIL Ensure that the framebuffer given by the WebGL layer is opaque for immersive - webgl promise_test: Unhandled rejection with value: "Session with params \"immersive-vr\" was rejected on device {\"supportsImmersive\":true,\"supportedModes\":[\"inline\",\"immersive-vr\"],\"views\":[{\"eye\":\"left\",\"projectionMatrix\":[1,0,0,0,0,1,0,0,3,2,-1,-1,0,0,-0.2,0],\"viewOffset\":{\"position\":[-0.1,0,0],\"orientation\":[0,0,0,1]},\"resolution\":{\"width\":200,\"height\":200}},{\"eye\":\"right\",\"projectionMatrix\":[1,0,0,0,0,1,0,0,3,2,-1,-1,0,0,-0.2,0],\"viewOffset\":{\"position\":[0.1,0,0],\"orientation\":[0,0,0,1]},\"resolution\":{\"width\":200,\"height\":200}}],\"viewerOrigin\":{\"position\":[0,0,0],\"orientation\":[0,0,0,1]},\"supportedFeatures\":[\"viewer\",\"local\",\"local-floor\",\"bounded-floor\",\"unbounded\",\"hit-test\",\"dom-overlay\",\"light-estimation\",\"anchors\",\"depth-sensing\"],\"environmentBlendMode\":\"opaque\",\"interactionMode\":\"world-space\"} with error: OperationError: Unable to create a framebuffer."
-FAIL Ensure that the framebuffer given by the WebGL layer is opaque for immersive - webgl2 assert_equals: expected 1282 but got 0
-PASS Ensure that the framebuffer given by the WebGL layer is opaque for non-immersive - webgl
-PASS Ensure that the framebuffer given by the WebGL layer is opaque for non-immersive - webgl2
-

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -2887,10 +2887,8 @@ void WebGLRenderingContextBase::makeXRCompatible(MakeXRCompatiblePromise&& promi
         //  Set context’s XR compatible boolean to true and resolve promise.
         // Otherwise: Queue a task on the WebGL task source to perform the following steps:
         // FIXME: add a way to verify that we're using a compatible graphics adapter.
-#if PLATFORM(COCOA)
         if (!m_context->enableRequiredWebXRExtensions())
             return;
-#endif
         m_attributes.xrCompatible = true;
         promise.resolve();
         rejectPromiseWithInvalidStateError.release();


### PR DESCRIPTION
#### c332cde05aa6dc0bc6bbc30be04be75c91e37cbb
<pre>
[WebXR] WebGLRenderingContextBase::makeXRCompatible doesn&apos;t request extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=301551">https://bugs.webkit.org/show_bug.cgi?id=301551</a>
<a href="https://rdar.apple.com/163681512">rdar://163681512</a>

Reviewed by Mike Wyrzykowski and Fujii Hironori.

WebGLRenderingContextBase::makeXRCompatible was not requesting required
extensions to support WebXROpaqueFramebuffer causing framebuffer creation
failure on GTK/WPE.

Enable tests marked previously as [ Failure ].

* LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https-expected.txt:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/visionos/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https-expected.txt.
* LayoutTests/platform/wpe/TestExpectations:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https-expected.txt: Removed.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::makeXRCompatible):

Canonical link: <a href="https://commits.webkit.org/302332@main">https://commits.webkit.org/302332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4db4f2580b7865a9237adf3a934d4e426a7ef1a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80158 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/61e8fa1f-58c7-418b-8169-a46e0a2851e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/920 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131733 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78650 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6c9c4803-379a-4bdd-8f9a-1c213df21640) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33483 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79449 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138627 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/837 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/913 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106389 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27087 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/704 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30238 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53279 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/929 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64217 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/780 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/836 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/871 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->