### PR TITLE
[GTK][WPE] Remove the WITH_OPENXR_RUNTIME environment variable

### DIFF
--- a/Tools/Scripts/webkitpy/port/monadodriver.py
+++ b/Tools/Scripts/webkitpy/port/monadodriver.py
@@ -59,7 +59,6 @@ class MonadoDriver(Driver):
 
     def _setup_environ_for_test(self):
         driver_environment = super(MonadoDriver, self)._setup_environ_for_test()
-        driver_environment['WITH_OPENXR_RUNTIME'] = 'y'
         driver_environment['XRT_COMPOSITOR_NULL'] = 'TRUE'
         driver_environment['XRT_NO_STDIN'] = 'TRUE'
         driver_environment['XR_RUNTIME_JSON'] = self._get_runtime_path(driver_environment)

--- a/Tools/Scripts/webkitpy/port/monadodriver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/monadodriver_unittest.py
@@ -66,7 +66,6 @@ class MonadoDriverTest(unittest.TestCase):
             ),
             None,
         )
-        self.assertEqual(driver._server_process.env['WITH_OPENXR_RUNTIME'], 'y')
         self.assertTrue(driver._server_process.started)
 
         driver._monado_service_process = None

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp
@@ -133,11 +133,6 @@ static void serverCallback(SoupServer*, SoupServerMessage* message, const char* 
 
 static void testWebKitWebXRLeaveImmersiveModeAndWaitUntilImmersiveModeChanged(WebXRTest* test, gconstpointer)
 {
-    if (!g_getenv("WITH_OPENXR_RUNTIME")) {
-        g_test_skip("Unable to run without an OpenXR runtime");
-        return;
-    }
-
     WebViewTest::NetworkPolicyGuard guard(test, WEBKIT_TLS_ERRORS_POLICY_IGNORE);
 
     g_assert_false(webkit_web_view_is_immersive_mode_enabled(test->m_webView.get()));
@@ -155,11 +150,6 @@ static void testWebKitWebXRLeaveImmersiveModeAndWaitUntilImmersiveModeChanged(We
 
 static void testWebKitXRPermissionRequest(WebXRTest* test, gconstpointer)
 {
-    if (!g_getenv("WITH_OPENXR_RUNTIME")) {
-        g_test_skip("Unable to run without an OpenXR runtime");
-        return;
-    }
-
     enum class Answer {
         Deny,
         Allow,


### PR DESCRIPTION
#### 742c0449ea780c8893b4930893d12f9e29152f6a
<pre>
[GTK][WPE] Remove the WITH_OPENXR_RUNTIME environment variable
<a href="https://bugs.webkit.org/show_bug.cgi?id=301731">https://bugs.webkit.org/show_bug.cgi?id=301731</a>

Reviewed by Adrian Perez de Castro.

The test runner scripts run-gtk-tests and run-wpe-tests automatically set the
WITH_OPENXR_RUNTIME env var if the monado-service command was found. And,
TestWebKitWebXR ran the tests only if the WITH_OPENXR_RUNTIME env var was set.
This didn&apos;t seem like a good idea. If the SDK happens to not contain the
monado-service command, the API tests are skipped. No one will realize the
problem. Additionally, if developers wanted to debug TestWebKitWebXR tests,
they had to set the WITH_OPENXR_RUNTIME env var before executing
TestWebKitWebXR without the test runner scripts.

* Tools/Scripts/webkitpy/port/monadodriver.py:
(MonadoDriver._setup_environ_for_test):
* Tools/Scripts/webkitpy/port/monadodriver_unittest.py:
(MonadoDriverTest.test_start):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp:
(testWebKitWebXRLeaveImmersiveModeAndWaitUntilImmersiveModeChanged):
(testWebKitXRPermissionRequest):

Canonical link: <a href="https://commits.webkit.org/302385@main">https://commits.webkit.org/302385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77db7f0cef82b8f01fa5c5ca74d2a60cc91b3b76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98150 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66067 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131875 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/855 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78778 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/128278 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33601 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109223 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106687 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106502 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/817 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30348 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53445 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20132 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1058 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/895 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Running checkout-pull-request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/951 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->