### PR TITLE
REGRESSION(302424@main): Broke the internal iOS build

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h
@@ -101,8 +101,10 @@ private:
     simd_float4 m_maxCorner;
 #endif
     std::optional<WebCore::DDModel::DDFloat4x4> m_transform;
+#if ENABLE(GPU_PROCESS_MODEL)
     float m_cameraDistance { 1.f };
     WebCore::StageModeOperation m_stageMode;
+#endif
 };
 
 }


### PR DESCRIPTION
#### d078cc2ab2dd12e843c65a5befe878dac95665fe
<pre>
REGRESSION(302424@main): Broke the internal iOS build
<a href="https://bugs.webkit.org/show_bug.cgi?id=301802">https://bugs.webkit.org/show_bug.cgi?id=301802</a>
<a href="https://rdar.apple.com/163849141">rdar://163849141</a>

Unreviewed build fix.

We guard the RemoteDDMeshProxy class members introduced in 302424@main
behind ENABLE_GPU_PROCESS_MODEL to address these unused variable errors:

```
In file included from /Source/WebKit/WebProcess/GPU/graphics/Model/ModelDowncastConvertToBackingContext.cpp:31:
/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h:104:11: error: private field &apos;m_cameraDistance&apos; is not used [-Werror,-Wunused-private-field]
  104 |     float m_cameraDistance { 1.f };
/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h:105:33: error: private field &apos;m_stageMode&apos; is not used [-Werror,-Wunused-private-field]
  105 |     WebCore::StageModeOperation m_stageMode;
2 errors generated.
```

* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h:

Canonical link: <a href="https://commits.webkit.org/302432@main">https://commits.webkit.org/302432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a21521167b95cfeca040530631c4c9f0890999fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136466 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/80461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c06eb2b-b654-432b-8c53-b64a62a4e7cc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98284 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/80461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ba9379da-c674-4caa-9291-1d595a7a80b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78930 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f7bd3f31-fc72-44b6-bb48-4b5c72c2d8da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/909 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79745 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138939 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106822 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106649 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30493 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53660 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20152 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1211 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64555 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1037 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1083 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1135 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->