### PR TITLE
[Build Speed] REGRESSION(302163@main): Reduce includes of CSSParser.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -39,6 +39,7 @@ css/CSSToLengthConversionData.h
 css/MediaList.h
 css/StyleSheetContents.cpp
 css/StyleSheetContents.h
+css/values/primitives/CSSPrimitiveData.h
 dom/CustomElementReactionQueue.h
 dom/Element.h
 dom/FragmentDirectiveRangeFinder.cpp

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -73,6 +73,7 @@
 #include "MutableCSSSelector.h"
 #include "NestingLevelIncrementer.h"
 #include "NodeDocument.h"
+#include "StyleColor.h"
 #include "StylePropertiesInlines.h"
 #include "StyleRule.h"
 #include "StyleRuleFunction.h"

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -34,7 +34,6 @@
 #include <WebCore/CSSParserTokenRange.h>
 #include <WebCore/CSSProperty.h>
 #include <WebCore/CSSPropertyNames.h>
-#include <WebCore/StyleColor.h>
 #include <WebCore/StyleRule.h>
 #include <memory>
 #include <wtf/Vector.h>
@@ -71,6 +70,10 @@ class StyleSheetContents;
 class ImmutableStyleProperties;
 class Element;
 class MutableStyleProperties;
+
+namespace Style {
+struct Color;
+}
 
 enum CSSAtRuleID : uint8_t;
 

--- a/Source/WebCore/svg/properties/SVGPropertyTraits.cpp
+++ b/Source/WebCore/svg/properties/SVGPropertyTraits.cpp
@@ -26,11 +26,14 @@
 #include "config.h"
 #include "SVGPropertyTraits.h"
 
-#include "ContainerNodeInlines.h"
+#include "CSSParser.h"
 #include "CSSPropertyParserConsumer+ColorInlines.h"
+#include "ColorSerialization.h"
+#include "ContainerNodeInlines.h"
 #include "RenderElement.h"
 #include "RenderObjectStyle.h"
 #include "SVGElement.h"
+#include "StyleColor.h"
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
@@ -82,6 +85,11 @@ Color SVGPropertyTraits<Color>::fromString(SVGElement& targetElement, const Stri
 int SVGPropertyTraits<int>::fromString(SVGElement&, const String& string)
 {
     return parseInteger<int>(string).value_or(0);
+}
+
+String SVGPropertyTraits<Color>::toString(const Color& type)
+{
+    return serializationForHTML(type);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/properties/SVGPropertyTraits.h
+++ b/Source/WebCore/svg/properties/SVGPropertyTraits.h
@@ -21,10 +21,8 @@
 
 #pragma once
 
-#include <WebCore/CSSParser.h>
 #include <WebCore/CSSPropertyParserConsumer+Color.h>
 #include <WebCore/Color.h>
-#include <WebCore/ColorSerialization.h>
 #include <WebCore/CommonAtomStrings.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FloatRect.h>
@@ -35,6 +33,10 @@
 namespace WebCore {
 
 class SVGElement;
+
+namespace Style {
+struct Color;
+}
 
 template<typename PropertyType>
 struct SVGPropertyTraits { };
@@ -51,7 +53,7 @@ template<>
 struct SVGPropertyTraits<Color> {
     static Color initialValue() { return Color(); }
     static Color fromString(SVGElement&, const String&);
-    static String toString(const Color& type) { return serializationForHTML(type); }
+    static String toString(const Color&);
 };
 
 template<>


### PR DESCRIPTION
#### 558951c36784bc87f02cd71fd1fdbcb2ee984ede
<pre>
[Build Speed] REGRESSION(302163@main): Reduce includes of CSSParser.h
<a href="https://rdar.apple.com/163815459">rdar://163815459</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301769">https://bugs.webkit.org/show_bug.cgi?id=301769</a>

Reviewed by Brandon Stewart and Simon Fraser.

In 302163@main, an include of CSSParser.h was added to SVGPropertyTraits. Prior
to 302163@main, CSSParser.h was included 16 times, for a total CPU cost of
2.7s. After that revision, CSSParser.h was included 340 times, for a total CPU
cost of 4m11s.

Replace the includes of CSSParser.h, ColorSerialization.h, and StyleColor.h in
SVGPropertyTraits.h with forward declarations and move inline functions into
the implementation file. And remove the include of StyleColor.h with a forward
declaration.

After this patch, CSSParser.h dropped from the 9th most expensive header back
down to near where it started at 568th with a total CPU cost of about 3s.

* Source/WebCore/css/parser/CSSParser.cpp:
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/svg/properties/SVGPropertyTraits.cpp:
(WebCore::SVGPropertyTraits&lt;Color&gt;::parse):
(WebCore::SVGPropertyTraits&lt;Color&gt;::toString):
* Source/WebCore/svg/properties/SVGPropertyTraits.h:
(WebCore::SVGPropertyTraits&lt;Color&gt;::parse): Deleted.
(WebCore::SVGPropertyTraits&lt;Color&gt;::toString): Deleted.

Canonical link: <a href="https://commits.webkit.org/302550@main">https://commits.webkit.org/302550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ca120c9fa9d46a3b3eddad2f8e193da8475c297

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1545 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/40126 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136665 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80679 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3926cbb2-7650-4d40-921a-e3d6ce28cef1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131160 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/1475 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98466 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80679 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6a50106f-858c-4035-aa01-a3358c872ecc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132236 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/1475 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/40126 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79109 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f54c63a5-8a97-4c39-9e91-f6e684096ebd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/1475 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/40126 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79943 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/1475 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/40126 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139138 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/1334 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1294 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106994 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1378 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/40126 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106827 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27198 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1091 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/40126 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53956 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20203 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/1406 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64772 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/1224 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1259 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/1328 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
<!--EWS-Status-Bubble-End-->