### PR TITLE
[run-jsc-stress-tests] Improve architecture checks

### DIFF
--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -624,7 +624,25 @@ if $cloop
 end
 
 $hostOS = determineOS unless $hostOS
-$architecture = determineArchitecture unless $architecture
+$architectureOfJSCBinary = determineArchitecture
+if not $architectureOfJSCBinary.nil? and not $architecture.nil? and $architectureOfJSCBinary != $architecture
+    $stderr.puts("Specified architecture (#{$architecture}) does not match that of the JSC binary (#{$architectureOfJSCBinary})")
+    exit(2)
+end
+if $architectureOfJSCBinary.nil?
+    if $architecture.nil?
+        $stderr.puts("Could not detect the architecture of the JSC binary and no --architecture given")
+        exit(2)
+    end
+else
+    # We have checked above that if $architecture is not nil, it matches architectureOfJSCBinary.
+    $architecture = $architectureOfJSCBinary
+end
+if $architecture.nil?
+    # Can only get here if there's a logic error above.
+    raise "Ended up with no $architecture"
+end
+
 $isFTLPlatform = !($architecture == "x86" || $architecture == "arm" || $architecture == "mips" || $architecture == "riscv64" || $hostOS == "playstation")
 # Special case armv7 and windows, we want to run the wasm tests temporarily without B3/Air support
 $isWasmPlatform = (not $cloop) && $jitTests && ($isFTLPlatform || $architecture == "arm" || ($hostOS == "windows" && $architecture == "x86_64"))


### PR DESCRIPTION
#### 70adcaf42365ccd5c7135ff1d4d500daa5afa205
<pre>
[run-jsc-stress-tests] Improve architecture checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=301753">https://bugs.webkit.org/show_bug.cgi?id=301753</a>

Reviewed by Carlos Alberto Lopez Perez.

`run-jsc-stress-tests` can inadvertently select the tests to run based
on the host system, whereas we may be testing a cross-compiled binary
(but have neglected to explicitly specify the architecture). This user
error leads to spurious failures; catch the error early instead.

Functionally, bail if the detected architecture (if any) doesn&apos;t match
an explicitly specified architecture. Also refuse to continue if we
can&apos;t detect the architecture of the JSC binary and the user hasn&apos;t
given us an --architecture either. Ensure we never try to run the tests
without knowing which architecture we&apos;re testing for.

Canonical link: <a href="https://commits.webkit.org/302469@main">https://commits.webkit.org/302469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a240f9799cb4fa08cbe5c6d301fed5fb22576dbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136365 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1178 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1117 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98199 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66106 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78850 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33657 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79645 "Built successfully") | 
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120976 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Compiled JSC (warnings); Found 6 jsc stress test failures: mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-baseline, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-dfg-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-ftl-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-llint ...; Compiled JSC (warnings); Running jscore-test-without-change") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109276 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138833 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127435 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106735 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106574 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27174 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/865 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30403 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53528 "Hash a240f979 for PR 53255 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1115 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160453 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/950 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40049 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1000 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->