### PR TITLE
BitmapImageSource unconditionally starts animations even if they should be disallowed (fast/images/page-wide-animation-toggle.html is timing out after 302278@main).

### DIFF
--- a/LayoutTests/fast/images/individual-animation-toggle.html
+++ b/LayoutTests/fast/images/individual-animation-toggle.html
@@ -16,7 +16,7 @@ async function toggleAnimationPlayState(shouldAnimate) {
     if (shouldAnimate) {
         debug("Resuming animation.");
         internals.resumeImageAnimation(gif);
-        await shouldBecomeEqual("internals.isImageAnimating(gif)", "false");
+        await shouldBecomeEqual("internals.isImageAnimating(gif)", "true");
     } else {
         debug("Pausing animation.");
         internals.pauseImageAnimation(gif);

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8358,6 +8358,6 @@ imported/w3c/web-platform-tests/editing/other/empty-elements-insertion.html [ Fa
 # webkit.org/b/301602 [ iOS 26 ] imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest.html is a constant text failure
 imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest.html [ Failure ]
 
-webkit.org/b/301655 fast/images/page-wide-animation-toggle.html [ Pass Timeout ]
+fast/images/page-wide-animation-toggle.html [ Pass ]
 
 webkit.org/b/301670 imported/w3c/web-platform-tests/css/css-anchor-position/popover-implicit-anchor.html [ Failure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2579,6 +2579,6 @@ webkit.org/b/300997 webrtc/filtering-ice-candidate-after-reload.html [ Pass Fail
 # https://bugs.webkit.org/show_bug.cgi?id=301143# [ macOS Tahoe ] fast/html/text-field-input-types.html is a constant text failure 
 [ Tahoe Debug ] fast/html/text-field-input-types.html [ Failure ]
 
-webkit.org/b/301655 fast/images/page-wide-animation-toggle.html [ Pass Timeout ]
+fast/images/page-wide-animation-toggle.html [ Pass ]
 
 webkit.org/b/301668 fast/repaint/iframe-avoid-redundant-repaint.html [ Pass Failure ]

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -843,13 +843,24 @@ Image* HTMLImageElement::image() const
 
 bool HTMLImageElement::allowsAnimation() const
 {
+    if (auto* image = this->image()) {
+        if (image->allowsAnimation() == ImageAllowsAnimation::Yes)
+            return true;
+        if (document().page())
+            return document().page()->imageAnimationEnabled();
+    }
+    return false;
+}
+
+bool HTMLImageElement::isAnimating() const
+{
     if (auto* image = this->image())
-        return image->allowsAnimation().value_or(document().page() ? document().page()->imageAnimationEnabled() : false);
+        return image->isAnimating();
     return false;
 }
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
-void HTMLImageElement::setAllowsAnimation(std::optional<bool> allowsAnimation)
+void HTMLImageElement::setAllowsAnimation(ImageAllowsAnimation allowsAnimation)
 {
     if (!document().settings().imageAnimationControlEnabled())
         return;
@@ -860,7 +871,7 @@ void HTMLImageElement::setAllowsAnimation(std::optional<bool> allowsAnimation)
             renderer->repaint();
 
         if (RefPtr page = document().page()) {
-            if (allowsAnimation.value_or(false))
+            if (allowsAnimation == ImageAllowsAnimation::Yes)
                 page->addIndividuallyPlayingAnimationElement(*this);
             else
                 page->removeIndividuallyPlayingAnimationElement(*this);

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -46,6 +46,7 @@ class SecurityOrigin;
 
 struct ImageCandidate;
 
+enum class ImageAllowsAnimation : uint8_t;
 enum class ReferrerPolicy : uint8_t;
 enum class RelevantMutation : bool;
 enum class RequestPriority : uint8_t;
@@ -160,8 +161,9 @@ public:
     bool allowsOrientationOverride() const;
 
     bool allowsAnimation() const;
+    bool isAnimating() const;
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
-    WEBCORE_EXPORT void setAllowsAnimation(std::optional<bool>);
+    WEBCORE_EXPORT void setAllowsAnimation(ImageAllowsAnimation);
 #endif
 
     String fetchPriorityForBindings() const;

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -306,6 +306,9 @@ bool BitmapImageSource::isAnimationAllowed() const
     if (m_frameAnimator && !m_frameAnimator->isAnimationAllowed())
         return false;
 
+    if (auto bitmapImage = m_bitmapImage.get(); bitmapImage && bitmapImage->allowsAnimation() == ImageAllowsAnimation::No)
+        return false;
+
     // ImageObserver may disallow animation.
     if (auto imageObserver = this->imageObserver())
         return imageObserver->allowsAnimation(*m_bitmapImage);
@@ -612,7 +615,8 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAtIndex
 
 Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::currentNativeImageForDrawing(SubsamplingLevel subsamplingLevel, const DecodingOptions& options)
 {
-    startAnimation(subsamplingLevel, options);
+    if (isAnimationAllowed())
+        startAnimation(subsamplingLevel, options);
 
     auto effectiveOptions = options;
 

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -53,6 +53,12 @@ class Timer;
 
 enum class CompositeOperator : uint8_t;
 
+enum class ImageAllowsAnimation : uint8_t {
+    No,
+    Yes,
+    FollowPageState,
+};
+
 // This class gets notified when an image creates or destroys decoded frames and when it advances animation frames.
 class ImageObserver;
 
@@ -134,8 +140,10 @@ public:
     virtual void resetAnimation() {}
     virtual bool isAnimating() const { return false; }
     WEBCORE_EXPORT bool animationPending() const;
-    std::optional<bool> allowsAnimation() const { return m_allowsAnimation; }
-    void setAllowsAnimation(std::optional<bool> allowsAnimation) { m_allowsAnimation = allowsAnimation; }
+
+    ImageAllowsAnimation allowsAnimation() const { return m_allowsAnimation; }
+    void setAllowsAnimation(ImageAllowsAnimation allowsAnimation) { m_allowsAnimation = allowsAnimation; }
+
     static bool systemAllowsAnimationControls() { return gSystemAllowsAnimationControls; }
     WEBCORE_EXPORT static void setSystemAllowsAnimationControls(bool allowsControls);
 
@@ -197,8 +205,8 @@ private:
     WeakPtr<ImageObserver> m_imageObserver;
     std::unique_ptr<ImageAdapter> m_adapter;
 
-    // A value of true or false will override the default Page::imageAnimationEnabled state.
-    std::optional<bool> m_allowsAnimation { std::nullopt };
+    // This will override the default Page::imageAnimationEnabled state.
+    ImageAllowsAnimation m_allowsAnimation { ImageAllowsAnimation::FollowPageState };
     std::unique_ptr<Timer> m_animationStartTimer;
     static bool gSystemAllowsAnimationControls;
 };

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -964,7 +964,7 @@ HTMLImageElement* HitTestResult::imageElement() const
 bool HitTestResult::isAnimating() const
 {
     if (auto* imageElement = this->imageElement())
-        return imageElement->allowsAnimation();
+        return imageElement->isAnimating();
     return false;
 }
 
@@ -981,7 +981,7 @@ void HitTestResult::pauseAnimation() const
 void HitTestResult::setAllowsAnimation(bool allowAnimation) const
 {
     if (auto* imageElement = this->imageElement()) {
-        imageElement->setAllowsAnimation(allowAnimation);
+        imageElement->setAllowsAnimation(allowAnimation ? ImageAllowsAnimation::Yes : ImageAllowsAnimation::No);
         if (auto* renderer = m_innerNonSharedNode->renderer())
             renderer->repaint();
     }

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -1043,9 +1043,9 @@ void RenderView::updatePlayStateForAllAnimations(const IntRect& visibleRect)
             } else if (image && image->isAnimated()) {
                 // Override any individual animation play state that may have been set.
                 if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(renderElement.element()))
-                    imageElement->setAllowsAnimation(std::nullopt);
+                    imageElement->setAllowsAnimation(ImageAllowsAnimation::FollowPageState);
                 else
-                    image->setAllowsAnimation(std::nullopt);
+                    image->setAllowsAnimation(ImageAllowsAnimation::FollowPageState);
 
                 // Animations of this type require a repaint to be paused or resumed.
                 if (shouldAnimate && hasPausedAnimation) {

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1191,12 +1191,12 @@ void Internals::setImageAnimationEnabled(bool enabled)
 
 void Internals::resumeImageAnimation(HTMLImageElement& element)
 {
-    element.setAllowsAnimation(true);
+    element.setAllowsAnimation(ImageAllowsAnimation::Yes);
 }
 
 void Internals::pauseImageAnimation(HTMLImageElement& element)
 {
-    element.setAllowsAnimation(false);
+    element.setAllowsAnimation(ImageAllowsAnimation::No);
 }
 #endif // ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 


### PR DESCRIPTION
#### f749eac650c4eaf6bd61ec0cd7274c6d04f66ca7
<pre>
BitmapImageSource unconditionally starts animations even if they should be disallowed (fast/images/page-wide-animation-toggle.html is timing out after <a href="https://commits.webkit.org/302278@main">302278@main</a>).
<a href="https://bugs.webkit.org/show_bug.cgi?id=301655">https://bugs.webkit.org/show_bug.cgi?id=301655</a>
<a href="https://rdar.apple.com/163668078">rdar://163668078</a>

Reviewed by NOBODY (OOPS!).

BitmapImageSource unconditionally rearms the animation timer in currentNativeImageForDrawing. In
fast/images/page-wide-animation-toggle.html we programmatically pause image animation to test that
we can pause an image animation independently of the page-wide setting. This test case started to
time out after <a href="https://commits.webkit.org/302278@main">302278@main</a> because it inadvertently relied on timing and sequencing of DOM timers
with the BitmapImageSource timer rearming behavior in the aforementioned function.

<a href="https://commits.webkit.org/302278@main">302278@main</a> introduced foreground DOM timer alignment for timers that have reached their maximum
nesting level. Because of this, the js-test.js `shouldBecome` function which polls for a condition
on some expression can become aligned if it polls enough or if there are many promises being awaited.
fast/images/page-wide-animation-toggle.html has this behavior - it polls multiple times in `shouldBecome`
which can cause the DOM timer to fire after the image source has restarted the timer.

This fixes the bug uncovered with this new DOM timer behavior by making the BitmapImageSource check if
animation is enabled first. Additionally, I refactored animation allowed flag in Image to instead use
a strongly typed enum to better communicate what each of the states mean.

Covered by existing tests.

* LayoutTests/fast/images/individual-animation-toggle.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::allowsAnimation const):
(WebCore::HTMLImageElement::isAnimating const):
(WebCore::HTMLImageElement::setAllowsAnimation):
* Source/WebCore/html/HTMLImageElement.h:

* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::isAnimationAllowed const):
(WebCore::BitmapImageSource::currentNativeImageForDrawing):

* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::allowsAnimation const):
(WebCore::Image::setAllowsAnimation):

* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::isAnimating const):
    We can allow animation without actually animating so use the new
    HTMLImageElement::isAnimating getter to decide whether or not
    the hit tested element is animating.
(WebCore::HitTestResult::setAllowsAnimation const):

* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::updatePlayStateForAllAnimations):

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resumeImageAnimation):
(WebCore::Internals::pauseImageAnimation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f749eac650c4eaf6bd61ec0cd7274c6d04f66ca7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129044 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1310 "Hash f749eac6 for PR 53246 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136424 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80413 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130915 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1234 "Hash f749eac6 for PR 53246 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1180 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98251 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66142 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131991 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/1234 "Hash f749eac6 for PR 53246 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78896 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/1234 "Hash f749eac6 for PR 53246 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33708 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79703 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/1234 "Hash f749eac6 for PR 53246 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34206 "Found 1 new test failure: fast/images/individual-animation-toggle.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138898 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1097 "Hash f749eac6 for PR 53246 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1066 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106788 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1151 "Hash f749eac6 for PR 53246 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111929 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106615 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30453 "Found 1 new test failure: fast/images/individual-animation-toggle.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53601 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1170 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64511 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1002 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1050 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1095 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->