### PR TITLE
[Build Speed] Reduce includes of CSSGradient.h

### DIFF
--- a/Source/WebCore/css/values/shapes/CSSCircleFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSCircleFunction.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include <WebCore/CSSGradient.h>
 #include <WebCore/CSSPosition.h>
 #include <WebCore/CSSPrimitiveNumericTypes.h>
 

--- a/Source/WebCore/css/values/shapes/CSSEllipseFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSEllipseFunction.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include <WebCore/CSSGradient.h>
 #include <WebCore/CSSPosition.h>
 #include <WebCore/CSSPrimitiveNumericTypes.h>
 


### PR DESCRIPTION
#### fff3b5d29fcf03663d9fac43145f8b1af7f7b4c7
<pre>
[Build Speed] Reduce includes of CSSGradient.h
<a href="https://rdar.apple.com/163804793">rdar://163804793</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301764">https://bugs.webkit.org/show_bug.cgi?id=301764</a>

Reviewed by Brandon Stewart, Simon Fraser, and Sam Weinig.

Prior to this patch, CSSGradient.h was the 15th most expensive header in a
unified WebCore build. It is included 317 times, at an average CPU cost of 369
ms on this machine, for a total CPU cost of nearly 2m.

However this header was included entirely unnecessarily in two other commonly
included headers. The include statements can be removed and replaced with
absolutely nothing.

After this patch, CSSGradient.h is now the 832nd most expensive header in a
unified WebCore build. It is included 11 times, for a total CPU cost of 2s, a
reduction of 98%.

* Source/WebCore/css/values/shapes/CSSCircleFunction.h:
* Source/WebCore/css/values/shapes/CSSEllipseFunction.h:

Canonical link: <a href="https://commits.webkit.org/302407@main">https://commits.webkit.org/302407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f33f73382961e3297bc0846af363800031afeec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136392 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c12b86c1-c26b-451d-a5bc-2617318114c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130882 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98223 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9176ad89-dae8-42ee-acd8-2d3f1dce4b00) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78868 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/22867c45-b85b-4d6a-821c-2ccde697a193) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33674 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79671 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138867 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106764 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106590 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27131 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/882 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30420 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53570 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1141 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/64497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/977 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1024 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1068 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->