### PR TITLE
[github perf] Deduplicate RuleFeatures using a hash

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -36,6 +36,7 @@
 #include <memory>
 #include <queue>
 #include <wtf/Assertions.h>
+#include <wtf/Hasher.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
@@ -1017,26 +1018,26 @@ bool isElementBackedPseudoElement(CSSSelector::PseudoElement pseudoElement)
     }
 }
 
+static bool shouldSkipForEqualMode(const CSSSelector& simpleSelector, ComplexSelectorsEqualMode mode)
+{
+    if (mode == ComplexSelectorsEqualMode::IgnoreNonElementBackedPseudoElements)
+        return simpleSelector.matchesPseudoElement() && !isElementBackedPseudoElement(simpleSelector.pseudoElement());
+    return false;
+};
+
 bool complexSelectorsEqual(const CSSSelector& complexA, const CSSSelector& complexB, ComplexSelectorsEqualMode mode)
 {
     auto aRelation = CSSSelector::Relation::Subselector;
     auto bRelation = CSSSelector::Relation::Subselector;
 
     for (auto a = &complexA, b = &complexB; a || b; a = a->precedingInComplexSelector(), b = b->precedingInComplexSelector()) {
-        if (mode == ComplexSelectorsEqualMode::IgnoreNonElementBackedPseudoElements) {
-            auto canSkipPseudoElement = [](const CSSSelector& simpleSelector) {
-                if (!simpleSelector.matchesPseudoElement())
-                    return false;
-                return !isElementBackedPseudoElement(simpleSelector.pseudoElement());
-            };
-            if (a && canSkipPseudoElement(*a)) {
-                aRelation = a->relation();
-                a = a->precedingInComplexSelector();
-            }
-            if (b && canSkipPseudoElement(*b)) {
-                bRelation = b->relation();
-                b = b->precedingInComplexSelector();
-            }
+        if (a && shouldSkipForEqualMode(*a, mode)) {
+            aRelation = a->relation();
+            a = a->precedingInComplexSelector();
+        }
+        if (b && shouldSkipForEqualMode(*b, mode)) {
+            bRelation = b->relation();
+            b = b->precedingInComplexSelector();
         }
         if (!a || !b)
             return a == b;
@@ -1048,6 +1049,53 @@ bool complexSelectorsEqual(const CSSSelector& complexA, const CSSSelector& compl
         bRelation = b->relation();
     }
     return true;
+}
+
+static void addSimpleSelector(Hasher& hasher, const CSSSelector& simpleSelector)
+{
+    // This hash does try to include every possible thing in a selector.
+    add(hasher, simpleSelector.match());
+
+    switch (simpleSelector.match()) {
+    case CSSSelector::Match::Tag:
+        add(hasher, simpleSelector.tagQName());
+        break;
+    case CSSSelector::Match::PseudoClass:
+        add(hasher, simpleSelector.pseudoClass());
+        break;
+    case CSSSelector::Match::PseudoElement:
+        add(hasher, simpleSelector.pseudoElement());
+        break;
+    case CSSSelector::Match::Exact:
+    case CSSSelector::Match::Set:
+    case CSSSelector::Match::List:
+    case CSSSelector::Match::Hyphen:
+    case CSSSelector::Match::Begin:
+    case CSSSelector::Match::End:
+    case CSSSelector::Match::Contain:
+        add(hasher, simpleSelector.attribute());
+        add(hasher, simpleSelector.value());
+        break;
+    default:
+        add(hasher, simpleSelector.value());
+        break;
+    }
+    if (simpleSelector.selectorList())
+        add(hasher, *simpleSelector.selectorList());
+}
+
+void addComplexSelector(Hasher& hasher, const CSSSelector& complexSelector, ComplexSelectorsEqualMode mode)
+{
+    auto relationToRight = CSSSelector::Relation::Subselector;
+    for (auto simpleSelector = &complexSelector; simpleSelector; simpleSelector = simpleSelector->precedingInComplexSelector()) {
+        if (shouldSkipForEqualMode(*simpleSelector, mode)) {
+            relationToRight = simpleSelector->relation();
+            continue;
+        }
+        add(hasher, relationToRight);
+        addSimpleSelector(hasher, *simpleSelector);
+        relationToRight = simpleSelector->relation();
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -288,6 +288,8 @@ bool complexSelectorMatchesElementBackedPseudoElement(const CSSSelector&);
 enum class ComplexSelectorsEqualMode : bool { Full, IgnoreNonElementBackedPseudoElements };
 bool complexSelectorsEqual(const CSSSelector&, const CSSSelector&, ComplexSelectorsEqualMode = ComplexSelectorsEqualMode::Full);
 
+void addComplexSelector(Hasher&, const CSSSelector&, ComplexSelectorsEqualMode = ComplexSelectorsEqualMode::Full);
+
 inline bool operator==(const PossiblyQuotedIdentifier& a, const AtomString& b) { return a.identifier == b; }
 
 inline const QualifiedName& CSSSelector::attribute() const

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -268,4 +268,11 @@ bool CSSSelectorList::operator==(const CSSSelectorList& other) const
     return true;
 }
 
+void add(Hasher& hasher, const CSSSelectorList& list)
+{
+    for (auto& selector : list)
+        addComplexSelector(hasher, selector);
+}
+
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -122,4 +122,6 @@ private:
     UniqueArray<CSSSelector> m_selectorArray;
 };
 
+void add(Hasher&, const CSSSelectorList&);
+
 } // namespace WebCore

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -159,6 +159,35 @@ static bool equalIgnoringPseudoElement(const RuleFeatureWithInvalidationSelector
         && a.invalidationSelector == b.invalidationSelector;
 }
 
+static void addIgnoringPseudoElement(Hasher& hasher, const RuleFeature& feature)
+{
+    addComplexSelector(hasher, feature.selector(), ComplexSelectorsEqualMode::IgnoreNonElementBackedPseudoElements);
+    add(hasher, feature.matchElement, feature.isNegation);
+}
+
+static void addIgnoringPseudoElement(Hasher& hasher, const RuleFeatureWithInvalidationSelector& feature)
+{
+    addIgnoringPseudoElement(hasher, static_cast<RuleFeature>(feature));
+    add(hasher, feature.invalidationSelector);
+}
+
+template<typename RuleFeatureType> unsigned RuleFeatureDeduplicationKey<RuleFeatureType>::hash() const
+{
+    Hasher hasher;
+    add(hasher, vector);
+    addIgnoringPseudoElement(hasher, feature);
+    return hasher.hash();
+}
+
+template<typename RuleFeatureType> bool RuleFeatureDeduplicationKey<RuleFeatureType>::operator==(const RuleFeatureDeduplicationKey& other) const
+{
+    // Selectors like '.foo' and '.foo::before' are equal for invalidation as they both invalidate the generating element.
+    return vector == other.vector && equalIgnoringPseudoElement(feature, other.feature);
+}
+
+template struct RuleFeatureDeduplicationKey<RuleFeature>;
+template struct RuleFeatureDeduplicationKey<RuleFeatureWithInvalidationSelector>;
+
 static MatchElement computeNextMatchElement(MatchElement matchElement, CSSSelector::Relation relation)
 {
     ASSERT(!isHasPseudoClassMatchElement(matchElement));
@@ -441,7 +470,7 @@ static PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::Ps
     return makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Universal);
 };
 
-void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<const StyleRuleScope>>& scopeRules)
+void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const RuleData& ruleData, const Vector<Ref<const StyleRuleScope>>& scopeRules)
 {
     SelectorFeatures selectorFeatures;
     recursivelyCollectFeaturesFromSelector(selectorFeatures, *ruleData.selector());
@@ -462,18 +491,16 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<
     if (ruleData.usedRuleTypes().contains(UsedRuleType::StartingStyle))
         hasStartingStyleRules = true;
 
-    auto addToVectorDeduplicating = [](auto& featureVector, auto&& featureToAdd) {
-        // FIXME: Make selectors hashable.
-        constexpr auto maximumSearchCount = 32;
-        auto count = 0;
-        for (auto& existing : makeReversedRange(featureVector)) {
-            if (++count > maximumSearchCount)
-                break;
-            // Selectors like '.foo' and '.foo::before' are equal for invalidation as they both invalidate the generating element.
-            if (equalIgnoringPseudoElement(existing, featureToAdd))
-                return;
-        }
-        featureVector.append(WTFMove(featureToAdd));
+    auto addToVectorDeduplicating = [&]<typename FeatureType>(auto& featureVector, FeatureType&& featureToAdd) {
+        auto deduplicationSet = [&] -> auto& {
+            if constexpr (std::same_as<FeatureType, RuleFeatureWithInvalidationSelector>)
+                return collectionContext.withInvalidationSelectorDeduplicationSet;
+            else
+                return collectionContext.deduplicationSet;
+        };
+        bool shouldAdd = deduplicationSet().add(RuleFeatureDeduplicationKey<FeatureType> { &featureVector, featureToAdd }).isNewEntry;
+        if (shouldAdd)
+            featureVector.append(WTFMove(featureToAdd));
     };
 
     auto addToMap = [&]<typename HostAffectingNames>(auto& map, auto& entries, HostAffectingNames hostAffectingNames) {

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -136,10 +136,11 @@ static bool shouldHaveBucketForAttributeName(const CSSSelector& attributeSelecto
 void RuleSet::addRule(const StyleRule& rule, unsigned selectorIndex, unsigned selectorListIndex)
 {
     RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleCount, { });
-    addRule(WTFMove(ruleData), 0, 0, 0);
+    // This path is used when building invalidation RuleSets, no need to collect features (nullptr CollectionContext).
+    addRule(WTFMove(ruleData), 0, 0, 0, nullptr);
 }
 
-void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerIdentifier, ContainerQueryIdentifier containerQueryIdentifier, ScopeRuleIdentifier scopeRuleIdentifier)
+void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerIdentifier, ContainerQueryIdentifier containerQueryIdentifier, ScopeRuleIdentifier scopeRuleIdentifier, RuleFeatureSet::CollectionContext* featureCollectionContext)
 {
     ASSERT(ruleData.position() == m_ruleCount);
 
@@ -170,7 +171,8 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
     };
     ruleData.setLinkMatchType(computeLinkMatchType());
 
-    m_features.collectFeatures(ruleData, scopeRules);
+    if (featureCollectionContext)
+        m_features.collectFeatures(*featureCollectionContext, ruleData, scopeRules);
 
     unsigned classBucketSize = 0;
     const CSSSelector* idSelector = nullptr;

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -147,7 +147,7 @@ private:
     using ContainerQueryIdentifier = unsigned;
     using ScopeRuleIdentifier = unsigned;
 
-    void addRule(RuleData&&, CascadeLayerIdentifier, ContainerQueryIdentifier, ScopeRuleIdentifier);
+    void addRule(RuleData&&, CascadeLayerIdentifier, ContainerQueryIdentifier, ScopeRuleIdentifier, RuleFeatureSet::CollectionContext*);
 
     struct ResolverMutatingRule {
         Ref<StyleRuleBase> rule;

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -304,7 +304,7 @@ void RuleSetBuilder::addStyleRuleWithSelectorList(const CSSSelectorList& selecto
     for (size_t selectorIndex = 0; selectorIndex != notFound; selectorIndex = selectorList.indexOfNextSelectorAfter(selectorIndex)) {
         RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleSet->ruleCount(), m_usedRuleTypes);
         m_mediaQueryCollector.addRuleIfNeeded(ruleData);
-        m_ruleSet->addRule(WTFMove(ruleData), m_currentCascadeLayerIdentifier, m_currentContainerQueryIdentifier, m_currentScopeIdentifier);
+        m_ruleSet->addRule(WTFMove(ruleData), m_currentCascadeLayerIdentifier, m_currentContainerQueryIdentifier, m_currentScopeIdentifier, &m_featureCollectionContext);
         ++selectorListIndex;
     }
 }

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -96,6 +96,8 @@ private:
 
     Vector<RuleSet::ResolverMutatingRule> m_collectedResolverMutatingRules;
     bool requiresStaticMediaQueryEvaluation { false };
+
+    RuleFeatureSet::CollectionContext m_featureCollectionContext;
 };
 
 }


### PR DESCRIPTION
#### b1b65ab7abea9c003935afb7ff84180ec1f71cfe
<pre>
[github perf] Deduplicate RuleFeatures using a hash
<a href="https://bugs.webkit.org/show_bug.cgi?id=301748">https://bugs.webkit.org/show_bug.cgi?id=301748</a>
<a href="https://rdar.apple.com/163781657">rdar://163781657</a>

Reviewed by Alan Baradlay.

Use hash instead of a linear search for more effective deduplication.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::shouldSkipForEqualMode):
(WebCore::complexSelectorsEqual):
(WebCore::addSimpleSelector):
(WebCore::addComplexSelector):

Add a hash function for CSSSelector.

* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::add):
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::addIgnoringPseudoElement):
(WebCore::Style::RuleFeatureDeduplicationKey&lt;RuleFeatureType&gt;::hash const):
(WebCore::Style::= const):
(WebCore::Style::RuleFeatureSet::collectFeatures):

Test if we have added an equivalent feature already.

* Source/WebCore/style/RuleFeature.h:
(WebCore::Style::RuleFeatureDeduplicationKey::Hash::hash):
(WebCore::Style::RuleFeatureDeduplicationKey::Hash::equal):

Add a key type.

(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/style/RuleSet.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addStyleRuleWithSelectorList):

Pass a context class that contains the transient deduplication hashes.

* Source/WebCore/style/RuleSetBuilder.h:

Canonical link: <a href="https://commits.webkit.org/302392@main">https://commits.webkit.org/302392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dc10b9d0680ea16f415a071a7783597e0a033bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128975 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80329 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5c38dbc7-00b6-4382-adcc-3d010a5390e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98191 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66097 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d7bf6cab-e761-4327-a86a-f700987b7849) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78819 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0ef86d7b-9566-4b24-ad17-14ec7c094d42) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33646 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79635 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138822 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106725 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/858 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30391 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53507 "Hash 0dc10b9d for PR 53251 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1105 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64426 "Found 139 new failures in WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm, WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp, WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm, WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm, WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp, WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm ...") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/939 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/990 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->