### PR TITLE
WKWebExtensionAPIDeclarativeNetRequest.BlockedLoadInPrivateBrowsingTest fails in debug builds

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -458,6 +458,7 @@ void WebExtensionController::addUserContentController(WebUserContentControllerPr
             continue;
 
         context->addInjectedContent(userContentController);
+        context->addDeclarativeNetRequestRules(userContentController);
     }
 }
 
@@ -469,8 +470,10 @@ void WebExtensionController::removeUserContentController(WebUserContentControlle
             return;
     }
 
-    for (Ref context : m_extensionContexts)
+    for (Ref context : m_extensionContexts) {
         context->removeInjectedContent(userContentController);
+        userContentController.removeContentRuleList(context->uniqueIdentifier());
+    }
 
     m_allNonPrivateUserContentControllers.remove(userContentController);
     m_allPrivateUserContentControllers.remove(userContentController);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -1562,6 +1562,20 @@ bool WebExtensionContext::purgeMatchedRulesFromBefore(const WallTime& startTime)
     return !m_matchedRules.isEmpty();
 }
 
+void WebExtensionContext::addDeclarativeNetRequestRules(WebUserContentControllerProxy& controllerProxy)
+{
+    API::ContentRuleListStore::defaultStoreSingleton().lookupContentRuleListFile(declarativeNetRequestContentRuleListFilePath(), uniqueIdentifier().isolatedCopy(), [this, protectedThis = Ref { *this }, controllerProxy = Ref { controllerProxy }](RefPtr<API::ContentRuleList> ruleList, std::error_code) {
+        if (!ruleList)
+            return;
+
+        // The extension could have been unloaded before this was called.
+        if (!isLoaded())
+            return;
+
+        controllerProxy->addContentRuleList(*ruleList, m_baseURL);
+    });
+}
+
 void WebExtensionContext::addDeclarativeNetRequestRulesToPrivateUserContentControllers()
 {
     API::ContentRuleListStore::defaultStoreSingleton().lookupContentRuleListFile(declarativeNetRequestContentRuleListFilePath(), uniqueIdentifier().isolatedCopy(), [this, protectedThis = Ref { *this }](RefPtr<API::ContentRuleList> ruleList, std::error_code) {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -591,6 +591,8 @@ public:
     void addInjectedContent(WebUserContentControllerProxy&);
     void removeInjectedContent(WebUserContentControllerProxy&);
 
+    void addDeclarativeNetRequestRules(WebUserContentControllerProxy&);
+
     bool handleContentRuleListNotificationForTab(WebExtensionTab&, const URL&, WebCore::ContentRuleListResults::Result);
     void incrementActionCountForTab(WebExtensionTab&, ssize_t incrementAmount);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -35,8 +35,7 @@
 
 namespace TestWebKitAPI {
 
-// FIXME: rdar://163669919 (REGRESSION(iOS26, Tahoe) [ iOS26 Tahoe Debug ]: TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.BlockedLoadInPrivateBrowsingTest is a constant timeout (301660))
-TEST(WKWebExtensionAPIDeclarativeNetRequest, DISABLED_BlockedLoadTest)
+TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadTest)
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<iframe src='/frame.html'></iframe>"_s } },
@@ -86,8 +85,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, DISABLED_BlockedLoadTest)
     Util::run(&receivedActionNotification);
 }
 
-// FIXME: rdar://163669919 (REGRESSION(iOS26, Tahoe) [ iOS26 Tahoe Debug ]: TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.BlockedLoadInPrivateBrowsingTest is a constant timeout (301660))
-TEST(WKWebExtensionAPIDeclarativeNetRequest, DISABLED_BlockedLoadInPrivateBrowsingTest)
+TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadInPrivateBrowsingTest)
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<iframe src='/frame.html'></iframe>"_s } },


### PR DESCRIPTION
#### b82dd5e6b1e44e9631e656b5b5b64253b7148fd5
<pre>
WKWebExtensionAPIDeclarativeNetRequest.BlockedLoadInPrivateBrowsingTest fails in debug builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=301720">https://bugs.webkit.org/show_bug.cgi?id=301720</a>
<a href="https://rdar.apple.com/163669919">rdar://163669919</a>

Reviewed by Timothy Hatcher.

When a WKUserContentController is created after an extension has already been loaded, declarativeNetRequest
rules were not applied to it.

To fix this, when a WebExtensionController::addUserContentController, make sure we apply the active DNR rules
for each extension.

This fixes WKWebExtensionAPIDeclarativeNetRequest.BlockedLoadInPrivateBrowsingTest, and re-enables the two skipped
tests.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::addUserContentController):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::addDeclarativeNetRequestRulesToUserContentController):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/302465@main">https://commits.webkit.org/302465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7ac8584a82cf4c75f32deed8599ea4a3fa39f7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80564 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b0331539-7baa-4440-b96d-cff2ad7c13c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98362 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66236 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/765b3bd5-b89f-4f28-b9d7-f2162bd998e3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132121 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1067 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115713 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79009 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2b5078c6-391e-4d86-8a1e-a4122986aaa6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/988 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/33830 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79833 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34326 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139026 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1225 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1184 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106894 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1277 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106730 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27167 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30573 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53813 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64651 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1124 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1169 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1222 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->