### PR TITLE
Remove a couple more static_cast in WebCore/dom and EventHandlerMac

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -42,10 +42,7 @@ bridge/runtime_array.cpp
 bridge/runtime_method.cpp
 bridge/runtime_object.cpp
 bridge/runtime_root.cpp
-dom/ElementRareData.h
-dom/Node.cpp
 dom/NodeRareData.h
-dom/UIEventWithKeyState.cpp
 domjit/DOMJITHelpers.h
 domjit/JSDocumentDOMJIT.cpp
 domjit/JSNodeDOMJIT.cpp
@@ -58,7 +55,6 @@ layout/layouttree/LayoutIterator.h
 layout/layouttree/LayoutTreeBuilder.cpp
 loader/cache/CachedResourceClientWalker.h
 mathml/MathMLRowElement.cpp
-[ Mac ] page/mac/EventHandlerMac.mm
 [ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
 platform/graphics/GraphicsLayer.cpp
 platform/graphics/ca/GraphicsLayerCA.cpp

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -365,7 +365,7 @@ inline bool ElementRareData::hasRandomCachingKeyMap() const
 inline ElementRareData* Element::elementRareData() const
 {
     ASSERT_WITH_SECURITY_IMPLICATION(hasRareData());
-    return static_cast<ElementRareData*>(rareData());
+    return downcast<ElementRareData>(rareData());
 }
 
 inline ShadowRoot* Node::shadowRoot() const
@@ -394,3 +394,7 @@ inline void Element::removeShadowRoot()
 }
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ElementRareData)
+    static bool isType(const WebCore::NodeRareData& rareData) { return rareData.isElementRareData(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -128,6 +128,7 @@ public:
     virtual bool isToggleEvent() const { return false; }
     virtual bool isTouchEvent() const { return false; }
     virtual bool isUIEvent() const { return false; }
+    virtual bool isUIEventWithKeyState() const { return false; }
     virtual bool isVersionChangeEvent() const { return false; }
     virtual bool isWheelEvent() const { return false; }
     virtual bool isXMLHttpRequestProgressEvent() const { return false; }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -247,7 +247,7 @@ void Node::dumpStatistics()
                     ++elementsWithNamedNodeMap;
             }
             auto* rareData = node.rareData();
-            auto useTypes = is<Element>(node) ? static_cast<ElementRareData*>(rareData)->useTypes() : rareData->useTypes();
+            auto useTypes = is<Element>(node) ? downcast<ElementRareData>(rareData)->useTypes() : rareData->useTypes();
             unsigned useTypeCount = 0;
             for (auto type : useTypes) {
                 UNUSED_PARAM(type);
@@ -367,8 +367,8 @@ inline void NodeRareData::operator delete(NodeRareData* nodeRareData, std::destr
         RareDataType::freeAfterDestruction(&value);
     };
 
-    if (nodeRareData->m_isElementRareData)
-        destroyAndFree(static_cast<ElementRareData&>(*nodeRareData));
+    if (auto* elementRareData = dynamicDowncast<ElementRareData>(*nodeRareData))
+        destroyAndFree(*elementRareData);
     else
         destroyAndFree(*nodeRareData);
 }

--- a/Source/WebCore/dom/UIEventWithKeyState.cpp
+++ b/Source/WebCore/dom/UIEventWithKeyState.cpp
@@ -79,7 +79,7 @@ UIEventWithKeyState* findEventWithKeyState(Event* event)
 {
     for (Event* e = event; e; e = e->underlyingEvent())
         if (e->isKeyboardEvent() || e->isMouseEvent())
-            return static_cast<UIEventWithKeyState*>(e);
+            return downcast<UIEventWithKeyState>(e);
     return 0;
 }
 

--- a/Source/WebCore/dom/UIEventWithKeyState.h
+++ b/Source/WebCore/dom/UIEventWithKeyState.h
@@ -73,11 +73,15 @@ protected:
     void setModifierKeys(bool ctrlKey, bool altKey, bool shiftKey, bool metaKey);
 
 private:
-    OptionSet<Modifier> m_modifiers;
-
     static OptionSet<Modifier> modifiersFromInitializer(const EventModifierInit& initializer);
+
+    bool isUIEventWithKeyState() const final { return true; }
+
+    OptionSet<Modifier> m_modifiers;
 };
 
 UIEventWithKeyState* findEventWithKeyState(Event*);
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENT(UIEventWithKeyState)

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -812,20 +812,13 @@ static ContainerNode* findEnclosingScrollableContainer(ContainerNode* node, cons
 
 static WeakPtr<ScrollableArea> scrollableAreaForEventTarget(Element* eventTarget)
 {
-    auto* widget = EventHandler::widgetForEventTarget(eventTarget);
-    if (!widget || !widget->isScrollView())
-        return { };
-
-    return static_cast<ScrollableArea&>(static_cast<ScrollView&>(*widget));
+    return dynamicDowncast<ScrollView>(EventHandler::widgetForEventTarget(eventTarget));
 }
     
 static bool eventTargetIsPlatformWidget(Element* eventTarget)
 {
-    Widget* widget = EventHandler::widgetForEventTarget(eventTarget);
-    if (!widget)
-        return false;
-    
-    return widget->platformWidget();
+    auto* widget = EventHandler::widgetForEventTarget(eventTarget);
+    return widget && widget->platformWidget();
 }
 
 static WeakPtr<ScrollableArea> scrollableAreaForContainerNode(ContainerNode& container)
@@ -858,7 +851,7 @@ void EventHandler::determineWheelEventTarget(const PlatformWheelEvent& wheelEven
         if (scrollableContainer)
             scrollableArea = scrollableAreaForContainerNode(*scrollableContainer);
         else
-            scrollableArea = static_cast<ScrollableArea&>(*view);
+            scrollableArea = *view;
     }
 
     LOG_WITH_STREAM(ScrollLatching, stream << "EventHandler::determineWheelEventTarget() - event " << wheelEvent << " found scrollableArea " << ValueOrNull(scrollableArea.get()) << ", latching state is " << page->scrollLatchingController());


### PR DESCRIPTION
#### 8db7d07dc11d580753e1426c6461fa9c3a653263
<pre>
Remove a couple more static_cast in WebCore/dom and EventHandlerMac
<a href="https://bugs.webkit.org/show_bug.cgi?id=301746">https://bugs.webkit.org/show_bug.cgi?id=301746</a>

Reviewed by Ryosuke Niwa.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Tested as neutral on Speedometer 3.0.

Canonical link: <a href="https://commits.webkit.org/302482@main">https://commits.webkit.org/302482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fbe15b19f4c1c251f66ce6d4ba1f996f75707dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80628 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4c0622b3-5e9a-4578-affc-9eb3eb5487b2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98413 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66314 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f747431e-3f3b-45bc-964f-682a8e25f580) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79064 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dc2fe31c-29d4-4676-a475-527c93ecfd38) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33889 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79895 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109493 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139090 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1287 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1241 "Found 1 new test failure: media/media-source/media-source-interruption-with-resume-allowing-play.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106944 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106782 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30626 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53896 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20174 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1359 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64715 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1183 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1220 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->