### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for RTCDataChannelRemoteHandler

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -323,7 +323,7 @@ void RTCDataChannel::fireOpenEventIfNeeded()
 
 Ref<RTCDataChannel> RTCDataChannel::create(ScriptExecutionContext& context, RTCDataChannelIdentifier identifier, String&& label, RTCDataChannelInit&& options, RTCDataChannelState state)
 {
-    RTCDataChannelRemoteHandler* remoteHandlerPtr = nullptr;
+    CheckedPtr<RTCDataChannelRemoteHandler> remoteHandlerPtr;
     std::unique_ptr<RTCDataChannelHandler> handler;
     if (identifier.processIdentifier() == Process::identifier())
         handler = RTCDataChannel::handlerFromIdentifier(identifier.object());

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h
@@ -35,23 +35,15 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class RTCDataChannelRemoteHandler;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::RTCDataChannelRemoteHandler> : std::true_type { };
-}
-
-namespace WebCore {
 
 class RTCDataChannelHandlerClient;
 class RTCDataChannelRemoteHandlerConnection;
 class RTCError;
 class FragmentedSharedBuffer;
 
-class RTCDataChannelRemoteHandler final : public RTCDataChannelHandler, public CanMakeWeakPtr<RTCDataChannelRemoteHandler> {
+class RTCDataChannelRemoteHandler final : public RTCDataChannelHandler, public CanMakeWeakPtr<RTCDataChannelRemoteHandler>, public CanMakeCheckedPtr<RTCDataChannelRemoteHandler> {
     WTF_MAKE_TZONE_ALLOCATED(RTCDataChannelRemoteHandler);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RTCDataChannelRemoteHandler);
 public:
     static std::unique_ptr<RTCDataChannelRemoteHandler> create(RTCDataChannelIdentifier, RefPtr<RTCDataChannelRemoteHandlerConnection>&&);
     RTCDataChannelRemoteHandler(RTCDataChannelIdentifier, Ref<RTCDataChannelRemoteHandlerConnection>&&);


### PR DESCRIPTION
#### 035ff781662af86b31a57893e36b30aa65eb2cc9
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for RTCDataChannelRemoteHandler
<a href="https://bugs.webkit.org/show_bug.cgi?id=301801">https://bugs.webkit.org/show_bug.cgi?id=301801</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::create):
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h:

Canonical link: <a href="https://commits.webkit.org/302453@main">https://commits.webkit.org/302453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48176e06f449f49630a0c0e86b566c57646d3daf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136472 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80470 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e965141f-a6a7-4cbf-a1e1-ba9bcdcf4dec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130964 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98290 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66167 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ebac972f-c71f-4a36-b9a2-4db232a60f57) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115640 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78935 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ca0c1182-6e15-4723-bf4f-166f76be7106) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33756 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79751 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109364 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34253 "Found 1 new test failure: fast/images/page-wide-animation-toggle.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138945 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106827 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106654 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27158 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/939 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53677 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1218 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64570 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1044 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1090 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1142 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->