### PR TITLE
Re-import trusted-types WPTs

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -12641,6 +12641,7 @@
         "web-platform-tests/svg/top-level-document/svg-image-document-svg-xml-mime-type-ref.html",
         "web-platform-tests/svg/types/helper-SVGElement.ownerSVGElement-02.svg",
         "web-platform-tests/test_keys_wdspec.html",
+        "web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph-ref.html",
         "web-platform-tests/trusted-types/support/HTMLScriptElement-internal-slot-support.html",
         "web-platform-tests/trusted-types/support/create-trusted-type-policies.html",
         "web-platform-tests/trusted-types/support/frame-without-trusted-types.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm-expected.txt
@@ -1,28 +1,12 @@
 
 
 
-FAIL setAttribute and setAttributeNode respect the element's node document's global's CSP;
- Element=iframe; Parent=div; Attribute=srcdoc assert_throws_js: function "() => {
-                  sourceElement.setAttributeNode(sourceAttr);
-                }" threw object "TypeError: This assignment requires a TrustedHTML" ("TypeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL setAttribute and setAttributeNode respect the element's node document's global's CSP;
- Element=script; Parent=div; Attribute=src assert_throws_js: function "() => {
-                  sourceElement.setAttributeNode(sourceAttr);
-                }" threw object "TypeError: This assignment requires a TrustedScriptURL" ("TypeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL setAttribute and setAttributeNode respect the element's node document's global's CSP;
- Element=script; Parent=svg; Attribute=href assert_throws_js: function "() => {
-                  sourceElement.setAttributeNode(sourceAttr);
-                }" threw object "TypeError: This assignment requires a TrustedScriptURL" ("TypeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL setAttribute and setAttributeNode respect the element's node document's global's CSP;
- Element=script; Parent=svg; Attribute=xlink:href assert_throws_js: function "() => {
-                  sourceElement.setAttributeNode(sourceAttr);
-                }" threw object "TypeError: This assignment requires a TrustedScriptURL" ("TypeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS setAttribute and setAttributeNode respect the element's node document's global's CSP;
+ Element=iframe; Parent=div; Attribute=srcdoc
+PASS setAttribute and setAttributeNode respect the element's node document's global's CSP;
+ Element=script; Parent=div; Attribute=src
+PASS setAttribute and setAttributeNode respect the element's node document's global's CSP;
+ Element=script; Parent=svg; Attribute=href
+PASS setAttribute and setAttributeNode respect the element's node document's global's CSP;
+ Element=script; Parent=svg; Attribute=xlink:href
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm.html
@@ -25,6 +25,7 @@
     <script>
       const passThroughPolicy = trustedTypes.createPolicy("passThrough", {
         createHTML: (s) => s,
+        createScript: (s) => s,
       });
 
       function runTest(aTestElement) {
@@ -111,10 +112,17 @@
                 // invokes <https://www.w3.org/TR/trusted-types/#validate-attribute-mutation>.
                 // The latter should throw when executing step 5.
 
-                assert_throws_js(TypeError, () => {
+                // There are cross-browser differences about which realm a node returned
+                // by Document.adoptNode belongs to. Here, we expect that Trusted Types will
+                // throw a exception from sourceElement's realm, but without
+                // taking a stance about whether this should be the window's or the iframe's
+                // realm.
+                // Discussion at: https://github.com/web-platform-tests/wpt/issues/45405
+                const expectedTypeError = new sourceElement.constructor.constructor(passThroughPolicy.createScript("return TypeError"))();
+                assert_throws_js(expectedTypeError, () => {
                   sourceElement.setAttributeNode(sourceAttr);
                 });
-                assert_throws_js(TypeError, () => {
+                assert_throws_js(expectedTypeError, () => {
                   sourceElement.setAttributeNS(
                     sourceAttr.namespaceURI,
                     sourceAttr.name,

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>CJK characters should remain the same in trusted script evaluation</title>
+</head>
+<body>
+    <p id="test-chinese">中文</p>
+    <p id="test-japanese">日本語</p>
+    <p id="test-korean">한국어</p>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>CJK characters should remain the same in trusted script evaluation</title>
+</head>
+<body>
+    <p id="test-chinese">中文</p>
+    <p id="test-japanese">日本語</p>
+    <p id="test-korean">한국어</p>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>CJK characters should remain the same in trusted script evaluation</title>
+    <link rel="match" href="cjk-string-assignment-to-paragraph-ref.html">
+    <meta name="assert" content="CJK characters should remain the same in trusted script evaluation">
+</head>
+<body>
+    <p id="test-chinese">Chinese</p>
+    <p id="test-japanese">Japanese</p>
+    <p id="test-korean">Korean</p>
+
+    <script>
+        const policy = trustedTypes.createPolicy('test', {
+            createScript: script => script
+        });
+        const trustedScript = policy.createScript(`
+            document.getElementById("test-chinese").textContent = "中文";
+            document.getElementById("test-japanese").textContent = "日本語";
+            document.getElementById("test-korean").textContent = "한국어"
+        `);
+        eval(trustedScript);
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-non-trusted-script-object-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-non-trusted-script-object-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Function constructor of stringified object and TrustedScript fails.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-non-trusted-script-object.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-non-trusted-script-object.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script nonce="abc" src="/resources/testharness.js"></script>
+  <script nonce="abc" src="/resources/testharnessreport.js"></script>
+  <script nonce="abc" src="support/helper.sub.js"></script>
+
+  <!-- Note: Trusted Types enforcement, and a CSP that does not blanket-allow eval. -->
+  <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-abc'; require-trusted-types-for 'script'">
+</head>
+<body>
+<script nonce="abc">
+  const p = createScript_policy(window, 1);
+  test(t => {
+    assert_throws_js(EvalError, _ => {
+      // Without Trusted Types enforcement, this would return 47
+      new Function({toString() { return "a"; }}, "return a + 42")(5);
+    });
+  }, "Function constructor of stringified object and TrustedScript fails.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/navigate-to-javascript-url-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/navigate-to-javascript-url-001.html
@@ -17,12 +17,19 @@
     assert_equals(violation.violatedDirective, "require-trusted-types-for");
     assert_equals(violation.disposition, "enforce");
     assert_equals(violation.sample, `Location href|${clipSampleIfNeeded(kJavaScriptURLCode)}`);
-    assert_equals(violation.lineNumber, 4);
-    // https://w3c.github.io/webappsec-csp/#create-violation-for-global does not
-    // say how to determine the location and browsers provide inconsistent
-    // values for column number, so just check it's at least the offset of the
-    // '=' character of window.
-    assert_greater_than_equal(violation.columnNumber, 9);
+
+    // https://w3c.github.io/webappsec-csp/#create-violation-for-global says,
+    // If the user agent [...] and can extract [... line and column number ...]
+    // We'll allow line and column number be absent. If either is present, we
+    // expect specific values.
+    if (violation.lineNumber || violation.columnNumber) {
+      assert_equals(violation.lineNumber, 4);
+      // https://w3c.github.io/webappsec-csp/#create-violation-for-global does
+      // not say how to determine the location and browsers provide inconsistent
+      // values for column number, so just check it's at least the offset of the
+      // '=' character of window.
+      assert_greater_than_equal(violation.columnNumber, 9);
+    }
     assert_equals(result.exception, null);
   }, "Setting window.location to a javascript: URL without a default policy should report a CSP violation instead of executing the JavaScript code.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/require-trusted-types-for-TypeError-belongs-to-the-global-object-realm-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/require-trusted-types-for-TypeError-belongs-to-the-global-object-realm-expected.txt
@@ -1,7 +1,5 @@
 
 
 PASS Setting innerHTML on a node inserted by the parser.
-FAIL Setting innerHTML on a node adopted from a subframe. assert_throws_js: function "_ => divAdoptedFromIframe.innerHTML = 'unsafe'" threw object "TypeError: This assignment requires a TrustedHTML" ("TypeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Setting innerHTML on a node adopted from a subframe.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/require-trusted-types-for-TypeError-belongs-to-the-global-object-realm.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/require-trusted-types-for-TypeError-belongs-to-the-global-object-realm.html
@@ -13,7 +13,8 @@
   promise_test(async t => {
     const iframe = document.createElement("iframe");
     const passThroughPolicy =
-          trustedTypes.createPolicy("passThrough", { createHTML: s => s });
+          trustedTypes.createPolicy("passThrough", { createHTML: s => s,
+                                                     createScript: s => s });
     iframe.srcdoc = passThroughPolicy.createHTML("<!DOCTYPE html><div></div>");
     await new Promise(resolve => {
       iframe.addEventListener("load", resolve);
@@ -21,6 +22,16 @@
     });
     const divAdoptedFromIframe =
           document.adoptNode(iframe.contentDocument.body.firstElementChild);
-    assert_throws_js(TypeError, _ => divAdoptedFromIframe.innerHTML = 'unsafe');
+
+    // There are cross-browser differences about which realm a node returned
+    // by Document.adoptNode belongs to. Here, we expect that Trusted Types will
+    // throw an exception from divAdoptedFromIframe's realm, but without
+    // taking a stance about whether this should be the window's or the iframe's
+    // realm.
+    // Discussion at: https://github.com/web-platform-tests/wpt/issues/45405
+    assert_throws_js(
+          divAdoptedFromIframe.constructor.constructor(
+              passThroughPolicy.createScript("return TypeError"))(),
+          _ => divAdoptedFromIframe.innerHTML = 'unsafe');
   }, "Setting innerHTML on a node adopted from a subframe.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative-expected.txt
@@ -227,25 +227,25 @@ PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtm
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element)
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element)
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element)
-PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element)
-PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element)
-PASS Attr.value works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element)
-PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element)
-PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element)
-PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element)
-PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element)
-PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element)
-PASS Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element)
-PASS Node.nodeValue works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element)
-PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element)
-PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element)
-PASS Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element)
-PASS Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element)
-PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element)
-PASS Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element)
-PASS Node.textContent works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element)
-PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element)
-PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element)
-PASS Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element)
-PASS Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element)
+FAIL Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Attr.value works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Attr.value works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.nodeValue works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.textContent works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+FAIL Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element) assert_equals: expected "safe_output" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative.html
@@ -10,12 +10,16 @@
   const input_string = "unsafe_input";
   const output_string = "safe_output";
   const other_string = "other_value";
-  let applyMutation, finalChecks;
+  let applyMutation;
+  let treatDefaultPolicyAsNoOp = false;
   function testCleanup() {
     applyMutation = undefined;
-    finalChecks = undefined;
+    treatDefaultPolicyAsNoOp = false;
   }
   function createTrustedType(input) {
+    if (treatDefaultPolicyAsNoOp)
+        return input;
+
     if (window.applyMutation) {
       assert_equals(input, input_string);
       window.applyMutation();
@@ -124,9 +128,11 @@
       let element = testData.element();
       let attributeNodeInCallback;
       window.applyMutation = function() {
+        treatDefaultPolicyAsNoOp = true;
         element.setAttributeNS(testData.attrNS, testData.attrName,
                                createTrustedOutput(testData.type,
                                                     other_string));
+        treatDefaultPolicyAsNoOp = false;
         attributeNodeInCallback = findAttribute(element, testData.attrNS,
                                                 testData.attrName);
       };
@@ -149,7 +155,9 @@
         if (ownerElement) {
           ownerElement.removeAttributeNode(setterData.lastAttributeNode);
         }
+        treatDefaultPolicyAsNoOp = true;
         otherElement.setAttributeNode(setterData.lastAttributeNode);
+        treatDefaultPolicyAsNoOp = false;
       };
       let returnValue;
       switch (setterData.api) {
@@ -167,7 +175,7 @@
           assert_equals(otherElement.attributes.length, 1);
           assert_equals(otherElement.getAttributeNS(testData.attrNS,
                                                     testData.attrName),
-                        output_string);
+                        other_string);
           break;
         case "Element.setAttributeNode":
         case "Element.setAttributeNodeNS":
@@ -187,7 +195,7 @@
           assert_equals(otherElement.attributes.length, 1);
           assert_equals(otherElement.getAttributeNS(testData.attrNS,
                                                     testData.attrName),
-                        output_string);
+                        input_string);
           break;
         case "Attr.value":
         case "Node.nodeValue":

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-no-default-policy-error-cases-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-no-default-policy-error-cases-expected.txt
@@ -1,0 +1,10 @@
+
+PASS setAttributeNode runs Trusted Types check before inuse checks
+PASS setAttributeNodeNS runs Trusted Types check before inuse checks
+PASS setNamedItem runs Trusted Types check before inuse checks
+PASS setNamedItemNS runs Trusted Types check before inuse checks
+PASS setAttributeNode runs Trusted Types check before same attribute early return
+PASS setAttributeNodeNS runs Trusted Types check before same attribute early return
+PASS setNamedItem runs Trusted Types check before same attribute early return
+PASS setNamedItemNS runs Trusted Types check before same attribute early return
+

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-no-default-policy-error-cases.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-no-default-policy-error-cases.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js" ></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/passthroughpolicy.js"></script>
+<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';">
+<script>
+  test(() => {
+    const element = document.createElement("div");
+    const otherElement = document.createElement("div");
+    element.setAttribute("onclick", passthroughpolicy.createScript("foo"));
+    assert_throws_js(TypeError, () => {
+      otherElement.setAttributeNode(element.attributes[0]);
+    });
+  }, "setAttributeNode runs Trusted Types check before inuse checks");
+
+  test(() => {
+    const element = document.createElement("div");
+    const otherElement = document.createElement("div");
+    element.setAttribute("onclick", passthroughpolicy.createScript("foo"));
+    assert_throws_js(TypeError, () => {
+      otherElement.setAttributeNodeNS(element.attributes[0]);
+    });
+  }, "setAttributeNodeNS runs Trusted Types check before inuse checks");
+
+  test(() => {
+    const element = document.createElement("div");
+    const otherElement = document.createElement("div");
+    element.setAttribute("onclick", passthroughpolicy.createScript("foo"));
+    assert_throws_js(TypeError, () => {
+      otherElement.attributes.setNamedItem(element.attributes[0]);
+    });
+  }, "setNamedItem runs Trusted Types check before inuse checks");
+
+  test(() => {
+    const element = document.createElement("div");
+    const otherElement = document.createElement("div");
+    element.setAttribute("onclick", passthroughpolicy.createScript("foo"));
+    assert_throws_js(TypeError, () => {
+      otherElement.attributes.setNamedItemNS(element.attributes[0]);
+    });
+  }, "setNamedItemNS runs Trusted Types check before inuse checks");
+
+  test(() => {
+    const element = document.createElement("div");
+    element.setAttribute("onclick", passthroughpolicy.createScript("foo"));
+    assert_throws_js(TypeError, () => {
+      element.setAttributeNode(element.attributes[0]);
+    });
+  }, "setAttributeNode runs Trusted Types check before same attribute early return");
+
+  test(() => {
+    const element = document.createElement("div");
+    element.setAttribute("onclick", passthroughpolicy.createScript("foo"));
+    assert_throws_js(TypeError, () => {
+      element.setAttributeNodeNS(element.attributes[0]);
+    });
+  }, "setAttributeNodeNS runs Trusted Types check before same attribute early return");
+
+  test(() => {
+    const element = document.createElement("div");
+    element.setAttribute("onclick", passthroughpolicy.createScript("foo"));
+    assert_throws_js(TypeError, () => {
+      element.attributes.setNamedItem(element.attributes[0]);
+    });
+  }, "setNamedItem runs Trusted Types check before same attribute early return");
+
+  test(() => {
+    const element = document.createElement("div");
+    element.setAttribute("onclick", passthroughpolicy.createScript("foo"));
+    assert_throws_js(TypeError, () => {
+      element.attributes.setNamedItemNS(element.attributes[0]);
+    });
+  }, "setNamedItemNS runs Trusted Types check before same attribute early return");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/attributes.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/attributes.js
@@ -284,8 +284,8 @@ const attributeSetterData = [
   {
     api:"Attr.value",
     acceptNS: true,
-      acceptTrustedTypeArgumentInIDL: false,
-      runSetter: function(element, attrNS, attrName, attrValue, type) {
+    acceptTrustedTypeArgumentInIDL: false,
+    runSetter: function(element, attrNS, attrName, attrValue, type) {
       element.setAttributeNS(attrNS, attrName, createTrustedOutput(type, ""));
       this.lastAttributeNode = findAttribute(element, attrNS, attrName);
       assert_true(!!this.lastAttributeNode);

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/w3c-import.log
@@ -104,6 +104,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-text-and-url-sinks.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-script-element.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-svg-script-element.html
+/LayoutTests/imported/w3c/web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/default-policy-callback-arguments.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/default-policy-report-only.html
@@ -123,6 +126,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-default-policy.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt.html
+/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-non-trusted-script-object.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/get-trusted-types-compliant-attribute-value.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/idlharness.window.js
@@ -163,6 +167,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-no-require-trusted-types.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-default-policy.html
+/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-no-default-policy-error-cases.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-no-default-policy.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-001.html


### PR DESCRIPTION
#### 9abe2046a18fcf8fb476ab5f46a44bb7becb74b0
<pre>
Re-import trusted-types WPTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=301695">https://bugs.webkit.org/show_bug.cgi?id=301695</a>

Reviewed by Frédéric Wang.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/fcbd42ef9838ccae6469e807b9bdc47a2fb5f2ff">https://github.com/web-platform-tests/wpt/commit/fcbd42ef9838ccae6469e807b9bdc47a2fb5f2ff</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/cjk-string-assignment-to-paragraph.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-non-trusted-script-object-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-non-trusted-script-object.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/navigate-to-javascript-url-001.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/require-trusted-types-for-TypeError-belongs-to-the-global-object-realm-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/require-trusted-types-for-TypeError-belongs-to-the-global-object-realm.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-no-default-policy-error-cases-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-no-default-policy-error-cases.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/attributes.js:
(return.nodeMap.setNamedItemNS.runSetter):
(return.nodeMap.setNamedItemNS):
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/302355@main">https://commits.webkit.org/302355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0ccec6cc891227b262bea62f29a8114037aa048

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136213 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80202 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98081 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65992 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78692 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33524 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79493 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138673 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106622 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27099 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/743 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30279 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53353 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/972 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/879 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/913 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->