### PR TITLE
[CSS Zoom] Certain form controls are larger than expected when zoomed in.

### DIFF
--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
@@ -81,7 +81,7 @@ void DateTimeNumericFieldElement::adjustMinInlineSize(RenderStyle& style) const
         inlineSize = std::max(inlineSize, font->width(RenderBlock::constructTextRun(numberString, style)));
     }
 
-    style.setLogicalMinWidth(Style::MinimumSize::Fixed { inlineSize });
+    style.setLogicalMinWidth(Style::MinimumSize::Fixed { inlineSize / style.usedZoomForLength().value });
 }
 
 int DateTimeNumericFieldElement::maximum() const

--- a/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
@@ -58,7 +58,7 @@ void DateTimeSymbolicFieldElement::adjustMinInlineSize(RenderStyle& style) const
     for (auto& symbol : m_symbols)
         inlineSize = std::max(inlineSize, font->width(RenderBlock::constructTextRun(symbol, style)));
 
-    style.setLogicalMinWidth(Style::MinimumSize::Fixed { inlineSize });
+    style.setLogicalMinWidth(Style::MinimumSize::Fixed { inlineSize / style.usedZoomForLength().value });
 }
 
 bool DateTimeSymbolicFieldElement::hasValue() const

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -173,6 +173,7 @@ void RenderTextControlSingleLine::layout()
             return autoFillButtonElement->renderBox();
         }();
 
+        auto usedZoomForLength = containerRenderer->style().usedZoomForLength().value;
         if (autoFillStrongPasswordButtonRenderer && innerTextRenderer && innerBlockRenderer) {
             auto newContainerHeight = innerTextLogicalHeight;
 
@@ -180,16 +181,16 @@ void RenderTextControlSingleLine::layout()
             if (autoFillStrongPasswordButtonRenderer->logicalTop() < innerBlockRenderer->logicalBottom())
                 newContainerHeight = std::max<LayoutUnit>(newContainerHeight, autoFillStrongPasswordButtonRenderer->logicalHeight());
 
-            containerRenderer->mutableStyle().setLogicalHeight(Style::PreferredSize::Fixed { newContainerHeight });
+            containerRenderer->mutableStyle().setLogicalHeight(Style::PreferredSize::Fixed { newContainerHeight / usedZoomForLength });
             setNeedsLayout(MarkOnlyThis);
         } else if (containerLogicalHeight > logicalHeightLimit) {
-            containerRenderer->mutableStyle().setLogicalHeight(Style::PreferredSize::Fixed { logicalHeightLimit });
+            containerRenderer->mutableStyle().setLogicalHeight(Style::PreferredSize::Fixed { logicalHeightLimit / usedZoomForLength });
             setNeedsLayout(MarkOnlyThis);
         } else if (containerRenderer->logicalHeight() < contentBoxLogicalHeight()) {
-            containerRenderer->mutableStyle().setLogicalHeight(Style::PreferredSize::Fixed { contentBoxLogicalHeight() });
+            containerRenderer->mutableStyle().setLogicalHeight(Style::PreferredSize::Fixed { contentBoxLogicalHeight() / usedZoomForLength });
             setNeedsLayout(MarkOnlyThis);
         } else
-            containerRenderer->mutableStyle().setLogicalHeight(Style::PreferredSize::Fixed { containerLogicalHeight });
+            containerRenderer->mutableStyle().setLogicalHeight(Style::PreferredSize::Fixed { containerLogicalHeight / usedZoomForLength });
     }
 
     // If we need another layout pass, we have changed one of children's height so we need to relayout them.
@@ -227,9 +228,10 @@ void RenderTextControlSingleLine::layout()
     HTMLElement* placeholderElement = inputElement().placeholderElement();
     if (RenderBox* placeholderBox = placeholderElement ? placeholderElement->renderBox() : 0) {
         auto innerTextWidth = LayoutUnit { };
+        auto usedZoomForLength = placeholderBox->style().usedZoomForLength().value;
         if (innerTextRenderer)
             innerTextWidth = innerTextRenderer->logicalWidth();
-        placeholderBox->mutableStyle().setWidth(Style::PreferredSize::Fixed { innerTextWidth - placeholderBox->horizontalBorderAndPaddingExtent() });
+        placeholderBox->mutableStyle().setWidth(Style::PreferredSize::Fixed { (innerTextWidth - placeholderBox->horizontalBorderAndPaddingExtent()) / usedZoomForLength });
         bool neededLayout = placeholderBox->needsLayout();
         bool placeholderBoxHadLayout = placeholderBox->everHadLayout();
         if (innerTextSizeChanged) {

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1437,25 +1437,26 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     // Width / Height
     // The width and height here are affected by the zoom.
     // FIXME: Check is flawed, since it doesn't take min-width/max-width into account.
-    auto controlSize = this->controlSize(appearance, fontCascade.get(), { style.width(), style.height() }, style.usedZoom());
+    auto zoomForDeterminingControlSize = Style::ZoomFactor { usedZoomForComputedStyle(style), style.deviceScaleFactor() };
+    auto controlSize = this->controlSize(appearance, fontCascade.get(), { style.width(), style.height() }, zoomForDeterminingControlSize.value);
     if (controlSize.width() != style.width())
         style.setWidth(Style::PreferredSize { controlSize.width() });
     if (controlSize.height() != style.height())
         style.setHeight(Style::PreferredSize { controlSize.height() });
 
     // Min-Width / Min-Height
-    auto minimumControlSize = this->minimumControlSize(appearance, fontCascade.get(), { style.minWidth(), style.minHeight() }, { style.width(), style.height() }, style.usedZoom());
+    auto minimumControlSize = this->minimumControlSize(appearance, fontCascade.get(), { style.minWidth(), style.minHeight() }, { style.width(), style.height() }, zoomForDeterminingControlSize.value);
 
     // FIXME: The min-width/min-heigh value should use `calc-size()` when supported to make non-specified overrides work.
 
-    auto usedZoom = style.usedZoomForLength();
+    auto usedZoomForLength = style.usedZoomForLength();
     if (auto fixedOverrideMinWidth = minimumControlSize.width().tryFixed()) {
         if (auto fixedOriginalMinWidth = style.minWidth().tryFixed()) {
-            if (fixedOverrideMinWidth->resolveZoom(usedZoom) > fixedOriginalMinWidth->resolveZoom(usedZoom))
+            if (fixedOverrideMinWidth->resolveZoom(usedZoomForLength) > fixedOriginalMinWidth->resolveZoom(usedZoomForLength))
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (auto percentageOriginalMinWidth = style.minWidth().tryPercentage()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (fixedOverrideMinWidth->resolveZoom(usedZoom) > percentageOriginalMinWidth->value)
+            if (fixedOverrideMinWidth->resolveZoom(usedZoomForLength) > percentageOriginalMinWidth->value)
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (fixedOverrideMinWidth->isPositive()) {
             style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
@@ -1463,7 +1464,7 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     } else if (auto percentageOverrideMinWidth = minimumControlSize.width().tryPercentage()) {
         if (auto fixedOriginalMinWidth = style.minWidth().tryFixed()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (percentageOverrideMinWidth->value > fixedOriginalMinWidth->resolveZoom(usedZoom))
+            if (percentageOverrideMinWidth->value > fixedOriginalMinWidth->resolveZoom(usedZoomForLength))
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (auto percentageOriginalMinWidth = style.minWidth().tryPercentage()) {
             if (percentageOverrideMinWidth->value > percentageOriginalMinWidth->value)
@@ -1474,11 +1475,11 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     }
     if (auto fixedOverrideMinHeight = minimumControlSize.height().tryFixed()) {
         if (auto fixedOriginalMinHeight = style.minHeight().tryFixed()) {
-            if (fixedOverrideMinHeight->resolveZoom(usedZoom) > fixedOriginalMinHeight->resolveZoom(usedZoom))
+            if (fixedOverrideMinHeight->resolveZoom(usedZoomForLength) > fixedOriginalMinHeight->resolveZoom(usedZoomForLength))
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (auto percentageOriginalMinHeight = style.minHeight().tryPercentage()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (fixedOverrideMinHeight->resolveZoom(usedZoom) > percentageOriginalMinHeight->value)
+            if (fixedOverrideMinHeight->resolveZoom(usedZoomForLength) > percentageOriginalMinHeight->value)
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (fixedOverrideMinHeight->isPositive()) {
             style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
@@ -1486,7 +1487,7 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     } else if (auto percentageOverrideMinHeight = minimumControlSize.height().tryPercentage()) {
         if (auto fixedOriginalMinHeight = style.minHeight().tryFixed()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (percentageOverrideMinHeight->value > fixedOriginalMinHeight->resolveZoom(usedZoom))
+            if (percentageOverrideMinHeight->value > fixedOriginalMinHeight->resolveZoom(usedZoomForLength))
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (auto percentageOriginalMinHeight = style.minHeight().tryPercentage()) {
             if (percentageOverrideMinHeight->value > percentageOriginalMinHeight->value)

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1249,7 +1249,7 @@ void RenderThemeMac::adjustListButtonStyle(RenderStyle& style, const Element* el
 #endif
 
     // Add a margin to place the button at end of the input field.
-    style.setMarginEnd(-4_css_px);
+    style.setMarginEnd(-4_css_px / style.usedZoomForLength().value);
 }
 
 #if ENABLE(SERVICE_CONTROLS)


### PR DESCRIPTION
#### 1680d5d9e2172a34be5abd2e285a1d038606752e
<pre>
[CSS Zoom] Certain form controls are larger than expected when zoomed in.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301754">https://bugs.webkit.org/show_bug.cgi?id=301754</a>
<a href="https://rdar.apple.com/163677896">rdar://163677896</a>

Reviewed by Lily Spiniolas.

In 302241@main and 302229@main we attempted to integrate our new zoom
logic into the existing form control code by factoring out zoom when
setting values on RenderStyle since the existing code was setting those
values with zoom applied. This would result in double zooming since you
would apply zoom when adding the value on RenderStyle and then
evaluating that value during layout. Unfortunately, it seems like I did
not quite get all of the pieces there and there were still some areas of
the code that needed that logic.

After turning on the feature flag, we realized that certain form controls
were still getting more zoom applied making them look larger at certain
scales when compared to trunk. This patch tries to address this by
fixing two main classes of bugs:

1.) Factoring out zoom in more pieces of the code by calling
usedZoomForLength(). This will return the RenderStyle::usedZoom when the
feature flag is enabled and 1.0f if it is not which should result in a
no-op for this divison.

2.) Changing uses of RenderStyle::usedZoom -&gt; RenderStyle::usedZoomForLength
that were added in the previous patches. The reason for this is because
otherwise we would end up with incorrect behavior with the feature flag
disabled. When it is off we want to make sure zoom is still added on
when setting the values on RenderStyle so we need make sure we do not
divide it out.

* Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp:
(WebCore::DateTimeNumericFieldElement::adjustMinInlineSize const):
* Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp:
(WebCore::DateTimeSymbolicFieldElement::adjustMinInlineSize const):
Both of these resulted in datetime fields that were wider than expected
when zoomed in. So when we compute the minimum sizes for these elements
we need to divide out the zoom.

* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::layout):
This code modifies the renderers by updating RenderStyle with values
that were computed from layout. Since these values off the renderers are
the used values they should already have zoom applied in so divide them
out here.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle const):
This code is unfortunately probably the most confusing. When determining
the *control sizes*, we do not want it to scale the values that it
comptues by the zoom factor (see sizeFromNSControlSize) so we use the
confusingly named usedZoomForComputedStyle to get a zoom of 1.0f if the
feature flag is enabled.

The code below that remains the same and is potentially dividing out the
zoom that was previously set on RenderStyle.

* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::paddingBoxForNumberField):
Divide out zoom for a case that was missed previously.

(WebCore::applyEmPadding):
Fix a case where we were unconditionally using RenderStyle::usedZoom
which is incorrect with the flag disabled.

(WebCore::RenderThemeCocoa::adjustTextFieldStyleForVectorBasedControls const):
Here we are dividing by the zoom factor again even though it is a fixed
value. This is because previously we would always see a padding of 1px
during layout at different scales. To account for this we need to divide
out zoom here so that we get 1px again when multiplying by the zoom.

(WebCore::applyCommonButtonPaddingToStyleForVectorBasedControls):
Fix a case where we were unconditionally using RenderStyle::usedZoom
which is incorrect with the flag disabled.

(WebCore::adjustInputElementButtonStyleForVectorBasedControls):
Divide out zoom for a case that was missed previously.

(WebCore::RenderThemeCocoa::adjustButtonStyleForVectorBasedControls const):
Same case as in adjustTextFieldStyleForVectorBasedControls.

(WebCore::RenderThemeCocoa::paintMenuListButtonDecorationsForVectorBasedControls):
Here we are reverting back to the logic we had previously with respect
to ConversionData. This is because in this code we *want* the conversion
data to use zoom to paint properly. Otherwise we would get small
decorations for the menu lists since they were not getting scaled.

* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::adjustListButtonStyle const):
Same case as in adjustTextFieldStyleForVectorBasedControls.

Canonical link: <a href="https://commits.webkit.org/302401@main">https://commits.webkit.org/302401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/158530db154a8fd89707d2d42e7f9c0a5e8ceed5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80345 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6e65c04f-9c97-4b39-b0d9-004890f4d286) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98204 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66108 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9aa88bf3-ffea-4e3b-8bba-1ee52341630d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78855 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/942dbc08-6094-4068-bb88-4f6d8c1fc935) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/850 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33661 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79648 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138837 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106740 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106578 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27130 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/869 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30407 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53534 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1118 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64439 "Found 24 new failures in Platform/IPC/ArgumentCoders.h, AutomationProtocolObjects.h, WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp, WebDriverBidiProtocolObjects.h, WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp, WebProcess/WebPage/WebFrame.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/953 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1003 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1048 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->