### PR TITLE
Add generic DefaultHash<> for types with hash() function and equality operator

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGIntegerCheckCombiningPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerCheckCombiningPhase.cpp
@@ -52,12 +52,6 @@ public:
     };
 
     struct RangeKey {
-        struct Hash {
-            static unsigned hash(const RangeKey& key) { return key.hash(); }
-            static bool equal(const RangeKey& a, const RangeKey& b) { return a == b; }
-            static constexpr bool safeToCompareToEmptyOrDeleted = false;
-        };
-
         static RangeKey addition(Edge edge)
         {
             RangeKey result;
@@ -376,7 +370,7 @@ private:
                 nodeIndex, origin, jsNumber(addend), source.useKind()));
     }
     
-    using RangeMap = UncheckedKeyHashMap<GenericHashKey<RangeKey, RangeKey::Hash>, Range>;
+    using RangeMap = UncheckedKeyHashMap<GenericHashKey<RangeKey>, Range>;
     RangeMap m_map;
     
     InsertionSet m_insertionSet;

--- a/Source/JavaScriptCore/ftl/FTLSlowPathCallKey.h
+++ b/Source/JavaScriptCore/ftl/FTLSlowPathCallKey.h
@@ -154,19 +154,9 @@ private:
     ScalarRegisterSet m_usedRegisters;
 };
 
-
-struct SlowPathCallKeyHash {
-    static unsigned hash(const SlowPathCallKey& key) { return key.hash(); }
-    static bool equal(const SlowPathCallKey& a, const SlowPathCallKey& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = false;
-};
-
 } } // namespace JSC::FTL
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::FTL::SlowPathCallKey> : JSC::FTL::SlowPathCallKeyHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::FTL::SlowPathCallKey> : public CustomHashTraits<JSC::FTL::SlowPathCallKey> { };

--- a/Source/JavaScriptCore/runtime/FunctionHasExecutedCache.h
+++ b/Source/JavaScriptCore/runtime/FunctionHasExecutedCache.h
@@ -36,12 +36,6 @@ namespace JSC {
 class FunctionHasExecutedCache {
 public:
     struct FunctionRange {
-        struct Hash {
-            static unsigned hash(const FunctionRange& key) { return key.hash(); }
-            static bool equal(const FunctionRange& a, const FunctionRange& b) { return a == b; }
-            static constexpr bool safeToCompareToEmptyOrDeleted = false;
-        };
-
         FunctionRange() {}
         friend bool operator==(const FunctionRange&, const FunctionRange&) = default;
         unsigned hash() const
@@ -59,7 +53,7 @@ public:
     Vector<std::tuple<bool, unsigned, unsigned>> getFunctionRanges(SourceID);
 
 private:
-    using RangeMap = UncheckedKeyHashMap<GenericHashKey<FunctionRange, FunctionRange::Hash>, bool>;
+    using RangeMap = UncheckedKeyHashMap<GenericHashKey<FunctionRange>, bool>;
     using SourceIDToRangeMap = UncheckedKeyHashMap<GenericHashKey<intptr_t>, RangeMap>;
     SourceIDToRangeMap m_rangeMap;
 };

--- a/Source/JavaScriptCore/runtime/TemplateObjectDescriptor.h
+++ b/Source/JavaScriptCore/runtime/TemplateObjectDescriptor.h
@@ -56,12 +56,6 @@ public:
 
     bool operator==(const TemplateObjectDescriptor& other) const { return m_hash == other.m_hash && m_rawStrings == other.m_rawStrings; }
 
-    struct Hasher {
-        static unsigned hash(const TemplateObjectDescriptor& key) { return key.hash(); }
-        static bool equal(const TemplateObjectDescriptor& a, const TemplateObjectDescriptor& b) { return a == b; }
-        static constexpr bool safeToCompareToEmptyOrDeleted = false;
-    };
-
     static unsigned calculateHash(const StringVector& rawStrings);
     ~TemplateObjectDescriptor();
 
@@ -110,10 +104,6 @@ inline unsigned TemplateObjectDescriptor::calculateHash(const StringVector& rawS
 } // namespace JSC
 
 namespace WTF {
-template<typename> struct DefaultHash;
-
-template<> struct DefaultHash<JSC::TemplateObjectDescriptor> : JSC::TemplateObjectDescriptor::Hasher { };
-
 template<> struct HashTraits<JSC::TemplateObjectDescriptor> : CustomHashTraits<JSC::TemplateObjectDescriptor> {
 };
 

--- a/Source/JavaScriptCore/runtime/TypeLocationCache.h
+++ b/Source/JavaScriptCore/runtime/TypeLocationCache.h
@@ -37,12 +37,6 @@ class VM;
 class TypeLocationCache {
 public:
     struct LocationKey {
-        struct Hash {
-            static unsigned hash(const LocationKey& key) { return key.hash(); }
-            static bool equal(const LocationKey& a, const LocationKey& b) { return a == b; }
-            static constexpr bool safeToCompareToEmptyOrDeleted = false;
-        };
-
         LocationKey() {}
         friend bool operator==(const LocationKey&, const LocationKey&) = default;
 
@@ -59,7 +53,7 @@ public:
 
     std::pair<TypeLocation*, bool> getTypeLocation(GlobalVariableID, SourceID, unsigned start, unsigned end, RefPtr<TypeSet>&&, VM*);
 private:
-    using LocationMap = UncheckedKeyHashMap<GenericHashKey<LocationKey, LocationKey::Hash>, TypeLocation*>;
+    using LocationMap = UncheckedKeyHashMap<GenericHashKey<LocationKey>, TypeLocation*>;
     LocationMap m_locationMap;
 };
 

--- a/Source/WTF/wtf/HashFunctions.h
+++ b/Source/WTF/wtf/HashFunctions.h
@@ -259,6 +259,17 @@ namespace WTF {
     template<typename T, typename U> struct DefaultHash<std::pair<T, U>> : PairHash<T, U> { };
     template<typename... Types> struct DefaultHash<std::tuple<Types...>> : TupleHash<Types...> { };
 
+    // Default hash for any type with a hash() member function and an equality operator.
+    template<typename T> concept HashableWithMemberFunction = std::equality_comparable<T> && requires(const T& t) {
+        { t.hash() } -> std::same_as<unsigned>;
+    };
+    template<HashableWithMemberFunction T> struct MemberBasedHash {
+        static unsigned hash(const T& key) { return key.hash(); }
+        static bool equal(const T& a, const T& b) { return a == b; }
+        static constexpr bool safeToCompareToEmptyOrDeleted = false;
+    };
+    template<HashableWithMemberFunction T> struct DefaultHash<T> : MemberBasedHash<T> { };
+
 } // namespace WTF
 
 using WTF::DefaultHash;

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -113,16 +113,10 @@ struct RuleFeatureDeduplicationKey {
 
     unsigned hash() const;
     bool operator==(const RuleFeatureDeduplicationKey&) const;
-
-    struct Hash {
-        static unsigned hash(const RuleFeatureDeduplicationKey& key) { return key.hash(); }
-        static bool equal(const RuleFeatureDeduplicationKey& a, const RuleFeatureDeduplicationKey& b) { return a == b; }
-        static constexpr bool safeToCompareToEmptyOrDeleted = false;
-    };
 };
 
 template<typename FeatureType>
-using RuleFeatureDeduplicationSetForFeatureType = HashSet<GenericHashKey<RuleFeatureDeduplicationKey<FeatureType>, typename RuleFeatureDeduplicationKey<FeatureType>::Hash>>;
+using RuleFeatureDeduplicationSetForFeatureType = HashSet<GenericHashKey<RuleFeatureDeduplicationKey<FeatureType>>>;
 using RuleFeatureDeduplicationSet = RuleFeatureDeduplicationSetForFeatureType<RuleFeature>;
 using RuleFeatureWithInvalidationSelectorDeduplicationSet = RuleFeatureDeduplicationSetForFeatureType<RuleFeatureWithInvalidationSelector>;
 

--- a/Source/WebKit/Shared/WebPageNetworkParameters.h
+++ b/Source/WebKit/Shared/WebPageNetworkParameters.h
@@ -55,12 +55,6 @@ private:
 
 namespace WTF {
 
-template<> struct DefaultHash<WebKit::WebPageNetworkParameters> {
-    static unsigned hash(const WebKit::WebPageNetworkParameters& key) { return key.hash(); }
-    static bool equal(const WebKit::WebPageNetworkParameters& a, const WebKit::WebPageNetworkParameters& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = false;
-};
-
 template<> struct HashTraits<WebKit::WebPageNetworkParameters> : public SimpleClassHashTraits<WebKit::WebPageNetworkParameters> { };
 
 } // namespace WTF


### PR DESCRIPTION
#### 106837a9c4ea12d4618f4fdb5d28f8a48b9abed3
<pre>
Add generic DefaultHash&lt;&gt; for types with hash() function and equality operator
<a href="https://bugs.webkit.org/show_bug.cgi?id=301803">https://bugs.webkit.org/show_bug.cgi?id=301803</a>
<a href="https://rdar.apple.com/163849870">rdar://163849870</a>

Reviewed by Darin Adler and Sam Weinig.

With this any moveable class or struct can be turned into a hash table key with minimal ceremony:

struct Foo {
    unsigned a;
    Field b;

    bool operator==(const Foo&amp;) = default;
    unsigned hash() const { return computeHash(a, b); }
};

HashSet&lt;GenericHashKey&lt;Foo&gt;&gt; set;

Also remove a bunch of now-unneeded DefaultHashes that match this pattern (with safeToCompareToEmptyOrDeleted = false).

* Source/JavaScriptCore/dfg/DFGIntegerCheckCombiningPhase.cpp:
(JSC::DFG::IntegerCheckCombiningPhase::RangeKey::Hash::hash): Deleted.
(JSC::DFG::IntegerCheckCombiningPhase::RangeKey::Hash::equal): Deleted.
* Source/JavaScriptCore/ftl/FTLSlowPathCallKey.h:
(JSC::FTL::SlowPathCallKeyHash::hash): Deleted.
(JSC::FTL::SlowPathCallKeyHash::equal): Deleted.
* Source/JavaScriptCore/runtime/FunctionHasExecutedCache.h:
(JSC::FunctionHasExecutedCache::FunctionRange::Hash::hash): Deleted.
(JSC::FunctionHasExecutedCache::FunctionRange::Hash::equal): Deleted.
* Source/JavaScriptCore/runtime/TemplateObjectDescriptor.h:
(JSC::TemplateObjectDescriptor::Hasher::hash): Deleted.
(JSC::TemplateObjectDescriptor::Hasher::equal): Deleted.
* Source/JavaScriptCore/runtime/TypeLocationCache.h:
(JSC::TypeLocationCache::LocationKey::Hash::hash): Deleted.
(JSC::TypeLocationCache::LocationKey::Hash::equal): Deleted.
* Source/WTF/wtf/HashFunctions.h:
(WTF::requires):

Add HashableWithMemberFunction concept.

(WTF::MemberBasedHash::hash):
(WTF::MemberBasedHash::equal):

Use it.

* Source/WebCore/style/RuleFeature.h:
(WebCore::Style::RuleFeatureDeduplicationKey::Hash::hash): Deleted.
(WebCore::Style::RuleFeatureDeduplicationKey::Hash::equal): Deleted.
* Source/WebKit/Shared/WebPageNetworkParameters.h:
(WTF::DefaultHash&lt;WebKit::WebPageNetworkParameters&gt;::hash): Deleted.
(WTF::DefaultHash&lt;WebKit::WebPageNetworkParameters&gt;::equal): Deleted.

Canonical link: <a href="https://commits.webkit.org/302440@main">https://commits.webkit.org/302440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5886110ae6e3bb9bb7034acd16c932a2c350c509

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129098 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80472 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4e15695c-3dd7-4dae-8102-62987be00fc7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1234 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98294 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66168 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b5086d28-9416-4855-8f02-bf15692a97f3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78939 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dc6098b3-211c-4658-8bcd-c526025eb9ce) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33761 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79756 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/121090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109369 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138950 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127550 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1150 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1118 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106830 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106657 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27151 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/944 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30505 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53688 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1223 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64575 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160564 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1049 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40075 "Found 5 new JSC stress test failures: mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-baseline, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-dfg-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-llint, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-no-ftl (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1095 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1147 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->