### PR TITLE
[JSC] Add WebAssembly debugger step-into support for calls and exception handling

### DIFF
--- a/JSTests/wasm/debugger/lib/core/base.py
+++ b/JSTests/wasm/debugger/lib/core/base.py
@@ -430,8 +430,7 @@ class BaseTestCase:
         if not self.start_debugger(test_file):
             return False
 
-        # Start LLDB
-        if not self.start_lldb():
+        if not self.start_lldb(connection_timeout=20.0):
             return False
 
         self.logger.success(f"Debugging session ready for {self.name}")

--- a/JSTests/wasm/debugger/resources/wasm/call-indirect.js
+++ b/JSTests/wasm/debugger/resources/wasm/call-indirect.js
@@ -1,0 +1,86 @@
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 2 function types
+    0x01, 0x08,             // section id=1, size=8
+    0x02,                   // 2 types
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+    0x60, 0x00, 0x01, 0x7f, // Type 1: (func [] -> [i32])
+
+    // [0x12] Import section: import JS function
+    0x02, 0x0e,             // section id=2, size=14
+    0x01,                   // 1 import
+    0x02, 0x6a, 0x73,       // module name "js" (length=2)
+    0x07, 0x6a, 0x73, 0x5f, 0x66, 0x75, 0x6e, 0x63, // field name "js_func" (length=7)
+    0x00, 0x01,             // import kind: function, type index 1
+
+    // [0x22] Function section: 2 functions
+    0x03, 0x03,             // section id=3, size=3
+    0x02,                   // 2 functions
+    0x00,                   // function 1: type 0 ([] -> [])
+    0x01,                   // function 2: type 1 ([] -> [i32])
+
+    // [0x27] Table section: for call_indirect
+    0x04, 0x04,             // section id=4, size=4
+    0x01,                   // 1 table
+    0x70,                   // element type: funcref
+    0x00, 0x02,             // limits: min=2
+
+    // [0x2d] Export section: export function 1 as "test"
+    0x07, 0x08,             // section id=7, size=8
+    0x01,                   // 1 export
+    0x04, 0x74, 0x65, 0x73, 0x74, // name "test" (length=4)
+    0x00, 0x01,             // export kind: function, function index 1
+
+    // [0x37] Element section: populate table
+    0x09, 0x08,             // section id=9, size=8
+    0x01,                   // 1 element segment
+    0x00,                   // flags=0 (active, table 0)
+    0x41, 0x00, 0x0b,       // offset expression: i32.const 0, end
+    0x02,                   // 2 elements
+    0x02,                   // element 0: function index 2 (wasm_func)
+    0x00,                   // element 1: function index 0 (js_func)
+
+    // [0x41] Code section
+    0x0a, 0x15,             // section id=10, size=21
+    0x02,                   // 2 functions
+
+    // [0x44] Function 1 (test): calls via call_indirect
+    0x0e,                   // function body size=14
+    0x00,                   // 0 local declarations
+    0x41, 0x00,             // [0x46] i32.const 0 (table index 0 = wasm)
+    0x11, 0x01, 0x00,       // [0x48] call_indirect type=1, table=0
+    0x1a,                   // [0x4b] drop
+    0x41, 0x01,             // [0x4c] i32.const 1 (table index 1 = js)
+    0x11, 0x01, 0x00,       // [0x4e] call_indirect type=1, table=0
+    0x1a,                   // [0x51] drop
+    0x0b,                   // [0x52] end
+
+    // [0x53] Function 2 (wasm_func): returns constant 42
+    0x04,                   // function body size=4
+    0x00,                   // 0 local declarations
+    0x41, 0x2a,             // [0x55] i32.const 42
+    0x0b                    // [0x57] end
+]);
+
+function js_func() {
+    return 99;
+}
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module, {
+    js: {
+        js_func: js_func
+    }
+});
+let test = instance_step.exports.test;
+
+let iteration = 0;
+for (; ;) {
+    test();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/call-ref.js
+++ b/JSTests/wasm/debugger/resources/wasm/call-ref.js
@@ -1,0 +1,80 @@
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 2 function types
+    0x01, 0x08,             // section id=1, size=8
+    0x02,                   // 2 types
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+    0x60, 0x00, 0x01, 0x7f, // Type 1: (func [] -> [i32])
+
+    // [0x12] Import section: import JS function
+    0x02, 0x0e,             // section id=2, size=14
+    0x01,                   // 1 import
+    0x02, 0x6a, 0x73,       // module name "js" (length=2)
+    0x07, 0x6a, 0x73, 0x5f, 0x66, 0x75, 0x6e, 0x63, // field name "js_func" (length=7)
+    0x00, 0x01,             // import kind: function, type index 1
+
+    // [0x22] Function section: 2 functions
+    0x03, 0x03,             // section id=3, size=3
+    0x02,                   // 2 functions
+    0x01,                   // function 1 (wasm_func): type 1 ([] -> [i32])
+    0x00,                   // function 2 (test): type 0 ([] -> [])
+
+    // [0x27] Export section: export function 2 as "test"
+    0x07, 0x08,             // section id=7, size=8
+    0x01,                   // 1 export
+    0x04, 0x74, 0x65, 0x73, 0x74, // name "test" (length=4)
+    0x00, 0x02,             // export kind: function, function index 2
+
+    // [0x31] Element section: declare functions for ref.func
+    0x09, 0x06,             // section id=9, size=6
+    0x01,                   // 1 element segment
+    0x03,                   // flags=3 (declarative mode)
+    0x00,                   // element kind: funcref
+    0x02,                   // 2 elements
+    0x01,                   // element 0: function index 1 (wasm_func)
+    0x00,                   // element 1: function index 0 (js_func)
+
+    // [0x39] Code section
+    0x0a, 0x13,             // section id=10, size=19
+    0x02,                   // 2 functions
+
+    // [0x3c] Function 1 (wasm_func): returns constant 42
+    0x04,                   // function body size=4
+    0x00,                   // 0 local declarations
+    0x41, 0x2a,             // [0x3e] i32.const 42
+    0x0b,                   // [0x40] end
+
+    // [0x41] Function 2 (test): calls wasm and JS functions via call_ref
+    0x0c,                   // function body size=12
+    0x00,                   // 0 local declarations
+    0xd2, 0x01,             // [0x43] ref.func 1 (wasm_func)
+    0x14, 0x01,             // [0x45] call_ref type 1
+    0x1a,                   // [0x47] drop
+    0xd2, 0x00,             // [0x48] ref.func 0 (js_func)
+    0x14, 0x01,             // [0x4a] call_ref type 1
+    0x1a,                   // [0x4c] drop
+    0x0b                    // [0x4d] end
+]);
+
+function js_func() {
+    return 99;
+}
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module, {
+    js: {
+        js_func: js_func
+    }
+});
+let test = instance_step.exports.test;
+
+let iteration = 0;
+for (; ;) {
+    test();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/call.js
+++ b/JSTests/wasm/debugger/resources/wasm/call.js
@@ -1,0 +1,68 @@
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 2 function types
+    0x01, 0x08,             // section id=1, size=8
+    0x02,                   // 2 types
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+    0x60, 0x00, 0x01, 0x7f, // Type 1: (func [] -> [i32])
+
+    // [0x12] Import section: import JS function
+    0x02, 0x0e,             // section id=2, size=14
+    0x01,                   // 1 import
+    0x02, 0x6a, 0x73,       // module name "js" (length=2)
+    0x07, 0x6a, 0x73, 0x5f, 0x66, 0x75, 0x6e, 0x63, // field name "js_func" (length=7)
+    0x00,                   // import kind: function
+    0x01,                   // type index 1
+
+    // [0x22] Function section: 2 functions
+    0x03, 0x03,             // section id=3, size=3
+    0x02,                   // 2 functions
+    0x00,                   // function 1: type 0 ([] -> [])
+    0x01,                   // function 2: type 1 ([] -> [i32])
+
+    // [0x27] Export section: export function 1 as "test"
+    0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x01,
+
+    // [0x31] Code section
+    0x0a,                   // section id=10
+    0x0f,                   // section size=15
+    0x02,                   // 2 functions
+
+    // [0x34] Function 1 (test): calls function 2 (wasm) and function 0 (imported JS)
+    0x08,                   // function body size=8
+    0x00,                   // 0 local declarations
+    0x10, 0x02,             // [0x36] call 2 (wasm func)
+    0x1a,                   // [0x38] drop
+    0x10, 0x00,             // [0x39] call 0 (js func)
+    0x1a,                   // [0x3b] drop
+    0x0b,                   // [0x3c] end
+
+    // [0x3d] Function 2 (wasm_func): returns constant 42
+    0x04,                   // function body size=4
+    0x00,                   // 0 local declarations
+    0x41, 0x2a,             // [0x3f] i32.const 42
+    0x0b                    // [0x41] end
+]);
+
+function js_func() {
+    return 99;
+}
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module, {
+    js: {
+        js_func: js_func
+    }
+});
+let test = instance_step.exports.test;
+
+let iteration = 0;
+for (; ;) {
+    test();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/delegate.js
+++ b/JSTests/wasm/debugger/resources/wasm/delegate.js
@@ -1,0 +1,196 @@
+// WebAssembly module with comprehensive try-delegate exception handling tests
+// Tests various delegate scenarios:
+// 1. Delegate to immediate parent (depth 0)
+// 2. Delegate to grandparent (depth 1)
+// 3. Delegate to great-grandparent (depth 2)
+// 4. Delegate to caller (function boundary)
+// 5. Delegate chains (multiple delegates)
+// 6. Delegate past catch_all handlers
+
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 2 function types
+    0x01, 0x08,             // section id=1, size=8
+    0x02,                   // 2 types
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> []) - void function for exception tag
+    0x60, 0x00, 0x01, 0x7f, // Type 1: (func [] -> [i32]) - function returning i32
+
+    // [0x12] Function section: 9 functions
+    0x03, 0x0a,             // section id=3, size=10
+    0x09,                   // 9 functions
+    0x01,                   // function 0 (thrower): type 1
+    0x01,                   // function 1 (delegate_to_parent): type 1
+    0x01,                   // function 2 (delegate_to_grandparent): type 1
+    0x01,                   // function 3 (delegate_to_great_grandparent): type 1
+    0x01,                   // function 4 (no_handler_delegates_to_caller): type 1
+    0x01,                   // function 5 (catches_delegated_from_callee): type 1
+    0x01,                   // function 6 (delegate_chain): type 1
+    0x01,                   // function 7 (delegate_past_catch_all): type 1
+    0x01,                   // function 8 (test_all): type 1
+
+    // [0x1e] Tag section: 1 exception tag
+    0x0d, 0x03,             // section id=13, size=3
+    0x01,                   // 1 tag
+    0x00, 0x00,             // attribute=0 (exception), type index 0 (void)
+
+    // [0x23] Export section: export function 8 as "test_all"
+    0x07, 0x0c,             // section id=7, size=12
+    0x01,                   // 1 export
+    0x08,                   // name length=8
+    0x74, 0x65, 0x73, 0x74, 0x5f, 0x61, 0x6c, 0x6c, // "test_all"
+    0x00, 0x08,             // export kind=function, function index=8
+
+    // [0x31] Code section
+    0x0a,                   // section id=10
+    0xa4, 0x01,             // section size=164
+    0x09,                   // 9 functions
+
+    // [0x35] Function 0: thrower - throws exception
+    // Virtual address base: 0x4000000000000036
+    0x06,                   // body size=6
+    0x00,                   // 0 locals
+    0x08, 0x00,             // [0x37] throw tag=0
+    0x41, 0x00,             // [0x39] i32.const 0 (unreachable)
+    0x0b,                   // [0x3b] end
+
+    // [0x3c] Function 1: delegate_to_parent - delegates to immediate parent (depth 0)
+    // Virtual address base: 0x400000000000003d
+    0x0f,                   // body size=15
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x3e] try (result i32) - outer
+    0x06, 0x7f,             // [0x40] try (result i32) - inner
+    0x08, 0x00,             // [0x42] throw tag=0
+    0x18, 0x00,             // [0x44] delegate 0 (to outer try at 0x46)
+    0x07, 0x00,             // [0x46] catch tag=0 (outer catch)
+    0x41, 0x01,             // [0x48] i32.const 1
+    0x0b,                   // [0x4a] end (outer try)
+    0x0b,                   // [0x4b] end (function)
+
+    // [0x4c] Function 2: delegate_to_grandparent - delegates to grandparent (depth 1)
+    // Virtual address base: 0x400000000000004d
+    0x17,                   // body size=23
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x4e] try (result i32) - grandparent
+    0x06, 0x7f,             // [0x50] try (result i32) - parent
+    0x06, 0x7f,             // [0x52] try (result i32) - inner
+    0x08, 0x00,             // [0x54] throw tag=0
+    0x18, 0x01,             // [0x56] delegate 1 (skip parent at 0x58, delegate to grandparent at 0x5e)
+    0x07, 0x00,             // [0x58] catch tag=0 (parent catch - skipped)
+    0x41, 0xe1, 0x00,       // [0x5a] i32.const 97
+    0x0b,                   // [0x5d] end (parent try)
+    0x07, 0x00,             // [0x5e] catch tag=0 (grandparent catch)
+    0x41, 0x02,             // [0x60] i32.const 2
+    0x0b,                   // [0x62] end (grandparent try)
+    0x0b,                   // [0x63] end (function)
+
+    // [0x64] Function 3: delegate_to_great_grandparent - delegates 2 levels up (depth 2)
+    // Virtual address base: 0x4000000000000065
+    0x1f,                   // body size=31
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x66] try (result i32) - great-grandparent
+    0x06, 0x7f,             // [0x68] try (result i32) - grandparent
+    0x06, 0x7f,             // [0x6a] try (result i32) - parent
+    0x06, 0x7f,             // [0x6c] try (result i32) - inner
+    0x08, 0x00,             // [0x6e] throw tag=0
+    0x18, 0x02,             // [0x70] delegate 2 (skip 2 levels, delegate to great-grandparent at 0x7e)
+    0x07, 0x00,             // [0x72] catch tag=0 (parent catch - skipped)
+    0x41, 0xde, 0x00,       // [0x74] i32.const 94
+    0x0b,                   // [0x77] end (parent try)
+    0x07, 0x00,             // [0x78] catch tag=0 (grandparent catch - skipped)
+    0x41, 0xdc, 0x00,       // [0x7a] i32.const 92
+    0x0b,                   // [0x7d] end (grandparent try)
+    0x07, 0x00,             // [0x7e] catch tag=0 (great-grandparent catch)
+    0x41, 0x03,             // [0x80] i32.const 3
+    0x0b,                   // [0x82] end (great-grandparent try)
+    0x0b,                   // [0x83] end (function)
+
+    // [0x84] Function 4: no_handler_delegates_to_caller - delegate to function boundary
+    // Virtual address base: 0x4000000000000085
+    0x08,                   // body size=8
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x86] try (result i32)
+    0x08, 0x00,             // [0x88] throw tag=0
+    0x18, 0x00,             // [0x8a] delegate 0 (to function boundary - propagates to caller)
+    0x0b,                   // [0x8c] end
+
+    // [0x8d] Function 5: catches_delegated_from_callee
+    // Virtual address base: 0x400000000000008e
+    0x0b,                   // body size=11
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x8f] try (result i32)
+    0x10, 0x04,             // [0x91] call function=4 (no_handler_delegates_to_caller)
+    0x07, 0x00,             // [0x93] catch tag=0
+    0x41, 0x04,             // [0x95] i32.const 4
+    0x0b,                   // [0x97] end (try)
+    0x0b,                   // [0x98] end (function)
+
+    // [0x99] Function 6: delegate_chain - multiple delegates in chain
+    // Virtual address base: 0x400000000000009a
+    0x13,                   // body size=19
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x9b] try (result i32) - outer
+    0x06, 0x7f,             // [0x9d] try (result i32) - middle
+    0x06, 0x7f,             // [0x9f] try (result i32) - inner
+    0x08, 0x00,             // [0xa1] throw tag=0
+    0x18, 0x00,             // [0xa3] delegate 0 (to middle try at 0x9d)
+    0x18, 0x00,             // [0xa5] delegate 0 (middle delegates to outer try at 0x9b)
+    0x07, 0x00,             // [0xa7] catch tag=0 (outer catch)
+    0x41, 0x05,             // [0xa9] i32.const 5
+    0x0b,                   // [0xab] end (outer try)
+    0x0b,                   // [0xac] end (function)
+
+    // [0xad] Function 7: delegate_past_catch_all - delegate skips catch_all handlers
+    // Virtual address base: 0x40000000000000ae
+    0x16,                   // body size=22
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0xaf] try (result i32) - grandparent
+    0x06, 0x7f,             // [0xb1] try (result i32) - parent
+    0x06, 0x7f,             // [0xb3] try (result i32) - inner
+    0x08, 0x00,             // [0xb5] throw tag=0
+    0x18, 0x01,             // [0xb7] delegate 1 (skip parent's catch_all, delegate to grandparent)
+    0x19,                   // [0xb9] catch_all (parent catch_all - skipped by delegate 1)
+    0x41, 0xd6, 0x00,       // [0xba] i32.const 86
+    0x0b,                   // [0xbd] end (parent try)
+    0x07, 0x00,             // [0xbe] catch tag=0 (grandparent catch)
+    0x41, 0x06,             // [0xc0] i32.const 6
+    0x0b,                   // [0xc2] end (grandparent try)
+    0x0b,                   // [0xc3] end (function)
+
+    // [0xc4] Function 8: test_all - orchestrates all delegate scenarios
+    // Virtual address base: 0x40000000000000c5
+    0x13,                   // body size=19
+    0x00,                   // 0 locals
+    0x10, 0x01,             // [0xc6] call function=1 (delegate_to_parent) → returns 1
+    0x10, 0x02,             // [0xc8] call function=2 (delegate_to_grandparent) → returns 2
+    0x6a,                   // [0xca] i32.add (1 + 2 = 3)
+    0x10, 0x03,             // [0xcb] call function=3 (delegate_to_great_grandparent) → returns 3
+    0x6a,                   // [0xcd] i32.add (3 + 3 = 6)
+    0x10, 0x05,             // [0xce] call function=5 (catches_delegated_from_callee) → returns 4
+    0x6a,                   // [0xd0] i32.add (6 + 4 = 10)
+    0x10, 0x06,             // [0xd1] call function=6 (delegate_chain) → returns 5
+    0x6a,                   // [0xd3] i32.add (10 + 5 = 15)
+    0x10, 0x07,             // [0xd4] call function=7 (delegate_past_catch_all) → returns 6
+    0x6a,                   // [0xd6] i32.add (15 + 6 = 21)
+    0x0b,                   // [0xd7] end (function)
+    // [0xd8] End of code section
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module, {});
+let test = instance_step.exports.test_all;
+
+let iteration = 0;
+for (; ;) {
+    let result = test();
+    iteration += 1;
+    if (iteration % 1e4 == 0) {
+        print("iteration=", iteration, "result=", result);
+        if (result !== 21) {
+            print("ERROR: Expected result=21, got result=", result);
+            throw new Error("Test failed");
+        }
+    }
+}

--- a/JSTests/wasm/debugger/resources/wasm/nop-drop-select-end.js
+++ b/JSTests/wasm/debugger/resources/wasm/nop-drop-select-end.js
@@ -1,0 +1,50 @@
+// This includes: Nop, Drop, Select, and End
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: (func [] -> [])
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+
+    // [0x0e] Function section: 1 function
+    0x03, 0x02, 0x01, 0x00,
+
+    // [0x12] Export section: export function 0 as "test"
+    0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x00,
+
+    // [0x1c] Code section
+    0x0a,                   // section id=10
+    0x16,                   // section size=22
+    0x01,                   // 1 function
+    0x14,                   // function body size=20
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x21] nop
+    0x41, 0x2a,             // [0x22] i32.const 42
+    0x1a,                   // [0x24] drop
+    0x41, 0x01,             // [0x25] i32.const 1
+    0x41, 0x02,             // [0x27] i32.const 2
+    0x41, 0x01,             // [0x29] i32.const 1
+    0x1b,                   // [0x2b] select
+    0x1a,                   // [0x2c] drop
+    0x02, 0x40,             // [0x2d] block
+    0x41, 0x05,             // [0x2f] i32.const 5
+    0x1a,                   // [0x31] drop
+    0x0b,                   // [0x32] end block
+    0x0b                    // [0x33] end function
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module);
+let test = instance_step.exports.test;
+
+let iteration = 0;
+for (; ;) {
+    test();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}
+
+
+

--- a/JSTests/wasm/debugger/resources/wasm/rethrow.js
+++ b/JSTests/wasm/debugger/resources/wasm/rethrow.js
@@ -1,0 +1,188 @@
+// WebAssembly module with comprehensive rethrow exception handling tests
+// Tests various rethrow scenarios:
+// 1. Basic rethrow in catch handler
+// 2. Rethrow in catch_all handler
+// 3. Rethrow after partial handling
+// 4. Rethrow across function boundaries (to caller)
+// 5. Rethrow chains (multiple rethrows through nested handlers)
+// 6. Mixed rethrow with catch and catch_all handlers
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 2 function types
+    0x01, 0x08,             // section id=1, size=8
+    0x02,                   // 2 types
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> []) - void function for exception tag
+    0x60, 0x00, 0x01, 0x7f, // Type 1: (func [] -> [i32]) - function returning i32
+
+    // [0x12] Function section: 8 functions
+    0x03, 0x09,             // section id=3, size=9
+    0x08,                   // 8 functions
+    0x01,                   // function 0 (basic_rethrow_in_catch): type 1
+    0x01,                   // function 1 (rethrow_in_catch_all): type 1
+    0x01,                   // function 2 (rethrow_after_partial_handling): type 1
+    0x01,                   // function 3 (rethrows_to_caller): type 1
+    0x01,                   // function 4 (catches_rethrown_from_callee): type 1
+    0x01,                   // function 5 (rethrow_chain): type 1
+    0x01,                   // function 6 (mixed_rethrow_with_catch_all): type 1
+    0x01,                   // function 7 (test_all): type 1
+
+    // [0x1d] Tag section: 1 exception tag
+    0x0d, 0x03,             // section id=13, size=3
+    0x01,                   // 1 tag
+    0x00, 0x00,             // attribute=0 (exception), type index 0 (void)
+
+    // [0x22] Export section: export function 7 as "test_all"
+    0x07, 0x0c,             // section id=7, size=12
+    0x01,                   // 1 export
+    0x08,                   // name length=8
+    0x74, 0x65, 0x73, 0x74, 0x5f, 0x61, 0x6c, 0x6c, // "test_all"
+    0x00, 0x07,             // export kind=function, function index=7
+
+    // [0x30] Code section
+    0x0a,                   // section id=10
+    0x97, 0x01,             // section size=151
+    0x08,                   // 8 functions
+
+    // [0x34] Function 0: basic_rethrow_in_catch - catch and immediately rethrow
+    // Virtual address base: 0x4000000000000035
+    0x12,                   // body size=18
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x36] try (result i32) - outer
+    0x06, 0x7f,             // [0x38] try (result i32) - inner
+    0x08, 0x00,             // [0x3a] throw tag=0
+    0x07, 0x00,             // [0x3c] catch tag=0 (inner catch)
+    0x09, 0x00,             // [0x3e] rethrow 0 (rethrow to outer try)
+    0x0b,                   // [0x40] end (inner try)
+    0x07, 0x00,             // [0x41] catch tag=0 (outer catch)
+    0x41, 0x01,             // [0x43] i32.const 1
+    0x0b,                   // [0x45] end (outer try)
+    0x0b,                   // [0x46] end (function)
+
+    // [0x47] Function 1: rethrow_in_catch_all - catch with catch_all and rethrow
+    // Virtual address base: 0x4000000000000048
+    0x11,                   // body size=17
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x49] try (result i32) - outer
+    0x06, 0x7f,             // [0x4b] try (result i32) - inner
+    0x08, 0x00,             // [0x4d] throw tag=0
+    0x19,                   // [0x4f] catch_all (inner catch_all)
+    0x09, 0x00,             // [0x50] rethrow 0 (rethrow unknown exception to outer)
+    0x0b,                   // [0x52] end (inner try)
+    0x07, 0x00,             // [0x53] catch tag=0 (outer catch)
+    0x41, 0x02,             // [0x55] i32.const 2
+    0x0b,                   // [0x57] end (outer try)
+    0x0b,                   // [0x58] end (function)
+
+    // [0x59] Function 2: rethrow_after_partial_handling - do work before rethrowing
+    // Virtual address base: 0x400000000000005a
+    0x12,                   // body size=18
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x5b] try (result i32) - outer
+    0x06, 0x7f,             // [0x5d] try (result i32) - inner
+    0x08, 0x00,             // [0x5f] throw tag=0
+    0x07, 0x00,             // [0x61] catch tag=0 (inner catch - partial handling)
+    0x09, 0x00,             // [0x63] rethrow 0 (rethrow after handling)
+    0x0b,                   // [0x65] end (inner try)
+    0x07, 0x00,             // [0x66] catch tag=0 (outer catch)
+    0x41, 0x03,             // [0x68] i32.const 3
+    0x0b,                   // [0x6a] end (outer try)
+    0x0b,                   // [0x6b] end (function)
+
+    // [0x6c] Function 3: rethrows_to_caller - function that catches and rethrows to caller
+    // Virtual address base: 0x400000000000006d
+    0x0b,                   // body size=11
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x6e] try (result i32)
+    0x08, 0x00,             // [0x70] throw tag=0
+    0x07, 0x00,             // [0x72] catch tag=0
+    0x09, 0x00,             // [0x74] rethrow 0 (rethrow to caller)
+    0x0b,                   // [0x76] end (try)
+    0x0b,                   // [0x77] end (function)
+
+    // [0x78] Function 4: catches_rethrown_from_callee - catches exception rethrown by function 3
+    // Virtual address base: 0x4000000000000079
+    0x0b,                   // body size=11
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x7a] try (result i32)
+    0x10, 0x03,             // [0x7c] call function=3 (rethrows_to_caller)
+    0x07, 0x00,             // [0x7e] catch tag=0
+    0x41, 0x04,             // [0x80] i32.const 4
+    0x0b,                   // [0x82] end (try)
+    0x0b,                   // [0x83] end (function)
+
+    // [0x84] Function 5: rethrow_chain - multiple rethrows through nested handlers
+    // Virtual address base: 0x4000000000000085
+    0x19,                   // body size=25
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x86] try (result i32) - outer
+    0x06, 0x7f,             // [0x88] try (result i32) - middle
+    0x06, 0x7f,             // [0x8a] try (result i32) - inner
+    0x08, 0x00,             // [0x8c] throw tag=0
+    0x07, 0x00,             // [0x8e] catch tag=0 (inner catch)
+    0x09, 0x00,             // [0x90] rethrow 0 (inner rethrows to middle)
+    0x0b,                   // [0x92] end (inner try)
+    0x07, 0x00,             // [0x93] catch tag=0 (middle catch)
+    0x09, 0x00,             // [0x95] rethrow 0 (middle rethrows to outer)
+    0x0b,                   // [0x97] end (middle try)
+    0x07, 0x00,             // [0x98] catch tag=0 (outer catch)
+    0x41, 0x05,             // [0x9a] i32.const 5
+    0x0b,                   // [0x9c] end (outer try)
+    0x0b,                   // [0x9d] end (function)
+
+    // [0x9e] Function 6: mixed_rethrow_with_catch_all - mix of catch and catch_all with rethrow
+    // Virtual address base: 0x400000000000009f
+    0x17,                   // body size=23
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0xa0] try (result i32) - outer
+    0x06, 0x7f,             // [0xa2] try (result i32) - middle
+    0x06, 0x7f,             // [0xa4] try (result i32) - inner
+    0x08, 0x00,             // [0xa6] throw tag=0
+    0x19,                   // [0xa8] catch_all (inner catch_all)
+    0x09, 0x00,             // [0xa9] rethrow 0 (rethrow from catch_all to middle catch)
+    0x0b,                   // [0xab] end (inner try)
+    0x07, 0x00,             // [0xac] catch tag=0 (middle catch)
+    0x09, 0x00,             // [0xae] rethrow 0 (rethrow from catch to outer catch_all)
+    0x0b,                   // [0xb0] end (middle try)
+    0x19,                   // [0xb1] catch_all (outer catch_all)
+    0x41, 0x06,             // [0xb2] i32.const 6
+    0x0b,                   // [0xb4] end (outer try)
+    0x0b,                   // [0xb5] end (function)
+
+    // [0xb6] Function 7: test_all - orchestrates all rethrow scenarios
+    // Virtual address base: 0x40000000000000b7
+    0x13,                   // body size=19
+    0x00,                   // 0 locals
+    0x10, 0x00,             // [0xb8] call function=0 (basic_rethrow_in_catch) → returns 1
+    0x10, 0x01,             // [0xba] call function=1 (rethrow_in_catch_all) → returns 2
+    0x6a,                   // [0xbc] i32.add (1 + 2 = 3)
+    0x10, 0x02,             // [0xbd] call function=2 (rethrow_after_partial_handling) → returns 3
+    0x6a,                   // [0xbf] i32.add (3 + 3 = 6)
+    0x10, 0x04,             // [0xc0] call function=4 (catches_rethrown_from_callee) → returns 4
+    0x6a,                   // [0xc2] i32.add (6 + 4 = 10)
+    0x10, 0x05,             // [0xc3] call function=5 (rethrow_chain) → returns 5
+    0x6a,                   // [0xc5] i32.add (10 + 5 = 15)
+    0x10, 0x06,             // [0xc6] call function=6 (mixed_rethrow_with_catch_all) → returns 6
+    0x6a,                   // [0xc8] i32.add (15 + 6 = 21)
+    0x0b,                   // [0xc9] end (function)
+    // [0xca] End of code section
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module, {});
+let test = instance_step.exports.test_all;
+
+let iteration = 0;
+for (; ;) {
+    let result = test();
+    iteration += 1;
+    if (iteration % 1e4 == 0) {
+        print("iteration=", iteration, "result=", result);
+        if (result !== 21) {
+            print("ERROR: Expected result=21, got result=", result);
+            throw new Error("Test failed");
+        }
+    }
+}

--- a/JSTests/wasm/debugger/resources/wasm/return-call-indirect.js
+++ b/JSTests/wasm/debugger/resources/wasm/return-call-indirect.js
@@ -1,0 +1,99 @@
+const wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 1 function type
+    0x01, 0x05,             // section id=1, size=5
+    0x01,                   // 1 type
+    0x60, 0x00, 0x01, 0x7f, // Type 0: (func [] -> [i32])
+
+    // [0x0f] Import section: import JS function
+    0x02, 0x0e,             // section id=2, size=14
+    0x01,                   // 1 import
+    0x02, 0x6a, 0x73,       // module name "js" (length=2)
+    0x07, 0x6a, 0x73, 0x5f, 0x66, 0x75, 0x6e, 0x63, // field name "js_func" (length=7)
+    0x00,                   // import kind: function
+    0x00,                   // type index 0
+
+    // [0x1f] Function section: 4 functions
+    0x03, 0x05,             // section id=3, size=5
+    0x04,                   // 4 functions
+    0x00,                   // function 1 (caller): type 0 ([] -> [i32])
+    0x00,                   // function 2 (test_wasm_tail): type 0 ([] -> [i32])
+    0x00,                   // function 3 (test_js_tail): type 0 ([] -> [i32])
+    0x00,                   // function 4 (wasm_func): type 0 ([] -> [i32])
+
+    // [0x26] Table section: for call_indirect
+    0x04, 0x04,             // section id=4, size=4
+    0x01,                   // 1 table
+    0x70,                   // funcref type
+    0x00, 0x02,             // limits: min=2, no max
+
+    // [0x2c] Export section: export function 1 as "test"
+    0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x01,
+
+    // [0x36] Element section: initialize table with functions
+    0x09, 0x08,             // section id=9, size=8
+    0x01,                   // 1 element segment
+    0x00,                   // flags: active, table index 0
+    0x41, 0x00, 0x0b,       // offset: i32.const 0, end
+    0x02,                   // 2 function indices
+    0x04,                   // table[0] = function 4 (wasm_func)
+    0x00,                   // table[1] = function 0 (js_func)
+
+    // [0x40] Code section
+    0x0a,                   // section id=10
+    0x21,                   // section size=33
+    0x04,                   // 4 functions
+
+    // [0x43] Function 1 (caller): calls test_wasm_tail and test_js_tail
+    0x0a,                   // function body size=10
+    0x00,                   // 0 local declarations
+    0x10, 0x02,             // [0x45] call 2 (test_wasm_tail)
+    0x10, 0x03,             // [0x47] call 3 (test_js_tail)
+    0x6a,                   // [0x49] i32.add
+    0x41, 0x01,             // [0x4a] i32.const 1
+    0x6a,                   // [0x4c] i32.add
+    0x0b,                   // [0x4d] end
+
+    // [0x4e] Function 2 (test_wasm_tail): tail calls wasm_func via table[0]
+    0x07,                   // function body size=7
+    0x00,                   // 0 local declarations
+    0x41, 0x00,             // [0x50] i32.const 0 (table[0] = wasm_func)
+    0x13, 0x00, 0x00,       // [0x52] return_call_indirect type 0, table 0
+    0x0b,                   // [0x55] end
+
+    // [0x56] Function 3 (test_js_tail): tail calls js_func via table[1]
+    0x07,                   // function body size=7
+    0x00,                   // 0 local declarations
+    0x41, 0x01,             // [0x58] i32.const 1 (table[1] = js_func)
+    0x13, 0x00, 0x00,       // [0x5a] return_call_indirect type 0, table 0
+    0x0b,                   // [0x5d] end
+
+    // [0x5e] Function 4 (wasm_func): returns constant 42
+    0x04,                   // function body size=4
+    0x00,                   // 0 local declarations
+    0x41, 0x2a,             // [0x60] i32.const 42
+    0x0b                    // [0x62] end
+]);
+
+function js_func() {
+    return 99;
+}
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module, {
+    js: {
+        js_func: js_func
+    }
+});
+let test = instance_step.exports.test;
+
+let iteration = 0;
+for (; ;) {
+    let result = test();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration, "result=", result);
+}

--- a/JSTests/wasm/debugger/resources/wasm/return-call-ref.js
+++ b/JSTests/wasm/debugger/resources/wasm/return-call-ref.js
@@ -1,0 +1,94 @@
+const wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 1 function type
+    0x01, 0x05,             // section id=1, size=5
+    0x01,                   // 1 type
+    0x60, 0x00, 0x01, 0x7f, // Type 0: (func [] -> [i32])
+
+    // [0x0f] Import section: import JS function
+    0x02, 0x0e,             // section id=2, size=14
+    0x01,                   // 1 import
+    0x02, 0x6a, 0x73,       // module name "js" (length=2)
+    0x07, 0x6a, 0x73, 0x5f, 0x66, 0x75, 0x6e, 0x63, // field name "js_func" (length=7)
+    0x00,                   // import kind: function
+    0x00,                   // type index 0
+
+    // [0x1f] Function section: 4 functions
+    0x03, 0x05,             // section id=3, size=5
+    0x04,                   // 4 functions
+    0x00,                   // function 1 (caller): type 0 ([] -> [i32])
+    0x00,                   // function 2 (test_wasm_tail): type 0 ([] -> [i32])
+    0x00,                   // function 3 (test_js_tail): type 0 ([] -> [i32])
+    0x00,                   // function 4 (wasm_func): type 0 ([] -> [i32])
+
+    // [0x26] Export section: export function 1 as "test"
+    0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x01,
+
+    // [0x30] Element section: declare functions for ref.func
+    0x09, 0x07,             // section id=9, size=7
+    0x01,                   // 1 element segment
+    0x03,                   // flags=3 (declarative mode)
+    0x00,                   // element kind: funcref
+    0x03,                   // 3 elements
+    0x04,                   // element 0: function index 4 (wasm_func)
+    0x00,                   // element 1: function index 0 (js_func)
+    0x01,                   // element 2: function index 1 (caller, for completeness)
+
+    // [0x39] Code section
+    0x0a,                   // section id=10
+    0x1f,                   // section size=31
+    0x04,                   // 4 functions
+
+    // [0x3c] Function 1 (caller): calls test_wasm_tail and test_js_tail
+    0x0a,                   // function body size=10
+    0x00,                   // 0 local declarations
+    0x10, 0x02,             // [0x3e] call 2 (test_wasm_tail)
+    0x10, 0x03,             // [0x40] call 3 (test_js_tail)
+    0x6a,                   // [0x42] i32.add
+    0x41, 0x01,             // [0x43] i32.const 1
+    0x6a,                   // [0x45] i32.add
+    0x0b,                   // [0x46] end
+
+    // [0x47] Function 2 (test_wasm_tail): tail calls wasm_func via ref.func
+    0x06,                   // function body size=6
+    0x00,                   // 0 local declarations
+    0xd2, 0x04,             // [0x49] ref.func 4 (wasm_func)
+    0x15, 0x00,             // [0x4b] return_call_ref type 0
+    0x0b,                   // [0x4d] end
+
+    // [0x4e] Function 3 (test_js_tail): tail calls js_func via ref.func
+    0x06,                   // function body size=6
+    0x00,                   // 0 local declarations
+    0xd2, 0x00,             // [0x50] ref.func 0 (js_func)
+    0x15, 0x00,             // [0x52] return_call_ref type 0
+    0x0b,                   // [0x54] end
+
+    // [0x55] Function 4 (wasm_func): returns constant 42
+    0x04,                   // function body size=4
+    0x00,                   // 0 local declarations
+    0x41, 0x2a,             // [0x57] i32.const 42
+    0x0b                    // [0x59] end
+]);
+
+function js_func() {
+    return 99;
+}
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module, {
+    js: {
+        js_func: js_func
+    }
+});
+let test = instance_step.exports.test;
+
+let iteration = 0;
+for (; ;) {
+    let result = test();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration, "result=", result);
+}

--- a/JSTests/wasm/debugger/resources/wasm/return-call.js
+++ b/JSTests/wasm/debugger/resources/wasm/return-call.js
@@ -1,0 +1,85 @@
+const wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 1 function type
+    0x01, 0x05,             // section id=1, size=5
+    0x01,                   // 1 type
+    0x60, 0x00, 0x01, 0x7f, // Type 0: (func [] -> [i32])
+
+    // [0x0f] Import section: import JS function
+    0x02, 0x0e,             // section id=2, size=14
+    0x01,                   // 1 import
+    0x02, 0x6a, 0x73,       // module name "js" (length=2)
+    0x07, 0x6a, 0x73, 0x5f, 0x66, 0x75, 0x6e, 0x63, // field name "js_func" (length=7)
+    0x00,                   // import kind: function
+    0x00,                   // type index 0
+
+    // [0x1f] Function section: 4 functions
+    0x03, 0x05,             // section id=3, size=5
+    0x04,                   // 4 functions
+    0x00,                   // function 1 (caller): type 0 ([] -> [i32])
+    0x00,                   // function 2 (test_wasm_tail): type 0 ([] -> [i32])
+    0x00,                   // function 3 (test_js_tail): type 0 ([] -> [i32])
+    0x00,                   // function 4 (wasm_func): type 0 ([] -> [i32])
+
+    // [0x26] Export section: export function 1 as "test"
+    0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x01,
+
+    // [0x30] Code section
+    0x0a,                   // section id=10
+    0x1f,                   // section size=31
+    0x04,                   // 4 functions
+
+    // [0x33] Function 1 (caller): calls test_wasm_tail and test_js_tail
+    0x0a,                   // function body size=10
+    0x00,                   // 0 local declarations
+    0x10, 0x02,             // [0x35] call 2 (test_wasm_tail)
+    0x10, 0x03,             // [0x37] call 3 (test_js_tail)
+    0x6a,                   // [0x39] i32.add
+    0x41, 0x01,             // [0x3a] i32.const 1
+    0x6a,                   // [0x3c] i32.add
+    0x0b,                   // [0x3d] end
+
+    // [0x3e] Function 2 (test_wasm_tail): tail calls wasm_func
+    0x06,                   // function body size=6
+    0x00,                   // 0 local declarations
+    0x12, 0x04,             // [0x40] return_call 4 (wasm_func)
+    0x41, 0x00,             // [0x42] i32.const 0 (unreachable)
+    0x0b,                   // [0x44] end
+
+    // [0x45] Function 3 (test_js_tail): tail calls js_func
+    0x06,                   // function body size=6
+    0x00,                   // 0 local declarations
+    0x12, 0x00,             // [0x47] return_call 0 (js_func)
+    0x41, 0x00,             // [0x49] i32.const 0 (unreachable)
+    0x0b,                   // [0x4b] end
+
+    // [0x4c] Function 4 (wasm_func): returns constant 42
+    0x04,                   // function body size=4
+    0x00,                   // 0 local declarations
+    0x41, 0x2a,             // [0x4e] i32.const 42
+    0x0b                    // [0x50] end
+]);
+
+function js_func() {
+    return 99;
+}
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module, {
+    js: {
+        js_func: js_func
+    }
+});
+
+let test = instance_step.exports.test;
+
+let iteration = 0;
+for (; ;) {
+    let result = test();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration, "result=", result);
+}

--- a/JSTests/wasm/debugger/resources/wasm/throw-catch-all.js
+++ b/JSTests/wasm/debugger/resources/wasm/throw-catch-all.js
@@ -1,0 +1,144 @@
+// WebAssembly module with comprehensive try-catch_all-throw exception handling tests
+// Tests various catch_all handler scenarios:
+// 1. Handler in the same function (callee catches its own exception with catch_all)
+// 2. Handler in the immediate caller (catch_all in caller)
+// 3. Handler in the caller's caller (grandparent with catch_all)
+// 4. Handler in the caller's caller's caller (great-grandparent with catch_all)
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 2 function types
+    0x01, 0x08,             // section id=1, size=8
+    0x02,                   // 2 types
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> []) - void function for exception tag
+    0x60, 0x00, 0x01, 0x7f, // Type 1: (func [] -> [i32]) - function returning i32
+
+    // [0x12] Function section: 8 functions
+    0x03, 0x09,             // section id=3, size=9
+    0x08,                   // 8 functions
+    0x01,                   // function 0 (thrower): type 1
+    0x01,                   // function 1 (catch_all_in_callee): type 1
+    0x01,                   // function 2 (no_handler): type 1
+    0x01,                   // function 3 (catch_all_from_caller): type 1
+    0x01,                   // function 4 (middle_no_handler): type 1
+    0x01,                   // function 5 (catch_all_from_grandparent): type 1
+    0x01,                   // function 6 (middle_no_handler2): type 1
+    0x01,                   // function 7 (test_all): type 1
+
+    // [0x1d] Tag section: 1 exception tag
+    0x0d, 0x03,             // section id=13, size=3
+    0x01,                   // 1 tag
+    0x00, 0x00,             // attribute=0 (exception), type index 0 (void)
+
+    // [0x22] Export section: export function 7 as "test_all"
+    0x07, 0x0c,             // section id=7, size=12
+    0x01,                   // 1 export
+    0x08,                   // name length=8
+    0x74, 0x65, 0x73, 0x74, 0x5f, 0x61, 0x6c, 0x6c, // "test_all"
+    0x00, 0x07,             // export kind=function, function index=7
+
+    // [0x30] Code section
+    0x0a,                   // section id=10
+    0x4e,                   // section size=78
+    0x08,                   // 8 functions
+
+    // [0x33] Function 0: thrower - throws exception
+    // Virtual address base: 0x4000000000000034
+    0x06,                   // body size=6
+    0x00,                   // 0 locals
+    0x08, 0x00,             // [0x35] throw tag=0
+    0x41, 0x00,             // [0x37] i32.const 0 (unreachable)
+    0x0b,                   // [0x39] end
+
+    // [0x3a] Function 1: catch_all_in_callee - catches own exception with catch_all
+    // Virtual address base: 0x400000000000003b
+    0x0c,                   // body size=12
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x3c] try (result i32)
+    0x08, 0x00,             // [0x3e] throw tag=0
+    0x41, 0x00,             // [0x40] i32.const 0
+    0x19,                   // [0x42] catch_all
+    0x41, 0x01,             // [0x43] i32.const 1
+    0x0b,                   // [0x45] end (try)
+    0x0b,                   // [0x46] end (function)
+
+    // [0x47] Function 2: no_handler - calls thrower without handling
+    // Virtual address base: 0x4000000000000048
+    0x04,                   // body size=4
+    0x00,                   // 0 locals
+    0x10, 0x00,             // [0x49] call function=0 (thrower)
+    0x0b,                   // [0x4b] end
+
+    // [0x4c] Function 3: catch_all_from_caller - catches from callee with catch_all
+    // Virtual address base: 0x400000000000004d
+    0x0a,                   // body size=10
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x4e] try (result i32)
+    0x10, 0x00,             // [0x50] call function=0 (thrower)
+    0x19,                   // [0x52] catch_all
+    0x41, 0x02,             // [0x53] i32.const 2
+    0x0b,                   // [0x55] end (try)
+    0x0b,                   // [0x56] end (function)
+
+    // [0x57] Function 4: middle_no_handler - calls no_handler
+    // Virtual address base: 0x4000000000000058
+    0x04,                   // body size=4
+    0x00,                   // 0 locals
+    0x10, 0x02,             // [0x59] call function=2 (no_handler)
+    0x0b,                   // [0x5b] end
+
+    // [0x5c] Function 5: catch_all_from_grandparent - catches from 2 levels with catch_all
+    // Virtual address base: 0x400000000000005d
+    0x0a,                   // body size=10
+    0x00,                   // 0 locals
+    0x06, 0x7f,             // [0x5e] try (result i32)
+    0x10, 0x04,             // [0x60] call function=4 (middle_no_handler)
+    0x19,                   // [0x62] catch_all
+    0x41, 0x03,             // [0x63] i32.const 3
+    0x0b,                   // [0x65] end (try)
+    0x0b,                   // [0x66] end (function)
+
+    // [0x67] Function 6: middle_no_handler2 - calls middle_no_handler
+    // Virtual address base: 0x4000000000000068
+    0x04,                   // body size=4
+    0x00,                   // 0 locals
+    0x10, 0x04,             // [0x69] call function=4 (middle_no_handler)
+    0x0b,                   // [0x6b] end
+
+    // [0x6c] Function 7: test_all - orchestrates all tests with catch_all
+    // Virtual address base: 0x400000000000006d
+    0x13,                   // body size=19
+    0x00,                   // 0 locals
+    0x10, 0x01,             // [0x6e] call function=1 (catch_all_in_callee) → returns 1
+    0x10, 0x03,             // [0x70] call function=3 (catch_all_from_caller) → returns 2
+    0x6a,                   // [0x72] i32.add (1 + 2 = 3)
+    0x06, 0x7f,             // [0x73] try (result i32)
+    0x10, 0x06,             // [0x75] call function=6 (middle_no_handler2) → throws
+    0x19,                   // [0x77] catch_all
+    0x41, 0x04,             // [0x78] i32.const 4
+    0x0b,                   // [0x7a] end (try)
+    0x6a,                   // [0x7b] i32.add (3 + 4 = 7)
+    0x10, 0x05,             // [0x7c] call function=5 (catch_all_from_grandparent) → returns 3
+    0x6a,                   // [0x7e] i32.add (7 + 3 = 10)
+    0x0b,                   // [0x7f] end (function)
+    // [0x80] End of code section
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module, {});
+let test = instance_step.exports.test_all;
+
+let iteration = 0;
+for (; ;) {
+    let result = test();
+    iteration += 1;
+    if (iteration % 1e4 == 0) {
+        print("iteration=", iteration, "result=", result);
+        if (result !== 10) {
+            print("ERROR: Expected result=10, got result=", result);
+            throw new Error("Test failed");
+        }
+    }
+}

--- a/JSTests/wasm/debugger/resources/wasm/throw-catch.js
+++ b/JSTests/wasm/debugger/resources/wasm/throw-catch.js
@@ -1,0 +1,135 @@
+// WebAssembly module with comprehensive try-catch-throw exception handling tests
+// Tests various exception handler scenarios:
+// 1. Handler in the same function (callee catches its own exception)
+// 2. Handler in the immediate caller
+// 3. Handler in the caller's caller (grandparent)
+// 4. Handler in the caller's caller's caller (great-grandparent)
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 2 function types
+    0x01, 0x08,             // section id=1, size=8
+    0x02,                   // 2 types
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> []) - void function for exception tag
+    0x60, 0x00, 0x01, 0x7f, // Type 1: (func [] -> [i32]) - function returning i32
+
+    // [0x12] Function section: 8 functions
+    0x03, 0x09,             // section id=3, size=9
+    0x08,                   // 8 functions
+    0x01,                   // function 0 (thrower): type 1
+    0x01,                   // function 1 (catch_in_callee): type 1
+    0x01,                   // function 2 (no_handler): type 1
+    0x01,                   // function 3 (catch_from_caller): type 1
+    0x01,                   // function 4 (middle_no_handler): type 1
+    0x01,                   // function 5 (catch_from_grandparent): type 1
+    0x01,                   // function 6 (middle_no_handler2): type 1
+    0x01,                   // function 7 (test_all): type 1
+
+    // [0x1d] Tag section: 1 exception tag
+    0x0d, 0x03,             // section id=13, size=3
+    0x01,                   // 1 tag
+    0x00, 0x00,             // attribute=0 (exception), type index 0 (void)
+
+    // [0x22] Export section: export function 7 as "test_all"
+    0x07, 0x0c,             // section id=7, size=12
+    0x01,                   // 1 export
+    0x08,                   // name length=8
+    0x74, 0x65, 0x73, 0x74, 0x5f, 0x61, 0x6c, 0x6c, // "test_all"
+    0x00, 0x07,             // export kind=function, function index=7
+
+    // [0x30] Code section
+    0x0a,                   // section id=10
+    0x52,                   // section size=82
+    0x08,                   // 8 functions
+
+    // [0x33] Function 0 (thrower): throws exception
+    0x06,                   // function body size=6
+    0x00,                   // 0 local declarations
+    0x08, 0x00,             // [0x35] throw tag 0
+    0x41, 0x00,             // [0x37] i32.const 0 (never reached)
+    0x0b,                   // [0x39] end
+
+    // [0x3a] Function 1 (catch_in_callee): catches its own exception
+    0x0d,                   // function body size=13
+    0x00,                   // 0 local declarations
+    0x06, 0x7f,             // [0x3c] try (result i32)
+    0x08, 0x00,             // [0x3e] throw tag 0
+    0x41, 0x00,             // [0x40] i32.const 0 (never reached)
+    0x07, 0x00,             // [0x42] catch tag 0
+    0x41, 0x01,             // [0x44] i32.const 1 (caught exception)
+    0x0b,                   // [0x46] end (try)
+    0x0b,                   // [0x47] end (function)
+
+    // [0x48] Function 2 (no_handler): calls thrower without handling
+    0x04,                   // function body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x00,             // [0x4a] call 0 (thrower)
+    0x0b,                   // [0x4c] end
+
+    // [0x4d] Function 3 (catch_from_caller): catches exception from callee
+    0x0b,                   // function body size=11
+    0x00,                   // 0 local declarations
+    0x06, 0x7f,             // [0x4f] try (result i32)
+    0x10, 0x00,             // [0x51] call 0 (thrower)
+    0x07, 0x00,             // [0x53] catch tag 0
+    0x41, 0x02,             // [0x55] i32.const 2 (caught from caller)
+    0x0b,                   // [0x57] end (try)
+    0x0b,                   // [0x58] end (function)
+
+    // [0x59] Function 4 (middle_no_handler): calls no_handler without handling
+    0x04,                   // function body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x02,             // [0x5b] call 2 (no_handler)
+    0x0b,                   // [0x5d] end
+
+    // [0x5e] Function 5 (catch_from_grandparent): catches from two levels deep
+    0x0b,                   // function body size=11
+    0x00,                   // 0 local declarations
+    0x06, 0x7f,             // [0x60] try (result i32)
+    0x10, 0x04,             // [0x62] call 4 (middle_no_handler)
+    0x07, 0x00,             // [0x64] catch tag 0
+    0x41, 0x03,             // [0x66] i32.const 3 (caught from grandparent)
+    0x0b,                   // [0x68] end (try)
+    0x0b,                   // [0x69] end (function)
+
+    // [0x6a] Function 6 (middle_no_handler2): another intermediate function
+    0x04,                   // function body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x04,             // [0x6c] call 4 (middle_no_handler)
+    0x0b,                   // [0x6e] end
+
+    // [0x6f] Function 7 (test_all): tests all scenarios and returns sum
+    0x14,                   // function body size=20
+    0x00,                   // 0 local declarations
+    0x10, 0x01,             // [0x71] call 1 (catch_in_callee) - returns 1
+    0x10, 0x03,             // [0x73] call 3 (catch_from_caller) - returns 2
+    0x6a,                   // [0x75] i32.add (1 + 2 = 3)
+    0x06, 0x7f,             // [0x76] try (result i32)
+    0x10, 0x06,             // [0x78] call 6 (middle_no_handler2) - throws from 3 levels deep
+    0x07, 0x00,             // [0x7a] catch tag 0
+    0x41, 0x04,             // [0x7c] i32.const 4 (caught from great-grandparent)
+    0x0b,                   // [0x7e] end (try)
+    0x6a,                   // [0x7f] i32.add (3 + 4 = 7)
+    0x10, 0x05,             // [0x80] call 5 (catch_from_grandparent) - returns 3
+    0x6a,                   // [0x82] i32.add (7 + 3 = 10)
+    0x0b                    // [0x83] end (function)
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module, {});
+let test = instance_step.exports.test_all;
+
+let iteration = 0;
+for (; ;) {
+    let result = test();
+    iteration += 1;
+    if (iteration % 1e4 == 0) {
+        print("iteration=", iteration, "result=", result);
+        if (result !== 10) {
+            print("ERROR: Expected result=10, got result=", result);
+            throw new Error("Test failed");
+        }
+    }
+}

--- a/JSTests/wasm/debugger/resources/wasm/throw-ref.js
+++ b/JSTests/wasm/debugger/resources/wasm/throw-ref.js
@@ -1,0 +1,407 @@
+// WebAssembly module with REAL throw_ref exception handling tests
+//
+// This binary is extracted from JSTests/wasm/spec-tests/throw_ref.wast.js
+// It uses the newer exception handling proposal with:
+//   - try_table (0x1f) instead of try (0x06)
+//   - catch_ref and catch_all_ref for catching with exception reference
+//   - throw_ref (0x0a) for re-throwing exception objects
+//   - exnref (0x69) type for exception references
+//
+// Catch kind encoding in try_table (WebAssembly binary format):
+//   0x00 = catch (catch specific tag, no exception object on stack)
+//   0x01 = catch_ref (catch specific tag, push exnref on stack)
+//   0x02 = catch_all (catch any exception, no exception object on stack)
+//   0x03 = catch_all_ref (catch any exception, push exnref on stack)
+//
+// Tests 7 scenarios:
+// 1. catch-throw_ref-0 - basic throw_ref that re-throws caught exception
+// 2. catch-throw_ref-1 - conditional throw_ref based on parameter
+// 3. catchall-throw_ref-0 - throw_ref in catch_all_ref handler
+// 4. catchall-throw_ref-1 - conditional throw_ref in catch_all_ref
+// 5. throw_ref-nested - nested exception handling with multiple exception objects
+// 6. throw_ref-recatch - catch exception, re-throw_ref, then catch again
+// 7. throw_ref-stack-polymorphism - tests stack polymorphism with throw_ref
+var wasm = new Uint8Array([
+    // ========== [0x00] WASM module header ==========
+    0x00, 0x61, 0x73, 0x6d,                     // [0x00] "\0asm" magic number
+    0x01, 0x00, 0x00, 0x00,                     // [0x04] version 1
+
+    // ========== [0x08] Type section ==========
+    // 3 function types
+    0x01,                                       // [0x08] section code = Type
+    0x8d, 0x80, 0x80, 0x80, 0x00,              // [0x09] section size = 13 (LEB128)
+    0x03,                                       // [0x0e] 3 types
+
+    // Type 0: () -> ()
+    0x60,                                       // [0x0f] func type
+    0x00,                                       // [0x10] 0 parameters
+    0x00,                                       // [0x11] 0 results
+
+    // Type 1: (i32) -> (i32)
+    0x60,                                       // [0x12] func type
+    0x01, 0x7f,                                 // [0x13] 1 parameter: i32
+    0x01, 0x7f,                                 // [0x15] 1 result: i32
+
+    // Type 2: (exnref) -> ()
+    0x60,                                       // [0x17] func type
+    0x01, 0x69,                                 // [0x18] 1 parameter: exnref (0x69)
+    0x00,                                       // [0x1a] 0 results
+
+    // ========== [0x1b] Function section ==========
+    // 7 functions
+    0x03,                                       // [0x1b] section code = Function
+    0x88, 0x80, 0x80, 0x80, 0x00,              // [0x1c] section size = 8 (LEB128)
+    0x07,                                       // [0x21] 7 functions
+    0x00,                                       // [0x22] function 0: type 0 () -> ()
+    0x01,                                       // [0x23] function 1: type 1 (i32) -> (i32)
+    0x00,                                       // [0x24] function 2: type 0 () -> ()
+    0x01,                                       // [0x25] function 3: type 1 (i32) -> (i32)
+    0x01,                                       // [0x26] function 4: type 1 (i32) -> (i32)
+    0x01,                                       // [0x27] function 5: type 1 (i32) -> (i32)
+    0x00,                                       // [0x28] function 6: type 0 () -> ()
+
+    // ========== [0x29] Tag section ==========
+    // 2 exception tags
+    0x0d,                                       // [0x29] section code = Tag (0x0d)
+    0x85, 0x80, 0x80, 0x80, 0x00,              // [0x2a] section size = 5 (LEB128)
+    0x02,                                       // [0x2f] 2 tags
+
+    // Tag 0: exception type 0 () -> ()
+    0x00,                                       // [0x30] tag attribute = 0 (exception)
+    0x00,                                       // [0x31] type index = 0
+
+    // Tag 1: exception type 0 () -> ()
+    0x00,                                       // [0x32] tag attribute = 0 (exception)
+    0x00,                                       // [0x33] type index = 0
+
+    // ========== [0x34] Export section ==========
+    // 7 exported functions
+    0x07,                                       // [0x34] section code = Export
+    0x9d, 0x81, 0x80, 0x80, 0x00,              // [0x35] section size = 157 (LEB128)
+    0x07,                                       // [0x3a] 7 exports
+
+    // Export 0: "catch-throw_ref-0" -> function 0
+    0x11,                                       // [0x3b] name length = 17
+    0x63, 0x61, 0x74, 0x63, 0x68, 0x2d, 0x74, 0x68, 0x72, 0x6f, 0x77, 0x5f, // "catch-throw_"
+    0x72, 0x65, 0x66, 0x2d, 0x30,              // "ref-0"
+    0x00,                                       // [0x4d] export kind = function
+    0x00,                                       // [0x4e] function index = 0
+
+    // Export 1: "catch-throw_ref-1" -> function 1
+    0x11,                                       // [0x4f] name length = 17
+    0x63, 0x61, 0x74, 0x63, 0x68, 0x2d, 0x74, 0x68, 0x72, 0x6f, 0x77, 0x5f, // "catch-throw_"
+    0x72, 0x65, 0x66, 0x2d, 0x31,              // "ref-1"
+    0x00,                                       // [0x61] export kind = function
+    0x01,                                       // [0x62] function index = 1
+
+    // Export 2: "catchall-throw_ref-0" -> function 2
+    0x14,                                       // [0x63] name length = 20
+    0x63, 0x61, 0x74, 0x63, 0x68, 0x61, 0x6c, 0x6c, 0x2d, 0x74, 0x68, 0x72, // "catchall-thr"
+    0x6f, 0x77, 0x5f, 0x72, 0x65, 0x66, 0x2d, 0x30, // "ow_ref-0"
+    0x00,                                       // [0x78] export kind = function
+    0x02,                                       // [0x79] function index = 2
+
+    // Export 3: "catchall-throw_ref-1" -> function 3
+    0x14,                                       // [0x7a] name length = 20
+    0x63, 0x61, 0x74, 0x63, 0x68, 0x61, 0x6c, 0x6c, 0x2d, 0x74, 0x68, 0x72, // "catchall-thr"
+    0x6f, 0x77, 0x5f, 0x72, 0x65, 0x66, 0x2d, 0x31, // "ow_ref-1"
+    0x00,                                       // [0x8f] export kind = function
+    0x03,                                       // [0x90] function index = 3
+
+    // Export 4: "throw_ref-nested" -> function 4
+    0x10,                                       // [0x91] name length = 16
+    0x74, 0x68, 0x72, 0x6f, 0x77, 0x5f, 0x72, 0x65, 0x66, 0x2d, 0x6e, 0x65, // "throw_ref-ne"
+    0x73, 0x74, 0x65, 0x64,                    // "sted"
+    0x00,                                       // [0xa2] export kind = function
+    0x04,                                       // [0xa3] function index = 4
+
+    // Export 5: "throw_ref-recatch" -> function 5
+    0x11,                                       // [0xa4] name length = 17
+    0x74, 0x68, 0x72, 0x6f, 0x77, 0x5f, 0x72, 0x65, 0x66, 0x2d, 0x72, 0x65, // "throw_ref-re"
+    0x63, 0x61, 0x74, 0x63, 0x68,              // "catch"
+    0x00,                                       // [0xb6] export kind = function
+    0x05,                                       // [0xb7] function index = 5
+
+    // Export 6: "throw_ref-stack-polymorphism" -> function 6
+    0x1c,                                       // [0xb8] name length = 28
+    0x74, 0x68, 0x72, 0x6f, 0x77, 0x5f, 0x72, 0x65, 0x66, 0x2d, 0x73, 0x74, // "throw_ref-st"
+    0x61, 0x63, 0x6b, 0x2d, 0x70, 0x6f, 0x6c, 0x79, 0x6d, 0x6f, 0x72, 0x70, // "ack-polymorp"
+    0x68, 0x69, 0x73, 0x6d,                    // "hism"
+    0x00,                                       // [0xd5] export kind = function
+    0x06,                                       // [0xd6] function index = 6
+
+    // ========== [0xd7] Code section ==========
+    // 7 function bodies
+    0x0a,                                       // [0xd7] section code = Code
+    0xf3, 0x81, 0x80, 0x80, 0x00,              // [0xd8] section size = 243 (LEB128)
+    0x07,                                       // [0xdd] 7 functions
+
+    // ========== Function 0: catch-throw_ref-0 ==========
+    // Type: () -> ()
+    // Virtual address: 0x40000000000000de
+    // Test: Throws exception, catches with catch_ref, then throw_ref re-throws it
+    // Expected: Should throw (not caught by outer handler)
+    0x90, 0x80, 0x80, 0x80, 0x00,              // [0xde] function size = 16 (LEB128)
+    0x00,                                       // [0xe3] 0 local declarations
+
+    0x02, 0x69,                                 // [0xe4] block exnref (result type = exnref)
+    0x1f, 0x40,                                 // [0xe6] try_table (block type = 0x40 for empty)
+    0x01,                                       // [0xe8] 1 catch clause
+    0x01,                                       // [0xe9] catch kind = 0x01 (catch_ref - catches with exnref on stack)
+    0x00,                                       // [0xea] tag index = 0
+    0x00,                                       // [0xeb] label = 0 (jump to block end)
+    0x08, 0x00,                                 // [0xec] throw tag=0
+    0x0b,                                       // [0xee] end try_table
+    0x00,                                       // [0xef] unreachable (if we get here, didn't catch)
+    0x0b,                                       // [0xf0] end block - exnref is on stack here
+    0x0a,                                       // [0xf1] throw_ref (re-throws the exnref from stack)
+    0x0b,                                       // [0xf2] end function
+
+    // ========== Function 1: catch-throw_ref-1 ==========
+    // Type: (i32) -> (i32)
+    // Virtual address: 0x40000000000000f3
+    // Test: Catches exception as exnref, conditionally throw_ref or return 23
+    // Expected: param=0 should throw, param=1 should return 23
+    0x9a, 0x80, 0x80, 0x80, 0x00,              // [0xf3] function size = 26 (LEB128)
+    0x00,                                       // [0xf8] 0 local declarations
+
+    0x02, 0x69,                                 // [0xf9] block exnref
+    0x1f, 0x7f,                                 // [0xfb] try_table i32 (result type = i32)
+    0x01,                                       // [0xfd] 1 catch clause
+    0x01,                                       // [0xfe] catch kind = 0x01 (catch_ref)
+    0x00,                                       // [0xff] tag index = 0
+    0x00,                                       // [0x100] label = 0 (jump to block end)
+    0x08, 0x00,                                 // [0x101] throw tag=0
+    0x0b,                                       // [0x103] end try_table
+    0x0f,                                       // [0x104] return (if no exception, return top of stack)
+    0x0b,                                       // [0x105] end block - exnref is on stack
+    0x20, 0x00,                                 // [0x106] local.get 0 (get parameter)
+    0x45,                                       // [0x108] i32.eqz (test if param == 0)
+    0x04, 0x02,                                 // [0x109] if (void) type=2
+    0x0a,                                       // [0x10b] throw_ref (if param==0, re-throw)
+    0x05,                                       // [0x10c] else
+    0x1a,                                       // [0x10d] drop (drop the exnref)
+    0x0b,                                       // [0x10e] end if
+    0x41, 0x17,                                 // [0x10f] i32.const 23
+    0x0b,                                       // [0x111] end function
+
+    // ========== Function 2: catchall-throw_ref-0 ==========
+    // Type: () -> ()
+    // Virtual address: 0x4000000000000112
+    // Test: Throws exception, catches with catch_all_ref (any exception), then throw_ref
+    // Expected: Should throw (re-thrown from catch_all_ref handler)
+    0x8e, 0x80, 0x80, 0x80, 0x00,              // [0x112] function size = 14 (LEB128)
+    0x00,                                       // [0x117] 0 local declarations
+
+    0x02, 0x69,                                 // [0x118] block exnref
+    0x1f, 0x69,                                 // [0x11a] try_table exnref (result type = exnref)
+    0x01,                                       // [0x11c] 1 catch clause
+    0x03,                                       // [0x11d] catch kind = 0x03 (catch_all_ref)
+    0x00,                                       // [0x11e] label = 0 (jump to block end)
+    0x08, 0x00,                                 // [0x11f] throw tag=0
+    0x0b,                                       // [0x121] end try_table
+    0x0b,                                       // [0x122] end block (exnref falls through to stack)
+    0x0a,                                       // [0x123] throw_ref
+    0x0b,                                       // [0x124] end function
+
+    // ========== Function 3: catchall-throw_ref-1 ==========
+    // Type: (i32) -> (i32)
+    // Virtual address: 0x4000000000000125
+    // Test: Catches with catch_all_ref, conditionally throw_ref or return 23
+    // Expected: param=0 should throw, param=1 should return 23
+    0x99, 0x80, 0x80, 0x80, 0x00,              // [0x125] function size = 25 (LEB128)
+    0x00,                                       // [0x12a] 0 local declarations
+
+    0x02, 0x69,                                 // [0x12b] block exnref
+    0x1f, 0x7f,                                 // [0x12d] try_table i32
+    0x01,                                       // [0x12f] 1 catch clause
+    0x03,                                       // [0x130] catch kind = 0x03 (catch_all_ref)
+    0x00,                                       // [0x131] label = 0
+    0x08, 0x00,                                 // [0x132] throw tag=0
+    0x0b,                                       // [0x134] end try_table
+    0x0f,                                       // [0x135] return
+    0x0b,                                       // [0x136] end block - exnref on stack
+    0x20, 0x00,                                 // [0x137] local.get 0
+    0x45,                                       // [0x139] i32.eqz
+    0x04, 0x02,                                 // [0x13a] if (void)
+    0x0a,                                       // [0x13c] throw_ref (if param==0)
+    0x05,                                       // [0x13d] else
+    0x1a,                                       // [0x13e] drop (drop exnref)
+    0x0b,                                       // [0x13f] end if
+    0x41, 0x17,                                 // [0x140] i32.const 23
+    0x0b,                                       // [0x142] end function
+
+    // ========== Function 4: throw_ref-nested ==========
+    // Type: (i32) -> (i32)
+    // Virtual address: 0x4000000000000143
+    // Test: Nested exception handling - catches two different exceptions, stores in locals,
+    //       then conditionally throw_ref based on parameter
+    // Expected: param=0 throws exn1, param=1 throws exn2, param=2 returns 23
+    0xba, 0x80, 0x80, 0x80, 0x00,              // [0x143] function size = 58 (LEB128)
+    0x01,                                       // [0x148] 1 local declaration group
+    0x02, 0x69,                                 // [0x149] 2 locals of type exnref
+
+    // Outer block to catch second exception
+    0x02, 0x69,                                 // [0x14b] block exnref
+    0x1f, 0x7f,                                 // [0x14d] try_table i32
+    0x01,                                       // [0x14f] 1 catch clause
+    0x01,                                       // [0x150] catch kind = 0x01 (catch_ref)
+    0x01,                                       // [0x151] tag index = 1
+    0x00,                                       // [0x152] label = 0
+    0x08, 0x01,                                 // [0x153] throw tag=1 (throw second exception)
+    0x0b,                                       // [0x155] end try_table
+    0x0f,                                       // [0x156] return
+    0x0b,                                       // [0x157] end block
+    0x21, 0x01,                                 // [0x158] local.set 1 (store exn2 in local 1)
+
+    // Inner block to catch first exception
+    0x02, 0x69,                                 // [0x15a] block exnref
+    0x1f, 0x7f,                                 // [0x15c] try_table i32
+    0x01,                                       // [0x15e] 1 catch clause
+    0x01,                                       // [0x15f] catch kind = 0x01 (catch_ref)
+    0x00,                                       // [0x160] tag index = 0
+    0x00,                                       // [0x161] label = 0
+    0x08, 0x00,                                 // [0x162] throw tag=0 (throw first exception)
+    0x0b,                                       // [0x164] end try_table
+    0x0f,                                       // [0x165] return
+    0x0b,                                       // [0x166] end block
+    0x21, 0x02,                                 // [0x167] local.set 2 (store exn1 in local 2)
+
+    // Now we have both exceptions in locals, decide which to throw_ref
+    0x20, 0x00,                                 // [0x169] local.get 0 (get parameter)
+    0x41, 0x00,                                 // [0x16b] i32.const 0
+    0x46,                                       // [0x16d] i32.eq (param == 0?)
+    0x04, 0x40,                                 // [0x16e] if (void)
+    0x20, 0x01,                                 // [0x170] local.get 1 (get exn2)
+    0x0a,                                       // [0x172] throw_ref (throw exn2 if param==0)
+    0x0b,                                       // [0x173] end if
+
+    0x20, 0x00,                                 // [0x174] local.get 0
+    0x41, 0x01,                                 // [0x176] i32.const 1
+    0x46,                                       // [0x178] i32.eq (param == 1?)
+    0x04, 0x40,                                 // [0x179] if (void)
+    0x20, 0x02,                                 // [0x17b] local.get 2 (get exn1)
+    0x0a,                                       // [0x17d] throw_ref (throw exn1 if param==1)
+    0x0b,                                       // [0x17e] end if
+
+    0x41, 0x17,                                 // [0x17f] i32.const 23 (if param >= 2)
+    0x0b,                                       // [0x181] end function
+
+    // ========== Function 5: throw_ref-recatch ==========
+    // Type: (i32) -> (i32)
+    // Virtual address: 0x4000000000000182
+    // Test: Catch exception, store it, then in another try_table throw_ref it,
+    //       and conditionally re-catch or let it propagate
+    // Expected: param=0 returns 23 (inner catch), param=1 returns 42 (outer catch)
+    0xac, 0x80, 0x80, 0x80, 0x00,              // [0x182] function size = 44 (LEB128)
+    0x01,                                       // [0x187] 1 local declaration group
+    0x01, 0x69,                                 // [0x188] 1 local of type exnref
+
+    // First catch - stores exception
+    0x02, 0x69,                                 // [0x18a] block exnref
+    0x1f, 0x7f,                                 // [0x18c] try_table i32
+    0x01,                                       // [0x18e] 1 catch clause
+    0x01,                                       // [0x18f] catch kind = 0x01 (catch_ref)
+    0x00,                                       // [0x190] tag index = 0
+    0x00,                                       // [0x191] label = 0
+    0x08, 0x00,                                 // [0x192] throw tag=0
+    0x0b,                                       // [0x194] end try_table
+    0x0f,                                       // [0x195] return
+    0x0b,                                       // [0x196] end block
+    0x21, 0x01,                                 // [0x197] local.set 1 (store caught exception)
+
+    // Second try_table - re-throw_ref the stored exception conditionally
+    0x02, 0x69,                                 // [0x199] block exnref
+    0x1f, 0x7f,                                 // [0x19b] try_table i32
+    0x01,                                       // [0x19d] 1 catch clause
+    0x01,                                       // [0x19e] catch kind = 0x01 (catch_ref)
+    0x00,                                       // [0x19f] tag index = 0
+    0x00,                                       // [0x1a0] label = 0
+    0x20, 0x00,                                 // [0x1a1] local.get 0 (get parameter)
+    0x45,                                       // [0x1a3] i32.eqz (param == 0?)
+    0x04, 0x40,                                 // [0x1a4] if (void)
+    0x20, 0x01,                                 // [0x1a6] local.get 1 (get stored exception)
+    0x0a,                                       // [0x1a8] throw_ref (re-throw if param==0)
+    0x0b,                                       // [0x1a9] end if
+    0x41, 0x2a,                                 // [0x1aa] i32.const 42 (if no throw_ref)
+    0x0b,                                       // [0x1ac] end try_table
+    0x0f,                                       // [0x1ad] return
+    0x0b,                                       // [0x1ae] end block (re-caught here if param==0)
+    0x1a,                                       // [0x1af] drop (drop re-caught exnref)
+    0x41, 0x17,                                 // [0x1b0] i32.const 23
+    0x0b,                                       // [0x1b2] end function
+
+    // ========== Function 6: throw_ref-stack-polymorphism ==========
+    // Type: () -> ()
+    // Virtual address: 0x40000000000001b3
+    // Test: Tests that throw_ref properly handles stack polymorphism
+    //       (unreachable code after throw_ref)
+    // Expected: Should throw
+    0x98, 0x80, 0x80, 0x80, 0x00,              // [0x1b3] function size = 24 (LEB128)
+    0x01,                                       // [0x1b8] 1 local declaration group
+    0x01, 0x69,                                 // [0x1b9] 1 local of type exnref
+
+    0x02, 0x69,                                 // [0x1bb] block exnref
+    0x1f, 0x7c,                                 // [0x1bd] try_table f64 (result type = f64)
+    0x01,                                       // [0x1bf] 1 catch clause
+    0x01,                                       // [0x1c0] catch kind = 0x01 (catch_ref)
+    0x00,                                       // [0x1c1] tag index = 0
+    0x00,                                       // [0x1c2] label = 0
+    0x08, 0x00,                                 // [0x1c3] throw tag=0
+    0x0b,                                       // [0x1c5] end try_table
+    0x00,                                       // [0x1c6] unreachable (never reached)
+    0x0b,                                       // [0x1c7] end block
+    0x21, 0x00,                                 // [0x1c8] local.set 0 (store exnref)
+    0x41, 0x01,                                 // [0x1ca] i32.const 1
+    0x20, 0x00,                                 // [0x1cc] local.get 0
+    0x0a,                                       // [0x1ce] throw_ref (always throws)
+    0x0b                                        // [0x1cf] end function
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module, {});
+
+// Test each function
+let tests = [
+    ["catch-throw_ref-0", [], true],           // should throw
+
+    ["catch-throw_ref-1", [0], true],          // should throw
+    ["catch-throw_ref-1", [1], false, 23],     // should return 23
+
+    ["catchall-throw_ref-0", [], true],        // should throw
+    ["catchall-throw_ref-1", [0], true],       // should throw
+    ["catchall-throw_ref-1", [1], false, 23],  // should return 23
+
+    ["throw_ref-nested", [0], true],           // should throw
+    ["throw_ref-nested", [1], true],           // should throw
+    ["throw_ref-nested", [2], false, 23],      // should return 23
+
+    ["throw_ref-recatch", [0], false, 23],     // should return 23
+    ["throw_ref-recatch", [1], false, 42],     // should return 42
+
+    ["throw_ref-stack-polymorphism", [], true] // should throw
+];
+
+let iteration = 0;
+for (; ;) {
+    for (let [name, args, shouldThrow, expected] of tests) {
+        try {
+            let result = instance_step.exports[name](...args);
+            if (shouldThrow) {
+                throw new Error(`${name}(${args}) should have thrown but returned ${result}`);
+            }
+            if (expected !== undefined && result !== expected) {
+                throw new Error(`${name}(${args}) expected ${expected} but got ${result}`);
+            }
+        } catch (e) {
+            if (!shouldThrow) {
+                throw new Error(`${name}(${args}) should not have thrown: ${e}`);
+            }
+        }
+    }
+
+    iteration += 1;
+    if (iteration % 1e4 == 0) {
+        print("iteration=", iteration, "all tests passed");
+    }
+}

--- a/JSTests/wasm/debugger/resources/wasm/try-table.js
+++ b/JSTests/wasm/debugger/resources/wasm/try-table.js
@@ -1,0 +1,200 @@
+// WebAssembly module with comprehensive try_table exception handling tests
+// Tests catch kinds 0x00 (catch without exnref) and 0x02 (catch_all without exnref)
+// Tests exception propagation through call stack:
+// 1. Handler in the same function (callee catches its own exception)
+// 2. Handler in the immediate caller
+// 3. Handler in the caller's caller (grandparent)
+// 4. Handler in the caller's caller's caller (great-grandparent)
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 2 function types
+    0x01, 0x08,             // section id=1, size=8
+    0x02,                   // 2 types
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> []) - void function for exception tag
+    0x60, 0x00, 0x01, 0x7f, // Type 1: (func [] -> [i32]) - function returning i32
+
+    // [0x12] Function section: 10 functions
+    0x03, 0x0b,             // section id=3, size=11
+    0x0a,                   // 10 functions
+    0x01,                   // function 0 (thrower): type 1
+    0x01,                   // function 1 (catch_in_callee): type 1
+    0x01,                   // function 2 (no_handler): type 1
+    0x01,                   // function 3 (catch_from_caller): type 1
+    0x01,                   // function 4 (middle_no_handler): type 1
+    0x01,                   // function 5 (catch_from_grandparent): type 1
+    0x01,                   // function 6 (middle_no_handler2): type 1
+    0x01,                   // function 7 (catch_all_in_callee): type 1
+    0x01,                   // function 8 (catch_all_from_caller): type 1
+    0x01,                   // function 9 (test_all): type 1
+
+    // [0x1f] Tag section: 1 exception tag
+    0x0d, 0x03,             // section id=13, size=3
+    0x01,                   // 1 tag
+    0x00, 0x00,             // attribute=0 (exception), type index 0 (void)
+
+    // [0x24] Export section: export function 9 as "test_all"
+    0x07, 0x0c,             // section id=7, size=12
+    0x01,                   // 1 export
+    0x08,                   // name length=8
+    0x74, 0x65, 0x73, 0x74, 0x5f, 0x61, 0x6c, 0x6c, // "test_all"
+    0x00, 0x09,             // export kind=function, function index=9
+
+    // [0x32] Code section
+    0x0a,                   // section id=10
+    0xa3, 0x01,             // section size=163
+    0x0a,                   // 10 functions
+
+    // [0x36] Function 0 (thrower): throws exception
+    0x06,                   // function body size=6
+    0x00,                   // 0 local declarations
+    0x08, 0x00,             // [0x38] throw tag 0
+    0x41, 0x00,             // [0x3a] i32.const 0 (never reached)
+    0x0b,                   // [0x3c] end
+
+    // [0x3d] Function 1 (catch_in_callee): catches its own exception with try_table/catch (kind 0x00)
+    0x13,                   // function body size=19
+    0x00,                   // 0 local declarations
+    0x02, 0x40,             // [0x3f] block $catch_handler (no result)
+    0x1f, 0x7f,             // [0x41] try_table (result i32)
+    0x01,                   // 1 catch clause
+    0x00, 0x00, 0x00,       // catch kind=0x00 (catch $exn), tag=0, label=0 ($catch_handler)
+    0x08, 0x00,             // [0x47] throw tag 0
+    0x41, 0x00,             // [0x49] i32.const 0 (never reached)
+    0x0b,                   // [0x4b] end (try_table)
+    0x0f,                   // [0x4c] return (normal path, i32.const 0 on stack)
+    0x0b,                   // [0x4d] end (block $catch_handler)
+    0x41, 0x01,             // [0x4e] i32.const 1 (exception caught)
+    0x0b,                   // [0x50] end (function)
+
+    // [0x51] Function 2 (no_handler): calls thrower without handling
+    0x04,                   // function body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x00,             // [0x53] call 0 (thrower)
+    0x0b,                   // [0x55] end
+
+    // [0x56] Function 3 (catch_from_caller): catches exception from callee with try_table/catch (kind 0x00)
+    0x11,                   // function body size=17
+    0x00,                   // 0 local declarations
+    0x02, 0x40,             // [0x58] block $catch_handler (no result)
+    0x1f, 0x7f,             // [0x5a] try_table (result i32)
+    0x01,                   // 1 catch clause
+    0x00, 0x00, 0x00,       // catch kind=0x00 (catch $exn), tag=0, label=0 ($catch_handler)
+    0x10, 0x00,             // [0x60] call 0 (thrower)
+    0x0b,                   // [0x62] end (try_table)
+    0x0f,                   // [0x63] return (normal path)
+    0x0b,                   // [0x64] end (block $catch_handler)
+    0x41, 0x02,             // [0x65] i32.const 2 (exception caught from caller)
+    0x0b,                   // [0x67] end (function)
+
+    // [0x68] Function 4 (middle_no_handler): calls no_handler without handling
+    0x04,                   // function body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x02,             // [0x6a] call 2 (no_handler)
+    0x0b,                   // [0x6c] end
+
+    // [0x6d] Function 5 (catch_from_grandparent): catches from two levels deep with try_table/catch (kind 0x00)
+    0x11,                   // function body size=17
+    0x00,                   // 0 local declarations
+    0x02, 0x40,             // [0x6f] block $catch_handler (no result)
+    0x1f, 0x7f,             // [0x71] try_table (result i32)
+    0x01,                   // 1 catch clause
+    0x00, 0x00, 0x00,       // catch kind=0x00 (catch $exn), tag=0, label=0 ($catch_handler)
+    0x10, 0x04,             // [0x77] call 4 (middle_no_handler)
+    0x0b,                   // [0x79] end (try_table)
+    0x0f,                   // [0x7a] return (normal path)
+    0x0b,                   // [0x7b] end (block $catch_handler)
+    0x41, 0x03,             // [0x7c] i32.const 3 (exception caught from grandparent)
+    0x0b,                   // [0x7e] end (function)
+
+    // [0x7f] Function 6 (middle_no_handler2): another intermediate function
+    0x04,                   // function body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x04,             // [0x81] call 4 (middle_no_handler)
+    0x0b,                   // [0x83] end
+
+    // [0x84] Function 7 (catch_all_in_callee): catches any exception with try_table/catch_all (kind 0x02)
+    0x12,                   // function body size=18
+    0x00,                   // 0 local declarations
+    0x02, 0x40,             // [0x86] block $catch_handler (no result)
+    0x1f, 0x40,             // [0x88] try_table (no result)
+    0x01,                   // 1 catch clause
+    0x02, 0x00,             // catch kind=0x02 (catch_all), label=0 ($catch_handler)
+    0x08, 0x00,             // [0x8d] throw tag 0
+    0x41, 0x00,             // [0x8f] i32.const 0 (never reached)
+    0x1a,                   // [0x91] drop (never reached)
+    0x0b,                   // [0x92] end (try_table)
+    0x0b,                   // [0x93] end (block $catch_handler)
+    0x41, 0x05,             // [0x94] i32.const 5 (exception caught by catch_all)
+    0x0b,                   // [0x96] end (function)
+
+    // [0x97] Function 8 (catch_all_from_caller): catches exception from callee with try_table/catch_all (kind 0x02)
+    0x10,                   // function body size=16
+    0x00,                   // 0 local declarations
+    0x02, 0x40,             // [0x99] block $catch_handler (no result)
+    0x1f, 0x40,             // [0x9b] try_table (no result)
+    0x01,                   // 1 catch clause
+    0x02, 0x00,             // catch kind=0x02 (catch_all), label=0 ($catch_handler)
+    0x10, 0x00,             // [0xa0] call 0 (thrower)
+    0x1a,                   // [0xa2] drop (never reached)
+    0x0b,                   // [0xa3] end (try_table)
+    0x0b,                   // [0xa4] end (block $catch_handler)
+    0x41, 0x06,             // [0xa5] i32.const 6 (exception caught from caller by catch_all)
+    0x0b,                   // [0xa7] end (function)
+
+    // [0xa8] Function 9 (test_all): tests all try_table scenarios
+    // Normal path: 1 + 2 + (exception at middle_no_handler2, so skips normal path)
+    // Exception path: drop(3) + 4 + 3 + 5 + 6 = 21
+    0x2f,                   // function body size=47
+    0x00,                   // 0 local declarations
+    0x10, 0x01,             // [0xaa] call 1 (catch_in_callee) - returns 1
+    0x10, 0x03,             // [0xac] call 3 (catch_from_caller) - returns 2
+    0x6a,                   // [0xae] i32.add (1 + 2 = 3)
+    0x02, 0x40,             // [0xaf] block $catch_handler (no result)
+    0x1f, 0x7f,             // [0xb1] try_table (result i32)
+    0x01,                   // 1 catch clause
+    0x00, 0x00, 0x00,       // catch kind=0x00 (catch $exn), tag=0, label=0 ($catch_handler)
+    0x10, 0x06,             // [0xb7] call 6 (middle_no_handler2) - throws from 3 levels deep
+    0x0b,                   // [0xb9] end (try_table)
+    0x41, 0x04,             // [0xba] i32.const 4 (normal path: great-grandparent would add 4)
+    0x6a,                   // [0xbc] i32.add
+    0x10, 0x05,             // [0xbd] call 5 (catch_from_grandparent)
+    0x6a,                   // [0xbf] i32.add
+    0x10, 0x07,             // [0xc0] call 7 (catch_all_in_callee)
+    0x6a,                   // [0xc2] i32.add
+    0x10, 0x08,             // [0xc3] call 8 (catch_all_from_caller)
+    0x6a,                   // [0xc5] i32.add
+    0x0f,                   // [0xc6] return (normal path)
+    0x0b,                   // [0xc7] end (block $catch_handler)
+    // Exception path: exception caught from middle_no_handler2
+    0x1a,                   // [0xc8] drop (drop the partial result: 3)
+    0x41, 0x04,             // [0xc9] i32.const 4
+    0x41, 0x03,             // [0xcb] i32.const 3
+    0x6a,                   // [0xcd] i32.add (4 + 3 = 7)
+    0x10, 0x05,             // [0xce] call 5 (catch_from_grandparent) - returns 3
+    0x6a,                   // [0xd0] i32.add (7 + 3 = 10)
+    0x10, 0x07,             // [0xd1] call 7 (catch_all_in_callee) - returns 5
+    0x6a,                   // [0xd3] i32.add (10 + 5 = 15)
+    0x10, 0x08,             // [0xd4] call 8 (catch_all_from_caller) - returns 6
+    0x6a,                   // [0xd6] i32.add (15 + 6 = 21)
+    0x0b                    // [0xd7] end (function)
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance_step = new WebAssembly.Instance(module, {});
+let test = instance_step.exports.test_all;
+
+let iteration = 0;
+for (; ;) {
+    let result = test();
+    iteration += 1;
+    if (iteration % 1e4 == 0) {
+        print("iteration=", iteration, "result=", result);
+        if (result !== 21) {
+            print("ERROR: Expected result=21, got result=", result);
+            throw new Error("Test failed");
+        }
+    }
+}

--- a/JSTests/wasm/debugger/resources/wasm/wat2wasm.js
+++ b/JSTests/wasm/debugger/resources/wasm/wat2wasm.js
@@ -1,0 +1,31 @@
+import { instantiate as instantiateGC, watToWasm } from "../../../gc/wast-wrapper.js"
+
+let wat = `
+  (module
+    (func (export "test") (param anyref) (result i32)
+      (block (result i32 i31ref)
+        (i32.const 42)
+        (local.get 0)
+        (br_on_cast 0 anyref i31ref)
+        (br 0 (i32.const 7) (ref.null i31)))
+      drop))
+`
+
+const binary = new Uint8Array(watToWasm(wat));
+const inst = instantiateGC(wat);
+
+print("Binary size:", binary.length, "bytes\n");
+
+print("Binary (hex):");
+let line = "";
+for (let i = 0; i < binary.length; i++) {
+    if (i % 16 === 0) {
+        if (line) print(line);
+        line = binary[i].toString(16).padStart(2, '0');
+    } else {
+        line += " " + binary[i].toString(16).padStart(2, '0');
+    }
+}
+if (line) print(line);
+
+print("\nTest: test(null) =", inst.exports.test(null));

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -482,3 +482,948 @@ class SwiftWasmTestCase(BaseTestCase):
             "mem reg 0x0000000000000000",
             patterns=["[0x0000000000000000-0x0000000000130000) rw- wasm_memory_0_0"],
         )
+
+
+class NopDropSelectEndTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/nop-drop-select-end.js")
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Breakpoint test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("b 0x4000000000000021")
+        self.send_lldb_command_or_raise("c")
+
+        patterns = [
+            ["->  0x4000000000000021: nop"],
+            ["->  0x4000000000000022: i32.const 42"],
+            ["->  0x4000000000000024: drop"],
+            ["->  0x4000000000000025: i32.const 1"],
+            ["->  0x4000000000000027: i32.const 2"],
+            ["->  0x4000000000000029: i32.const 1"],
+            ["->  0x400000000000002b: f32.select"],
+            ["->  0x400000000000002c: drop"],
+            ["->  0x400000000000002d: block"],
+            ["->  0x400000000000002f: i32.const 5"],
+            ["->  0x4000000000000031: drop"],
+            ["->  0x4000000000000032: end"],
+            ["->  0x4000000000000033: end"],
+        ]
+
+        for _ in range(10):
+            for pattern in patterns:
+                self.send_lldb_command_or_raise("si")
+                self.send_lldb_command_or_raise("dis", patterns=pattern)
+
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
+
+class CallTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/call.js")
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Breakpoint test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("b 0x4000000000000036")
+        self.send_lldb_command_or_raise("c")
+
+        patterns = [
+            ["->  0x4000000000000036: call   2"],
+            ["->  0x400000000000003f: i32.const 42"],
+            ["->  0x4000000000000041: end"],
+            ["->  0x4000000000000038: drop"],
+            ["->  0x4000000000000039: call   0"],
+            ["->  0x400000000000003b: drop"],
+            ["->  0x400000000000003c: end"],
+        ]
+
+        for _ in range(10):
+            for pattern in patterns:
+                self.send_lldb_command_or_raise("dis", patterns=pattern)
+                self.send_lldb_command_or_raise("si")
+
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
+
+class CallIndirectTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/call-indirect.js")
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Breakpoint test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("b 0x4000000000000046")
+        self.send_lldb_command_or_raise("c")
+
+        patterns = [
+            ["->  0x4000000000000046: i32.const 0"],
+            ["->  0x4000000000000048: call_indirect 1"],
+            ["->  0x4000000000000055: i32.const 42"],
+            ["->  0x4000000000000057: end"],
+            ["->  0x400000000000004b: drop"],
+            ["->  0x400000000000004c: i32.const 1"],
+            ["->  0x400000000000004e: call_indirect 1"],
+            ["->  0x4000000000000051: drop"],
+            ["->  0x4000000000000052: end"],
+        ]
+
+        for _ in range(10):
+            for pattern in patterns:
+                self.send_lldb_command_or_raise("dis", patterns=pattern)
+                self.send_lldb_command_or_raise("si")
+
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
+
+class CallRefTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/call-ref.js")
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Breakpoint test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("b 0x4000000000000043")
+        self.send_lldb_command_or_raise("c")
+
+        patterns = [
+            ["->  0x4000000000000043"],
+            ["->  0x4000000000000045"],
+            ["->  0x400000000000003e: i32.const 42"],
+            ["->  0x4000000000000040: end"],
+            ["->  0x4000000000000047: drop"],
+            ["->  0x4000000000000048"],
+            ["->  0x400000000000004a"],
+            ["->  0x400000000000004c: drop"],
+            ["->  0x400000000000004d: end"],
+        ]
+
+        for _ in range(10):
+            for pattern in patterns:
+                self.send_lldb_command_or_raise("si")
+                self.send_lldb_command_or_raise("dis", patterns=pattern)
+
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
+
+class ReturnCallTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/return-call.js")
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Tail call test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("b 0x4000000000000035")
+        self.send_lldb_command_or_raise("c")
+
+        patterns = [
+            ["->  0x4000000000000035: call   2"],
+            ["->  0x4000000000000040: return_call 4"],
+            ["->  0x400000000000004e: i32.const 42"],
+            ["->  0x4000000000000050: end"],
+            ["->  0x4000000000000037: call   3"],
+            ["->  0x4000000000000047: return_call 0"],
+            ["->  0x4000000000000039: i32.add"],
+            ["->  0x400000000000003a: i32.const 1"],
+            ["->  0x400000000000003c: i32.add"],
+            ["->  0x400000000000003d: end"],
+        ]
+
+        for _ in range(10):
+            for pattern in patterns:
+                self.send_lldb_command_or_raise("dis", patterns=pattern)
+                self.send_lldb_command_or_raise("si")
+
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
+
+class ReturnCallIndirectTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/return-call-indirect.js")
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Tail call indirect test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("b 0x4000000000000045")
+        self.send_lldb_command_or_raise("c")
+
+        patterns = [
+            ["->  0x4000000000000045: call   2"],
+            ["->  0x4000000000000050: i32.const 0"],
+            ["->  0x4000000000000052: return_call_indirect 0"],
+            ["->  0x4000000000000060: i32.const 42"],
+            ["->  0x4000000000000062: end"],
+            ["->  0x4000000000000047: call   3"],
+            ["->  0x4000000000000058: i32.const 1"],
+            ["->  0x400000000000005a: return_call_indirect 0"],
+            ["->  0x4000000000000049: i32.add"],
+            ["->  0x400000000000004a: i32.const 1"],
+            ["->  0x400000000000004c: i32.add"],
+            ["->  0x400000000000004d: end"],
+        ]
+
+        for _ in range(10):
+            for pattern in patterns:
+                self.send_lldb_command_or_raise("dis", patterns=pattern)
+                self.send_lldb_command_or_raise("si")
+
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
+
+class ReturnCallRefTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/return-call-ref.js")
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Tail call ref test failed: {e}")
+
+    def stepTest(self):
+        for _ in range(10):
+            self.send_lldb_command_or_raise("b 0x400000000000003e")
+            self.send_lldb_command_or_raise("c")
+
+            patterns = [
+                ["->  0x400000000000003e: call   2"],
+                ["->  0x4000000000000049"],
+                ["->  0x400000000000004b"],
+                ["->  0x4000000000000057: i32.const 42"],
+                ["->  0x4000000000000059: end"],
+                ["->  0x4000000000000040: call   3"],
+                ["->  0x4000000000000050"],
+                ["->  0x4000000000000052"],
+                ["->  0x4000000000000042: i32.add"],
+                ["->  0x4000000000000043: i32.const 1"],
+                ["->  0x4000000000000045: i32.add"],
+                ["->  0x4000000000000046: end"],
+            ]
+
+            for pattern in patterns:
+                self.send_lldb_command_or_raise("dis", patterns=pattern)
+                self.send_lldb_command_or_raise("si")
+
+            self.send_lldb_command_or_raise(
+                "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+            )
+
+
+class ThrowCatchTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/throw-catch.js")
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Tail call ref test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("b 0x4000000000000071")
+        self.send_lldb_command_or_raise("c")
+
+        patterns = [
+            ["->  0x4000000000000071: call   1"],
+            ["->  0x400000000000003c: try    i32"],
+            ["->  0x400000000000003e: throw  0"],
+            ["->  0x4000000000000044: i32.const 1"],
+            ["->  0x4000000000000046: end"],
+            ["->  0x4000000000000047: end"],
+            ["->  0x4000000000000073: call   3"],
+            ["->  0x400000000000004f: try    i32"],
+            ["->  0x4000000000000051: call   0"],
+            ["->  0x4000000000000035: throw  0"],
+            ["->  0x4000000000000055: i32.const 2"],
+            ["->  0x4000000000000057: end"],
+            ["->  0x4000000000000058: end"],
+            ["->  0x4000000000000075: i32.add"],
+            ["->  0x4000000000000076: try    i32"],
+            ["->  0x4000000000000078: call   6"],
+            ["->  0x400000000000006c: call   4"],
+            ["->  0x400000000000005b: call   2"],
+            ["->  0x400000000000004a: call   0"],
+            ["->  0x4000000000000035: throw  0"],
+            ["->  0x400000000000007c: i32.const 4"],
+            ["->  0x400000000000007e: end"],
+            ["->  0x400000000000007f: i32.add"],
+            ["->  0x4000000000000080: call   5"],
+            ["->  0x4000000000000060: try    i32"],
+            ["->  0x4000000000000062: call   4"],
+            ["->  0x400000000000005b: call   2"],
+            ["->  0x400000000000004a: call   0"],
+            ["->  0x4000000000000035: throw  0"],
+            ["->  0x4000000000000066: i32.const 3"],
+            ["->  0x4000000000000068: end"],
+            ["->  0x4000000000000069: end"],
+            ["->  0x4000000000000082: i32.add"],
+            ["->  0x4000000000000083: end"],
+        ]
+
+        for _ in range(10):
+            for pattern in patterns:
+                self.send_lldb_command_or_raise("dis", patterns=pattern)
+                self.send_lldb_command_or_raise("si")
+
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
+
+class ThrowCatchAllTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/throw-catch-all.js")
+
+        # FIXME: LLDB crashes on this test.
+        # try:
+        #     for _ in range(1):
+        #         self.stepTest()
+
+        # except Exception as e:
+        #     raise Exception(f"Throw catch_all test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("b 0x400000000000006e")
+        self.send_lldb_command_or_raise("c")
+
+        patterns = [
+            ["->  0x400000000000006e: call   1"],
+            ["->  0x400000000000003c: try    i32"],
+            ["->  0x400000000000003e: throw  0"],
+            ["->  0x4000000000000043: i32.const 1"],
+            ["->  0x4000000000000045: end"],
+            ["->  0x4000000000000046: end"],
+            ["->  0x4000000000000070: call   3"],
+            ["->  0x400000000000004e: try    i32"],
+            ["->  0x4000000000000050: call   0"],
+            ["->  0x4000000000000035: throw  0"],
+            ["->  0x4000000000000053: i32.const 2"],
+            ["->  0x4000000000000055: end"],
+            ["->  0x4000000000000056: end"],
+            ["->  0x4000000000000072: i32.add"],
+            ["->  0x4000000000000073: try    i32"],
+            ["->  0x4000000000000075: call   6"],
+            ["->  0x4000000000000069: call   4"],
+            ["->  0x4000000000000059: call   2"],
+            ["->  0x4000000000000049: call   0"],
+            ["->  0x4000000000000035: throw  0"],
+            ["->  0x4000000000000078: i32.const 4"],
+            ["->  0x400000000000007a: end"],
+            ["->  0x400000000000007b: i32.add"],
+            ["->  0x400000000000007c: call   5"],
+            ["->  0x400000000000005e: try    i32"],
+            ["->  0x4000000000000060: call   4"],
+            ["->  0x4000000000000059: call   2"],
+            ["->  0x4000000000000049: call   0"],
+            ["->  0x4000000000000035: throw  0"],
+            ["->  0x4000000000000063: i32.const 3"],
+            ["->  0x4000000000000065: end"],
+            ["->  0x4000000000000066: end"],
+            ["->  0x400000000000007e: i32.add"],
+            ["->  0x400000000000007f: end"],
+        ]
+
+        for _ in range(10):
+            for pattern in patterns:
+                self.send_lldb_command_or_raise("dis", patterns=pattern)
+                self.send_lldb_command_or_raise("si")
+
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
+
+class DelegateTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/delegate.js")
+
+        # FIXME: LLDB crashes on this test.
+        # try:
+        #     for _ in range(1):
+        #         self.stepTest()
+
+        # except Exception as e:
+        #     raise Exception(f"Delegate test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("b 0x40000000000000c6")
+        self.send_lldb_command_or_raise("c")
+
+        patterns = [
+            # Test function entry
+            ["->  0x40000000000000c6: call   1"],
+            # Function 1: delegate_to_parent - delegate depth 0
+            ["->  0x400000000000003e: try    i32"],
+            ["->  0x4000000000000040: try    i32"],
+            ["->  0x4000000000000042: throw  0"],
+            ["->  0x4000000000000048: i32.const 1"],  # caught by parent
+            ["->  0x400000000000004a: end"],
+            ["->  0x400000000000004b: end"],
+            # Back to test_all
+            ["->  0x40000000000000c8: call   2"],
+            # Function 2: delegate_to_grandparent - delegate depth 1
+            ["->  0x400000000000004e: try    i32"],
+            ["->  0x4000000000000050: try    i32"],
+            ["->  0x4000000000000052: try    i32"],
+            ["->  0x4000000000000054: throw  0"],
+            [
+                "->  0x4000000000000060: i32.const 2"
+            ],  # caught by grandparent (skipped parent)
+            ["->  0x4000000000000062: end"],
+            ["->  0x4000000000000063: end"],
+            # Back to test_all
+            ["->  0x40000000000000ca: i32.add"],
+            ["->  0x40000000000000cb: call   3"],
+            # Function 3: delegate_to_great_grandparent - delegate depth 2
+            ["->  0x4000000000000066: try    i32"],
+            ["->  0x4000000000000068: try    i32"],
+            ["->  0x400000000000006a: try    i32"],
+            ["->  0x400000000000006c: try    i32"],
+            ["->  0x400000000000006e: throw  0"],
+            [
+                "->  0x4000000000000080: i32.const 3"
+            ],  # caught by great-grandparent (skipped 2 levels)
+            ["->  0x4000000000000082: end"],
+            ["->  0x4000000000000083: end"],
+            # Back to test_all
+            ["->  0x40000000000000cd: i32.add"],
+            ["->  0x40000000000000ce: call   5"],
+            # Function 5: catches_delegated_from_callee
+            ["->  0x400000000000008f: try    i32"],
+            ["->  0x4000000000000091: call   4"],
+            # Function 4: no_handler_delegates_to_caller - delegates to caller
+            ["->  0x4000000000000086: try    i32"],
+            ["->  0x4000000000000088: throw  0"],
+            # Back to function 5's catch handler
+            [
+                "->  0x4000000000000095: i32.const 4"
+            ],  # caller catches delegated exception
+            ["->  0x4000000000000097: end"],
+            ["->  0x4000000000000098: end"],
+            # Back to test_all
+            ["->  0x40000000000000d0: i32.add"],
+            ["->  0x40000000000000d1: call   6"],
+            # Function 6: delegate_chain - multiple delegates in chain
+            ["->  0x400000000000009b: try    i32"],
+            ["->  0x400000000000009d: try    i32"],
+            ["->  0x400000000000009f: try    i32"],
+            ["->  0x40000000000000a1: throw  0"],
+            # Inner delegates to middle, middle delegates to outer
+            [
+                "->  0x40000000000000a9: i32.const 5"
+            ],  # outer catches after delegate chain
+            ["->  0x40000000000000ab: end"],
+            ["->  0x40000000000000ac: end"],
+            # Back to test_all
+            ["->  0x40000000000000d3: i32.add"],
+            ["->  0x40000000000000d4: call   7"],
+            # Function 7: delegate_past_catch_all - delegate skips catch_all
+            ["->  0x40000000000000af: try    i32"],
+            ["->  0x40000000000000b1: try    i32"],
+            ["->  0x40000000000000b3: try    i32"],
+            ["->  0x40000000000000b5: throw  0"],
+            [
+                "->  0x40000000000000c0: i32.const 6"
+            ],  # grandparent catches (skipped parent's catch_all)
+            ["->  0x40000000000000c2: end"],
+            ["->  0x40000000000000c3: end"],
+            # Back to test_all final add
+            ["->  0x40000000000000d6: i32.add"],
+            ["->  0x40000000000000d7: end"],
+        ]
+
+        for _ in range(10):
+            for pattern in patterns:
+                self.send_lldb_command_or_raise("dis", patterns=pattern)
+                self.send_lldb_command_or_raise("si")
+
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
+
+class RethrowTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/rethrow.js")
+
+        # FIXME: LLDB crashes on this test.
+        # try:
+        #     for _ in range(1):
+        #         self.stepTest()
+
+        # except Exception as e:
+        #     raise Exception(f"Rethrow test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("b 0x40000000000000b8")
+        self.send_lldb_command_or_raise("c")
+
+        patterns = [
+            # Test function entry
+            ["->  0x40000000000000b8: call   0"],
+            # Function 0: basic_rethrow_in_catch
+            ["->  0x4000000000000036: try    i32"],
+            ["->  0x4000000000000038: try    i32"],
+            ["->  0x400000000000003a: throw  0"],
+            ["->  0x400000000000003e: rethrow 0"],
+            ["->  0x4000000000000043: i32.const 1"],  # outer catches rethrown exception
+            ["->  0x4000000000000045: end"],
+            ["->  0x4000000000000046: end"],
+            # Back to test_all
+            ["->  0x40000000000000ba: call   1"],
+            # Function 1: rethrow_in_catch_all
+            ["->  0x4000000000000049: try    i32"],
+            ["->  0x400000000000004b: try    i32"],
+            ["->  0x400000000000004d: throw  0"],
+            ["->  0x4000000000000050: rethrow 0"],
+            [
+                "->  0x4000000000000055: i32.const 2"
+            ],  # outer catches rethrown from catch_all
+            ["->  0x4000000000000057: end"],
+            ["->  0x4000000000000058: end"],
+            # Back to test_all
+            ["->  0x40000000000000bc: i32.add"],
+            ["->  0x40000000000000bd: call   2"],
+            # Function 2: rethrow_after_partial_handling
+            ["->  0x400000000000005b: try    i32"],
+            ["->  0x400000000000005d: try    i32"],
+            ["->  0x400000000000005f: throw  0"],
+            ["->  0x4000000000000063: rethrow 0"],
+            [
+                "->  0x4000000000000068: i32.const 3"
+            ],  # outer catches rethrown after partial handling
+            ["->  0x400000000000006a: end"],
+            ["->  0x400000000000006b: end"],
+            # Back to test_all
+            ["->  0x40000000000000bf: i32.add"],
+            ["->  0x40000000000000c0: call   4"],
+            # Function 4: catches_rethrown_from_callee
+            ["->  0x400000000000007a: try    i32"],
+            ["->  0x400000000000007c: call   3"],
+            # Function 3: rethrows_to_caller
+            ["->  0x400000000000006e: try    i32"],
+            ["->  0x4000000000000070: throw  0"],
+            ["->  0x4000000000000074: rethrow 0"],
+            # Back to function 4's catch handler
+            [
+                "->  0x4000000000000080: i32.const 4"
+            ],  # caller catches rethrown exception
+            ["->  0x4000000000000082: end"],
+            ["->  0x4000000000000083: end"],
+            # Back to test_all
+            ["->  0x40000000000000c2: i32.add"],
+            ["->  0x40000000000000c3: call   5"],
+            # Function 5: rethrow_chain - multiple rethrows through nested handlers
+            ["->  0x4000000000000086: try    i32"],
+            ["->  0x4000000000000088: try    i32"],
+            ["->  0x400000000000008a: try    i32"],
+            ["->  0x400000000000008c: throw  0"],
+            ["->  0x4000000000000090: rethrow 0"],  # inner rethrows to middle
+            ["->  0x4000000000000095: rethrow 0"],  # middle rethrows to outer
+            [
+                "->  0x400000000000009a: i32.const 5"
+            ],  # outer catches after rethrow chain
+            ["->  0x400000000000009c: end"],
+            ["->  0x400000000000009d: end"],
+            # Back to test_all
+            ["->  0x40000000000000c5: i32.add"],
+            ["->  0x40000000000000c6: call   6"],
+            # Function 6: mixed_rethrow_with_catch_all
+            ["->  0x40000000000000a0: try    i32"],
+            ["->  0x40000000000000a2: try    i32"],
+            ["->  0x40000000000000a4: try    i32"],
+            ["->  0x40000000000000a6: throw  0"],
+            [
+                "->  0x40000000000000a9: rethrow 0"
+            ],  # rethrow from catch_all to middle catch
+            [
+                "->  0x40000000000000ae: rethrow 0"
+            ],  # rethrow from catch to outer catch_all
+            [
+                "->  0x40000000000000b2: i32.const 6"
+            ],  # outer catch_all catches rethrown exception
+            ["->  0x40000000000000b4: end"],
+            ["->  0x40000000000000b5: end"],
+            # Back to test_all final add
+            ["->  0x40000000000000c8: i32.add"],
+            ["->  0x40000000000000c9: end"],
+        ]
+
+        for _ in range(10):
+            for pattern in patterns:
+                self.send_lldb_command_or_raise("dis", patterns=pattern)
+                self.send_lldb_command_or_raise("si")
+
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
+
+class ThrowRefTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/throw-ref.js")
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Throw_ref test failed: {e}")
+
+    def test_function_iteration(self, patterns):
+        for pattern in patterns:
+            self.send_lldb_command_or_raise("si")
+            self.send_lldb_command_or_raise("dis", patterns=[pattern])
+
+    def test_function_with_breakpoint(self, entry_address, iterations):
+        # Set breakpoint at function entry
+        self.send_lldb_command_or_raise(f"b {entry_address}")
+        self.send_lldb_command_or_raise("c")
+
+        # Verify we're at function entry
+        entry_pattern = f"->  {entry_address}: block  exnref"
+        self.send_lldb_command_or_raise("dis", patterns=[entry_pattern])
+
+        # Run each iteration
+        for i, patterns in enumerate(iterations):
+            if i > 0:
+                # Continue to next iteration and verify we're at entry
+                self.send_lldb_command_or_raise("c")
+                self.send_lldb_command_or_raise("dis", patterns=[entry_pattern])
+
+            # Step through all patterns for this iteration
+            self.test_function_iteration(patterns)
+
+        # Remove breakpoint
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
+    def stepTest(self):
+        # Define all test patterns at the top for clarity
+        # Function 0: catch-throw_ref-0 - basic throw_ref
+        func0_iter1 = [
+            "->  0x40000000000000e6: try_table",
+            "->  0x40000000000000ec: throw  0",
+            "->  0x40000000000000f1: throw_ref",
+        ]
+
+        # Function 1: catch-throw_ref-1 - conditional throw_ref (param=0 throws, param=1 returns 23)
+        func1_iter1 = [
+            "->  0x40000000000000fb: try_table i32",
+            "->  0x4000000000000101: throw  0",
+            "->  0x4000000000000106: local.get 0",
+            "->  0x4000000000000108: i32.eqz",
+            "->  0x4000000000000109: if",
+            "->  0x400000000000010b: throw_ref",
+        ]
+        func1_iter2 = [
+            "->  0x40000000000000fb: try_table i32",
+            "->  0x4000000000000101: throw  0",
+            "->  0x4000000000000106: local.get 0",
+            "->  0x4000000000000108: i32.eqz",
+            "->  0x4000000000000109: if",
+            "->  0x400000000000010d: drop",
+            "->  0x400000000000010e: end",
+            "->  0x400000000000010f: i32.const 23",
+            "->  0x4000000000000111: end",
+        ]
+
+        # Function 2: catchall-throw_ref-0 - catch_all_ref with throw_ref
+        func2_iter1 = [
+            "->  0x400000000000011a: try_table exnref",
+            "->  0x400000000000011f: throw  0",
+            "->  0x4000000000000123: throw_ref",
+        ]
+
+        # Function 3: catchall-throw_ref-1 - conditional catch_all_ref
+        func3_iter1 = [
+            "->  0x400000000000012d: try_table i32",
+            "->  0x4000000000000132: throw  0",
+            "->  0x4000000000000137: local.get 0",
+            "->  0x4000000000000139: i32.eqz",
+            "->  0x400000000000013a: if",
+            "->  0x400000000000013c: throw_ref",
+        ]
+        func3_iter2 = [
+            "->  0x400000000000012d: try_table i32",
+            "->  0x4000000000000132: throw  0",
+            "->  0x4000000000000137: local.get 0",
+            "->  0x4000000000000139: i32.eqz",
+            "->  0x400000000000013a: if",
+            "->  0x400000000000013e: drop",
+            "->  0x400000000000013f: end",
+            "->  0x4000000000000140: i32.const 23",
+            "->  0x4000000000000142: end",
+        ]
+
+        # Function 4: throw_ref-nested - stores two different exceptions (3 iterations)
+        # Entry at 0x14b is verified by helper, patterns start from 0x14d
+        # Structure: Two sequential blocks (not nested), each catches a different exception
+        func4_nested_common = [
+            "->  0x400000000000014d: try_table i32",
+            "->  0x4000000000000153: throw  1",
+            "->  0x4000000000000158: local.set 1",
+            "->  0x400000000000015a: block  exnref",
+            "->  0x400000000000015c: try_table i32",
+            "->  0x4000000000000162: throw  0",
+            "->  0x4000000000000167: local.set 2",
+            "->  0x4000000000000169: local.get 0",
+            "->  0x400000000000016b: i32.const 0",
+            "->  0x400000000000016d: i32.eq",
+            "->  0x400000000000016e: if",
+        ]
+        func4_iter1 = func4_nested_common + [
+            "->  0x4000000000000170: local.get 1",
+            "->  0x4000000000000172: throw_ref",
+        ]
+        func4_iter2 = func4_nested_common + [
+            "->  0x4000000000000174: local.get 0",
+            "->  0x4000000000000176: i32.const 1",
+            "->  0x4000000000000178: i32.eq",
+            "->  0x4000000000000179: if",
+            "->  0x400000000000017b: local.get 2",
+            "->  0x400000000000017d: throw_ref",
+        ]
+        func4_iter3 = func4_nested_common + [
+            "->  0x4000000000000174: local.get 0",
+            "->  0x4000000000000176: i32.const 1",
+            "->  0x4000000000000178: i32.eq",
+            "->  0x4000000000000179: if",
+            "->  0x400000000000017f: i32.const 23",
+            "->  0x4000000000000181: end",
+        ]
+
+        # Function 5: throw_ref-recatch - catch, store, re-throw_ref, re-catch
+        # Two sequential try_table blocks
+        func5_iter1 = [
+            "->  0x400000000000018c: try_table i32",
+            "->  0x4000000000000192: throw  0",
+            "->  0x4000000000000197: local.set 1",
+            "->  0x4000000000000199: block  exnref",
+            "->  0x400000000000019b: try_table i32",
+            "->  0x40000000000001a1: local.get 0",
+            "->  0x40000000000001a3: i32.eqz",
+            "->  0x40000000000001a4: if",
+            "->  0x40000000000001a6: local.get 1",
+            "->  0x40000000000001a8: throw_ref",
+            "->  0x40000000000001af: drop",
+            "->  0x40000000000001b0: i32.const 23",
+            "->  0x40000000000001b2: end",
+        ]
+        func5_iter2 = [
+            "->  0x400000000000018c: try_table i32",
+            "->  0x4000000000000192: throw  0",
+            "->  0x4000000000000197: local.set 1",
+            "->  0x4000000000000199: block  exnref",
+            "->  0x400000000000019b: try_table i32",
+            "->  0x40000000000001a1: local.get 0",
+            "->  0x40000000000001a3: i32.eqz",
+            "->  0x40000000000001a4: if",
+            "->  0x40000000000001aa: i32.const 42",
+            "->  0x40000000000001ac: end",
+            "->  0x40000000000001ad: return",
+        ]
+
+        # Function 6: throw_ref-stack-polymorphism - tests polymorphic throw_ref
+        func6_iter1 = [
+            "->  0x40000000000001bd: try_table f64",
+            "->  0x40000000000001c3: throw  0",
+            "->  0x40000000000001c8: local.set 0",
+            "->  0x40000000000001ca: i32.const 1",
+            "->  0x40000000000001cc: local.get 0",
+            "->  0x40000000000001ce: throw_ref",
+        ]
+
+        # Execute all test functions
+        self.test_function_with_breakpoint("0x40000000000000e4", [func0_iter1])
+        self.test_function_with_breakpoint(
+            "0x40000000000000f9", [func1_iter1, func1_iter2]
+        )
+        self.test_function_with_breakpoint("0x4000000000000118", [func2_iter1])
+        self.test_function_with_breakpoint(
+            "0x400000000000012b", [func3_iter1, func3_iter2]
+        )
+        self.test_function_with_breakpoint(
+            "0x400000000000014b", [func4_iter1, func4_iter2, func4_iter3]
+        )
+        self.test_function_with_breakpoint(
+            "0x400000000000018a", [func5_iter1, func5_iter2]
+        )
+        self.test_function_with_breakpoint("0x40000000000001bb", [func6_iter1])
+
+
+class TryTableTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/try-table.js")
+
+        # FIXME: LLDB crashes on this test.
+        # try:
+        #     for _ in range(1):
+        #         self.stepTest()
+
+        # except Exception as e:
+        #     raise Exception(f"Try table test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("b 0x40000000000000aa")
+        self.send_lldb_command_or_raise("c")
+
+        patterns = [
+            ["->  0x40000000000000aa: call   1"],
+            ["->  0x400000000000003f: block"],
+            ["->  0x4000000000000041: try_table i32"],
+            ["->  0x4000000000000047: throw  0"],
+            ["->  0x400000000000004e: i32.const 1"],
+            ["->  0x4000000000000050: end"],
+            ["->  0x40000000000000ac: call   3"],
+            ["->  0x4000000000000058: block"],
+            ["->  0x400000000000005a: try_table i32"],
+            ["->  0x4000000000000060: call   0"],
+            ["->  0x4000000000000038: throw  0"],
+            ["->  0x4000000000000065: i32.const 2"],
+            ["->  0x4000000000000067: end"],
+            ["->  0x40000000000000ae: i32.add"],
+            ["->  0x40000000000000af: block"],
+            ["->  0x40000000000000b1: try_table i32"],
+            ["->  0x40000000000000b7: call   6"],
+            ["->  0x4000000000000081: call   4"],
+            ["->  0x400000000000006a: call   2"],
+            ["->  0x4000000000000053: call   0"],
+            ["->  0x4000000000000038: throw  0"],
+            ["->  0x40000000000000c8: drop"],
+            ["->  0x40000000000000c9: i32.const 4"],
+            ["->  0x40000000000000cb: i32.const 3"],
+            ["->  0x40000000000000cd: i32.add"],
+            ["->  0x40000000000000ce: call   5"],
+            ["->  0x400000000000006f: block"],
+            ["->  0x4000000000000071: try_table i32"],
+            ["->  0x4000000000000077: call   4"],
+            ["->  0x400000000000006a: call   2"],
+            ["->  0x4000000000000053: call   0"],
+            ["->  0x4000000000000038: throw  0"],
+            ["->  0x400000000000007c: i32.const 3"],
+            ["->  0x400000000000007e: end"],
+            ["->  0x40000000000000d0: i32.add"],
+            ["->  0x40000000000000d1: call   7"],
+            ["->  0x4000000000000086: block"],
+            ["->  0x4000000000000088: try_table"],
+            ["->  0x400000000000008d: throw  0"],
+            ["->  0x4000000000000094: i32.const 5"],
+            ["->  0x4000000000000096: end"],
+            ["->  0x40000000000000d3: i32.add"],
+            ["->  0x40000000000000d4: call   8"],
+            ["->  0x4000000000000099: block"],
+            ["->  0x400000000000009b: try_table"],
+            ["->  0x40000000000000a0: call   0"],
+            ["->  0x4000000000000038: throw  0"],
+            ["->  0x40000000000000a5: i32.const 6"],
+            ["->  0x40000000000000a7: end"],
+            ["->  0x40000000000000d6: i32.add"],
+            ["->  0x40000000000000d7: end"],
+        ]
+
+        for _ in range(10):
+            for pattern in patterns:
+                self.send_lldb_command_or_raise("dis", patterns=pattern)
+                self.send_lldb_command_or_raise("si")
+
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2254,11 +2254,18 @@
 		FF0F568D2E33437C002A232A /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932F5BD90822A1C700736975 /* JavaScriptCore.framework */; };
 		FF0F569A2E3348CA002A232A /* testwasmdebugger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF0F56992E3348CA002A232A /* testwasmdebugger.cpp */; };
 		FF0F569C2E334C90002A232A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF0F569B2E334C90002A232A /* Foundation.framework */; };
+		FF1344662EB3F2A600940C00 /* ExtGCTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF1344652EB3F2A600940C00 /* ExtGCTests.cpp */; };
+		FF18EBC52EA5C73E00185CFA /* TestUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF18EBC42EA5C73E00185CFA /* TestUtilities.cpp */; };
 		FF1D8E872CE7C9BF00E211DD /* VerifierSlotVisitorScope.h in Headers */ = {isa = PBXBuildFile; fileRef = FF1D8E862CE7C9BF00E211DD /* VerifierSlotVisitorScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF31EC8E2D947F0500D9CB81 /* DFGCloneHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FF31EC8B2D947F0500D9CB81 /* DFGCloneHelper.h */; };
 		FF3394AA2CB4944E004AFF6A /* RegExpSubstringGlobalAtomCache.h in Headers */ = {isa = PBXBuildFile; fileRef = FF3394A92CB4941B004AFF6A /* RegExpSubstringGlobalAtomCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF6A4D7E2E663147001FB92C /* WasmModuleDebugInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = FF6A4D7D2E663147001FB92C /* WasmModuleDebugInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFA2E02A2EA16F37006661A3 /* ControlFlowTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0222EA16F37006661A3 /* ControlFlowTests.cpp */; };
+		FFA2E02C2EA16F37006661A3 /* SpecialTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0242EA16F37006661A3 /* SpecialTests.cpp */; };
+		FFA2E02D2EA16F37006661A3 /* BinaryTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0212EA16F37006661A3 /* BinaryTests.cpp */; };
+		FFA2E02E2EA16F37006661A3 /* MemoryTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0232EA16F37006661A3 /* MemoryTests.cpp */; };
+		FFA2E02F2EA16F37006661A3 /* UnaryTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0262EA16F37006661A3 /* UnaryTests.cpp */; };
 		FFB951142C043CA800349750 /* OrderedHashTableHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB951132C043CA800349750 /* OrderedHashTableHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFB963922E38302B0069A70F /* WasmBreakpointManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB9638F2E38302B0069A70F /* WasmBreakpointManager.h */; };
 		FFCC9A412BDD7C4700C75345 /* OrderedHashTable.h in Headers */ = {isa = PBXBuildFile; fileRef = FFCC9A402BDD7C4700C75345 /* OrderedHashTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6293,6 +6300,8 @@
 		FF0F56942E33437C002A232A /* testwasmdebugger */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = testwasmdebugger; sourceTree = BUILT_PRODUCTS_DIR; };
 		FF0F56992E3348CA002A232A /* testwasmdebugger.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = testwasmdebugger.cpp; sourceTree = "<group>"; };
 		FF0F569B2E334C90002A232A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		FF1344652EB3F2A600940C00 /* ExtGCTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExtGCTests.cpp; sourceTree = "<group>"; };
+		FF18EBC42EA5C73E00185CFA /* TestUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestUtilities.cpp; sourceTree = "<group>"; };
 		FF1D8E862CE7C9BF00E211DD /* VerifierSlotVisitorScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VerifierSlotVisitorScope.h; sourceTree = "<group>"; };
 		FF27D0E42BE2AEDB00397A8C /* OrderedHashTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OrderedHashTable.cpp; sourceTree = "<group>"; };
 		FF31EC8B2D947F0500D9CB81 /* DFGCloneHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DFGCloneHelper.h; path = dfg/DFGCloneHelper.h; sourceTree = "<group>"; };
@@ -6301,6 +6310,12 @@
 		FF3394AB2CB4948E004AFF6A /* RegExpSubstringGlobalAtomCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RegExpSubstringGlobalAtomCache.cpp; sourceTree = "<group>"; };
 		FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WaiterListManager.h; sourceTree = "<group>"; };
 		FF6A4D7D2E663147001FB92C /* WasmModuleDebugInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmModuleDebugInfo.h; sourceTree = "<group>"; };
+		FFA2E0212EA16F37006661A3 /* BinaryTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BinaryTests.cpp; sourceTree = "<group>"; };
+		FFA2E0222EA16F37006661A3 /* ControlFlowTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ControlFlowTests.cpp; sourceTree = "<group>"; };
+		FFA2E0232EA16F37006661A3 /* MemoryTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryTests.cpp; sourceTree = "<group>"; };
+		FFA2E0242EA16F37006661A3 /* SpecialTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SpecialTests.cpp; sourceTree = "<group>"; };
+		FFA2E0252EA16F37006661A3 /* TestUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestUtilities.h; sourceTree = "<group>"; };
+		FFA2E0262EA16F37006661A3 /* UnaryTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnaryTests.cpp; sourceTree = "<group>"; };
 		FFB77C2828FF561B00F3C55B /* WaiterListManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WaiterListManager.cpp; sourceTree = "<group>"; };
 		FFB951132C043CA800349750 /* OrderedHashTableHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashTableHelper.h; sourceTree = "<group>"; };
 		FFB9638F2E38302B0069A70F /* WasmBreakpointManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmBreakpointManager.h; sourceTree = "<group>"; };
@@ -10493,9 +10508,25 @@
 			path = offlineasm;
 			sourceTree = "<group>";
 		};
+		FFA2E0292EA16F37006661A3 /* tests */ = {
+			isa = PBXGroup;
+			children = (
+				FFA2E0212EA16F37006661A3 /* BinaryTests.cpp */,
+				FFA2E0222EA16F37006661A3 /* ControlFlowTests.cpp */,
+				FF1344652EB3F2A600940C00 /* ExtGCTests.cpp */,
+				FFA2E0232EA16F37006661A3 /* MemoryTests.cpp */,
+				FFA2E0242EA16F37006661A3 /* SpecialTests.cpp */,
+				FF18EBC42EA5C73E00185CFA /* TestUtilities.cpp */,
+				FFA2E0252EA16F37006661A3 /* TestUtilities.h */,
+				FFA2E0262EA16F37006661A3 /* UnaryTests.cpp */,
+			);
+			path = tests;
+			sourceTree = "<group>";
+		};
 		FFD49E662E276CA10083E383 /* debugger */ = {
 			isa = PBXGroup;
 			children = (
+				FFA2E0292EA16F37006661A3 /* tests */,
 				FF0F56992E3348CA002A232A /* testwasmdebugger.cpp */,
 				FFB963902E38302B0069A70F /* WasmBreakpointManager.cpp */,
 				FFB9638F2E38302B0069A70F /* WasmBreakpointManager.h */,
@@ -13724,7 +13755,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FFA2E02D2EA16F37006661A3 /* BinaryTests.cpp in Sources */,
+				FFA2E02A2EA16F37006661A3 /* ControlFlowTests.cpp in Sources */,
+				FF1344662EB3F2A600940C00 /* ExtGCTests.cpp in Sources */,
+				FFA2E02E2EA16F37006661A3 /* MemoryTests.cpp in Sources */,
+				FFA2E02C2EA16F37006661A3 /* SpecialTests.cpp in Sources */,
+				FF18EBC52EA5C73E00185CFA /* TestUtilities.cpp in Sources */,
 				FF0F569A2E3348CA002A232A /* testwasmdebugger.cpp in Sources */,
+				FFA2E02F2EA16F37006661A3 /* UnaryTests.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -111,6 +111,7 @@
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/threads/BinarySemaphore.h>
 #include <wtf/threads/Signals.h>
 

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -63,6 +63,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <JavaScriptCore/ThunkGenerator.h>
 #include <JavaScriptCore/VMThreadContext.h>
 #include <JavaScriptCore/WasmContext.h>
+#include <JavaScriptCore/WasmDebugServerUtilities.h>
 #include <JavaScriptCore/WeakGCMap.h>
 #include <JavaScriptCore/WriteBarrier.h>
 #include <wtf/BumpPointerAllocator.h>
@@ -1111,6 +1112,13 @@ public:
     bool isWasmStopWorldActive() { return m_isWasmStopWorldActive; }
     void setIsWasmStopWorldActive(bool isWasmStopWorldActive) { m_isWasmStopWorldActive = isWasmStopWorldActive; }
 
+#if ENABLE(WEBASSEMBLY)
+    bool takeStepIntoWasmCall() { return m_stepIntoEvent.take(Wasm::StepIntoEvent::StepIntoCall); }
+    void setStepIntoWasmCall() { m_stepIntoEvent.set(Wasm::StepIntoEvent::StepIntoCall); }
+    bool takeStepIntoWasmThrow() { return m_stepIntoEvent.take(Wasm::StepIntoEvent::StepIntoThrow); }
+    void setStepIntoWasmThrow() { m_stepIntoEvent.set(Wasm::StepIntoEvent::StepIntoThrow); }
+#endif
+
 private:
     VM(VMType, HeapType, WTF::RunLoop* = nullptr, bool* success = nullptr);
     static VM*& sharedInstanceInternal();
@@ -1237,6 +1245,10 @@ private:
     bool m_executionForbiddenOnTermination { false };
     bool m_isDebuggerHookInjected { false };
     bool m_isWasmStopWorldActive { false };
+
+#if ENABLE(WEBASSEMBLY)
+    Wasm::StepIntoEvent m_stepIntoEvent;
+#endif
 
     Lock m_loopHintExecutionCountLock;
     UncheckedKeyHashMap<const JSInstruction*, std::pair<unsigned, std::unique_ptr<uintptr_t>>> m_loopHintExecutionCounts;

--- a/Source/JavaScriptCore/shell/CMakeLists.txt
+++ b/Source/JavaScriptCore/shell/CMakeLists.txt
@@ -83,9 +83,22 @@ if (DEVELOPER_MODE)
     set(testdfg_PRIVATE_INCLUDE_DIRECTORIES ${jsc_PRIVATE_INCLUDE_DIRECTORIES})
     set(testdfg_FRAMEWORKS ${jsc_FRAMEWORKS})
 
-    set(testwasmdebugger_SOURCES ../wasm/debugger/testwasmdebugger.cpp)
+    set(testwasmdebugger_SOURCES
+        ../wasm/debugger/testwasmdebugger.cpp
+
+        ../wasm/debugger/tests/BinaryTests.cpp
+        ../wasm/debugger/tests/ControlFlowTests.cpp
+        ../wasm/debugger/tests/ExtGCTests.cpp
+        ../wasm/debugger/tests/MemoryTests.cpp
+        ../wasm/debugger/tests/SpecialTests.cpp
+        ../wasm/debugger/tests/TestUtilities.cpp
+        ../wasm/debugger/tests/UnaryTests.cpp
+    )
     set(testwasmdebugger_DEFINITIONS ${jsc_PRIVATE_DEFINITIONS})
-    set(testwasmdebugger_PRIVATE_INCLUDE_DIRECTORIES ${jsc_PRIVATE_INCLUDE_DIRECTORIES})
+    set(testwasmdebugger_PRIVATE_INCLUDE_DIRECTORIES
+        ${jsc_PRIVATE_INCLUDE_DIRECTORIES}
+        ${JAVASCRIPTCORE_DIR}/wasm/debugger/tests
+    )
     set(testwasmdebugger_FRAMEWORKS ${jsc_FRAMEWORKS})
 
     WEBKIT_EXECUTABLE_DECLARE(testapi)

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -436,6 +436,7 @@ public:
     FunctionCodeIndex functionIndex() const { return m_functionIndex; }
     void setEntrypoint(CodePtr<WasmEntryPtrTag>);
     const uint8_t* bytecode() const { return m_bytecode; }
+    const uint8_t* bytecodeEnd() const { return m_bytecodeEnd; }
     const uint8_t* metadata() const { return m_metadata.span().data(); }
 
     unsigned numLocals() const { return m_numLocals; }

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -560,7 +560,7 @@ public:
                     bool isControlFlowInstruction = Wasm::isControlFlowInstructionWithExtGC(currentOpcode, [this]() {
                         return m_parser->currentExtendedOpcode();
                     });
-                    if (!isControlFlowInstruction)
+                    if (!isControlFlowInstruction || currentOpcode == AnnotatedSelect)
                         RECORD_NEXT_INSTRUCTION(curPC(), nextPC());
                 }
             }
@@ -2154,7 +2154,7 @@ void IPIntGenerator::resolveEntryTarget(unsigned index, IPIntLocation loc)
         // write delta PC and delta MC
         IPInt::BlockMetadata md = { static_cast<int32_t>(loc.pc - src.pc), static_cast<int32_t>(loc.mc - src.mc) };
         WRITE_TO_METADATA(m_metadata->m_metadata.mutableSpan().data() + src.mc, md, IPInt::BlockMetadata);
-        RECORD_NEXT_INSTRUCTION(src.pc, loc.pc);
+        RECORD_NEXT_INSTRUCTION(src.pc, loc.pc); // FIXME: coalescing sequential blocks - should update instead of adding
     }
     if (control.isLoop) {
         for (auto& src : control.m_awaitingBranchTarget) {

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -39,7 +39,7 @@ struct ModuleInformation;
 struct FunctionDebugInfo;
 
 Expected<std::unique_ptr<FunctionIPIntMetadataGenerator>, String> parseAndCompileMetadata(std::span<const uint8_t>, const TypeDefinition&, ModuleInformation&, FunctionCodeIndex functionIndex);
-void parseForDebugInfo(std::span<const uint8_t>, const TypeDefinition&, ModuleInformation&, FunctionCodeIndex, FunctionDebugInfo&);
+JS_EXPORT_PRIVATE void parseForDebugInfo(std::span<const uint8_t>, const TypeDefinition&, ModuleInformation&, FunctionCodeIndex, FunctionDebugInfo&);
 
 } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmPlan.h
@@ -74,7 +74,7 @@ public:
     virtual void work() = 0;
     virtual bool multiThreaded() const = 0;
 
-    void waitForCompletion();
+    JS_EXPORT_PRIVATE void waitForCompletion();
     // Returns true if it cancelled the plan.
     bool tryRemoveContextAndCancelIfLast(VM&);
 

--- a/Source/JavaScriptCore/wasm/debugger/README.md
+++ b/Source/JavaScriptCore/wasm/debugger/README.md
@@ -110,7 +110,7 @@ Virtual Memory Layout:
 - **[DONE]** `continue`: Resume WebAssembly execution
 - **[DONE]** `breakpoint set`: Set breakpoints at virtual addresses
 - **[DONE]** `step over`: Step over function calls
-- **[DONE]** `step in`: Step into function calls
+- **[DONE]** `step in`: Step into function calls and exception handlers
 - **[DONE]** `step out`: Step out of current function
 - **[DONE]** `step instruction`: Single step through bytecode
 
@@ -126,17 +126,41 @@ Virtual Memory Layout:
 
 ## Testing
 
-### Automated Tests
+### Unit Tests
+
+The debugger includes comprehensive unit tests that validate debug info generation
+for WebAssembly opcodes:
 
 ```bash
-# Run WebAssembly debugger unit tests
+# Run unit tests via WebKit build system
 ./Tools/Scripts/run-javascriptcore-tests --testwasmdebugger
+```
 
+**Opcode Coverage (Base OpType):**
+- **[DONE]** Special Ops (FOR_EACH_WASM_SPECIAL_OP)
+- **[DONE]** Control Flow Ops (FOR_EACH_WASM_CONTROL_FLOW_OP)
+- **[DONE]** Unary Ops (FOR_EACH_WASM_UNARY_OP)
+- **[DONE]** Binary Ops (FOR_EACH_WASM_BINARY_OP)
+- **[DONE]** Memory Load Ops (FOR_EACH_WASM_MEMORY_LOAD_OP)
+- **[DONE]** Memory Store Ops (FOR_EACH_WASM_MEMORY_STORE_OP)
+
+**Extended Opcode Coverage:**
+- **[TODO]** Ext1OpType (FOR_EACH_WASM_EXT1_OP)
+- **[PARTIAL]** ExtGCOpType (FOR_EACH_WASM_GC_OP) - 2 control flow ops fully tested (BrOnCast, BrOnCastFail), 29 non-control-flow ops have stub tests
+- **[TODO]** ExtAtomicOpType (FOR_EACH_WASM_EXT_ATOMIC_OP)
+- **[TODO]** ExtSIMDOpType (FOR_EACH_WASM_EXT_SIMD_OP)
+
+### Integration Tests
+
+The `JSTests/wasm/debugger` includes a comprehensive test framework with auto-discovery,
+parallel execution, and process isolation capabilities:
+
+```bash
 # Run comprehensive test framework with LLDB and wasm debugger
 python3 JSTests/wasm/debugger/test-wasm-debugger.py
 ```
 
-The `JSTests/wasm/debugger` includes a comprehensive test framework with auto-discovery, parallel execution, and process isolation capabilities. For details, see [JSTests/wasm/debugger/README.md](../../../../JSTests/wasm/debugger/README.md).
+For details, see [JSTests/wasm/debugger/README.md](../../../../JSTests/wasm/debugger/README.md).
 
 ### Manual Testing
 
@@ -178,17 +202,17 @@ See [RWI_ARCHITECTURE.md](./RWI_ARCHITECTURE.md) for complete setup instructions
 - **Solution**: Extend debugging protocol to expose WASM operand stack contents with proper type information
 - **Benefits**: Complete variable inspection during debugging, better understanding of WASM execution state
 
-### Step Into Call Instructions
+### Extended Opcode Test Coverage
 
-- **Issue**: Step into breakpoints not implemented for CallIndirect instructions
-- **Location**: `WasmExecutionHandler.cpp:298-299`
-- **Solution**: Add step into breakpoint support for indirect function calls
-
-### Control Flow Debug Info Validation
-
-- **Issue**: Not all WebAssembly control flow bytecodes may have correct debug info collection for next instruction mappings
-- **Location**: `WasmIPIntGenerator.cpp` - Various control flow instruction handlers
-- **Solution**: Systematically test each control flow bytecode (block, loop, if, try, catch, br, br_if, br_table, call, call_indirect, return, etc.) to ensure corresponding debug info is collected correctly for accurate stepping behavior
+- **Issue**: Current unit tests only cover base OpType opcodes; ExtGCOpType has partial coverage with stub implementations
+- **Complete Coverage**:
+  - ExtGCOpType control flow: BrOnCast, BrOnCastFail (fully tested)
+- **Partial Coverage**:
+  - ExtGCOpType non-control-flow: 29 opcodes have stub tests that need proper implementation
+- **Missing Coverage**:
+  - Ext1OpType (table operations, saturated truncation)
+  - ExtAtomicOpType (atomic operations)
+  - ExtSIMDOpType (SIMD operations)
 
 ### Client Session Management
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
@@ -44,6 +44,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+class CalleeBits;
 class VM;
 class CallFrame;
 class JSWebAssemblyInstance;
@@ -122,8 +123,9 @@ public:
     void trackModule(Module&);
     void untrackModule(Module&);
 
-    bool interruptRequested() const;
     void setInterruptBreakpoint(JSWebAssemblyInstance*, IPIntCallee*);
+    void setStepIntoBreakpointForCall(VM&, CalleeBits, JSWebAssemblyInstance*);
+    void setStepIntoBreakpointForThrow(VM&, JSWebAssemblyInstance*);
     bool stopCode(CallFrame*, JSWebAssemblyInstance*, IPIntCallee*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*);
 
     void setPort(uint64_t port) { m_port = port; }

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
@@ -34,14 +34,71 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "JSWebAssemblyInstance.h"
 #include "NativeCallee.h"
 #include "WasmCallee.h"
+#include "WasmIPIntGenerator.h"
+#include "WasmOps.h"
 #include "WasmVirtualAddress.h"
 #include <cstring>
-#include <span>
+#include <wtf/DataLog.h>
 #include <wtf/Vector.h>
-#include <wtf/text/StringView.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace JSC {
 namespace Wasm {
+
+String stringToHex(StringView str)
+{
+    StringBuilder result;
+    CString utf8 = str.utf8();
+    for (size_t i = 0; i < utf8.length(); ++i)
+        result.append(hex(static_cast<uint8_t>(utf8.data()[i]), 2, Lowercase));
+    return result.toString();
+}
+
+void logWasmLocalValue(size_t index, const JSC::IPInt::IPIntLocal& local, const Wasm::Type& localType)
+{
+    dataLog("  Local[", index, "] (", localType, "): ");
+
+    switch (localType.kind) {
+    case TypeKind::I32:
+        dataLogLn("i32=", local.i32, " [index ", index, "]");
+        break;
+    case TypeKind::I64:
+        dataLogLn("i64=", local.i64, " [index ", index, "]");
+        break;
+    case TypeKind::F32:
+        dataLogLn("f32=", local.f32, " [index ", index, "]");
+        break;
+    case TypeKind::F64:
+        dataLogLn("f64=", local.f64, " [index ", index, "]");
+        break;
+    case TypeKind::V128:
+        dataLogLn("v128=0x", hex(local.v128.u64x2[1], 16, Lowercase), hex(local.v128.u64x2[0], 16, Lowercase), " [index ", index, "]");
+        break;
+    case TypeKind::Ref:
+    case TypeKind::RefNull:
+        dataLogLn("ref=", local.ref, " [index ", index, "]");
+        break;
+    default:
+        dataLogLn("raw=0x", hex(local.i64, 16, Lowercase), " [index ", index, "]");
+        break;
+    }
+}
+
+uint64_t parseHex(StringView str, uint64_t defaultValue)
+{
+    if (str.isEmpty())
+        return defaultValue;
+    auto result = parseInteger<uint64_t>(str, 16);
+    return result.value_or(defaultValue);
+}
+
+uint32_t parseDecimal(StringView str, uint32_t defaultValue)
+{
+    if (str.isEmpty())
+        return defaultValue;
+    auto result = parseInteger<uint32_t>(str, 10);
+    return result.value_or(defaultValue);
+}
 
 // Splits a string using a sequence of delimiters with exact matching.
 // Returns empty vector if any delimiter is missing.

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -68,7 +68,8 @@ public:
     void handleThreadStopInfo(StringView packet);
     void reset();
 
-    void setInterruptBreakpoint(JSWebAssemblyInstance*, IPIntCallee*);
+    void setBreakpointAtEntry(JSWebAssemblyInstance*, IPIntCallee*, Breakpoint::Type);
+    void setBreakpointAtPC(JSWebAssemblyInstance*, FunctionCodeIndex, Breakpoint::Type, const uint8_t* pc);
     void setBreakpoint(StringView packet);
     void removeBreakpoint(StringView packet);
 
@@ -162,10 +163,9 @@ private:
     friend class DebugServer;
 
     enum class DebuggerState : uint8_t {
-        ReplyFailed,
-        Replied,
-        StopRequested,
-        ContinueRequested,
+        Replied, // Received LLDB message replied.
+        StopRequested, // Requested mutator to stop.
+        ContinueRequested, // Requested mutator to continue.
     };
 
     enum class MutatorState : uint8_t {
@@ -173,10 +173,7 @@ private:
         Stopped,
     };
 
-    void stopOneTimeBreakpoint(StopReason&&);
-    void stopRegularBreakpoint(StopReason&&);
-    template<typename LockType>
-    void stopImpl(LockType&);
+    void stopImpl(StopReason&&);
 
     void sendStopReply(AbstractLocker&);
     void sendReplyOK();

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.cpp
@@ -46,7 +46,7 @@ namespace Wasm {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ModuleDebugInfo);
 
-Vector<uint32_t>* FunctionDebugInfo::findNextInstructions(uint32_t offset)
+UncheckedKeyHashSet<uint32_t>* FunctionDebugInfo::findNextInstructions(uint32_t offset)
 {
     auto itr = offsetToNextInstructions.find(offset);
     return itr == offsetToNextInstructions.end() ? nullptr : &itr->value;
@@ -55,7 +55,7 @@ Vector<uint32_t>* FunctionDebugInfo::findNextInstructions(uint32_t offset)
 void FunctionDebugInfo::addNextInstruction(uint32_t offset, uint32_t nextInstruction)
 {
     dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleDebugInfo] addNextInstruction offset:", RawHex(offset), " nextInstruction:", RawHex(nextInstruction));
-    offsetToNextInstructions.add(offset, Vector<uint32_t>()).iterator->value.append(nextInstruction);
+    offsetToNextInstructions.add(offset, UncheckedKeyHashSet<uint32_t>()).iterator->value.add(nextInstruction);
 }
 
 void FunctionDebugInfo::addLocalType(Type type)

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.h
@@ -29,6 +29,7 @@
 
 #include <wtf/DataLog.h>
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -40,11 +41,11 @@ struct ModuleInformation;
 class FunctionCodeIndex;
 
 struct FunctionDebugInfo {
-    Vector<uint32_t>* findNextInstructions(uint32_t offset);
+    JS_EXPORT_PRIVATE UncheckedKeyHashSet<uint32_t>* findNextInstructions(uint32_t offset);
     void addNextInstruction(uint32_t offset, uint32_t nextInstruction);
     void addLocalType(Type);
 
-    using OffsetToNextInstructions = UncheckedKeyHashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+    using OffsetToNextInstructions = UncheckedKeyHashMap<uint32_t, UncheckedKeyHashSet<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
     OffsetToNextInstructions offsetToNextInstructions;
     Vector<Type> locals;
 };

--- a/Source/JavaScriptCore/wasm/debugger/tests/BinaryTests.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/BinaryTests.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestUtilities.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <wtf/DataLog.h>
+#include <wtf/text/MakeString.h>
+
+using namespace JSC;
+using namespace JSC::Wasm;
+
+namespace WasmDebugInfoTest {
+
+static bool testI32BinaryOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x01, // [0] i32.const 1
+        0x41, 0x02, // [2] i32.const 2
+        static_cast<uint8_t>(opcode), // [4] binary op
+        0x1a, // [5] drop
+        0x0b // [6] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 5 } },
+    });
+}
+
+static bool testI64BinaryOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x42, 0x01, // [0] i64.const 1
+        0x42, 0x02, // [2] i64.const 2
+        static_cast<uint8_t>(opcode), // [4] binary op
+        0x1a, // [5] drop
+        0x0b // [6] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 5 } },
+    });
+}
+
+static bool testF32BinaryOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x43, 0x00, 0x00, 0x80, 0x3f, // [0] f32.const 1.0
+        0x43, 0x00, 0x00, 0x00, 0x40, // [5] f32.const 2.0
+        static_cast<uint8_t>(opcode), // [10] binary op
+        0x1a, // [11] drop
+        0x0b // [12] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 5 } },
+        { 5, { 10 } },
+        { 10, { 11 } },
+    });
+}
+
+static bool testF64BinaryOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, // [0] f64.const 1.0
+        0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, // [9] f64.const 2.0
+        static_cast<uint8_t>(opcode), // [18] binary op
+        0x1a, // [19] drop
+        0x0b // [20] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 9 } },
+        { 9, { 18 } },
+        { 18, { 19 } },
+    });
+}
+
+void testAllBinaryOps()
+{
+    dataLogLn("=== Testing All Binary Ops Coverage ===");
+    dataLogLn("Total binary opcodes in WasmOps.h: ", TOTAL_BINARY_OPS);
+
+    int opsTested = 0;
+    int opsSucceeded = 0;
+
+#define TEST_BINARY_OP(name, id, b3, inc, leftType, rightType, resultType) \
+    do { \
+        opsTested++; \
+        testsRun++; \
+        bool success = false; \
+        constexpr auto leftTypeStr = #leftType##_s; \
+        if (leftTypeStr == "I32"_s) { \
+            success = testI32BinaryOpcode(static_cast<OpType>(id)); \
+        } else if (leftTypeStr == "I64"_s) { \
+            success = testI64BinaryOpcode(static_cast<OpType>(id)); \
+        } else if (leftTypeStr == "F32"_s) { \
+            success = testF32BinaryOpcode(static_cast<OpType>(id)); \
+        } else if (leftTypeStr == "F64"_s) { \
+            success = testF64BinaryOpcode(static_cast<OpType>(id)); \
+        } \
+        if (success) { \
+            opsSucceeded++; \
+            testsPassed++; \
+        } else { \
+            testsFailed++; \
+            dataLogLn("FAILED: ", #name, " binary opcode test"); \
+        } \
+    } while (0);
+
+    FOR_EACH_WASM_BINARY_OP(TEST_BINARY_OP)
+
+#undef TEST_BINARY_OP
+
+    TEST_ASSERT(opsTested == TOTAL_BINARY_OPS, makeString("Tested all "_s, String::number(TOTAL_BINARY_OPS), " binary ops"_s).utf8().data());
+    TEST_ASSERT(opsSucceeded == TOTAL_BINARY_OPS, makeString("All "_s, String::number(TOTAL_BINARY_OPS), " binary ops passed strict validation"_s).utf8().data());
+
+    dataLogLn("  Successfully tested with strict mapping validation: ", opsSucceeded, " / ", opsTested, " binary ops");
+    dataLogLn("All binary ops coverage testing completed");
+}
+
+} // namespace WasmDebugInfoTest
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/ControlFlowTests.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ControlFlowTests.cpp
@@ -1,0 +1,434 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestUtilities.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <wtf/DataLog.h>
+
+using namespace JSC;
+using namespace JSC::Wasm;
+
+namespace WasmDebugInfoTest {
+
+static bool testUnreachableOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x00, // [0] unreachable
+        0x0b // [1] end
+    };
+
+    // IPIntGenerator::didParseOpcode() skips debug info recording for unreachable blocks.
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+    return module.parseAndVerifyDebugInfo(opcode, { });
+}
+
+static bool testNopOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x01, // [0] nop
+        0x41, 0x2a, // [1] i32.const 42
+        0x1a, // [3] drop
+        0x0b // [4] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    // nop, drop, and end are not in the mappings because they're handled directly
+    // in ExecutionHandler::step() by setting breakpoint at currentPC + 1
+    return module.parseAndVerifyDebugInfo(opcode, { { 1, { 3 } } });
+}
+static bool testDropOpcode(OpType opcode) { return testNopOpcode(opcode); }
+static bool testEndOpcode(OpType opcode) { return testNopOpcode(opcode); }
+
+static bool testBlockOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x02, 0x40, // [0] block $b0
+        0x41, 0x01, // [2] i32.const 1
+        0x04, 0x40, // [4] if
+        0x0c, 0x01, // [6] br 1 (to after $b0)
+        0x0b, // [8] end if
+        0x41, 0x00, // [9] i32.const 0
+        0x04, 0x40, // [11] if
+        0x0c, 0x01, // [13] br 1 (to after $b0)
+        0x0b, // [15] end if
+        0x0b, // [16] end $b0
+
+        0x02, 0x40, // [17] block $b1
+        0x41, 0x01, // [19] i32.const 1
+        0x04, 0x40, // [21] if
+        0x0c, 0x01, // [23] br 1 (to after $b1)
+        0x0b, // [25] end if
+        0x41, 0x00, // [26] i32.const 0
+        0x04, 0x40, // [28] if
+        0x0c, 0x01, // [30] br 1 (to after $b1)
+        0x0b, // [32] end if
+        0x0b, // [33] end $b1
+
+        0x0b // [34] end function
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 6, 9 } },
+        { 6, { 19 } }, // br 1 jumps past $b0 to first instruction in $b1
+        { 9, { 11 } },
+        { 11, { 13, 16 } },
+        { 13, { 19 } }, // br 1 jumps past $b0 to first instruction in $b1
+        { 17, { 19 } },
+        { 19, { 21 } },
+        { 21, { 23, 26 } },
+        { 23, { 34 } }, // br 1 jumps past $b1 to end function
+        { 26, { 28 } },
+        { 28, { 30, 33 } },
+        { 30, { 34 } }, // br 1 jumps past $b1 to end function
+    });
+}
+static bool testBrOpcode(OpType opcode) { return testBlockOpcode(opcode); }
+
+static bool testLoopOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x00, // [0] i32.const 0
+        0x21, 0x00, // [2] local.set 0 (counter)
+        0x03, 0x40, // [4] loop (void)
+        0x20, 0x00, // [6] local.get 0
+        0x41, 0x03, // [8] i32.const 3
+        0x49, // [10] i32.lt_s
+        0x04, 0x40, // [11] if (void)
+        0x20, 0x00, // [13] local.get 0
+        0x41, 0x01, // [15] i32.const 1
+        0x6a, // [17] i32.add
+        0x21, 0x00, // [18] local.set 0
+        0x0c, 0x01, // [20] br 1 (back to loop start)
+        0x0b, // [22] end if
+        0x0b, // [23] end loop
+        0x0b // [24] end function
+    };
+
+    SourceModule module = createWasmModuleWithLocals(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 6 } },
+        { 6, { 8 } },
+        { 8, { 10 } },
+        { 10, { 11 } },
+        { 11, { 13, 23 } },
+        { 13, { 15 } },
+        { 15, { 17 } },
+        { 17, { 18 } },
+        { 18, { 20 } },
+        { 20, { 4 } },
+    });
+}
+
+static bool testIfOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x01, // [0] i32.const 1
+        0x04, 0x40, // [2] if (void)
+        0x41, 0x2a, // [4] i32.const 42
+        0x1a, // [6] drop
+        0x05, // [7] else
+        0x41, 0x63, // [8] i32.const 99
+        0x1a, // [10] drop
+        0x0b, // [11] end if
+        0x0b // [12] end function
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4, 8 } },
+        { 4, { 6 } },
+        { 7, { 12 } },
+        { 8, { 10 } },
+    });
+}
+static bool testElseOpcode(OpType opcode) { return testIfOpcode(opcode); }
+
+static bool testBrIfOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x02, 0x40, // [0] block $b0
+        0x41, 0x01, // [2] i32.const 1
+        0x0d, 0x00, // [4] br_if 0 (break to after block $b0 if true)
+        0x41, 0x2a, // [6] i32.const 42
+        0x1a, // [8] drop
+        0x0b, // [9] end block $b0
+        0x02, 0x40, // [10] block $b1
+        0x41, 0x00, // [12] i32.const 0
+        0x0d, 0x00, // [14] br_if 0 (break to after block $b1 if true)
+        0x41, 0x63, // [16] i32.const 99
+        0x1a, // [18] drop
+        0x0b, // [19] end block $b1
+        0x0b // [20] end function
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 6, 12 } }, // br_if: continue (6) or jump past $b0 end to $b1 start (12)
+        { 6, { 8 } },
+        { 10, { 12 } },
+        { 12, { 14 } },
+        { 14, { 16, 20 } }, // br_if: continue (16) or jump to function end (20)
+        { 16, { 18 } },
+    });
+}
+
+static bool testBrTableOpcode(OpType opcode)
+{
+    // Create a br_table with distinct branch targets
+    Vector<uint8_t> functionBody = {
+        0x02, 0x40, // [0] block $b0
+        0x02, 0x40, // [2] block $b1
+        0x02, 0x40, // [4] block $b2
+        0x20, 0x00, // [6] local.get 0 (param: i32 selector)
+        0x0e, 0x02, 0x02, 0x01, 0x00, // [8] br_table [2, 1] default:0
+        // index=0 → label 2 (after $b0), index=1 → label 1 (after $b1), index>=2 → label 0 (after $b2)
+        0x0b, // [13] end $b2
+        0x41, 0x2a, // [14] i32.const 42 (after $b2)
+        0x1a, // [16] drop
+        0x0b, // [17] end $b1
+        0x41, 0x63, // [18] i32.const 99 (after $b1)
+        0x1a, // [20] drop
+        0x0b, // [21] end $b0
+        0x0b // [22] end function
+    };
+
+    SourceModule module = SourceModule::create()
+        .withFunctionType({ 0x7f }, { }) // [i32] -> []
+        .withFunctionBody(functionBody)
+        .build();
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        // FIXME: Block coalescing (offsets 0→2→4→6) should ideally result in { 0, { 6 } } only,
+        // but exit handlers in resolveExitTarget/coalesceControlFlow use ADD mode instead of UPDATE mode,
+        // accumulating all intermediate targets {2, 4, 6}. This doesn't break debugger functionality
+        // but could be optimized to use UPDATE mode like resolveEntryTarget does.
+        { 0, { 2, 4, 6 } },
+        { 6, { 8 } },
+        { 8, { 14, 18, 22 } },
+        { 14, { 16 } },
+        { 18, { 20 } },
+    });
+}
+
+static bool testReturnOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x01, // [0] i32.const 1
+        0x04, 0x40, // [2] if
+        0x0f, // [4] return
+        0x0b, // [5] end if
+        0x0b // [6] end function
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    // This is handled directly in ExecutionHandler::step().
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4, 6 } },
+    });
+}
+
+static bool testSelectOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x2a, // [0] i32.const 42
+        0x41, 0x63, // [2] i32.const 99
+        0x41, 0x01, // [4] i32.const 1
+        0x1b, // [6] select
+        0x1a, // [7] drop
+        0x0b // [8] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    // This is handled directly in ExecutionHandler::step().
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 6 } },
+    });
+}
+
+static bool testAnnotatedSelectOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x2a, // [0] i32.const 42
+        0x41, 0x63, // [2] i32.const 99
+        0x41, 0x01, // [4] i32.const 1
+        0x1c, 0x01, 0x7f, // [6] select (result i32)
+        0x1a, // [9] drop
+        0x0b // [10] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 6 } },
+        { 6, { 9 } },
+    });
+}
+
+static bool testBrOnNullOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x02, 0x40, // [0] block $b0
+        0xd0, 0x6f, // [2] ref.null extern
+        0xd5, 0x00, // [4] br_on_null 0
+        0x1a, // drop the non-null ref - offset 6
+        0xd0, 0x6f, // [7] ref.null extern
+        0xd5, 0x00, // [9] br_on_null 0
+        0x1a, // drop the non-null ref - offset 11
+        0x0b, // [12] end $b0
+
+        0x02, 0x40, // [13] block $b1
+        0xd0, 0x6f, // [15] ref.null extern
+        0xd5, 0x00, // [17] br_on_null 0
+        0x1a, // drop the non-null ref - offset 19
+        0xd0, 0x6f, // [20] ref.null extern
+        0xd5, 0x00, // [22] br_on_null 0
+        0x1a, // drop the non-null ref - offset 24
+        0x0b, // [25] end $b1
+
+        0x0b // [26] end function
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 6, 15 } },
+        { 7, { 9 } },
+        { 9, { 11, 15 } },
+        { 13, { 15 } },
+        { 15, { 17 } },
+        { 17, { 19, 26 } },
+        { 20, { 22 } },
+        { 22, { 24, 26 } },
+    });
+}
+
+static bool testBrOnNonNullOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x02, 0x40, // [0] block $b0
+        0x20, 0x00, // [2] local.get 0 (funcref param)
+        0xd6, 0x00, // [4] br_on_non_null 0
+        0x20, 0x00, // [6] local.get 0
+        0xd6, 0x00, // [8] br_on_non_null 0
+        0x0b, // [10] end $b0
+
+        0x02, 0x40, // [11] block $b1
+        0x20, 0x00, // [13] local.get 0
+        0xd6, 0x00, // [15] br_on_non_null 0
+        0x20, 0x00, // [17] local.get 0
+        0xd6, 0x00, // [19] br_on_non_null 0
+        0x0b, // [21] end $b1
+
+        0x0b // [22] end function
+    };
+
+    SourceModule module = SourceModule::create()
+        .withFunctionType({ toLEB128(TypeKind::Funcref) }, { })
+        .withFunctionBody(functionBody)
+        .build();
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 6, 13 } },
+        { 6, { 8 } },
+        { 8, { 10, 13 } },
+        { 11, { 13 } },
+        { 13, { 15 } },
+        { 15, { 17, 22 } },
+        { 17, { 19 } },
+        { 19, { 21, 22 } },
+    });
+}
+
+// Exception handling opcodes require runtime testing because genericUnwind() dynamically
+// computes handler PCs. See runtime tests in JSTests/wasm/debugger/resources/wasm/:
+//   throw-catch.js, throw-catch-all.js, rethrow.js, throw-ref.js, delegate.js, try-table.js
+static bool testTryOpcode(OpType) { return true; }
+static bool testCatchOpcode(OpType) { return true; }
+static bool testThrowOpcode(OpType) { return true; }
+static bool testRethrowOpcode(OpType) { return true; }
+static bool testThrowRefOpcode(OpType) { return true; }
+static bool testDelegateOpcode(OpType) { return true; }
+static bool testCatchAllOpcode(OpType) { return true; }
+static bool testTryTableOpcode(OpType) { return true; }
+
+void testAllControlFlowOps()
+{
+    dataLogLn("=== Testing All Control Flow Ops Coverage ===");
+    dataLogLn("Total control flow opcodes in WasmOps.h: ", TOTAL_CONTROL_OPS);
+
+    int opsTested = 0;
+    int opsSucceeded = 0;
+
+#define TEST_CONTROL_FLOW_OP(name, id, b3, inc) \
+    do { \
+        opsTested++; \
+        testsRun++; \
+        if (test##name##Opcode(OpType::name)) { \
+            opsSucceeded++; \
+            testsPassed++; \
+        } else { \
+            testsFailed++; \
+            dataLogLn("FAILED: ", #name, " opcode test"); \
+        } \
+    } while (0);
+
+    FOR_EACH_WASM_CONTROL_FLOW_OP(TEST_CONTROL_FLOW_OP)
+
+#undef TEST_CONTROL_FLOW_OP
+
+    dataLogLn("  Successfully tested: ", opsSucceeded, " / ", opsTested, " control flow ops");
+    dataLogLn("All control flow ops coverage testing completed");
+}
+
+} // namespace WasmDebugInfoTest
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExtGCTests.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExtGCTests.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestUtilities.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <wtf/DataLog.h>
+#include <wtf/text/MakeString.h>
+
+using namespace JSC;
+using namespace JSC::Wasm;
+
+namespace WasmDebugInfoTest {
+
+static bool testBrOnCastOpcode(ExtGCOpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x02, 0x01, // [0] block (result i32 i31ref)
+        0x41, 0x2a, // [2] i32.const 42
+        0x20, 0x00, // [4] local.get 0 (anyref param)
+        0xfb, 0x18, // [6] br_on_cast (ExtGC opcode 0x18)
+        0x03, // [8] flags (0x03 = both nullable)
+        0x00, // [9] branch depth 0
+        0x6e, // [10] source ref type: anyref
+        0x6c, // [11] target ref type: i31ref
+        0x41, 0x07, // [12] i32.const 7
+        0xd0, 0x6c, // [14] ref.null i31ref
+        0x0c, 0x00, // [16] br 0
+        0x0b, // [18] end block
+        0x1a, // [19] drop
+        0x0b // [20] end function
+    };
+
+    SourceModule module = SourceModule::create()
+        .withFunctionType({ 0x6e }, { 0x7f }) // Type 0: (anyref) -> i32
+        .withAdditionalType({ }, { 0x7f, 0x6c }) // Type 1: () -> (i32, i31ref)
+        .withFunctionBody(functionBody)
+        .build();
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 6 } },
+        { 6, { 12, 19 } },
+        { 12, { 14 } },
+        { 14, { 16 } },
+        { 16, { 19 } }
+    });
+}
+
+static bool testBrOnCastFailOpcode(ExtGCOpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x02, 0x01, // [0] block (result i32 anyref)
+        0x41, 0x2a, // [2] i32.const 42
+        0x20, 0x00, // [4] local.get 0 (anyref param)
+        0xfb, 0x19, // [6] br_on_cast_fail (ExtGC opcode 0x19)
+        0x03, // [8] flags (0x03 = both nullable)
+        0x00, // [9] branch depth 0
+        0x6e, // [10] source ref type: anyref
+        0x6c, // [11] target ref type: i31ref
+        0x1a, // [12] drop (i31ref from successful cast)
+        0x41, 0x07, // [13] i32.const 7
+        0x20, 0x00, // [15] local.get 0 (push anyref again)
+        0x0c, 0x00, // [17] br 0
+        0x0b, // [19] end block
+        0x1a, // [20] drop (anyref)
+        0x0b // [21] end function
+    };
+
+    SourceModule module = SourceModule::create()
+        .withFunctionType({ 0x6e }, { 0x7f }) // Type 0: (anyref) -> i32
+        .withAdditionalType({ }, { 0x7f, 0x6e }) // Type 1: () -> (i32, anyref)
+        .withFunctionBody(functionBody)
+        .build();
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 6 } },
+        { 6, { 12, 20 } },
+        { 13, { 15 } },
+        { 15, { 17 } },
+        { 17, { 20 } }
+    });
+}
+
+// FIXME: Implement proper test for ExtGCOpType::name
+#define DEFINE_EXTGC_OP_TEST(name) \
+static bool test##name##Opcode(ExtGCOpType) \
+{ \
+    return true; \
+}
+
+DEFINE_EXTGC_OP_TEST(StructNew)
+DEFINE_EXTGC_OP_TEST(StructNewDefault)
+DEFINE_EXTGC_OP_TEST(StructGet)
+DEFINE_EXTGC_OP_TEST(StructGetS)
+DEFINE_EXTGC_OP_TEST(StructGetU)
+DEFINE_EXTGC_OP_TEST(StructSet)
+DEFINE_EXTGC_OP_TEST(ArrayNew)
+DEFINE_EXTGC_OP_TEST(ArrayNewDefault)
+DEFINE_EXTGC_OP_TEST(ArrayNewFixed)
+DEFINE_EXTGC_OP_TEST(ArrayNewData)
+DEFINE_EXTGC_OP_TEST(ArrayNewElem)
+DEFINE_EXTGC_OP_TEST(ArrayGet)
+DEFINE_EXTGC_OP_TEST(ArrayGetS)
+DEFINE_EXTGC_OP_TEST(ArrayGetU)
+DEFINE_EXTGC_OP_TEST(ArraySet)
+DEFINE_EXTGC_OP_TEST(ArrayLen)
+DEFINE_EXTGC_OP_TEST(ArrayFill)
+DEFINE_EXTGC_OP_TEST(ArrayCopy)
+DEFINE_EXTGC_OP_TEST(ArrayInitData)
+DEFINE_EXTGC_OP_TEST(ArrayInitElem)
+DEFINE_EXTGC_OP_TEST(RefTest)
+DEFINE_EXTGC_OP_TEST(RefTestNull)
+DEFINE_EXTGC_OP_TEST(RefCast)
+DEFINE_EXTGC_OP_TEST(RefCastNull)
+DEFINE_EXTGC_OP_TEST(AnyConvertExtern)
+DEFINE_EXTGC_OP_TEST(ExternConvertAny)
+DEFINE_EXTGC_OP_TEST(RefI31)
+DEFINE_EXTGC_OP_TEST(I31GetS)
+DEFINE_EXTGC_OP_TEST(I31GetU)
+
+#undef DEFINE_EXTGC_OP_TEST
+
+void testAllExtGCOps()
+{
+    dataLogLn("=== Testing All ExtGC Ops Coverage ===");
+    dataLogLn("Total ExtGC opcodes in WasmOps.h: ", TOTAL_EXTGC_OPS);
+
+    int opsTested = 0;
+    int opsSucceeded = 0;
+
+#define TEST_EXTGC_OP(name, id, b3, inc) do { \
+        opsTested++; \
+        testsRun++; \
+        if (test##name##Opcode(ExtGCOpType::name)) { \
+            opsSucceeded++; \
+            testsPassed++; \
+        } else { \
+            testsFailed++; \
+            dataLogLn("FAILED: ", #name, " ExtGC opcode test"); \
+        } \
+    } while (0);
+
+    FOR_EACH_WASM_GC_OP(TEST_EXTGC_OP)
+
+#undef TEST_EXTGC_OP
+
+    TEST_ASSERT(opsTested == TOTAL_EXTGC_OPS,
+        makeString("Tested all "_s, String::number(TOTAL_EXTGC_OPS), " ExtGC ops"_s).utf8().data());
+    TEST_ASSERT(opsSucceeded == TOTAL_EXTGC_OPS,
+        makeString("All "_s, String::number(TOTAL_EXTGC_OPS), " ExtGC ops completed"_s).utf8().data());
+
+    dataLogLn("  Successfully tested: ", opsSucceeded, " / ", opsTested, " ExtGC ops");
+    dataLogLn("All ExtGC ops coverage testing completed");
+}
+
+} // namespace WasmDebugInfoTest
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/MemoryTests.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/MemoryTests.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestUtilities.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <span>
+#include <wtf/DataLog.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringView.h>
+
+using namespace JSC;
+using namespace JSC::Wasm;
+
+namespace WasmDebugInfoTest {
+
+static bool testMemoryLoadOpcode(OpType opcode, std::span<const char>)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x00, // [0] i32.const 0 (address)
+        static_cast<uint8_t>(opcode), // [2] load opcode
+        0x00, // [3] alignment (LEB128)
+        0x00, // [4] offset (LEB128)
+        0x1a, // [5] drop
+        0x0b // [6] end
+    };
+
+    SourceModule module = createWasmModuleWithMemory(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 5 } } });
+}
+
+static bool testMemoryStoreOpcode(OpType opcode, std::span<const char> valueType)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x00, // [0] i32.const 0 (address)
+    };
+
+    StringView valueTypeStr(valueType);
+    if (valueTypeStr.startsWith("I32"_s)) {
+        functionBody.appendVector(Vector<uint8_t> {
+            0x41, 0x2a, // [2] i32.const 42
+            static_cast<uint8_t>(opcode), // [4] store
+            0x00, // [5] alignment
+            0x00, // [6] offset
+            0x0b // [7] end
+        });
+
+        SourceModule module = createWasmModuleWithMemory(functionBody);
+
+        return module.parseAndVerifyDebugInfo(opcode, {
+            { 0, { 2 } },
+            { 2, { 4 } },
+            { 4, { 7 } }
+        });
+    } else if (valueTypeStr.startsWith("I64"_s)) {
+        functionBody.appendVector(Vector<uint8_t> {
+            0x42, 0x2a, // [2] i64.const 42
+            static_cast<uint8_t>(opcode), // [4] store
+            0x00, // [5] alignment
+            0x00, // [6] offset
+            0x0b // [7] end
+        });
+
+        SourceModule module = createWasmModuleWithMemory(functionBody);
+
+        return module.parseAndVerifyDebugInfo(opcode, {
+            { 0, { 2 } },
+            { 2, { 4 } },
+            { 4, { 7 } }
+        });
+    } else if (valueTypeStr.startsWith("F32"_s)) {
+        functionBody.appendVector(Vector<uint8_t> {
+            0x43, 0x00, 0x00, 0x80, 0x3f, // [2] f32.const 1.0
+            static_cast<uint8_t>(opcode), // [7] store
+            0x00, // [8] alignment
+            0x00, // [9] offset
+            0x0b // [10] end
+        });
+
+        SourceModule module = createWasmModuleWithMemory(functionBody);
+
+        return module.parseAndVerifyDebugInfo(opcode, {
+            { 0, { 2 } },
+            { 2, { 7 } },
+            { 7, { 10 } }
+        });
+    } else { // F64
+        functionBody.appendVector(Vector<uint8_t> {
+            0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, // [2] f64.const 1.0
+            static_cast<uint8_t>(opcode), // [11] store
+            0x00, // [12] alignment
+            0x00, // [13] offset
+            0x0b // [14] end
+        });
+
+        SourceModule module = createWasmModuleWithMemory(functionBody);
+
+        return module.parseAndVerifyDebugInfo(opcode, {
+            { 0, { 2 } },
+            { 2, { 11 } },
+            { 11, { 14 } }
+        });
+    }
+}
+
+void testAllMemoryOps()
+{
+    dataLogLn("=== Testing All Memory Ops Coverage ===");
+    dataLogLn("Total memory load opcodes in WasmOps.h: ", TOTAL_MEMORY_LOAD_OPS);
+    dataLogLn("Total memory store opcodes in WasmOps.h: ", TOTAL_MEMORY_STORE_OPS);
+
+    int loadOpsTested = 0;
+    int loadOpsSucceeded = 0;
+    int storeOpsTested = 0;
+    int storeOpsSucceeded = 0;
+
+#define TEST_MEMORY_LOAD_OP(name, opcode, b3type, width, type) \
+    do { \
+        loadOpsTested++; \
+        testsRun++; \
+        if (testMemoryLoadOpcode(OpType::name, #type)) { \
+            loadOpsSucceeded++; \
+            testsPassed++; \
+        } else { \
+            testsFailed++; \
+            dataLogLn("FAILED: ", #name, " memory load test"); \
+        } \
+    } while (0);
+
+    FOR_EACH_WASM_MEMORY_LOAD_OP(TEST_MEMORY_LOAD_OP)
+
+#undef TEST_MEMORY_LOAD_OP
+
+#define TEST_MEMORY_STORE_OP(name, opcode, b3type, width, type) \
+    do { \
+        storeOpsTested++; \
+        testsRun++; \
+        if (testMemoryStoreOpcode(OpType::name, #type)) { \
+            storeOpsSucceeded++; \
+            testsPassed++; \
+        } else { \
+            testsFailed++; \
+            dataLogLn("FAILED: ", #name, " memory store test"); \
+        } \
+    } while (0);
+
+    FOR_EACH_WASM_MEMORY_STORE_OP(TEST_MEMORY_STORE_OP)
+
+#undef TEST_MEMORY_STORE_OP
+
+    TEST_ASSERT(loadOpsTested == TOTAL_MEMORY_LOAD_OPS, makeString("Tested all "_s, String::number(TOTAL_MEMORY_LOAD_OPS), " memory load ops"_s).utf8().data());
+    TEST_ASSERT(loadOpsSucceeded == TOTAL_MEMORY_LOAD_OPS, makeString("All "_s, String::number(TOTAL_MEMORY_LOAD_OPS), " memory load ops passed strict validation"_s).utf8().data());
+
+    TEST_ASSERT(storeOpsTested == TOTAL_MEMORY_STORE_OPS, makeString("Tested all "_s, String::number(TOTAL_MEMORY_STORE_OPS), " memory store ops"_s).utf8().data());
+    TEST_ASSERT(storeOpsSucceeded == TOTAL_MEMORY_STORE_OPS, makeString("All "_s, String::number(TOTAL_MEMORY_STORE_OPS), " memory store ops passed strict validation"_s).utf8().data());
+
+    dataLogLn("  Successfully tested with strict mapping validation: ", loadOpsSucceeded, " / ", loadOpsTested, " memory load ops");
+    dataLogLn("  Successfully tested with strict mapping validation: ", storeOpsSucceeded, " / ", storeOpsTested, " memory store ops");
+    dataLogLn("All memory ops coverage testing completed");
+}
+
+} // namespace WasmDebugInfoTest
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/SpecialTests.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/SpecialTests.cpp
@@ -1,0 +1,480 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestUtilities.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <wtf/DataLog.h>
+#include <wtf/text/MakeString.h>
+
+using namespace JSC;
+using namespace JSC::Wasm;
+
+namespace WasmDebugInfoTest {
+
+static bool testI32ConstOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x2a, // [0] i32.const 42
+        0x1a, // [2] drop
+        0x0b // [3] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, { { 0, { 2 } } });
+}
+
+static bool testI64ConstOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x42, 0x2a, // [0] i64.const 42
+        0x1a, // [2] drop
+        0x0b // [3] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, { { 0, { 2 } } });
+}
+
+static bool testF32ConstOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x43, 0x00, 0x00, 0x80, 0x3f, // [0] f32.const 1.0
+        0x1a, // [5] drop
+        0x0b // [6] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, { { 0, { 5 } } });
+}
+
+static bool testF64ConstOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, // [0] f64.const 1.0
+        0x1a, // [9] drop
+        0x0b // [10] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, { { 0, { 9 } } });
+}
+
+static bool testGetLocalOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x2a, // [0] i32.const 42
+        0x21, 0x00, // [2] local.set 0
+        0x20, 0x00, // [4] local.get 0
+        0x1a, // [6] drop
+        0x0b // [7] end
+    };
+
+    SourceModule module = createWasmModuleWithLocals(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 6 } }
+    });
+}
+
+static bool testSetLocalOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x2a, // [0] i32.const 42
+        0x21, 0x00, // [2] local.set 0
+        0x0b // [4] end
+    };
+
+    SourceModule module = createWasmModuleWithLocals(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } }
+    });
+}
+
+static bool testTeeLocalOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x2a, // [0] i32.const 42
+        0x22, 0x00, // [2] local.tee 0
+        0x1a, // [4] drop
+        0x0b // [5] end
+    };
+
+    SourceModule module = createWasmModuleWithLocals(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } }
+    });
+}
+
+static bool testGetGlobalOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x23, 0x00, // [0] global.get 0
+        0x1a, // [2] drop
+        0x0b // [3] end
+    };
+
+    SourceModule module = createWasmModuleWithGlobals(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, { { 0, { 2 } } });
+}
+
+static bool testSetGlobalOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x2a, // [0] i32.const 42
+        0x24, 0x00, // [2] global.set 0
+        0x0b // [4] end
+    };
+
+    SourceModule module = createWasmModuleWithGlobals(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } }
+    });
+}
+
+static bool testTableGetOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x00, // [0] i32.const 0
+        0x25, 0x00, // [2] table.get 0
+        0x1a, // [4] drop
+        0x0b // [5] end
+    };
+
+    SourceModule module = createWasmModuleWithTable(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } }
+    });
+}
+
+static bool testTableSetOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x00, // [0] i32.const 0 (index)
+        0xd0, 0x70, // [2] ref.null func
+        0x26, 0x00, // [4] table.set 0
+        0x0b // [6] end
+    };
+
+    SourceModule module = createWasmModuleWithTable(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 6 } }
+    });
+}
+
+static bool testCurrentMemoryOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x3f, 0x00, // [0] memory.size
+        0x1a, // [2] drop
+        0x0b // [3] end
+    };
+
+    SourceModule module = createWasmModuleWithMemory(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, { { 0, { 2 } } });
+}
+
+static bool testGrowMemoryOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x01, // [0] i32.const 1
+        0x40, 0x00, // [2] memory.grow
+        0x1a, // [4] drop
+        0x0b // [5] end
+    };
+
+    SourceModule module = createWasmModuleWithMemory(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } }
+    });
+}
+
+static bool testRefNullOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0xd0, 0x70, // [0] ref.null func
+        0x1a, // [2] drop
+        0x0b // [3] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, { { 0, { 2 } } });
+}
+
+static bool testRefIsNullOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0xd0, 0x70, // [0] ref.null func
+        0xd1, // [2] ref.is_null
+        0x1a, // [3] drop
+        0x0b // [4] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 3 } },
+    });
+}
+
+static bool testRefFuncOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0xd2, 0x00, // [0] ref.func 0
+        0x0b // [2] end
+    };
+
+    SourceModule module = SourceModule::create()
+        .withFunctionType({ }, { toLEB128(TypeKind::Funcref) })
+        .withFunctionBody(functionBody)
+        .build();
+
+    return module.parseAndVerifyDebugInfo(opcode, { { 0, { 2 } } });
+}
+
+static bool testRefEqOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0xd0, 0x6d, // [0] ref.null eq
+        0xd0, 0x6d, // [2] ref.null eq
+        0xd3, // [4] ref.eq
+        0x0b // [5] end
+    };
+
+    SourceModule module = SourceModule::create()
+        .withFunctionType({ }, { toLEB128(TypeKind::I32) })
+        .withFunctionBody(functionBody)
+        .build();
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 5 } },
+    });
+}
+
+static bool testRefAsNonNullOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x20, 0x00, // [0] local.get 0
+        0xd4, // [2] ref.as_non_null
+        0x0b // [3] end
+    };
+
+    SourceModule module = SourceModule::create()
+        .withFunctionType({ toLEB128(TypeKind::Funcref) }, { toLEB128(TypeKind::Funcref) })
+        .withFunctionBody(functionBody)
+        .build();
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 3 } },
+    });
+}
+
+// Note: Call instructions have two debugging behaviors:
+// 1. Step-over: Maps call instruction -> next instruction (tested here via offsetToNextInstructions)
+// 2. Step-into: Handled at runtime in ExecutionHandler::step() when target is IPInt mode
+// This test verifies the step-over case where we map the call to the next instruction.
+static bool testCallOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x2a, // [0] i32.const 42
+        0x10, 0x00, // [2] call 0 (recursive call)
+        0x1a, // [4] drop
+        0x0b // [5] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+    });
+}
+
+static bool testCallIndirectOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x2a, // [0] i32.const 42 (function argument)
+        0x41, 0x00, // [2] i32.const 0 (table index)
+        0x11, 0x00, 0x00, // [4] call_indirect type=0 table=0
+        0x0b // [7] end (function returns the i32 result)
+    };
+
+    SourceModule module = SourceModule::create()
+        .withFunctionType({ toLEB128(TypeKind::I32) }, { toLEB128(TypeKind::I32) })
+        .withTable()
+        .withFunctionBody(functionBody)
+        .build();
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+        { 4, { 7 } },
+    });
+}
+
+static bool testCallRefOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0xd2, 0x00, // [0] ref.func 0
+        0x14, 0x00, // [2] call_ref type=0
+        0x0b // [4] end
+    };
+
+    SourceModule module = SourceModule::create()
+        .withFunctionType({ }, { toLEB128(TypeKind::I32) })
+        .withFunctionBody(functionBody)
+        .build();
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } },
+    });
+}
+
+static bool testTailCallOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x2a, // [0] i32.const 42
+        0x12, 0x00, // [2] tail_call 0 (recursive tail call)
+        0x0b // [4] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    // Tail calls return to caller's caller, not to the next instruction
+    // Step-over is handled at runtime by setting breakpoint at caller
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } }
+    });
+}
+
+static bool testTailCallIndirectOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x2a, // [0] i32.const 42 (function argument)
+        0x41, 0x00, // [2] i32.const 0 (table index)
+        0x13, 0x00, 0x00, // [4] tail_call_indirect type=0 table=0
+        0x0b // [7] end
+    };
+
+    SourceModule module = SourceModule::create()
+        .withFunctionType({ toLEB128(TypeKind::I32) }, { toLEB128(TypeKind::I32) })
+        .withTable()
+        .withFunctionBody(functionBody)
+        .build();
+
+    // Tail calls return to caller's caller, not to the next instruction
+    // Step-over is handled at runtime by setting breakpoint at caller
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 4 } }
+    });
+}
+
+static bool testTailCallRefOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0xd2, 0x00, // [0] ref.func 0
+        0x15, 0x00, // [2] tail_call_ref type=0
+        0x0b // [4] end
+    };
+
+    SourceModule module = SourceModule::create()
+        .withFunctionType({ }, { toLEB128(TypeKind::I32) })
+        .withFunctionBody(functionBody)
+        .build();
+
+    // Tail calls return to caller's caller, not to the next instruction
+    // Step-over is handled at runtime by setting breakpoint at caller
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } }
+    });
+}
+
+void testAllSpecialOps()
+{
+    dataLogLn("=== Testing All Special Ops Coverage ===");
+    dataLogLn("Total special opcodes in WasmOps.h: ", TOTAL_SPECIAL_OPS);
+
+    int opsTested = 0;
+    int opsSucceeded = 0;
+
+#define TEST_SPECIAL_OP(name, id, b3, inc) \
+    do { \
+        opsTested++; \
+        testsRun++; \
+        if (test##name##Opcode(OpType::name)) { \
+            opsSucceeded++; \
+            testsPassed++; \
+        } else { \
+            testsFailed++; \
+            dataLogLn("FAILED: ", #name, " special opcode test"); \
+        } \
+    } while (0);
+
+    FOR_EACH_WASM_SPECIAL_OP(TEST_SPECIAL_OP)
+
+#undef TEST_SPECIAL_OP
+
+    TEST_ASSERT(opsTested == TOTAL_SPECIAL_OPS,
+        makeString("Tested all "_s, String::number(TOTAL_SPECIAL_OPS), " special ops"_s).utf8().data());
+    TEST_ASSERT(opsSucceeded == TOTAL_SPECIAL_OPS,
+        makeString("All "_s, String::number(TOTAL_SPECIAL_OPS), " special ops completed"_s).utf8().data());
+
+    dataLogLn("  Successfully tested: ", opsSucceeded, " / ", opsTested, " special ops");
+    dataLogLn("All special ops coverage testing completed");
+}
+
+} // namespace WasmDebugInfoTest
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/TestUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/TestUtilities.cpp
@@ -1,0 +1,514 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestUtilities.h"
+
+#include <wtf/DataLog.h>
+
+#if ENABLE(WEBASSEMBLY)
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+#include "InitializeThreading.h"
+#include "JSLock.h"
+#include "Options.h"
+#include "VM.h"
+#include "WasmIPIntPlan.h"
+#include "WasmModuleDebugInfo.h"
+#include "WasmModuleInformation.h"
+#include "WasmOps.h"
+#include "WasmTypeDefinition.h"
+#include "WasmWorklist.h"
+#include <wtf/HexNumber.h>
+#include <wtf/ListDump.h>
+#include <wtf/text/MakeString.h>
+
+#if OS(WINDOWS)
+#include <wtf/win/WTFCRTDebug.h>
+#endif
+
+using namespace JSC;
+using namespace JSC::Wasm;
+
+namespace WasmDebugInfoTest {
+
+int testsRun = 0;
+int testsPassed = 0;
+int testsFailed = 0;
+
+VM* gTestVM;
+
+SourceModule SourceModule::create()
+{
+    SourceModule module;
+    // Default: [] -> []
+    module.m_params = { };
+    module.m_results = { };
+    module.m_vm = gTestVM;
+    return module;
+}
+
+SourceModule& SourceModule::withFunctionType(Vector<uint8_t> params, Vector<uint8_t> results)
+{
+    m_params = WTFMove(params);
+    m_results = WTFMove(results);
+    return *this;
+}
+
+SourceModule& SourceModule::withAdditionalType(Vector<uint8_t> params, Vector<uint8_t> results)
+{
+    Vector<uint8_t> typeEntry;
+    typeEntry.append(0x60); // Function type
+    typeEntry.append(static_cast<uint8_t>(params.size()));
+    typeEntry.appendVector(params);
+    typeEntry.append(static_cast<uint8_t>(results.size()));
+    typeEntry.appendVector(results);
+    m_additionalTypes.append(WTFMove(typeEntry));
+    return *this;
+}
+
+SourceModule& SourceModule::withLocals(uint32_t count, uint8_t type)
+{
+    m_localsDeclaration = { 0x01, static_cast<uint8_t>(count), type };
+    return *this;
+}
+
+SourceModule& SourceModule::withGlobals(bool isMutable)
+{
+    m_globalSection = {
+        0x06, // Section ID: Global
+        0x06, // Section length
+        0x01, // 1 global
+        toLEB128(TypeKind::I32), // Type: i32
+        static_cast<uint8_t>(isMutable ? 0x01 : 0x00), // Mutability
+        0x41, 0x00, // i32.const 0
+        0x0b // end
+    };
+    return *this;
+}
+
+SourceModule& SourceModule::withTable()
+{
+    m_tableSection = {
+        0x04, // Section ID: Table
+        0x04, // Section length
+        0x01, // 1 table
+        0x70, // Type: funcref
+        0x00, // flags: no maximum
+        0x01 // min elements: 1
+    };
+    return *this;
+}
+
+SourceModule& SourceModule::withMemory()
+{
+    m_memorySection = {
+        0x05, // Section ID: Memory
+        0x03, // Section length
+        0x01, // 1 memory
+        0x00, // flags: no maximum
+        0x01 // min pages: 1
+    };
+    return *this;
+}
+
+SourceModule& SourceModule::withFunctionBody(const Vector<uint8_t>& body)
+{
+    m_functionBody = body;
+    return *this;
+}
+
+SourceModule SourceModule::build()
+{
+    RELEASE_ASSERT(!m_isBuilt);
+    m_isBuilt = true;
+
+    // Body size = function body + locals declaration (or just 0x00 if no locals)
+    uint32_t localsSize = m_localsDeclaration.isEmpty() ? 1 : m_localsDeclaration.size();
+    uint32_t bodySize = m_functionBody.size() + localsSize;
+    uint32_t sectionLength = 2 + bodySize; // func count + body size byte + body
+
+    Vector<uint8_t> module = {
+        // Magic number: 0x00 0x61 0x73 0x6d
+        0x00, 0x61, 0x73, 0x6d,
+        // Version: 1
+        0x01, 0x00, 0x00, 0x00
+    };
+
+    // Type section (1+ function types)
+    uint32_t typeCount = 1 + m_additionalTypes.size();
+
+    // Calculate main function type size
+    uint32_t mainTypeSize = 1 + 1 + m_params.size() + 1 + m_results.size(); // 0x60 + param_count + params + result_count + results
+
+    // Calculate additional types size
+    uint32_t additionalTypesSize = 0;
+    for (const auto& typeEntry : m_additionalTypes)
+        additionalTypesSize += typeEntry.size();
+
+    uint32_t typeSectionLength = 1 + mainTypeSize + additionalTypesSize; // type_count + main_type + additional_types
+
+    module.appendVector(Vector<uint8_t> {
+        0x01, // Section ID: Type
+        static_cast<uint8_t>(typeSectionLength), // Section length
+        static_cast<uint8_t>(typeCount) // Number of types
+    });
+
+    // Main function type (type index 0)
+    module.appendVector(Vector<uint8_t> {
+        0x60, // Function type
+        static_cast<uint8_t>(m_params.size()) // param count
+    });
+    module.appendVector(m_params);
+    module.append(static_cast<uint8_t>(m_results.size())); // result count
+    module.appendVector(m_results);
+
+    // Additional types (type index 1, 2, ...)
+    for (const auto& typeEntry : m_additionalTypes)
+        module.appendVector(typeEntry);
+
+    // Function section (1 function with type 0)
+    module.appendVector(Vector<uint8_t> {
+        0x03, // Section ID: Function
+        0x02, // Section length
+        0x01, // 1 function
+        0x00 // Type index 0
+    });
+
+    // Optional sections (in correct WASM section order)
+    if (!m_tableSection.isEmpty())
+        module.appendVector(m_tableSection);
+
+    if (!m_memorySection.isEmpty())
+        module.appendVector(m_memorySection);
+
+    if (!m_globalSection.isEmpty())
+        module.appendVector(m_globalSection);
+
+    // Export section
+    module.appendVector(Vector<uint8_t> {
+        0x07, // Section ID: Export
+        0x05, // Section length
+        0x01, // 1 export
+        0x01, // Name length: 1
+        'f', // Export name
+        0x00, // Export kind: function
+        0x00 // Function index 0
+    });
+
+    // Code section (function bodies)
+    module.appendVector(Vector<uint8_t> {
+        0x0a, // Section ID: Code
+        static_cast<uint8_t>(sectionLength), // Section length
+        0x01, // 1 function body
+        static_cast<uint8_t>(bodySize) // Body size
+    });
+
+    // functionDataStart points to where the locals count byte is (first byte of function payload)
+    functionDataStart = module.size();
+
+    if (m_localsDeclaration.isEmpty()) {
+        module.append(0x00); // 0 local variable declarations
+        bytecodeStart = module.size(); // bytecodeStart points to where bytecode begins (after locals)
+    } else {
+        module.appendVector(m_localsDeclaration);
+        bytecodeStart = module.size(); // bytecodeStart points to where bytecode begins (after locals)
+    }
+
+    module.appendVector(m_functionBody);
+
+    SourceModule result;
+    result.bytes = WTFMove(module);
+    result.functionDataStart = functionDataStart;
+    result.bytecodeStart = bytecodeStart;
+    result.m_vm = m_vm;
+    return result;
+}
+
+SourceModule createWasmModuleWithBytecode(const Vector<uint8_t>& functionBody)
+{
+    return SourceModule::create()
+        .withFunctionType({ }, { }) // [] -> []
+        .withFunctionBody(functionBody)
+        .build();
+}
+
+SourceModule createWasmModuleWithLocals(const Vector<uint8_t>& functionBody)
+{
+    return SourceModule::create()
+        .withFunctionType({ }, { }) // [] -> []
+        .withLocals(1, toLEB128(TypeKind::I32)) // 1 local of type i32
+        .withFunctionBody(functionBody)
+        .build();
+}
+
+SourceModule createWasmModuleWithGlobals(const Vector<uint8_t>& functionBody, bool mutableGlobal)
+{
+    return SourceModule::create()
+        .withFunctionType({ }, { }) // [] -> []
+        .withGlobals(mutableGlobal)
+        .withFunctionBody(functionBody)
+        .build();
+}
+
+SourceModule createWasmModuleWithTable(const Vector<uint8_t>& functionBody)
+{
+    return SourceModule::create()
+        .withFunctionType({ }, { }) // [] -> []
+        .withTable()
+        .withFunctionBody(functionBody)
+        .build();
+}
+
+SourceModule createWasmModuleWithMemory(const Vector<uint8_t>& functionBody)
+{
+    return SourceModule::create()
+        .withFunctionType({ }, { }) // [] -> []
+        .withMemory()
+        .withFunctionBody(functionBody)
+        .build();
+}
+
+bool verifyOpcodeInModule(const SourceModule& sourceModule, JSC::Wasm::OpType expectedOpcode)
+{
+    uint8_t opcodeByte = static_cast<uint8_t>(expectedOpcode);
+    for (size_t i = 0; i < sourceModule.bytes.size(); i++) {
+        if (sourceModule.bytes[i] == opcodeByte)
+            return true;
+    }
+
+    dataLogLn("ERROR: Module does not contain expected opcode 0x", hex(opcodeByte, 2, WTF::HexConversionMode::Lowercase), " ", expectedOpcode);
+    return false;
+}
+
+static bool verifyExtGCOpcodeInModule(const SourceModule& sourceModule, JSC::Wasm::ExtGCOpType expectedOpcode)
+{
+    uint8_t extGCPrefix = static_cast<uint8_t>(JSC::Wasm::OpType::ExtGC);
+    uint8_t extGCOpcode = static_cast<uint8_t>(expectedOpcode);
+    for (size_t i = 0; i < sourceModule.bytes.size() - 1; i++) {
+        if (sourceModule.bytes[i] == extGCPrefix && sourceModule.bytes[i + 1] == extGCOpcode)
+            return true;
+    }
+
+    dataLogLn("ERROR: Module does not contain expected ExtGC opcode 0xfb 0x", hex(extGCOpcode, 2, WTF::HexConversionMode::Lowercase), " ", expectedOpcode);
+    return false;
+}
+
+static OffsetToNextInstructions convertMappingsToAbsolute(uint32_t bytecodeStart, std::initializer_list<std::pair<uint32_t, std::initializer_list<uint32_t>>> mappings)
+{
+    OffsetToNextInstructions expectedMappings;
+    for (const auto& [from, tos] : mappings) {
+        UncheckedKeyHashSet<uint32_t> targets;
+        for (uint32_t to : tos)
+            targets.add(bytecodeStart + to);
+        expectedMappings.add(bytecodeStart + from, WTFMove(targets));
+    }
+    return expectedMappings;
+}
+
+template<typename OpcodeType>
+static bool parseAndVerifyDebugInfoImpl(JSC::VM* vm, const SourceModule& sourceModule, OpcodeType expectedOpcode, const OffsetToNextInstructions& expectedMappings)
+{
+    RELEASE_ASSERT(vm);
+
+    JSC::JSLockHolder lock(*vm);
+
+    Ref<JSC::Wasm::IPIntPlan> plan = adoptRef(*new JSC::Wasm::IPIntPlan(*vm, Vector<uint8_t>(sourceModule.bytes), JSC::Wasm::CompilerMode::FullCompile, JSC::Wasm::Plan::dontFinalize()));
+    if (plan->failed()) {
+        dataLogLn("ERROR: Failed to parse WASM module: ", plan->errorMessage());
+        return false;
+    }
+
+    JSC::Wasm::ensureWorklist().enqueue(plan.get());
+    plan->waitForCompletion();
+    if (plan->failed()) {
+        dataLogLn("ERROR: WASM module validation failed: ", plan->errorMessage());
+        return false;
+    }
+
+    Ref<JSC::Wasm::ModuleInformation> moduleInfo = plan->takeModuleInformation();
+    if (moduleInfo->functions.isEmpty()) {
+        dataLogLn("ERROR: No functions found in module");
+        return false;
+    }
+
+    RELEASE_ASSERT(moduleInfo->debugInfo && !moduleInfo->debugInfo->source.isEmpty());
+
+    JSC::Wasm::FunctionCodeIndex functionIndex = JSC::Wasm::FunctionCodeIndex { 0 };
+    const auto& function = moduleInfo->functions[functionIndex];
+    JSC::Wasm::FunctionSpaceIndex spaceIndex = moduleInfo->toSpaceIndex(functionIndex);
+    JSC::Wasm::TypeIndex typeIndex = moduleInfo->typeIndexFromFunctionIndexSpace(spaceIndex);
+    Ref typeDefinition = JSC::Wasm::TypeInformation::get(typeIndex);
+
+    auto functionData = moduleInfo->debugInfo->source.subspan(function.start, function.data.size());
+    JSC::Wasm::FunctionDebugInfo debugInfo;
+    JSC::Wasm::parseForDebugInfo(functionData, typeDefinition, moduleInfo.get(), functionIndex, debugInfo);
+
+    size_t expectedSize = expectedMappings.size();
+
+    auto toRelative = [&](uint32_t absOffset) {
+        return absOffset - sourceModule.bytecodeStart;
+    };
+
+    auto toRelativeSet = [&](const UncheckedKeyHashSet<uint32_t>& absSet) {
+        Vector<uint32_t> relative;
+        for (uint32_t abs : absSet)
+            relative.append(abs - sourceModule.bytecodeStart);
+        std::sort(relative.begin(), relative.end());
+        return relative;
+    };
+
+    // Check that actual and expected have exactly the same number of entries
+    if (debugInfo.offsetToNextInstructions.size() != expectedSize) {
+        dataLogLn("ERROR: Expected ", expectedSize, " mapping entries, but found ", debugInfo.offsetToNextInstructions.size());
+        dataLogLn("Opcode: ", expectedOpcode);
+        dataLogLn("Expected mappings (relative offsets):");
+        for (const auto& entry : expectedMappings)
+            dataLogLn("  ", toRelative(entry.key), " -> ", listDump(toRelativeSet(entry.value)));
+        dataLogLn("Actual mappings (relative offsets):");
+        for (const auto& entry : debugInfo.offsetToNextInstructions)
+            dataLogLn("  ", toRelative(entry.key), " -> ", listDump(toRelativeSet(entry.value)));
+        return false;
+    }
+
+    // If no expected mappings, we're done (both are empty)
+    if (expectedMappings.isEmpty())
+        return true;
+
+    // Verify each expected entry exists and matches exactly
+    for (const auto& expectedEntry : expectedMappings) {
+        uint32_t expectedOffset = expectedEntry.key;
+        const UncheckedKeyHashSet<uint32_t>& expectedNextOffsets = expectedEntry.value;
+
+        UncheckedKeyHashSet<uint32_t>* actualNextOffsets = debugInfo.findNextInstructions(expectedOffset);
+        if (!actualNextOffsets) {
+            dataLogLn("ERROR: Expected mapping at offset ", toRelative(expectedOffset), " is missing from actual mappings");
+            dataLogLn("Opcode: ", expectedOpcode);
+            dataLogLn("Expected: ", listDump(toRelativeSet(expectedNextOffsets)));
+            dataLogLn("Actual mappings (relative offsets):");
+            for (const auto& entry : debugInfo.offsetToNextInstructions)
+                dataLogLn("  ", toRelative(entry.key), " -> ", listDump(toRelativeSet(entry.value)));
+            return false;
+        }
+
+        if (actualNextOffsets->size() != expectedNextOffsets.size()) {
+            dataLogLn("ERROR: Offset ", toRelative(expectedOffset), " has ", actualNextOffsets->size(), " next instructions, expected ", expectedNextOffsets.size());
+            dataLogLn("Actual: ", listDump(toRelativeSet(*actualNextOffsets)));
+            dataLogLn("Expected: ", listDump(toRelativeSet(expectedNextOffsets)));
+            return false;
+        }
+
+        for (uint32_t expectedNext : expectedNextOffsets) {
+            if (!actualNextOffsets->contains(expectedNext)) {
+                dataLogLn("ERROR: Offset ", toRelative(expectedOffset), " missing expected next offset ", toRelative(expectedNext));
+                dataLogLn("Actual: ", listDump(toRelativeSet(*actualNextOffsets)));
+                dataLogLn("Expected: ", listDump(toRelativeSet(expectedNextOffsets)));
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+template<typename OpcodeType>
+static bool verifyOpcode(const SourceModule& sourceModule, OpcodeType expectedOpcode)
+{
+    if constexpr (std::is_same_v<OpcodeType, JSC::Wasm::OpType>)
+        return verifyOpcodeInModule(sourceModule, expectedOpcode);
+    else if constexpr (std::is_same_v<OpcodeType, JSC::Wasm::ExtGCOpType>)
+        return verifyExtGCOpcodeInModule(sourceModule, expectedOpcode);
+    else {
+        static_assert(std::is_same_v<OpcodeType, JSC::Wasm::OpType> || std::is_same_v<OpcodeType, JSC::Wasm::ExtGCOpType>, "Unsupported opcode type");
+        return false;
+    }
+}
+
+template<typename OpcodeType>
+bool SourceModule::parseAndVerifyDebugInfo(OpcodeType expectedOpcode, std::initializer_list<std::pair<uint32_t, std::initializer_list<uint32_t>>> mappings) const
+{
+    if (!verifyOpcode(*this, expectedOpcode))
+        return false;
+
+    return parseAndVerifyDebugInfoImpl(m_vm, *this, expectedOpcode, convertMappingsToAbsolute(bytecodeStart, mappings));
+}
+
+template bool SourceModule::parseAndVerifyDebugInfo(JSC::Wasm::OpType, std::initializer_list<std::pair<uint32_t, std::initializer_list<uint32_t>>>) const;
+template bool SourceModule::parseAndVerifyDebugInfo(JSC::Wasm::ExtGCOpType, std::initializer_list<std::pair<uint32_t, std::initializer_list<uint32_t>>>) const;
+
+static int test()
+{
+    dataLogLn("Starting WASM Debug Info Test Suite");
+    dataLogLn("===============================================");
+
+    JSC::initialize();
+    JSC::Options::setOption("enableWasmDebugger=true");
+
+    RefPtr<VM> vm = VM::create();
+    gTestVM = vm.get();
+
+    dataLogLn("\n--- Macro-Driven Opcode Coverage Tests ---");
+    testAllControlFlowOps();
+    testAllUnaryOps();
+    testAllBinaryOps();
+    testAllMemoryOps();
+    testAllSpecialOps();
+    testAllExtGCOps();
+
+    // FIXME: Add tests for remaining extended opcode families: Ext1OpType, ExtAtomicOpType, and ExtSIMDOpType
+
+    dataLogLn("===============================================");
+    dataLogLn("Test Results:");
+    dataLogLn("  Tests run: ", testsRun);
+    dataLogLn("  Passed: ", testsPassed);
+    dataLogLn("  Failed: ", testsFailed);
+
+    if (!testsFailed) {
+        dataLogLn("All tests PASSED!");
+        dataLogLn("WASM debug info infrastructure is working correctly");
+        dataLogLn("allWasmDebugInfoTestsPassed");
+    } else {
+        dataLogLn("Some tests FAILED!");
+        dataLogLn("WASM debug info infrastructure needs attention");
+    }
+
+    gTestVM = nullptr;
+    JSLockHolder lock(*vm);
+    vm = nullptr;
+
+    return testsFailed;
+}
+
+} // namespace WasmDebugInfoTest
+
+int testWasmDebugInfo()
+{
+    return WasmDebugInfoTest::test();
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/TestUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/tests/TestUtilities.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "InitializeThreading.h"
+#include "JSLock.h"
+#include "VM.h"
+#include "WasmIPIntPlan.h"
+#include "WasmModuleDebugInfo.h"
+#include "WasmModuleInformation.h"
+#include "WasmOps.h"
+#include "WasmTypeDefinition.h"
+#include "WasmWorklist.h"
+#include <initializer_list>
+#include <utility>
+#include <wtf/DataLog.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+#include <wtf/HexNumber.h>
+#include <wtf/ListDump.h>
+#include <wtf/Vector.h>
+
+namespace WasmDebugInfoTest {
+
+using OffsetToNextInstructions = UncheckedKeyHashMap<uint32_t, UncheckedKeyHashSet<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+
+class SourceModule {
+public:
+    Vector<uint8_t> bytes;
+    uint32_t functionDataStart; // Offset where function payload starts (after body size, points to locals count)
+    uint32_t bytecodeStart; // Offset where actual bytecode starts (after locals declaration)
+
+    template<typename OpcodeType>
+    bool parseAndVerifyDebugInfo(OpcodeType expectedOpcode, std::initializer_list<std::pair<uint32_t, std::initializer_list<uint32_t>>> mappings) const;
+
+
+    static SourceModule create();
+    SourceModule& withFunctionType(Vector<uint8_t> params, Vector<uint8_t> results);
+    SourceModule& withAdditionalType(Vector<uint8_t> params, Vector<uint8_t> results);
+    SourceModule& withLocals(uint32_t count, uint8_t type);
+    SourceModule& withGlobals(bool isMutable = true);
+    SourceModule& withTable();
+    SourceModule& withMemory();
+    SourceModule& withFunctionBody(const Vector<uint8_t>& body);
+    SourceModule build();
+
+private:
+    Vector<uint8_t> m_functionBody;
+    Vector<uint8_t> m_params;
+    Vector<uint8_t> m_results;
+    Vector<Vector<uint8_t>> m_additionalTypes; // Additional types for blocks/etc
+    Vector<uint8_t> m_globalSection;
+    Vector<uint8_t> m_tableSection;
+    Vector<uint8_t> m_memorySection;
+    Vector<uint8_t> m_localsDeclaration;
+    JSC::VM* m_vm { nullptr };
+    bool m_isBuilt { false };
+};
+
+extern int testsRun;
+extern int testsPassed;
+extern int testsFailed;
+
+extern JSC::VM* gTestVM;
+
+static inline uint8_t toLEB128(JSC::Wasm::TypeKind kind) { return static_cast<uint8_t>(kind) & 0x7f; }
+
+#define TEST_ASSERT(condition, message) \
+    do { \
+        WasmDebugInfoTest::testsRun++; \
+        if (condition) { \
+            WasmDebugInfoTest::testsPassed++; \
+            dataLogLn("PASS: ", message); \
+        } else { \
+            WasmDebugInfoTest::testsFailed++; \
+            dataLogLn("FAIL: ", message, " (", #condition, ")"); \
+        } \
+    } while (0)
+
+#define COUNT_OP(...) +1
+static constexpr int TOTAL_SPECIAL_OPS = 0 FOR_EACH_WASM_SPECIAL_OP(COUNT_OP);
+static constexpr int TOTAL_CONTROL_OPS = 0 FOR_EACH_WASM_CONTROL_FLOW_OP(COUNT_OP);
+static constexpr int TOTAL_UNARY_OPS = 0 FOR_EACH_WASM_UNARY_OP(COUNT_OP);
+static constexpr int TOTAL_BINARY_OPS = 0 FOR_EACH_WASM_BINARY_OP(COUNT_OP);
+static constexpr int TOTAL_MEMORY_LOAD_OPS = 0 FOR_EACH_WASM_MEMORY_LOAD_OP(COUNT_OP);
+static constexpr int TOTAL_MEMORY_STORE_OPS = 0 FOR_EACH_WASM_MEMORY_STORE_OP(COUNT_OP);
+static constexpr int TOTAL_EXTGC_OPS = 0 FOR_EACH_WASM_GC_OP(COUNT_OP);
+#undef COUNT_OP
+
+SourceModule createWasmModuleWithBytecode(const Vector<uint8_t>& functionBody);
+SourceModule createWasmModuleWithLocals(const Vector<uint8_t>& functionBody);
+SourceModule createWasmModuleWithGlobals(const Vector<uint8_t>& functionBody, bool mutableGlobal = true);
+SourceModule createWasmModuleWithTable(const Vector<uint8_t>& functionBody);
+SourceModule createWasmModuleWithMemory(const Vector<uint8_t>& functionBody);
+
+void testAllControlFlowOps();
+void testAllUnaryOps();
+void testAllBinaryOps();
+void testAllMemoryOps();
+void testAllSpecialOps();
+void testAllExtGCOps();
+
+bool verifyOpcodeInModule(const SourceModule&, JSC::Wasm::OpType expectedOpcode);
+
+} // namespace WasmDebugInfoTest
+
+int testWasmDebugInfo();
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/UnaryTests.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/UnaryTests.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestUtilities.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <wtf/DataLog.h>
+#include <wtf/text/MakeString.h>
+
+using namespace JSC;
+using namespace JSC::Wasm;
+
+namespace WasmDebugInfoTest {
+
+static bool testI32UnaryOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x41, 0x01, // [0] i32.const 1
+        static_cast<uint8_t>(opcode), // [2] unary op
+        0x1a, // [3] drop
+        0x0b // [4] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 3 } },
+    });
+}
+
+static bool testI64UnaryOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x42, 0x01, // [0] i64.const 1
+        static_cast<uint8_t>(opcode), // [2] unary op
+        0x1a, // [3] drop
+        0x0b // [4] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 2 } },
+        { 2, { 3 } },
+    });
+}
+
+static bool testF32UnaryOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x43, 0x00, 0x00, 0x80, 0x3f, // [0] f32.const 1.0
+        static_cast<uint8_t>(opcode), // [5] unary op
+        0x1a, // [6] drop
+        0x0b // [7] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 5 } },
+        { 5, { 6 } },
+    });
+}
+
+static bool testF64UnaryOpcode(OpType opcode)
+{
+    Vector<uint8_t> functionBody = {
+        0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, // [0] f64.const 1.0
+        static_cast<uint8_t>(opcode), // [9] unary op
+        0x1a, // [10] drop
+        0x0b // [11] end
+    };
+
+    SourceModule module = createWasmModuleWithBytecode(functionBody);
+
+    return module.parseAndVerifyDebugInfo(opcode, {
+        { 0, { 9 } },
+        { 9, { 10 } },
+    });
+}
+
+void testAllUnaryOps()
+{
+    dataLogLn("=== Testing All Unary Ops Coverage ===");
+    dataLogLn("Total unary opcodes in WasmOps.h: ", TOTAL_UNARY_OPS);
+
+    int opsTested = 0;
+    int opsSucceeded = 0;
+
+#define TEST_UNARY_OP(name, id, b3, inc, inputType, outputType) \
+    do { \
+        opsTested++; \
+        testsRun++; \
+        bool success = false; \
+        constexpr auto inputTypeStr = #inputType##_s; \
+        if (inputTypeStr == "I32"_s) { \
+            success = testI32UnaryOpcode(static_cast<OpType>(id)); \
+        } else if (inputTypeStr == "I64"_s) { \
+            success = testI64UnaryOpcode(static_cast<OpType>(id)); \
+        } else if (inputTypeStr == "F32"_s) { \
+            success = testF32UnaryOpcode(static_cast<OpType>(id)); \
+        } else if (inputTypeStr == "F64"_s) { \
+            success = testF64UnaryOpcode(static_cast<OpType>(id)); \
+        } \
+        if (success) { \
+            opsSucceeded++; \
+            testsPassed++; \
+        } else { \
+            testsFailed++; \
+            dataLogLn("FAILED: ", #name, " unary opcode test"); \
+        } \
+    } while (0);
+
+    FOR_EACH_WASM_UNARY_OP(TEST_UNARY_OP)
+
+#undef TEST_UNARY_OP
+
+    TEST_ASSERT(opsTested == TOTAL_UNARY_OPS,
+        makeString("Tested all "_s, String::number(TOTAL_UNARY_OPS), " unary ops"_s).utf8().data());
+    TEST_ASSERT(opsSucceeded == TOTAL_UNARY_OPS,
+        makeString("All "_s, String::number(TOTAL_UNARY_OPS), " unary ops passed strict validation"_s).utf8().data());
+
+    dataLogLn("  Successfully tested with strict mapping validation: ", opsSucceeded, " / ", opsTested, " unary ops");
+    dataLogLn("All unary ops coverage testing completed");
+}
+
+} // namespace WasmDebugInfoTest
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
+++ b/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
@@ -474,13 +474,6 @@ inline bool isControlFlowInstruction(OpType op)
     FOR_EACH_WASM_CONTROL_FLOW_OP(CREATE_CASE)
         return true;
 #undef CREATE_CASE
-    case OpType::Call:
-    case OpType::CallIndirect:
-    case OpType::CallRef:
-    case OpType::TailCall:
-    case OpType::TailCallIndirect:
-    case OpType::TailCallRef:
-        return true;
     default:
         break;
     }


### PR DESCRIPTION
#### 7bf4dbaedeed630919f673e7822168ff3d1c003f
<pre>
[JSC] Add WebAssembly debugger step-into support for calls and exception handling
<a href="https://rdar.apple.com/163724778">rdar://163724778</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301704">https://bugs.webkit.org/show_bug.cgi?id=301704</a>

Reviewed by Yusuke Suzuki.

This patch implements step-into functionality for the WebAssembly debugger,
allowing developers to step into function calls and exception handlers when
debugging WebAssembly code in IPInt mode.

Implementation approach:
- Introduced StepIntoEvent flag mechanism in VM to coordinate between the
  debugger (step command) and code execution (call/throw slow paths)
- When stepping on a call instruction, the debugger sets a flag in the VM
- When the call executes in prepare_call*, the flag is consumed and a
  breakpoint is set at the callee entry (if the target is IPInt)
- Similar mechanism for throw instructions - flag is set on step, consumed
  when exception handler is determined by genericUnwind()

Key changes:
- VM: Added StepIntoEvent member with take/set methods for Call and Throw events
- DebugServer: New setStepIntoBreakpointForCall() and setStepIntoBreakpointForThrow()
  methods that consume flags and conditionally set breakpoints
- WasmIPIntSlowPaths: Added IPINT_HANDLE_STEP_INTO_CALL macro called in all
  prepare_call* functions, and IPINT_HANDLE_STEP_INTO_THROW macro called in
  all throw/rethrow/throw_ref functions
- ExecutionHandler: Simplified step() implementation to use debug info for
  control flow, and use flag-based approach for calls/throws instead of
  manually analyzing metadata

Test Coverage:
- Unit tests: OpType opcodes (FOR_EACH_WASM_*_OP macros)
- Runtime tests: Integration tests covering step-into/over/out
  - Exception handling: throw-catch, throw-catch-all, rethrow, throw-ref, delegate, try-table
  - Function calls: call, call-indirect, call-ref
  - Tail calls: return-call, return-call-indirect, return-call-ref

Future Work:
  - Extended opcode families (Ext1OpType, ExtGCOpType, ExtAtomicOpType, ExtSIMDOpType)

The flag-based mechanism ensures proper coordination between debugger and
execution: flags are always consumed when instructions execute (even if
target is non-IPInt compiled code), preventing flag persistence bugs.

Canonical link: <a href="https://commits.webkit.org/302503@main">https://commits.webkit.org/302503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e50d263f0add925b551efe56c10d2672ec718b38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136391 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80365 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/81c73d31-c195-41d7-879c-3b3e20532ba3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1143 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98227 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66116 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3f4eff42-b6d0-4710-8461-58112d51e2b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78871 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/acfe14dd-f634-4e6b-9de5-866649c7961c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33678 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79670 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121002 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109297 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138866 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127460 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106771 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106597 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27200 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/881 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30423 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53566 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1140 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64477 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160478 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/974 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40054 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1023 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1067 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->