### PR TITLE
[masonry] Remove unused function hasEnoughSpaceAtPosition

### DIFF
--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -240,10 +240,4 @@ GridArea GridMasonryLayout::masonryGridAreaFromGridAxisSpan(const GridSpan& grid
         ? GridArea { m_masonryAxisSpan, gridAxisSpan }
         : GridArea { gridAxisSpan, m_masonryAxisSpan };
 }
-
-bool GridMasonryLayout::hasEnoughSpaceAtPosition(unsigned startingPosition, unsigned spanLength) const
-{
-    ASSERT(startingPosition < m_gridAxisTracksCount);
-    return (startingPosition + spanLength) <= m_gridAxisTracksCount;
-}
 } // end namespace WebCore

--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -76,7 +76,6 @@ private:
     bool hasDefiniteGridAxisPosition(const RenderBox& gridItem, Style::GridTrackSizingDirection masonryDirection) const;
     GridArea masonryGridAreaFromGridAxisSpan(const GridSpan&) const;
     GridSpan gridAxisSpanFromArea(const GridArea&) const;
-    bool hasEnoughSpaceAtPosition(unsigned startingPosition, unsigned spanLength) const;
 
     unsigned m_gridAxisTracksCount;
 


### PR DESCRIPTION
#### 9685a9e73d22416723086ef14b7d9e0ea94d7cc0
<pre>
[masonry] Remove unused function hasEnoughSpaceAtPosition
<a href="https://bugs.webkit.org/show_bug.cgi?id=301735">https://bugs.webkit.org/show_bug.cgi?id=301735</a>
<a href="https://rdar.apple.com/problem/163760231">rdar://problem/163760231</a>

Reviewed by Sammy Gill.

hasEnoughSpaceAtPosition() was never called anywhere in the code. Let&apos;s remove it.

* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::masonryGridAreaFromGridAxisSpan const):
(WebCore::GridMasonryLayout::hasEnoughSpaceAtPosition const): Deleted.
* Source/WebCore/rendering/GridMasonryLayout.h:

Canonical link: <a href="https://commits.webkit.org/302382@main">https://commits.webkit.org/302382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36a0ff5082655a507939947c448c6c368d32940e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80297 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/729a8e96-bf2c-4122-9816-121e27411c64) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130810 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98160 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66069 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/864abfb9-532a-4ecc-a1e2-546cd2079413) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78788 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e494d9a6-74dd-477f-bda6-e2589d42e83a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/795 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33613 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79598 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109232 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138784 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106696 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106511 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27115 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/823 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30359 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53455 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1069 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64389 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Checked out pull request; Found 51081 issues; Running display-safer-cpp-results") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/905 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/961 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1000 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->