### PR TITLE
Ensure that fixed anchor positioned boxes can be scrolled into view

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-000-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-000-expected.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed Box 2D</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in both axes */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    left: calc(100% - 4em);
+    top: calc(100% - 4em);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should NOT trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  window.scroll(0, 0);
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-000-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-000-ref.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed Box 2D</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in both axes */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    left: calc(100% - 4em);
+    top: calc(100% - 4em);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should NOT trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  window.scroll(0, 0);
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-000.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-000.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Test: Scroll-to-Focus Fixed Box 2D</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-management-apis">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#position-property">
+
+<link rel="match" href="scroll-to-anchored-fixed-000-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in both axes */
+  .fixed {
+    position: fixed;
+    position-anchor: --foo;
+    left: calc(100% - 4em);
+    top: calc(100% - 4em);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should NOT trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001-expected.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed anchor()ed Box 2D</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in both axes */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    left: anchor(left);
+    top: anchor(top);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001-ref.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed anchor()ed Box 2D</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in both axes */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    left: anchor(left);
+    top: anchor(top);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Test: Scroll-to-Focus Fixed anchor()ed Box 2D</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#scroll">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-management-apis">
+
+<link rel="match" href="scroll-to-anchored-fixed-001-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in both axes */
+  .fixed {
+    position: fixed;
+    position-anchor: --foo;
+    left: anchor(left);
+    top: anchor(top);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002-expected.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed position-area Box 2D</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in both axes */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    position-area: center;
+    place-self: start;
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002-ref.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed position-area Box 2D</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in both axes */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    position-area: center;
+    place-self: start;
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Test: Scroll-to-Focus Fixed position-area Box 2D</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#scroll">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-management-apis">
+
+<link rel="match" href="scroll-to-anchored-fixed-002-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in both axes */
+  .fixed {
+    position: fixed;
+    position-anchor: --foo;
+    position-area: center;
+    place-self: start;
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-003-expected.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed anchor()ed Box Vertical</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in vertical axis */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    left: calc(100vw - 5em);
+    top: anchor(top);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  window.scroll(0, window.scrollY);
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-003-ref.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed anchor()ed Box Vertical</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in vertical axis */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    left: calc(100vw - 5em);
+    top: anchor(top);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  window.scroll(0, window.scrollY);
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-003.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Test: Scroll-to-Focus Fixed anchor()ed Box Vertical</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#scroll">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-management-apis">
+
+<link rel="match" href="scroll-to-anchored-fixed-003-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in vertical axis */
+  .fixed {
+    position: fixed;
+    position-anchor: --foo;
+    left: calc(100vw - 5em);
+    top: anchor(top);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-004-expected.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed position-area Box Vertical</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in vertical axis */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    position-area: center span-all;
+    place-self: start;
+    left: calc(100vw - 5em);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  window.scroll(0, window.scrollY);
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-004-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-004-ref.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed position-area Box Vertical</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in vertical axis */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    position-area: center span-all;
+    place-self: start;
+    left: calc(100vw - 5em);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  window.scroll(0, window.scrollY);
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-004.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Test: Scroll-to-Focus Fixed position-area Box Vertical</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#scroll">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-management-apis">
+
+<link rel="match" href="scroll-to-anchored-fixed-004-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in vertical axis */
+  .fixed {
+    position: fixed;
+    position-anchor: --foo;
+    position-area: center span-all;
+    place-self: start;
+    left: calc(100vw - 5em);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-005-expected.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed anchor()ed Box Horizontal</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in horizontal axis */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    top: calc(100vh - 5em);
+    left: anchor(left);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  window.scroll(window.scrollX, 0);
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-005-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-005-ref.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed anchor()ed Box Horizontal</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in horizontal axis */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    top: calc(100vh - 5em);
+    left: anchor(left);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  window.scroll(window.scrollX, 0);
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-005.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Test: Scroll-to-Focus Fixed anchor()ed Box Horizontal</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#scroll">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-management-apis">
+
+<link rel="match" href="scroll-to-anchored-fixed-005-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in horizontal axis */
+  .fixed {
+    position: fixed;
+    position-anchor: --foo;
+    top: calc(100vh - 5em);
+    left: anchor(left);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-006-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-006-expected.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed position-area Box Vertical</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in horizontal axis */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    position-area: span-all center;
+    place-self: start;
+    top: calc(100vh - 5em);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  window.scroll(window.scrollX, 0);
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-006-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-006-ref.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed position-area Box Vertical</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in horizontal axis */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    position-area: span-all center;
+    place-self: start;
+    top: calc(100vh - 5em);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  window.scroll(window.scrollX, 0);
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-006.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Test: Scroll-to-Focus Fixed position-area Box Horizontal</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#scroll">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-management-apis">
+
+<link rel="match" href="scroll-to-anchored-fixed-006-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in horizontal axis */
+  .fixed {
+    position: fixed;
+    position-anchor: --foo;
+    position-area: span-all center;
+    place-self: start;
+    top: calc(100vh - 5em);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -981,9 +981,10 @@ private:
 
     static MonotonicTime sCurrentPaintTimeStamp; // used for detecting decoded resource thrash in the cache
 
-    void scrollRectToVisibleInChildView(const LayoutRect& absoluteRect, bool insideFixed, const ScrollRectToVisibleOptions&, const HTMLFrameOwnerElement*);
-    void scrollRectToVisibleInTopLevelView(const LayoutRect& absoluteRect, bool insideFixed, const ScrollRectToVisibleOptions&);
-    LayoutRect getPossiblyFixedRectToExpose(const LayoutRect& visibleRect, const LayoutRect& exposeRect, bool insideFixed, const ScrollAlignment& alignX, const ScrollAlignment& alignY) const;
+    void scrollRectToVisibleInChildView(const LayoutRect& absoluteRect, EnumSet<BoxAxis> isFixed, const ScrollRectToVisibleOptions&, const HTMLFrameOwnerElement*);
+    void scrollRectToVisibleInTopLevelView(const LayoutRect& absoluteRect, EnumSet<BoxAxis> isFixed, const ScrollRectToVisibleOptions&);
+    LayoutRect getPossiblyFixedRectToExpose(const LayoutRect& visibleRect, const LayoutRect& exposeRect, EnumSet<BoxAxis> isFixed, const ScrollAlignment& alignX, const ScrollAlignment& alignY) const;
+    LayoutRect getPossiblyFixedRectToExpose(const LayoutRect& visibleRect, const LayoutRect& exposeRect, bool isFixed, const ScrollAlignment& alignX, const ScrollAlignment& alignY) const;
 
     float deviceScaleFactor() const final;
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -71,13 +71,17 @@ public:
     AnchorScrollAdjuster(RenderBox& anchored, const RenderBoxModelObject& defaultAnchor);
     RenderBox* anchored() const;
 
-    bool mayNeedAdjustment() const { return m_needsXAdjustment | m_needsYAdjustment; }
     inline bool isEmpty() const;
+    bool mayNeedAdjustment() const { return m_needsXAdjustment | m_needsYAdjustment; }
+    bool mayNeedXAdjustment() const { return m_needsXAdjustment; }
+    bool mayNeedYAdjustment() const { return m_needsYAdjustment; }
+
     bool isHidden() const { return m_isHidden; }
     void setHidden(bool hide) { m_isHidden = hide; }
 
     inline void addSnapshot(const RenderBox& scroller);
     inline void addViewportSnapshot(const RenderView&);
+    bool hasViewportSnapshot() const { return m_adjustForViewport; }
 
     enum Diff : uint8_t { New, SnapshotsDiffer, SnapshotsMatch };
     bool recaptureDiffers(const AnchorScrollAdjuster&) const; // Snapshot differences can require invalidation.


### PR DESCRIPTION
#### 1ebd10ef5e85c57c79434682ce73af0895e1e65a
<pre>
Ensure that fixed anchor positioned boxes can be scrolled into view
<a href="https://bugs.webkit.org/show_bug.cgi?id=300515">https://bugs.webkit.org/show_bug.cgi?id=300515</a>
<a href="https://rdar.apple.com/162378346">rdar://162378346</a>
Reviewed by Simon Fraser.

In the past, it was impossible for a fixed-positioned box outside the viewport
to be scrolled into view. However, with anchor positioning, scrolling the
page can bring the box into view when it has a default anchor.

This patch teaches our scrollRectToVisible() function to scroll the page for
anchor-positioned boxes by allowing each axis to be treated as fixed or not
independently when determining whether/how to scroll the page.

This is particularly important functionality for keyboard navigation.

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-000-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-000.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-003-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-003.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-004-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-004.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-005-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-005.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-006-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-006.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-000-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-000-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-000.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-003-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-004-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-004-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-004.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-005-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-005-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-005.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-006-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-006-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-006.html: Added.

Add tests.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::adjustForScrollByAnchor):
(WebCore::LocalFrameView::scrollRectToVisible):
(WebCore::LocalFrameView::scrollRectToVisibleInChildView):
(WebCore::LocalFrameView::scrollRectToVisibleInTopLevelView):
(WebCore::LocalFrameView::getPossiblyFixedRectToExpose const):
* Source/WebCore/page/LocalFrameView.h:

Allow for single-axis fixed behavior for scrollRectToVisible() and friends.

* Source/WebCore/style/AnchorPositionEvaluator.h:
(WebCore::AnchorScrollAdjuster::mayNeedAdjustment const):
(WebCore::AnchorScrollAdjuster::mayNeedXAdjustment const):
(WebCore::AnchorScrollAdjuster::mayNeedYAdjustment const):
(WebCore::AnchorScrollAdjuster::hasViewportSnapshot const):

Expose some internal adjuster data for public use.

Canonical link: <a href="https://commits.webkit.org/302368@main">https://commits.webkit.org/302368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/903dc2c440977c6998927cc0c3beb8753cf03214

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128875 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80242 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7fd45bf4-d9c8-4b13-b0f4-7121359d3a73) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98117 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66026 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8b010df4-44b6-4846-bc97-1f2e30d7d206) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78731 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dcda9c98-f131-4bca-9adf-ac99f13750d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33557 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79537 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109191 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138719 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106656 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106467 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27106 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/771 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53405 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1017 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64327 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/860 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/916 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/952 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->