### PR TITLE
[GLib API] Function jsc_value_array_buffer_get_data() is not introspectable

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCValue.cpp
@@ -1568,7 +1568,7 @@ gboolean jsc_value_is_array_buffer(JSCValue* value)
 /**
  * jsc_value_array_buffer_get_data:
  * @value: A #JSCValue
- * @size: (nullable): location where to store the size of the memory region.
+ * @size: (out) (optional): location where to store the size of the memory region.
  *
  * Gets a pointer to memory that contains the array buffer data.
  *
@@ -1586,7 +1586,8 @@ gboolean jsc_value_is_array_buffer(JSCValue* value)
  * the meantime. Consider taking a copy of the data and using the copy instead
  * in asynchronous code.
  *
- * Returns: (transfer none): pointer to memory.
+ * Returns: (transfer none) (array length=size) (element-type guint8):
+ *   pointer to memory.
  *
  * Since: 2.38
  */


### PR DESCRIPTION
#### db4ddb1de5837df65325e13a00fb8a1a107a1f95
<pre>
[GLib API] Function jsc_value_array_buffer_get_data() is not introspectable
<a href="https://bugs.webkit.org/show_bug.cgi?id=301723">https://bugs.webkit.org/show_bug.cgi?id=301723</a>

Reviewed by Carlos Garcia Campos.

Update the GObject Introspection annotations for the the
jsc_value_array_buffer_get_data() to reflect the fact that it
returns a pointer to an array of bytes, and that the &quot;size&quot;
parameters is a return value that indicates the length of the
array.

Canonical link: <a href="https://commits.webkit.org/302377@main">https://commits.webkit.org/302377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf0daa3a19aa36fa4444970da4cd35b95d872b86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136294 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80274 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98139 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66047 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78763 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33589 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79574 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120912 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109221 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138764 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127367 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106679 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106492 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27113 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/802 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30337 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53435 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1048 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64362 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160383 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/886 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40033 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/942 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->