### PR TITLE
AX: focused node should be nullptr when a different frame has focus

### DIFF
--- a/LayoutTests/accessibility/mac/active-descendant-after-visibility-change.html
+++ b/LayoutTests/accessibility/mac/active-descendant-after-visibility-change.html
@@ -19,6 +19,7 @@
 
 <script>
 var output = "This test ensures objects that aria-activedescendant is correct after a visibility change.\n\n";
+var done = false;
 
 document.getElementById("open").addEventListener("click", () => {
     document.getElementById("listbox").hidden = false;
@@ -37,6 +38,11 @@ function notifyCallback(element, notification) {
             return;
         }
 
+        if (done) {
+            return;
+        }
+
+        done = true;
         output += `The listbox option should be focused: ${axFocused.role} ${axFocused.title}\n`;
         accessibilityController.removeNotificationListener();
         debug(output);

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -524,9 +524,11 @@ AccessibilityObject* AccessibilityScrollView::crossFrameParentObject() const
         ancestorElement = ancestorElement->parentElementInComposedTree();
     }
 
-    if (ancestorAccessibilityObject->isIgnored())
+    if (ancestorAccessibilityObject && ancestorAccessibilityObject->isIgnored())
         return ancestorAccessibilityObject->parentObjectUnignored();
-    return ancestorAccessibilityObject.get();
+
+    // TODO: this should return a RefPtr
+    return ancestorAccessibilityObject.unsafeGet();  // NOLINT
 }
 
 AccessibilityObject* AccessibilityScrollView::crossFrameChildObject() const

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6589,18 +6589,17 @@ bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions&
     }
 
     if (m_focusedElement) {
-
         if (settings().navigationAPIEnabled())
             window()->navigation().setFocusChanged(FocusDidChange::Yes);
+    }
 
 #if PLATFORM(GTK)
-        // GTK relies on creating the AXObjectCache when a focus change happens.
-        if (CheckedPtr cache = axObjectCache())
+    // GTK relies on creating the AXObjectCache when a focus change happens.
+    if (CheckedPtr cache = axObjectCache())
 #else
-        if (CheckedPtr cache = existingAXObjectCache())
+    if (CheckedPtr cache = existingAXObjectCache())
 #endif
-            cache->onFocusChange(oldFocusedElement.get(), newFocusedElement);
-    }
+        cache->onFocusChange(oldFocusedElement.get(), newFocusedElement);
 
     if (RefPtr page = this->page())
         page->chrome().focusedElementChanged(protectedFocusedElement().get(), page->focusController().focusedLocalFrame(), options, broadcast);

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -250,7 +250,7 @@ id WebProcess::accessibilityFocusedUIElement()
             bool foundValidTree = false;
             switchOn(tree,
                 [&] (RefPtr<AXIsolatedTree>& typedTree) {
-                    if (typedTree) {
+                    if (typedTree && typedTree->focusedNode()) {
                         OptionSet<ActivityState> state = typedTree->lockedPageActivityState();
                         if (state.containsAll({ ActivityState::IsVisible, ActivityState::IsFocused, ActivityState::WindowIsActive }))
                             foundValidTree = true;


### PR DESCRIPTION
#### ee35cc63fdab16c3d96fe632dae98b90552315e5
<pre>
AX: focused node should be nullptr when a different frame has focus
<a href="https://bugs.webkit.org/show_bug.cgi?id=301760">https://bugs.webkit.org/show_bug.cgi?id=301760</a>
<a href="https://rdar.apple.com/163797834">rdar://163797834</a>

Reviewed by Joshua Hoffman.

This is a fix that applies when the ENABLE_ACCESSIBILITY_LOCAL_FRAME
flag is enabled, in preparation for site isolation.

Previously, there was one AXObjectCache for the whole page, and the
current focused element always returned the focused element from any
frame. If there was no focused element, the root was returned.

With this flag enabled (required for site isolation), there&apos;s one
AXObjectCache for each frame. When determining the focused node across
all frames in the current process, each frame is now keeping track of
focus separately - that means that frames that are not currently
focused must return nullptr as their own focused node.

This required three main changes:
- Document needs to call AXObjectCache::onFocusChange even if the new
  focused element is nullptr
- WebProcess::accessibilityFocusedUIElement() needs to only consider frames
  where the focused node is not nullptr
- AXObjectCache::focusedObjectForLocalFrame should only return the root
  as a fallback if the current frame has focus but no specific element
  is focused. Otherwise it should return nullptr

This fixes the following layout tests (with ENABLE_ACCESSIBILITY_LOCAL_FRAME enabled):
  accessibility/mac/search-with-frames.html [ Failure ]
  accessibility/scroll-to-global-point-iframe-nested.html [ Failure ]
  accessibility/scroll-to-make-visible-iframe.html [ Failure ]
  accessibility/scroll-to-global-point-iframe-nested.html [ Failure ]

* LayoutTests/accessibility/mac/active-descendant-after-visibility-change.html:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::focusedObjectForLocalFrame):
(WebCore::AXObjectCache::getOrCreateIsolatedTree):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::crossFrameParentObject const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setFocusedElement):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):

Canonical link: <a href="https://commits.webkit.org/302501@main">https://commits.webkit.org/302501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e84e512a226f27ecbe44cfa3e6be8934ff00c8ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136636 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80652 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98431 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66332 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79082 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33907 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79915 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139109 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106961 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112124 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106799 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27199 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1082 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30644 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53930 "Hash e84e512a for PR 53260 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1379 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64735 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1202 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1302 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->