### PR TITLE
Always allocate SQLiteDatabase in heap

### DIFF
--- a/Source/WebCore/Modules/webdatabase/Database.h
+++ b/Source/WebCore/Modules/webdatabase/Database.h
@@ -31,6 +31,7 @@
 #include "SQLiteDatabase.h"
 #include <wtf/Deque.h>
 #include <wtf/Lock.h>
+#include <wtf/UniqueRef.h>
 
 namespace WebCore {
 
@@ -165,7 +166,7 @@ private:
     bool m_opened { false };
     bool m_new { false };
 
-    SQLiteDatabase m_sqliteDatabase;
+    UniqueRef<SQLiteDatabase> m_sqliteDatabase;
 
     const Ref<DatabaseAuthorizer> m_databaseAuthorizer;
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
@@ -171,7 +171,7 @@ private:
 
     // This lock protects m_database, m_originLockMap, m_databaseDirectoryPath, m_originsBeingDeleted, m_beingCreated, and m_beingDeleted.
     Lock m_databaseGuard;
-    SQLiteDatabase m_database WTF_GUARDED_BY_LOCK(m_databaseGuard);
+    const UniqueRef<SQLiteDatabase> m_database WTF_GUARDED_BY_LOCK(m_databaseGuard);
 
     using OriginLockMap = HashMap<String, Ref<OriginLock>>;
     OriginLockMap m_originLockMap WTF_GUARDED_BY_LOCK(m_databaseGuard);

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -6,7 +6,6 @@ Modules/model-element/HTMLModelElement.cpp
 Modules/push-api/PushDatabase.cpp
 Modules/storage/WorkerStorageConnection.cpp
 Modules/webaudio/AudioWorkletGlobalScope.cpp
-Modules/webdatabase/SQLStatement.cpp
 accessibility/AXObjectCache.cpp
 accessibility/AccessibilityListBoxOption.cpp
 accessibility/AccessibilityMathMLElement.cpp

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -47,7 +47,7 @@ class DatabaseAuthorizer;
 class SQLiteStatement;
 class SQLiteTransaction;
 
-class SQLiteDatabase final : public CanMakeThreadSafeCheckedPtr<SQLiteDatabase, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
+class SQLiteDatabase final : public CanMakeThreadSafeCheckedPtr<SQLiteDatabase> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(SQLiteDatabase, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(SQLiteDatabase);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SQLiteDatabase);

--- a/Source/WebKit/NetworkProcess/DatabaseUtilities.h
+++ b/Source/WebKit/NetworkProcess/DatabaseUtilities.h
@@ -70,7 +70,7 @@ protected:
     WebCore::PrivateClickMeasurement buildPrivateClickMeasurementFromDatabase(WebCore::SQLiteStatement&, PrivateClickMeasurementAttributionType) const;
 
     const String m_storageFilePath;
-    mutable WebCore::SQLiteDatabase m_database;
+    const UniqueRef<WebCore::SQLiteDatabase> m_database;
     mutable WebCore::SQLiteTransaction m_transaction;
 };
 

--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.h
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.h
@@ -69,7 +69,7 @@ private:
 
     Ref<WorkQueue> m_workQueue;
     AllowDatabaseWrite m_allowDatabaseWrite { AllowDatabaseWrite::Yes };
-    WebCore::SQLiteDatabase m_db;
+    UniqueRef<WebCore::SQLiteDatabase> m_db;
     HashMap<String, ListHashSet<String>> m_pageURLToIconURLMap;
     Lock m_pageURLToIconURLMapLock;
     HashMap<String, std::pair<WebCore::PlatformImagePtr, MonotonicTime>> m_loadedIcons WTF_GUARDED_BY_LOCK(m_loadedIconsLock);


### PR DESCRIPTION
#### 367524a996af42ef3aeb9451706ecaafd27fd0c4
<pre>
Always allocate SQLiteDatabase in heap
<a href="https://bugs.webkit.org/show_bug.cgi?id=301793">https://bugs.webkit.org/show_bug.cgi?id=301793</a>

Reviewed by Geoffrey Garen.

Always allocate SQLiteDatabase in heap so that operator delete destructs it.

No new tests since there should be no behavioral differences.

* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::databaseNameAndVersionFromFile):
* Source/WebCore/Modules/webdatabase/Database.cpp:
(WebCore::Database::Database):
(WebCore::Database::interrupt):
(WebCore::Database::performOpenAndVerify):
(WebCore::Database::closeDatabase):
(WebCore::Database::getActualVersionForTransaction):
(WebCore::Database::incrementalVacuumIfNeeded):
* Source/WebCore/Modules/webdatabase/Database.h:
* Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp:
(WebCore::DatabaseTracker::DatabaseTracker):
(WebCore::DatabaseTracker::openTrackerDatabase):
(WebCore::DatabaseTracker::hasEntryForOriginNoLock):
(WebCore::DatabaseTracker::hasEntryForDatabase):
(WebCore::DatabaseTracker::fullPathForDatabaseNoLock):
(WebCore::DatabaseTracker::origins):
(WebCore::DatabaseTracker::databaseNamesNoLock):
(WebCore::DatabaseTracker::detailsForNameAndOrigin):
(WebCore::DatabaseTracker::setDatabaseDetails):
(WebCore::DatabaseTracker::quotaNoLock):
(WebCore::DatabaseTracker::setQuota):
(WebCore::DatabaseTracker::addDatabase):
(WebCore::DatabaseTracker::deleteOrigin):
(WebCore::DatabaseTracker::deleteDatabase):
* Source/WebCore/Modules/webdatabase/DatabaseTracker.h:
* Source/WebCore/Modules/webdatabase/SQLStatement.cpp:
(WebCore::SQLStatement::execute):
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/platform/sql/SQLiteDatabase.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::ResourceLoadStatisticsStore):
(WebKit::ResourceLoadStatisticsStore::loadWebsitesWithUserInteraction):
(WebKit::ResourceLoadStatisticsStore::deleteTable):
(WebKit::ResourceLoadStatisticsStore::missingUniqueIndices):
(WebKit::ResourceLoadStatisticsStore::migrateDataToPCMDatabaseIfNecessary):
(WebKit::ResourceLoadStatisticsStore::addMissingTablesIfNecessary):
(WebKit::ResourceLoadStatisticsStore::createUniqueIndices):
(WebKit::ResourceLoadStatisticsStore::createSchema):
(WebKit::ResourceLoadStatisticsStore::insertDomainRelationshipList):
(WebKit::ResourceLoadStatisticsStore::aggregatedThirdPartyData const):
(WebKit::ResourceLoadStatisticsStore::incrementRecordsDeletedCountForDomains):
(WebKit::ResourceLoadStatisticsStore::recursivelyFindNonPrevalentDomainsThatRedirectedToThisDomain):
(WebKit::ResourceLoadStatisticsStore::markAsPrevalentIfHasRedirectedToPrevalent):
(WebKit::ResourceLoadStatisticsStore::findNotVeryPrevalentResources):
(WebKit::ResourceLoadStatisticsStore::runIncrementalVacuumCommand):
(WebKit::ResourceLoadStatisticsStore::requestStorageAccess):
(WebKit::ResourceLoadStatisticsStore::revokeStorageAccessPermission):
(WebKit::ResourceLoadStatisticsStore::grandfatherDataForDomains):
(WebKit::ResourceLoadStatisticsStore::clearTopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement):
(WebKit::ResourceLoadStatisticsStore::setDomainsAsPrevalent):
(WebKit::ResourceLoadStatisticsStore::clearDatabaseContents):
(WebKit::ResourceLoadStatisticsStore::cookieAccess):
(WebKit::ResourceLoadStatisticsStore::hasUserGrantedStorageAccessThroughPrompt):
(WebKit::ResourceLoadStatisticsStore::domainsToBlockAndDeleteCookiesFor const):
(WebKit::ResourceLoadStatisticsStore::domainsToBlockButKeepCookiesFor const):
(WebKit::ResourceLoadStatisticsStore::domainsWithUserInteractionAsFirstParty const):
(WebKit::ResourceLoadStatisticsStore::domainsWithStorageAccess const):
(WebKit::ResourceLoadStatisticsStore::domains const):
(WebKit::ResourceLoadStatisticsStore::clearGrandfathering):
(WebKit::ResourceLoadStatisticsStore::pruneStatisticsIfNeeded):
(WebKit::ResourceLoadStatisticsStore::isCorrectSubStatisticsCount):
(WebKit::ResourceLoadStatisticsStore::appendSubStatisticList const):
(WebKit::ResourceLoadStatisticsStore::updateOperatingDatesParameters):
(WebKit::ResourceLoadStatisticsStore::includeTodayAsOperatingDateIfNecessary):
(WebKit::ResourceLoadStatisticsStore::insertExpiredStatisticForTesting):
* Source/WebKit/NetworkProcess/DatabaseUtilities.cpp:
(WebKit::DatabaseUtilities::DatabaseUtilities):
(WebKit::DatabaseUtilities::scopedStatement const):
(WebKit::DatabaseUtilities::openDatabaseAndCreateSchemaIfNecessary):
(WebKit::DatabaseUtilities::enableForeignKeys):
(WebKit::DatabaseUtilities::close):
(WebKit::DatabaseUtilities::interrupt):
(WebKit::DatabaseUtilities::currentTableAndIndexQueries):
(WebKit::DatabaseUtilities::migrateDataToNewTablesIfNecessary):
(WebKit::DatabaseUtilities::columnsForTable):
(WebKit::DatabaseUtilities::addMissingColumnToTable):
* Source/WebKit/NetworkProcess/DatabaseUtilities.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
(WebKit::PCM::Database::createUniqueIndices):
(WebKit::PCM::Database::createSchema):
(WebKit::PCM::Database::insertPrivateClickMeasurement):
(WebKit::PCM::Database::markAllUnattributedPrivateClickMeasurementAsExpiredForTesting):
(WebKit::PCM::Database::findPrivateClickMeasurement):
(WebKit::PCM::Database::removeUnattributed):
(WebKit::PCM::Database::allAttributedPrivateClickMeasurement):
(WebKit::PCM::Database::privateClickMeasurementToStringForTesting const):
(WebKit::PCM::Database::markAttributedPrivateClickMeasurementsAsExpiredForTesting):
(WebKit::PCM::Database::clearPrivateClickMeasurement):
(WebKit::PCM::Database::clearExpiredPrivateClickMeasurement):
(WebKit::PCM::Database::clearSentAttribution):
(WebKit::PCM::Database::markReportAsSentToDestination):
(WebKit::PCM::Database::markReportAsSentToSource):
(WebKit::PCM::Database::earliestTimesToSend):
(WebKit::PCM::Database::domainID):
(WebKit::PCM::Database::getDomainStringFromDomainID const):
(WebKit::PCM::Database::ensureDomainID):
* Source/WebKit/UIProcess/API/glib/IconDatabase.cpp:
(WebKit::IconDatabase::IconDatabase):
(WebKit::IconDatabase::~IconDatabase):
(WebKit::IconDatabase::createTablesIfNeeded):
(WebKit::IconDatabase::populatePageURLToIconURLsMap):
(WebKit::IconDatabase::clearStatements):
(WebKit::IconDatabase::pruneTimerFired):
(WebKit::IconDatabase::startPruneTimer):
(WebKit::IconDatabase::iconIDForIconURL):
(WebKit::IconDatabase::setIconIDForPageURL):
(WebKit::IconDatabase::iconData):
(WebKit::IconDatabase::addIcon):
(WebKit::IconDatabase::updateIconTimestamp):
(WebKit::IconDatabase::deleteIcon):
(WebKit::IconDatabase::checkIconURLAndSetPageURLIfNeeded):
(WebKit::IconDatabase::loadIconsForPageURL):
(WebKit::IconDatabase::setIconForPageURL):
(WebKit::IconDatabase::clear):
* Source/WebKit/UIProcess/API/glib/IconDatabase.h:

Canonical link: <a href="https://commits.webkit.org/302499@main">https://commits.webkit.org/302499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/949b0432e5752c13edfd7b179dcf0e38122a0756

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80498 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a7a447f0-e155-499e-a701-c877675a9e9b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98312 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66187 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/18108ffa-4d6b-41c1-9de4-596766d89422) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78957 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ed6bd6dd-a40b-4922-bffe-cdea64828659) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33779 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79777 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138972 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1171 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1137 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/backdrop-filter-animated.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106848 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106675 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53733 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20183 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1244 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64596 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1070 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1116 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1168 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->