### PR TITLE
Always allocate SharedStringHashStore in heap

### DIFF
--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
@@ -39,25 +39,25 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSWOriginStore);
 using namespace WebCore;
 
 WebSWOriginStore::WebSWOriginStore()
-    : m_store(*this)
+    : m_store(makeUniqueRef<SharedStringHashStore>(*this))
 {
 }
 
 void WebSWOriginStore::addToStore(const SecurityOriginData& origin)
 {
-    m_store.scheduleAddition(computeSharedStringHash(origin.toString()));
-    m_store.flushPendingChanges();
+    m_store->scheduleAddition(computeSharedStringHash(origin.toString()));
+    m_store->flushPendingChanges();
 }
 
 void WebSWOriginStore::removeFromStore(const SecurityOriginData& origin)
 {
-    m_store.scheduleRemoval(computeSharedStringHash(origin.toString()));
-    m_store.flushPendingChanges();
+    m_store->scheduleRemoval(computeSharedStringHash(origin.toString()));
+    m_store->flushPendingChanges();
 }
 
 void WebSWOriginStore::clearStore()
 {
-    m_store.clear();
+    m_store->clear();
 }
 
 void WebSWOriginStore::importComplete()
@@ -71,7 +71,7 @@ void WebSWOriginStore::registerSWServerConnection(WebSWServerConnection& connect
 {
     m_webSWServerConnections.add(connection);
 
-    if (!m_store.isEmpty())
+    if (!m_store->isEmpty())
         sendStoreHandle(connection);
 
     if (m_isImported)
@@ -85,7 +85,7 @@ void WebSWOriginStore::unregisterSWServerConnection(WebSWServerConnection& conne
 
 void WebSWOriginStore::sendStoreHandle(WebSWServerConnection& connection)
 {
-    auto handle = m_store.createSharedMemoryHandle();
+    auto handle = m_store->createSharedMemoryHandle();
     if (!handle)
         return;
     connection.send(Messages::WebSWClientConnection::SetSWOriginTableSharedMemory(WTFMove(*handle)));

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.h
@@ -34,7 +34,7 @@ namespace WebKit {
 
 class WebSWServerConnection;
 
-class WebSWOriginStore final : public WebCore::SWOriginStore, private SharedStringHashStore::Client {
+class WebSWOriginStore final : public WebCore::SWOriginStore, public SharedStringHashStore::Client {
     WTF_MAKE_TZONE_ALLOCATED(WebSWOriginStore);
 public:
     WebSWOriginStore();
@@ -53,7 +53,7 @@ private:
     // SharedStringHashStore::Client.
     void didInvalidateSharedMemory() final;
 
-    SharedStringHashStore m_store;
+    const UniqueRef<SharedStringHashStore> m_store;
     bool m_isImported { false };
     WeakHashSet<WebSWServerConnection> m_webSWServerConnections;
 };

--- a/Source/WebKit/Shared/SharedStringHashStore.h
+++ b/Source/WebKit/Shared/SharedStringHashStore.h
@@ -33,7 +33,7 @@
 
 namespace WebKit {
 
-class SharedStringHashStore : public CanMakeCheckedPtr<SharedStringHashStore, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
+class SharedStringHashStore : public CanMakeCheckedPtr<SharedStringHashStore> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SharedStringHashStore);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SharedStringHashStore);
 public:

--- a/Source/WebKit/UIProcess/VisitedLinkStore.h
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.h
@@ -39,7 +39,7 @@ namespace WebKit {
 
 class WebProcessProxy;
     
-class VisitedLinkStore final : public API::ObjectImpl<API::Object::Type::VisitedLinkStore>, public IPC::MessageReceiver, public Identified<VisitedLinkTableIdentifier>, private SharedStringHashStore::Client {
+class VisitedLinkStore final : public API::ObjectImpl<API::Object::Type::VisitedLinkStore>, public IPC::MessageReceiver, public Identified<VisitedLinkTableIdentifier>, public SharedStringHashStore::Client {
 public:
     static Ref<VisitedLinkStore> create();
     VisitedLinkStore();
@@ -70,7 +70,7 @@ private:
     void sendStoreHandleToProcess(WebProcessProxy&);
 
     WeakHashSet<WebProcessProxy> m_processes;
-    SharedStringHashStore m_linkHashStore;
+    const UniqueRef<SharedStringHashStore> m_linkHashStore;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### eb006a37a9276d892c58aff4b8060c58d1ca0ad5
<pre>
Always allocate SharedStringHashStore in heap
<a href="https://bugs.webkit.org/show_bug.cgi?id=301781">https://bugs.webkit.org/show_bug.cgi?id=301781</a>

Reviewed by Geoffrey Garen.

Always allocate SharedStringHashStore in heap so that operator delete will be used for its destruction.

No new tests since there should be no behavioral differences.

* Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp:
(WebKit::WebSWOriginStore::WebSWOriginStore):
(WebKit::WebSWOriginStore::addToStore):
(WebKit::WebSWOriginStore::removeFromStore):
(WebKit::WebSWOriginStore::clearStore):
(WebKit::WebSWOriginStore::registerSWServerConnection):
(WebKit::WebSWOriginStore::sendStoreHandle):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.h:
* Source/WebKit/Shared/SharedStringHashStore.h:
* Source/WebKit/UIProcess/VisitedLinkStore.cpp:
(WebKit::VisitedLinkStore::VisitedLinkStore):
(WebKit::VisitedLinkStore::addProcess):
(WebKit::VisitedLinkStore::addVisitedLinkHash):
(WebKit::VisitedLinkStore::containsVisitedLinkHash):
(WebKit::VisitedLinkStore::removeVisitedLinkHash):
(WebKit::VisitedLinkStore::removeAll):
(WebKit::VisitedLinkStore::sendStoreHandleToProcess):
* Source/WebKit/UIProcess/VisitedLinkStore.h:

Canonical link: <a href="https://commits.webkit.org/302420@main">https://commits.webkit.org/302420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcc95252ace92b72b2660b1913c65a006dde2fb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136426 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/45641166-4e0d-468b-af16-c70db6a19213) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98249 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b7a44dae-0f63-46be-8cac-add548d825d5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78894 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2168e12b-70fb-49ff-aade-2f8350908a9f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/877 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79705 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138900 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106787 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106614 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30456 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53603 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20150 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1171 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64512 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1003 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1051 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1096 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->