### PR TITLE
Unreviewed, reverting 302347@main (233654426e8b)

### DIFF
--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -183,13 +183,6 @@ struct FontPlatformOpticalSize {
     Variant<RetainPtr<CFNumberRef>, String> opticalSize;
 };
 
-struct FontPlatformFeatureSetting {
-    std::optional<RetainPtr<CFNumberRef>> type;
-    std::optional<RetainPtr<CFNumberRef>> selector;
-    std::optional<RetainPtr<CFStringRef>> tag;
-    std::optional<RetainPtr<CFNumberRef>> value;
-};
-
 struct FontPlatformSerializedAttributes {
     static std::optional<FontPlatformSerializedAttributes> fromCF(CFDictionaryRef);
     RetainPtr<CFDictionaryRef> toCFDictionary() const;
@@ -218,7 +211,8 @@ struct FontPlatformSerializedAttributes {
     std::optional<FontPlatformOpticalSize> opticalSize;
     std::optional<FontPlatformSerializedTraits> traits;
 
-    std::optional<Vector<FontPlatformFeatureSetting>> featureSettings;
+    // FIXME: featureSettings is an array of CFDictionaries whose layouts are highly variable
+    std::optional<RetainPtr<CFArrayRef>> featureSettings;
 
 #if HAVE(ADDITIONAL_FONT_PLATFORM_SERIALIZED_ATTRIBUTES)
     std::optional<RetainPtr<CFNumberRef>> additionalNumber;

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -372,54 +372,8 @@ std::optional<FontPlatformSerializedAttributes> FontPlatformSerializedAttributes
     if (traits && CFGetTypeID(traits.get()) == CFDictionaryGetTypeID())
         result.traits = FontPlatformSerializedTraits::fromCF(traits.get());
 
-    RetainPtr settings = checked_cf_cast<CFArrayRef>(CFDictionaryGetValue(dictionary, kCTFontFeatureSettingsAttribute));
-    if (settings && CFGetTypeID(settings.get()) == CFArrayGetTypeID()) {
-        Vector<FontPlatformFeatureSetting> featureSettings;
-        for (CFIndex i = 0; i < CFArrayGetCount(settings.get()); ++i) {
-            RetainPtr object = CFArrayGetValueAtIndex(settings.get(), i);
-            if (CFGetTypeID(object.get()) == CFDictionaryGetTypeID()) {
-                featureSettings.append(FontPlatformFeatureSetting {
-                    checked_cf_cast<CFNumberRef>(CFDictionaryGetValue(checked_cf_cast<CFDictionaryRef>(object.get()), kCTFontFeatureTypeIdentifierKey)),
-                    checked_cf_cast<CFNumberRef>(CFDictionaryGetValue(checked_cf_cast<CFDictionaryRef>(object.get()), kCTFontFeatureSelectorIdentifierKey)),
-                    checked_cf_cast<CFStringRef>(CFDictionaryGetValue(checked_cf_cast<CFDictionaryRef>(object.get()), kCTFontOpenTypeFeatureTag)),
-                    checked_cf_cast<CFNumberRef>(CFDictionaryGetValue(checked_cf_cast<CFDictionaryRef>(object.get()), kCTFontOpenTypeFeatureValue))
-                });
-            } else {
-                RetainPtr<CFTypeRef> typeOrTag = nullptr;
-                RetainPtr<CFNumberRef> selectorOrValue = nullptr;
-                if (CFGetTypeID(object.get()) == CFArrayGetTypeID()) {
-                    RetainPtr array = checked_cf_cast<CFArrayRef>(object.get());
-                    CFIndex count = CFArrayGetCount(array.get());
-                    if (!count)
-                        continue;
+    EXTRACT_TYPED_VALUE(kCTFontFeatureSettingsAttribute, CFArray, result.featureSettings);
 
-                    typeOrTag = CFArrayGetValueAtIndex(array.get(), 0);
-                    if (count > 1)
-                        selectorOrValue = checked_cf_cast<CFNumberRef>(CFArrayGetValueAtIndex(array.get(), 1));
-                }
-
-                if (!typeOrTag)
-                    continue;
-
-                if (CFGetTypeID(typeOrTag.get()) == CFNumberGetTypeID()) {
-                    featureSettings.append(FontPlatformFeatureSetting {
-                        checked_cf_cast<CFNumberRef>(typeOrTag.get()),
-                        selectorOrValue,
-                        nullptr,
-                        nullptr
-                    });
-                } else {
-                    featureSettings.append(FontPlatformFeatureSetting {
-                        nullptr,
-                        nullptr,
-                        checked_cf_cast<CFStringRef>(typeOrTag.get()),
-                        selectorOrValue
-                    });
-                }
-            }
-        }
-        result.featureSettings = featureSettings;
-    }
     return WTFMove(result);
 }
 
@@ -466,22 +420,7 @@ RetainPtr<CFDictionaryRef> FontPlatformSerializedAttributes::toCFDictionary() co
     INJECT_CF_VALUE(additionalFontPlatformSerializedAttributesNumberDictionaryKey(), additionalNumber);
 #endif
 
-    if (featureSettings) {
-        RetainPtr settingsArray = adoptCF(CFArrayCreateMutable(nullptr, Checked<CFIndex>(featureSettings->size()), &kCFTypeArrayCallBacks));
-        for (const FontPlatformFeatureSetting& setting : *featureSettings) {
-            RetainPtr destinationSetting = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-            if (setting.type)
-                CFDictionaryAddValue(destinationSetting.get(), kCTFontFeatureTypeIdentifierKey, setting.type->get());
-            if (setting.selector)
-                CFDictionaryAddValue(destinationSetting.get(), kCTFontFeatureSelectorIdentifierKey, setting.selector->get());
-            if (setting.tag)
-                CFDictionaryAddValue(destinationSetting.get(), kCTFontOpenTypeFeatureTag, setting.tag->get());
-            if (setting.value)
-                CFDictionaryAddValue(destinationSetting.get(), kCTFontOpenTypeFeatureValue, setting.value->get());
-            CFArrayAppendValue(settingsArray.get(), destinationSetting.get());
-        }
-        CFDictionaryAddValue(result.get(), kCTFontFeatureSettingsAttribute, settingsArray.get());
-    }
+    INJECT_CF_VALUE(kCTFontFeatureSettingsAttribute, featureSettings);
 
     if (opticalSize) {
         if (auto opticalSizeCF = opticalSize->toCF())

--- a/Source/WebKit/Shared/WebCoreFont.serialization.in
+++ b/Source/WebKit/Shared/WebCoreFont.serialization.in
@@ -110,13 +110,6 @@ header: <WebCore/FontPlatformData.h>
     Variant<RetainPtr<CFNumberRef>, String> opticalSize;
 };
 
-[CustomHeader] struct WebCore::FontPlatformFeatureSetting {
-    std::optional<RetainPtr<CFNumberRef>> type;
-    std::optional<RetainPtr<CFNumberRef>> selector;
-    std::optional<RetainPtr<CFStringRef>> tag;
-    std::optional<RetainPtr<CFNumberRef>> value;
-};
-
 [CustomHeader] struct WebCore::FontPlatformSerializedAttributes {
     String fontName;
     String descriptorLanguage;
@@ -142,7 +135,7 @@ header: <WebCore/FontPlatformData.h>
     std::optional<WebCore::FontPlatformOpticalSize> opticalSize;
     std::optional<WebCore::FontPlatformSerializedTraits> traits;
 
-    std::optional<Vector<WebCore::FontPlatformFeatureSetting>> featureSettings;
+    std::optional<RetainPtr<CFArrayRef>> featureSettings;
 
 #if HAVE(ADDITIONAL_FONT_PLATFORM_SERIALIZED_ATTRIBUTES)
     std::optional<RetainPtr<CFNumberRef>> additionalNumber;

--- a/Source/WebKit/Shared/cf/CFTypes.serialization.in
+++ b/Source/WebKit/Shared/cf/CFTypes.serialization.in
@@ -31,6 +31,9 @@
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFString()] CFStringRef wrapped by WTF::String {
 }
 
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFArray()] CFArrayRef wrapped by WebKit::CoreIPCCFArray {
+}
+
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFDictionary()] CFDictionaryRef wrapped by WebKit::CoreIPCCFDictionary {
 }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -102,6 +102,7 @@ struct CFHolderForTesting {
 
     using ValueType = Variant<
         std::nullptr_t,
+        RetainPtr<CFArrayRef>,
         RetainPtr<CFBooleanRef>,
         RetainPtr<CFCharacterSetRef>,
         RetainPtr<CFDataRef>,
@@ -287,6 +288,8 @@ CFHolderForTesting cfHolder(CFTypeRef type)
     if (!type)
         return { nullptr };
     CFTypeID typeID = CFGetTypeID(type);
+    if (typeID == CFArrayGetTypeID())
+        return { (CFArrayRef)type };
     if (typeID == CFBooleanGetTypeID())
         return { (CFBooleanRef)type };
     if (typeID == CFCharacterSetGetTypeID())
@@ -1260,6 +1263,20 @@ TEST(IPCSerialization, Basic)
         (id)accessControlRef.get(),
         @{ @"key": NSNull.null }
     ];
+
+    runTestCFWithExpectedResult({ (__bridge CFArrayRef)@[
+        nestedArray,
+        (id)trust.get(),
+        NSUUID.UUID, // Removed when encoding because CFUUIDRef is not a recognized type in CFArrayRef or CFDictionaryRef
+        @{
+            @"should be removed before encoding" : NSUUID.UUID,
+            NSUUID.UUID : @"should also be removed before encoding"
+        }
+    ] }, { (__bridge CFArrayRef)@[
+        nestedArray,
+        (id)trust.get(),
+        @{ }
+    ] });
 
     runTestCFWithExpectedResult({ (__bridge CFDictionaryRef) @{
         @"key" : nestedArray,


### PR DESCRIPTION
#### 29d91d0db143810739c2d43697f130e7fc40274a
<pre>
Unreviewed, reverting 302347@main (233654426e8b)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301770">https://bugs.webkit.org/show_bug.cgi?id=301770</a>
<a href="https://rdar.apple.com/163815601">rdar://163815601</a>

REGRESSION(302347@main) [ Debug ]: 2X TestIPC (API-Tests) are a constant crash

Reverted change:

    Move FontPlatformSerializedAttributes off of using a CFArray for serialization
    <a href="https://bugs.webkit.org/show_bug.cgi?id=301567">https://bugs.webkit.org/show_bug.cgi?id=301567</a>
    <a href="https://rdar.apple.com/163561063">rdar://163561063</a>
    302347@main (233654426e8b)

Canonical link: <a href="https://commits.webkit.org/302404@main">https://commits.webkit.org/302404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07cce7c5864063c0611a394e0711261816f13f8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136411 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130901 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/1221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1166 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131977 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/1221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/78884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/1221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/33696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79690 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/1221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/34194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138885 "Failed to checkout and rebase branch from PR 53270") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/1084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/138885 "Failed to checkout and rebase branch from PR 53270") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/1141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/111917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/138885 "Failed to checkout and rebase branch from PR 53270") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/30441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20140 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/1158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/64501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/1085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->