### PR TITLE
WebKit::PaymentSetupFeatures should be serialized using a Vector not an NSArray

### DIFF
--- a/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.serialization.in
+++ b/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.serialization.in
@@ -26,7 +26,7 @@ headers: <pal/cocoa/PassKitSoftLink.h>
 
 header: "ApplePayPaymentSetupFeaturesWebKit.h"
 [CustomHeader] class WebKit::PaymentSetupFeatures {
-    [SecureCodingAllowed=[NSArray.class, PAL::getPKPaymentSetupFeatureClassSingleton()]] RetainPtr<NSArray> m_platformFeatures;
+    Vector<RetainPtr<PKPaymentSetupFeature>> serializableFeatures();
 };
 
 #endif

--- a/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h
+++ b/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h
@@ -45,10 +45,12 @@ namespace WebKit {
 class PaymentSetupFeatures {
 public:
     PaymentSetupFeatures(Vector<Ref<WebCore::ApplePaySetupFeature>>&&);
+    PaymentSetupFeatures(Vector<RetainPtr<PKPaymentSetupFeature>>&&);
     PaymentSetupFeatures(RetainPtr<NSArray>&& = nullptr);
 
     NSArray *platformFeatures() const { return m_platformFeatures.get(); }
     RetainPtr<NSArray> protectedPlatformFeatures() const { return m_platformFeatures; }
+    Vector<RetainPtr<PKPaymentSetupFeature>> serializableFeatures() const;
     operator Vector<Ref<WebCore::ApplePaySetupFeature>>() const;
 
 private:


### PR DESCRIPTION
#### 32f809319794ec2dc660c540ef1414962063a530
<pre>
WebKit::PaymentSetupFeatures should be serialized using a Vector not an NSArray
<a href="https://bugs.webkit.org/show_bug.cgi?id=301684">https://bugs.webkit.org/show_bug.cgi?id=301684</a>
<a href="https://rdar.apple.com/163704473">rdar://163704473</a>

Reviewed by Abrar Rahman Protyasha.

Ports WebKit::PaymentSetupFeatures to be serialized as a Vector of
PKPaymentSetupFeature instead of an opaque NSArray.

* Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.mm:
(WebKit::toPlatformFeatures):
(WebKit::PaymentSetupFeatures::PaymentSetupFeatures):
(WebKit::PaymentSetupFeatures::serializableFeatures const):
* Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.serialization.in:
* Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h:

Canonical link: <a href="https://commits.webkit.org/302376@main">https://commits.webkit.org/302376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00d3d7b53e65b8c9b17f5fd4420e8b9d6a8627a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80186 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/72c3e16b-4d9a-464e-9b22-4b96cc37b41f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98067 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65977 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b825417d-8b06-4b18-8b68-0db6a9e7bfdf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78676 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/46ff5222-0d64-4484-849d-1077132cc4c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/708 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79477 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138657 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106607 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106420 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27112 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/735 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30265 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53326 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64249 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/808 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/864 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/898 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->