### PR TITLE
[css-grid] Remove extra assert check

### DIFF
--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2252,16 +2252,14 @@ LayoutRange RenderGrid::gridAreaRangeForOutOfFlow(const RenderBox& gridItem, Sty
     LayoutUnit end;
 
     auto& positions = this->positions(direction);
-    if (positions.isEmpty()) {
-        ASSERT_WITH_SECURITY_IMPLICATION(!positions.isEmpty());
+    if (positions.isEmpty())
         return LayoutRange(borderEdge, isRowAxis ? clientLogicalWidth() : clientLogicalHeight());
-    }
 
     if (startIsAuto)
         start = borderEdge;
-    else {
+    else
         start = positions[startLine];
-    }
+
     if (endIsAuto)
         end = (isRowAxis ? clientLogicalWidth() : clientLogicalHeight()) + borderEdge;
     else {


### PR DESCRIPTION
#### 68011d153140f8066fd876be8dc3a128f04a809f
<pre>
[css-grid] Remove extra assert check
<a href="https://bugs.webkit.org/show_bug.cgi?id=301734">https://bugs.webkit.org/show_bug.cgi?id=301734</a>
<a href="https://rdar.apple.com/problem/163759224">rdar://problem/163759224</a>

Reviewed by NOBODY (OOPS!).

This assert cannot be hit because the above if check already proves the opposite.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::gridAreaRangeForOutOfFlow const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68011d153140f8066fd876be8dc3a128f04a809f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136315 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80294 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8c9c5024-671a-4ef4-8306-129e45d3aa1c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98159 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66086 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7aeaf1c5-3a40-489c-8009-cb67cd0c10d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78787 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/18efaa58-0aa1-4e48-baeb-cbfd3263b71f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33610 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79595 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138781 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106694 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106509 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/820 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30356 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53453 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1066 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64386 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/903 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/959 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/998 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->