### PR TITLE
initialClip is not transformed by the CTM, leading to cursor clipping during dictation

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -48,7 +48,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(Recorder);
 Recorder::Recorder(IsDeferred isDeferred, const GraphicsContextState& state, const FloatRect& initialClip, const AffineTransform& initialCTM, const DestinationColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode)
     : GraphicsContext(isDeferred, state)
     , m_colorSpace(colorSpace)
-    , m_initialClip(initialClip)
+    , m_initialClip(initialCTM.mapRect(initialClip))
     , m_drawGlyphsMode(drawGlyphsMode)
 #if USE(CORE_TEXT)
     , m_initialScale(initialCTM.xScale())
@@ -207,7 +207,15 @@ bool Recorder::updateStateForEndTransparencyLayer()
 
 void Recorder::updateStateForResetClip()
 {
-    currentState().clipBounds = m_initialClip;
+    currentState().clipBounds = initialClip();
+}
+
+FloatRect Recorder::initialClip() const
+{
+    if (auto inverse = ctm().inverse())
+        return inverse->mapRect(m_initialClip);
+
+    return m_initialClip;
 }
 
 void Recorder::updateStateForClip(const FloatRect& rect)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -125,7 +125,7 @@ protected:
     WEBCORE_EXPORT void updateStateForClipToImageBuffer(const FloatRect&);
     WEBCORE_EXPORT void updateStateForApplyDeviceScaleFactor(float);
     WEBCORE_EXPORT bool decomposeDrawGlyphsIfNeeded(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& anchorPoint, FontSmoothingMode);
-    FloatRect initialClip() const { return m_initialClip; }
+    WEBCORE_EXPORT FloatRect initialClip() const;
     DrawGlyphsMode drawGlyphsMode() const { return m_drawGlyphsMode; }
 
     const DestinationColorSpace& colorSpace() const final { return m_colorSpace; }

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -259,15 +259,23 @@ struct DrawSystemImage {
 struct ResetClipRect {
     void operator()(WebCore::GraphicsContext& c)
     {
+        c.translate(10, 10);
+        c.save();
         c.resetClip();
+        c.restore();
     }
 
     static String description()
     {
         return R"DL(
+(translate
+  (x 10.00)
+  (y 10.00))
+(save)
 (reset-clip)
 (clip
-  (rect at (0,0) size 77x88)))DL"_s;
+  (rect at (-10,-10) size 77x88))
+(restore))DL"_s;
     }
 };
 


### PR DESCRIPTION
#### 8d7b28e8a7123325243f1521cfcf0abce5fd50c5
<pre>
initialClip is not transformed by the CTM, leading to cursor clipping during dictation
<a href="https://rdar.apple.com/161084596">rdar://161084596</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301729">https://bugs.webkit.org/show_bug.cgi?id=301729</a>

Reviewed by Simon Fraser.

There was a missing transform on the display list side with regards to initial clip
and a duplicate transform occurring on the GraphicsContextCG side.

* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::Recorder):
As seen in Recorder&apos;s constructor, the state stack expects the clipping
matrix to be transformed:

    m_stateStack.append({ state, initialCTM, initialCTM.mapRect(initialClip) });

but we had left m_initialClip assigned to the untranformed clip rect and then
later directly assigned it to currentState().clipBounds which incorrectly mapped
the untransformed clip rect to the clip bounds.

(WebCore::DisplayList::Recorder::updateStateForResetClip):

The GraphicsContextCG side is invoked via RemoteGraphicsContextProxy::resetClip()
which calls Recorder::updateStateForClip() which we see:
   currentState().clipBounds.intersect(currentState().ctm.mapRect(rect));

but when we pass initialClip(), we want the result of:

m_initialClip = CTM * (some matrix K) * m_initialClip

solving for K, K = CTM^(-1) which is what initialClip() returns now.

(WebCore::DisplayList::Recorder::initialClip const):
The CTM should always be invertible but handle the case, e.g., a zero
scale, where it is not invertible.

I hesitate to add a debug assertion as I&apos;m not sure if there are valid
use cases for a zero transform which would cause the assertion to trigger.

* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
(WebCore::DisplayList::Recorder::initialClip const): Deleted.
Moved to the .cpp file

* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp:
Update test to add a transform which would have detected this bug.

Canonical link: <a href="https://commits.webkit.org/302552@main">https://commits.webkit.org/302552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48e506f12a4706cfb6f74051e4b2a6e02ae90566

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129288 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1544 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40125 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136664 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80677 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98465 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66362 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1a6153b2-6540-47cb-95a7-16650460cc2b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1170 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/40125 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79108 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9c07135d-1477-408c-80c0-e24eb6202c31) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1079 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/40125 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79942 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109529 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/40125 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139137 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106992 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1377 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/40125 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106825 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27237 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1095 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/40125 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53955 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1405 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64771 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/1223 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1258 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/1327 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
<!--EWS-Status-Bubble-End-->