### PR TITLE
REGRESSION (301918@main ): MiniBrowser no longer loads the default URL after changing it

### DIFF
--- a/Tools/MiniBrowser/mac/AppDelegate.m
+++ b/Tools/MiniBrowser/mac/AppDelegate.m
@@ -265,9 +265,6 @@ static NSNumber *_currentBadge;
     if (targetURLIndex != NSNotFound && targetURLIndex + 1 < [args count])
         sTargetURL = [args objectAtIndex:targetURLIndex + 1];
 
-    if (!sTargetURL || [sTargetURL isEqualToString:@""])
-        sTargetURL = _settingsController.defaultURL;
-
     const NSUInteger siteIsolationIndex = [args indexOfObject:kSiteIsolationArgumentString];
     sForceSiteIsolationSetting = (siteIsolationIndex != NSNotFound && siteIsolationIndex + 1 < [args count]);
     if (sForceSiteIsolationSetting) {
@@ -375,6 +372,17 @@ static NSNumber *_currentBadge;
     return controller;
 }
 
+- (NSString *)targetURL
+{
+    NSString *url = sTargetURL;
+    sTargetURL = nil;
+
+    if (!url || [url isEqualToString:@""])
+        url = _settingsController.defaultURL;
+
+    return url;
+}
+
 - (IBAction)newWindow:(id)sender
 {
     BrowserWindowController *controller = [self createBrowserWindowController:sender];
@@ -382,7 +390,7 @@ static NSNumber *_currentBadge;
         return;
 
     [[controller window] makeKeyAndOrderFront:sender];
-    [controller loadURLString:sTargetURL];
+    [controller loadURLString:[self targetURL]];
 
     if (sOpenWebInspector)
         [controller showHideWebInspector:sender];
@@ -398,7 +406,7 @@ static NSNumber *_currentBadge;
     [[controller window] makeKeyAndOrderFront:sender];
     [_browserWindowControllers addObject:controller];
 
-    [controller loadURLString:sTargetURL];
+    [controller loadURLString:[self targetURL]];
 
     if (sOpenWebInspector)
         [controller showHideWebInspector:sender];


### PR DESCRIPTION
#### 282d46f26f13e22124f8736795ced453e55a335b
<pre>
REGRESSION (301918@main ): MiniBrowser no longer loads the default URL after changing it
<a href="https://bugs.webkit.org/show_bug.cgi?id=301733">https://bugs.webkit.org/show_bug.cgi?id=301733</a>
<a href="https://rdar.apple.com/163754269">rdar://163754269</a>

Reviewed by Simon Fraser.

Use url argument only once. Second window uses the url from system defaults.

* Tools/MiniBrowser/mac/AppDelegate.m:
(-[BrowserAppDelegate _parseArguments]):
(-[BrowserAppDelegate targetURL]):
(-[BrowserAppDelegate newWindow:]):
(-[BrowserAppDelegate newPrivateWindow:]):

Canonical link: <a href="https://commits.webkit.org/302441@main">https://commits.webkit.org/302441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a003b07d1088060d0b8bac3f32637907f72b9b16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136449 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80460 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9189359c-b905-4bdb-91b4-53bef55351ba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98270 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66155 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/93dde386-a823-4197-8c4d-e4e8fbf9aa99) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78916 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dc43275e-9ca9-4ccc-8744-4f335601e28b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33732 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79728 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109339 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138923 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1089 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106809 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106636 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27152 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/917 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30477 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53631 "Hash a003b07d for PR 53289 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1194 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1022 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1069 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1118 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->