### PR TITLE
[cocoa] Can't open web archives in some apps

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4988,12 +4988,16 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
             else {
                 auto nonPersistentDataStore = WebsiteDataStore::createNonPersistent();
                 replacedDataStoreForWebArchiveLoad = websiteDataStore.ptr();
-                websiteDataStore = WTFMove(nonPersistentDataStore);
+                m_websiteDataStore = WTFMove(nonPersistentDataStore);
+                m_configuration->protectedProcessPool()->pageBeginUsingWebsiteDataStore(*this, protectedWebsiteDataStore());
+                websiteDataStore = m_websiteDataStore;
                 processSwapRequestedByClient = ProcessSwapRequestedByClient::Yes;
             }
             loadedWebArchive = LoadedWebArchive::Yes;
         } else if (didLoadWebArchive()) {
-            websiteDataStore = m_replacedDataStoreForWebArchiveLoad.releaseNonNull();
+            m_configuration->protectedProcessPool()->pageEndUsingWebsiteDataStore(*this, protectedWebsiteDataStore());
+            m_websiteDataStore = m_replacedDataStoreForWebArchiveLoad.releaseNonNull();
+            websiteDataStore = m_websiteDataStore;
             m_replacedDataStoreForWebArchiveLoad = nullptr;
             processSwapRequestedByClient = ProcessSwapRequestedByClient::Yes;
         }


### PR DESCRIPTION
#### 3e5c28ab427893062a493fab9b03fece43dde982
<pre>
[cocoa] Can&apos;t open web archives in some apps
<a href="https://bugs.webkit.org/show_bug.cgi?id=301744">https://bugs.webkit.org/show_bug.cgi?id=301744</a>
<a href="https://rdar.apple.com/158724576">rdar://158724576</a>

Reviewed by Alex Christensen and Sihui Liu.

In 274565@main, we began loading all web archives in a temporary non-persistent
datastore. Then, beginning in 293040@main, we began tracking the cookie version
in the data store instead of the NetworkProcessProxy. When combined, this
behavior may caused an inconsistency with the new cookie versioning logic where
the NetworkStorageSession was initialized with one cookies version (0) and the
load request included the cookies version of the original datastore. When that
happens, a data task can become stalled indefinitely. This patch overwrites the
WebPageProxy&apos;s m_websiteDataStore member with the temporary non-persistent
datastore while that is being used, and then restores it on the next
navigation. Not overwriting the member variable was probably an oversight in
the original patch, but it seems like this is the first time that is causing a
problem.

Test: Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
* Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm:
(TestWebKitAPI::TEST(LoadWebArchive, ClientNavigationSucceedWithCookie)):

Canonical link: <a href="https://commits.webkit.org/302394@main">https://commits.webkit.org/302394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/352a49627277f4ae5c8f85eb9079d949f35a97a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80328 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/54715983-a1de-4761-adfc-e2e3f0c2e981) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98182 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66095 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/68d48f64-e9f2-4324-9e20-7336f029147b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78810 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7763c765-268f-41a9-a572-c6b7ab3567dd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33637 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79622 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109255 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138808 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106716 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106539 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/847 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30382 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53490 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20135 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1092 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64413 "Found 155 new failures in WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm, WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp, WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm, WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm, WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp, WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm, WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm ...") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/926 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/978 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1023 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->