### PR TITLE
[Navigation API] Fix event ordering for intercepted traverse navigations.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject_currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering for same-document navigation.back() intercepted by passing a rejected promise to intercept() assert_array_equals: expected property 2 to be "currententrychange" but got "handler run" (expected array ["promise microtask", "navigate", "currententrychange", "handler run", "committed fulfilled", "navigateerror", "finished rejected", "transition.finished rejected"] got ["promise microtask", "navigate", "handler run", "currententrychange", "committed fulfilled", "navigateerror", "finished rejected", "transition.finished rejected"])
+PASS event and promise ordering for same-document navigation.back() intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept_currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering for same-document navigation.back() intercepted by intercept() assert_array_equals: expected property 2 to be "currententrychange" but got "handler run" (expected array ["promise microtask", "navigate", "currententrychange", "handler run", "committed fulfilled", "navigatesuccess", "finished fulfilled", "transition.finished fulfilled"] got ["promise microtask", "navigate", "handler run", "currententrychange", "committed fulfilled", "navigatesuccess", "finished fulfilled", "transition.finished fulfilled"])
+PASS event and promise ordering for same-document navigation.back() intercepted by intercept()
 

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -364,42 +364,15 @@ void HistoryItem::clearChildren()
     m_client->clearChildren(*this);
 }
 
-// We do same-document navigation if going to a different item and if either of the following is true:
+// We do same-document navigation if going to a different item and the following is true:
 // - The other item corresponds to the same document (for history entries created via pushState or fragment changes).
-// - The other item corresponds to the same set of documents, including frames (for history entries created via regular navigation)
 bool HistoryItem::shouldDoSameDocumentNavigationTo(HistoryItem& otherItem) const
 {
-    // The following logic must be kept in sync with WebKit::WebBackForwardListItem::itemIsInSameDocument().
     if (m_itemID == otherItem.itemID())
         return false;
 
-    if (stateObject() || otherItem.stateObject())
-        return documentSequenceNumber() == otherItem.documentSequenceNumber();
-    
-    if ((url().hasFragmentIdentifier() || otherItem.url().hasFragmentIdentifier()) && equalIgnoringFragmentIdentifier(url(), otherItem.url()))
-        return documentSequenceNumber() == otherItem.documentSequenceNumber();
-    
-    return hasSameDocumentTree(otherItem);
-}
-
-// Does a recursive check that this item and its descendants have the same
-// document sequence numbers as the other item.
-bool HistoryItem::hasSameDocumentTree(HistoryItem& otherItem) const
-{
-    if (documentSequenceNumber() != otherItem.documentSequenceNumber())
-        return false;
-        
-    if (children().size() != otherItem.children().size())
-        return false;
-
-    for (size_t i = 0; i < children().size(); i++) {
-        Ref child = children()[i].get();
-        RefPtr otherChild = otherItem.childItemWithDocumentSequenceNumber(child->documentSequenceNumber());
-        if (!otherChild || !child->hasSameDocumentTree(*otherChild))
-            return false;
-    }
-
-    return true;
+    // The following logic must be kept in sync with WebKit::WebBackForwardListItem::itemIsInSameDocument().
+    return documentSequenceNumber() == otherItem.documentSequenceNumber();
 }
 
 String HistoryItem::formContentType() const

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -232,8 +232,6 @@ private:
 
     static int64_t generateSequenceNumber();
 
-    bool hasSameDocumentTree(HistoryItem& otherItem) const;
-
     String m_urlString;
     String m_originalURLString;
     String m_referrer;

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -88,6 +88,11 @@ private:
 
 enum class ShouldCopyStateObjectFromCurrentEntry : bool { No, Yes };
 
+// Controls whether updateForNavigation should fulfill the committed promise immediately.
+// For intercepted traversals, timing depends on handler presence (see spec).
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#notify-about-the-committed-to-entry
+enum class ShouldNotifyCommitted : bool { No, Yes };
+
 class Navigation final : public RefCounted<Navigation>, public EventTarget, public LocalDOMWindowProperty {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Navigation);
 public:
@@ -148,7 +153,7 @@ public:
     bool dispatchPushReplaceReloadNavigateEvent(const URL&, NavigationNavigationType, bool isSameDocument, FormState*, SerializedScriptValue* classicHistoryAPIState = nullptr, Element* sourceElement = nullptr);
     bool dispatchDownloadNavigateEvent(const URL&, const String& downloadFilename, Element* sourceElement = nullptr);
 
-    void updateForNavigation(Ref<HistoryItem>&&, NavigationNavigationType, ShouldCopyStateObjectFromCurrentEntry = ShouldCopyStateObjectFromCurrentEntry::No);
+    void updateForNavigation(Ref<HistoryItem>&&, NavigationNavigationType, ShouldCopyStateObjectFromCurrentEntry = ShouldCopyStateObjectFromCurrentEntry::No, ShouldNotifyCommitted = ShouldNotifyCommitted::Yes);
     void updateForReactivation(Vector<Ref<HistoryItem>>&& newHistoryItems, HistoryItem& reactivatedItem, HistoryItem* previousItem);
 
     RefPtr<NavigationActivation> createForPageswapEvent(HistoryItem* newItem, DocumentLoader*, bool fromBackForwardCache);
@@ -182,6 +187,7 @@ public:
     Ref<AbortHandler> registerAbortHandler();
 
     RefPtr<NavigateEvent> protectedOngoingNavigateEvent() { return m_ongoingNavigateEvent; }
+    bool hasInterceptedOngoingNavigateEvent() const { return m_ongoingNavigateEvent && m_ongoingNavigateEvent->wasIntercepted(); }
 
     void updateNavigationEntry(Ref<HistoryItem>&&, ShouldCopyStateObjectFromCurrentEntry);
 

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -79,16 +79,6 @@ WebBackForwardListItem* WebBackForwardListItem::itemForID(BackForwardItemIdentif
     return allItems().get(identifier);
 }
 
-static const FrameState* childItemWithDocumentSequenceNumber(const FrameState& frameState, int64_t number)
-{
-    for (auto& child : frameState.children) {
-        if (child->documentSequenceNumber == number)
-            return child.ptr();
-    }
-
-    return nullptr;
-}
-
 static const FrameState* childItemWithTarget(const FrameState& frameState, const String& target)
 {
     for (auto& child : frameState.children) {
@@ -99,43 +89,16 @@ static const FrameState* childItemWithTarget(const FrameState& frameState, const
     return nullptr;
 }
 
-static bool documentTreesAreEqual(const FrameState& a, const FrameState& b)
-{
-    if (a.documentSequenceNumber != b.documentSequenceNumber)
-        return false;
-
-    if (a.children.size() != b.children.size())
-        return false;
-
-    for (auto& child : a.children) {
-        const FrameState* otherChild = childItemWithDocumentSequenceNumber(b, child->documentSequenceNumber);
-        if (!otherChild || !documentTreesAreEqual(child, *otherChild))
-            return false;
-    }
-
-    return true;
-}
-
 bool WebBackForwardListItem::itemIsInSameDocument(const WebBackForwardListItem& other) const
 {
     if (m_pageID != other.m_pageID)
         return false;
 
     // The following logic must be kept in sync with WebCore::HistoryItem::shouldDoSameDocumentNavigationTo().
-
     Ref mainFrameState = this->mainFrameState();
     Ref otherMainFrameState = other.mainFrameState();
 
-    if (mainFrameState->stateObjectData || otherMainFrameState->stateObjectData)
-        return mainFrameState->documentSequenceNumber == otherMainFrameState->documentSequenceNumber;
-
-    URL url = URL({ }, mainFrameState->urlString);
-    URL otherURL = URL({ }, otherMainFrameState->urlString);
-
-    if ((url.hasFragmentIdentifier() || otherURL.hasFragmentIdentifier()) && equalIgnoringFragmentIdentifier(url, otherURL))
-        return mainFrameState->documentSequenceNumber == otherMainFrameState->documentSequenceNumber;
-
-    return documentTreesAreEqual(mainFrameState, otherMainFrameState);
+    return mainFrameState->documentSequenceNumber == otherMainFrameState->documentSequenceNumber;
 }
 
 static bool hasSameFrames(const FrameState& a, const FrameState& b)


### PR DESCRIPTION
#### 035a4bdb885da801fc9332853c25038ec4f7823a
<pre>
[Navigation API] Fix event ordering for intercepted traverse navigations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301713">https://bugs.webkit.org/show_bug.cgi?id=301713</a>
<a href="https://rdar.apple.com/161445256">rdar://161445256</a>

Reviewed by Alex Christensen.

This patch addresses two interrelated issues with Navigation API traverse navigations:

1. Event ordering for intercepted traverse navigations
For intercepted traverse navigations, the currententrychange event was firing in the wrong order
relative to intercept handlers, and the committed promise timing was incorrect.

The timing now matches the HTML Navigation API specification:
- Fire navigate event
- If intercepted, update Navigation API state and fire currententrychange BEFORE handlers run
- Fulfill committed promise AFTER handlers are invoked (but before they complete)
- Only reject committed promise if it hasn&apos;t been fulfilled yet

This fix is covered by these two wpt tests:
- navigation-api/ordering-and-transition/back-same-document-intercept-reject.html?currententrychange
- navigation-api/ordering-and-transition/back-same-document-intercept.html?currententrychange

2. Same-document navigation detection with modified iframe structures
The previous implementation of shouldDoSameDocumentNavigationTo() contained overly complex
conditional logic that prevented proper same-document detection when Navigation API intercepts
modified the DOM structure (e.g., adding/removing iframes).

Historical context:
The complex logic dates back to 2010 (bugs 44217 and 46324), when explicit checks for stateObject,
fragment identifiers, and frame tree structure were added to prevent full page reloads during
history.pushState() with changing iframe structures. However, these checks all ultimately reduce
to the same documentSequenceNumber comparison, making them redundant given correct
documentSequenceNumber management.

The Navigation API intercept case exposed this redundancy: when an intercept handler modifies the
iframe structure, the old hasSameDocumentTree() check would fail despite both items having the
same documentSequenceNumber, causing incorrect cross-document navigation.

Technical correctness:
documentSequenceNumber follows a well-defined invariant across all navigation paths:
- New document load: generates new documentSequenceNumber (clipAtTarget=true)
- Same-document navigation (pushState/fragment/intercept): copies from previousItem (clipAtTarget=false)
- Client redirect to different URL: reset() generates new documentSequenceNumber

This invariant is maintained in:
- HistoryItem creation via createItemTree()
- Fragment navigation via updateBackForwardListForFragmentScroll()
- pushState/replaceState operations
- Navigation API intercepts
- Client redirects via updateCurrentItem()

The simplified logic relying solely on documentSequenceNumber comparison is both theoretically
correct and empirically validated by comprehensive test coverage, including the original 2010
regression tests for iframe structure changes.

Tests: All existing Navigation API and history tests pass, including:
- fast/history/same-document-iframes-changing-pushstate.html (from 2010)
- fast/history/same-document-iframes-changing-fragment.html (from 2010)

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept_currententrychange-expected.txt:
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::shouldDoSameDocumentNavigationTo const):
(WebCore::HistoryItem::hasSameDocumentTree const): Deleted.
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadInSameDocument):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::rejectFinishedPromise):
(WebCore::Navigation::updateForNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):
* Source/WebCore/page/Navigation.h:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::itemIsInSameDocument const):
(WebKit::childItemWithDocumentSequenceNumber): Deleted.
(WebKit::documentTreesAreEqual): Deleted.

Canonical link: <a href="https://commits.webkit.org/302418@main">https://commits.webkit.org/302418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c6e2779a7bd93794ff1534e91d4935ca59e1fcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136421 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c02e697-70fe-4cf3-b022-c36a41cb41ae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98248 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fbecfd0e-fd6a-47d3-a88a-f5ea5b58b596) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78893 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ff11816c-7fd9-42e2-b633-7d09702ddae3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33706 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79700 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138895 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106783 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106610 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27139 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/901 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30451 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53598 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64508 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/999 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1047 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1092 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->