### PR TITLE
[Temporal] Fix Instant toString() for certain instants with negative micro/nanoseconds

### DIFF
--- a/JSTests/stress/temporal-instant.js
+++ b/JSTests/stress/temporal-instant.js
@@ -246,6 +246,11 @@ shouldThrow(() => new Temporal.Instant('abc123'), SyntaxError);
         shouldBe(i5.toString({ fractionalSecondDigits: 8, roundingMode: 'halfExpand' }), '2000-01-01T00:00:00.00000000Z');
     }
     {
+        // should round towards negative infinity when taking epoch milliseconds
+        const i6 = new Temporal.Instant(-1000000000000001000n);
+        shouldBe(i6.toString(), '1938-04-24T22:13:19.999999Z');
+    }
+    {
         // round to nearest hour with halfCeil
         const i7 = new Temporal.Instant(-1000000000000000000n);
         shouldBe(i7.round({smallestUnit: 'hour', roundingIncrement: 1, roundingMode: 'halfCeil' }).toString(), "1938-04-24T22:00:00Z");

--- a/Source/JavaScriptCore/runtime/TemporalInstant.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.cpp
@@ -381,7 +381,10 @@ String TemporalInstant::toString(JSGlobalObject* globalObject, JSValue optionsVa
 // https://tc39.es/proposal-temporal/#sec-temporal-temporalinstanttostring
 String TemporalInstant::toString(ISO8601::ExactTime exactTime, JSObject* timeZone, PrecisionData precision)
 {
-    GregorianDateTime gregorianDateTime { static_cast<double>(exactTime.epochMilliseconds()), LocalTimeOffset { } };
+    // We want to round down the epoch milliseconds so that we can add
+    // the microseconds and nanoseconds back in -- hence the call to
+    // floorEpochMilliseconds().
+    GregorianDateTime gregorianDateTime { static_cast<double>(exactTime.floorEpochMilliseconds()), LocalTimeOffset { } };
     StringBuilder builder;
 
     // If the year is outside the bounds of 0 and 9999 inclusive we want to


### PR DESCRIPTION
#### 6294e8df2ea0965b109d4fc9aac034b52e28e56a
<pre>
[Temporal] Fix Instant toString() for certain instants with negative micro/nanoseconds
<a href="https://bugs.webkit.org/show_bug.cgi?id=301717">https://bugs.webkit.org/show_bug.cgi?id=301717</a>

Reviewed by Yusuke Suzuki.

Temporal.Instant.toString should use floorEpochMilliseconds() instead
of epochMilliseconds() (see comments in code for the reasoning).

* JSTests/stress/temporal-instant.js:
(shouldNotBe):
* Source/JavaScriptCore/runtime/TemporalInstant.cpp:

Canonical link: <a href="https://commits.webkit.org/302460@main">https://commits.webkit.org/302460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d93abb33ab462275f812437f3a47b495c827b06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80534 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98341 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66211 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78989 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33806 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79809 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121141 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109414 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139002 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127602 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1163 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106873 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106708 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/27164 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/988 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30549 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53778 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20167 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1274 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64627 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160616 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1100 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40096 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->