### PR TITLE
REGRESSION(iOS26): TestWebKitAPI.NavigationSwipeTests.RestoreFirstResponderAfterNavigationSwipe is a constant failure

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -83,6 +83,7 @@ struct WKAppPrivacyReportTestingData {
 - (BOOL)_beginBackSwipeForTesting;
 - (BOOL)_completeBackSwipeForTesting;
 - (void)_resetNavigationGestureStateForTesting;
+@property (nonatomic, readonly) BOOL _didCallEndSwipeGestureForTesting;
 
 - (void)_setShareSheetCompletesImmediatelyWithResolutionForTesting:(BOOL)resolved;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -369,6 +369,15 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 #endif
 }
 
+- (BOOL)_didCallEndSwipeGestureForTesting
+{
+#if PLATFORM(MAC)
+    return _impl->didCallEndSwipeGestureForTesting();
+#else
+    return _gestureController && _gestureController->didCallEndSwipeGesture();
+#endif
+}
+
 - (void)_resetNavigationGestureStateForTesting
 {
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -214,6 +214,7 @@ public:
     // Testing
     bool beginSimulatedSwipeInDirectionForTesting(SwipeDirection);
     bool completeSimulatedSwipeInDirectionForTesting(SwipeDirection);
+    bool didCallEndSwipeGesture() const { return m_didCallEndSwipeGesture; }
 
 private:
     explicit ViewGestureController(WebPageProxy&);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -743,6 +743,7 @@ public:
 
     bool beginBackSwipeForTesting();
     bool completeBackSwipeForTesting();
+    bool didCallEndSwipeGestureForTesting() const;
 
     bool useFormSemanticContext() const;
     void semanticContextDidChange();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6314,6 +6314,12 @@ bool WebViewImpl::completeBackSwipeForTesting()
     return gestureController && gestureController->completeSimulatedSwipeInDirectionForTesting(ViewGestureController::SwipeDirection::Back);
 }
 
+bool WebViewImpl::didCallEndSwipeGestureForTesting() const
+{
+    RefPtr gestureController = m_gestureController;
+    return gestureController && gestureController->didCallEndSwipeGesture();
+}
+
 void WebViewImpl::effectiveAppearanceDidChange()
 {
     m_page->effectiveAppearanceDidChange();


### PR DESCRIPTION
#### 836e95d333f07b1b7dd8e1a173f5e20d23443dd3
<pre>
REGRESSION(iOS26): TestWebKitAPI.NavigationSwipeTests.RestoreFirstResponderAfterNavigationSwipe is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=301656">https://bugs.webkit.org/show_bug.cgi?id=301656</a>
<a href="https://rdar.apple.com/163668275">rdar://163668275</a>

Reviewed by Abrar Rahman Protyasha.

On iOS 26, UIKit calls `-[_UIViewControllerTransitionContext completeTransition:]` asynchronously
after ending a swipe transition animation (as a part of a larger set of changes to support
interruptible parallax transition animations). `-completeTransition:` then goes on to invoke the
swipe transition context&apos;s completion handler. However, the API tests in `NavigationSwipeTests`
currently expect this to happen synchronously after calling `_completeStoppedInteractiveTransition`
to simulate ending the swipe gesture. As a result, some of these tests either fail or are otherwise
no longer testing what they intend because they depend on `ViewGestureController::endSwipeGesture`
being called in `_completeStoppedInteractiveTransition`.

Fix this by waiting for `endSwipeGesture` to be invoked after `_completeStoppedInteractiveTransition`
by adding a new testing hook to check the state of `m_didCallEndSwipeGesture`, and spinning the
runloop until it has been set.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _didCallEndSwipeGestureForTesting]):
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::beginSwipeGesture):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::didCallEndSwipeGestureForTesting const):

Add plumbing for a new testing property, `-[WKWebView _didCallEndSwipeGestureForTesting]`. See above
for more details.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationSwipeTests.mm:
(TestWebKitAPI::simulateBackSwipeAndWaitForGestureToEnd):

Add a helper to simulate a swipe (with an optional callback to invoke in between beginning and
completing the swipe). Deploy this in the three tests below to make sure we wait for the full swipe
interaction to complete.

(TestWebKitAPI::TEST(NavigationSwipeTests, RestoreFirstResponderAfterNavigationSwipe)):
(TestWebKitAPI::TEST(NavigationSwipeTests, DoNotBecomeFirstResponderAfterNavigationSwipeIfWebViewIsUnparented)):
(TestWebKitAPI::TEST(NavigationSwipeTests, DoNotAssertWhenSnapshottingZeroSizeView)):
(TestWebKitAPI::TEST(NavigationSwipeTests, DISABLED_RestoreFirstResponderAfterNavigationSwipe)): Deleted.

Canonical link: <a href="https://commits.webkit.org/302423@main">https://commits.webkit.org/302423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/640e5f6b4a68dae105881b9366a375687b02f9fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136447 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/93a913bc-742f-4e1c-833d-807873482fd3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98267 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/729a9b67-35f4-492f-9aa3-0bcb06482685) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78913 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/af94591f-6337-417e-840f-a6483b9b8125) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33729 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79726 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109337 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138921 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106804 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106632 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27142 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/914 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30474 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53626 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1192 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64530 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1020 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1067 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1116 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->