### PR TITLE
[Temporal] Fix rounding bug with instants and halfCeil rounding mode

### DIFF
--- a/JSTests/stress/temporal-instant.js
+++ b/JSTests/stress/temporal-instant.js
@@ -245,6 +245,11 @@ shouldThrow(() => new Temporal.Instant('abc123'), SyntaxError);
         const i5 = Temporal.Instant.from('1999-12-31T23:59:59.999999999Z');
         shouldBe(i5.toString({ fractionalSecondDigits: 8, roundingMode: 'halfExpand' }), '2000-01-01T00:00:00.00000000Z');
     }
+    {
+        // round to nearest hour with halfCeil
+        const i7 = new Temporal.Instant(-1000000000000000000n);
+        shouldBe(i7.round({smallestUnit: 'hour', roundingIncrement: 1, roundingMode: 'halfCeil' }).toString(), "1938-04-24T22:00:00Z");
+    }
 }
 
 // leap second is constrained

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -656,6 +656,8 @@ Int128 roundNumberToIncrementAsIfPositive(Int128 x, Int128 increment, RoundingMo
         r2 = quotient;
     }
     auto doubleRemainder = absInt128(remainder * 2);
+    auto cmp = (doubleRemainder < increment ? -1 : doubleRemainder == increment ? 0 : 1)
+        * (x < 0 ? -1 : 1);
     auto even = r1 % 2;
     if (quotient * increment == x)
         return x;
@@ -663,9 +665,9 @@ Int128 roundNumberToIncrementAsIfPositive(Int128 x, Int128 increment, RoundingMo
         return r1 * increment;
     if (unsignedRoundingMode == UnsignedRoundingMode::Infinity)
         return r2 * increment;
-    if (doubleRemainder < increment)
+    if (cmp < 0)
         return r1 * increment;
-    if (doubleRemainder > increment)
+    if (cmp > 0)
         return r2 * increment;
     if (unsignedRoundingMode == UnsignedRoundingMode::HalfZero)
         return r1 * increment;


### PR DESCRIPTION
#### 04589551859212426d455bfb31a31548f8e62f75
<pre>
[Temporal] Fix rounding bug with instants and halfCeil rounding mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=301724">https://bugs.webkit.org/show_bug.cgi?id=301724</a>

Reviewed by Yusuke Suzuki.

roundNumberToIncrementAsIfPositive() wasn&apos;t following the spec.

* JSTests/stress/temporal-instant.js:
(shouldNotBe):
* Source/JavaScriptCore/runtime/TemporalObject.cpp:
(JSC::roundNumberToIncrementAsIfPositive):

Canonical link: <a href="https://commits.webkit.org/302403@main">https://commits.webkit.org/302403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebaa14afa0963479211c1451b47be48ae098819f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136291 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80270 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98138 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66045 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78767 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33585 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79571 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120909 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138753 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127364 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106673 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111808 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106486 "") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/799 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30333 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53432 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20139 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1045 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64359 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160380 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/883 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40032 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->