### PR TITLE
Add parsing support for `white-space-trim`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt
@@ -104,15 +104,15 @@ PASS Setting 'text-wrap-style' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'text-wrap-style' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'text-wrap-style' to a transform: perspective(10em) throws TypeError
 PASS Setting 'text-wrap-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL Can set 'white-space-trim' to CSS-wide keywords: initial Invalid property white-space-trim
-FAIL Can set 'white-space-trim' to CSS-wide keywords: inherit Invalid property white-space-trim
-FAIL Can set 'white-space-trim' to CSS-wide keywords: unset Invalid property white-space-trim
-FAIL Can set 'white-space-trim' to CSS-wide keywords: revert Invalid property white-space-trim
-FAIL Can set 'white-space-trim' to var() references:  var(--A) Invalid property white-space-trim
-FAIL Can set 'white-space-trim' to the 'none' keyword: none Invalid property white-space-trim
-FAIL Can set 'white-space-trim' to the 'discard-before' keyword: discard-before Invalid property white-space-trim
-FAIL Can set 'white-space-trim' to the 'discard-after' keyword: discard-after Invalid property white-space-trim
-FAIL Can set 'white-space-trim' to the 'discard-inner' keyword: discard-inner Invalid property white-space-trim
+PASS Can set 'white-space-trim' to CSS-wide keywords: initial
+PASS Can set 'white-space-trim' to CSS-wide keywords: inherit
+PASS Can set 'white-space-trim' to CSS-wide keywords: unset
+PASS Can set 'white-space-trim' to CSS-wide keywords: revert
+PASS Can set 'white-space-trim' to var() references:  var(--A)
+PASS Can set 'white-space-trim' to the 'none' keyword: none
+PASS Can set 'white-space-trim' to the 'discard-before' keyword: discard-before
+PASS Can set 'white-space-trim' to the 'discard-after' keyword: discard-after
+PASS Can set 'white-space-trim' to the 'discard-inner' keyword: discard-inner
 PASS Setting 'white-space-trim' to a length: 0px throws TypeError
 PASS Setting 'white-space-trim' to a length: -3.14em throws TypeError
 PASS Setting 'white-space-trim' to a length: 3.14cm throws TypeError
@@ -139,8 +139,8 @@ PASS Setting 'white-space-trim' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'white-space-trim' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'white-space-trim' to a transform: perspective(10em) throws TypeError
 PASS Setting 'white-space-trim' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'white-space-trim' does not support 'discard-before discard-after' Invalid property white-space-trim
-FAIL 'white-space-trim' does not support 'discard-before discard-inner' Invalid property white-space-trim
-FAIL 'white-space-trim' does not support 'discard-after discard-inner' Invalid property white-space-trim
-FAIL 'white-space-trim' does not support 'discard-before discard-after discard-inner' Invalid property white-space-trim
+FAIL 'white-space-trim' does not support 'discard-before discard-after' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
+FAIL 'white-space-trim' does not support 'discard-before discard-inner' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
+FAIL 'white-space-trim' does not support 'discard-after discard-inner' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
+FAIL 'white-space-trim' does not support 'discard-before discard-after discard-inner' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1638,6 +1638,20 @@ CSSUnprefixedBackdropFilterEnabled:
       "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
       default: false
 
+CSSWhiteSpaceTrimEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS white-space-collapse property"
+  humanReadableDescription: "Enable white-space-collapse CSS property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSWordBreakAutoPhraseEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1374,6 +1374,12 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
+#define TYPE WhiteSpaceTrim
+#define FOR_EACH(CASE) CASE(DiscardBefore) CASE(DiscardAfter) CASE(DiscardInner) CASE(None)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
 #define TYPE WordBreak
 #define FOR_EACH(CASE) CASE(Normal) CASE(BreakAll) CASE(KeepAll) CASE(BreakWord) CASE(AutoPhrase)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8251,6 +8251,25 @@
                 "url": "https://www.w3.org/TR/css-text-4/#white-space-collapsing"
             }
         },
+        "white-space-trim": {
+            "animation-type": "discrete",
+            "inherited": false,
+            "initial": "none",
+            "values": [
+                "none",
+                "discard-before",
+                "discard-after",
+                "discard-inner"
+            ],
+            "codegen-properties": {
+                "settings-flag": "cssWhiteSpaceTrimEnabled",
+                "parser-grammar": "<<values>>"
+            },
+            "specification": {
+                "category": "css-text",
+                "url": "https://www.w3.org/TR/css-text-4/#white-space-trim"
+            }
+        },
         "widows": {
             "animation-type": "by computed value",
             "inherited": true,

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -889,6 +889,15 @@ preserve-breaks
 // discard
 // preserve-spaces
 
+
+//
+// CSS_PROP_WHITE_SPACE_TRIM
+//
+// none
+discard-before
+discard-after
+discard-inner
+
 //
 // CSS_PROP__KHTML_NBSP_MODE
 //

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -213,6 +213,7 @@ enum class VectorEffect : uint8_t;
 enum class Visibility : uint8_t;
 enum class WhiteSpace : uint8_t;
 enum class WhiteSpaceCollapse : uint8_t;
+enum class WhiteSpaceTrim : uint8_t;
 enum class WindRule : bool;
 enum class WordBreak : uint8_t;
 
@@ -810,6 +811,7 @@ public:
     inline bool breakWords() const;
 
     WhiteSpaceCollapse whiteSpaceCollapse() const { return static_cast<WhiteSpaceCollapse>(m_inheritedFlags.whiteSpaceCollapse); }
+    inline WhiteSpaceTrim whiteSpaceTrim() const;
     TextWrapMode textWrapMode() const { return static_cast<TextWrapMode>(m_inheritedFlags.textWrapMode); }
     TextWrapStyle textWrapStyle() const { return static_cast<TextWrapStyle>(m_inheritedFlags.textWrapStyle); }
 
@@ -1443,6 +1445,7 @@ public:
     inline void setImageRendering(ImageRendering);
 
     void setWhiteSpaceCollapse(WhiteSpaceCollapse v) { m_inheritedFlags.whiteSpaceCollapse = static_cast<unsigned>(v); }
+    void setWhiteSpaceTrim(WhiteSpaceTrim);
 
     void setTextWrapMode(TextWrapMode v) { m_inheritedFlags.textWrapMode = static_cast<unsigned>(v); }
     void setTextWrapStyle(TextWrapStyle v) { m_inheritedFlags.textWrapStyle = static_cast<unsigned>(v); }
@@ -2052,6 +2055,7 @@ public:
     static inline Style::ViewTransitionName initialViewTransitionName();
     static constexpr Visibility initialVisibility();
     static constexpr WhiteSpaceCollapse initialWhiteSpaceCollapse();
+    static constexpr WhiteSpaceTrim initialWhiteSpaceTrim();
     static constexpr Style::WebkitBorderSpacing initialBorderHorizontalSpacing();
     static constexpr Style::WebkitBorderSpacing initialBorderVerticalSpacing();
     static inline Style::Cursor initialCursor();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1465,6 +1465,17 @@ TextStream& operator<<(TextStream& ts, WhiteSpaceCollapse whiteSpaceCollapse)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, WhiteSpaceTrim whiteSpaceTrim)
+{
+    switch (whiteSpaceTrim) {
+    case WhiteSpaceTrim::None: ts << "none"_s; break;
+    case WhiteSpaceTrim::DiscardBefore: ts << "discard-before"_s; break;
+    case WhiteSpaceTrim::DiscardAfter: ts << "discard-after"_s; break;
+    case WhiteSpaceTrim::DiscardInner: ts << "discard-inner"_s; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, WordBreak wordBreak)
 {
     switch (wordBreak) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -594,6 +594,13 @@ enum class WhiteSpaceCollapse : uint8_t {
     BreakSpaces
 };
 
+enum class WhiteSpaceTrim : uint8_t {
+    None,
+    DiscardBefore,
+    DiscardAfter,
+    DiscardInner
+};
+
 enum class ReflectionDirection : uint8_t {
     Below,
     Above,
@@ -1383,6 +1390,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, UserSelect);
 WTF::TextStream& operator<<(WTF::TextStream&, Visibility);
 WTF::TextStream& operator<<(WTF::TextStream&, WhiteSpace);
 WTF::TextStream& operator<<(WTF::TextStream&, WhiteSpaceCollapse);
+WTF::TextStream& operator<<(WTF::TextStream&, WhiteSpaceTrim);
 WTF::TextStream& operator<<(WTF::TextStream&, WordBreak);
 WTF::TextStream& operator<<(WTF::TextStream&, MathShift);
 WTF::TextStream& operator<<(WTF::TextStream&, MathStyle);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -179,6 +179,7 @@ inline const Style::Color& RenderStyle::caretColor() const { return m_rareInheri
 inline const Style::Clip& RenderStyle::clip() const { return m_nonInheritedData->rareData->clip; }
 inline const Style::ClipPath& RenderStyle::clipPath() const { return m_nonInheritedData->rareData->clipPath; }
 inline bool RenderStyle::collapseWhiteSpace() const { return collapseWhiteSpace(whiteSpaceCollapse()); }
+inline WhiteSpaceTrim RenderStyle::whiteSpaceTrim() const { return static_cast<WhiteSpaceTrim>(m_nonInheritedData->rareData->whiteSpaceTrim); }
 inline ColumnAxis RenderStyle::columnAxis() const { return static_cast<ColumnAxis>(m_nonInheritedData->miscData->multiCol->axis); }
 inline Style::ColumnCount RenderStyle::columnCount() const { return m_nonInheritedData->miscData->multiCol->count; }
 inline ColumnFill RenderStyle::columnFill() const { return static_cast<ColumnFill>(m_nonInheritedData->miscData->multiCol->fill); }
@@ -620,6 +621,7 @@ inline Style::ViewTransitionName RenderStyle::initialViewTransitionName() { retu
 constexpr Visibility RenderStyle::initialVisibility() { return Visibility::Visible; }
 inline const NameScope RenderStyle::initialTimelineScope() { return { }; }
 constexpr WhiteSpaceCollapse RenderStyle::initialWhiteSpaceCollapse() { return WhiteSpaceCollapse::Collapse; }
+constexpr WhiteSpaceTrim RenderStyle::initialWhiteSpaceTrim() { return WhiteSpaceTrim::None; }
 constexpr Style::Widows RenderStyle::initialWidows() { return CSS::Keyword::Auto { }; }
 constexpr WordBreak RenderStyle::initialWordBreak() { return WordBreak::Normal; }
 inline Style::WordSpacing RenderStyle::initialWordSpacing() { return CSS::Keyword::Normal { }; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -359,6 +359,7 @@ inline void RenderStyle::setVisitedLinkTextStrokeColor(Style::Color&& value) { S
 inline void RenderStyle::setWidows(Style::Widows widows) { SET(m_rareInheritedData, widows, widows); }
 inline void RenderStyle::setWidth(Style::PreferredSize&& length) { SET_NESTED(m_nonInheritedData, boxData, m_width, WTFMove(length)); }
 inline void RenderStyle::setWordBreak(WordBreak rule) { SET(m_rareInheritedData, wordBreak, static_cast<unsigned>(rule)); }
+inline void RenderStyle::setWhiteSpaceTrim(WhiteSpaceTrim value) { SET_NESTED(m_nonInheritedData, rareData, whiteSpaceTrim, static_cast<unsigned>(value)); }
 inline void RenderStyle::setWordSpacing(Style::WordSpacing&& wordSpacing) { SET_NESTED(m_inheritedData, fontData, wordSpacing, WTFMove(wordSpacing)); }
 inline void RenderStyle::setCornerBottomLeftShape(Style::CornerShapeValue&& shape) { SET_NESTED(m_nonInheritedData, surroundData, border.m_cornerShapes.bottomLeft(), WTFMove(shape)); }
 inline void RenderStyle::setCornerBottomRightShape(Style::CornerShapeValue&& shape) { SET_NESTED(m_nonInheritedData, surroundData, border.m_cornerShapes.bottomRight(), WTFMove(shape)); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -143,6 +143,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , anchorFunctionScrollCompensatedAxes(0)
     , isPopoverInvoker(false)
     , useSVGZoomRulesForLength(false)
+    , whiteSpaceTrim(static_cast<unsigned>(RenderStyle::initialWhiteSpaceTrim()))
 {
 }
 
@@ -250,6 +251,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , anchorFunctionScrollCompensatedAxes(o.anchorFunctionScrollCompensatedAxes)
     , isPopoverInvoker(o.isPopoverInvoker)
     , useSVGZoomRulesForLength(o.useSVGZoomRulesForLength)
+    , whiteSpaceTrim(o.whiteSpaceTrim)
 {
 }
 

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -272,6 +272,7 @@ public:
     PREFERRED_TYPE(bool) unsigned usesTreeCountingFunctions : 1;
     PREFERRED_TYPE(bool) unsigned isPopoverInvoker : 1;
     PREFERRED_TYPE(bool) unsigned useSVGZoomRulesForLength : 1;
+    PREFERRED_TYPE(WhiteSpaceTrim) unsigned whiteSpaceTrim : 3;
 
 private:
     StyleRareNonInheritedData();


### PR DESCRIPTION
#### 336d5832b252cf4b968bc3619aea5f1b64133d31
<pre>
Add parsing support for `white-space-trim`
<a href="https://bugs.webkit.org/show_bug.cgi?id=256923">https://bugs.webkit.org/show_bug.cgi?id=256923</a>

Reviewed by NOBODY (OOPS!).

Add parsing support for `white-space-trim`

Spec: <a href="https://www.w3.org/TR/css-text-4/#white-space-trim">https://www.w3.org/TR/css-text-4/#white-space-trim</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::whiteSpaceTrim const):
(WebCore::RenderStyle::initialWhiteSpaceTrim):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setWhiteSpaceTrim):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/336d5832b252cf4b968bc3619aea5f1b64133d31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136276 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80257 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1029 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66038 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78740 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/768 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33578 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79556 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120899 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109206 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34072 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138738 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127351 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/962 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/931 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html imported/w3c/web-platform-tests/css/css-view-transitions/backdrop-filter-animated.html (failure)") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111801 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/788 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30328 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53421 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1032 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64344 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160364 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/873 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40026 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->