### PR TITLE
Unreviewed, revert 292054@main as it broke device motion / orientation in third-party iframes

### DIFF
--- a/Source/WebCore/dom/DeviceMotionController.cpp
+++ b/Source/WebCore/dom/DeviceMotionController.cpp
@@ -55,10 +55,10 @@ void DeviceMotionController::suspendUpdates()
     m_client->stopUpdating();
 }
 
-void DeviceMotionController::resumeUpdates(const SecurityOriginData& origin)
+void DeviceMotionController::resumeUpdates()
 {
     if (hasListeners())
-        m_client->startUpdating(origin);
+        m_client->startUpdating();
 }
 
 #endif

--- a/Source/WebCore/dom/DeviceMotionController.h
+++ b/Source/WebCore/dom/DeviceMotionController.h
@@ -47,7 +47,7 @@ public:
     // FIXME: We should look to reconcile the iOS and OpenSource differences with this class
     // so that we can either remove these methods or remove the PLATFORM(IOS_FAMILY)-guard.
     void suspendUpdates();
-    void resumeUpdates(const SecurityOriginData&);
+    void resumeUpdates();
 #endif
 
     void didChangeDeviceMotion(DeviceMotionData*);

--- a/Source/WebCore/dom/DeviceOrientationController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationController.cpp
@@ -61,10 +61,10 @@ void DeviceOrientationController::suspendUpdates()
     m_client->stopUpdating();
 }
 
-void DeviceOrientationController::resumeUpdates(const SecurityOriginData& origin)
+void DeviceOrientationController::resumeUpdates()
 {
     if (hasListeners())
-        m_client->startUpdating(origin);
+        m_client->startUpdating();
 }
 
 #else

--- a/Source/WebCore/dom/DeviceOrientationController.h
+++ b/Source/WebCore/dom/DeviceOrientationController.h
@@ -50,7 +50,7 @@ public:
     // FIXME: We should look to reconcile the iOS and OpenSource differences with this class
     // so that we can either remove these methods or remove the PLATFORM(IOS_FAMILY)-guard.
     void suspendUpdates();
-    void resumeUpdates(const SecurityOriginData&);
+    void resumeUpdates();
 #else
     bool hasLastData() override;
     RefPtr<Event> getLastEvent() override;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3740,11 +3740,10 @@ void Document::resumeDeviceMotionAndOrientationUpdates()
         return;
     m_areDeviceMotionAndOrientationUpdatesSuspended = false;
 #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
-    auto origin = securityOrigin().data();
     if (m_deviceMotionController)
-        m_deviceMotionController->resumeUpdates(origin);
+        m_deviceMotionController->resumeUpdates();
     if (m_deviceOrientationController)
-        m_deviceOrientationController->resumeUpdates(origin);
+        m_deviceOrientationController->resumeUpdates();
 #endif
 }
 

--- a/Source/WebCore/page/DeviceClient.h
+++ b/Source/WebCore/page/DeviceClient.h
@@ -32,7 +32,6 @@
 
 namespace WebCore {
 class DeviceClient;
-class SecurityOriginData;
 }
 
 namespace WebCore {
@@ -43,7 +42,7 @@ class DeviceClient : public CanMakeWeakPtr<DeviceClient>, public CanMakeCheckedP
 public:
     virtual ~DeviceClient() = default;
 
-    virtual void startUpdating(const SecurityOriginData&) = 0;
+    virtual void startUpdating() = 0;
     virtual void stopUpdating() = 0;
 
     virtual bool isDeviceMotionClient() const { return false; }

--- a/Source/WebCore/page/DeviceController.cpp
+++ b/Source/WebCore/page/DeviceController.cpp
@@ -46,10 +46,6 @@ DeviceController::~DeviceController() = default;
 
 void DeviceController::addDeviceEventListener(LocalDOMWindow& window)
 {
-    RefPtr document = window.document();
-    if (!document)
-        return;
-
     bool wasEmpty = m_listeners.isEmpty();
     m_listeners.add(&window);
 
@@ -60,7 +56,7 @@ void DeviceController::addDeviceEventListener(LocalDOMWindow& window)
     }
 
     if (wasEmpty)
-        checkedClient()->startUpdating(document->securityOrigin().data());
+        checkedClient()->startUpdating();
 }
 
 void DeviceController::removeDeviceEventListener(LocalDOMWindow& window)

--- a/Source/WebCore/platform/ios/DeviceMotionClientIOS.h
+++ b/Source/WebCore/platform/ios/DeviceMotionClientIOS.h
@@ -46,7 +46,7 @@ public:
     DeviceMotionClientIOS(RefPtr<DeviceOrientationUpdateProvider>&&);
     ~DeviceMotionClientIOS() override;
     void setController(DeviceMotionController*) override;
-    void startUpdating(const SecurityOriginData&) override;
+    void startUpdating() override;
     void stopUpdating() override;
     DeviceMotionData* lastMotion() const override;
     void deviceMotionControllerDestroyed() override;

--- a/Source/WebCore/platform/ios/DeviceMotionClientIOS.mm
+++ b/Source/WebCore/platform/ios/DeviceMotionClientIOS.mm
@@ -51,12 +51,12 @@ void DeviceMotionClientIOS::setController(DeviceMotionController* controller)
     m_controller = controller;
 }
 
-void DeviceMotionClientIOS::startUpdating(const SecurityOriginData& origin)
+void DeviceMotionClientIOS::startUpdating()
 {
     m_updating = true;
 
     if (m_deviceOrientationUpdateProvider) {
-        m_deviceOrientationUpdateProvider->startUpdatingDeviceMotion(*this, origin);
+        m_deviceOrientationUpdateProvider->startUpdatingDeviceMotion(*this);
         return;
     }
 

--- a/Source/WebCore/platform/ios/DeviceOrientationClientIOS.h
+++ b/Source/WebCore/platform/ios/DeviceOrientationClientIOS.h
@@ -46,7 +46,7 @@ public:
     DeviceOrientationClientIOS(RefPtr<DeviceOrientationUpdateProvider>&&);
     ~DeviceOrientationClientIOS() override;
     void setController(DeviceOrientationController*) override;
-    void startUpdating(const SecurityOriginData&) override;
+    void startUpdating() override;
     void stopUpdating() override;
     DeviceOrientationData* lastOrientation() const override;
     void deviceOrientationControllerDestroyed() override;

--- a/Source/WebCore/platform/ios/DeviceOrientationClientIOS.mm
+++ b/Source/WebCore/platform/ios/DeviceOrientationClientIOS.mm
@@ -51,12 +51,12 @@ void DeviceOrientationClientIOS::setController(DeviceOrientationController* cont
     m_controller = controller;
 }
 
-void DeviceOrientationClientIOS::startUpdating(const SecurityOriginData& origin)
+void DeviceOrientationClientIOS::startUpdating()
 {
     m_updating = true;
 
     if (m_deviceOrientationUpdateProvider) {
-        m_deviceOrientationUpdateProvider->startUpdatingDeviceOrientation(*this, origin);
+        m_deviceOrientationUpdateProvider->startUpdatingDeviceOrientation(*this);
         return;
     }
 

--- a/Source/WebCore/platform/ios/DeviceOrientationUpdateProvider.h
+++ b/Source/WebCore/platform/ios/DeviceOrientationUpdateProvider.h
@@ -38,10 +38,10 @@ class DeviceOrientationUpdateProvider : public RefCounted<DeviceOrientationUpdat
 public:
     virtual ~DeviceOrientationUpdateProvider() { }
 
-    virtual void startUpdatingDeviceOrientation(MotionManagerClient&, const SecurityOriginData&) = 0;
+    virtual void startUpdatingDeviceOrientation(MotionManagerClient&) = 0;
     virtual void stopUpdatingDeviceOrientation(MotionManagerClient&) = 0;
 
-    virtual void startUpdatingDeviceMotion(MotionManagerClient&, const SecurityOriginData&) = 0;
+    virtual void startUpdatingDeviceMotion(MotionManagerClient&) = 0;
     virtual void stopUpdatingDeviceMotion(MotionManagerClient&) = 0;
 
     virtual void deviceOrientationChanged(double, double, double, double, double) = 0;

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.cpp
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.cpp
@@ -47,7 +47,7 @@ void DeviceOrientationClientMock::setController(DeviceOrientationController* con
     ASSERT(m_controller);
 }
 
-void DeviceOrientationClientMock::startUpdating(const SecurityOriginData&)
+void DeviceOrientationClientMock::startUpdating()
 {
     m_isUpdating = true;
 }

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
@@ -48,7 +48,7 @@ public:
 
     // DeviceOrientationClient
     WEBCORE_EXPORT void setController(DeviceOrientationController*) override;
-    WEBCORE_EXPORT void startUpdating(const SecurityOriginData&) override;
+    WEBCORE_EXPORT void startUpdating() override;
     WEBCORE_EXPORT void stopUpdating() override;
     DeviceOrientationData* lastOrientation() const override { return m_orientation.get(); }
     void deviceOrientationControllerDestroyed() override { }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12921,14 +12921,6 @@ void WebPageProxy::shouldAllowDeviceOrientationAndMotionAccess(IPC::Connection& 
     protectedWebsiteDataStore()->protectedDeviceOrientationAndMotionAccessController()->shouldAllowAccess(*this, *frame, WTFMove(frameInfo), mayPrompt, WTFMove(completionHandler));
 }
 
-bool WebPageProxy::originHasDeviceOrientationAndMotionAccess(const WebCore::SecurityOriginData& origin)
-{
-    if (!protectedPreferences()->deviceOrientationPermissionAPIEnabled())
-        return true;
-
-    return protectedWebsiteDataStore()->protectedDeviceOrientationAndMotionAccessController()->cachedDeviceOrientationPermission(origin) == DeviceOrientationOrMotionPermissionState::Granted;
-}
-
 #endif
 
 
@@ -15276,14 +15268,6 @@ void WebPageProxy::willAcquireUniversalFileReadSandboxExtension(WebProcessProxy&
 
 void WebPageProxy::simulateDeviceOrientationChange(double alpha, double beta, double gamma)
 {
-#if ENABLE(DEVICE_ORIENTATION)
-    auto origin = SecurityOrigin::createFromString(protectedPageLoadState()->activeURL())->data();
-    if (!originHasDeviceOrientationAndMotionAccess(origin)) {
-        WEBPAGEPROXY_RELEASE_LOG_ERROR(Process, "simulateDeviceOrientationChange: Not sending simulated orientation change to page because origin %" SENSITIVE_LOG_STRING " does not have access.", origin.toString().utf8().data());
-        return;
-    }
-#endif
-
     send(Messages::WebPage::SimulateDeviceOrientationChange(alpha, beta, gamma));
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2176,7 +2176,6 @@ public:
 
 #if ENABLE(DEVICE_ORIENTATION)
     void shouldAllowDeviceOrientationAndMotionAccess(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, bool mayPrompt, CompletionHandler<void(WebCore::DeviceOrientationOrMotionPermissionState)>&&);
-    bool originHasDeviceOrientationAndMotionAccess(const WebCore::SecurityOriginData&);
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
@@ -48,10 +48,10 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    void startUpdatingDeviceOrientation(const WebCore::SecurityOriginData&);
+    void startUpdatingDeviceOrientation();
     void stopUpdatingDeviceOrientation();
 
-    void startUpdatingDeviceMotion(const WebCore::SecurityOriginData&);
+    void startUpdatingDeviceMotion();
     void stopUpdatingDeviceMotion();
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in
@@ -28,9 +28,9 @@
     EnabledBy=DeviceOrientationEventEnabled
 ]
 messages -> WebDeviceOrientationUpdateProviderProxy {
-    StartUpdatingDeviceOrientation(WebCore::SecurityOriginData origin);
+    StartUpdatingDeviceOrientation();
     StopUpdatingDeviceOrientation();
-    StartUpdatingDeviceMotion(WebCore::SecurityOriginData origin);
+    StartUpdatingDeviceMotion();
     StopUpdatingDeviceMotion();
 }
 #endif

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
@@ -57,12 +57,8 @@ WebDeviceOrientationUpdateProviderProxy::~WebDeviceOrientationUpdateProviderProx
         page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
 }
 
-void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceOrientation(const WebCore::SecurityOriginData& origin)
+void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceOrientation()
 {
-    RefPtr page = m_page.get();
-    if (!page || !page->originHasDeviceOrientationAndMotionAccess(origin))
-        return;
-
     [[WebCoreMotionManager sharedManager] addOrientationClient:this];
 }
 
@@ -71,12 +67,8 @@ void WebDeviceOrientationUpdateProviderProxy::stopUpdatingDeviceOrientation()
     [[WebCoreMotionManager sharedManager] removeOrientationClient:this];
 }
 
-void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceMotion(const WebCore::SecurityOriginData& origin)
+void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceMotion()
 {
-    RefPtr page = m_page.get();
-    if (!page || !page->originHasDeviceOrientationAndMotionAccess(origin))
-        return;
-
     [[WebCoreMotionManager sharedManager] addMotionClient:this];
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.cpp
@@ -50,10 +50,10 @@ WebDeviceOrientationUpdateProvider::~WebDeviceOrientationUpdateProvider()
     WebProcess::singleton().removeMessageReceiver(Messages::WebDeviceOrientationUpdateProvider::messageReceiverName(), m_pageIdentifier);
 }
 
-void WebDeviceOrientationUpdateProvider::startUpdatingDeviceOrientation(WebCore::MotionManagerClient& client, const WebCore::SecurityOriginData& origin)
+void WebDeviceOrientationUpdateProvider::startUpdatingDeviceOrientation(WebCore::MotionManagerClient& client)
 {
     if (m_deviceOrientationClients.isEmptyIgnoringNullReferences() && m_page)
-        m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StartUpdatingDeviceOrientation(origin));
+        m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StartUpdatingDeviceOrientation());
 
     m_deviceOrientationClients.add(client);
 }
@@ -67,10 +67,10 @@ void WebDeviceOrientationUpdateProvider::stopUpdatingDeviceOrientation(WebCore::
         m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StopUpdatingDeviceOrientation());
 }
 
-void WebDeviceOrientationUpdateProvider::startUpdatingDeviceMotion(WebCore::MotionManagerClient& client, const WebCore::SecurityOriginData& origin)
+void WebDeviceOrientationUpdateProvider::startUpdatingDeviceMotion(WebCore::MotionManagerClient& client)
 {
     if (m_deviceMotionClients.isEmptyIgnoringNullReferences() && m_page)
-        m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StartUpdatingDeviceMotion(origin));
+        m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StartUpdatingDeviceMotion());
 
     m_deviceMotionClients.add(client);
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.h
@@ -49,9 +49,9 @@ private:
     ~WebDeviceOrientationUpdateProvider();
 
     // WebCore::DeviceOrientationUpdateProvider
-    void startUpdatingDeviceOrientation(WebCore::MotionManagerClient&, const WebCore::SecurityOriginData&) final;
+    void startUpdatingDeviceOrientation(WebCore::MotionManagerClient&) final;
     void stopUpdatingDeviceOrientation(WebCore::MotionManagerClient&) final;
-    void startUpdatingDeviceMotion(WebCore::MotionManagerClient&, const WebCore::SecurityOriginData&) final;
+    void startUpdatingDeviceMotion(WebCore::MotionManagerClient&) final;
     void stopUpdatingDeviceMotion(WebCore::MotionManagerClient&) final;
     void deviceOrientationChanged(double, double, double, double, double) final;
     void deviceMotionChanged(double, double, double, double, double, double, std::optional<double>, std::optional<double>, std::optional<double>) final;

--- a/Source/WebKitLegacy/mac/WebView/WebDeviceOrientationProviderMock.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDeviceOrientationProviderMock.mm
@@ -54,8 +54,7 @@ using namespace WebCore;
 
 - (void)startUpdating
 {
-    auto placeholderOrigin = WebCore::SecurityOriginData { };
-    m_core->startUpdating(placeholderOrigin);
+    m_core->startUpdating();
 }
 
 - (void)stopUpdating


### PR DESCRIPTION
#### 4d9dc43df4699353b095c1308d06a2d34e593dac
<pre>
Unreviewed, revert 292054@main as it broke device motion / orientation in third-party iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=301751">https://bugs.webkit.org/show_bug.cgi?id=301751</a>
<a href="https://rdar.apple.com/163218053">rdar://163218053</a>

* Source/WebCore/dom/DeviceMotionController.cpp:
(WebCore::DeviceMotionController::resumeUpdates):
* Source/WebCore/dom/DeviceMotionController.h:
* Source/WebCore/dom/DeviceOrientationController.cpp:
(WebCore::DeviceOrientationController::resumeUpdates):
* Source/WebCore/dom/DeviceOrientationController.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resumeDeviceMotionAndOrientationUpdates):
* Source/WebCore/page/DeviceClient.h:
* Source/WebCore/page/DeviceController.cpp:
(WebCore::DeviceController::addDeviceEventListener):
* Source/WebCore/platform/ios/DeviceMotionClientIOS.h:
* Source/WebCore/platform/ios/DeviceMotionClientIOS.mm:
(WebCore::DeviceMotionClientIOS::startUpdating):
* Source/WebCore/platform/ios/DeviceOrientationClientIOS.h:
* Source/WebCore/platform/ios/DeviceOrientationClientIOS.mm:
(WebCore::DeviceOrientationClientIOS::startUpdating):
* Source/WebCore/platform/ios/DeviceOrientationUpdateProvider.h:
* Source/WebCore/platform/mock/DeviceOrientationClientMock.cpp:
(WebCore::DeviceOrientationClientMock::startUpdating):
* Source/WebCore/platform/mock/DeviceOrientationClientMock.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::simulateDeviceOrientationChange):
(WebKit::WebPageProxy::originHasDeviceOrientationAndMotionAccess): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm:
(WebKit::WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceOrientation):
(WebKit::WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceMotion):
* Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.cpp:
(WebKit::WebDeviceOrientationUpdateProvider::startUpdatingDeviceOrientation):
(WebKit::WebDeviceOrientationUpdateProvider::startUpdatingDeviceMotion):
* Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.h:
* Source/WebKitLegacy/mac/WebView/WebDeviceOrientationProviderMock.mm:
(-[WebDeviceOrientationProviderMockInternal startUpdating]):

Canonical link: <a href="https://commits.webkit.org/302386@main">https://commits.webkit.org/302386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5a0244b54a76f4251b6e4400d87fce2a847ad2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80331 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7950857e-7c01-4ac6-9cd0-0a77bc353cab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98193 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66099 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ae861a34-dff4-4af7-8169-2d9104433e57) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78821 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b18282b6-15ef-4b15-8224-9c0b8d83d9d7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33649 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79637 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138825 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106728 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106548 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27118 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/857 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30394 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53519 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1107 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64428 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/941 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1037 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->