### PR TITLE
Control-click on YouTube video does not show video controls

### DIFF
--- a/LayoutTests/fast/events/contextmenu-items-match-node-receiving-contextmenu-event-expected.txt
+++ b/LayoutTests/fast/events/contextmenu-items-match-node-receiving-contextmenu-event-expected.txt
@@ -1,0 +1,3 @@
+The node which receives a 'contextmenu' event should be the node hit-tested when determining which items to show.
+
+PASS: The node hit-tested for the context menu matches the node the contextmenu event was fired on.

--- a/LayoutTests/fast/events/contextmenu-items-match-node-receiving-contextmenu-event.html
+++ b/LayoutTests/fast/events/contextmenu-items-match-node-receiving-contextmenu-event.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+        }
+        video {
+            width: 400px;
+            height: 300px;
+            position: absolute;
+            left: 100px;
+            top: 100px;
+        }
+        #overlay {
+            width: 50px;
+            height: 50px;
+            background: red;
+            position: absolute;
+            z-index: 1;
+        }
+    </style>
+</head>
+<body>
+    <p>The node which receives a 'contextmenu' event should be the node hit-tested when determining which items to show.</p>
+    <video id="video" src="../../media/resources/white.mp4"></video>
+    <span id="output"></span>
+    <div id="overlay"></div>
+    <script>
+        var videoReceivedContextMenuEvent = false;
+        var videoLoaded = false;
+
+        video.addEventListener("contextmenu", (e) => {
+            videoReceivedContextMenuEvent = true;
+            overlay.style.left = (e.pageX + 1) + "px";
+            overlay.style.top = (e.pageY + 1) + "px";
+        });
+
+        video.addEventListener("loadeddata", () => {
+            videoLoaded = true;
+        });
+
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            testRunner.dumpAsText();
+        }
+
+        function hasMenuItemContainingTitle(items, titleToQuery) {
+            if (!items)
+                return false;
+            for (let item of items) {
+                let title = item.title || item;
+                if (title.includes?.(titleToQuery))
+                    return true;
+            }
+            return false;
+        }
+
+        function logMessage(msg) {
+            document.getElementById("output").innerText = msg;
+        }
+
+        onload = async () => {
+            if (!window.testRunner)
+                return;
+
+            await eventSender.asyncMouseMoveTo(200.5, 250.5);
+            let items = await eventSender.contextClick();
+
+            let isVideoContextMenu = hasMenuItemContainingTitle(items, "Show Controls");
+            if (!videoLoaded)
+                logMessage("FAIL: The video failed to load; the test could not complete.");
+            else if (isVideoContextMenu == videoReceivedContextMenuEvent)
+                logMessage("PASS: The node hit-tested for the context menu matches the node the contextmenu event was fired on.");
+            else {
+                logMessage("FAIL: The node hit-tested for the context menu does not match the node the contextmenu event was fired on.");
+                var contextmenuMsg = videoReceivedContextMenuEvent ? "fired" : "did not fire";
+                var hitTestForItemsMsg = isVideoContextMenu ? "was" : "was not";
+                logMessage("The contextmenu event " + contextmenuMsg + " on the video, but the video " + hitTestForItemsMsg + " hit-tested when determining which items to show.");
+            }
+            // Esc key to hide the context menu.
+            await eventSender.keyDown(String.fromCharCode(0x001B), null);
+
+            testRunner.notifyDone();
+        }
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4864,6 +4864,8 @@ webkit.org/b/157179 fast/events/dropzone-005.html [ Failure ]
 webkit.org/b/157179 fast/events/ondragenter.html [ Failure ]
 webkit.org/b/157179 fast/events/remove-target-with-shadow-in-drag.html [ Failure ]
 
+webkit.org/b/301856 fast/events/contextmenu-items-match-node-receiving-contextmenu-event.html [ Skip ]
+
 webkit.org/b/163779 http/tests/xmlhttprequest/on-network-timeout-error-during-preflight.html [ Skip ] # Timeout.
 
 imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4340,6 +4340,8 @@ fast/css/sticky/sticky-top-zoomed.html [ ImageOnlyFailure ]
 fast/events/wheel/wheel-event-destroys-frame.html [ Skip ] # Timeout
 fast/text/install-font-style-recalc.html [ Skip ] # Timeout
 
+webkit.org/b/301856 fast/events/contextmenu-items-match-node-receiving-contextmenu-event.html [ Skip ]
+
 
 # Tests depend on the system timezone.
 storage/indexeddb/modern/date-basic-private.html [ Failure Pass ]

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -239,7 +239,7 @@ std::unique_ptr<ContextMenu> ContextMenuController::maybeCreateContextMenu(Event
     if (!frame)
         return nullptr;
 
-    auto result = frame->eventHandler().hitTestResultAtPoint(LayoutPoint(mouseEvent->absoluteLocation()), WTFMove(hitType));
+    auto result = frame->eventHandler().hitTestResultAtPoint(flooredIntPoint(mouseEvent->absoluteLocation()), WTFMove(hitType));
     if (!result.innerNonSharedNode())
         return nullptr;
 

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -267,6 +267,11 @@ inline WebCore::IntPoint toIntPoint(const WKPoint& wkPoint)
     return WebCore::IntPoint(static_cast<int>(wkPoint.x), static_cast<int>(wkPoint.y));
 }
 
+inline WebCore::DoublePoint toDoublePoint(const WKPoint& wkPoint)
+{
+    return WebCore::DoublePoint(wkPoint.x, wkPoint.y);
+}
+
 inline WebCore::IntRect toIntRect(const WKRect& wkRect)
 {
     return WebCore::IntRect(static_cast<int>(wkRect.origin.x), static_cast<int>(wkRect.origin.y),

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -171,7 +171,7 @@ WKArrayRef WKBundlePageCopyContextMenuAtPointInWindow(WKBundlePageRef pageRef, W
     if (!page)
         return nullptr;
 
-    RefPtr contextMenu = WebKit::toProtectedImpl(pageRef)->contextMenuAtPointInWindow(page->mainFrame().frameID(), WebKit::toIntPoint(point));
+    RefPtr contextMenu = WebKit::toProtectedImpl(pageRef)->contextMenuAtPointInWindow(page->mainFrame().frameID(), WebKit::toDoublePoint(point));
     if (!contextMenu)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3369,7 +3369,7 @@ Ref<WebContextMenu> WebPage::protectedContextMenu()
     return contextMenu();
 }
 
-RefPtr<WebContextMenu> WebPage::contextMenuAtPointInWindow(FrameIdentifier frameID, const IntPoint& point)
+RefPtr<WebContextMenu> WebPage::contextMenuAtPointInWindow(FrameIdentifier frameID, const DoublePoint& point)
 {
     RefPtr frame = WebProcess::singleton().webFrame(frameID);
     if (!frame)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1195,7 +1195,7 @@ public:
 #if ENABLE(CONTEXT_MENUS)
     WebContextMenu& contextMenu();
     Ref<WebContextMenu> protectedContextMenu();
-    RefPtr<WebContextMenu> contextMenuAtPointInWindow(WebCore::FrameIdentifier, const WebCore::IntPoint&);
+    RefPtr<WebContextMenu> contextMenuAtPointInWindow(WebCore::FrameIdentifier, const WebCore::DoublePoint&);
 #endif
 
     static bool canHandleRequest(const WebCore::ResourceRequest&);


### PR DESCRIPTION
#### 5336d0544d6b8a9d3db284ad17b7df75584d0141
<pre>
Control-click on YouTube video does not show video controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=301730">https://bugs.webkit.org/show_bug.cgi?id=301730</a>
<a href="https://rdar.apple.com/162276991">rdar://162276991</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

After fractional coordinates were enabled in 298383@main,
`ContextMenuController::maybeCreateContextMenu` converted the absolute location
of the mouse from a DoublePoint to a LayoutPoint. Previously, it was an IntPoint
which was converted to a LayoutPoint.

This difference is responsible for causing right-clicking or control-clicking
on a YouTube video to fail to show video controls because the hit test began
to return the element used for YouTube&apos;s own context menu rather than hitting
the video.

We fix this by effectively restoring the old behavior; the DoublePoint absolute
location is now floored before it is converted to a LayoutPoint.

While this fix results in a loss of precision, it is arguably more correct to
floor the point because we currently do not report fractional coordinates for
contextmenu events, and the hit test now reflects this by using the exact same
point that we report for the event coordinates.

`eventSender.contextClick()` now respects fractional coordinates for the mouse
position instead of flooring the location.

Test: fast/events/contextmenu-items-match-node-receiving-contextmenu-event.html

* LayoutTests/fast/events/contextmenu-items-match-node-receiving-contextmenu-event-expected.txt: Added.
* LayoutTests/fast/events/contextmenu-items-match-node-receiving-contextmenu-event.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::maybeCreateContextMenu):
* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
(WebKit::toDoublePoint):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageCopyContextMenuAtPointInWindow):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::contextMenuAtPointInWindow):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/302489@main">https://commits.webkit.org/302489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdac931f283651b5f664e204228c988c0612cf05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80624 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5ccf6e9c-6bdf-408e-ace7-e05ec09c6a62) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98410 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66313 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/394efd29-8026-4a92-8f30-85a34eb90a39) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1109 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115762 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79060 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0486b2f1-18a4-46ec-bdf5-d63ce7d49216) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33881 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79892 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109487 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34375 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139086 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1284 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106941 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106779 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1060 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30619 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53889 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20179 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1356 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64712 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1180 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1218 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1279 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->