### PR TITLE
Always allocate RemoteLayerTreeTransaction in heap

### DIFF
--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -343,7 +343,10 @@ template<typename T> struct ArgumentCoder<UniqueRef<T>> {
         auto object = decoder.template decode<T>();
         if (!object)
             return std::nullopt;
-        return makeUniqueRef<T>(WTFMove(*object));
+        if constexpr (std::is_same_v<decltype(object), std::optional<UniqueRef<T>>>)
+            return object;
+        else
+            return makeUniqueRef<T>(WTFMove(*object));
     }
 };
 

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -140,9 +140,9 @@ public:
     }
 
     template<typename T>
-    std::optional<T> decode()
+    auto decode()
     {
-        std::optional<T> t { ArgumentCoder<std::remove_cvref_t<T>>::decode(*this) };
+        auto t = ArgumentCoder<std::remove_cvref_t<T>>::decode(*this);
         if (!t) [[unlikely]]
             markInvalid();
         return t;
@@ -208,7 +208,7 @@ private:
 };
 
 template<>
-inline std::optional<Attachment> Decoder::decode<Attachment>()
+inline auto Decoder::decode<Attachment>()
 {
     return takeLastAttachment();
 }

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -92,6 +92,7 @@ class SerializedType(object):
         self.condition = condition
         self.encoders = ['Encoder']
         self.return_ref = False
+        self.return_uniqueref = False
         self.construct_subclass = None
         self.create_using = False
         self.populate_from_empty_constructor = False
@@ -133,6 +134,8 @@ class SerializedType(object):
                         self.nested = True
                     elif attribute == 'RefCounted':
                         self.return_ref = True
+                    elif attribute == 'UniqueRef':
+                        self.return_uniqueref = True
                     elif attribute == 'DisableMissingMemberCheck':
                         self.disableMissingMemberCheck = True
                     elif attribute == 'RValue':
@@ -543,6 +546,8 @@ def one_argument_coder_declaration(type, template_argument):
             result.append(f'    static void encode({encoder}&, const {name_with_template}&);')
     if type.return_ref:
         result.append(f'    static std::optional<Ref<{name_with_template}>> decode(Decoder&);')
+    elif type.return_uniqueref:
+        result.append(f'    static std::optional<UniqueRef<{name_with_template}>> decode(Decoder&);')
     else:
         result.append(f'    static std::optional<{name_with_template}> decode(Decoder&);')
     result.append('};')
@@ -999,6 +1004,8 @@ def construct_type(type, specialization, indentation):
         result.append(f'{indent(indentation)}{fulltype}::{type.create_using}(')
     elif type.return_ref:
         result.append(f'{indent(indentation)}{fulltype}::create(')
+    elif type.return_uniqueref:
+        result.append(f'{indent(indentation)}makeUniqueRef<{fulltype}>(')
     else:
         result.append(f'{indent(indentation)}{fulltype} {{')
     if type.parent_class is not None:
@@ -1076,6 +1083,8 @@ def generate_one_impl(type, template_argument, serialized_types):
         result.append(f'std::optional<RetainPtr<{name_with_template}>> ArgumentCoder<RetainPtr<{name_with_template}>>::decode(Decoder& decoder)')
     elif type.return_ref:
         result.append(f'std::optional<Ref<{name_with_template}>> ArgumentCoder<{name_with_template}>::decode(Decoder& decoder)')
+    elif type.return_uniqueref:
+        result.append(f'std::optional<UniqueRef<{name_with_template}>> ArgumentCoder<{name_with_template}>::decode(Decoder& decoder)')
     else:
         result.append(f'std::optional<{name_with_template}> ArgumentCoder<{name_with_template}>::decode(Decoder& decoder)')
     result.append('{')
@@ -1085,11 +1094,17 @@ def generate_one_impl(type, template_argument, serialized_types):
             result.append('    if (!decoder.isValid()) [[unlikely]]')
             result.append('        return std::nullopt;')
             if type.populate_from_empty_constructor and not type.has_optional_tuple_bits():
-                result.append(f'    {name_with_template} result;')
+                if type.return_uniqueref:
+                    result.append(f'    auto result = makeUniqueRef<{name_with_template}>();')
+                else:
+                    result.append(f'    {name_with_template} result;')
                 for member in type.serialized_members():
                     if member.condition is not None:
                         result.append(f'#if {member.condition}')
-                    result.append(f'    result.{member.name} = WTFMove(*{member.name});')
+                    if type.return_uniqueref:
+                        result.append(f'    result->{member.name} = WTFMove(*{member.name});')
+                    else:
+                        result.append(f'    result.{member.name} = WTFMove(*{member.name});')
                     if member.condition is not None:
                         result.append('#endif')
                 result.append('    return { WTFMove(result) };')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -56,6 +56,7 @@
 #include <Namespace/OuterClass.h>
 #endif
 #include <Namespace/ReturnRefClass.h>
+#include <Namespace/ReturnUniqueRefClass.h>
 #if USE(APPKIT)
 #include <WebCore/AppKitControlSystemImage.h>
 #endif
@@ -305,6 +306,25 @@ std::optional<Ref<Namespace::ReturnRefClass>> ArgumentCoder<Namespace::ReturnRef
             WTFMove(*functionCallmember2),
             WTFMove(*uniqueMember)
         )
+    };
+}
+
+void ArgumentCoder<Namespace::ReturnUniqueRefClass>::encode(Encoder& encoder, const Namespace::ReturnUniqueRefClass& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.someValie())>, int>);
+
+    encoder << instance.someValie();
+}
+
+std::optional<UniqueRef<Namespace::ReturnUniqueRefClass>> ArgumentCoder<Namespace::ReturnUniqueRefClass>::decode(Decoder& decoder)
+{
+    auto someValie = decoder.decode<int>();
+    if (!decoder.isValid()) [[unlikely]]
+        return std::nullopt;
+    return {
+        makeUniqueRef<Namespace::ReturnUniqueRefClass>(
+            WTFMove(*someValie)
+        }
     };
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -57,6 +57,7 @@ enum class Incredible;
 
 namespace Namespace {
 class ReturnRefClass;
+class ReturnUniqueRefClass;
 struct EmptyConstructorStruct;
 class EmptyConstructorWithIf;
 #if ENABLE(TEST_FEATURE)
@@ -165,6 +166,11 @@ template<> struct ArgumentCoder<Namespace::Subnamespace::StructName> {
 template<> struct ArgumentCoder<Namespace::ReturnRefClass> {
     static void encode(Encoder&, const Namespace::ReturnRefClass&);
     static std::optional<Ref<Namespace::ReturnRefClass>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<Namespace::ReturnUniqueRefClass> {
+    static void encode(Encoder&, const Namespace::ReturnUniqueRefClass&);
+    static std::optional<UniqueRef<Namespace::ReturnUniqueRefClass>> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<Namespace::EmptyConstructorStruct> {

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -57,6 +57,7 @@
 #include <Namespace/OuterClass.h>
 #endif
 #include <Namespace/ReturnRefClass.h>
+#include <Namespace/ReturnUniqueRefClass.h>
 #if USE(APPKIT)
 #include <WebCore/AppKitControlSystemImage.h>
 #endif
@@ -171,6 +172,12 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             {
                 "std::unique_ptr<int>"_s,
                 "uniqueMember"_s
+            },
+        } },
+        { "Namespace::ReturnUniqueRefClass"_s, {
+            {
+                "int"_s,
+                "someValie()"_s
             },
         } },
         { "Namespace::EmptyConstructorStruct"_s, {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -29,6 +29,10 @@ headers: "StructHeader.h" "FirstMemberType.h" "SecondMemberType.h"
     std::unique_ptr<int> uniqueMember
 }
 
+[UniqueRef] class Namespace::ReturnUniqueRefClass {
+    int someValie()
+}
+
 [LegacyPopulateFromEmptyConstructor] struct Namespace::EmptyConstructorStruct {
     int m_int;
     double m_double;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -109,7 +109,7 @@ header: "RemoteLayerBackingStore.h"
 #endif
 };
 
-[LegacyPopulateFromEmptyConstructor, DisableMissingMemberCheck] class WebKit::RemoteLayerTreeTransaction {
+[UniqueRef, LegacyPopulateFromEmptyConstructor, DisableMissingMemberCheck] class WebKit::RemoteLayerTreeTransaction {
 {
     Markable<WebCore::PlatformLayerIdentifier> m_rootLayerID;
     WebKit::ChangedLayers m_changedLayers;
@@ -299,7 +299,7 @@ using WebKit::PageData::TransactionCallbackID = IPC::AsyncReplyID;
 #endif
 };
 
-using WebKit::RemoteLayerTreeCommitBundle::RootFrameData = std::pair<WebKit::RemoteLayerTreeTransaction, WebKit::RemoteScrollingCoordinatorTransaction>;
+using WebKit::RemoteLayerTreeCommitBundle::RootFrameData = std::pair<UniqueRef<WebKit::RemoteLayerTreeTransaction>, WebKit::RemoteScrollingCoordinatorTransaction>;
 
 struct WebKit::RemoteLayerTreeCommitBundle {
     Vector<WebKit::RemoteLayerTreeCommitBundle::RootFrameData> transactions;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
@@ -59,7 +59,7 @@ struct MainFrameData {
 };
 
 struct RemoteLayerTreeCommitBundle {
-    using RootFrameData = std::pair<RemoteLayerTreeTransaction, RemoteScrollingCoordinatorTransaction>;
+    using RootFrameData = std::pair<UniqueRef<RemoteLayerTreeTransaction>, RemoteScrollingCoordinatorTransaction>;
 
     Vector<RootFrameData> transactions;
     PageData pageData;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -85,7 +85,7 @@ struct ChangedLayers {
     ~ChangedLayers();
 };
 
-class RemoteLayerTreeTransaction final : public CanMakeCheckedPtr<RemoteLayerTreeTransaction, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
+class RemoteLayerTreeTransaction final : public CanMakeCheckedPtr<RemoteLayerTreeTransaction> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeTransaction);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeTransaction);
 public:
@@ -242,6 +242,7 @@ public:
 
 private:
     friend struct IPC::ArgumentCoder<RemoteLayerTreeTransaction>;
+    friend UniqueRef<RemoteLayerTreeTransaction> WTF::makeUniqueRefWithoutFastMallocCheck<RemoteLayerTreeTransaction>();
 
     // Do not use, IPC constructor only
     explicit RemoteLayerTreeTransaction();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -289,12 +289,12 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
         MESSAGE_CHECK_BASE(state.commitLayerTreeMessageState == CommitLayerTreePending || state.commitLayerTreeMessageState == MissedCommit || state.commitLayerTreeMessageState == Idle, connection);
         MESSAGE_CHECK_BASE(state.pendingLayerTreeTransactionID, connection);
         // FIXME: transactionID() should be a property of the bundle.
-        MESSAGE_CHECK_BASE(bundle.transactions.first().first.transactionID() == *state.pendingLayerTreeTransactionID, connection);
+        MESSAGE_CHECK_BASE(bundle.transactions.first().first->transactionID() == *state.pendingLayerTreeTransactionID, connection);
     }
 
     bool hasMainFrameProcessTransaction { false };
     for (const auto& [layerTreeTransaction, scrollingTreeTransaction] : bundle.transactions) {
-        if (layerTreeTransaction.isMainFrameProcessTransaction()) {
+        if (layerTreeTransaction->isMainFrameProcessTransaction()) {
             hasMainFrameProcessTransaction = true;
             break;
         }
@@ -314,7 +314,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
     __block Vector<MachSendRight, 16> sendRights;
     for (auto& transaction : bundle.transactions) {
         // commitLayerTreeTransaction consumes the incoming buffers, so we need to grab them first.
-        for (auto& [layerID, properties] : CheckedRef { transaction.first }->changedLayerProperties()) {
+        for (auto& [layerID, properties] : CheckedRef { transaction.first.get() }->changedLayerProperties()) {
             auto* backingStoreProperties = properties->backingStoreOrProperties.properties.get();
             if (!backingStoreProperties)
                 continue;
@@ -364,7 +364,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
     WeakPtr weakThis { *this };
 
     for (auto& transaction : bundle.transactions) {
-        commitLayerTreeTransaction(connection, CheckedRef { transaction.first }.get(), transaction.second, bundle.mainFrameData);
+        commitLayerTreeTransaction(connection, CheckedRef { transaction.first.get() }.get(), transaction.second, bundle.mainFrameData);
         if (!weakThis)
             return;
     }


### PR DESCRIPTION
#### 967c00b0776ebd259b8610d273688fd083febacf
<pre>
Always allocate RemoteLayerTreeTransaction in heap
<a href="https://bugs.webkit.org/show_bug.cgi?id=301778">https://bugs.webkit.org/show_bug.cgi?id=301778</a>

Reviewed by Geoffrey Garen.

Always allocate RemoteLayerTreeTransaction in heap so that operator delete will be used for its destruction.

No new tests since there should be no behavioral differences.

Canonical link: <a href="https://commits.webkit.org/302495@main">https://commits.webkit.org/302495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d9fbe8a63aef03e456899212e825eccebf6f8e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80585 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e357af28-53ec-431b-a045-c43a2fea3d31) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98379 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66279 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2a80ee2b-2adf-406b-9540-c503ce1aaa37) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1081 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115727 "Found 16 new API test failures: TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder.DecodeArray, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder.DecodePair, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/StreamConnectionEncoder.DecodeArray, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/StreamConnectionEncoder.DecodeVariant, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder.DecodeValue, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder.DecodeVector, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder.DecodeVariant, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/StreamConnectionEncoder.DecodeValue, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder.DecodeUniquePtr, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/StreamConnectionEncoder.DecodeVector ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79027 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/45117637-bf4b-4baf-8d80-dbd72f06e583) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/128542 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1001 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79850 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109449 "Found 16 new API test failures: TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder.DecodeArray, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder.DecodePair, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/StreamConnectionEncoder.DecodeArray, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/StreamConnectionEncoder.DecodeVariant, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder.DecodeValue, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder.DecodeVector, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder.DecodeVariant, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/StreamConnectionEncoder.DecodeValue, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder.DecodeUniquePtr, TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/StreamConnectionEncoder.DecodeVector ... (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139044 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106909 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/128622 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1295 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106745 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1024 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30587 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53840 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20182 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1316 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64669 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1142 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1187 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1240 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->