### PR TITLE
REGRESSION: Some Feral games are crashing on launch

### DIFF
--- a/LayoutTests/fast/images/hdr-unaccelerated-image-blur-filter-expected.html
+++ b/LayoutTests/fast/images/hdr-unaccelerated-image-blur-filter-expected.html
@@ -3,8 +3,7 @@
         width: 200px;
         height: 200px;
         display: inline-block;
-        background-color: lime;
-        will-change: transform;
+        background-color: rgb(0, 243, 0);
         filter: blur(4px);
     }
 </style>

--- a/LayoutTests/fast/images/hdr-unaccelerated-image-blur-filter.html
+++ b/LayoutTests/fast/images/hdr-unaccelerated-image-blur-filter.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ AcceleratedDrawingEnabled=false ] -->
-<meta name="fuzzy" content="maxDifference=0-12; totalPixels=0-44912" />
+<meta name="fuzzy" content="maxDifference=0-71; totalPixels=0-49284" />
 <style>
     .image-box {
         width: 200px;
         height: 200px;
-        will-change: transform;
         filter: blur(4px);
     }
 </style>

--- a/Source/WebCore/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebCore/Configurations/AllowedSPI-legacy.toml
@@ -564,6 +564,7 @@ symbols = [
     "CGIOSurfaceContextCreateImage",
     "CGIOSurfaceContextCreateImageReference",
     "CGIOSurfaceContextGetColorSpace",
+    "CGIOSurfaceContextGetBitmapInfo",
     "CGImageGetCachingFlags",
     "CGImageSetCachingFlags",
     "CGImageSetProperty",

--- a/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
@@ -382,6 +382,7 @@ CGContextRef CGIOSurfaceContextCreate(IOSurfaceRef, size_t, size_t, size_t, size
 CGImageRef CGIOSurfaceContextCreateImage(CGContextRef);
 CGImageRef CGIOSurfaceContextCreateImageReference(CGContextRef);
 CGColorSpaceRef CGIOSurfaceContextGetColorSpace(CGContextRef);
+size_t CGIOSurfaceContextGetBitmapInfo(CGContextRef);
 void CGIOSurfaceContextSetDisplayMask(CGContextRef, uint32_t mask);
 IOSurfaceRef CGIOSurfaceContextGetSurface(CGContextRef);
 void CGIOSurfaceContextInvalidateSurface(CGContextRef);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -122,7 +122,7 @@ RefPtr<Filter> CanvasRenderingContext2D::createFilter(const FloatRect& bounds) c
     if (!page)
         return nullptr;
 
-    auto preferredFilterRenderingModes = page->preferredFilterRenderingModes();
+    auto preferredFilterRenderingModes = page->preferredFilterRenderingModes(*context);
     auto filter = CSSFilterRenderer::create(*renderer, state().filter, preferredFilterRenderingModes, { 1, 1 }, bounds, *context);
     if (!filter)
         return nullptr;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4910,23 +4910,34 @@ void Page::recomputeTextAutoSizingInAllFrames()
 
 #endif
 
-OptionSet<FilterRenderingMode> Page::preferredFilterRenderingModes() const
+OptionSet<FilterRenderingMode> Page::preferredFilterRenderingModes(const GraphicsContext& context) const
 {
     OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
 #if USE(CORE_IMAGE)
     if (settings().acceleratedFiltersEnabled())
         modes.add(FilterRenderingMode::Accelerated);
 #endif
+
 #if USE(SKIA)
     if (settings().acceleratedCompositingEnabled())
         modes.add(FilterRenderingMode::Accelerated);
 #endif
+
+    UNUSED_PARAM(context);
+
 #if USE(GRAPHICS_CONTEXT_FILTERS)
-    if (settings().graphicsContextFiltersEnabled())
-        modes.add(FilterRenderingMode::GraphicsContext);
-    if (settings().graphicsContextBlurFilterEnabled())
-        modes.add(FilterRenderingMode::GraphicsContextBlur);
+#if !HAVE(FIX_FOR_RADAR_104392017)
+    if (context.renderingMode() == RenderingMode::Accelerated || !context.knownToHaveFloatBasedBacking()) {
 #endif
+        if (settings().graphicsContextFiltersEnabled())
+            modes.add(FilterRenderingMode::GraphicsContext);
+        if (settings().graphicsContextBlurFilterEnabled())
+            modes.add(FilterRenderingMode::GraphicsContextBlur);
+#if !HAVE(FIX_FOR_RADAR_104392017)
+    }
+#endif
+#endif
+
     return modes;
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -131,6 +131,7 @@ class Element;
 class FocusController;
 class FormData;
 class Frame;
+class GraphicsContext;
 class HTMLElement;
 class HTMLImageElement;
 class HTMLMediaElement;
@@ -697,7 +698,7 @@ public:
     WEBCORE_EXPORT void recomputeTextAutoSizingInAllFrames();
 #endif
 
-    OptionSet<FilterRenderingMode> preferredFilterRenderingModes() const;
+    OptionSet<FilterRenderingMode> preferredFilterRenderingModes(const GraphicsContext&) const;
 
     const FloatBoxExtent& fullscreenInsets() const { return m_fullscreenInsets; }
     WEBCORE_EXPORT void setFullscreenInsets(const FloatBoxExtent&);

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -196,6 +196,8 @@ public:
     virtual bool isCALayerContext() const = 0;
 #endif
 
+    virtual bool knownToHaveFloatBasedBacking() const { return false; }
+
     virtual RenderingMode renderingMode() const { return RenderingMode::Unaccelerated; }
     WEBCORE_EXPORT RenderingMode renderingModeForCompatibleBuffer() const;
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1441,6 +1441,17 @@ bool GraphicsContextCG::isCALayerContext() const
     return m_isLayerCGContext;
 }
 
+bool GraphicsContextCG::knownToHaveFloatBasedBacking() const
+{
+    auto context = platformContext();
+
+    if (CGContextGetType(context) == kCGContextTypeIOSurface)
+        return CGIOSurfaceContextGetBitmapInfo(context) & kCGBitmapFloatComponents;
+    if (CGContextGetType(context) == kCGContextTypeBitmap)
+        return CGBitmapContextGetBitmapInfo(context) & kCGBitmapFloatComponents;
+    return false;
+}
+
 RenderingMode GraphicsContextCG::renderingMode() const
 {
     return m_renderingMode;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -84,6 +84,7 @@ public:
     void strokeEllipse(const FloatRect& ellipse) final;
 
     bool isCALayerContext() const final;
+    bool knownToHaveFloatBasedBacking() const final;
 
     RenderingMode renderingMode() const final;
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3628,7 +3628,7 @@ GraphicsContext* RenderLayer::setupFilters(GraphicsContext& destinationContext, 
 
     auto rootRelativeBounds = calculateLayerBounds(paintingInfo.rootLayer, offsetFromRoot, { RenderLayer::PreserveAncestorFlags });
 
-    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, paintingInfo.paintBehavior, enclosingIntRect(rootRelativeBounds), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect), backgroundRect.rect());
+    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, enclosingIntRect(rootRelativeBounds), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect), backgroundRect.rect());
     if (!filterContext)
         return nullptr;
 

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -142,18 +142,12 @@ IntOutsets RenderLayerFilters::calculateOutsets(RenderElement& renderer, const F
     return CSSFilterRenderer::calculateOutsets(renderer, filter, targetBoundingBox);
 }
 
-GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, OptionSet<PaintBehavior> paintBehavior, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect)
+GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect)
 {
     auto expandedDirtyRect = dirtyRect;
     auto targetBoundingBox = intersection(filterBoxRect, dirtyRect);
 
-    auto preferredFilterRenderingModes = renderer.page().preferredFilterRenderingModes();
-#if PLATFORM(COCOA) && !HAVE(FIX_FOR_RADAR_104392017)
-    if (context.renderingMode() == RenderingMode::Unaccelerated && paintBehavior.contains(PaintBehavior::DrawsHDRContent))
-        preferredFilterRenderingModes.remove(FilterRenderingMode::GraphicsContext);
-#else
-    UNUSED_PARAM(paintBehavior);
-#endif
+    auto preferredFilterRenderingModes = renderer.page().preferredFilterRenderingModes(context);
 
     auto outsets = calculateOutsets(renderer, targetBoundingBox);
     if (!outsets.isZero()) {

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -71,7 +71,7 @@ public:
     // Per render
     LayoutRect repaintRect() const { return m_repaintRect; }
 
-    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, OptionSet<PaintBehavior>, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect);
+    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect);
     void applyFilterEffect(GraphicsContext& destinationContext);
 
 private:

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -133,7 +133,7 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const Float
     if (!image || image->isNull())
         return &Image::nullImage();
 
-    auto preferredFilterRenderingModes = renderer->protectedPage()->preferredFilterRenderingModes();
+    auto preferredFilterRenderingModes = renderer->protectedPage()->preferredFilterRenderingModes(destinationContext);
     auto sourceImageRect = FloatRect { { }, size };
 
     auto cssFilter = CSSFilterRenderer::create(const_cast<RenderElement&>(*renderer), m_filter, preferredFilterRenderingModes, FloatSize { 1, 1 }, sourceImageRect, NullGraphicsContext());

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -128,7 +128,7 @@ auto LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const
     // Determine scale factor for filter. The size of intermediate ImageBuffers shouldn't be bigger than kMaxFilterSize.
     ImageBuffer::sizeNeedsClamping(filterData->sourceImageRect.size(), filterScale);
 
-    auto preferredFilterModes = renderer.page().preferredFilterRenderingModes();
+    auto preferredFilterModes = renderer.page().preferredFilterRenderingModes(*context);
 
     // Create the SVGFilterRenderer object.
     filterData->filter = SVGFilterRenderer::create(contextElement.get(), filterElement, preferredFilterModes, filterScale, filterRegion, targetBoundingBox, *context, RenderingResourceIdentifier::generate());

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -113,6 +113,15 @@ void RemoteGraphicsContextProxy::didBecomeUnresponsive() const
     backend->didBecomeUnresponsive();
 }
 
+bool RemoteGraphicsContextProxy::knownToHaveFloatBasedBacking() const
+{
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    return m_contentsFormat && *m_contentsFormat == ContentsFormat::RGBA16F;
+#else
+    return false;
+#endif
+}
+
 RenderingMode RemoteGraphicsContextProxy::renderingMode() const
 {
     return m_renderingMode;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -75,6 +75,8 @@ protected:
 private:
     void didBecomeUnresponsive() const;
 
+    bool knownToHaveFloatBasedBacking() const final;
+
     WebCore::RenderingMode renderingMode() const final;
 
     void save(WebCore::GraphicsContextState::Purpose) final;


### PR DESCRIPTION
#### 8ad60ae162b242aaf9039b6e289552cddc37c292
<pre>
REGRESSION: Some Feral games are crashing on launch
<a href="https://bugs.webkit.org/show_bug.cgi?id=301708">https://bugs.webkit.org/show_bug.cgi?id=301708</a>
<a href="https://rdar.apple.com/163220052">rdar://163220052</a>

Reviewed by Simon Fraser.

The crash happens when applying CG filters on float16 unaccelerated backing store.
Recently CG filters were in enabled for all CSS filters; see 300183@main and
300173@main. The problem with this scenario is not supported by the system frames
right now.

302306@main tried fixed this issue by falling back to software filters in this case.
This change addresses the case where an HDR image is styled with a CSS filters and
is displayed on an unaccelerated backing store. This scenario can be hit with
snapshotting like tab preview, print-preview, save to PDF and printing.

But it turned out that AppKit can create float16 unaccelerated backing stories.
So the fix should be more generic than fixing the HDR images scenario.

Till <a href="https://rdar.apple.com/104392017">rdar://104392017</a> is fixed, CSS filters will fall back to software filters if
they are applied to float16 unaccelerated backing stores.

* LayoutTests/fast/images/hdr-unaccelerated-image-blur-filter-expected.html:
* LayoutTests/fast/images/hdr-unaccelerated-image-blur-filter.html:
Having `will-change: transform;` on the element forces compositing. In this case
CSS filters will be applied by CA. Remove it so the WebKit filters can be tested.

* Source/WebCore/Configurations/AllowedSPI-legacy.toml:
* Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::createFilter const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::preferredFilterRenderingModes const):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::knownToHaveFloatBasedBacking const):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::knownToHaveFloatBasedBacking const):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::setupFilters):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/RenderLayerFilters.h:
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::applyResource):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::knownToHaveFloatBasedBacking const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h:

Canonical link: <a href="https://commits.webkit.org/302365@main">https://commits.webkit.org/302365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd28413d3b6e46a3158f1a019413908fd5d7a002

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80250 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ecdedbd0-7b48-485b-b92f-a8c8cb498404) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1018 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98123 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5c7c51d4-3afe-4d8b-b4e0-e93fb433610b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131830 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/832 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78737 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/68086058-6ac6-479b-a8fb-599a7aa44951) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33564 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79545 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138727 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/927 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106472 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/781 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30317 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53414 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20127 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1025 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64335 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/868 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/924 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/960 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->