### PR TITLE
[GARDENING][ Tahoe ] TestWebKitAPI.WebKit.ClickAutoFillButton (api-test) is a constant timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -1128,7 +1128,12 @@ static bool readyForClick;
 
 @end
 
+// FIXME: rdar://163129797 ([ Tahoe ] TestWebKitAPI.WebKit.ClickAutoFillButton (api-test) is a constant timeout (301201))
+#if #if (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000)
+TEST(WebKit, DISABLED_ClickAutoFillButton)
+#else
 TEST(WebKit, ClickAutoFillButton)
+#endif
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ClickAutoFillButton"];
 


### PR DESCRIPTION
#### e3ed23d48418f8c9cb74283f68418316fabb125e
<pre>
[GARDENING][ Tahoe ] TestWebKitAPI.WebKit.ClickAutoFillButton (api-test) is a constant timeout
<a href="https://rdar.apple.com/163129797">rdar://163129797</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301201">https://bugs.webkit.org/show_bug.cgi?id=301201</a>

Unreviewed test gardening/ API-test disable for Tahoe while under investigation.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
((WebKit, DISABLED_ClickAutoFillButton)(WebKit, ClickAutoFillButton)):
((WebKit, ClickAutoFillButton)): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3ed23d48418f8c9cb74283f68418316fabb125e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128879 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1136 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39712 "Hash e3ed23d4 for PR 53216 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136262 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/89455783-e24c-44be-b6e7-c73f10bdbdd7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130750 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/1087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1014 "Hash e3ed23d4 for PR 53216 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/43915c8d-d99a-4bdd-85b6-6185b14ff459) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131826 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/1087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/39712 "Hash e3ed23d4 for PR 53216 does not build (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/78727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/1087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/39712 "Hash e3ed23d4 for PR 53216 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79541 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/1087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/39712 "Hash e3ed23d4 for PR 53216 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138723 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/1014 "Hash e3ed23d4 for PR 53216 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/1006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/39712 "Hash e3ed23d4 for PR 53216 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106464 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/39712 "Hash e3ed23d4 for PR 53216 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1021 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->