### PR TITLE
Increase number of PlayStation EWS bots once more

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -47,6 +47,9 @@
     { "name": "playstation-ews-004", "platform": "playstation" },
     { "name": "playstation-ews-005", "platform": "playstation" },
     { "name": "playstation-ews-006", "platform": "playstation" },
+    { "name": "playstation-ews-007", "platform": "playstation" },
+    { "name": "playstation-ews-008", "platform": "playstation" },
+    { "name": "playstation-ews-009", "platform": "playstation" },
     { "name": "win-bot-001", "platform": "win" },
     { "name": "win-bot-002", "platform": "win" },
     { "name": "win-bot-003", "platform": "win" },
@@ -366,7 +369,7 @@
       "name": "PlayStation-Build-EWS", "shortname": "playstation", "icon": "buildOnly",
       "factory": "PlayStationBuildFactory", "configuration": "release",
       "architectures": ["x86_64"], "platform": "playstation",
-      "workernames": ["playstation-ews-001", "playstation-ews-002", "playstation-ews-003", "playstation-ews-004", "playstation-ews-005", "playstation-ews-006"]
+      "workernames": ["playstation-ews-001", "playstation-ews-002", "playstation-ews-003", "playstation-ews-004", "playstation-ews-005", "playstation-ews-006", "playstation-ews-007", "playstation-ews-008", "playstation-ews-009"]
     },
     {
       "name": "Win-Build-EWS", "shortname": "win", "icon": "buildOnly",


### PR DESCRIPTION
#### c33103d6c3b26f256b88bff2b48d636712f2ef0d
<pre>
Increase number of PlayStation EWS bots once more
<a href="https://bugs.webkit.org/show_bug.cgi?id=301740">https://bugs.webkit.org/show_bug.cgi?id=301740</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-build/config.json:
Add playstation-ews-007 through -009.

Canonical link: <a href="https://commits.webkit.org/302419@main">https://commits.webkit.org/302419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc345dfc76ed1072673f681337e38041a3942da6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1199 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39777 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136325 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80303 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130817 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Running checkout-pull-request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98166 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66077 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33618 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79606 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138792 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106701 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/128376 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1061 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106518 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/830 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53470 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20149 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1076 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/910 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->