### PR TITLE
Address more safer cpp warnings in WebKit/WebProcess/

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -47,8 +47,6 @@ Platform/IPC/ArgumentCoders.h
 [ iOS ] UIProcess/ios/forms/WKFormPopover.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
-WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
-WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
 [ Mac ] WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -59,12 +57,7 @@ WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
-WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
-WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
-WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
-WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
-WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
 [ iOS ] WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.mm
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
@@ -109,7 +109,7 @@ void WebExtensionAPIAlarms::createAlarm(NSString *name, NSDictionary *alarmInfo,
             initialInterval = repeatInterval;
     }
 
-    if (!extensionContext().inTestingMode()) {
+    if (!protectedExtensionContext()->inTestingMode()) {
         // Enforce a minimum interval outside of testing.
         initialInterval = std::max(initialInterval, webExtensionMinimumAlarmInterval);
         repeatInterval = repeatInterval ? std::max(repeatInterval, webExtensionMinimumAlarmInterval) : 0_s;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
@@ -321,8 +321,9 @@ static NSDictionary *toWebAPI(const Vector<WebExtensionMatchedRuleParameters>& m
 
 void WebExtensionAPIDeclarativeNetRequest::getMatchedRules(NSDictionary *filter, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    bool hasFeedbackPermission = extensionContext().hasPermission("declarativeNetRequestFeedback"_s);
-    bool hasActiveTabPermission = extensionContext().hasPermission("activeTab"_s);
+    Ref extensionContext = this->extensionContext();
+    bool hasFeedbackPermission = extensionContext->hasPermission("declarativeNetRequestFeedback"_s);
+    bool hasActiveTabPermission = extensionContext->hasPermission("activeTab"_s);
 
     if (!hasFeedbackPermission && !hasActiveTabPermission) {
         *outExceptionString = toErrorString(nullString(), nullString(), @"either the 'declarativeNetRequestFeedback' or 'activeTab' permission is required").createNSString().autorelease();
@@ -361,7 +362,7 @@ void WebExtensionAPIDeclarativeNetRequest::getMatchedRules(NSDictionary *filter,
         }
 
         callback->call(toWebAPI(result.value()));
-    }, extensionContext().identifier());
+    }, extensionContext->identifier());
 }
 
 void WebExtensionAPIDeclarativeNetRequest::isRegexSupported(NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -117,7 +117,7 @@ double WebExtensionAPIDevToolsInspectedWindow::tabId(WebPage& page)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/tabId
 
-    auto result = extensionContext().tabIdentifier(page);
+    auto result = protectedExtensionContext()->tabIdentifier(page);
     return toWebAPI(result ? result.value() : WebExtensionTabConstants::NoneIdentifier);
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -88,7 +88,7 @@ bool WebExtensionAPIExtension::parseViewFilters(NSDictionary *filter, std::optio
 
 bool WebExtensionAPIExtension::isPropertyAllowed(const ASCIILiteral& name, WebPage*)
 {
-    if (extensionContext().isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
+    if (protectedExtensionContext()->isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
     // This method was removed in manifest version 3.
@@ -110,7 +110,7 @@ JSValue *WebExtensionAPIExtension::getBackgroundPage(JSContextRef context)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getBackgroundPage
 
-    auto backgroundPage = extensionContext().backgroundPage();
+    auto backgroundPage = protectedExtensionContext()->backgroundPage();
     if (!backgroundPage)
         return toJSValue(context, JSValueMakeNull(context));
 
@@ -131,24 +131,25 @@ NSArray *WebExtensionAPIExtension::getViews(JSContextRef context, NSDictionary *
 
     NSMutableArray *result = [NSMutableArray array];
 
+    Ref extensionContext = this->extensionContext();
     // Only include the background page if there aren't any filters specified.
     // Any of the filters (type, tabId, or windowId) would preclude the background page.
     if (!anyFiltersSpecified) {
-        if (auto backgroundPage = extensionContext().backgroundPage()) {
+        if (auto backgroundPage = extensionContext->backgroundPage()) {
             if (auto *windowObject = toWindowObject(context, *backgroundPage))
                 [result addObject:windowObject];
         }
     }
 
     if (!viewType || viewType == ViewType::Popup) {
-        for (auto& page : extensionContext().popupPages(tabIdentifier, windowIdentifier)) {
+        for (auto& page : extensionContext->popupPages(tabIdentifier, windowIdentifier)) {
             if (auto *windowObject = toWindowObject(context, page))
                 [result addObject:windowObject];
         }
     }
 
     if (!viewType || viewType == ViewType::Tab) {
-        for (auto& page : extensionContext().tabPages(tabIdentifier, windowIdentifier)) {
+        for (auto& page : extensionContext->tabPages(tabIdentifier, windowIdentifier)) {
             if (auto *windowObject = toWindowObject(context, page))
                 [result addObject:windowObject];
         }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -253,7 +253,7 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
             return false;
         }
 
-        outClickCallback = WebExtensionCallbackHandler::create(clickCallback.context.JSGlobalContextRef, JSValueToObject(clickCallback.context.JSGlobalContextRef, clickCallback.JSValueRef, nullptr), runtime());
+        outClickCallback = WebExtensionCallbackHandler::create(clickCallback.context.JSGlobalContextRef, JSValueToObject(clickCallback.context.JSGlobalContextRef, clickCallback.JSValueRef, nullptr), protectedRuntime());
     }
 
     NSDictionary *iconDictionary;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -46,29 +46,30 @@ namespace WebKit {
 
 bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPage* page)
 {
-    if (extensionContext().isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
+    Ref extensionContext = this->extensionContext();
+    if (extensionContext->isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
     if (name == "action"_s)
-        return extensionContext().supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext().manifest(), @"action", false);
+        return extensionContext->supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext->manifest(), @"action", false);
 
 #if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
     if (name == "bookmarks"_s)
-        return page->corePage()->settings().webExtensionBookmarksEnabled() && extensionContext().hasPermission("bookmarks"_s);
+        return page->corePage()->settings().webExtensionBookmarksEnabled() && extensionContext->hasPermission("bookmarks"_s);
 #endif
 
     if (name == "commands"_s)
-        return objectForKey<NSDictionary>(extensionContext().manifest(), @"commands", false);
+        return objectForKey<NSDictionary>(extensionContext->manifest(), @"commands", false);
 
     if (name == "declarativeNetRequest"_s)
-        return extensionContext().hasPermission(name) || extensionContext().hasPermission("declarativeNetRequestWithHostAccess"_s);
+        return extensionContext->hasPermission(name) || extensionContext->hasPermission("declarativeNetRequestWithHostAccess"_s);
 
     if (name == "browserAction"_s)
-        return !extensionContext().supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext().manifest(), @"browser_action", false);
+        return !extensionContext->supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext->manifest(), @"browser_action", false);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     if (name == "devtools"_s)
-        return objectForKey<NSString>(extensionContext().manifest(), @"devtools_page") && page && (page->isInspectorPage() || extensionContext().isInspectorBackgroundPage(*page));
+        return objectForKey<NSString>(extensionContext->manifest(), @"devtools_page") && page && (page->isInspectorPage() || extensionContext->isInspectorBackgroundPage(*page));
 #else
     if (name == "devtools"_s)
         return false;
@@ -77,34 +78,34 @@ bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPa
     if (name == "notifications"_s) {
         // FIXME: <rdar://problem/57202210> Add support for browser.notifications.
         // Notifications are currently only available in test mode as an empty stub.
-        if (!extensionContext().inTestingMode())
+        if (!extensionContext->inTestingMode())
             return false;
         goto finish;
     }
 
     if (name == "pageAction"_s)
-        return !extensionContext().supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext().manifest(), @"page_action", false);
+        return !extensionContext->supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext->manifest(), @"page_action", false);
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
     // If the extension requests both sidePanel and sidebarAction, we will give them sidebarAction --
     // we check in sidePanel that there is no sidebar_action key, but we do not check in sidebarAction
     // that there is no sidePanel permission
     if (name == "sidePanel"_s)
-        return page->corePage()->settings().webExtensionSidebarEnabled() && extensionContext().hasPermission("sidePanel"_s) && !objectForKey<NSDictionary>(extensionContext().manifest(), @"sidebar_action", true);
+        return page->corePage()->settings().webExtensionSidebarEnabled() && extensionContext->hasPermission("sidePanel"_s) && !objectForKey<NSDictionary>(extensionContext->manifest(), @"sidebar_action", true);
     if (name == "sidebarAction"_s)
-        return page->corePage()->settings().webExtensionSidebarEnabled() && objectForKey<NSDictionary>(extensionContext().manifest(), @"sidebar_action", true);
+        return page->corePage()->settings().webExtensionSidebarEnabled() && objectForKey<NSDictionary>(extensionContext->manifest(), @"sidebar_action", true);
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
     if (name == "storage"_s)
-        return extensionContext().hasPermission(name) || extensionContext().hasPermission("unlimitedStorage"_s);
+        return extensionContext->hasPermission(name) || extensionContext->hasPermission("unlimitedStorage"_s);
 
     if (name == "test"_s)
-        return extensionContext().inTestingMode();
+        return extensionContext->inTestingMode();
 
 finish:
     // The rest of the property names marked dynamic in WebExtensionAPINamespace.idl match permission names.
     // Check for the permission to determine if the property is allowed to be accessed.
-    return extensionContext().hasPermission(name);
+    return extensionContext->hasPermission(name);
 }
 
 WebExtensionAPIAction& WebExtensionAPINamespace::action()
@@ -234,7 +235,7 @@ WebExtensionAPIRuntime& WebExtensionAPINamespace::runtime() const
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime
 
     if (!m_runtime) {
-        m_runtime = WebExtensionAPIRuntime::create(contentWorldType(), extensionContext());
+        m_runtime = WebExtensionAPIRuntime::create(contentWorldType(), protectedExtensionContext());
         m_runtime->setPropertyPath("runtime"_s, this);
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -199,7 +199,7 @@ WebExtensionAPIEvent& WebExtensionAPIPort::onMessage()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port#onmessage
 
     if (!m_onMessage)
-        m_onMessage = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::PortOnMessage);
+        lazyInitialize(m_onMessage, WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::PortOnMessage));
 
     return *m_onMessage;
 }
@@ -209,7 +209,7 @@ WebExtensionAPIEvent& WebExtensionAPIPort::onDisconnect()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port#ondisconnect
 
     if (!m_onDisconnect)
-        m_onDisconnect = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::PortOnDisconnect);
+        lazyInitialize(m_onDisconnect, WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::PortOnDisconnect));
 
     return *m_onDisconnect;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -52,7 +52,7 @@ namespace WebKit {
 
 bool WebExtensionAPIStorageArea::isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*)
 {
-    if (extensionContext().isUnsupportedAPI(propertyPath(), propertyName)) [[unlikely]]
+    if (protectedExtensionContext()->isUnsupportedAPI(propertyPath(), propertyName)) [[unlikely]]
         return false;
 
     static NeverDestroyed<HashSet<AtomString>> syncStorageProperties { HashSet { AtomString("QUOTA_BYTES_PER_ITEM"_s), AtomString("MAX_ITEMS"_s), AtomString("MAX_WRITE_OPERATIONS_PER_HOUR"_s), AtomString("MAX_WRITE_OPERATIONS_PER_MINUTE"_s) } };

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
@@ -42,7 +42,7 @@ namespace WebKit {
 
 bool WebExtensionAPIStorage::isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*)
 {
-    if (extensionContext().isUnsupportedAPI(propertyPath(), propertyName)) [[unlikely]]
+    if (protectedExtensionContext()->isUnsupportedAPI(propertyPath(), propertyName)) [[unlikely]]
         return false;
 
     if (propertyName == "session"_s)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -607,7 +607,7 @@ bool isValid(std::optional<WebExtensionTabIdentifier> identifier, NSString **out
 
 bool WebExtensionAPITabs::isPropertyAllowed(const ASCIILiteral& name, WebPage*)
 {
-    if (extensionContext().isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
+    if (protectedExtensionContext()->isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
     static NeverDestroyed<HashSet<AtomString>> removedInManifestVersion3 { HashSet { AtomString("executeScript"_s), AtomString("getSelected"_s), AtomString("insertCSS"_s), AtomString("removeCSS"_s) } };
@@ -1053,7 +1053,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame& frame, JSCont
         if (result)
             return;
 
-        port->setError(runtime().reportError(result.error().createNSString().get(), globalContext.get()));
+        port->setError(protectedRuntime()->reportError(result.error().createNSString().get(), globalContext.get()));
         port->disconnect();
     }, extensionContext().identifier());
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
@@ -52,7 +52,7 @@ void WebExtensionAPIWebNavigationEvent::invokeListenersWithArgument(id argument,
         if (filter && ![filter matchesURL:targetURL])
             continue;
 
-        listener.first->call(argument);
+        Ref { *listener.first }->call(argument);
     }
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm
@@ -67,6 +67,11 @@ WebExtensionAPIWebPageRuntime& WebExtensionAPIWebPageNamespace::runtime() const
     return *m_runtime;
 }
 
+Ref<WebExtensionAPIWebPageRuntime> WebExtensionAPIWebPageNamespace::protectedRuntime() const
+{
+    return runtime();
+}
+
 WebExtensionAPITest& WebExtensionAPIWebPageNamespace::test()
 {
     // Documentation: None (Testing Only)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
@@ -59,7 +59,7 @@ void WebExtensionAPIWebRequestEvent::enumerateListeners(WebExtensionTabIdentifie
         if (filter && ![filter matchesRequestForResourceOfType:resourceType URL:resourceURL.createNSURL().get() tabID:toWebAPI(tabIdentifier) windowID:toWebAPI(windowIdentifier)])
             continue;
 
-        function(*listener.callback, listener.extraInfo);
+        function(Ref { *listener.callback }, listener.extraInfo);
     }
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -378,7 +378,7 @@ bool isValid(std::optional<WebExtensionWindowIdentifier> identifier, NSString **
 
 bool WebExtensionAPIWindows::isPropertyAllowed(const ASCIILiteral& name, WebPage*)
 {
-    if (extensionContext().isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
+    if (protectedExtensionContext()->isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
@@ -54,7 +54,7 @@ void WebExtensionAPIWindowsEvent::invokeListenersWithArgument(id argument, Optio
         if (!listener.second.containsAny(windowTypeFilter))
             continue;
 
-        listener.first->call(argument);
+        Ref { *listener.first }->call(argument);
     }
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -85,6 +85,7 @@ public:
     WebExtensionAPIAction& pageAction() { return action(); }
     WebExtensionAPIPermissions& permissions();
     WebExtensionAPIRuntime& runtime() const final;
+    Ref<WebExtensionAPIRuntime> protectedRuntime() const { return runtime(); }
     WebExtensionAPIScripting& scripting();
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
     WebExtensionAPISidePanel& sidePanel();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
@@ -75,8 +75,10 @@ public:
     WebExtensionContentWorldType contentWorldType() const { return m_contentWorldType; }
 
     virtual WebExtensionAPIRuntimeBase& runtime() const { return *m_runtime; }
+    Ref<WebExtensionAPIRuntimeBase> protectedRuntime() const { return runtime(); }
 
     WebExtensionContextProxy& extensionContext() const { return *m_extensionContext; }
+    Ref<WebExtensionContextProxy> protectedExtensionContext() const { return extensionContext(); }
     bool hasExtensionContext() const { return !!m_extensionContext; }
 
     const String& propertyPath() const { return m_propertyPath; }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -147,8 +147,8 @@ private:
     RetainPtr<JSValue> m_error;
     std::optional<WebExtensionMessageSenderParameters> m_senderParameters;
 
-    RefPtr<WebExtensionAPIEvent> m_onMessage;
-    RefPtr<WebExtensionAPIEvent> m_onDisconnect;
+    const RefPtr<WebExtensionAPIEvent> m_onMessage;
+    const RefPtr<WebExtensionAPIEvent> m_onDisconnect;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -62,6 +62,7 @@ class WebExtensionAPIRuntime : public WebExtensionAPIObject, public WebExtension
 
 public:
     WebExtensionAPIRuntime& runtime() const final { return const_cast<WebExtensionAPIRuntime&>(*this); }
+    Ref<WebExtensionAPIRuntime> protectedRuntime() const { return runtime(); }
 
 #if PLATFORM(COCOA)
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
@@ -114,6 +115,7 @@ class WebExtensionAPIWebPageRuntime : public WebExtensionAPIObject, public WebEx
 
 public:
     WebExtensionAPIWebPageRuntime& runtime() const final { return const_cast<WebExtensionAPIWebPageRuntime&>(*this); }
+    Ref<WebExtensionAPIWebPageRuntime> protectedRuntime() const { return runtime(); }
 
 #if PLATFORM(COCOA)
     void sendMessage(WebPage&, WebFrame&, const String& extensionID, const String& messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
@@ -45,6 +45,7 @@ public:
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
 
     WebExtensionAPIWebPageRuntime& runtime() const;
+    Ref<WebExtensionAPIWebPageRuntime> protectedRuntime() const;
     WebExtensionAPITest& test();
 
 private:

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
@@ -241,7 +241,8 @@ NSDictionary *toNSDictionary(JSContextRef context, JSValueRef valueRef, NullValu
         JSRetainPtr propertyName = JSPropertyNameArrayGetNameAtIndex(propertyNames, i);
         if (!propertyName)
             continue;
-        JSValueRef item = JSObjectGetProperty(context, object, propertyName.get(), 0);
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG JSValueRef item = JSObjectGetProperty(context, object, propertyName.get(), 0);
 
         // Chrome does not include null values in dictionaries for web extensions.
         if (nullPolicy == NullValuePolicy::NotAllowed && JSValueIsNull(context, item))
@@ -279,8 +280,10 @@ JSValueRef toJSValueRef(JSContextRef context, const String& string, NullOrEmptyS
         [[fallthrough]];
 
     case NullOrEmptyString::NullStringAsEmptyString:
-        if (JSRetainPtr stringRef = toJSString(string))
-            return JSValueMakeString(context, stringRef.get());
+        if (JSRetainPtr stringRef = toJSString(string)) {
+            // This is a safer cpp false positive (rdar://163760990).
+            SUPPRESS_UNCOUNTED_ARG return JSValueMakeString(context, stringRef.get());
+        }
         return JSValueMakeNull(context);
     }
 }
@@ -327,7 +330,8 @@ JSValueRef deserializeJSONString(JSContextRef context, const String& jsonString)
         return JSValueMakeNull(context);
 
     if (JSRetainPtr string = toJSString(jsonString)) {
-        if (JSValueRef value = JSValueMakeFromJSONString(context, string.get()))
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG if (JSValueRef value = JSValueMakeFromJSONString(context, string.get()))
             return value;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -176,9 +176,10 @@ bool isDictionary(JSContextRef context, JSValueRef value)
     JSObjectRef thisObject = JSValueToObject(context, value, nullptr);
     JSObjectRef globalObject = JSContextGetGlobalObject(context);
 
-    JSValueRef protoObject = JSObjectGetProperty(context, thisObject, protoString.get(), nullptr);
-    JSObjectRef contextObject = JSValueToObject(context, JSObjectGetProperty(context, globalObject, objectString.get(), nullptr), nullptr);
-    JSValueRef prototypeObject = JSObjectGetProperty(context, contextObject, prototypeString.get(), nullptr);
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG JSValueRef protoObject = JSObjectGetProperty(context, thisObject, protoString.get(), nullptr);
+    SUPPRESS_UNCOUNTED_ARG JSObjectRef contextObject = JSValueToObject(context, JSObjectGetProperty(context, globalObject, objectString.get(), nullptr), nullptr);
+    SUPPRESS_UNCOUNTED_ARG JSValueRef prototypeObject = JSObjectGetProperty(context, contextObject, prototypeString.get(), nullptr);
 
     return JSValueIsStrictEqual(context, protoObject, prototypeObject);
 }
@@ -190,7 +191,8 @@ bool isRegularExpression(JSContextRef context, JSValueRef value)
 
     JSRetainPtr regexpString = toJSString("RegExp");
     JSObjectRef globalObject = JSContextGetGlobalObject(context);
-    JSObjectRef regexpValue = JSValueToObject(context, JSObjectGetProperty(context, globalObject, regexpString.get(), nullptr), nullptr);
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG JSObjectRef regexpValue = JSValueToObject(context, JSObjectGetProperty(context, globalObject, regexpString.get(), nullptr), nullptr);
 
     return JSValueIsInstanceOfConstructor(context, value, regexpValue, nullptr);
 }
@@ -202,7 +204,8 @@ bool isThenable(JSContextRef context, JSValueRef value)
 
     JSRetainPtr thenableString = toJSString("then");
     JSObjectRef valueObject = JSValueToObject(context, value, nullptr);
-    JSValueRef thenableObject = JSObjectGetProperty(context, valueObject, thenableString.get(), nullptr);
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG JSValueRef thenableObject = JSObjectGetProperty(context, valueObject, thenableString.get(), nullptr);
 
     return isFunction(context, thenableObject);
 }

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -69,7 +69,8 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
     if (!browserString)
         return;
 
-    auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
     if (namespaceObject && JSValueIsObject(context, namespaceObject))
         return;
 
@@ -89,10 +90,13 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
 
     namespaceObject = toJS(context, WebExtensionAPINamespace::create(contentWorldType, *extension).ptr());
 
-    JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
 
-    if (JSRetainPtr chromeString = toJSString("chrome"))
-        JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    if (JSRetainPtr chromeString = toJSString("chrome")) {
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    }
 }
 
 void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(WebPage& page, WebFrame& frame, DOMWrapperWorld& world)
@@ -110,7 +114,8 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
     if (!browserString)
         return;
 
-    auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
     if (namespaceObject && JSValueIsObject(context, namespaceObject))
         return;
 
@@ -118,9 +123,12 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
 
     namespaceObject = toJS(context, WebExtensionAPINamespace::create(WebExtensionContentWorldType::Main, *extension).ptr());
 
-    JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
-    if (JSRetainPtr chromeString = toJSString("chrome"))
-        JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    if (JSRetainPtr chromeString = toJSString("chrome")) {
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    }
 }
 
 void WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary(WebFrame& frame, DOMWrapperWorld& world)
@@ -132,13 +140,15 @@ void WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary(WebFrame&
     if (!browserString)
         return;
 
-    auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
     if (namespaceObject && JSValueIsObject(context, namespaceObject))
         return;
 
     namespaceObject = toJS(context, WebExtensionAPIWebPageNamespace::create(WebExtensionContentWorldType::WebPage).ptr());
 
-    JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
 }
 
 static WebExtensionFrameParameters toFrameParameters(WebFrame& frame, const URL& url, bool includeDocumentIdentifier = true)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -56,27 +56,27 @@ WKTypeID WKBundleFrameGetTypeID()
 
 bool WKBundleFrameIsMainFrame(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->isMainFrame();
+    return WebKit::toProtectedImpl(frameRef)->isMainFrame();
 }
 
 WKBundleFrameRef WKBundleFrameGetParentFrame(WKBundleFrameRef frameRef)
 {
-    return toAPI(WebKit::toImpl(frameRef)->parentFrame().get());
+    return toAPI(WebKit::toProtectedImpl(frameRef)->parentFrame().get());
 }
 
 WKURLRef WKBundleFrameCopyURL(WKBundleFrameRef frameRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toImpl(frameRef)->url());
+    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(frameRef)->url());
 }
 
 WKURLRef WKBundleFrameCopyProvisionalURL(WKBundleFrameRef frameRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toImpl(frameRef)->provisionalURL());
+    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(frameRef)->provisionalURL());
 }
 
 WKFrameLoadState WKBundleFrameGetFrameLoadState(WKBundleFrameRef frameRef)
 {
-    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return kWKFrameLoadStateFinished;
 
@@ -95,12 +95,12 @@ WKFrameLoadState WKBundleFrameGetFrameLoadState(WKBundleFrameRef frameRef)
 
 WKArrayRef WKBundleFrameCopyChildFrames(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(&WebKit::toImpl(frameRef)->childFrames().leakRef());    
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&WebKit::toImpl(frameRef)->childFrames().leakRef());
 }
 
 JSGlobalContextRef WKBundleFrameGetJavaScriptContext(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->jsContext();
+    return WebKit::toProtectedImpl(frameRef)->jsContext();
 }
 
 WKBundleFrameRef WKBundleFrameForJavaScriptContext(JSContextRef context)
@@ -110,22 +110,22 @@ WKBundleFrameRef WKBundleFrameForJavaScriptContext(JSContextRef context)
 
 JSGlobalContextRef WKBundleFrameGetJavaScriptContextForWorld(WKBundleFrameRef frameRef, WKBundleScriptWorldRef worldRef)
 {
-    return WebKit::toImpl(frameRef)->jsContextForWorld(WebKit::toImpl(worldRef));
+    return WebKit::toProtectedImpl(frameRef)->jsContextForWorld(WebKit::toProtectedImpl(worldRef).get());
 }
 
 JSValueRef WKBundleFrameGetJavaScriptWrapperForNodeForWorld(WKBundleFrameRef frameRef, WKBundleNodeHandleRef nodeHandleRef, WKBundleScriptWorldRef worldRef)
 {
-    return WebKit::toImpl(frameRef)->jsWrapperForWorld(WebKit::toImpl(nodeHandleRef), WebKit::toImpl(worldRef));
+    return WebKit::toProtectedImpl(frameRef)->jsWrapperForWorld(WebKit::toProtectedImpl(nodeHandleRef).get(), WebKit::toProtectedImpl(worldRef).get());
 }
 
 JSValueRef WKBundleFrameGetJavaScriptWrapperForRangeForWorld(WKBundleFrameRef frameRef, WKBundleRangeHandleRef rangeHandleRef, WKBundleScriptWorldRef worldRef)
 {
-    return WebKit::toImpl(frameRef)->jsWrapperForWorld(WebKit::toImpl(rangeHandleRef), WebKit::toImpl(worldRef));
+    return WebKit::toProtectedImpl(frameRef)->jsWrapperForWorld(WebKit::toProtectedImpl(rangeHandleRef).get(), WebKit::toProtectedImpl(worldRef).get());
 }
 
 WKStringRef WKBundleFrameCopyName(WKBundleFrameRef frameRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(frameRef)->name());
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(frameRef)->name());
 }
 
 WKStringRef WKBundleFrameCopyCounterValue(WKBundleFrameRef frameRef, JSObjectRef element)
@@ -135,27 +135,27 @@ WKStringRef WKBundleFrameCopyCounterValue(WKBundleFrameRef frameRef, JSObjectRef
 
 unsigned WKBundleFrameGetPendingUnloadCount(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->pendingUnloadCount();
+    return WebKit::toProtectedImpl(frameRef)->pendingUnloadCount();
 }
 
 WKBundlePageRef WKBundleFrameGetPage(WKBundleFrameRef frameRef)
 {
-    return toAPI(WebKit::toImpl(frameRef)->page());
+    return toAPI(WebKit::toProtectedImpl(frameRef)->page());
 }
 
 void WKBundleFrameStopLoading(WKBundleFrameRef frameRef)
 {
-    WebKit::toImpl(frameRef)->stopLoading();
+    WebKit::toProtectedImpl(frameRef)->stopLoading();
 }
 
 WKStringRef WKBundleFrameCopyLayerTreeAsText(WKBundleFrameRef frameRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(frameRef)->layerTreeAsText());
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(frameRef)->layerTreeAsText());
 }
 
 bool WKBundleFrameAllowsFollowingLink(WKBundleFrameRef frameRef, WKURLRef urlRef)
 {
-    return WebKit::toImpl(frameRef)->allowsFollowingLink(URL { WebKit::toWTFString(urlRef) });
+    return WebKit::toProtectedImpl(frameRef)->allowsFollowingLink(URL { WebKit::toWTFString(urlRef) });
 }
 
 bool WKBundleFrameHandlesPageScaleGesture(WKBundleFrameRef)
@@ -166,57 +166,57 @@ bool WKBundleFrameHandlesPageScaleGesture(WKBundleFrameRef)
 
 WKRect WKBundleFrameGetContentBounds(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(WebKit::toImpl(frameRef)->contentBounds());
+    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->contentBounds());
 }
 
 WKRect WKBundleFrameGetVisibleContentBounds(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(WebKit::toImpl(frameRef)->visibleContentBounds());
+    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->visibleContentBounds());
 }
 
 WKRect WKBundleFrameGetVisibleContentBoundsExcludingScrollbars(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(WebKit::toImpl(frameRef)->visibleContentBoundsExcludingScrollbars());
+    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->visibleContentBoundsExcludingScrollbars());
 }
 
 WKSize WKBundleFrameGetScrollOffset(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(WebKit::toImpl(frameRef)->scrollOffset());
+    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->scrollOffset());
 }
 
 bool WKBundleFrameHasHorizontalScrollbar(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->hasHorizontalScrollbar();
+    return WebKit::toProtectedImpl(frameRef)->hasHorizontalScrollbar();
 }
 
 bool WKBundleFrameHasVerticalScrollbar(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->hasVerticalScrollbar();
+    return WebKit::toProtectedImpl(frameRef)->hasVerticalScrollbar();
 }
 
 bool WKBundleFrameGetDocumentBackgroundColor(WKBundleFrameRef frameRef, double* red, double* green, double* blue, double* alpha)
 {
-    return WebKit::toImpl(frameRef)->getDocumentBackgroundColor(red, green, blue, alpha);
+    return WebKit::toProtectedImpl(frameRef)->getDocumentBackgroundColor(red, green, blue, alpha);
 }
 
 WKStringRef WKBundleFrameCopySuggestedFilenameForResourceWithURL(WKBundleFrameRef frameRef, WKURLRef urlRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(frameRef)->suggestedFilenameForResourceWithURL(URL { WebKit::toWTFString(urlRef) }));
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(frameRef)->suggestedFilenameForResourceWithURL(URL { WebKit::toWTFString(urlRef) }));
 }
 
 WKStringRef WKBundleFrameCopyMIMETypeForResourceWithURL(WKBundleFrameRef frameRef, WKURLRef urlRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(frameRef)->mimeTypeForResourceWithURL(URL { WebKit::toWTFString(urlRef) }));
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(frameRef)->mimeTypeForResourceWithURL(URL { WebKit::toWTFString(urlRef) }));
 }
 
 bool WKBundleFrameContainsAnyFormElements(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->containsAnyFormElements();
+    return WebKit::toProtectedImpl(frameRef)->containsAnyFormElements();
 }
 
 bool WKBundleFrameContainsAnyFormControls(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->containsAnyFormControls();
+    return WebKit::toProtectedImpl(frameRef)->containsAnyFormControls();
 }
 
 void WKBundleFrameSetTextDirection(WKBundleFrameRef frameRef, WKStringRef directionRef)
@@ -224,7 +224,7 @@ void WKBundleFrameSetTextDirection(WKBundleFrameRef frameRef, WKStringRef direct
     if (!frameRef)
         return;
 
-    WebKit::toImpl(frameRef)->setTextDirection(WebKit::toWTFString(directionRef));
+    WebKit::toProtectedImpl(frameRef)->setTextDirection(WebKit::toWTFString(directionRef));
 }
 
 void WKBundleFrameSetAccessibleName(WKBundleFrameRef frameRef, WKStringRef accessibleNameRef)
@@ -232,7 +232,7 @@ void WKBundleFrameSetAccessibleName(WKBundleFrameRef frameRef, WKStringRef acces
     if (!frameRef)
         return;
 
-    WebKit::toImpl(frameRef)->setAccessibleName(AtomString { WebKit::toWTFString(accessibleNameRef) });
+    WebKit::toProtectedImpl(frameRef)->setAccessibleName(AtomString { WebKit::toWTFString(accessibleNameRef) });
 }
 
 WKDataRef WKBundleFrameCopyWebArchive(WKBundleFrameRef frameRef)
@@ -243,7 +243,7 @@ WKDataRef WKBundleFrameCopyWebArchive(WKBundleFrameRef frameRef)
 WKDataRef WKBundleFrameCopyWebArchiveFilteringSubframes(WKBundleFrameRef frameRef, WKBundleFrameFrameFilterCallback frameFilterCallback, void* context)
 {
 #if PLATFORM(COCOA)
-    RetainPtr<CFDataRef> data = WebKit::toImpl(frameRef)->webArchiveData(frameFilterCallback, context);
+    RetainPtr<CFDataRef> data = WebKit::toProtectedImpl(frameRef)->webArchiveData(frameFilterCallback, context);
     if (data)
         return WKDataCreate(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()));
 #else
@@ -260,7 +260,7 @@ bool WKBundleFrameCallShouldCloseOnWebView(WKBundleFrameRef frameRef)
     if (!frameRef)
         return true;
 
-    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return true;
 
@@ -270,21 +270,21 @@ bool WKBundleFrameCallShouldCloseOnWebView(WKBundleFrameRef frameRef)
 WKBundleHitTestResultRef WKBundleFrameCreateHitTestResult(WKBundleFrameRef frameRef, WKPoint point)
 {
     ASSERT(frameRef);
-    return WebKit::toAPI(WebKit::toImpl(frameRef)->hitTest(WebKit::toIntPoint(point)).leakRef());
+    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->hitTest(WebKit::toIntPoint(point)).leakRef());
 }
 
 WKSecurityOriginRef WKBundleFrameCopySecurityOrigin(WKBundleFrameRef frameRef)
 {
-    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return 0;
 
-    return WebKit::toCopiedAPI(&coreFrame->document()->securityOrigin());
+    return WebKit::toCopiedAPI(coreFrame->protectedDocument()->protectedSecurityOrigin().ptr());
 }
 
 void WKBundleFrameFocus(WKBundleFrameRef frameRef)
 {
-    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return;
 
@@ -296,12 +296,12 @@ void _WKBundleFrameGenerateTestReport(WKBundleFrameRef frameRef, WKStringRef mes
     if (!frameRef)
         return;
 
-    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return;
 
     if (RefPtr document = coreFrame->document())
-        document->reportingScope().generateTestReport(WebKit::toWTFString(message), WebKit::toWTFString(group));
+        document->protectedReportingScope()->generateTestReport(WebKit::toWTFString(message), WebKit::toWTFString(group));
 }
 
 void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
@@ -312,7 +312,7 @@ void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
     auto getAXObjectCache = [&frameRef] () -> CheckedPtr<WebCore::AXObjectCache> {
         WebCore::AXObjectCache::enableAccessibility();
 
-        RefPtr frame = WebKit::toImpl(frameRef)->coreLocalFrame();
+        RefPtr frame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
         RefPtr document = frame ? frame->rootFrame().document() : nullptr;
         return document ? document->axObjectCache() : nullptr;
     };
@@ -338,6 +338,6 @@ void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
     CheckedPtr cache = getAXObjectCache();
-    RefPtr root = cache ? cache->rootObjectForFrame(*WebKit::toImpl(frameRef)->coreLocalFrame()) : nullptr;
+    RefPtr root = cache ? cache->rootObjectForFrame(*WebKit::toProtectedImpl(frameRef)->protectedCoreLocalFrame()) : nullptr;
     return root ? root->wrapper() : nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp
@@ -82,13 +82,13 @@ WKTypeID WKBundleNodeHandleGetTypeID()
 WKBundleNodeHandleRef WKBundleNodeHandleCreate(JSContextRef contextRef, JSObjectRef objectRef)
 {
     RefPtr<WebKit::InjectedBundleNodeHandle> nodeHandle = WebKit::InjectedBundleNodeHandle::getOrCreate(contextRef, objectRef);
-    return toAPI(nodeHandle.leakRef());
+    SUPPRESS_UNCOUNTED_ARG return toAPI(nodeHandle.leakRef());
 }
 
 WKBundleNodeHandleRef WKBundleNodeHandleCopyDocument(WKBundleNodeHandleRef nodeHandleRef)
 {
-    RefPtr<WebKit::InjectedBundleNodeHandle> nodeHandle = WebKit::toImpl(nodeHandleRef)->document();
-    return toAPI(nodeHandle.leakRef());
+    RefPtr<WebKit::InjectedBundleNodeHandle> nodeHandle = WebKit::toProtectedImpl(nodeHandleRef)->document();
+    SUPPRESS_UNCOUNTED_ARG return toAPI(nodeHandle.leakRef());
 }
 
 WKRect WKBundleNodeHandleGetRenderRect(WKBundleNodeHandleRef nodeHandleRef, bool* isReplaced)
@@ -99,8 +99,8 @@ WKRect WKBundleNodeHandleGetRenderRect(WKBundleNodeHandleRef nodeHandleRef, bool
 
 WKImageRef WKBundleNodeHandleCopySnapshotWithOptions(WKBundleNodeHandleRef nodeHandleRef, WKSnapshotOptions options)
 {
-    RefPtr<WebKit::WebImage> image = WebKit::toImpl(nodeHandleRef)->renderedImage(WebKit::toSnapshotOptions(options), options & kWKSnapshotOptionsExcludeOverflow);
-    return toAPI(image.leakRef());
+    RefPtr<WebKit::WebImage> image = WebKit::toProtectedImpl(nodeHandleRef)->renderedImage(WebKit::toSnapshotOptions(options), options & kWKSnapshotOptionsExcludeOverflow);
+    SUPPRESS_UNCOUNTED_ARG return toAPI(image.leakRef());
 }
 
 WKBundleRangeHandleRef WKBundleNodeHandleCopyVisibleRange(WKBundleNodeHandleRef)
@@ -111,17 +111,17 @@ WKBundleRangeHandleRef WKBundleNodeHandleCopyVisibleRange(WKBundleNodeHandleRef)
 
 WKRect WKBundleNodeHandleGetElementBounds(WKBundleNodeHandleRef elementHandleRef)
 {
-    return WebKit::toAPI(WebKit::toImpl(elementHandleRef)->elementBounds());
+    return WebKit::toAPI(WebKit::toProtectedImpl(elementHandleRef)->elementBounds());
 }
 
 void WKBundleNodeHandleSetHTMLInputElementValueForUser(WKBundleNodeHandleRef htmlInputElementHandleRef, WKStringRef valueRef)
 {
-    WebKit::toImpl(htmlInputElementHandleRef)->setHTMLInputElementValueForUser(WebKit::toWTFString(valueRef));
+    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setHTMLInputElementValueForUser(WebKit::toWTFString(valueRef));
 }
 
 void WKBundleNodeHandleSetHTMLInputElementSpellcheckEnabled(WKBundleNodeHandleRef htmlInputElementHandleRef, bool enabled)
 {
-    WebKit::toImpl(htmlInputElementHandleRef)->setHTMLInputElementSpellcheckEnabled(enabled);
+    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setHTMLInputElementSpellcheckEnabled(enabled);
 }
 
 bool WKBundleNodeHandleGetHTMLInputElementAutoFilled(WKBundleNodeHandleRef)
@@ -132,17 +132,17 @@ bool WKBundleNodeHandleGetHTMLInputElementAutoFilled(WKBundleNodeHandleRef)
 
 void WKBundleNodeHandleSetHTMLInputElementAutoFilled(WKBundleNodeHandleRef htmlInputElementHandleRef, bool filled)
 {
-    WebKit::toImpl(htmlInputElementHandleRef)->setHTMLInputElementAutoFilled(filled);
+    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setHTMLInputElementAutoFilled(filled);
 }
 
 void WKBundleNodeHandleSetHTMLInputElementAutoFilledAndViewable(WKBundleNodeHandleRef htmlInputElementHandleRef, bool autoFilledAndViewable)
 {
-    WebKit::toImpl(htmlInputElementHandleRef)->setHTMLInputElementAutoFilledAndViewable(autoFilledAndViewable);
+    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setHTMLInputElementAutoFilledAndViewable(autoFilledAndViewable);
 }
 
 void WKBundleNodeHandleSetHTMLInputElementAutoFilledAndObscured(WKBundleNodeHandleRef htmlInputElementHandleRef, bool autoFilledAndObscured)
 {
-    WebKit::toImpl(htmlInputElementHandleRef)->setHTMLInputElementAutoFilledAndObscured(autoFilledAndObscured);
+    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setHTMLInputElementAutoFilledAndObscured(autoFilledAndObscured);
 }
 
 bool WKBundleNodeHandleGetHTMLInputElementAutoFillButtonEnabled(WKBundleNodeHandleRef)
@@ -153,17 +153,17 @@ bool WKBundleNodeHandleGetHTMLInputElementAutoFillButtonEnabled(WKBundleNodeHand
 
 void WKBundleNodeHandleSetHTMLInputElementAutoFillButtonEnabledWithButtonType(WKBundleNodeHandleRef htmlInputElementHandleRef, WKAutoFillButtonType autoFillButtonType)
 {
-    WebKit::toImpl(htmlInputElementHandleRef)->setHTMLInputElementAutoFillButtonEnabled(toAutoFillButtonType(autoFillButtonType));
+    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setHTMLInputElementAutoFillButtonEnabled(toAutoFillButtonType(autoFillButtonType));
 }
 
 WKAutoFillButtonType WKBundleNodeHandleGetHTMLInputElementAutoFillButtonType(WKBundleNodeHandleRef htmlInputElementHandleRef)
 {
-    return toWKAutoFillButtonType(WebKit::toImpl(htmlInputElementHandleRef)->htmlInputElementAutoFillButtonType());
+    return toWKAutoFillButtonType(WebKit::toProtectedImpl(htmlInputElementHandleRef)->htmlInputElementAutoFillButtonType());
 }
 
 WKAutoFillButtonType WKBundleNodeHandleGetHTMLInputElementLastAutoFillButtonType(WKBundleNodeHandleRef htmlInputElementHandleRef)
 {
-    return toWKAutoFillButtonType(WebKit::toImpl(htmlInputElementHandleRef)->htmlInputElementLastAutoFillButtonType());
+    return toWKAutoFillButtonType(WebKit::toProtectedImpl(htmlInputElementHandleRef)->htmlInputElementLastAutoFillButtonType());
 }
 
 bool WKBundleNodeHandleGetHTMLInputElementAutoFillAvailable(WKBundleNodeHandleRef)
@@ -174,7 +174,7 @@ bool WKBundleNodeHandleGetHTMLInputElementAutoFillAvailable(WKBundleNodeHandleRe
 
 void WKBundleNodeHandleSetHTMLInputElementAutoFillAvailable(WKBundleNodeHandleRef htmlInputElementHandleRef, bool autoFillAvailable)
 {
-    WebKit::toImpl(htmlInputElementHandleRef)->setAutoFillAvailable(autoFillAvailable);
+    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setAutoFillAvailable(autoFillAvailable);
 }
 
 WKRect WKBundleNodeHandleGetHTMLInputElementAutoFillButtonBounds(WKBundleNodeHandleRef)
@@ -185,12 +185,12 @@ WKRect WKBundleNodeHandleGetHTMLInputElementAutoFillButtonBounds(WKBundleNodeHan
 
 bool WKBundleNodeHandleGetHTMLInputElementLastChangeWasUserEdit(WKBundleNodeHandleRef htmlInputElementHandleRef)
 {
-    return WebKit::toImpl(htmlInputElementHandleRef)->htmlInputElementLastChangeWasUserEdit();
+    return WebKit::toProtectedImpl(htmlInputElementHandleRef)->htmlInputElementLastChangeWasUserEdit();
 }
 
 bool WKBundleNodeHandleGetHTMLTextAreaElementLastChangeWasUserEdit(WKBundleNodeHandleRef htmlTextAreaElementHandleRef)
 {
-    return WebKit::toImpl(htmlTextAreaElementHandleRef)->htmlTextAreaElementLastChangeWasUserEdit();
+    return WebKit::toProtectedImpl(htmlTextAreaElementHandleRef)->htmlTextAreaElementLastChangeWasUserEdit();
 }
 
 WKBundleNodeHandleRef WKBundleNodeHandleCopyHTMLTableCellElementCellAbove(WKBundleNodeHandleRef)
@@ -201,8 +201,8 @@ WKBundleNodeHandleRef WKBundleNodeHandleCopyHTMLTableCellElementCellAbove(WKBund
 
 WKBundleFrameRef WKBundleNodeHandleCopyDocumentFrame(WKBundleNodeHandleRef documentHandleRef)
 {
-    RefPtr<WebKit::WebFrame> frame = WebKit::toImpl(documentHandleRef)->documentFrame();
-    return toAPI(frame.leakRef());
+    RefPtr<WebKit::WebFrame> frame = WebKit::toProtectedImpl(documentHandleRef)->documentFrame();
+    SUPPRESS_UNCOUNTED_ARG return toAPI(frame.leakRef());
 }
 
 WKBundleFrameRef WKBundleNodeHandleCopyHTMLFrameElementContentFrame(WKBundleNodeHandleRef htmlFrameElementHandleRef)
@@ -213,8 +213,8 @@ WKBundleFrameRef WKBundleNodeHandleCopyHTMLFrameElementContentFrame(WKBundleNode
 
 WKBundleFrameRef WKBundleNodeHandleCopyHTMLIFrameElementContentFrame(WKBundleNodeHandleRef htmlIFrameElementHandleRef)
 {
-    RefPtr<WebKit::WebFrame> frame = WebKit::toImpl(htmlIFrameElementHandleRef)->htmlIFrameElementContentFrame();
-    return toAPI(frame.leakRef());
+    RefPtr<WebKit::WebFrame> frame = WebKit::toProtectedImpl(htmlIFrameElementHandleRef)->htmlIFrameElementContentFrame();
+    SUPPRESS_UNCOUNTED_ARG return toAPI(frame.leakRef());
 }
 
 bool WKBundleNodeHandleGetHTMLInputElementAutofilled(WKBundleNodeHandleRef htmlInputElementHandleRef)
@@ -235,7 +235,7 @@ void WKBundleNodeHandleSetHTMLInputElementAutoFillButtonEnabled(WKBundleNodeHand
 
 WKBundleFrameRef WKBundleNodeHandleCopyOwningDocumentFrame(WKBundleNodeHandleRef documentHandleRef)
 {
-    if (RefPtr document = WebKit::toImpl(documentHandleRef)->document())
-        return toAPI(document->documentFrame().leakRef());
+    if (RefPtr document = WebKit::toProtectedImpl(documentHandleRef)->document())
+        SUPPRESS_UNCOUNTED_ARG return toAPI(document->documentFrame().leakRef());
     return nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -424,7 +424,7 @@ bool InjectedBundleNodeHandle::isSelectElement() const
 bool InjectedBundleNodeHandle::isSelectableTextNode() const
 {
     if (CheckedPtr renderText = dynamicDowncast<RenderText>(m_node->renderer()))
-        return renderText->style().usedUserSelect() != UserSelect::None;
+        return renderText->checkedStyle()->usedUserSelect() != UserSelect::None;
     return false;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
@@ -134,7 +134,7 @@ RefPtr<WebImage> InjectedBundleRangeHandle::renderedImage(SnapshotOptions option
 #endif
 
     VisibleSelection oldSelection = frame->selection().selection();
-    frame->selection().setSelection(range);
+    frame->checkedSelection()->setSelection(range);
 
     float scaleFactor = options.contains(SnapshotOption::ExcludeDeviceScaleFactor) ? 1 : frame->page()->deviceScaleFactor();
     IntRect paintRect = enclosingIntRect(unionRectIgnoringZeroRects(RenderObject::absoluteBorderAndTextRects(range)));
@@ -167,7 +167,7 @@ RefPtr<WebImage> InjectedBundleRangeHandle::renderedImage(SnapshotOptions option
     frameView->paint(graphicsContext, paintRect);
     frameView->setPaintBehavior(oldPaintBehavior);
 
-    frame->selection().setSelection(oldSelection);
+    frame->checkedSelection()->setSelection(oldSelection);
 
     return snapshot;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
@@ -59,7 +59,7 @@ InjectedBundleDOMWindowExtension* InjectedBundleDOMWindowExtension::get(DOMWindo
 }
 
 InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension(WebFrame* frame, InjectedBundleScriptWorld* world)
-    : m_coreExtension(DOMWindowExtension::create(frame->coreLocalFrame() ? frame->coreLocalFrame()->window() : nullptr, world->coreWorld()))
+    : m_coreExtension(DOMWindowExtension::create(frame->coreLocalFrame() ? frame->protectedCoreLocalFrame()->protectedWindow().get() : nullptr, world->protectedCoreWorld().get()))
 {
     allExtensions().add(m_coreExtension.get(), *this);
 }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
@@ -238,7 +238,7 @@ void WebInspectorUIExtensionController::evaluateScriptForExtension(const Inspect
         WTFMove(optionalArguments)
     };
 
-    m_frontendClient->frontendAPIDispatcher().dispatchCommandWithResultAsync("evaluateScriptForExtension"_s, WTFMove(arguments), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](WebCore::InspectorFrontendAPIDispatcher::EvaluationResult&& result) mutable {
+    m_frontendClient->protectedFrontendAPIDispatcher()->dispatchCommandWithResultAsync("evaluateScriptForExtension"_s, WTFMove(arguments), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](WebCore::InspectorFrontendAPIDispatcher::EvaluationResult&& result) mutable {
         if (!weakThis) {
             completionHandler(makeUnexpected(std::nullopt), Inspector::ExtensionError::ContextDestroyed);
             return;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -136,6 +136,10 @@
 #import "PDFKitSPI.h"
 #endif
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+#include "WebExtensionControllerProxy.h"
+#endif
+
 #import "PDFKitSoftLink.h"
 
 #define WEBPAGE_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [webPageID=%" PRIu64 "] WebPage::" fmt, this, m_identifier.toUInt64(), ##__VA_ARGS__)
@@ -2060,6 +2064,13 @@ bool WebPage::isSpeaking() const
     auto [result] = sendResult.takeReplyOr(false);
     return result;
 }
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+RefPtr<WebExtensionControllerProxy> WebPage::protectedWebExtensionControllerProxy() const
+{
+    return webExtensionControllerProxy();
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -395,7 +395,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         RemoteScrollingCoordinatorTransaction scrollingTransaction;
 #if ENABLE(ASYNC_SCROLLING)
         if (webPage->scrollingCoordinator())
-            scrollingTransaction = downcast<RemoteScrollingCoordinator>(*webPage->scrollingCoordinator()).buildTransaction(rootLayer.frameID);
+            scrollingTransaction = downcast<RemoteScrollingCoordinator>(*webPage->protectedScrollingCoordinator()).buildTransaction(rootLayer.frameID);
         scrollingTransaction.setFrameIdentifier(rootLayer.frameID);
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6215,6 +6215,11 @@ ScrollingCoordinator* WebPage::scrollingCoordinator() const
 {
     return protectedCorePage()->scrollingCoordinator();
 }
+
+RefPtr<ScrollingCoordinator> WebPage::protectedScrollingCoordinator() const
+{
+    return scrollingCoordinator();
+}
 #endif
 
 WebPage::SandboxExtensionTracker::~SandboxExtensionTracker()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -602,6 +602,7 @@ public:
 
 #if ENABLE(ASYNC_SCROLLING)
     WebCore::ScrollingCoordinator* scrollingCoordinator() const;
+    RefPtr<WebCore::ScrollingCoordinator> protectedScrollingCoordinator() const;
 #endif
 
     WebPageGroupProxy* pageGroup() const { return m_pageGroup.get(); }
@@ -1732,6 +1733,7 @@ public:
 
 #if ENABLE(WK_WEB_EXTENSIONS) && PLATFORM(COCOA)
     WebExtensionControllerProxy* webExtensionControllerProxy() const { return m_webExtensionController.get(); }
+    RefPtr<WebExtensionControllerProxy> protectedWebExtensionControllerProxy() const;
 #endif
 
     WebCore::UserInterfaceLayoutDirection userInterfaceLayoutDirection() const { return m_userInterfaceLayoutDirection; }


### PR DESCRIPTION
#### 4df7f26c0e755b5cf325c468dae75636a3bd743c
<pre>
Address more safer cpp warnings in WebKit/WebProcess/
<a href="https://bugs.webkit.org/show_bug.cgi?id=301741">https://bugs.webkit.org/show_bug.cgi?id=301741</a>

Reviewed by Anne van Kesteren.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm:
(WebKit::WebExtensionAPIAlarms::createAlarm):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::getMatchedRules):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::tabId):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::isPropertyAllowed):
(WebKit::WebExtensionAPIExtension::getBackgroundPage):
(WebKit::WebExtensionAPIExtension::getViews):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::parseCreateAndUpdateProperties):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed):
(WebKit::WebExtensionAPINamespace::runtime const):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
(WebKit::WebExtensionAPIPort::onMessage):
(WebKit::WebExtensionAPIPort::onDisconnect):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::isPropertyAllowed):
(WebKit::WebExtensionAPIRuntime::getBackgroundPage):
(WebKit::WebExtensionAPIRuntime::connect):
(WebKit::WebExtensionAPIRuntime::connectNative):
(WebKit::WebExtensionAPIWebPageRuntime::sendMessage):
(WebKit::WebExtensionAPIWebPageRuntime::connect):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm:
(WebKit::WebExtensionAPIStorage::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::isPropertyAllowed):
(WebKit::WebExtensionAPITabs::connect):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm:
(WebKit::WebExtensionAPIWebNavigationEvent::invokeListenersWithArgument):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm:
(WebKit::WebExtensionAPIWebPageNamespace::protectedRuntime const):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm:
(WebKit::WebExtensionAPIWebRequestEvent::enumerateListeners):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm:
(WebKit::WebExtensionAPIWindowsEvent::invokeListenersWithArgument):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
(WebKit::WebExtensionAPINamespace::protectedRuntime const):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h:
(WebKit::WebExtensionAPIObject::protectedRuntime const):
(WebKit::WebExtensionAPIObject::protectedExtensionContext const):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
(WebKit::WebExtensionAPIRuntime::protectedRuntime const):
(WebKit::WebExtensionAPIWebPageRuntime::protectedRuntime const):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::toNSDictionary):
(WebKit::toJSValueRef):
(WebKit::deserializeJSONString):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::isDictionary):
(WebKit::isRegularExpression):
(WebKit::isThenable):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
(WebKit::WebExtensionControllerProxy::globalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKBundleFrameIsMainFrame):
(WKBundleFrameGetParentFrame):
(WKBundleFrameCopyURL):
(WKBundleFrameCopyProvisionalURL):
(WKBundleFrameGetFrameLoadState):
(WKBundleFrameCopyChildFrames):
(WKBundleFrameGetJavaScriptContext):
(WKBundleFrameGetJavaScriptContextForWorld):
(WKBundleFrameGetJavaScriptWrapperForNodeForWorld):
(WKBundleFrameGetJavaScriptWrapperForRangeForWorld):
(WKBundleFrameCopyName):
(WKBundleFrameGetPendingUnloadCount):
(WKBundleFrameGetPage):
(WKBundleFrameStopLoading):
(WKBundleFrameCopyLayerTreeAsText):
(WKBundleFrameAllowsFollowingLink):
(WKBundleFrameGetContentBounds):
(WKBundleFrameGetVisibleContentBounds):
(WKBundleFrameGetVisibleContentBoundsExcludingScrollbars):
(WKBundleFrameGetScrollOffset):
(WKBundleFrameHasHorizontalScrollbar):
(WKBundleFrameHasVerticalScrollbar):
(WKBundleFrameGetDocumentBackgroundColor):
(WKBundleFrameCopySuggestedFilenameForResourceWithURL):
(WKBundleFrameCopyMIMETypeForResourceWithURL):
(WKBundleFrameContainsAnyFormElements):
(WKBundleFrameContainsAnyFormControls):
(WKBundleFrameSetTextDirection):
(WKBundleFrameSetAccessibleName):
(WKBundleFrameCopyWebArchiveFilteringSubframes):
(WKBundleFrameCallShouldCloseOnWebView):
(WKBundleFrameCreateHitTestResult):
(WKBundleFrameCopySecurityOrigin):
(WKBundleFrameFocus):
(_WKBundleFrameGenerateTestReport):
(_WKAccessibilityRootObjectForTesting):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp:
(WKBundleNodeHandleCreate):
(WKBundleNodeHandleCopyDocument):
(WKBundleNodeHandleCopySnapshotWithOptions):
(WKBundleNodeHandleGetElementBounds):
(WKBundleNodeHandleSetHTMLInputElementValueForUser):
(WKBundleNodeHandleSetHTMLInputElementSpellcheckEnabled):
(WKBundleNodeHandleSetHTMLInputElementAutoFilled):
(WKBundleNodeHandleSetHTMLInputElementAutoFilledAndViewable):
(WKBundleNodeHandleSetHTMLInputElementAutoFilledAndObscured):
(WKBundleNodeHandleSetHTMLInputElementAutoFillButtonEnabledWithButtonType):
(WKBundleNodeHandleGetHTMLInputElementAutoFillButtonType):
(WKBundleNodeHandleGetHTMLInputElementLastAutoFillButtonType):
(WKBundleNodeHandleSetHTMLInputElementAutoFillAvailable):
(WKBundleNodeHandleGetHTMLInputElementLastChangeWasUserEdit):
(WKBundleNodeHandleGetHTMLTextAreaElementLastChangeWasUserEdit):
(WKBundleNodeHandleCopyDocumentFrame):
(WKBundleNodeHandleCopyHTMLIFrameElementContentFrame):
(WKBundleNodeHandleCopyOwningDocumentFrame):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::isSelectableTextNode const):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp:
(WebKit::InjectedBundleRangeHandle::renderedImage):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp:
(WebKit::InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension):
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp:
(WebKit::WebInspectorUIExtensionController::evaluateScriptForExtension):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::protectedWebExtensionControllerProxy const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::protectedScrollingCoordinator const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/302387@main">https://commits.webkit.org/302387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13d70de918e72c6c5f034bd4fdd8460b7965e2b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80338 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/865ff0cf-ee0c-4739-b4a8-915b59cccef7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98197 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66103 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9160ed53-e3d6-41d7-9e54-e7f5ee0d0ad0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131930 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78840 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4388516a-1d78-46c1-acfe-60cea65a3228) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/829 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33653 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79643 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138831 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1038 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1008 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106732 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1098 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111877 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/106572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27119 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30398 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53526 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1113 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64434 "Found 24 new failures in Platform/IPC/ArgumentCoders.h, AutomationProtocolObjects.h, WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp, WebDriverBidiProtocolObjects.h, WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/947 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1043 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->