### PR TITLE
Apply pending accelerated actions as a post-layout task.

### DIFF
--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -202,8 +202,6 @@ AnimationTimeline::ShouldUpdateAnimationsAndSendEvents DocumentTimeline::documen
 
 void DocumentTimeline::documentDidUpdateAnimationsAndSendEvents()
 {
-    applyPendingAcceleratedAnimations();
-
     if (!m_animationResolutionScheduled)
         scheduleNextTick();
 }
@@ -411,6 +409,11 @@ void DocumentTimeline::animationAcceleratedRunningStateDidChange(WebAnimation& a
         scheduleAnimationResolution();
     else
         clearTickScheduleTimer();
+}
+
+void DocumentTimeline::runPostLayoutTasks()
+{
+    applyPendingAcceleratedAnimations();
 }
 
 void DocumentTimeline::applyPendingAcceleratedAnimations()

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -65,6 +65,7 @@ public:
     void transitionDidComplete(Ref<CSSTransition>&&);
 
     void animationAcceleratedRunningStateDidChange(WebAnimation&);
+    void runPostLayoutTasks();
     void detachFromDocument() override;
 
     void enqueueAnimationEvent(AnimationEventBase&);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10815,8 +10815,10 @@ void Document::updateAnimationsAndSendEvents()
         timelinesController->updateAnimationsAndSendEvents(window->frozenNowTimestamp());
 }
 
-void Document::updateStaleScrollTimelines()
+void Document::runPostLayoutAnimationTasks()
 {
+    if (m_timeline)
+        m_timeline->runPostLayoutTasks();
     if (CheckedPtr timelinesController = this->timelinesController())
         timelinesController->updateStaleScrollTimelines();
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1832,7 +1832,7 @@ public:
     WEBCORE_EXPORT static const Logger& sharedLogger();
 
     void updateAnimationsAndSendEvents();
-    void updateStaleScrollTimelines();
+    void runPostLayoutAnimationTasks();
     WEBCORE_EXPORT DocumentTimeline& timeline();
     DocumentTimeline* existingTimeline() const { return m_timeline.get(); }
     Vector<RefPtr<WebAnimation>> getAnimations();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2295,7 +2295,7 @@ void Page::updateRendering()
 
     // https://drafts.csswg.org/scroll-animations-1/#event-loop
     forEachDocument([] (Document& document) {
-        document.updateStaleScrollTimelines();
+        document.runPostLayoutAnimationTasks();
     });
 
     runProcessingStep(RenderingUpdateStep::FocusFixup, [&] (Document& document) {


### PR DESCRIPTION
#### 9757112864d634a4afb622704f345c1506036cf0
<pre>
Apply pending accelerated actions as a post-layout task.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9757112864d634a4afb622704f345c1506036cf0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136296 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80276 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bc11dd47-6849-48b7-82f2-7c71c9755c62) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1049 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98145 "Found 1 new test failure: webanimations/accelerated-animation-removed-permanently-when-forward-filling.html (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66051 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ea0a4b5f-e5f7-42e0-881b-1ea8a91ed8fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131864 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/852 "Too many flaky failures: compositing/animation/layer-for-filling-animation.html, compositing/backing/animate-into-view-with-descendant.html, compositing/backing/animate-into-view.html, compositing/backing/backing-store-attachment-animating-outside-viewport.html, compositing/backing/transform-transition-from-outside-view.html, fast/events/ios/do-not-show-keyboard-when-focusing-after-blur.html, fast/forms/ios/accessory-bar-navigation.html, fast/forms/ios/focus-input-via-button.html, fast/forms/ios/focus-long-textarea.html, fast/forms/ios/zoom-after-input-tap-wide-input.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78772 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5e6f68e8-ec00-40bf-8d2a-2daa8d738e2a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/783 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33593 "Found 7 new test failures: compositing/animation/layer-for-filling-animation.html compositing/backing/animate-into-view-with-descendant.html compositing/backing/animate-into-view.html compositing/backing/backing-store-attachment-animating-outside-viewport.html compositing/backing/transform-transition-from-outside-view.html compositing/geometry/limit-layer-bounds-opacity-transition.html webanimations/transform-accelerated-animation-removed-one-frame-after-finished-promise.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79576 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109220 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34087 "Found 7 new test failures: compositing/animation/layer-for-filling-animation.html compositing/backing/animate-into-view-with-descendant.html compositing/backing/animate-into-view.html compositing/backing/backing-store-attachment-animating-outside-viewport.html compositing/backing/transform-transition-from-outside-view.html compositing/geometry/limit-layer-bounds-opacity-transition.html webanimations/transform-accelerated-animation-removed-one-frame-after-finished-promise.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138761 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/977 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/949 "Found 7 new test failures: compositing/animation/layer-for-filling-animation.html compositing/backing/animate-into-view-with-descendant.html compositing/backing/animate-into-view.html compositing/backing/backing-store-attachment-animating-outside-viewport.html compositing/backing/transform-transition-from-outside-view.html compositing/geometry/limit-layer-bounds-opacity-transition.html webanimations/transform-accelerated-animation-removed-one-frame-after-finished-promise.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106682 "Found 2 new test failures: compositing/geometry/limit-layer-bounds-opacity-transition.html webanimations/accelerated-animation-removed-permanently-when-forward-filling.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106495 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/806 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30341 "Found 7 new test failures: compositing/animation/layer-for-filling-animation.html compositing/backing/animate-into-view-with-descendant.html compositing/backing/animate-into-view.html compositing/backing/backing-store-attachment-animating-outside-viewport.html compositing/backing/transform-transition-from-outside-view.html compositing/geometry/limit-layer-bounds-opacity-transition.html webanimations/transform-accelerated-animation-removed-one-frame-after-finished-promise.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53437 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64364 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/888 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/944 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/983 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->