### PR TITLE
[Site Isolation] Skip API Test TestWebKitAPI.WebKit.LayoutMilestonesWithAllContentInFrame in site isolation

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/LayoutMilestonesWithAllContentInFrame.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/LayoutMilestonesWithAllContentInFrame.cpp
@@ -30,6 +30,7 @@
 #include "PlatformUtilities.h"
 #include "PlatformWebView.h"
 #include "Test.h"
+#include "Tests/WebKitCocoa/SiteIsolationUtilities.h"
 #include <WebKit/WKContextPrivate.h>
 #include <WebKit/WKRetainPtr.h>
 
@@ -79,6 +80,10 @@ TEST(WebKit, FirstVisuallyNonEmptyLayoutAfterPageCacheRestore)
     WKContextSetCacheModel(context.get(), kWKCacheModelPrimaryWebBrowser); // Enables the back/forward cache.
 
     PlatformWebView webView(context.get());
+
+    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
+    if (isSiteIsolationEnabled(static_cast<WKWebView*>(webView.platformView())))
+        return;
 
     WKPageNavigationClientV3 loaderClient;
     zeroBytes(loaderClient);


### PR DESCRIPTION
#### f95c46e68b6b62b717991dc19082422854664f84
<pre>
[Site Isolation] Skip API Test TestWebKitAPI.WebKit.LayoutMilestonesWithAllContentInFrame in site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=301732">https://bugs.webkit.org/show_bug.cgi?id=301732</a>

Reviewed by Sihui Liu.

Skip API Test TestWebKitAPI.WebKit.LayoutMilestonesWithAllContentInFrame in site isolation

* Tools/TestWebKitAPI/Tests/WebKit/LayoutMilestonesWithAllContentInFrame.cpp:
(TestWebKitAPI::TEST(WebKit, FirstVisuallyNonEmptyLayoutAfterPageCacheRestore)):

Canonical link: <a href="https://commits.webkit.org/302399@main">https://commits.webkit.org/302399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06aeac58758f47621c9c1eb856accdf94df7ad0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136309 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80287 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98152 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66059 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33603 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79589 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138775 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/986 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/958 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106688 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106503 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30349 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53447 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20137 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1060 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/897 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/953 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->