### PR TITLE
Web Inspector: Remove the unused Page.navigate inspector command

### DIFF
--- a/LayoutTests/http/tests/inspector/target/pause-on-inline-debugger-statement.html
+++ b/LayoutTests/http/tests/inspector/target/pause-on-inline-debugger-statement.html
@@ -12,8 +12,7 @@ function test()
         name: "InlineDebuggerStatement",
         description: "Check that new provisional page can be paused before navigation.",
         async test() {
-            const url = "http://localhost:8000/inspector/target/resources/inline-debugger-statement.html";
-            WI.mainTarget.PageAgent.navigate(url);
+            InspectorTest.evaluateInPage(`window.location.href = "http://localhost:8000/inspector/target/resources/inline-debugger-statement.html";`);
 
             await WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Paused);
 

--- a/LayoutTests/http/tests/inspector/target/provisional-load-cancels-previous-load.html
+++ b/LayoutTests/http/tests/inspector/target/provisional-load-cancels-previous-load.html
@@ -5,6 +5,11 @@
 <script src="../resources/inspector-test.js"></script>
 <script src="../resources/stable-id-map.js"></script>
 <script>
+function navigate()
+{
+    window.location.href = "http://localhost:8000/inspector/target/provisional-load-cancels-previous-load.html";
+}
+
 function test()
 {
     let suite = InspectorTest.createAsyncSuite("Target.PSON");
@@ -15,7 +20,6 @@ function test()
         test(resolve, reject) {
             let targetIdMap = new StableIdMap;
             InspectorTest.log(`Current target is ${targetIdMap.get(WI.mainTarget.identifier)}.`);
-            const url = "http://localhost:8000/inspector/target/provisional-load-cancels-previous-load.html";
             let navigatedTwice = false;
 
             let originalResumeIfPaused = WI.Target.prototype._resumeIfPaused;
@@ -39,7 +43,7 @@ function test()
 
                     // Send two consequtive navigation requests. The latter will cancel provisional
                     // load of the former.
-                    WI.mainTarget.PageAgent.navigate(url);
+                    InspectorTest.evaluateInPage(`navigate();`);
                 }
             });
 
@@ -67,7 +71,7 @@ function test()
             })
             .then(resolve);
 
-            WI.mainTarget.PageAgent.navigate(url);
+            InspectorTest.evaluateInPage(`navigate();`);
         }
     });
 

--- a/Source/JavaScriptCore/inspector/protocol/Page.json
+++ b/Source/JavaScriptCore/inspector/protocol/Page.json
@@ -146,14 +146,6 @@
             ]
         },
         {
-            "name": "navigate",
-            "description": "Navigates current page to the given URL.",
-            "targetTypes": ["page"],
-            "parameters": [
-                { "name": "url", "type": "string", "description": "URL to navigate the page to." }
-            ]
-        },
-        {
             "name": "overrideUserAgent",
             "description": "Override's the user agent of the inspected page",
             "targetTypes": ["page"],

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -197,25 +197,6 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::reload(std::optiona
     return { };
 }
 
-Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::navigate(const String& url)
-{
-    RefPtr localMainFrame = m_inspectedPage->localMainFrame();
-    if (!localMainFrame)
-        return { };
-    RefPtr localTopDocument = m_inspectedPage->localTopDocument();
-    if (!localTopDocument)
-        return { };
-
-    UserGestureIndicator indicator { IsProcessingUserGesture::Yes, localTopDocument.get() };
-
-    ResourceRequest resourceRequest { localTopDocument->completeURL(url) };
-    FrameLoadRequest frameLoadRequest { *localTopDocument, localTopDocument->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), InitiatedByMainFrame::Unknown };
-    frameLoadRequest.disableNavigationToInvalidURL();
-    localMainFrame->loader().changeLocation(WTFMove(frameLoadRequest));
-
-    return { };
-}
-
 Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::overrideUserAgent(const String& value)
 {
     m_userAgentOverride = value;

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -75,7 +75,6 @@ public:
     Inspector::Protocol::ErrorStringOr<void> enable();
     Inspector::Protocol::ErrorStringOr<void> disable();
     Inspector::Protocol::ErrorStringOr<void> reload(std::optional<bool>&& ignoreCache, std::optional<bool>&& revalidateAllResources);
-    Inspector::Protocol::ErrorStringOr<void> navigate(const String& url);
     Inspector::Protocol::ErrorStringOr<void> overrideUserAgent(const String&);
     Inspector::Protocol::ErrorStringOr<void> overrideSetting(Inspector::Protocol::Page::Setting, std::optional<bool>&& value);
     Inspector::Protocol::ErrorStringOr<void> overrideUserPreference(Inspector::Protocol::Page::UserPreferenceName, std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);


### PR DESCRIPTION
#### 5871ac509bb43fd3b731e5dc8ff5c5bed2c4d8a0
<pre>
Web Inspector: Remove the unused Page.navigate inspector command
<a href="https://webkit.org/b/302424">https://webkit.org/b/302424</a>
<a href="https://rdar.apple.com/164585900">rdar://164585900</a>

Reviewed by Devin Rousso.

The Page.navigate inspector command is not used in the frontend in any
user-facing functions. It&apos;s only used in three layout tests, which could
be replaced by setting `window.location.href` in JS.

Remove this command and rewrite those three tests so we don&apos;t need to
maintain it anymore.

* LayoutTests/http/tests/inspector/target/pause-on-inline-debugger-statement.html:
* LayoutTests/http/tests/inspector/target/provisional-load-cancels-previous-load.html:
* Source/JavaScriptCore/inspector/protocol/Page.json:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::navigate): Deleted.
* Source/WebCore/inspector/agents/InspectorPageAgent.h:

Canonical link: <a href="https://commits.webkit.org/302985@main">https://commits.webkit.org/302985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b850f00698bf20511e49b0ee204510f89f8c42d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82370 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ef25b508-fc36-4233-89b1-0d863cd91caf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/2893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99592 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/15037799-d09d-444c-9c38-bcb78372f2b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80301 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35186 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81406 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122732 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140630 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129182 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2790 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108097 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108050 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27512 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31815 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55787 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2860 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66249 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162197 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2680 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40453 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2881 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2786 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->