### PR TITLE
REGRESSION(iOS26) TestWebKitAPI.WKNavigationAction.UserInputState is a constant timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm
@@ -288,8 +288,7 @@ TEST(WKNavigationAction, TargetFrameName)
     EXPECT_NULL(targetFrameNames[4]);
 }
 
-// FIXME: rdar://163673801 (REGRESSION(iOS26) TestWebKitAPI.WKNavigationAction.UserInputState is a constant timeout (301666))
-#if PLATFORM(MAC)
+#if PLATFORM(MAC) || PLATFORM(IOS)
 
 TEST(WKNavigationAction, UserInputState)
 {
@@ -336,4 +335,4 @@ TEST(WKNavigationAction, UserInputState)
 #endif
 }
 
-#endif
+#endif // PLATFORM(MAC) || PLATFORM(IOS)

--- a/Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.h
+++ b/Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.h
@@ -48,7 +48,7 @@ class MouseEventTestHarness {
 public:
     MouseEventTestHarness(TestWKWebView *);
 
-    MouseEventTestHarness() = delete;
+    ~MouseEventTestHarness();
 
     void mouseMove(CGFloat x, CGFloat y);
 

--- a/Tools/TestWebKitAPI/ios/UIKitTestingHelpers.mm
+++ b/Tools/TestWebKitAPI/ios/UIKitTestingHelpers.mm
@@ -54,7 +54,7 @@ static GestureStateOverrideMap& allStateOverrides()
 
 - (void)_clearOverriddenStateForTesting
 {
-    allStateOverrides().clear();
+    allStateOverrides().remove(self);
 }
 
 @end


### PR DESCRIPTION
#### 4eabc0e7c1804781998281a82dff79f059791de2
<pre>
REGRESSION(iOS26) TestWebKitAPI.WKNavigationAction.UserInputState is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=301666">https://bugs.webkit.org/show_bug.cgi?id=301666</a>
<a href="https://rdar.apple.com/163673801">rdar://163673801</a>

Reviewed by Abrar Rahman Protyasha.

Similar to <a href="https://webkit.org/b/301654">https://webkit.org/b/301654</a>, this test is also failing because the mouse and hover
gesture recognizers no longer change state when using `-setState:`.

Fix this by deploying the new testing helper, `-_setStateForTesting:`, to force the `-state`
property to return overridden values.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm:
(TEST(WKNavigationAction, UserInputState)):
* Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.h:
* Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.mm:
(TestWebKitAPI::MouseEventTestHarness::~MouseEventTestHarness):
(TestWebKitAPI::MouseEventTestHarness::mouseMove):
(TestWebKitAPI::MouseEventTestHarness::mouseDown):
(TestWebKitAPI::MouseEventTestHarness::mouseUp):
(TestWebKitAPI::MouseEventTestHarness::mouseCancel):

Now that calling `-touchesEnded:withEvent:`, etc. no longer causes the actual state to transition
in these API tests, we need to have the test itself force the state transition.

* Tools/TestWebKitAPI/ios/UIKitTestingHelpers.mm:
(-[UIGestureRecognizer _clearOverriddenStateForTesting]):

Drive-by fix: this was intended to only clear the state override map for the current gesture
recognizer, not all gestures.

Canonical link: <a href="https://commits.webkit.org/302426@main">https://commits.webkit.org/302426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7603541f8bc183c0ae3f50a0c83ed3cba1ac821b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136455 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c5857e04-4031-4678-8772-52e8d6ba9faa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98275 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/62054350-620c-4e84-9e84-7a141905bfce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78921 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/880f91a8-7d88-4692-b4a4-5321d6ce24f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33737 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79734 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138929 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1095 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106813 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/128505 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106640 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27144 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/922 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30482 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53640 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1200 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160541 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1027 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/160541 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1073 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1124 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->