### PR TITLE
Fix untyped malloc() calls in third-party dav1d project

### DIFF
--- a/Source/WebCore/PAL/ThirdParty/dav1d/src/decode.c
+++ b/Source/WebCore/PAL/ThirdParty/dav1d/src/decode.c
@@ -3213,7 +3213,11 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
     const int re_sz = f->sb128h * f->frame_hdr->tiling.cols;
     if (re_sz != f->lf.re_sz) {
         freep(&f->lf.tx_lpf_right_edge[0]);
+#ifdef __APPLE__
+        f->lf.tx_lpf_right_edge[0] = malloc(re_sz * 32 * 2 * sizeof(*f->lf.tx_lpf_right_edge[0]));
+#else
         f->lf.tx_lpf_right_edge[0] = malloc(re_sz * 32 * 2);
+#endif
         if (!f->lf.tx_lpf_right_edge[0]) {
             f->lf.re_sz = 0;
             goto error;

--- a/Source/WebCore/PAL/ThirdParty/dav1d/src/thread_task.c
+++ b/Source/WebCore/PAL/ThirdParty/dav1d/src/thread_task.c
@@ -177,8 +177,13 @@ static int create_filter_sbrow(Dav1dFrameContext *const f,
     const int uses_2pass = f->c->n_fc > 1;
     int num_tasks = f->sbh * (1 + uses_2pass);
     if (num_tasks > f->task_thread.num_tasks) {
+#ifdef __APPLE__
+        size_t size;
+        tasks = realloc(f->task_thread.tasks, (size = num_tasks * sizeof(*tasks)));
+#else
         const size_t size = sizeof(Dav1dTask) * num_tasks;
         tasks = realloc(f->task_thread.tasks, size);
+#endif
         if (!tasks) return -1;
         memset(tasks, 0, size);
         f->task_thread.tasks = tasks;
@@ -227,8 +232,13 @@ int dav1d_task_create_tile_sbrow(Dav1dFrameContext *const f, const int pass,
     const int num_tasks = f->frame_hdr->tiling.cols * f->frame_hdr->tiling.rows;
     int alloc_num_tasks = num_tasks * (1 + uses_2pass);
     if (alloc_num_tasks > f->task_thread.num_tile_tasks) {
+#ifdef __APPLE__
+        size_t size;
+        tasks = realloc(f->task_thread.tile_tasks[0], (size = alloc_num_tasks * sizeof(*tasks)));
+#else
         const size_t size = sizeof(Dav1dTask) * alloc_num_tasks;
         tasks = realloc(f->task_thread.tile_tasks[0], size);
+#endif
         if (!tasks) return -1;
         memset(tasks, 0, size);
         f->task_thread.tile_tasks[0] = tasks;


### PR DESCRIPTION
#### c669685acc9e9b2fcd4773f97478e9502b7ede7a
<pre>
Fix untyped malloc() calls in third-party dav1d project
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=301675">https://bugs.webkit.org/show_bug.cgi?id=301675</a>&gt;
&lt;<a href="https://rdar.apple.com/163688955">rdar://163688955</a>&gt;

Reviewed by Geoffrey Garen.

Use sizeof() in the function parameter list when computing size for
malloc() and realloc() to fix untyped calls.

* Source/WebCore/PAL/ThirdParty/dav1d/src/decode.c:
(dav1d_decode_frame_init):
- Multiply size by sizeof(*f-&gt;lf.tx_lpf_right_edge[0]) which is
  sizeof(uint8_t) which is 1 to fix the bug.
* Source/WebCore/PAL/ThirdParty/dav1d/src/thread_task.c:
(create_filter_sbrow):
(dav1d_task_create_tile_sbrow):
- Move the assignment of `size` inside the realloc() calls so we don&apos;t
  duplicate the calculation, but still provide a type hint to the
  compiler.
- Switch from sizeof(Dav1dTask) to sizeof(*tasks) so we don&apos;t duplicate
  the type.

Canonical link: <a href="https://commits.webkit.org/302369@main">https://commits.webkit.org/302369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8b9768851707d08119bd71c50b9ff795ac5432f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80159 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0d3bd3b5-9f15-4ba4-8661-2af92c709d2c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98044 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65954 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6f150304-a7c5-45c9-8185-aac30fc4cd4a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78653 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/93b60b1a-febd-4250-a67c-1fe6db063339) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33485 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79450 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109121 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138628 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106584 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111709 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106391 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/705 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30240 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53280 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20128 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/930 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64218 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/781 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/872 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->