### PR TITLE
Skip using nodesForInsertion vector for appending children created from HTML parser.

### DIFF
--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -336,6 +336,27 @@ static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertion(ContainerNode&
 }
 
 template<typename DOMInsertionWork>
+static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertionDeferringPostInsertionCallbacks(ContainerNode& containerNode, Node& child, Node* beforeChild,
+    ContainerNode::ChildChange::Source source, ReplacedAllChildren replacedAllChildren, NodeVector& postInsertionNotificationTargets, NOESCAPE const DOMInsertionWork& doNodeInsertion)
+{
+    auto childChange = makeChildChangeForInsertion(containerNode, child, beforeChild, source, replacedAllChildren);
+
+    {
+        WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
+        ScriptDisallowedScope::InMainThread scriptDisallowedScope;
+        Style::ChildChangeInvalidation styleInvalidation(containerNode, childChange);
+
+        if (containerNode.isShadowRoot() || containerNode.isInShadowTree()) [[unlikely]]
+            containerNode.containingShadowRoot()->resolveSlotsBeforeNodeInsertionOrRemoval();
+
+        doNodeInsertion();
+        ChildListMutationScope(containerNode).childAdded(child);
+        notifyChildNodeInserted(containerNode, child, postInsertionNotificationTargets);
+    }
+    containerNode.childrenChanged(childChange);
+}
+
+template<typename DOMInsertionWork>
 static ALWAYS_INLINE void executeParserNodeInsertionIntoIsolatedTreeWithoutNotifyingParent(ContainerNode& containerNode, Node& child, NOESCAPE const DOMInsertionWork& doNodeInsertion)
 {
     {
@@ -877,6 +898,11 @@ ExceptionOr<void> ContainerNode::appendChildWithoutPreInsertionValidityCheck(Nod
 {
     Ref protectedThis { *this };
 
+    if (auto* fragment = dynamicDowncast<DocumentFragment>(newChild)) {
+        if (fragment->isDocumentFragmentForInnerOuterHTML())
+            return appendChildrenFromInnerOuterHTMLFragment(*fragment);
+    }
+
     NodeVector targets;
     auto removeResult = removeSelfOrChildNodesForInsertion(newChild, targets);
     if (removeResult.hasException())
@@ -910,6 +936,41 @@ ExceptionOr<void> ContainerNode::appendChildWithoutPreInsertionValidityCheck(Nod
         });
     }
 
+    dispatchSubtreeModifiedEvent();
+    return { };
+}
+
+ExceptionOr<void> ContainerNode::appendChildrenFromInnerOuterHTMLFragment(DocumentFragment& fragment)
+{
+    ASSERT(fragment.isDocumentFragmentForInnerOuterHTML());
+    ASSERT(!fragment.wrapper());
+
+    if (!fragment.hasChildNodes())
+        return { };
+
+    InspectorInstrumentation::willInsertDOMNode(protectedDocument(), *this);
+
+    ChildListMutationScope mutation(*this);
+    NodeVector postInsertionNotificationTargets;
+
+    while (RefPtr child = fragment.firstChild()) {
+        RefPtr nextSibling = child->nextSibling();
+        fragment.removeBetween(nullptr, nextSibling.get(), *child);
+
+        executeNodeInsertionWithScriptAssertionDeferringPostInsertionCallbacks(*this, *child, nullptr, ChildChange::Source::API, ReplacedAllChildren::No, postInsertionNotificationTargets, [&] {
+            child->setTreeScopeRecursively(treeScope());
+            appendChildCommon(*child);
+        });
+    }
+
+    ASSERT(ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree(*this));
+    for (auto& target : postInsertionNotificationTargets)
+        target->didFinishInsertingNode();
+
+    for (RefPtr child = firstChild(); child; child = child->nextSibling())
+        dispatchChildInsertionEvents(*child);
+
+    fragment.rebuildSVGExtensionsElementsIfNecessary();
     dispatchSubtreeModifiedEvent();
     return { };
 }

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -27,6 +27,7 @@
 
 namespace WebCore {
 
+class DocumentFragment;
 class HTMLCollection;
 class RadioNodeList;
 class RenderElement;
@@ -178,6 +179,7 @@ private:
 
     void removeBetween(Node* previousChild, Node* nextChild, Node& oldChild);
     ExceptionOr<void> appendChildWithoutPreInsertionValidityCheck(Node&);
+    ExceptionOr<void> appendChildrenFromInnerOuterHTMLFragment(DocumentFragment&);
 
     void insertBeforeCommon(Node& nextChild, Node& oldChild);
     void appendChildCommon(Node&);


### PR DESCRIPTION
#### 133827d481cbfc523eff39baa6e387f501c9566d
<pre>
Skip using nodesForInsertion vector for appending children created from HTML parser.
<a href="https://bugs.webkit.org/show_bug.cgi?id=301722">https://bugs.webkit.org/show_bug.cgi?id=301722</a>
<a href="https://rdar.apple.com/163748446">rdar://163748446</a>

Reviewed by NOBODY (OOPS!).

Skip using nodesForInsertion vector for appending children created from HTML parser.

When setting innerHTML or outerHTML, we construct a temporary DocumentFragment to build the subtree
of the parsed markup. These children are then moved to become children of the target
element for innerHTML, or replace the existing subtree for outerHTML.

Currently, we store all top-level nodes from the fragment into a vector of Ref&lt;Node&gt;
before inserting them. This vector exists to protect against mutation events that could
modify the tree during iteration. However, for DocumentFragments created specifically
for innerHTML/outerHTML, this protection is unnecessary because the fragment is internal (not exposed to JavaScript) so external mutations should not be able to occur while doing the insertion process.


This patch adds a fast path that directly appends children from innerHTML/outerHTML
fragments without the intermediate vector allocation and appends. To maintain correctness, the patch
defers post-insertion callbacks until after all children are inserted into the permanent container.
This is necessary because these callbacks may need the tree to be fully constructed to work correctly once fired.

This is an overall insignificant but .7% - .8% speedup in SP3 subtests TodoMVC-JavaScript-ES6-Webpack-Complex-DOM and TodoMVC-jQuery because they are heavy in fast parsing.

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::appendChildWithoutPreInsertionValidityCheck):
(WebCore::ContainerNode::appendChildrenFromInnerOuterHTMLFragment):
* Source/WebCore/dom/ContainerNode.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/133827d481cbfc523eff39baa6e387f501c9566d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80380 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ae36a9a8-d41f-457e-b773-7125ad80970c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1161 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98236 "Found 2 new test failures: fast/dom/MutationObserver/removed-out-of-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66121 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b7470e68-e158-45c7-95aa-3e69b645c060) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131972 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/936 "Found 1 new test failure: fast/dom/MutationObserver/removed-out-of-order.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78880 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6d253265-3235-402c-bb49-b903167f8647) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/864 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33692 "Found 2 new test failures: fast/dom/MutationObserver/removed-out-of-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79685 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109304 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34190 "Found 2 new test failures: fast/dom/MutationObserver/removed-out-of-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138880 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1079 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1053 "Found 2 new test failures: fast/dom/MutationObserver/removed-out-of-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106777 "Found 2 new test failures: fast/dom/MutationObserver/removed-out-of-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106603 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/890 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30437 "Found 2 new test failures: fast/dom/MutationObserver/removed-out-of-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53584 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1153 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64493 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/987 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1036 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1080 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->