### PR TITLE
Attr setValue early returns incorrectly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative-expected.txt
@@ -227,25 +227,25 @@ PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtm
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element)
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element)
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element)
-FAIL Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Attr.value works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Attr.value works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.textContent works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element) assert_equals: expected "safe_output" but got ""
-FAIL Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element) assert_equals: expected "safe_output" but got ""
+PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element)
+PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element)
+PASS Attr.value works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element)
+PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element)
+PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element)
+PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element)
+PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element)
 

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -115,9 +115,9 @@ ExceptionOr<void> Attr::setValue(const AtomString& value)
 
                 verifiedValue = compliantValue.releaseReturnValue();
 
-                if (RefPtr newElement = m_element.get(); newElement != element) {
-                    if (!newElement)
-                        m_standaloneValue = WTFMove(verifiedValue);
+                element = m_element.get();
+                if (!element) {
+                    m_standaloneValue = WTFMove(verifiedValue);
                     return { };
                 }
             }


### PR DESCRIPTION
#### 6b5d7bbb9e827f8024bb3db7ac972dba0730b5ae
<pre>
Attr setValue early returns incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=301696">https://bugs.webkit.org/show_bug.cgi?id=301696</a>

Reviewed by Anne van Kesteren.

The specification has been updated so that this early return is no longer needed.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative-expected.txt:
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::setValue):

Canonical link: <a href="https://commits.webkit.org/303376@main">https://commits.webkit.org/303376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b578c4b8392145c61291f9622b9b37f1cf81425

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139589 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/83985 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/100962 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/68320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81753 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3105 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/984 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82808 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/111875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142235 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4236 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/36991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109332 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109506 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27764 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3215 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114567 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57472 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4290 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/32961 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4121 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67736 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4381 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->