### PR TITLE
WebKit::InteractionInformationAtPosition should use a Vector for serialization not an opaque NSArray

### DIFF
--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
@@ -40,6 +40,8 @@
 #include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
 
+OBJC_CLASS DDScannerResult;
+
 namespace WebKit {
 
 struct InteractionInformationAtPosition {
@@ -50,17 +52,43 @@ struct InteractionInformationAtPosition {
         return response;
     }
 
-    InteractionInformationRequest request;
-
-    bool canBeValid { true };
-    std::optional<bool> hitNodeOrWindowHasDoubleClickListener;
-
     enum class Selectability : uint8_t {
         Selectable,
         UnselectableDueToFocusableElement,
         UnselectableDueToUserSelectNoneOrQuirk,
         UnselectableDueToMediaControls,
     };
+
+    InteractionInformationAtPosition() = default;
+    InteractionInformationAtPosition(InteractionInformationRequest&&, bool canBeValid, std::optional<bool> hitNodeOrWindowHasDoubleClickListener, Selectability&&, bool isSelected, bool prefersDraggingOverTextSelection, bool isNearMarkedText, bool touchCalloutEnabled, bool isLink, bool isImage,
+#if ENABLE(MODEL_PROCESS)
+        bool isInteractiveModel,
+#endif
+        bool isAttachment, bool isAnimatedImage, bool isAnimating, bool canShowAnimationControls, bool isPausedVideo, bool isElement, bool isContentEditable, Markable<WebCore::ScrollingNodeID>&& containerScrollingNodeID,
+#if ENABLE(DATA_DETECTION)
+        bool isDataDetectorLink,
+#endif
+        bool preventTextInteraction, bool elementContainsImageOverlay, bool isImageOverlayText,
+#if ENABLE(SPATIAL_IMAGE_DETECTION)
+        bool isSpatialImage,
+#endif
+        bool isInPlugin, bool needsPointerTouchCompatibilityQuirk, WebCore::FloatPoint&& adjustedPointForNodeRespondingToClickEvents, URL&&, URL&& imageURL, String&& imageMIMEType, String&& title, String&& idAttribute, WebCore::IntRect&& bounds,
+#if PLATFORM(MACCATALYST)
+        WebCore::IntRect&& caretRect,
+#endif
+        RefPtr<WebCore::ShareableBitmap>&&, String&& textBefore, String&& textAfter, CursorContext&&, RefPtr<WebCore::TextIndicator>&&,
+#if ENABLE(DATA_DETECTION)
+        String&& dataDetectorIdentifier, Vector<RetainPtr<DDScannerResult>>&&, WebCore::IntRect&& dataDetectorBounds,
+#endif
+#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
+        Vector<WebCore::ElementAnimationContext>&& animationsAtPoint,
+#endif
+        std::optional<WebCore::ElementContext>&&, std::optional<WebCore::ElementContext>&& hostImageOrVideoElementContext);
+
+    InteractionInformationRequest request;
+
+    bool canBeValid { true };
+    std::optional<bool> hitNodeOrWindowHasDoubleClickListener;
 
     Selectability selectability { Selectability::Selectable };
 
@@ -115,12 +143,12 @@ struct InteractionInformationAtPosition {
     WebCore::IntRect dataDetectorBounds;
 #endif
 
-    std::optional<WebCore::ElementContext> elementContext;
-    std::optional<WebCore::ElementContext> hostImageOrVideoElementContext;
-
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     Vector<WebCore::ElementAnimationContext> animationsAtPoint;
 #endif
+
+    std::optional<WebCore::ElementContext> elementContext;
+    std::optional<WebCore::ElementContext> hostImageOrVideoElementContext;
 
     // Copy compatible optional bits forward (for example, if we have a InteractionInformationAtPosition
     // with snapshots in it, and perform another request for the same point without requesting the snapshots,
@@ -128,6 +156,9 @@ struct InteractionInformationAtPosition {
     void mergeCompatibleOptionalInformation(const InteractionInformationAtPosition& oldInformation);
 
     bool isSelectable() const { return selectability == Selectability::Selectable; }
+#if ENABLE(DATA_DETECTION)
+    Vector<RetainPtr<DDScannerResult>> serializableDataDetectorResults() const;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.mm
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.mm
@@ -27,11 +27,96 @@
 #import "InteractionInformationAtPosition.h"
 
 #import "ArgumentCodersCocoa.h"
+#import <wtf/cocoa/VectorCocoa.h>
 #import <pal/cocoa/DataDetectorsCoreSoftLink.h>
 
 namespace WebKit {
 
 #if PLATFORM(IOS_FAMILY)
+
+InteractionInformationAtPosition::InteractionInformationAtPosition(InteractionInformationRequest&& request, bool canBeValid, std::optional<bool> hitNodeOrWindowHasDoubleClickListener, Selectability&& selectability, bool isSelected, bool prefersDraggingOverTextSelection, bool isNearMarkedText, bool touchCalloutEnabled, bool isLink, bool isImage,
+#if ENABLE(MODEL_PROCESS)
+    bool isInteractiveModel,
+#endif
+    bool isAttachment, bool isAnimatedImage, bool isAnimating, bool canShowAnimationControls, bool isPausedVideo, bool isElement, bool isContentEditable, Markable<WebCore::ScrollingNodeID>&& containerScrollingNodeID,
+#if ENABLE(DATA_DETECTION)
+    bool isDataDetectorLink,
+#endif
+    bool preventTextInteraction, bool elementContainsImageOverlay, bool isImageOverlayText,
+#if ENABLE(SPATIAL_IMAGE_DETECTION)
+    bool isSpatialImage,
+#endif
+    bool isInPlugin, bool needsPointerTouchCompatibilityQuirk, WebCore::FloatPoint&& adjustedPointForNodeRespondingToClickEvents, URL&& url, URL&& imageURL, String&& imageMIMEType, String&& title, String&& idAttribute, WebCore::IntRect&& bounds,
+#if PLATFORM(MACCATALYST)
+    WebCore::IntRect&& caretRect,
+#endif
+    RefPtr<WebCore::ShareableBitmap>&& image, String&& textBefore, String&& textAfter, CursorContext&& cursorContext, RefPtr<WebCore::TextIndicator>&& textIndicator,
+#if ENABLE(DATA_DETECTION)
+    String&& dataDetectorIdentifier, Vector<RetainPtr<DDScannerResult>>&& dataDetectorResults, WebCore::IntRect&& dataDetectorBounds,
+#endif
+#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
+    Vector<WebCore::ElementAnimationContext>&& animationsAtPoint,
+#endif
+    std::optional<WebCore::ElementContext>&& elementContext, std::optional<WebCore::ElementContext>&& hostImageOrVideoElementContext)
+        : request(WTFMove(request))
+        , canBeValid(canBeValid)
+        , hitNodeOrWindowHasDoubleClickListener(hitNodeOrWindowHasDoubleClickListener)
+        , selectability(selectability)
+        , isSelected(isSelected)
+        , prefersDraggingOverTextSelection(prefersDraggingOverTextSelection)
+        , isNearMarkedText(isNearMarkedText)
+        , touchCalloutEnabled(touchCalloutEnabled)
+        , isLink(isLink)
+        , isImage(isImage)
+#if ENABLE(MODEL_PROCESS)
+        , isInteractiveModel(isInteractiveModel)
+#endif
+        , isAttachment(isAttachment)
+        , isAnimatedImage(isAnimatedImage)
+        , isAnimating(isAnimating)
+        , canShowAnimationControls(canShowAnimationControls)
+        , isPausedVideo(isPausedVideo)
+        , isElement(isElement)
+        , isContentEditable(isContentEditable)
+        , containerScrollingNodeID(WTFMove(containerScrollingNodeID))
+#if ENABLE(DATA_DETECTION)
+        , isDataDetectorLink(isDataDetectorLink)
+#endif
+        , preventTextInteraction(preventTextInteraction)
+        , elementContainsImageOverlay(elementContainsImageOverlay)
+        , isImageOverlayText(isImageOverlayText)
+#if ENABLE(SPATIAL_IMAGE_DETECTION)
+        , isSpatialImage(isSpatialImage)
+#endif
+        , isInPlugin(isInPlugin)
+        , needsPointerTouchCompatibilityQuirk(needsPointerTouchCompatibilityQuirk)
+        , adjustedPointForNodeRespondingToClickEvents(WTFMove(adjustedPointForNodeRespondingToClickEvents))
+        , url(WTFMove(url))
+        , imageURL(WTFMove(imageURL))
+        , imageMIMEType(WTFMove(imageMIMEType))
+        , title(WTFMove(title))
+        , idAttribute(WTFMove(idAttribute))
+        , bounds(WTFMove(bounds))
+#if PLATFORM(MACCATALYST)
+        , caretRect(WTFMove(caretRect))
+#endif
+        , image(WTFMove(image))
+        , textBefore(WTFMove(textBefore))
+        , textAfter(WTFMove(textAfter))
+        , cursorContext(WTFMove(cursorContext))
+        , textIndicator(WTFMove(textIndicator))
+#if ENABLE(DATA_DETECTION)
+        , dataDetectorIdentifier(WTFMove(dataDetectorIdentifier))
+        , dataDetectorResults(createNSArray(WTFMove(dataDetectorResults), [](RetainPtr<DDScannerResult>&& result) { return result.get(); }))
+        , dataDetectorBounds(WTFMove(dataDetectorBounds))
+#endif
+#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
+        , animationsAtPoint(WTFMove(animationsAtPoint))
+#endif
+        , elementContext(WTFMove(elementContext))
+        , hostImageOrVideoElementContext(WTFMove(hostImageOrVideoElementContext))
+{
+}
 
 void InteractionInformationAtPosition::mergeCompatibleOptionalInformation(const InteractionInformationAtPosition& oldInformation)
 {
@@ -44,6 +129,15 @@ void InteractionInformationAtPosition::mergeCompatibleOptionalInformation(const 
     if (oldInformation.request.includeLinkIndicator && !request.includeLinkIndicator)
         textIndicator = oldInformation.textIndicator;
 }
+
+#if ENABLE(DATA_DETECTION)
+Vector<RetainPtr<DDScannerResult>> InteractionInformationAtPosition::serializableDataDetectorResults() const
+{
+    return makeVector(dataDetectorResults.get(), [](DDScannerResult *result) {
+        return std::optional(RetainPtr<DDScannerResult>(result));
+    });
+}
+#endif // ENABLE(DATA_DETECTION)
 
 #endif // PLATFORM(IOS_FAMILY)
 

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
@@ -84,16 +84,16 @@ struct WebKit::InteractionInformationAtPosition {
     RefPtr<WebCore::TextIndicator> textIndicator;
 #if ENABLE(DATA_DETECTION)
     String dataDetectorIdentifier;
-    [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClassSingleton()]] RetainPtr<NSArray> dataDetectorResults;
+    Vector<RetainPtr<DDScannerResult>> serializableDataDetectorResults();
     WebCore::IntRect dataDetectorBounds;
 #endif
-
-    std::optional<WebCore::ElementContext> elementContext;
-    std::optional<WebCore::ElementContext> hostImageOrVideoElementContext;
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     Vector<WebCore::ElementAnimationContext> animationsAtPoint;
 #endif
+
+    std::optional<WebCore::ElementContext> elementContext;
+    std::optional<WebCore::ElementContext> hostImageOrVideoElementContext;
 };
 
 #endif


### PR DESCRIPTION
#### 3861878b6d62ccf4b4d9100ecf600b76d1f9efd5
<pre>
WebKit::InteractionInformationAtPosition should use a Vector for serialization not an opaque NSArray
<a href="https://bugs.webkit.org/show_bug.cgi?id=301691">https://bugs.webkit.org/show_bug.cgi?id=301691</a>
<a href="https://rdar.apple.com/163708795">rdar://163708795</a>

Reviewed by Abrar Rahman Protyasha.

Ports InteractionInformationAtPosition to serialize it&apos;s DataDetectorResults
as a Vector&lt;RetainPtr&lt;DDScannerResults&gt;&gt; instead of an opaque NSArray.

* Source/WebKit/Shared/ios/InteractionInformationAtPosition.h:
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.mm:
(WebKit::InteractionInformationAtPosition::InteractionInformationAtPosition):
(WebKit::hostImageOrVideoElementContext):
(WebKit::InteractionInformationAtPosition::serializableDataDetectorResults const):
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in:

Canonical link: <a href="https://commits.webkit.org/302496@main">https://commits.webkit.org/302496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54cd964f923f824f43432f52a2bd6ac7000928f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129256 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80647 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/07588ad4-d4ef-4d9f-8512-d76128da7a9c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98426 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66344 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3f5537a7-e721-4a3f-9b07-845bcf0ed9aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79077 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f456c7e6-f4d2-4b46-8c01-fa401297ab0d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1053 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79911 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109506 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (failure); re-run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139105 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106956 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106794 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27196 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1077 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30639 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53924 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1375 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64731 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1198 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1235 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1298 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->