### PR TITLE
Always allocate SessionWrapper in heap

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -59,7 +59,7 @@ enum class NegotiatedLegacyTLS : bool;
 class LegacyCustomProtocolManager;
 class NetworkSessionCocoa;
 
-struct SessionWrapper : public CanMakeWeakPtr<SessionWrapper>, public CanMakeCheckedPtr<SessionWrapper, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
+struct SessionWrapper : public CanMakeWeakPtr<SessionWrapper>, public CanMakeCheckedPtr<SessionWrapper> {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(SessionWrapper);
     WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(SessionWrapper);
 
@@ -77,9 +77,13 @@ struct SessionWrapper : public CanMakeWeakPtr<SessionWrapper>, public CanMakeChe
 struct IsolatedSession {
     WTF_MAKE_TZONE_ALLOCATED(IsolatedSession);
 public:
-    CheckedRef<SessionWrapper> checkedSessionWithCredentialStorage() { return sessionWithCredentialStorage; }
+    IsolatedSession()
+        : sessionWithCredentialStorage(makeUniqueRef<SessionWrapper>())
+    { }
 
-    SessionWrapper sessionWithCredentialStorage;
+    CheckedRef<SessionWrapper> checkedSessionWithCredentialStorage() { return sessionWithCredentialStorage.get(); }
+
+    UniqueRef<SessionWrapper> sessionWithCredentialStorage;
     WallTime lastUsed;
 };
 
@@ -97,15 +101,18 @@ public:
 
     std::unique_ptr<IsolatedSession> appBoundSession;
 
-    CheckedRef<SessionWrapper> checkedSessionWithCredentialStorage() { return sessionWithCredentialStorage; }
-    CheckedRef<SessionWrapper> checkedEphemeralStatelessSession() { return ephemeralStatelessSession; }
+    CheckedRef<SessionWrapper> checkedSessionWithCredentialStorage() { return sessionWithCredentialStorage.get(); }
+    CheckedRef<SessionWrapper> checkedEphemeralStatelessSession() { return ephemeralStatelessSession.get(); }
 
-    SessionWrapper sessionWithCredentialStorage;
-    SessionWrapper ephemeralStatelessSession;
+    UniqueRef<SessionWrapper> sessionWithCredentialStorage;
+    UniqueRef<SessionWrapper> ephemeralStatelessSession;
 
 private:
 
-    SessionSet() = default;
+    SessionSet()
+        : sessionWithCredentialStorage(makeUniqueRef<SessionWrapper>())
+        , ephemeralStatelessSession(makeUniqueRef<SessionWrapper>())
+    { }
 };
 
 class NetworkSessionCocoa final : public NetworkSession {


### PR DESCRIPTION
#### 73c23f03f5bdaa4875a72ac2fceec171853ef089
<pre>
Always allocate SessionWrapper in heap
<a href="https://bugs.webkit.org/show_bug.cgi?id=301747">https://bugs.webkit.org/show_bug.cgi?id=301747</a>

Reviewed by Geoffrey Garen.

Always allocate SessionWrapper in heap so that operator delete will be used for its destruction.

No new tests since there should be no behavioral differences.

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
(WebKit::IsolatedSession::IsolatedSession):
(WebKit::IsolatedSession::checkedSessionWithCredentialStorage):
(WebKit::SessionSet::checkedSessionWithCredentialStorage):
(WebKit::SessionSet::checkedEphemeralStatelessSession):
(WebKit::SessionSet::SessionSet):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::hstsStorage const):
(WebKit::NetworkSessionCocoa::nsCredentialStorage const):
(WebKit::SessionSet::initializeEphemeralStatelessSessionIfNeeded):
(WebKit::NetworkSessionCocoa::appBoundSession):
(WebKit::SessionSet::isolatedSession):
(WebKit::NetworkSessionCocoa::invalidateAndCancelSessionSet):
(WebKit::NetworkSessionCocoa::createWebSocketTask):
(WebKit::NetworkSessionCocoa::addWebSocketTask):
(WebKit::NetworkSessionCocoa::removeWebSocketTask):
(WebKit::NetworkSessionCocoa::addWebPageNetworkParameters):
(WebKit::NetworkSessionCocoa::hostNamesWithAlternativeServices const):
(WebKit::NetworkSessionCocoa::deleteAlternativeServicesForHostNames):
(WebKit::NetworkSessionCocoa::clearAlternativeServices):

Canonical link: <a href="https://commits.webkit.org/302414@main">https://commits.webkit.org/302414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c4f2bb055bf135d6f47794f74c68d96a115cba8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136347 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80324 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98187 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66092 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78815 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/818 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79627 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109260 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138814 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106720 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106542 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/849 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30387 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53496 "Hash 9c4f2bb0 for PR 53250 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20145 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1097 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64498 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/931 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/982 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1028 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->