### PR TITLE
Remove the `weakRandomUint32` function

### DIFF
--- a/Source/JavaScriptCore/API/ExtraSymbolsForTAPI.h
+++ b/Source/JavaScriptCore/API/ExtraSymbolsForTAPI.h
@@ -26,17 +26,6 @@
 #pragma once
 
 #include "JSContextRef.h"
-#include <wtf/ExportMacros.h>
-
-// MARK: JavaScriptCore
 
 extern "C" JS_EXPORT void JSSynchronousGarbageCollectForDebugging(JSContextRef);
 extern "C" JS_EXPORT void JSSynchronousEdenCollectForDebugging(JSContextRef);
-
-// MARK: WTF
-
-namespace WTF {
-// Can be removed when https://commits.webkit.org/256555@main is sufficiently
-// old that all supported versions of Safari have the change.
-WTF_EXPORT_PRIVATE unsigned weakRandomUint32();
-}

--- a/Source/WTF/wtf/WeakRandomNumber.cpp
+++ b/Source/WTF/wtf/WeakRandomNumber.cpp
@@ -40,18 +40,4 @@ template<> unsigned weakRandomNumber<unsigned>()
     return s_weakRandom.getUint32();
 }
 
-#if PLATFORM(COCOA)
-
-// Older versions of Safari frameworks were using weakRandomUint32.
-// Remove this once we no longer need to support those.
-
-WTF_EXPORT_PRIVATE unsigned weakRandomUint32();
-
-unsigned weakRandomUint32()
-{
-    return random();
-}
-
-#endif
-
 }


### PR DESCRIPTION
#### 295904c7a5aeecdfde6c921669394d080a4693db
<pre>
Remove the `weakRandomUint32` function
<a href="https://bugs.webkit.org/show_bug.cgi?id=301705">https://bugs.webkit.org/show_bug.cgi?id=301705</a>
<a href="https://rdar.apple.com/163737653">rdar://163737653</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

<a href="https://commits.webkit.org/256555@main">https://commits.webkit.org/256555@main</a> is now sufficiently old that all supported versions of Safari
have the change.

* Source/JavaScriptCore/API/ExtraSymbolsForTAPI.h:
* Source/WTF/wtf/WeakRandomNumber.cpp:
(WTF::weakRandomUint32): Deleted.

Canonical link: <a href="https://commits.webkit.org/302363@main">https://commits.webkit.org/302363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e482e555e57e0f7cbedc9919edf7c3e85b4f9227

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136255 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80238 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a9145a30-b90b-45b8-99d7-1728b3b9ed6d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98108 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/64d5975e-3d85-44eb-a722-6fa0e147a1c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78720 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9b84b426-ec64-477d-80c9-16af736f0fb3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33547 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79534 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120882 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138716 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127331 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106646 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111770 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/106459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27103 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/772 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30302 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53402 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1014 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64323 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160343 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/857 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40018 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/949 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->