### PR TITLE
Port WebExtensionCallbackHandler to CPP

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -119,7 +119,7 @@ void WebExtensionAPIAction::getTitle(NSDictionary *details, Ref<WebExtensionCall
             return;
         }
 
-        callback->call(result.value().createNSString().get());
+        callback->call(JSValueMakeString(callback->globalContext(), toJSString(result.value()).get()));
     }, extensionContext().identifier());
 }
 
@@ -178,7 +178,7 @@ void WebExtensionAPIAction::getBadgeText(NSDictionary *details, Ref<WebExtension
             return;
         }
 
-        callback->call(result.value().createNSString().get());
+        callback->call(JSValueMakeString(callback->globalContext(), toJSString(result.value()).get()));
     }, extensionContext().identifier());
 }
 
@@ -229,7 +229,7 @@ void WebExtensionAPIAction::getBadgeBackgroundColor(NSDictionary *details, Ref<W
 
     // FIXME: <rdar://problem/57666368> Implement getting/setting the extension toolbar item's badge background color.
 
-    callback->call(@[ @255, @0, @0, @255 ]);
+    callback->call(fromArray(callback->globalContext(), { 255, 0, 0, 255 }));
 }
 
 void WebExtensionAPIAction::setBadgeBackgroundColor(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -301,7 +301,7 @@ void WebExtensionAPIAction::isEnabled(NSDictionary *details, Ref<WebExtensionCal
             return;
         }
 
-        callback->call(@(result.value()));
+        callback->call(JSValueMakeBoolean(callback->globalContext(), result.value()));
     }, extensionContext().identifier());
 }
 
@@ -627,7 +627,7 @@ void WebExtensionAPIAction::getPopup(NSDictionary *details, Ref<WebExtensionCall
             return;
         }
 
-        callback->call(result.value().createNSString().get());
+        callback->call(JSValueMakeString(callback->globalContext(), toJSString(result.value()).get()));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
@@ -123,7 +123,7 @@ void WebExtensionAPIAlarms::get(NSString *name, Ref<WebExtensionCallbackHandler>
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/get
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsGet(name ?: emptyAlarmName), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionAlarmParameters>&& alarm) {
-        callback->call(toWebAPI(alarm));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(alarm)));
     }, extensionContext().identifier());
 }
 
@@ -132,7 +132,7 @@ void WebExtensionAPIAlarms::getAll(Ref<WebExtensionCallbackHandler>&& callback)
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/getAll
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsGetAll(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<WebExtensionAlarmParameters> alarms) {
-        callback->call(toWebAPI(alarms));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(alarms)));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
@@ -76,7 +76,7 @@ void WebExtensionAPICommands::getAll(Ref<WebExtensionCallbackHandler>&& callback
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/getAll
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::CommandsGetAll(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<WebExtensionCommandParameters> commands) {
-        callback->call(toAPI(commands));
+        callback->call(toJSValueRef(callback->globalContext(), toAPI(commands)));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
@@ -215,7 +215,7 @@ void WebExtensionAPICookies::get(NSDictionary *details, Ref<WebExtensionCallback
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -277,7 +277,7 @@ void WebExtensionAPICookies::getAll(NSDictionary *details, Ref<WebExtensionCallb
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -341,7 +341,7 @@ void WebExtensionAPICookies::set(NSDictionary *details, Ref<WebExtensionCallback
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -361,7 +361,7 @@ void WebExtensionAPICookies::remove(NSDictionary *details, Ref<WebExtensionCallb
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -375,7 +375,7 @@ void WebExtensionAPICookies::getAllCookieStores(Ref<WebExtensionCallbackHandler>
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm
@@ -76,8 +76,7 @@ void WebExtensionContextProxy::dispatchDevToolsExtensionPanelShownEvent(Inspecto
 
         for (auto& listener : extensionPanel->onShown().listeners()) {
             auto globalContext = listener->globalContext();
-            auto *windowObject = toWindowObject(globalContext, *frame) ?: NSNull.null;
-            listener->call(windowObject);
+            listener->call(toWindowObject(globalContext, *frame));
         }
     });
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
@@ -61,10 +61,7 @@ void WebExtensionAPIDevToolsPanels::createPanel(WebPageProxyIdentifier webPagePr
         Ref extensionPanel = WebExtensionAPIDevToolsExtensionPanel::create(*this);
         m_extensionPanels.set(result.value(), extensionPanel);
 
-        auto globalContext = callback->globalContext();
-        auto *panelValue = toJSValue(globalContext, toJS(globalContext, extensionPanel.ptr()));
-
-        callback->call(panelValue);
+        callback->call(toJS(callback->globalContext(), extensionPanel.ptr()));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
@@ -67,7 +67,7 @@ void WebExtensionAPIEvent::invokeListenersWithArgument(id argument1)
     auto listenersCopy = m_listeners;
 
     for (RefPtr listener : listenersCopy)
-        listener->call(argument1);
+        listener->call(toJSValueRef(listener->globalContext(), argument1));
 }
 
 void WebExtensionAPIEvent::invokeListenersWithArgument(id argument1, id argument2)
@@ -79,7 +79,10 @@ void WebExtensionAPIEvent::invokeListenersWithArgument(id argument1, id argument
     auto listenersCopy = m_listeners;
 
     for (RefPtr listener : listenersCopy)
-        listener->call(argument1, argument2);
+        listener->call(
+            toJSValueRef(listener->globalContext(), argument1),
+            toJSValueRef(listener->globalContext(), argument2)
+        );
 }
 
 void WebExtensionAPIEvent::invokeListenersWithArgument(id argument1, id argument2, id argument3)
@@ -91,7 +94,11 @@ void WebExtensionAPIEvent::invokeListenersWithArgument(id argument1, id argument
     auto listenersCopy = m_listeners;
 
     for (RefPtr listener : listenersCopy)
-        listener->call(argument1, argument2, argument3);
+        listener->call(
+            toJSValueRef(listener->globalContext(), argument1),
+            toJSValueRef(listener->globalContext(), argument2),
+            toJSValueRef(listener->globalContext(), argument3)
+        );
 }
 
 void WebExtensionAPIEvent::addListener(WebCore::FrameIdentifier frameIdentifier, RefPtr<WebExtensionCallbackHandler> listener)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
@@ -91,17 +91,17 @@ void WebExtensionAPILocalization::getAcceptLanguages(Ref<WebExtensionCallbackHan
         [acceptLanguages addObject:[NSLocale localeWithLocaleIdentifier:localeIdentifier].languageCode];
     }
 
-    callback->call(acceptLanguages.array);
+    callback->call(toJSValueRef(callback->globalContext(), acceptLanguages.array));
 }
 
 void WebExtensionAPILocalization::getPreferredSystemLanguages(Ref<WebExtensionCallbackHandler>&& callback)
 {
-    callback->call(NSLocale.preferredLanguages);
+    callback->call(toJSValueRef(callback->globalContext(), NSLocale.preferredLanguages));
 }
 
 void WebExtensionAPILocalization::getSystemUILanguage(Ref<WebExtensionCallbackHandler>&& callback)
 {
-    callback->call(NSLocale._deviceLanguage);
+    callback->call(toJSValueRef(callback->globalContext(), NSLocale._deviceLanguage));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -509,7 +509,7 @@ void WebExtensionContextProxy::dispatchMenusClickedEvent(const WebExtensionMenuI
         WebCore::UserGestureIndicator gestureIndicator(WebCore::IsProcessingUserGesture::Yes, coreFrame ? coreFrame->document() : nullptr);
 
         if (RefPtr clickHandler = namespaceObject.menus().clickHandlers().get(menuItemParameters.identifier))
-            clickHandler->call(info, tab);
+            clickHandler->call(toJSValueRef(clickHandler->globalContext(), info), toJSValueRef(clickHandler->globalContext(), tab));
 
         namespaceObject.menus().onClicked().invokeListenersWithArgument(info, tab);
     });

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -159,9 +159,11 @@ void WebExtensionAPIPort::fireMessageEventIfNeeded(id message)
 
     for (auto& listener : m_onMessage->listeners()) {
         auto globalContext = listener->globalContext();
-        auto *port = toJSValue(globalContext, toJS(globalContext, this));
 
-        listener->call(message, port);
+        listener->call(
+            toJSValueRef(globalContext, message),
+            toJS(globalContext, this)
+        );
     }
 }
 
@@ -186,9 +188,8 @@ void WebExtensionAPIPort::fireDisconnectEventIfNeeded()
 
     for (auto& listener : m_onDisconnect->listeners()) {
         auto globalContext = listener->globalContext();
-        auto *port = toJSValue(globalContext, toJS(globalContext, this));
 
-        listener->call(port);
+        listener->call(toJS(globalContext, this));
     }
 
     m_onDisconnect->removeAllListeners();

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
@@ -192,7 +192,7 @@ void WebExtensionAPIScripting::executeScript(NSDictionary *script, Ref<WebExtens
         if (!result)
             callback->reportError(result.error().createNSString().get());
         else
-            callback->call(toWebAPI(result.value(), false));
+            callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value(), false)));
     }, extensionContext().identifier());
 }
 
@@ -257,7 +257,7 @@ void WebExtensionAPIScripting::getRegisteredContentScripts(NSDictionary *filter,
         if (!result)
             callback->reportError(result.error().createNSString().get());
         else
-            callback->call(toWebAPI(result.value()));
+            callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -82,7 +82,7 @@ void WebExtensionAPIStorageArea::get(WebPageProxyIdentifier webPageProxyIdentifi
 
     if (keysWithDefaultValues) {
         if (!keysWithDefaultValues.count) {
-            callback->call(@{ });
+            callback->call(JSObjectMake(callback->globalContext(), nullptr, nullptr));
             return;
         }
 
@@ -91,7 +91,7 @@ void WebExtensionAPIStorageArea::get(WebPageProxyIdentifier webPageProxyIdentifi
 
     if (NSArray *keys = dynamic_objc_cast<NSArray>(items)) {
         if (!keys.count) {
-            callback->call(@{ });
+            callback->call(JSObjectMake(callback->globalContext(), nullptr, nullptr));
             return;
         }
 
@@ -113,7 +113,7 @@ void WebExtensionAPIStorageArea::get(WebPageProxyIdentifier webPageProxyIdentifi
         });
 
         deserializedData = keysWithDefaultValues ? mergeDictionaries(deserializedData, keysWithDefaultValues) : deserializedData;
-        callback->call(deserializedData);
+        callback->call(toJSValueRef(callback->globalContext(), deserializedData));
     }, extensionContext().identifier());
 }
 
@@ -125,7 +125,7 @@ void WebExtensionAPIStorageArea::getKeys(WebPageProxyIdentifier webPageProxyIden
             return;
         }
 
-        callback->call(createNSArray(result.value()).get());
+        callback->call(fromArray(callback->globalContext(), WTFMove(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -149,7 +149,7 @@ void WebExtensionAPIStorageArea::getBytesInUse(WebPageProxyIdentifier webPagePro
         if (!result)
             callback->reportError(result.error().createNSString().get());
         else
-            callback->call(@(result.value()));
+            callback->call(JSValueMakeNumber(callback->globalContext(), result.value()));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -632,7 +632,7 @@ void WebExtensionAPITabs::createTab(WebPageProxyIdentifier webPageProxyIdentifie
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -650,7 +650,7 @@ void WebExtensionAPITabs::query(WebPageProxyIdentifier webPageProxyIdentifier, N
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -668,7 +668,7 @@ void WebExtensionAPITabs::get(double tabID, Ref<WebExtensionCallbackHandler>&& c
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -682,7 +682,7 @@ void WebExtensionAPITabs::getCurrent(WebPageProxyIdentifier webPageProxyIdentifi
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -712,7 +712,7 @@ void WebExtensionAPITabs::getSelected(WebPageProxyIdentifier webPageProxyIdentif
 
         ASSERT(tabs.size() == 1);
 
-        callback->call(toWebAPI(tabs.first()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(tabs.first())));
     }, extensionContext().identifier());
 }
 
@@ -734,7 +734,7 @@ void WebExtensionAPITabs::duplicate(double tabID, NSDictionary *properties, Ref<
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -756,7 +756,7 @@ void WebExtensionAPITabs::update(WebPageProxyIdentifier webPageProxyIdentifier, 
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -881,7 +881,7 @@ void WebExtensionAPITabs::getZoom(WebPageProxyIdentifier webPageProxyIdentifier,
             return;
         }
 
-        callback->call(@(result.value()));
+        callback->call(JSValueMakeNumber(callback->globalContext(), result.value()));
     }, extensionContext().identifier());
 }
 
@@ -918,11 +918,13 @@ void WebExtensionAPITabs::detectLanguage(WebPageProxyIdentifier webPageProxyIden
         }
 
         if (result.value().isEmpty()) {
-            callback->call(unknownLanguageValue);
+            // This is a safer cpp false positive (rdar://163760990).
+            SUPPRESS_UNCOUNTED_ARG callback->call(JSValueMakeString(callback->globalContext(), toJSString(unknownLanguageValue).get()));
             return;
         }
 
-        callback->call(result.value().createNSString().get());
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG callback->call(JSValueMakeString(callback->globalContext(), toJSString(result.value()).get()));
     }, extensionContext().identifier());
 }
 
@@ -965,11 +967,13 @@ void WebExtensionAPITabs::captureVisibleTab(WebPageProxyIdentifier webPageProxyI
         }
 
         if (result.value().isEmpty()) {
-            callback->call(emptyDataURLValue);
+            // This is a safer cpp false positive (rdar://163760990).
+            SUPPRESS_UNCOUNTED_ARG callback->call(JSValueMakeString(callback->globalContext(), toJSString(emptyDataURLValue).get()));
             return;
         }
 
-        callback->call(result.value().string().createNSString().get());
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG callback->call(JSValueMakeString(callback->globalContext(), toJSString(result.value().string()).get()));
     }, extensionContext().identifier());
 }
 
@@ -1012,7 +1016,7 @@ void WebExtensionAPITabs::sendMessage(WebFrame& frame, double tabID, const Strin
             return;
         }
 
-        callback->call(parseJSON(result.value().createNSString().get(), JSONOptions::FragmentsAllowed));
+        callback->call(fromJSON(callback->globalContext(), JSON::Value::parseJSON(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -1078,7 +1082,7 @@ void WebExtensionAPITabs::executeScript(WebPageProxyIdentifier webPageProxyIdent
             return;
         }
 
-        callback->call(toWebAPI(result.value(), true));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value(), true)));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
@@ -100,7 +100,7 @@ void WebExtensionAPIWebNavigation::getAllFrames(NSDictionary *details, Ref<WebEx
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -135,7 +135,7 @@ void WebExtensionAPIWebNavigation::getFrame(NSDictionary *details, Ref<WebExtens
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
@@ -52,7 +52,9 @@ void WebExtensionAPIWebNavigationEvent::invokeListenersWithArgument(id argument,
         if (filter && ![filter matchesURL:targetURL])
             continue;
 
-        Ref { *listener.first }->call(argument);
+        Ref listenerRef = Ref { *listener.first };
+        auto globalContext = listenerRef->globalContext();
+        listenerRef->call(toJSValueRef(globalContext, argument));
     }
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
@@ -320,7 +320,7 @@ void WebExtensionContextProxy::resourceLoadDidSendRequest(WebExtensionTabIdentif
                     [details setObject:requestBody forKey:requestBodyKey];
             }
 
-            listener.call(details);
+            listener.call(toJSValueRef(listener.globalContext(), details));
 
             [details removeObjectForKey:requestBodyKey];
         });
@@ -336,7 +336,7 @@ void WebExtensionContextProxy::resourceLoadDidSendRequest(WebExtensionTabIdentif
                 [details setObject:requestHeaders.get() forKey:requestHeadersKey];
             }
 
-            listener.call(details);
+            listener.call(toJSValueRef(listener.globalContext(), details));
 
             [details removeObjectForKey:requestHeadersKey];
         });
@@ -361,7 +361,7 @@ void WebExtensionContextProxy::resourceLoadDidPerformHTTPRedirection(WebExtensio
                 [details setObject:responseHeaders forKey:responseHeadersKey];
             }
 
-            listener.call(details);
+            listener.call(toJSValueRef(listener.globalContext(), details));
 
             [details removeObjectForKey:responseHeadersKey];
         });
@@ -421,7 +421,7 @@ void WebExtensionContextProxy::resourceLoadDidReceiveResponse(WebExtensionTabIde
                 [details setObject:responseHeaders forKey:responseHeadersKey];
             }
 
-            listener.call(details);
+            listener.call(toJSValueRef(listener.globalContext(), details));
 
             [details removeObjectForKey:responseHeadersKey];
         });
@@ -462,7 +462,7 @@ void WebExtensionContextProxy::resourceLoadDidCompleteWithError(WebExtensionTabI
                 [details setObject:responseHeaders forKey:responseHeadersKey];
             }
 
-            listener.call(details);
+            listener.call(toJSValueRef(listener.globalContext(), details));
 
             [details removeObjectForKey:responseHeadersKey];
         });

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
@@ -66,7 +66,7 @@ void WebExtensionAPIWebRequestEvent::enumerateListeners(WebExtensionTabIdentifie
 void WebExtensionAPIWebRequestEvent::invokeListenersWithArgument(NSDictionary *argument, WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier windowIdentifier, const ResourceLoadInfo& resourceLoadInfo)
 {
     enumerateListeners(tabIdentifier, windowIdentifier, resourceLoadInfo, [argument = RetainPtr { argument }](auto& listener, auto&) {
-        listener.call(argument.get());
+        listener.call(toJSValueRef(listener.globalContext(), argument.get()));
     });
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -404,7 +404,7 @@ void WebExtensionAPIWindows::createWindow(NSDictionary *data, Ref<WebExtensionCa
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -427,7 +427,7 @@ void WebExtensionAPIWindows::get(WebPageProxyIdentifier webPageProxyIdentifier, 
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -446,7 +446,7 @@ void WebExtensionAPIWindows::getCurrent(WebPageProxyIdentifier webPageProxyIdent
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -465,7 +465,7 @@ void WebExtensionAPIWindows::getLastFocused(NSDictionary *info, Ref<WebExtension
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -484,7 +484,7 @@ void WebExtensionAPIWindows::getAll(NSDictionary *info, Ref<WebExtensionCallback
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 
@@ -506,7 +506,7 @@ void WebExtensionAPIWindows::update(double windowID, NSDictionary *info, Ref<Web
             return;
         }
 
-        callback->call(toWebAPI(result.value()));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
@@ -54,7 +54,9 @@ void WebExtensionAPIWindowsEvent::invokeListenersWithArgument(id argument, Optio
         if (!listener.second.containsAny(windowTypeFilter))
             continue;
 
-        Ref { *listener.first }->call(argument);
+        Ref listenerRef = Ref { *listener.first };
+        auto globalContext = listenerRef->globalContext();
+        listenerRef->call(toJSValueRef(globalContext, argument));
     }
 }
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -36,6 +36,351 @@
 
 namespace WebKit {
 
+WebExtensionCallbackHandler::WebExtensionCallbackHandler(JSContextRef context, JSObjectRef callbackFunction, WebExtensionAPIRuntimeBase& runtime)
+    : m_callbackFunction(callbackFunction)
+    , m_globalContext(JSContextGetGlobalContext(context))
+    , m_runtime(&runtime)
+{
+    ASSERT(context);
+    ASSERT(callbackFunction);
+
+    JSValueProtect(m_globalContext.get(), m_callbackFunction);
+}
+
+WebExtensionCallbackHandler::WebExtensionCallbackHandler(JSContextRef context, WebExtensionAPIRuntimeBase& runtime)
+    : m_globalContext(JSContextGetGlobalContext(context))
+    , m_runtime(&runtime)
+{
+    ASSERT(context);
+}
+
+WebExtensionCallbackHandler::WebExtensionCallbackHandler(JSContextRef context, JSObjectRef resolveFunction, JSObjectRef rejectFunction)
+    : m_callbackFunction(resolveFunction)
+    , m_rejectFunction(rejectFunction)
+    , m_globalContext(JSContextGetGlobalContext(context))
+{
+    ASSERT(context);
+    ASSERT(resolveFunction);
+    ASSERT(rejectFunction);
+
+    JSValueProtect(m_globalContext.get(), m_callbackFunction);
+    JSValueProtect(m_globalContext.get(), m_rejectFunction);
+}
+
+WebExtensionCallbackHandler::~WebExtensionCallbackHandler()
+{
+    if (m_callbackFunction)
+        JSValueUnprotect(m_globalContext.get(), m_callbackFunction);
+
+    if (m_rejectFunction)
+        JSValueUnprotect(m_globalContext.get(), m_rejectFunction);
+}
+
+JSValueRef WebExtensionCallbackHandler::callbackFunction() const
+{
+    if (!m_globalContext || !m_callbackFunction)
+        return nil;
+
+    return m_callbackFunction;
+}
+
+template<size_t ArgumentCount>
+JSValueRef callWithArguments(JSObjectRef callbackFunction, JSRetainPtr<JSGlobalContextRef>& globalContext, std::array<JSValueRef, ArgumentCount>&& arguments)
+{
+    if (!globalContext || !callbackFunction)
+        return nil;
+    return JSObjectCallAsFunction(globalContext.get(), callbackFunction, nullptr, ArgumentCount, arguments.data(), nullptr);
+}
+
+void WebExtensionCallbackHandler::reportError(const String& message)
+{
+    if (!m_globalContext)
+        return;
+
+    if (RefPtr runtime = m_runtime) {
+        runtime->reportError(message, *this);
+        return;
+    }
+
+    if (!m_rejectFunction)
+        return;
+
+    RELEASE_LOG_ERROR(Extensions, "Promise rejected: %" PUBLIC_LOG_STRING, message.utf8().data());
+
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG JSValueRef messageValue = JSValueMakeString(m_globalContext.get(), toJSString(message).get());
+    JSValueRef error = JSObjectMakeError(m_globalContext.get(), 1, &messageValue, nullptr);
+
+    callWithArguments<1>(m_rejectFunction, m_globalContext, { error });
+}
+
+JSValueRef WebExtensionCallbackHandler::call()
+{
+    return callWithArguments<0>(m_callbackFunction, m_globalContext, { });
+}
+
+JSValueRef WebExtensionCallbackHandler::call(JSValueRef argument)
+{
+    return callWithArguments<1>(m_callbackFunction, m_globalContext, {
+        argument
+    });
+}
+
+JSValueRef WebExtensionCallbackHandler::call(JSValueRef argumentOne, JSValueRef argumentTwo)
+{
+    return callWithArguments<2>(m_callbackFunction, m_globalContext, {
+        argumentOne,
+        argumentTwo
+    });
+}
+
+JSValueRef WebExtensionCallbackHandler::call(JSValueRef argumentOne, JSValueRef argumentTwo, JSValueRef argumentThree)
+{
+    return callWithArguments<3>(m_callbackFunction, m_globalContext, {
+        argumentOne,
+        argumentTwo,
+        argumentThree
+    });
+}
+
+RefPtr<WebExtensionCallbackHandler> toJSCallbackHandler(JSContextRef context, JSValueRef callbackValue, WebExtensionAPIRuntimeBase& runtime)
+{
+    ASSERT(context);
+
+    if (!callbackValue)
+        return nullptr;
+
+    JSObjectRef callbackFunction = JSValueToObject(context, callbackValue, nullptr);
+    if (!callbackFunction)
+        return nullptr;
+
+    if (!JSObjectIsFunction(context, callbackFunction))
+        return nullptr;
+
+    return WebExtensionCallbackHandler::create(context, callbackFunction, runtime);
+}
+
+String toString(JSContextRef context, JSValueRef value, NullStringPolicy nullStringPolicy)
+{
+    ASSERT(context);
+    ASSERT(value);
+
+    switch (nullStringPolicy) {
+    case NullStringPolicy::NullAndUndefinedAsNullString:
+        if (JSValueIsUndefined(context, value))
+            return nullString();
+        [[fallthrough]];
+
+    case NullStringPolicy::NullAsNullString:
+        if (JSValueIsNull(context, value))
+            return nullString();
+        [[fallthrough]];
+
+    case NullStringPolicy::NoNullString:
+        // Don't try to convert other objects into strings.
+        if (!JSValueIsString(context, value))
+            return nullString();
+
+        JSRetainPtr string(Adopt, JSValueToStringCopy(context, value, 0));
+        return toString(string.get());
+    }
+}
+
+String toString(JSStringRef string)
+{
+    if (!string)
+        return nullString();
+
+    Vector<char> buffer(JSStringGetMaximumUTF8CStringSize(string));
+    JSStringGetUTF8CString(string, buffer.mutableSpan().data(), buffer.size());
+    return String::fromUTF8(buffer.span().data());
+}
+
+JSValueRef toWindowObject(JSContextRef context, WebFrame& frame)
+{
+    ASSERT(context);
+
+    auto frameContext = frame.jsContext();
+    if (!frameContext)
+        return JSValueMakeNull(context);
+
+    return JSContextGetGlobalObject(frameContext) ?: JSValueMakeNull(context);
+}
+
+JSValueRef toWindowObject(JSContextRef context, WebPage& page)
+{
+    ASSERT(context);
+
+    return toWindowObject(context, page.mainWebFrame());
+}
+
+JSValueRef toJSValueRef(JSContextRef context, const String& string, NullOrEmptyString nullOrEmptyString)
+{
+    ASSERT(context);
+
+    switch (nullOrEmptyString) {
+    case NullOrEmptyString::NullStringAsNull:
+        if (string.isEmpty())
+            return JSValueMakeNull(context);
+        [[fallthrough]];
+
+    case NullOrEmptyString::NullStringAsEmptyString:
+        if (JSRetainPtr stringRef = toJSString(string)) {
+            // This is a safer cpp false positive (rdar://163760990).
+            SUPPRESS_UNCOUNTED_ARG return JSValueMakeString(context, stringRef.get());
+        }
+
+        return JSValueMakeNull(context);
+    }
+}
+
+JSObjectRef toJSError(JSContextRef context, const String& string)
+{
+    ASSERT(context);
+
+    RELEASE_LOG_ERROR(Extensions, "Exception thrown: %" PUBLIC_LOG_STRING, string.utf8().data());
+
+    JSValueRef messageArgument = toJSValueRef(context, string, NullOrEmptyString::NullStringAsEmptyString);
+
+    return JSObjectMakeError(context, 1, &messageArgument, nullptr);
+}
+
+JSValueRef deserializeJSONString(JSContextRef context, const String& jsonString)
+{
+    ASSERT(context);
+
+    if (jsonString.isEmpty())
+        return JSValueMakeNull(context);
+
+    if (JSRetainPtr string = toJSString(jsonString)) {
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG if (JSValueRef value = JSValueMakeFromJSONString(context, string.get()))
+            return value;
+    }
+
+    return JSValueMakeNull(context);
+}
+
+String serializeJSObject(JSContextRef context, JSValueRef value, JSValueRef* exception)
+{
+    ASSERT(context);
+
+    if (!value)
+        return nullString();
+
+    JSRetainPtr string(Adopt, JSValueCreateJSONString(context, value, 0, exception));
+
+    return toString(string.get());
+}
+
+static JSValueRef fromJSONArray(JSContextRef context, const JSON::Array& array)
+{
+    if (!context)
+        return nullptr;
+
+    if (!array)
+        return JSValueMakeUndefined(context);
+
+    Vector<JSValueRef> retArray;
+    for (Ref value : array)
+        retArray.append(fromJSON(context, value.get()));
+
+    return JSObjectMakeArray(context, retArray.size(), retArray.span().data(), nullptr);
+}
+
+static JSValueRef fromJSONObject(JSContextRef context, const JSON::Object& object)
+{
+    if (!context)
+        return nullptr;
+
+    if (!object)
+        return JSValueMakeUndefined(context);
+
+    auto result = JSObjectMake(context, nullptr, nullptr);
+
+    for (auto& key : object.keys()) {
+        if (auto value = object.getValue(key)) {
+            JSRetainPtr jsKey = toJSString(key);
+            // This is a safer cpp false positive (rdar://163760990).
+            SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, result, jsKey.get(), fromJSON(context, value), 0, nullptr);
+        }
+    }
+
+    return result;
+}
+
+JSValueRef fromJSON(JSContextRef context, RefPtr<JSON::Value> value)
+{
+    if (!context)
+        return nullptr;
+
+    if (!value)
+        return JSValueMakeUndefined(context);
+
+    switch (value->type()) {
+    case JSON::Value::Type::Boolean:
+        return JSValueMakeBoolean(context, value->asBoolean().value());
+    case JSON::Value::Type::String:
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG return JSValueMakeString(context, toJSString(value->asString()).get());
+    case JSON::Value::Type::Integer:
+    case JSON::Value::Type::Double:
+        return JSValueMakeNumber(context, value->asDouble().value());
+    case JSON::Value::Type::Object:
+        return fromJSONObject(context, *(value->asObject()));
+    case JSON::Value::Type::Array:
+        return fromJSONArray(context, *(value->asArray()));
+    case JSON::Value::Type::Null:
+        return JSValueMakeNull(context);
+    }
+
+    return JSValueMakeUndefined(context);
+}
+
+JSValueRef fromArray(JSContextRef context, Vector<JSValueRef>&& array)
+{
+    if (!context)
+        return nullptr;
+
+    return JSObjectMakeArray(context, array.size(), array.span().data(), nullptr);
+}
+
+JSValueRef fromArray(JSContextRef context, Vector<size_t>&& array)
+{
+    if (!context)
+        return nullptr;
+
+    return fromArray(context, array.map([&context](auto num) {
+        return JSValueMakeNumber(context, num);
+    }));
+}
+
+JSValueRef fromArray(JSContextRef context, Vector<String>&& array)
+{
+    if (!context)
+        return nullptr;
+
+    return fromArray(context, array.map([&context](auto str) {
+        return JSValueMakeString(context, toJSString(str).get());
+    }));
+}
+
+JSValueRef fromObject(JSContextRef context, HashMap<String, JSValueRef>&& object)
+{
+    if (!context)
+        return nullptr;
+
+    auto result = JSObjectMake(context, nullptr, nullptr);
+
+    for (auto& key : object.keys()) {
+        JSRetainPtr jsKey = toJSString(key);
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, result, jsKey.get(), object.get(key), 0, nullptr);
+    }
+
+    return result;
+}
+
 static HashMap<JSGlobalContextRef, JSWeakObjectMapRef>& wrapperCache()
 {
     static NeverDestroyed<HashMap<JSGlobalContextRef, JSWeakObjectMapRef>> wrappers;
@@ -169,9 +514,9 @@ bool isDictionary(JSContextRef context, JSValueRef value)
     if (isThenable(context, value))
         return false;
 
-    JSRetainPtr protoString = toJSString("__proto__");
-    JSRetainPtr objectString = toJSString("Object");
-    JSRetainPtr prototypeString = toJSString("prototype");
+    JSRetainPtr protoString = toJSString("__proto__"_s);
+    JSRetainPtr objectString = toJSString("Object"_s);
+    JSRetainPtr prototypeString = toJSString("prototype"_s);
 
     JSObjectRef thisObject = JSValueToObject(context, value, nullptr);
     JSObjectRef globalObject = JSContextGetGlobalObject(context);
@@ -189,7 +534,7 @@ bool isRegularExpression(JSContextRef context, JSValueRef value)
     if (!context || !JSValueIsObject(context, value))
         return false;
 
-    JSRetainPtr regexpString = toJSString("RegExp");
+    JSRetainPtr regexpString = toJSString("RegExp"_s);
     JSObjectRef globalObject = JSContextGetGlobalObject(context);
     // This is a safer cpp false positive (rdar://163760990).
     SUPPRESS_UNCOUNTED_ARG JSObjectRef regexpValue = JSValueToObject(context, JSObjectGetProperty(context, globalObject, regexpString.get(), nullptr), nullptr);
@@ -202,7 +547,7 @@ bool isThenable(JSContextRef context, JSValueRef value)
     if (!context || !JSValueIsObject(context, value))
         return false;
 
-    JSRetainPtr thenableString = toJSString("then");
+    JSRetainPtr thenableString = toJSString("then"_s);
     JSObjectRef valueObject = JSValueToObject(context, value, nullptr);
     // This is a safer cpp false positive (rdar://163760990).
     SUPPRESS_UNCOUNTED_ARG JSValueRef thenableObject = JSObjectGetProperty(context, valueObject, thenableString.get(), nullptr);

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -815,7 +815,7 @@ ${functionSignature}
 EOF
 
                 my $keyArgumentName = $specifiedParameters[0]->name;
-                push(@contents, "    auto ${keyArgumentName} = toJSString(argumentCount > 0 ? " . $self->_platformTypeConstructor($specifiedParameters[0], "arguments[0]") . " : nil);\n");
+                push(@contents, "    auto ${keyArgumentName} = toJSString(argumentCount > 0 ? " . $self->_platformTypeConstructor($specifiedParameters[0], "arguments[0]") . "_s : emptyString());\n");
 
                 if ($isGetPropertyFunction) {
                     push(@contents, "\n");
@@ -1732,7 +1732,7 @@ EOF
         return unless $_->extendedAttributes->{"Dynamic"} or $_->extendedAttributes->{"MainWorldOnly"};
 
         my $name = $_->name;
-        return "    JSPropertyNameAccumulatorAddName(propertyNames, toJSString(\"${name}\").get());\n" unless $hasDynamicProperties;
+        return "    JSPropertyNameAccumulatorAddName(propertyNames, toJSString(\"${name}\"_s).get());\n" unless $hasDynamicProperties;
 
         my $condition = &$generateCondition($_);
         my $conditionalString = conditionalString($_);
@@ -1740,7 +1740,7 @@ EOF
         my $content = "";
         $content .= "#if ${conditionalString}\n" if $conditionalString;
         $content .= "    if (${condition})\n";
-        $content .= "        JSPropertyNameAccumulatorAddName(propertyNames, toJSString(\"${name}\").get());\n";
+        $content .= "        JSPropertyNameAccumulatorAddName(propertyNames, toJSString(\"${name}\"_s).get());\n";
         $content .= "#endif // ${conditionalString}\n" if $conditionalString;
         $content .= "\n";
         return $content;

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -65,7 +65,7 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
     auto context = frame.jsContextForWorld(world);
     auto globalObject = JSContextGetGlobalObject(context);
 
-    JSRetainPtr browserString = toJSString("browser");
+    JSRetainPtr browserString = toJSString("browser"_s);
     if (!browserString)
         return;
 
@@ -93,7 +93,7 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
     // This is a safer cpp false positive (rdar://163760990).
     SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
 
-    if (JSRetainPtr chromeString = toJSString("chrome")) {
+    if (JSRetainPtr chromeString = toJSString("chrome"_s)) {
         // This is a safer cpp false positive (rdar://163760990).
         SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
     }
@@ -110,7 +110,7 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
     auto context = frame.jsContextForServiceWorkerWorld(world);
     auto globalObject = JSContextGetGlobalObject(context);
 
-    JSRetainPtr browserString = toJSString("browser");
+    JSRetainPtr browserString = toJSString("browser"_s);
     if (!browserString)
         return;
 
@@ -125,7 +125,7 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
 
     // This is a safer cpp false positive (rdar://163760990).
     SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
-    if (JSRetainPtr chromeString = toJSString("chrome")) {
+    if (JSRetainPtr chromeString = toJSString("chrome"_s)) {
         // This is a safer cpp false positive (rdar://163760990).
         SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
     }
@@ -136,7 +136,7 @@ void WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary(WebFrame&
     auto context = frame.jsContextForWorld(world);
     auto globalObject = JSContextGetGlobalObject(context);
 
-    JSRetainPtr browserString = toJSString("browser");
+    JSRetainPtr browserString = toJSString("browser"_s);
     if (!browserString)
         return;
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -203,12 +203,12 @@ void WebExtensionContextProxy::enumerateFramesAndNamespaceObjects(NOESCAPE const
         auto globalObject = JSContextGetGlobalObject(context);
 
         RefPtr<WebExtensionAPINamespace> namespaceObjectImpl;
-        auto browserNamespaceObject = JSObjectGetProperty(context, globalObject, toJSString("browser").get(), nullptr);
+        auto browserNamespaceObject = JSObjectGetProperty(context, globalObject, toJSString("browser"_s).get(), nullptr);
         if (browserNamespaceObject && JSValueIsObject(context, browserNamespaceObject))
             namespaceObjectImpl = toWebExtensionAPINamespace(context, browserNamespaceObject);
 
         if (!namespaceObjectImpl) {
-            auto chromeNamespaceObject = JSObjectGetProperty(context, globalObject, toJSString("chrome").get(), nullptr);
+            auto chromeNamespaceObject = JSObjectGetProperty(context, globalObject, toJSString("chrome"_s).get(), nullptr);
             if (chromeNamespaceObject && JSValueIsObject(context, chromeNamespaceObject))
                 namespaceObjectImpl = toWebExtensionAPINamespace(context, chromeNamespaceObject);
         }
@@ -227,7 +227,7 @@ void WebExtensionContextProxy::enumerateFramesAndWebPageNamespaceObjects(NOESCAP
         auto globalObject = JSContextGetGlobalObject(context);
 
         RefPtr<WebExtensionAPIWebPageNamespace> namespaceObjectImpl;
-        auto browserNamespaceObject = JSObjectGetProperty(context, globalObject, toJSString("browser").get(), nullptr);
+        auto browserNamespaceObject = JSObjectGetProperty(context, globalObject, toJSString("browser"_s).get(), nullptr);
         if (browserNamespaceObject && JSValueIsObject(context, browserNamespaceObject))
             namespaceObjectImpl = toWebExtensionAPIWebPageNamespace(context, browserNamespaceObject);
 


### PR DESCRIPTION
#### 1f6e780fe3eecf00bfd700423e6a086481a760aa
<pre>
Port WebExtensionCallbackHandler to CPP
<a href="https://bugs.webkit.org/show_bug.cgi?id=301784">https://bugs.webkit.org/show_bug.cgi?id=301784</a>

Reviewed by Timothy Hatcher.

This updates the WebExtensionCallbackHandler code to use C++, and ports all usage of call() to using JSValueRefs. As well, utility functions to create JSValueRefs from arrays, JSON, or dictionary objects are added, instead of relying on the JSValue* Cocoa API and converting that to JSValueRef.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::getTitle):
(WebKit::WebExtensionAPIAction::getBadgeText):
(WebKit::WebExtensionAPIAction::getBadgeBackgroundColor):
(WebKit::WebExtensionAPIAction::isEnabled):
(WebKit::WebExtensionAPIAction::getPopup):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm:
(WebKit::WebExtensionAPIAlarms::get):
(WebKit::WebExtensionAPIAlarms::getAll):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm:
(WebKit::WebExtensionAPICommands::getAll):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm:
(WebKit::WebExtensionAPICookies::get):
(WebKit::WebExtensionAPICookies::getAll):
(WebKit::WebExtensionAPICookies::set):
(WebKit::WebExtensionAPICookies::remove):
(WebKit::WebExtensionAPICookies::getAllCookieStores):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::getEnabledRulesets):
(WebKit::WebExtensionAPIDeclarativeNetRequest::getDynamicRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::getSessionRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::getMatchedRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::isRegexSupported):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchDevToolsExtensionPanelShownEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::eval):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm:
(WebKit::WebExtensionAPIDevToolsPanels::createPanel):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm:
(WebKit::WebExtensionAPIEvent::invokeListenersWithArgument):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::getBackgroundPage):
(WebKit::WebExtensionAPIExtension::getViews):
(WebKit::WebExtensionAPIExtension::isAllowedFileSchemeAccess):
(WebKit::WebExtensionAPIExtension::isAllowedIncognitoAccess):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm:
(WebKit::WebExtensionAPILocalization::getAcceptLanguages):
(WebKit::WebExtensionAPILocalization::getPreferredSystemLanguages):
(WebKit::WebExtensionAPILocalization::getSystemUILanguage):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchMenusClickedEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
(WebKit::WebExtensionAPIPermissions::getAll):
(WebKit::WebExtensionAPIPermissions::contains):
(WebKit::WebExtensionAPIPermissions::request):
(WebKit::WebExtensionAPIPermissions::remove):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
(WebKit::WebExtensionAPIPort::fireMessageEventIfNeeded):
(WebKit::WebExtensionAPIPort::fireDisconnectEventIfNeeded):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::getPlatformInfo):
(WebKit::WebExtensionAPIRuntime::getBackgroundPage):
(WebKit::WebExtensionAPIRuntime::sendMessage):
(WebKit::WebExtensionAPIRuntime::sendNativeMessage):
(WebKit::WebExtensionAPIWebPageRuntime::sendMessage):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeConnectEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::WebExtensionAPIScripting::executeScript):
(WebKit::WebExtensionAPIScripting::getRegisteredContentScripts):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::get):
(WebKit::WebExtensionAPIStorageArea::getKeys):
(WebKit::WebExtensionAPIStorageArea::getBytesInUse):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::createTab):
(WebKit::WebExtensionAPITabs::query):
(WebKit::WebExtensionAPITabs::get):
(WebKit::WebExtensionAPITabs::getCurrent):
(WebKit::WebExtensionAPITabs::getSelected):
(WebKit::WebExtensionAPITabs::duplicate):
(WebKit::WebExtensionAPITabs::update):
(WebKit::WebExtensionAPITabs::getZoom):
(WebKit::WebExtensionAPITabs::detectLanguage):
(WebKit::WebExtensionAPITabs::captureVisibleTab):
(WebKit::WebExtensionAPITabs::sendMessage):
(WebKit::WebExtensionAPITabs::executeScript):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm:
(WebKit::WebExtensionAPIWebNavigation::getAllFrames):
(WebKit::WebExtensionAPIWebNavigation::getFrame):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm:
(WebKit::WebExtensionAPIWebNavigationEvent::invokeListenersWithArgument):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm:
(WebKit::WebExtensionContextProxy::resourceLoadDidSendRequest):
(WebKit::WebExtensionContextProxy::resourceLoadDidPerformHTTPRedirection):
(WebKit::WebExtensionContextProxy::resourceLoadDidReceiveResponse):
(WebKit::WebExtensionContextProxy::resourceLoadDidCompleteWithError):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm:
(WebKit::WebExtensionAPIWebRequestEvent::invokeListenersWithArgument):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::createWindow):
(WebKit::WebExtensionAPIWindows::get):
(WebKit::WebExtensionAPIWindows::getCurrent):
(WebKit::WebExtensionAPIWindows::getLastFocused):
(WebKit::WebExtensionAPIWindows::getAll):
(WebKit::WebExtensionAPIWindows::update):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm:
(WebKit::WebExtensionAPIWindowsEvent::invokeListenersWithArgument):
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::WebExtensionCallbackHandler::WebExtensionCallbackHandler): Deleted.
(WebKit::WebExtensionCallbackHandler::~WebExtensionCallbackHandler): Deleted.
(WebKit::WebExtensionCallbackHandler::callbackFunction const): Deleted.
(WebKit::callWithArguments): Deleted.
(WebKit::WebExtensionCallbackHandler::reportError): Deleted.
(WebKit::WebExtensionCallbackHandler::call): Deleted.
(WebKit::toString): Deleted.
(WebKit::toJSCallbackHandler): Deleted.
(WebKit::deserializeJSONString): Deleted.
(WebKit::serializeJSObject): Deleted.
(WebKit::toJSError): Deleted.
(WebKit::toJSString): Deleted.
(WebKit::toWindowObject): Deleted.
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::WebExtensionCallbackHandler::WebExtensionCallbackHandler):
(WebKit::WebExtensionCallbackHandler::~WebExtensionCallbackHandler):
(WebKit::WebExtensionCallbackHandler::callbackFunction const):
(WebKit::callWithArguments):
(WebKit::WebExtensionCallbackHandler::reportError):
(WebKit::WebExtensionCallbackHandler::call):
(WebKit::toJSCallbackHandler):
(WebKit::toString):
(WebKit::toWindowObject):
(WebKit::toJSValueRef):
(WebKit::toJSError):
(WebKit::deserializeJSONString):
(WebKit::serializeJSObject):
(WebKit::fromJSONArray):
(WebKit::fromJSONObject):
(WebKit::fromJSON):
(WebKit::fromArray):
(WebKit::fromObject):
(WebKit::isDictionary):
(WebKit::isRegularExpression):
(WebKit::isThenable):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
(WebKit::toJSString):
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
(_dynamicAttributesImplementation):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
(WebKit::WebExtensionControllerProxy::globalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::enumerateFramesAndNamespaceObjects):
(WebKit::WebExtensionContextProxy::enumerateFramesAndWebPageNamespaceObjects):

Canonical link: <a href="https://commits.webkit.org/302549@main">https://commits.webkit.org/302549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/109e2e364239931a9ded4adf4388ec8617d5b1ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136736 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80765 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98518 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66423 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79167 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33990 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80013 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109580 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34491 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139209 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107044 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106887 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1146 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30725 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54052 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20201 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1477 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64840 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1294 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1330 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->