### PR TITLE
Enforce strict memory safety across WebKit

### DIFF
--- a/Source/WebKit/Configurations/Base.xcconfig
+++ b/Source/WebKit/Configurations/Base.xcconfig
@@ -120,7 +120,7 @@ SWIFT_VERSION = $(SWIFT_VERSION$(WK_XCODE_16));
 SWIFT_VERSION_XCODE_BEFORE_16 = 5.0;
 SWIFT_VERSION_XCODE_SINCE_16 = 6.0;
 
-OTHER_SWIFT_FLAGS = $(inherited) -no-warnings-as-errors -Xfrontend -experimental-spi-only-imports $(OTHER_SWIFT_FLAGS$(WK_XCODE_16)) @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/platform-enabled-swift-args.$(arch).resp @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/swift-tba-availability-macros.resp;
+OTHER_SWIFT_FLAGS = $(inherited) -Xfrontend -experimental-spi-only-imports $(OTHER_SWIFT_FLAGS$(WK_XCODE_16)) @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/platform-enabled-swift-args.$(arch).resp @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/swift-tba-availability-macros.resp;
 OTHER_SWIFT_FLAGS_XCODE_BEFORE_16 = -Xfrontend -enable-experimental-concurrency -Xfrontend -enable-upcoming-feature -Xfrontend IsolatedDefaultValues;
 
 WK_ENABLE_SWIFTUI = YES;

--- a/Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift
@@ -38,7 +38,8 @@ final class WKURLSchemeHandlerAdapter: NSObject, WKURLSchemeHandler {
     func webView(_ webView: WKWebView, start urlSchemeTask: any WKURLSchemeTask) {
         let task = Task {
             do {
-                for try await result in wrapped.reply(for: urlSchemeTask.request) {
+                // Safety: this is actually safe; false positive is rdar://154775389
+                for try await unsafe result in wrapped.reply(for: urlSchemeTask.request) {
                     try Task.checkCancellation()
 
                     switch result {

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
@@ -87,8 +87,12 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
         let interaction = NSTextFinder()
         interaction.isIncrementalSearchingEnabled = true
         interaction.incrementalSearchingShouldDimContentView = false
-        interaction.client = webView
-        interaction.findBarContainer = self
+        // Safety: both the folloowing two properties are
+        // @property (assign) which means non-owning.
+        // We therefore have to guarantee that webView and self
+        // outlive the interaction. rdar://163268246 is working on this.
+        unsafe interaction.client = webView
+        unsafe interaction.findBarContainer = self
         #else
         guard let interaction = webView?.findInteraction else {
             return nil
@@ -187,7 +191,8 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
                 return
             }
 
-            webView.window?.makeFirstResponder(webView)
+            // Safety: rdar://163268246 working on proving safety here.
+            unsafe webView.window?.makeFirstResponder(webView)
         }
     }
     #endif
@@ -266,7 +271,8 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
 
             webView.delegate = self
             #if os(macOS)
-            findInteraction?.wrapped.client = webView
+            // Safety: rdar://163268246 working on proving safety here.
+            unsafe findInteraction?.wrapped.client = webView
             #endif
         }
     }

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -292,7 +292,10 @@ struct EquatableScrollBounceBehavior: Equatable {
     let behavior: ScrollBounceBehavior
 
     static func == (lhs: EquatableScrollBounceBehavior, rhs: EquatableScrollBounceBehavior) -> Bool {
-        unsafeBitCast(lhs.behavior, to: Int8.self) == unsafeBitCast(rhs.behavior, to: Int8.self)
+        // Safety: ScrollBounceBehavior is opaque, but stores data, so is guaranteed
+        // to be at least 1 byte long. We will compare just that first byte.
+        // This is a temporary workaround for rdar://145030632.
+        unsafe unsafeBitCast(lhs.behavior, to: Int8.self) == unsafeBitCast(rhs.behavior, to: Int8.self)
     }
 }
 


### PR DESCRIPTION
#### 55c7cd08092ae78fdb524eb3d4e5fde6abb7e8eb
<pre>
Enforce strict memory safety across WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=300439">https://bugs.webkit.org/show_bug.cgi?id=300439</a>
<a href="https://rdar.apple.com/162275605">rdar://162275605</a>

Reviewed by Richard Robinson.

Other WebKit configuration files promote some (few) classes of Swift warnings
to errors. These errors were being suppressed in some cases; this removes that
suppression.

The only class of warning being promoted to error is the strict memory safety
warnings; these become errors. This PR therefore also fixes the remaining
strict memory safety issues.

This is the second attempt at removing this suppression. The first attempt
caused trouble due to these safety errors which did not show up on the EWS bots
in use at the time. EWS is now building using SDK versions which should
correctly show up any remaining problems.

Canonical link: <a href="https://commits.webkit.org/302849@main">https://commits.webkit.org/302849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60a1900aeaf90fc87400d67172595698fb713c69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80717 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5953b822-8490-4fe4-9a04-68b387ef6dc4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98221 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66397 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b1c90a74-ffd2-4105-9d61-896e7a2c5266) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115566 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78866 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/56783287-c6de-4520-9f40-4d03640a6209) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/855 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79660 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138849 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1037 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107011 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106855 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27437 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/878 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30426 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54003 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1438 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64469 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/976 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1291 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1360 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->