### PR TITLE
Assert when ProcessThrottler is used off of the main thread

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -130,6 +130,7 @@ enum class SDKAlignedBehavior {
     CrashWhenPreconnectingFromBackgroundThread,
     ExecutionTimingChangeOfModuleScripts,
     GetBoundingClientRectZoomed,
+    CrashWhenMutatingProcessAssertionsFromBackgroundThread,
 
     NumberOfBehaviors
 };


### PR DESCRIPTION
#### 5dd0f6f337f2feb43027cf03ca3f70dcc696f71f
<pre>
Assert when ProcessThrottler is used off of the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=301714">https://bugs.webkit.org/show_bug.cgi?id=301714</a>
<a href="https://rdar.apple.com/163741299">rdar://163741299</a>

Reviewed by Chris Dumez.

We see crashes and CPU spins in ProcessThrottler due to the HashMap in ProcessAssertionCache ending
up in a corrupt state. The logs are showing that this map is being mutated by multiple threads
(e.g. clients who call `-evaluateJavascript:completionHandler:` on a background thread).

This patch notifies the client about misuse of WebKit APIs off the main thread with a fault. When
linking against newer SDKs, we make this an actual RELEASE_ASSERT and crash the entire UIProcess.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::assertIfCalledFromBackgroundThread):
(WebKit::ProcessThrottler::addActivity):
(WebKit::ProcessThrottler::removeActivity):
(WebKit::ProcessThrottler::invalidateAllActivities):
(WebKit::ProcessThrottler::setThrottleState):

Canonical link: <a href="https://commits.webkit.org/302397@main">https://commits.webkit.org/302397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ad1d5913d7a7393d43bd8ed1f076eb10a80392c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80252 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/565585b7-334c-4eaa-b73b-bfab8e9db621) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98119 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66033 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/615312a2-d5f6-4381-8f66-1960f4d52b39) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78733 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/04778d6b-39a0-49c0-9c90-6713c93365ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33568 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79547 "Built successfully") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120895 "Found 6 new JSC stress test failures: mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-baseline, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-dfg-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-ftl-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-llint, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-no-ftl (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138729 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127344 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106660 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106471 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27128 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/783 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30321 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53416 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1027 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64337 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160356 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/870 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40022 "Failed to checkout and rebase branch from PR 53219") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/926 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/962 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->