### PR TITLE
[Swift in WebKit] Fix some missing includes and compile guards in WTF

### DIFF
--- a/Source/WTF/wtf/AbstractCanMakeCheckedPtr.h
+++ b/Source/WTF/wtf/AbstractCanMakeCheckedPtr.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace WTF {
 
 // Use this class when an abstract base class needs CheckedPtr/CheckedRef support, and the

--- a/Source/WTF/wtf/BlockObjCExceptions.h
+++ b/Source/WTF/wtf/BlockObjCExceptions.h
@@ -23,6 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#pragma once
+
+#ifdef __OBJC__
+
 #import <Foundation/NSException.h>
 
 WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_ASSERT void ReportBlockedObjCException(NSException *);
@@ -30,3 +34,4 @@ WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_ASSERT void ReportBlockedObjCException(NSExc
 #define BEGIN_BLOCK_OBJC_EXCEPTIONS @try {
 #define END_BLOCK_OBJC_EXCEPTIONS } @catch(NSException *localException) { ReportBlockedObjCException(localException); }
 
+#endif // __OBJC__

--- a/Source/WTF/wtf/NotFound.h
+++ b/Source/WTF/wtf/NotFound.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace WTF {
 
 constexpr size_t notFound = static_cast<size_t>(-1);

--- a/Source/WTF/wtf/ObjCRuntimeExtras.h
+++ b/Source/WTF/wtf/ObjCRuntimeExtras.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#ifdef __OBJC__
+
 #import <Foundation/Foundation.h>
 #import <objc/message.h>
 #import <wtf/MallocSpan.h>
@@ -89,3 +91,5 @@ using WTF::protocol_copyPropertyListSpan;
 using WTF::protocol_copyProtocolListSpan;
 
 #endif // __cplusplus
+
+#endif // __OBJC__

--- a/Source/WTF/wtf/TypeCasts.h
+++ b/Source/WTF/wtf/TypeCasts.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <cstddef>
+#include <memory>
 #include <type_traits>
+#include <utility>
+#include <wtf/Compiler.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/TypeTraits.h
+++ b/Source/WTF/wtf/TypeTraits.h
@@ -30,7 +30,9 @@
 
 #pragma once
 
+#include <cstddef>
 #include <type_traits>
+#include <utility>
 #include <wtf/Forward.h>
 
 // SFINAE depends on overload resolution. We indicate the overload we'd prefer

--- a/Source/WTF/wtf/ValidatedReinterpretCast.h
+++ b/Source/WTF/wtf/ValidatedReinterpretCast.h
@@ -27,10 +27,10 @@
 
 #pragma once
 
-#include "Compiler.h"
-#include "Platform.h"
 #include <bit>
 #include <cstdint>
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
 #include <wtf/text/ASCIILiteral.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/VectorHash.h
+++ b/Source/WTF/wtf/VectorHash.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "HashFunctions.h"
-#include "Hasher.h"
+#include <wtf/HashFunctions.h>
+#include <wtf/Hasher.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/cocoa/NSStringExtras.h
+++ b/Source/WTF/wtf/cocoa/NSStringExtras.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#ifdef __OBJC__
+
 #import <Foundation/Foundation.h>
 #import <wtf/StdLibExtras.h>
 
@@ -40,3 +42,5 @@ inline const char* safePrintfType(NSString *string) { return string.UTF8String; 
 }
 
 using WTF::span;
+
+#endif // __OBJC__

--- a/Source/WTF/wtf/cocoa/NSURLExtras.h
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#ifdef __OBJC__
+
 #import <Foundation/Foundation.h>
 
 namespace WTF {
@@ -46,3 +48,5 @@ WTF_EXPORT_PRIVATE NSURL *URLWithUserTypedStringDeprecated(NSString *);
 WTF_EXPORT_PRIVATE BOOL isUserVisibleURL(NSString *);
 
 } // namespace WTF
+
+#endif // __OBJC__

--- a/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
+++ b/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __OBJC__
+
 #import <wtf/Assertions.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/TollFreeBridging.h>
@@ -188,3 +190,5 @@ using WTF::bridge_id_cast;
 using WTF::checked_objc_cast;
 using WTF::dynamic_objc_cast;
 using WTF::is_objc;
+
+#endif // __OBJC__

--- a/Source/WTF/wtf/cocoa/VectorCocoa.h
+++ b/Source/WTF/wtf/cocoa/VectorCocoa.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#ifdef __OBJC__
+
 #include <wtf/BlockPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
@@ -123,3 +125,5 @@ inline RetainPtr<dispatch_data_t> makeDispatchData(Vector<T>&& vector)
 using WTF::createNSArray;
 using WTF::makeDispatchData;
 using WTF::makeVector;
+
+#endif // __OBJC__

--- a/Source/WTF/wtf/spi/cocoa/NSLocaleSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/NSLocaleSPI.h
@@ -27,6 +27,8 @@
 
 DECLARE_SYSTEM_HEADER
 
+#ifdef __OBJC__
+
 #import <Foundation/Foundation.h>
 
 #if USE(APPLE_INTERNAL_SDK)
@@ -40,3 +42,4 @@ DECLARE_SYSTEM_HEADER
 + (nonnull NSArray<NSString *> *)matchedLanguagesFromAvailableLanguages:(nonnull NSArray<NSString *> *)availableLanguages forPreferredLanguages:(nonnull NSArray<NSString *> *)preferredLanguages;
 @end
 
+#endif // __OBJC__

--- a/Source/WTF/wtf/spi/cocoa/NSObjCRuntimeSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/NSObjCRuntimeSPI.h
@@ -27,6 +27,8 @@
 
 DECLARE_SYSTEM_HEADER
 
+#ifdef __OBJC__
+
 #if USE(APPLE_INTERNAL_SDK)
 #include <Foundation/NSObjCRuntime_Private.h>
 #endif
@@ -50,3 +52,5 @@ DECLARE_SYSTEM_HEADER
 #define NS_DIRECT_MEMBERS
 #endif
 #endif
+
+#endif // __OBJC__

--- a/Source/WTF/wtf/spi/darwin/ReasonSPI.h
+++ b/Source/WTF/wtf/spi/darwin/ReasonSPI.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Compiler.h>
+#include <wtf/Platform.h>
 
 DECLARE_SYSTEM_HEADER
 

--- a/Source/WTF/wtf/spi/mac/MetadataSPI.h
+++ b/Source/WTF/wtf/spi/mac/MetadataSPI.h
@@ -27,6 +27,8 @@
 
 DECLARE_SYSTEM_HEADER
 
+#ifdef __OBJC__
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #include <CoreServices/CoreServicesPriv.h>
@@ -38,3 +40,5 @@ WTF_EXTERN_C_BEGIN
 Boolean MDItemSetAttribute(MDItemRef, CFStringRef name, CFTypeRef attr);
 
 WTF_EXTERN_C_END
+
+#endif // __OBJC__

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCF.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCF.h
@@ -20,8 +20,11 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
 #include <wtf/text/cf/TextBreakIteratorCFCharacterCluster.h>
 #include <wtf/text/cf/TextBreakIteratorCFStringTokenizer.h>
+
+#if PLATFORM(COCOA)
 
 namespace WTF {
 
@@ -104,3 +107,5 @@ private:
 };
 
 } // namespace WTF
+
+#endif // PLATFORM(COCOA)

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h
@@ -20,10 +20,13 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/spi/cf/CFStringSPI.h>
 #include <wtf/text/StringView.h>
 #include <wtf/text/cocoa/ContextualizedCFString.h>
+
+#if PLATFORM(COCOA)
 
 namespace WTF {
 
@@ -99,3 +102,5 @@ private:
 };
 
 }
+
+#endif // PLATFORM(COCOA)

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
@@ -20,12 +20,18 @@
 
 #pragma once
 
+#if PLATFORM(COCOA)
 #include <CoreFoundation/CoreFoundation.h>
+#endif
+
+#include <wtf/Platform.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/spi/cf/CFStringSPI.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/StringView.h>
 #include <wtf/text/cocoa/ContextualizedCFString.h>
+
+#if PLATFORM(COCOA)
 
 namespace WTF {
 
@@ -130,3 +136,5 @@ private:
 };
 
 }
+
+#endif // PLATFORM(COCOA)

--- a/Source/WTF/wtf/text/cocoa/ContextualizedCFString.h
+++ b/Source/WTF/wtf/text/cocoa/ContextualizedCFString.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if PLATFORM(COCOA)
+
 #include <CoreFoundation/CoreFoundation.h>
 #include <wtf/RetainPtr.h>
 
@@ -36,3 +40,5 @@ class StringView;
 WTF_EXPORT_PRIVATE RetainPtr<CFStringRef> createContextualizedCFString(StringView, StringView priorContext);
 
 } // namespace WTF
+
+#endif // PLATFORM(COCOA)

--- a/Source/WTF/wtf/text/cocoa/ContextualizedNSString.h
+++ b/Source/WTF/wtf/text/cocoa/ContextualizedNSString.h
@@ -25,9 +25,13 @@
 
 #pragma once
 
+#ifdef __OBJC__
+
 #import <Foundation/Foundation.h>
 #import <wtf/text/StringView.h>
 
 @interface WTFContextualizedNSString : NSString
 - (instancetype)initWithContext:(StringView)context contents:(StringView)contents;
 @end
+
+#endif // __OBJC__


### PR DESCRIPTION
#### 543dd66c35df334b4120842ec386780b3e1c4dde
<pre>
[Swift in WebKit] Fix some missing includes and compile guards in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=301736">https://bugs.webkit.org/show_bug.cgi?id=301736</a>
<a href="https://rdar.apple.com/163760601">rdar://163760601</a>

Reviewed by Aditya Keerthi.

Fix some issues in WTF that prevent proper modularization:

- Add some missing include statements (since all headers must be self-contained)
- Add some missing Cocoa / ObjC guards (since all headers must work with both C++ and Obj-C++)

* Source/WTF/wtf/AbstractCanMakeCheckedPtr.h:
* Source/WTF/wtf/BlockObjCExceptions.h:
* Source/WTF/wtf/NotFound.h:
* Source/WTF/wtf/ObjCRuntimeExtras.h:
* Source/WTF/wtf/TypeCasts.h:
* Source/WTF/wtf/TypeTraits.h:
* Source/WTF/wtf/ValidatedReinterpretCast.h:
* Source/WTF/wtf/VectorHash.h:
* Source/WTF/wtf/cocoa/NSStringExtras.h:
* Source/WTF/wtf/cocoa/NSURLExtras.h:
* Source/WTF/wtf/cocoa/TypeCastsCocoa.h:
* Source/WTF/wtf/cocoa/VectorCocoa.h:
* Source/WTF/wtf/spi/cocoa/NSLocaleSPI.h:
* Source/WTF/wtf/spi/cocoa/NSObjCRuntimeSPI.h:
* Source/WTF/wtf/spi/darwin/ReasonSPI.h:
* Source/WTF/wtf/spi/mac/MetadataSPI.h:
* Source/WTF/wtf/text/cf/TextBreakIteratorCF.h:
* Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h:
* Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h:
* Source/WTF/wtf/text/cocoa/ContextualizedCFString.h:
* Source/WTF/wtf/text/cocoa/ContextualizedNSString.h:

Canonical link: <a href="https://commits.webkit.org/302374@main">https://commits.webkit.org/302374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98f9db7727859dea8937ad872b09d693289f7672

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136321 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80299 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0c534989-dc4d-4377-a66b-27cd0953c7a1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1074 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66074 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115503 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/74ac8a97-4ec5-4951-ad61-e0c8368c76b2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/800 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33617 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Running layout-tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79601 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120934 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138787 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127392 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106700 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106517 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27111 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/827 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30363 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53458 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running compile-webkit") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1072 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64392 "") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160410 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/907 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40041 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/963 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1003 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->