### PR TITLE
Resync `css/CSS2/floats` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/huge-width-after-float.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/huge-width-after-float.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/37312">
+
+<div style="float: left"></div>
+<div style="width: 10000000000px; overflow: scroll"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/w3c-import.log
@@ -22,3 +22,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/float-rewind-parallel-flow-1-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/float-rewind-parallel-flow-2-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/float-rewind-parallel-flow-3-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/huge-width-after-float.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/float-in-inline-anonymous-block-with-overflow-hidden.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/float-in-inline-anonymous-block-with-overflow-hidden.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>CSS Test: A float wrapped in an anonymous block should be visible within a container with overflow: hidden.</title>
-<link rel="author" href="mailto:obrufrau@igalia.com" title="Oriol Brufrau">
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
 <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
 <link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level" />
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/w3c-import.log
@@ -252,6 +252,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/hit-test-floats-003.html
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/hit-test-floats-004.html
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/hit-test-floats-005.html
+/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/inheritance.html
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/intrinsic-size-float-and-line-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/intrinsic-size-float-and-line.html
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/line-pushed-by-floats-crash.html


### PR DESCRIPTION
#### 7af9277abfb9ffbc2b732857d1c091f11de525fa
<pre>
Resync `css/CSS2/floats` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=301676">https://bugs.webkit.org/show_bug.cgi?id=301676</a>
<a href="https://rdar.apple.com/163690700">rdar://163690700</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/bc9587088f1e5621317f3db04b0f0d5f8e008b4f">https://github.com/web-platform-tests/wpt/commit/bc9587088f1e5621317f3db04b0f0d5f8e008b4f</a>

* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/huge-width-after-float.html:
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/float-in-inline-anonymous-block-with-overflow-hidden.html:
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/floats/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/302342@main">https://commits.webkit.org/302342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6c244677fb50d8cd19b9fbe31a4d315d5fea11c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80161 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bde08be3-0716-4624-9a6f-9d4ec2c99054) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98046 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65946 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78655 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8c3bbd59-b021-4139-a47c-0b730f2cca2e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33486 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79452 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138630 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/863 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106586 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106393 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27094 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/708 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30241 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53283 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/932 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/783 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/839 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/874 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->