### PR TITLE
Reject incompatible CSS Typed OM value types for color properties

### DIFF
--- a/LayoutTests/fast/css/css-typed-om/style-property-map-color-type-validation-expected.txt
+++ b/LayoutTests/fast/css/css-typed-om/style-property-map-color-type-validation-expected.txt
@@ -1,0 +1,13 @@
+Checks that StylePropertyMap.set() validates type compatibility for color properties.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS target.attributeStyleMap.set('color', ...borderValues) threw exception TypeError: Invalid type for property.
+PASS target.attributeStyleMap.set('background-color', ...borderValues) threw exception TypeError: Invalid type for property.
+PASS target.attributeStyleMap.set('color', CSSStyleValue.parse('color', 'red')) did not throw exception.
+PASS target.style.color is "red"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/css-typed-om/style-property-map-color-type-validation.html
+++ b/LayoutTests/fast/css/css-typed-om/style-property-map-color-type-validation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<div id="target"></div>
+<script>
+description("Checks that StylePropertyMap.set() validates type compatibility for color properties.");
+
+// Test that color properties reject non-color values
+// Color properties should not accept border-image-width values (or other incompatible types)
+let target = document.getElementById("target");
+
+// Get a non-color value from border-image-width (returns BorderImageWidth CSSValue)
+let borderValues = target.computedStyleMap().getAll('border-image-width');
+
+// Attempting to use border-image-width values for color properties should throw TypeError
+shouldThrow("target.attributeStyleMap.set('color', ...borderValues)", '"TypeError: Invalid type for property"');
+shouldThrow("target.attributeStyleMap.set('background-color', ...borderValues)", '"TypeError: Invalid type for property"');
+
+// Verify color still accepts valid color values
+shouldNotThrow("target.attributeStyleMap.set('color', CSSStyleValue.parse('color', 'red'))");
+shouldBeEqualToString("target.style.color", "red");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -125,6 +125,10 @@ ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& pr
             return Exception { ExceptionCode::TypeError, "Invalid value: This property doesn't allow <number> input"_s };
     }
 
+    // Type compatibility check: color properties cannot accept BorderImageWidth or other non-color-related values
+    if (CSSProperty::isColorProperty(propertyID) && value->isBorderImageWidthValue())
+        return Exception { ExceptionCode::TypeError, "Invalid type for property"_s };
+
     // FIXME: CSSValuePair has specific behavior related to coalescing its 2 values when they are equal.
     // Throw an error when using them with Typed OM to avoid subtle bugs when the serialization isn't representative of the value.
     if (auto pair = dynamicDowncast<CSSValuePair>(value)) {


### PR DESCRIPTION
#### 1da28cc9d63e5c84f264ce852e5df66f3ab18752
<pre>
Reject incompatible CSS Typed OM value types for color properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=301782">https://bugs.webkit.org/show_bug.cgi?id=301782</a>
<a href="https://rdar.apple.com/163122497">rdar://163122497</a>

Reviewed by NOBODY (OOPS!).

Fix crash that occurs in RenderThemeMac::systemColor() when CSS Typed
OM&apos;s attributeStyleMap.set() is used to set a color property with a
BorderImageWidthValue. The crash occurs because the incompatible value
gets misinterpreted as a KeywordColor with valueID=0 (CSSValueInvalid),
and attempting to look up 0 in the systemStyleColors HashMap triggers
an assertion failure since 0 is the empty value sentinel for integer keys.

Fix by adding type validation in StylePropertyMap::set() to reject
BorderImageWidthValue for color properties, throwing a TypeError instead
of crashing.

Test: fast/css/css-typed-om/style-property-map-color-type-validation.html

* LayoutTests/fast/css/css-typed-om/style-property-map-color-type-validation-expected.txt: Added.
* LayoutTests/fast/css/css-typed-om/style-property-map-color-type-validation.html: Added.
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::StylePropertyMap::set):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1da28cc9d63e5c84f264ce852e5df66f3ab18752

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80403 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b06a8057-b39a-4dac-9f80-c03f35b809da) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98253 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66130 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/faa124bf-8695-4c58-93c1-e7e74b9659d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78898 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/19d7fde9-bb74-456a-a374-1dad2acb797c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33713 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79708 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138903 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106790 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106617 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/903 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53606 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1174 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64515 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1006 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1054 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1099 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->