### PR TITLE
Wasm FunctionParser should use the result type from the 'if' instruction signature

### DIFF
--- a/JSTests/wasm/regress/if-expr-type.js
+++ b/JSTests/wasm/regress/if-expr-type.js
@@ -1,0 +1,40 @@
+import * as assert from '../assert.js';
+import { watToWasm } from "../gc/wast-wrapper.js";
+
+const wat = String.raw `
+(module
+    (type $0 (sub (array (mut f64))))
+    (data $0 "\fa\a1\03\b7\f7\87Cz\93G\df\b2\0c\e9\99\a0\ff\e3\9f\b5\85)\88\\J\10\f5\94\c8A\cf5\de\87I7o\06\8c2\14\a3q\84w\82\c1\15\f1\1f_\db\81C\81|6\cb\04#\8a")
+    (func $main (export "main")
+        (array.init_data $0 0
+            ;; The return value of 'if' is declared nullable, but the expression in the 'else' branch is not.
+            ;; That expression is left on the expression stack representing the result of 'if'.
+            ;; Despite that, 'if' as a whole should be treated as nullable.
+            (if (result (ref null $0))
+                (i32.const 1)
+                (then
+                    (ref.cast nullref (ref.null none))
+                )
+                (else
+                    (array.new_default $0 (i32.const 1))
+                )
+            )
+            (i32.const 0)
+            (i32.const 0)
+            (i32.const 0)
+        )
+    )
+)`;
+
+async function test() {
+    const buffer = await watToWasm(wat);
+    const module = new WebAssembly.Module(buffer);
+    const instance = new WebAssembly.Instance(module, {});
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        // The generated code for array.init_data should include a null check so the null returned in the 'then' branch is detected as expected
+        assert.throws(instance.exports.main, WebAssembly.RuntimeError, "array.init_data to a null reference");
+    }
+}
+
+await test();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3576,7 +3576,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addIf(Value condition, BlockSignature s
 PartialResult WARN_UNUSED_RETURN BBQJIT::addElse(ControlData& data, Stack& expressionStack)
 {
     data.flushAndSingleExit(*this, data, expressionStack, false, true);
-    ControlData dataElse(ControlData::UseBlockCallingConventionOfOtherBranch, BlockType::Block, data);
+    ControlData dataElse(ControlData::UseBlockCallingConventionOfOtherBranch, BlockType::Else, data);
     data.linkJumps(&m_jit);
     dataElse.addBranch(m_jit.jump());
     data.linkIfBranch(&m_jit); // Link specifically the conditional branch of the preceding If
@@ -3604,7 +3604,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addElseToUnreachable(ControlData& data)
     // state entering the else block.
     data.flushAtBlockBoundary(*this, 0, m_parser->expressionStack(), true);
 
-    ControlData dataElse(ControlData::UseBlockCallingConventionOfOtherBranch, BlockType::Block, data);
+    ControlData dataElse(ControlData::UseBlockCallingConventionOfOtherBranch, BlockType::Else, data);
     data.linkJumps(&m_jit);
     dataElse.addBranch(m_jit.jump()); // Still needed even when the parent was unreachable to avoid running code within the else block.
     data.linkIfBranch(&m_jit); // Link specifically the conditional branch of the preceding If

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -681,6 +681,7 @@ public:
 
     struct ControlData {
         static bool isIf(const ControlData& control) { return control.blockType() == BlockType::If; }
+        static bool isElse(const ControlData& control) { return control.blockType() == BlockType::Else; }
         static bool isTry(const ControlData& control) { return control.blockType() == BlockType::Try; }
         static bool isAnyCatch(const ControlData& control) { return control.blockType() == BlockType::Catch; }
         static bool isCatch(const ControlData& control) { return isAnyCatch(control) && control.catchKind() == CatchKind::Catch; }

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -143,6 +143,7 @@ public:
     // for a dummy top-level block from parseBody() that cannot be jumped to.
     struct ControlData {
         static bool isIf(const ControlData&) { return false; }
+        static bool isElse(const ControlData&) { return false; }
         static bool isTry(const ControlData&) { return false; }
         static bool isAnyCatch(const ControlData&) { return false; }
         static bool isCatch(const ControlData&) { return false; }

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -172,6 +172,7 @@ public:
         }
 
         static bool isIf(const ControlData& control) { return control.blockType() == BlockType::If; }
+        static bool isElse(const ControlData& control) { return control.blockType() == BlockType::Else; }
         static bool isTry(const ControlData& control) { return control.blockType() == BlockType::Try; }
         static bool isTryTable(const ControlData& control) { return control.blockType() == BlockType::TryTable; }
         static bool isAnyCatch(const ControlData& control) { return control.blockType() == BlockType::Catch; }
@@ -190,6 +191,9 @@ public:
             switch (blockType()) {
             case BlockType::If:
                 out.print("If:       ");
+                break;
+            case BlockType::Else:
+                out.print("Else:     ");
                 break;
             case BlockType::Block:
                 out.print("Block:    ");

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -168,6 +168,7 @@ public:
         }
 
         static bool isIf(const ControlData& control) { return control.blockType() == BlockType::If; }
+        static bool isElse(const ControlData& control) { return control.blockType() == BlockType::Else; }
         static bool isTry(const ControlData& control) { return control.blockType() == BlockType::Try; }
         static bool isTryTable(const ControlData& control) { return control.blockType() == BlockType::TryTable; }
         static bool isAnyCatch(const ControlData& control) { return control.blockType() == BlockType::Catch; }
@@ -186,6 +187,9 @@ public:
             switch (blockType()) {
             case BlockType::If:
                 out.print("If:       ");
+                break;
+            case BlockType::Else:
+                out.print("Else:     ");
                 break;
             case BlockType::Block:
                 out.print("Block:    ");


### PR DESCRIPTION
#### 1c34bb6fde435a9b659618f1589b00f59093ad79
<pre>
Wasm FunctionParser should use the result type from the &apos;if&apos; instruction signature
<a href="https://bugs.webkit.org/show_bug.cgi?id=301707">https://bugs.webkit.org/show_bug.cgi?id=301707</a>
<a href="https://rdar.apple.com/162581991">rdar://162581991</a>

Reviewed by Dan Hecht.

This patch addresses a problem that was exposed by <a href="https://bugs.webkit.org/show_bug.cgi?id=297569.">https://bugs.webkit.org/show_bug.cgi?id=297569.</a>
After the change, BBQ emits null checks conditionally based on nullability of the types
involved. That exposed an existing problem which may cause the nullability of an `if`
expression to be determined incorrectly by the FunctionParser.

The failure scenario is illustrated by the included test. The `if` instruction is declared
as producing a `RefNull($0)`. The `else` branch produces a `Ref($0)`, which typechecks
because `Ref($0)` is a subtype of `RefNull($0)`. After processing the `if` instruction,
the expression stack contains a TypedExpression of type `Ref($0)` left by the `else`
branch. This is a problem because that expression now represents the entire `if`, so the
type of `if` is incorrectly narrowed to the type of the `else` branch. `array.init_data`
is then generated without a null check and fails when execution takes the `then` branch
which produces a null reference.

The spec requires the result type of `if` to be the result type of the signature
associated with the `if`. This is illustrated by the `if`, `else`, and `end` cases in
<a href="https://webassembly.github.io/spec/core/appendix/algorithm.html#validation-of-opcode-sequences.">https://webassembly.github.io/spec/core/appendix/algorithm.html#validation-of-opcode-sequences.</a>
The patch makes the following changes to implement the spec behavior:

- A new `BlockType::Else` value is introduced, to distinguish blocks following an &apos;else&apos;
instruction from other blocks. This is a useful distinction, present in the spec algorithm
and already privately implemented by IPIntGenerator as the `isElse` field. The field
in IPIntGenerator is removed because it&apos;s no longer necessary.

- `FunctionParser::unify` is renamed to a more specific `checkExpressionStack`. The
function does not actually do any unification, and the original name contributed to hiding the
problem of not joining the types of `if` branches.

- The renamed `FunctionParser::checkExpressionStack` is given an extra boolean parameter
`forceSignature`. When its value is true, the types of values on the expression stack are
replaced after a successful type check with types from the expected signature.

- Wasm parser uses the new parameter to replace types on the stack with signature types
when processing an `end` instruction at the end of an `if-else`.

Test: JSTests/wasm/regress/if-expr-type.js
Canonical link: <a href="https://commits.webkit.org/302606@main">https://commits.webkit.org/302606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49b5582b74f8659e342f741fedb5886c694c9319

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81082 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ab163ddc-2d2d-44e0-bef5-0db8684bb48a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98746 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66596 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/155ab881-3175-4e9d-9d9a-1cc20af7c69b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79417 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e869a3e8-d0f9-4fe2-b5d1-191c145fc0b4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34238 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80288 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121620 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139494 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128080 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107265 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107119 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27275 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/1373 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30960 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54431 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1746 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65109 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161094 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1566 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40180 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1600 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1668 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->