### PR TITLE
[Build Speed] Reduce includes of StyleBasicShape.h

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3452,6 +3452,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/shapes/StylePathOperationWrappers.h
     style/values/shapes/StylePolygonFunction.h
     style/values/shapes/StyleRectFunction.h
+    style/values/shapes/StyleShapeForward.h
     style/values/shapes/StyleShapeFunction.h
     style/values/shapes/StyleShapeImageThreshold.h
     style/values/shapes/StyleShapeMargin.h

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <WebCore/CSSPrimitiveNumeric.h>
 #include <WebCore/FontBaseline.h>
 #include <WebCore/LayoutRange.h>
 #include <WebCore/LocalFrameView.h>
@@ -31,6 +32,7 @@
 #include <WebCore/ScrollSnapOffsetsInfo.h>
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/ShapeOutsideInfo.h>
+#include <WebCore/StyleUnevaluatedCalculation.h>
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -30,6 +30,7 @@
 #include "InlineIteratorTextBox.h"
 #include "PaintInfo.h"
 #include "RenderObject.h"
+#include "StylePrimitiveNumeric.h"
 #include "TextBoxSelectableRange.h"
 #include "TextDecorationPainter.h"
 #include "TextRun.h"

--- a/Source/WebCore/rendering/shapes/LayoutShape.h
+++ b/Source/WebCore/rendering/shapes/LayoutShape.h
@@ -31,7 +31,7 @@
 
 #include <WebCore/LayoutRect.h>
 #include <WebCore/Path.h>
-#include <WebCore/StyleBasicShape.h>
+#include <WebCore/StyleShapeForward.h>
 #include <WebCore/WritingMode.h>
 #include <wtf/RefCounted.h>
 

--- a/Source/WebCore/style/values/shapes/StyleShapeForward.h
+++ b/Source/WebCore/style/values/shapes/StyleShapeForward.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/CSSValueKeywords.h>
+
+namespace WebCore {
+
+enum CSSValueID : uint16_t;
+template<CSSValueID C, typename T> struct FunctionNotation;
+
+namespace Style {
+
+struct Circle;
+struct Ellipse;
+struct Inset;
+struct Path;
+struct Polygon;
+struct Shape;
+
+using CircleFunction = FunctionNotation<CSSValueCircle, Circle>;
+using EllipseFunction = FunctionNotation<CSSValueEllipse, Ellipse>;
+using InsetFunction = FunctionNotation<CSSValueInset, Inset>;
+using PathFunction = FunctionNotation<CSSValuePath, Path>;
+using PolygonFunction = FunctionNotation<CSSValuePolygon, Polygon>;
+using ShapeFunction = FunctionNotation<CSSValueShape, Shape>;
+
+using BasicShape = Variant<
+    CircleFunction,
+    EllipseFunction,
+    InsetFunction,
+    PathFunction,
+    PolygonFunction,
+    ShapeFunction
+>;
+
+}
+
+}


### PR DESCRIPTION
#### f9db93196fba762fe33ab135f6704b14bcc6b93c
<pre>
[Build Speed] Reduce includes of StyleBasicShape.h
<a href="https://rdar.apple.com/163812454">rdar://163812454</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301767">https://bugs.webkit.org/show_bug.cgi?id=301767</a>

Reviewed by Sam Weinig.

Before this patch, StyleBasicShape.h was the 4th most expensive header in a
Unified WebCore build. It was included 310 times, at an average cost of 1121
ms, for a total CPU cost of 5m47s.

It is included in 4 headers total, and in only one of those can its full
definitions be replaced with forward declarations. That forward declaration is
complex enough to warrant its own header file, StyleShapeForward.h.

After this patch, StyleBasicShape.h is the 24th most expensive header. It is
included 210 times for a total CPU cost of 1m37s.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/TextBoxPainter.h:
* Source/WebCore/rendering/shapes/LayoutShape.h:
* Source/WebCore/style/values/shapes/StyleShapeForward.h: Added.

Canonical link: <a href="https://commits.webkit.org/302486@main">https://commits.webkit.org/302486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5d4e35d2728987ef23c158433e34973e63195d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80395 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/20b00818-e34f-4424-8cd7-8ba470cd50a5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1162 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66133 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7900e271-2858-49ca-93de-cff7ac21a626) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115578 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3b9b74e3-6fa9-4082-843e-8e7da0267560) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33693 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79686 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138881 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1080 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106779 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106605 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27188 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/892 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30438 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53585 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1154 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64494 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/988 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1037 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1081 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->