### PR TITLE
Replace std::enable_if with requires/concepts (part 1)

### DIFF
--- a/Source/JavaScriptCore/assembler/CodeLocation.h
+++ b/Source/JavaScriptCore/assembler/CodeLocation.h
@@ -69,7 +69,8 @@ public:
     template<typename T = void*>
     T dataLocation() const { return Base::template dataLocation<T>(); }
 
-    template<typename T, typename = std::enable_if_t<std::is_base_of<CodeLocationCommon<tag>, T>::value>>
+    template<typename T>
+        requires (std::is_base_of_v<CodeLocationCommon<tag>, T>)
     operator T()
     {
         return T(CodePtr<tag>::fromTaggedPtr(this->taggedPtr()));

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -158,7 +158,8 @@ public:
     
     // These methods are used to link or set values at code generation time.
 
-    template<PtrTag tag, typename Func, typename = std::enable_if_t<std::is_function<typename std::remove_pointer<Func>::type>::value>>
+    template<PtrTag tag, typename Func>
+        requires (std::is_function_v<typename std::remove_pointer_t<Func>>)
     void link(Call call, Func funcName)
     {
         CodePtr<tag> function(funcName);

--- a/Source/WTF/wtf/ArgumentCoder.h
+++ b/Source/WTF/wtf/ArgumentCoder.h
@@ -34,7 +34,7 @@ namespace IPC {
 class Decoder;
 class Encoder;
 
-template<typename T, typename = void> struct ArgumentCoder;
+template<typename> struct ArgumentCoder;
 
 template<>
 struct ArgumentCoder<bool> {
@@ -56,7 +56,8 @@ struct ArgumentCoder<bool> {
 };
 
 template<typename T>
-struct ArgumentCoder<T, typename std::enable_if_t<std::is_arithmetic_v<T>>> {
+    requires (std::is_arithmetic_v<T>)
+struct ArgumentCoder<T> {
     template<typename Encoder>
     static void encode(Encoder& encoder, T value)
     {
@@ -71,7 +72,8 @@ struct ArgumentCoder<T, typename std::enable_if_t<std::is_arithmetic_v<T>>> {
 };
 
 template<typename T>
-struct ArgumentCoder<T, typename std::enable_if_t<std::is_enum_v<T>>> {
+    requires (std::is_enum_v<T>)
+struct ArgumentCoder<T> {
     template<typename Encoder>
     static void encode(Encoder& encoder, T value)
     {

--- a/Source/WTF/wtf/CagedPtr.h
+++ b/Source/WTF/wtf/CagedPtr.h
@@ -79,8 +79,8 @@ public:
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // We need the template here so that the type of U is deduced at usage time rather than class time. U should always be T.
     template<typename U = T>
-    WTF_UNSAFE_BUFFER_USAGE typename std::enable_if<!std::is_same<void, U>::value, T>::type&
-    /* T& */ at(size_t index) const { return get()[index]; }
+        requires (!std::same_as<void, U>)
+    WTF_UNSAFE_BUFFER_USAGE U& at(size_t index) const { return get()[index]; }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     CagedPtr(CagedPtr& other)

--- a/Source/WTF/wtf/CallbackAggregator.h
+++ b/Source/WTF/wtf/CallbackAggregator.h
@@ -72,7 +72,8 @@ template<typename> class EagerCallbackAggregator;
 template <typename Out, typename... In>
 class EagerCallbackAggregator<Out(In...)> : public ThreadSafeRefCounted<EagerCallbackAggregator<Out(In...)>> {
 public:
-    template<typename CallableType, class = typename std::enable_if<std::is_rvalue_reference<CallableType&&>::value>::type>
+    template<typename CallableType>
+        requires (std::is_rvalue_reference_v<CallableType&&>)
     static Ref<EagerCallbackAggregator> create(CallableType&& callback, In... defaultArgs)
     {
         return adoptRef(*new EagerCallbackAggregator(std::forward<CallableType>(callback), std::forward<In>(defaultArgs)...));

--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -139,19 +139,19 @@ private:
     unsigned char m_overflowed;
 };
 
-template <typename T, class OverflowHandler = CrashOnOverflow> class Checked;
-template <typename T> struct RemoveChecked;
-template <typename T> struct RemoveChecked<Checked<T>>;
+template<typename, typename = CrashOnOverflow> class Checked;
+template<typename> struct RemoveChecked;
+template<typename T> struct RemoveChecked<Checked<T>>;
 
-template <typename Target, typename Source, bool isTargetBigger = sizeof(Target) >= sizeof(Source), bool targetSigned = std::numeric_limits<Target>::is_signed, bool sourceSigned = std::numeric_limits<Source>::is_signed> struct BoundsChecker;
-template <typename Target, typename Source> struct BoundsChecker<Target, Source, false, false, false> {
+template<typename Target, typename Source, bool isTargetBigger = sizeof(Target) >= sizeof(Source), bool targetSigned = std::numeric_limits<Target>::is_signed, bool sourceSigned = std::numeric_limits<Source>::is_signed> struct BoundsChecker;
+template<typename Target, typename Source> struct BoundsChecker<Target, Source, false, false, false> {
     static bool constexpr inBounds(Source value)
     {
         // Same signedness so implicit type conversion will always increase precision to widest type.
         return value <= std::numeric_limits<Target>::max();
     }
 };
-template <typename Target, typename Source> struct BoundsChecker<Target, Source, false, true, true> {
+template<typename Target, typename Source> struct BoundsChecker<Target, Source, false, true, true> {
     static bool constexpr inBounds(Source value)
     {
         // Same signedness so implicit type conversion will always increase precision to widest type.
@@ -159,7 +159,7 @@ template <typename Target, typename Source> struct BoundsChecker<Target, Source,
     }
 };
 
-template <typename Target, typename Source> struct BoundsChecker<Target, Source, false, false, true> {
+template<typename Target, typename Source> struct BoundsChecker<Target, Source, false, false, true> {
     static bool constexpr inBounds(Source value)
     {
         // When converting value to unsigned Source, value will become a big value if value is negative.
@@ -168,7 +168,7 @@ template <typename Target, typename Source> struct BoundsChecker<Target, Source,
     }
 };
 
-template <typename Target, typename Source> struct BoundsChecker<Target, Source, false, true, false> {
+template<typename Target, typename Source> struct BoundsChecker<Target, Source, false, true, false> {
     static bool constexpr inBounds(Source value)
     {
         // The unsigned Source type has greater precision than the target so max(Target) -> Source will widen.
@@ -176,7 +176,7 @@ template <typename Target, typename Source> struct BoundsChecker<Target, Source,
     }
 };
 
-template <typename Target, typename Source> struct BoundsChecker<Target, Source, true, false, false> {
+template<typename Target, typename Source> struct BoundsChecker<Target, Source, true, false, false> {
     static bool constexpr inBounds(Source)
     {
         // Same sign, greater or same precision.
@@ -184,7 +184,7 @@ template <typename Target, typename Source> struct BoundsChecker<Target, Source,
     }
 };
 
-template <typename Target, typename Source> struct BoundsChecker<Target, Source, true, true, true> {
+template<typename Target, typename Source> struct BoundsChecker<Target, Source, true, true, true> {
     static bool constexpr inBounds(Source)
     {
         // Same sign, greater or same precision.
@@ -192,7 +192,7 @@ template <typename Target, typename Source> struct BoundsChecker<Target, Source,
     }
 };
 
-template <typename Target, typename Source> struct BoundsChecker<Target, Source, true, true, false> {
+template<typename Target, typename Source> struct BoundsChecker<Target, Source, true, true, false> {
     static bool constexpr inBounds(Source value)
     {
         // Target is signed with greater or same precision. If strictly greater, it is always safe.
@@ -202,7 +202,7 @@ template <typename Target, typename Source> struct BoundsChecker<Target, Source,
     }
 };
 
-template <typename Target, typename Source> struct BoundsChecker<Target, Source, true, false, true> {
+template<typename Target, typename Source> struct BoundsChecker<Target, Source, true, false, true> {
     static bool constexpr inBounds(Source value)
     {
         // Target is unsigned with greater precision.
@@ -210,12 +210,12 @@ template <typename Target, typename Source> struct BoundsChecker<Target, Source,
     }
 };
 
-template <typename Target, typename Source> static inline constexpr bool isInBounds(Source value)
+template<typename Target, typename Source> static inline constexpr bool isInBounds(Source value)
 {
     return BoundsChecker<Target, Source>::inBounds(value);
 }
 
-template <typename Target, typename Source> static inline constexpr bool convertSafely(Source input, Target& output)
+template<typename Target, typename Source> static inline constexpr bool convertSafely(Source input, Target& output)
 {
     if (!isInBounds<Target>(input))
         return false;
@@ -223,64 +223,64 @@ template <typename Target, typename Source> static inline constexpr bool convert
     return true;
 }
 
-template <typename T> struct RemoveChecked {
+template<typename T> struct RemoveChecked {
     typedef T CleanType;
     static constexpr CleanType DefaultValue = 0;
 };
 
-template <typename T> struct RemoveChecked<Checked<T, CrashOnOverflow>> {
+template<typename T> struct RemoveChecked<Checked<T, CrashOnOverflow>> {
     typedef typename RemoveChecked<T>::CleanType CleanType;
     static constexpr CleanType DefaultValue = 0;
 };
 
-template <typename T> struct RemoveChecked<Checked<T, RecordOverflow>> {
+template<typename T> struct RemoveChecked<Checked<T, RecordOverflow>> {
     typedef typename RemoveChecked<T>::CleanType CleanType;
     static constexpr CleanType DefaultValue = 0;
 };
 
 // The ResultBase and SignednessSelector are used to workaround typeof not being
 // available in MSVC
-template <typename U, typename V, bool uIsBigger = (sizeof(U) > sizeof(V)), bool sameSize = (sizeof(U) == sizeof(V))> struct ResultBase;
-template <typename U, typename V> struct ResultBase<U, V, true, false> {
+template<typename U, typename V, bool uIsBigger = (sizeof(U) > sizeof(V)), bool sameSize = (sizeof(U) == sizeof(V))> struct ResultBase;
+template<typename U, typename V> struct ResultBase<U, V, true, false> {
     typedef U ResultType;
 };
 
-template <typename U, typename V> struct ResultBase<U, V, false, false> {
+template<typename U, typename V> struct ResultBase<U, V, false, false> {
     typedef V ResultType;
 };
 
-template <typename U> struct ResultBase<U, U, false, true> {
+template<typename U> struct ResultBase<U, U, false, true> {
     typedef U ResultType;
 };
 
-template <typename U, typename V, bool uIsSigned = std::numeric_limits<U>::is_signed, bool vIsSigned = std::numeric_limits<V>::is_signed> struct SignednessSelector;
-template <typename U, typename V> struct SignednessSelector<U, V, true, true> {
+template<typename U, typename V, bool uIsSigned = std::numeric_limits<U>::is_signed, bool vIsSigned = std::numeric_limits<V>::is_signed> struct SignednessSelector;
+template<typename U, typename V> struct SignednessSelector<U, V, true, true> {
     typedef U ResultType;
 };
 
-template <typename U, typename V> struct SignednessSelector<U, V, false, false> {
+template<typename U, typename V> struct SignednessSelector<U, V, false, false> {
     typedef U ResultType;
 };
 
-template <typename U, typename V> struct SignednessSelector<U, V, true, false> {
+template<typename U, typename V> struct SignednessSelector<U, V, true, false> {
     typedef V ResultType;
 };
 
-template <typename U, typename V> struct SignednessSelector<U, V, false, true> {
+template<typename U, typename V> struct SignednessSelector<U, V, false, true> {
     typedef U ResultType;
 };
 
-template <typename U, typename V> struct ResultBase<U, V, false, true> {
+template<typename U, typename V> struct ResultBase<U, V, false, true> {
     typedef typename SignednessSelector<U, V>::ResultType ResultType;
 };
 
-template <typename U, typename V> struct Result : ResultBase<typename RemoveChecked<U>::CleanType, typename RemoveChecked<V>::CleanType> {
+template<typename U, typename V> struct Result : ResultBase<typename RemoveChecked<U>::CleanType, typename RemoveChecked<V>::CleanType> {
 };
 
-template <typename LHS, typename RHS, typename ResultType = typename Result<LHS, RHS>::ResultType, 
+template<typename LHS, typename RHS, typename ResultType = typename Result<LHS, RHS>::ResultType,
     bool lhsSigned = std::numeric_limits<LHS>::is_signed, bool rhsSigned = std::numeric_limits<RHS>::is_signed> struct ArithmeticOperations;
 
-template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOperations<LHS, RHS, ResultType, true, true> {
+template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOperations<LHS, RHS, ResultType, true, true> {
     // LHS and RHS are signed types
 
     // Helper function
@@ -396,7 +396,7 @@ template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOper
 
 };
 
-template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOperations<LHS, RHS, ResultType, false, false> {
+template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOperations<LHS, RHS, ResultType, false, false> {
     // LHS and RHS are unsigned types so bounds checks are nice and easy
     static inline bool add(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
     {
@@ -479,7 +479,7 @@ template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOper
 
 };
 
-template <typename ResultType> struct ArithmeticOperations<int, unsigned, ResultType, true, false> {
+template<typename ResultType> struct ArithmeticOperations<int, unsigned, ResultType, true, false> {
     static inline bool add(int64_t lhs, int64_t rhs, ResultType& result)
     {
         ResultType temp;
@@ -533,7 +533,7 @@ template <typename ResultType> struct ArithmeticOperations<int, unsigned, Result
     }
 };
 
-template <typename ResultType> struct ArithmeticOperations<unsigned, int, ResultType, false, true> {
+template<typename ResultType> struct ArithmeticOperations<unsigned, int, ResultType, false, true> {
     static inline bool add(int64_t lhs, int64_t rhs, ResultType& result)
     {
         return ArithmeticOperations<int, unsigned, ResultType>::add(rhs, lhs, result);
@@ -560,18 +560,20 @@ template <typename ResultType> struct ArithmeticOperations<unsigned, int, Result
     }
 };
 
-template <class OverflowHandler, typename = std::enable_if_t<!std::is_scalar<OverflowHandler>::value>>
+template<class OverflowHandler>
+    requires (!std::is_scalar_v<OverflowHandler>)
 inline constexpr bool observesOverflow() { return true; }
 
-template <>
+template<>
 inline constexpr bool observesOverflow<AssertNoOverflow>() { return ASSERT_ENABLED; }
 
-template <typename U, typename V, typename R> static inline bool safeAdd(U lhs, V rhs, R& result)
+template<typename U, typename V, typename R> static inline bool safeAdd(U lhs, V rhs, R& result)
 {
     return ArithmeticOperations<U, V, R>::add(lhs, rhs, result);
 }
 
-template <class OverflowHandler, typename U, typename V, typename R, typename = std::enable_if_t<!std::is_scalar<OverflowHandler>::value>>
+template<class OverflowHandler, typename U, typename V, typename R>
+    requires (!std::is_scalar_v<OverflowHandler>)
 static inline bool safeAdd(U lhs, V rhs, R& result)
 {
     if (observesOverflow<OverflowHandler>())
@@ -580,12 +582,13 @@ static inline bool safeAdd(U lhs, V rhs, R& result)
     return true;
 }
 
-template <typename U, typename V, typename R> static inline bool safeSub(U lhs, V rhs, R& result)
+template<typename U, typename V, typename R> static inline bool safeSub(U lhs, V rhs, R& result)
 {
     return ArithmeticOperations<U, V, R>::sub(lhs, rhs, result);
 }
 
-template <class OverflowHandler, typename U, typename V, typename R, typename = std::enable_if_t<!std::is_scalar<OverflowHandler>::value>>
+template<class OverflowHandler, typename U, typename V, typename R>
+    requires (!std::is_scalar_v<OverflowHandler>)
 static inline bool safeSub(U lhs, V rhs, R& result)
 {
     if (observesOverflow<OverflowHandler>())
@@ -594,17 +597,18 @@ static inline bool safeSub(U lhs, V rhs, R& result)
     return true;
 }
 
-template <typename U, typename V, typename R> static inline bool safeMultiply(U lhs, V rhs, R& result)
+template<typename U, typename V, typename R> static inline bool safeMultiply(U lhs, V rhs, R& result)
 {
     return ArithmeticOperations<U, V, R>::multiply(lhs, rhs, result);
 }
 
-template <typename U, typename V, typename R> static inline bool safeDivide(U lhs, V rhs, R& result)
+template<typename U, typename V, typename R> static inline bool safeDivide(U lhs, V rhs, R& result)
 {
     return ArithmeticOperations<U, V, R>::divide(lhs, rhs, result);
 }
 
-template <class OverflowHandler, typename U, typename V, typename R, typename = std::enable_if_t<!std::is_scalar<OverflowHandler>::value>>
+template<class OverflowHandler, typename U, typename V, typename R>
+    requires (!std::is_scalar_v<OverflowHandler>)
 static inline bool safeMultiply(U lhs, V rhs, R& result)
 {
     if (observesOverflow<OverflowHandler>())
@@ -613,7 +617,8 @@ static inline bool safeMultiply(U lhs, V rhs, R& result)
     return true;
 }
 
-template <class OverflowHandler, typename U, typename V, typename R, typename = std::enable_if_t<!std::is_scalar<OverflowHandler>::value>>
+template<class OverflowHandler, typename U, typename V, typename R>
+    requires (!std::is_scalar_v<OverflowHandler>)
 static inline bool safeDivide(U lhs, V rhs, R& result)
 {
     if (observesOverflow<OverflowHandler>())
@@ -622,16 +627,16 @@ static inline bool safeDivide(U lhs, V rhs, R& result)
     return true;
 }
 
-template <typename U, typename V> static inline bool safeEquals(U lhs, V rhs)
+template<typename U, typename V> static inline bool safeEquals(U lhs, V rhs)
 {
     return ArithmeticOperations<U, V>::equals(lhs, rhs);
 }
 
 enum ResultOverflowedTag { ResultOverflowed };
     
-template <typename T, class OverflowHandler> class Checked : public OverflowHandler {
+template<typename T, class OverflowHandler> class Checked : public OverflowHandler {
 public:
-    template <typename _T, class _OverflowHandler> friend class Checked;
+    template<typename _T, class _OverflowHandler> friend class Checked;
     constexpr Checked()
         : m_value(0)
     {
@@ -650,21 +655,21 @@ public:
         m_value = static_cast<T>(value.m_value);
     }
 
-    template <typename U> constexpr Checked(U value)
+    template<typename U> constexpr Checked(U value)
     {
         if (!isInBounds<T>(value))
             this->overflowed();
         m_value = static_cast<T>(value);
     }
     
-    template <typename V> constexpr Checked(const Checked<T, V>& rhs)
+    template<typename V> constexpr Checked(const Checked<T, V>& rhs)
         : m_value(rhs.m_value)
     {
         if (rhs.hasOverflowed())
             this->overflowed();
     }
     
-    template <typename U> constexpr Checked(const Checked<U, OverflowHandler>& rhs)
+    template<typename U> constexpr Checked(const Checked<U, OverflowHandler>& rhs)
         : OverflowHandler(rhs)
     {
         if (!isInBounds<T>(rhs.m_value))
@@ -672,7 +677,7 @@ public:
         m_value = static_cast<T>(rhs.m_value);
     }
     
-    template <typename U, typename V> constexpr Checked(const Checked<U, V>& rhs)
+    template<typename U, typename V> constexpr Checked(const Checked<U, V>& rhs)
     {
         if (rhs.hasOverflowed())
             this->overflowed();
@@ -690,12 +695,12 @@ public:
         return *this;
     }
     
-    template <typename U> Checked& operator=(U value)
+    template<typename U> Checked& operator=(U value)
     {
         return *this = Checked(value);
     }
     
-    template <typename U, typename V> Checked& operator=(const Checked<U, V>& rhs)
+    template<typename U, typename V> Checked& operator=(const Checked<U, V>& rhs)
     {
         return *this = Checked(rhs);
     }
@@ -764,49 +769,49 @@ public:
     }
 
     // Mutating assignment
-    template <typename U> Checked& operator+=(U rhs)
+    template<typename U> Checked& operator+=(U rhs)
     {
         if (!safeAdd<OverflowHandler>(m_value, rhs, m_value))
             this->overflowed();
         return *this;
     }
 
-    template <typename U> Checked& operator-=(U rhs)
+    template<typename U> Checked& operator-=(U rhs)
     {
         if (!safeSub<OverflowHandler>(m_value, rhs, m_value))
             this->overflowed();
         return *this;
     }
 
-    template <typename U> Checked& operator*=(U rhs)
+    template<typename U> Checked& operator*=(U rhs)
     {
         if (!safeMultiply<OverflowHandler>(m_value, rhs, m_value))
             this->overflowed();
         return *this;
     }
 
-    template <typename U> Checked& operator/=(U rhs)
+    template<typename U> Checked& operator/=(U rhs)
     {
         if (!safeDivide<OverflowHandler>(m_value, rhs, m_value))
             this->overflowed();
         return *this;
     }
 
-    template <typename U, typename V> Checked& operator+=(Checked<U, V> rhs)
+    template<typename U, typename V> Checked& operator+=(Checked<U, V> rhs)
     {
         if (rhs.hasOverflowed())
             this->overflowed();
         return *this += rhs.m_value;
     }
 
-    template <typename U, typename V> Checked& operator-=(Checked<U, V> rhs)
+    template<typename U, typename V> Checked& operator-=(Checked<U, V> rhs)
     {
         if (rhs.hasOverflowed())
             this->overflowed();
         return *this -= rhs.m_value;
     }
 
-    template <typename U, typename V> Checked& operator*=(Checked<U, V> rhs)
+    template<typename U, typename V> Checked& operator*=(Checked<U, V> rhs)
     {
         if (rhs.hasOverflowed())
             this->overflowed();
@@ -814,25 +819,25 @@ public:
     }
 
     // Equality comparisons
-    template <typename V> bool operator==(Checked<T, V> rhs)
+    template<typename V> bool operator==(Checked<T, V> rhs)
     {
         return value() == rhs.value();
     }
 
-    template <typename U> bool operator==(U rhs)
+    template<typename U> bool operator==(U rhs)
     {
         if (this->hasOverflowed())
             this->crash();
         return safeEquals(m_value, rhs);
     }
     
-    template <typename U, typename V> bool operator==(Checked<U, V> rhs)
+    template<typename U, typename V> bool operator==(Checked<U, V> rhs)
     {
         return value() == Checked(rhs.value());
     }
 
     // Other comparisons
-    template <typename V> std::strong_ordering operator<=>(Checked<T, V> rhs) const
+    template<typename V> std::strong_ordering operator<=>(Checked<T, V> rhs) const
     {
         return value() <=> rhs.value();
     }
@@ -850,7 +855,7 @@ private:
     T m_value;
 };
 
-template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator+(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
+template<typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator+(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
 {
     if (lhs.hasOverflowed() || rhs.hasOverflowed()) [[unlikely]]
         return ResultOverflowed;
@@ -860,7 +865,7 @@ template <typename U, typename V, typename OverflowHandler> static inline Checke
     return result;
 }
 
-template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator-(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
+template<typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator-(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
 {
     if (lhs.hasOverflowed() || rhs.hasOverflowed()) [[unlikely]]
         return ResultOverflowed;
@@ -870,7 +875,7 @@ template <typename U, typename V, typename OverflowHandler> static inline Checke
     return result;
 }
 
-template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator*(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
+template<typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator*(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
 {
     if (lhs.hasOverflowed() || rhs.hasOverflowed()) [[unlikely]]
         return ResultOverflowed;
@@ -880,7 +885,7 @@ template <typename U, typename V, typename OverflowHandler> static inline Checke
     return result;
 }
 
-template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator/(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
+template<typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator/(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
 {
     if (lhs.hasOverflowed() || rhs.hasOverflowed()) [[unlikely]]
         return ResultOverflowed;
@@ -890,42 +895,42 @@ template <typename U, typename V, typename OverflowHandler> static inline Checke
     return result;
 }
 
-template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator+(Checked<U, OverflowHandler> lhs, V rhs)
+template<typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator+(Checked<U, OverflowHandler> lhs, V rhs)
 {
     return lhs + Checked<V, OverflowHandler>(rhs);
 }
 
-template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator-(Checked<U, OverflowHandler> lhs, V rhs)
+template<typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator-(Checked<U, OverflowHandler> lhs, V rhs)
 {
     return lhs - Checked<V, OverflowHandler>(rhs);
 }
 
-template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator*(Checked<U, OverflowHandler> lhs, V rhs)
+template<typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator*(Checked<U, OverflowHandler> lhs, V rhs)
 {
     return lhs * Checked<V, OverflowHandler>(rhs);
 }
 
-template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator/(Checked<U, OverflowHandler> lhs, V rhs)
+template<typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator/(Checked<U, OverflowHandler> lhs, V rhs)
 {
     return lhs / Checked<V, OverflowHandler>(rhs);
 }
 
-template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator+(U lhs, Checked<V, OverflowHandler> rhs)
+template<typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator+(U lhs, Checked<V, OverflowHandler> rhs)
 {
     return Checked<U, OverflowHandler>(lhs) + rhs;
 }
 
-template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator-(U lhs, Checked<V, OverflowHandler> rhs)
+template<typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator-(U lhs, Checked<V, OverflowHandler> rhs)
 {
     return Checked<U, OverflowHandler>(lhs) - rhs;
 }
 
-template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator*(U lhs, Checked<V, OverflowHandler> rhs)
+template<typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator*(U lhs, Checked<V, OverflowHandler> rhs)
 {
     return Checked<U, OverflowHandler>(lhs) * rhs;
 }
 
-template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator/(U lhs, Checked<V, OverflowHandler> rhs)
+template<typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator/(U lhs, Checked<V, OverflowHandler> rhs)
 {
     return Checked<U, OverflowHandler>(lhs) / rhs;
 }

--- a/Source/WTF/wtf/CodePtr.h
+++ b/Source/WTF/wtf/CodePtr.h
@@ -202,7 +202,8 @@ public:
 
     // Disallow any casting operations (except for booleans). Instead, the client
     // should be asking taggedPtr() explicitly.
-    template<typename T, typename = std::enable_if_t<!std::is_same<T, bool>::value>>
+    template<typename T>
+        requires (!std::same_as<T, bool>)
     operator T() = delete;
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/WTF/wtf/CompactPointerTuple.h
+++ b/Source/WTF/wtf/CompactPointerTuple.h
@@ -77,7 +77,8 @@ public:
         ASSERT(this->pointer() == pointer);
     }
 
-    template<typename OtherPointerType, typename = std::enable_if<std::is_pointer<PointerType>::value && std::is_convertible<OtherPointerType, PointerType>::value>>
+    template<typename OtherPointerType>
+        requires (std::is_pointer_v<PointerType> && std::is_convertible_v<OtherPointerType, PointerType>)
     CompactPointerTuple(CompactPointerTuple<OtherPointerType, Type>&& other)
         : m_data { std::exchange(other.m_data, { }) }
     {
@@ -128,7 +129,8 @@ public:
     {
     }
 
-    template<typename OtherPointerType, typename = std::enable_if<std::is_pointer<PointerType>::value && std::is_convertible<OtherPointerType, PointerType>::value>>
+    template<typename OtherPointerType>
+        requires (std::is_pointer_v<PointerType> && std::is_convertible_v<OtherPointerType, PointerType>)
     CompactPointerTuple(CompactPointerTuple<OtherPointerType, Type>&& other)
         : m_pointer { std::exchange(other.m_pointer, { }) }
         , m_type { std::exchange(other.m_type, { }) }

--- a/Source/WTF/wtf/CompactPtr.h
+++ b/Source/WTF/wtf/CompactPtr.h
@@ -153,7 +153,8 @@ public:
 
     void swap(CompactPtr& other) { std::swap(m_ptr, other.m_ptr); }
 
-    template <typename Other, typename = std::enable_if_t<Other::isCompactedType>>
+    template<typename Other>
+        requires Other::isCompactedType
     void swap(Other& other)
     {
         T* t1 = get();

--- a/Source/WTF/wtf/CompactUniquePtrTuple.h
+++ b/Source/WTF/wtf/CompactUniquePtrTuple.h
@@ -54,7 +54,8 @@ class CompactUniquePtrTuple final {
 public:
     CompactUniquePtrTuple() = default;
 
-    template <typename U, typename UDeleter, typename = std::enable_if_t<std::is_same<UDeleter, Deleter>::value || std::is_same<UDeleter, std::default_delete<U>>::value>>
+    template<typename U, typename UDeleter>
+        requires (std::same_as<UDeleter, Deleter> || std::same_as<UDeleter, std::default_delete<U>>)
     CompactUniquePtrTuple(CompactUniquePtrTuple<U, Type, UDeleter>&& other)
         : m_data { std::exchange(other.m_data, { }) }
     {
@@ -65,7 +66,8 @@ public:
         setPointer(nullptr);
     }
 
-    template <typename U, typename UDeleter, typename = std::enable_if_t<std::is_same<UDeleter, Deleter>::value || std::is_same<UDeleter, std::default_delete<U>>::value>>
+    template<typename U, typename UDeleter>
+        requires (std::same_as<UDeleter, Deleter> || std::same_as<UDeleter, std::default_delete<U>>)
     CompactUniquePtrTuple<T, Type, Deleter>& operator=(CompactUniquePtrTuple<U, Type, UDeleter>&& other)
     {
         CompactUniquePtrTuple moved { WTFMove(other) };
@@ -88,7 +90,8 @@ public:
         m_data.setPointer(nullptr);
     }
 
-    template <typename U, typename UDeleter, typename = std::enable_if_t<std::is_same<UDeleter, Deleter>::value || std::is_same<UDeleter, std::default_delete<U>>::value>>
+    template<typename U, typename UDeleter>
+        requires (std::same_as<UDeleter, Deleter> || std::same_as<UDeleter, std::default_delete<U>>)
     void setPointer(std::unique_ptr<U, UDeleter>&& pointer)
     {
         deletePointer();
@@ -117,7 +120,7 @@ private:
     template<typename U, typename E, typename... Args> friend CompactUniquePtrTuple<U, E> makeCompactUniquePtr(Args&&... args);
     template<typename U, typename E, typename D, typename... Args> friend CompactUniquePtrTuple<U, E, D> makeCompactUniquePtr(Args&&... args);
 
-    template <typename, typename, typename> friend class CompactUniquePtrTuple;
+    template<typename, typename, typename> friend class CompactUniquePtrTuple;
 
     CompactPointerTuple<T*, Type> m_data;
 };

--- a/Source/WTF/wtf/CompletionHandler.h
+++ b/Source/WTF/wtf/CompletionHandler.h
@@ -52,7 +52,8 @@ public:
 
     CompletionHandler() = default;
 
-    template<typename CallableType, class = typename std::enable_if<std::is_rvalue_reference<CallableType&&>::value>::type>
+    template<typename CallableType>
+        requires (std::is_rvalue_reference_v<CallableType&&>)
     CompletionHandler(CallableType&& callable, ThreadLikeAssertion callThread = CompletionHandlerCallThread::ConstructionThread)
         : m_function(std::forward<CallableType>(callable))
         , m_callThread(WTFMove(callThread))
@@ -109,7 +110,8 @@ public:
     using OutType = Out;
     using InTypes = std::tuple<In...>;
 
-    template<typename CallableType, class = typename std::enable_if<std::is_rvalue_reference<CallableType&&>::value>::type>
+    template<typename CallableType>
+        requires (std::is_rvalue_reference_v<CallableType&&>)
     CompletionHandlerWithFinalizer(CallableType&& callable, Function<void(Function<Out(In...)>&)>&& finalizer, ThreadLikeAssertion callThread = CompletionHandlerCallThread::ConstructionThread)
         : m_function(std::forward<CallableType>(callable))
         , m_finalizer(WTFMove(finalizer))

--- a/Source/WTF/wtf/EnumClassOperatorOverloads.h
+++ b/Source/WTF/wtf/EnumClassOperatorOverloads.h
@@ -28,14 +28,14 @@
 #include <type_traits>
 
 #define OVERLOAD_OPERATOR_FOR_ENUM_CLASS_WHEN(enumName, op, enableExpression) \
-    template<typename T> \
-    constexpr auto operator op(enumName enumEntry, T value) -> std::enable_if_t<(enableExpression), T> \
+    template<typename T> requires (enableExpression) \
+    constexpr auto operator op(enumName enumEntry, T value) -> T \
     { \
         return static_cast<T>(enumEntry) op value; \
     } \
     \
-    template<typename T> \
-    constexpr auto operator op(T value, enumName enumEntry) -> std::enable_if_t<(enableExpression), T> \
+    template<typename T> requires (enableExpression) \
+    constexpr auto operator op(T value, enumName enumEntry) -> T \
     { \
         return value op static_cast<T>(enumEntry); \
     } \

--- a/Source/WTF/wtf/EnumTraits.h
+++ b/Source/WTF/wtf/EnumTraits.h
@@ -102,13 +102,15 @@ struct EnumValueChecker<T, EnumValues<E>> {
 
 template<typename E> bool isValidEnum(std::underlying_type_t<E>);
 
-template<typename E, typename = std::enable_if_t<!std::is_same_v<std::underlying_type_t<E>, bool>>>
+template<typename E>
+    requires (!std::same_as<std::underlying_type_t<E>, bool>)
 bool isValidEnumForPersistence(std::underlying_type_t<E> t)
 {
     return EnumValueChecker<std::underlying_type_t<E>, typename EnumTraitsForPersistence<E>::values>::isValidEnumForPersistence(t);
 }
 
-template<typename E, typename = std::enable_if_t<std::is_same_v<std::underlying_type_t<E>, bool>>>
+template<typename E>
+    requires (std::same_as<std::underlying_type_t<E>, bool>)
 constexpr bool isValidEnumForPersistence(bool t)
 {
     return !t || t == 1;
@@ -140,7 +142,8 @@ struct ZeroBasedContiguousEnumChecker<T, EnumValues<E>> {
     }
 };
 
-template<typename E, typename = std::enable_if_t<!std::is_same_v<std::underlying_type_t<E>, bool>>>
+template<typename E>
+    requires (!std::is_same_v<std::underlying_type_t<E>, bool>)
 constexpr bool isZeroBasedContiguousEnum()
 {
     return ZeroBasedContiguousEnumChecker<std::underlying_type_t<E>, typename EnumTraits<E>::values>::isZeroBasedContiguousEnum();

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -414,19 +414,17 @@ public: \
 using __thisIsAlsoHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
 
 template<typename T>
-inline constexpr std::enable_if_t<WTF::IsTypeComplete<std::remove_pointer_t<T>>, bool> allowCompactPointers()
+inline constexpr bool allowCompactPointers()
 {
-    return std::remove_pointer_t<T>::allowCompactPointers;
-}
-
-template<typename T>
-inline constexpr std::enable_if_t<!WTF::IsTypeComplete<std::remove_pointer_t<T>>, bool> allowCompactPointers()
-{
-    // We want to support compact pointers to incomplete types too, so we have this fallback:
-    // if a type is incomplete, AllowCompactPointers can be specialized on its pointer type,
-    // in which case we'll return its value. This is mostly accomplished using the below
-    // WTF_ALLOW_COMPACT_POINTERS_TO_INCOMPLETE_TYPE macro.
-    return AllowCompactPointers<std::remove_const_t<std::remove_pointer_t<T>>*>::value;
+    if constexpr (WTF::IsTypeComplete<std::remove_pointer_t<T>>)
+        return std::remove_pointer_t<T>::allowCompactPointers;
+    else {
+        // We want to support compact pointers to incomplete types too, so we have this fallback:
+        // if a type is incomplete, AllowCompactPointers can be specialized on its pointer type,
+        // in which case we'll return its value. This is mostly accomplished using the below
+        // WTF_ALLOW_COMPACT_POINTERS_TO_INCOMPLETE_TYPE macro.
+        return AllowCompactPointers<std::remove_const_t<std::remove_pointer_t<T>>*>::value;
+    }
 }
 
 using WTF::FastAlignedMalloc;

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -146,7 +146,7 @@ template<typename> class RetainPtr;
 template<typename> class ScopedLambda;
 template<typename> class StringBuffer;
 template<typename> class StringParsingBuffer;
-template<typename, typename = void> class StringTypeAdapter;
+template<typename> class StringTypeAdapter;
 template<typename> class UniqueRef;
 template<typename T, class... Args> UniqueRef<T> makeUniqueRef(Args&&...);
 template<typename, size_t = 0> class VariantList;

--- a/Source/WTF/wtf/Function.h
+++ b/Source/WTF/wtf/Function.h
@@ -74,11 +74,13 @@ public:
     Function() = default;
     Function(std::nullptr_t) { }
 
-    template<typename CallableType, class = typename std::enable_if<!(std::is_pointer<CallableType>::value && std::is_function<typename std::remove_pointer<CallableType>::type>::value) && std::is_rvalue_reference<CallableType&&>::value>::type>
+    template<typename CallableType>
+        requires (!(std::is_pointer_v<CallableType> && std::is_function_v<typename std::remove_pointer_t<CallableType>>) && std::is_rvalue_reference_v<CallableType&&>)
     Function(CallableType&& callable)
         : m_callableWrapper(makeUnique<Detail::CallableWrapper<CallableType, Out, In...>>(std::forward<CallableType>(callable))) { }
 
-    template<typename FunctionType, class = typename std::enable_if<std::is_pointer<FunctionType>::value && std::is_function<typename std::remove_pointer<FunctionType>::type>::value>::type>
+    template<typename FunctionType>
+        requires (std::is_pointer_v<FunctionType> && std::is_function_v<typename std::remove_pointer_t<FunctionType>>)
     Function(FunctionType f)
         : m_callableWrapper(makeUnique<Detail::CallableWrapper<FunctionType, Out, In...>>(std::forward<FunctionType>(f))) { }
 
@@ -103,14 +105,16 @@ public:
 
     explicit operator bool() const { return !!m_callableWrapper; }
 
-    template<typename CallableType, class = typename std::enable_if<!(std::is_pointer<CallableType>::value && std::is_function<typename std::remove_pointer<CallableType>::type>::value) && std::is_rvalue_reference<CallableType&&>::value>::type>
+    template<typename CallableType>
+        requires (!(std::is_pointer_v<CallableType> && std::is_function_v<typename std::remove_pointer_t<CallableType>>) && std::is_rvalue_reference_v<CallableType&&>)
     Function& operator=(CallableType&& callable)
     {
         m_callableWrapper = makeUnique<Detail::CallableWrapper<CallableType, Out, In...>>(std::forward<CallableType>(callable));
         return *this;
     }
 
-    template<typename FunctionType, class = typename std::enable_if<std::is_pointer<FunctionType>::value && std::is_function<typename std::remove_pointer<FunctionType>::type>::value>::type>
+    template<typename FunctionType>
+        requires (std::is_pointer_v<FunctionType> && std::is_function_v<typename std::remove_pointer_t<FunctionType>>)
     Function& operator=(FunctionType f)
     {
         m_callableWrapper = makeUnique<Detail::CallableWrapper<FunctionType, Out, In...>>(std::forward<FunctionType>(f));

--- a/Source/WTF/wtf/FunctionTraits.h
+++ b/Source/WTF/wtf/FunctionTraits.h
@@ -51,7 +51,8 @@ template<typename T>
 static constexpr unsigned computeCCallSlots() { return slotsForCCallArgument<T>(); }
 
 template<typename T, typename... Ts>
-static constexpr std::enable_if_t<!!sizeof...(Ts), unsigned> computeCCallSlots() { return computeCCallSlots<Ts...>() + slotsForCCallArgument<T>(); }
+    requires (sizeof...(Ts) > 0)
+static constexpr unsigned computeCCallSlots() { return computeCCallSlots<Ts...>() + slotsForCCallArgument<T>(); }
 
 #endif
 
@@ -63,7 +64,8 @@ struct FunctionTraits<Result(Args...)> {
 
     static constexpr std::size_t arity = sizeof...(Args);
 
-    template <std::size_t n, typename = std::enable_if_t<(n < arity)>>
+    template<std::size_t n>
+        requires (n < arity)
     using ArgumentType = typename std::tuple_element<n, std::tuple<Args...>>::type;
     using ArgumentTypes = std::tuple<Args...>;
 

--- a/Source/WTF/wtf/HashFunctions.h
+++ b/Source/WTF/wtf/HashFunctions.h
@@ -173,28 +173,32 @@ namespace WTF {
     template<typename... Types>
     struct TupleHash {
         template<size_t I = 0>
-        static typename std::enable_if<I < sizeof...(Types) - 1, unsigned>::type hash(const std::tuple<Types...>& t)
+            requires (I < sizeof...(Types) - 1)
+        static unsigned hash(const std::tuple<Types...>& t)
         {
             using IthTupleElementType = typename std::tuple_element<I, typename std::tuple<Types...>>::type;
             return pairIntHash(DefaultHash<IthTupleElementType>::hash(std::get<I>(t)), hash<I + 1>(t));
         }
 
         template<size_t I = 0>
-        static typename std::enable_if<I == sizeof...(Types) - 1, unsigned>::type hash(const std::tuple<Types...>& t)
+            requires (I == sizeof...(Types) - 1)
+        static unsigned hash(const std::tuple<Types...>& t)
         {
             using IthTupleElementType = typename std::tuple_element<I, typename std::tuple<Types...>>::type;
             return DefaultHash<IthTupleElementType>::hash(std::get<I>(t));
         }
 
         template<size_t I = 0>
-        static typename std::enable_if<I < sizeof...(Types) - 1, bool>::type equal(const std::tuple<Types...>& a, const std::tuple<Types...>& b)
+            requires (I < sizeof...(Types) - 1)
+        static bool equal(const std::tuple<Types...>& a, const std::tuple<Types...>& b)
         {
             using IthTupleElementType = typename std::tuple_element<I, typename std::tuple<Types...>>::type;
             return DefaultHash<IthTupleElementType>::equal(std::get<I>(a), std::get<I>(b)) && equal<I + 1>(a, b);
         }
 
         template<size_t I = 0>
-        static typename std::enable_if<I == sizeof...(Types) - 1, bool>::type equal(const std::tuple<Types...>& a, const std::tuple<Types...>& b)
+            requires (I == sizeof...(Types) - 1)
+        static bool equal(const std::tuple<Types...>& a, const std::tuple<Types...>& b)
         {
             using IthTupleElementType = typename std::tuple_element<I, typename std::tuple<Types...>>::type;
             return DefaultHash<IthTupleElementType>::equal(std::get<I>(a), std::get<I>(b));

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -201,16 +201,16 @@ public:
     bool isSubset(const OtherCollection&);
 
     // Overloads for smart pointer values that take the raw pointer type as the parameter.
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, TakeType>::type take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
+    template<SmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<SmartPtr V = ValueType> bool contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<SmartPtr V = ValueType> bool remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
+    template<SmartPtr V = ValueType> TakeType take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
 
     // Overloads for non-nullable smart pointer values that take the raw reference type as the parameter.
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, TakeType>::type take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
+    template<NonNullableSmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<NonNullableSmartPtr V = ValueType> bool contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<NonNullableSmartPtr V = ValueType> bool remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
+    template<NonNullableSmartPtr V = ValueType> TakeType take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
 
     static bool isValidValue(const ValueType&);
 
@@ -508,57 +508,57 @@ inline bool HashSet<T, U, V, W, shouldValidateKey>::isSubset(const OtherCollecti
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
-template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type
+template<SmartPtr V>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> iterator
 {
     return m_impl.template find<HashSetTranslator<Traits, HashFunctions>, shouldValidateKey>(value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
-template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
+template<SmartPtr V>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> bool
 {
     return m_impl.template contains<HashSetTranslator<Traits, HashFunctions>, shouldValidateKey>(value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
-template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
+template<SmartPtr V>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> bool
 {
     return remove(find(value));
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
-template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, TakeType>::type
+template<SmartPtr V>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> TakeType
 {
     return take(find(value));
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
-template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, iterator>::type
+template<NonNullableSmartPtr V>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> iterator
 {
     return find(&value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
-template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
+template<NonNullableSmartPtr V>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> bool
 {
     return contains(&value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
-template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
+template<NonNullableSmartPtr V>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> bool
 {
     return remove(&value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
-template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, TakeType>::type
+template<NonNullableSmartPtr V>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> TakeType
 {
     return take(&value);
 }

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -421,45 +421,51 @@ private:
     }
 
 public:
-
-    template <typename V = T>
-    std::enable_if_t<std::is_same_v<bool, V> || std::is_same_v<Value, V>> addItem(bool value)
+    template<typename V = T>
+        requires (std::same_as<bool, V> || std::same_as<Value, V>)
+    void addItem(bool value)
     {
         castedArray().pushBoolean(value);
     }
 
-    template <typename V = T>
-    std::enable_if_t<std::is_same_v<int, V> || std::is_same_v<Value, V>> addItem(int value)
+    template<typename V = T>
+        requires (std::same_as<int, V> || std::same_as<Value, V>)
+    void addItem(int value)
     {
         castedArray().pushInteger(value);
     }
 
-    template <typename V = T>
-    std::enable_if_t<std::is_same_v<double, V> || std::is_same_v<Value, V>> addItem(double value)
+    template<typename V = T>
+        requires (std::same_as<double, V> || std::same_as<Value, V>)
+    void addItem(double value)
     {
         castedArray().pushDouble(value);
     }
 
-    template <typename V = T>
-    std::enable_if_t<std::is_same_v<String, V> || std::is_same_v<Value, V>> addItem(const String& value)
+    template<typename V = T>
+        requires (std::same_as<String, V> || std::same_as<Value, V>)
+    void addItem(const String& value)
     {
         castedArray().pushString(value);
     }
 
-    template <typename V = T>
-    std::enable_if_t<std::is_base_of_v<Value, V> && !std::is_base_of_v<ObjectBase, V> && !std::is_base_of_v<ArrayBase, V>> addItem(Ref<Value>&& value)
+    template<typename V = T>
+        requires (std::is_base_of_v<Value, V> && !std::is_base_of_v<ObjectBase, V> && !std::is_base_of_v<ArrayBase, V>)
+    void addItem(Ref<Value>&& value)
     {
         castedArray().pushValue(WTFMove(value));
     }
 
-    template <typename V = T>
-    std::enable_if_t<std::is_base_of_v<ObjectBase, V>> addItem(Ref<ObjectBase>&& value)
+    template<typename V = T>
+        requires (std::is_base_of_v<ObjectBase, V>)
+    void addItem(Ref<ObjectBase>&& value)
     {
         castedArray().pushObject(WTFMove(value));
     }
 
-    template <typename V = T>
-    std::enable_if_t<std::is_base_of_v<ArrayBase, V>> addItem(Ref<ArrayBase>&& value)
+    template<typename V = T>
+        requires (std::is_base_of_v<ArrayBase, V>)
+    void addItem(Ref<ArrayBase>&& value)
     {
         castedArray().pushArray(WTFMove(value));
     }

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -164,20 +164,20 @@ public:
     void clear();
 
     // Overloads for smart pointer values that take the raw pointer type as the parameter.
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, const_iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, AddResult>::type insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*, const ValueType&);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, AddResult>::type insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*, ValueType&&);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
+    template<SmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
+    template<SmartPtr V = ValueType> const_iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<SmartPtr V = ValueType> bool contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<SmartPtr V = ValueType> AddResult insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*, const ValueType&);
+    template<SmartPtr V = ValueType> AddResult insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*, ValueType&&);
+    template<SmartPtr V = ValueType> bool remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
 
     // Overloads for non-nullable smart pointer values that take the raw reference type as the parameter.
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, const_iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, AddResult>::type insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&, const ValueType&);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, AddResult>::type insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&, ValueType&&);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
+    template<NonNullableSmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
+    template<NonNullableSmartPtr V = ValueType> const_iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<NonNullableSmartPtr V = ValueType> bool contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<NonNullableSmartPtr V = ValueType> AddResult insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&, const ValueType&);
+    template<NonNullableSmartPtr V = ValueType> AddResult insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&, ValueType&&);
+    template<NonNullableSmartPtr V = ValueType> bool remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
 
 private:
     void unlink(Node*);
@@ -708,8 +708,8 @@ inline void ListHashSet<T, U>::clear()
 }
 
 template<typename T, typename U>
-template<typename V>
-inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type
+template<SmartPtr V>
+inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> iterator
 {
     auto it = m_impl.template find<BaseTranslator, ShouldValidateKey::Yes>(value);
     if (it == m_impl.end())
@@ -718,8 +718,8 @@ inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::U
 }
 
 template<typename T, typename U>
-template<typename V>
-inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, const_iterator>::type
+template<SmartPtr V>
+inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> const_iterator
 {
     auto it = m_impl.template find<BaseTranslator, ShouldValidateKey::Yes>(value);
     if (it == m_impl.end())
@@ -728,71 +728,71 @@ inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::U
 }
 
 template<typename T, typename U>
-template<typename V>
-inline auto ListHashSet<T, U>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
+template<SmartPtr V>
+inline auto ListHashSet<T, U>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> bool
 {
     return m_impl.template contains<BaseTranslator, ShouldValidateKey::Yes>(value);
 }
 
 template<typename T, typename U>
-template<typename V>
-inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* beforeValue, const ValueType& newValue) -> typename std::enable_if<IsSmartPtr<V>::value, AddResult>::type
+template<SmartPtr V>
+inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* beforeValue, const ValueType& newValue) -> AddResult
 {
     return insertBefore(find(beforeValue), newValue);
 }
 
 template<typename T, typename U>
-template<typename V>
-inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* beforeValue, ValueType&& newValue) -> typename std::enable_if<IsSmartPtr<V>::value, AddResult>::type
+template<SmartPtr V>
+inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* beforeValue, ValueType&& newValue) -> AddResult
 {
     return insertBefore(find(beforeValue), WTFMove(newValue));
 }
 
 template<typename T, typename U>
-template<typename V>
-inline auto ListHashSet<T, U>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
+template<SmartPtr V>
+inline auto ListHashSet<T, U>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> bool
 {
     return remove(find(value));
 }
 
 template<typename T, typename U>
-template<typename V>
-inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, iterator>::type
+template<NonNullableSmartPtr V>
+inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> iterator
 {
     return find(&value);
 }
 
 template<typename T, typename U>
-template<typename V>
-inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, const_iterator>::type
+template<NonNullableSmartPtr V>
+inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> const_iterator
 {
     return find(&value);
 }
 
 template<typename T, typename U>
-template<typename V>
-inline auto ListHashSet<T, U>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
+template<NonNullableSmartPtr V>
+inline auto ListHashSet<T, U>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> bool
 {
     return contains(&value);
 }
 
 template<typename T, typename U>
-template<typename V>
-inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& beforeValue, const ValueType& newValue) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, AddResult>::type
+template<NonNullableSmartPtr V>
+inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& beforeValue, const ValueType& newValue) -> AddResult
 {
     return insertBefore(&beforeValue, newValue);
 }
 
 template<typename T, typename U>
-template<typename V>
-inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& beforeValue, ValueType&& newValue) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, AddResult>::type
+template<NonNullableSmartPtr V>
+inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& beforeValue, ValueType&& newValue) -> AddResult
 {
     return insertBefore(&beforeValue, WTFMove(newValue));
 }
 
 template<typename T, typename U>
-template<typename V>
-inline auto ListHashSet<T, U>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
+template<NonNullableSmartPtr V>
+inline auto ListHashSet<T, U>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> bool
 {
     return remove(&value);
 }

--- a/Source/WTF/wtf/Lock.h
+++ b/Source/WTF/wtf/Lock.h
@@ -192,12 +192,13 @@ inline void assertIsHeld(const UnfairLock& lock) WTF_ASSERTS_ACQUIRED_LOCK(lock)
 // Locker specialization to use with Lock and UnfairLock that integrates with thread safety analysis.
 // Non-movable simple scoped lock holder.
 // Example: Locker locker { m_lock };
-template <typename T>
+template<typename T>
 #if ENABLE(UNFAIR_LOCK)
-class WTF_CAPABILITY_SCOPED_LOCK Locker<T, std::enable_if_t<std::is_same_v<T, Lock> || std::is_same_v<T, UnfairLock>>> : public AbstractLocker {
+    requires (std::same_as<T, Lock> || std::same_as<T, UnfairLock>)
 #else
-class WTF_CAPABILITY_SCOPED_LOCK Locker<T, std::enable_if_t<std::is_same_v<T, Lock>>> : public AbstractLocker {
+    requires (std::same_as<T, Lock>)
 #endif
+class WTF_CAPABILITY_SCOPED_LOCK Locker<T> : public AbstractLocker {
 public:
     explicit Locker(T& lock) WTF_ACQUIRES_LOCK(lock)
         : m_lock(lock)

--- a/Source/WTF/wtf/Locker.h
+++ b/Source/WTF/wtf/Locker.h
@@ -64,7 +64,7 @@ template<typename T> class DropLockForScope;
 using AdoptLockTag = std::adopt_lock_t;
 constexpr AdoptLockTag AdoptLock;
 
-template<typename T, typename = void>
+template<typename T>
 class [[nodiscard]] Locker : public AbstractLocker { // NOLINT
 public:
     explicit Locker(T& lockable) : m_lockable(&lockable) { lock(); }

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -44,29 +44,29 @@ namespace WTF {
 
 template<typename T>
 struct LogArgument {
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, bool>, String> toString(bool argument) { return argument ? "true"_s : "false"_s; }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, int>, String> toString(int argument) { return String::number(argument); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, unsigned>, String> toString(unsigned argument) { return String::number(argument); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, unsigned long>, String> toString(unsigned long argument) { return String::number(argument); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, long>, String> toString(long argument) { return String::number(argument); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, unsigned long long>, String> toString(unsigned long long argument) { return String::number(argument); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, long long>, String> toString(long long argument) { return String::number(argument); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, unsigned short>, String> toString(unsigned short argument) { return String::number(argument); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, short>, String> toString(short argument) { return String::number(argument); }
-    template<typename U = T> static std::enable_if_t<std::is_enum_v<U>, String> toString(U argument) { return String::number(static_cast<typename std::underlying_type<U>::type>(argument)); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, float>, String> toString(float argument) { return String::number(argument); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, double>, String> toString(double argument) { return String::number(argument); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<typename std::remove_reference_t<U>, AtomString>, String> toString(const AtomString& argument) { return argument.string(); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<typename std::remove_reference_t<U>, String>, String> toString(String argument) { return argument; }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<typename std::remove_reference_t<U>, StringBuilder*>, String> toString(StringBuilder* argument) { return argument->toString(); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<typename std::remove_reference_t<U>, StringView>, String> toString(const StringView& argument) { return argument.toString(); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, const char*>, String> toString(const char* argument) { return String::fromLatin1(argument); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, ASCIILiteral>, String> toString(ASCIILiteral argument) { return argument; }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, std::span<const char8_t>>, String> toString(std::span<const char8_t> argument) { return argument; }
+    template<typename U = T> requires (std::same_as<U, bool>) static String toString(bool argument) { return argument ? "true"_s : "false"_s; }
+    template<typename U = T> requires (std::same_as<U, int>) static String toString(int argument) { return String::number(argument); }
+    template<typename U = T> requires (std::same_as<U, unsigned>) static String toString(unsigned argument) { return String::number(argument); }
+    template<typename U = T> requires (std::same_as<U, unsigned long>) static String toString(unsigned long argument) { return String::number(argument); }
+    template<typename U = T> requires (std::same_as<U, long>) static String toString(long argument) { return String::number(argument); }
+    template<typename U = T> requires (std::same_as<U, unsigned long long>) static String toString(unsigned long long argument) { return String::number(argument); }
+    template<typename U = T> requires (std::same_as<U, long long>) static String toString(long long argument) { return String::number(argument); }
+    template<typename U = T> requires (std::same_as<U, unsigned short>) static String toString(unsigned short argument) { return String::number(argument); }
+    template<typename U = T> requires (std::same_as<U, short>) static String toString(short argument) { return String::number(argument); }
+    template<typename U = T> requires (std::is_enum_v<U>) static String toString(U argument) { return String::number(static_cast<typename std::underlying_type<U>::type>(argument)); }
+    template<typename U = T> requires (std::same_as<U, float>) static String toString(float argument) { return String::number(argument); }
+    template<typename U = T> requires (std::same_as<U, double>) static String toString(double argument) { return String::number(argument); }
+    template<typename U = T> requires (std::same_as<typename std::remove_reference_t<U>, AtomString>) static String toString(const AtomString& argument) { return argument.string(); }
+    template<typename U = T> requires (std::same_as<typename std::remove_reference_t<U>, String>) static String toString(String argument) { return argument; }
+    template<typename U = T> requires (std::same_as<typename std::remove_reference_t<U>, StringBuilder*>) static String toString(StringBuilder* argument) { return argument->toString(); }
+    template<typename U = T> requires (std::same_as<typename std::remove_reference_t<U>, StringView>) static String toString(const StringView& argument) { return argument.toString(); }
+    template<typename U = T> requires (std::same_as<U, const char*>) static String toString(const char* argument) { return String::fromLatin1(argument); }
+    template<typename U = T> requires (std::same_as<U, ASCIILiteral>) static String toString(ASCIILiteral argument) { return argument; }
+    template<typename U = T> requires (std::same_as<U, std::span<const char8_t>>) static String toString(std::span<const char8_t> argument) { return argument; }
 #ifdef __OBJC__
-    template<typename U = T> static std::enable_if_t<std::is_base_of_v<NSError, std::remove_pointer_t<U>>, String> toString(NSError *argument) { return String(argument.localizedDescription); }
-    template<typename U = T> static std::enable_if_t<std::is_base_of_v<NSObject, std::remove_pointer_t<U>>, String> toString(NSObject *argument) { return String(argument.description); }
-    template<typename U = T> static std::enable_if_t<std::is_base_of_v<NSProxy, std::remove_pointer_t<U>>, String> toString(NSProxy *argument) { return String(argument.description); }
+    template<typename U = T> requires (std::is_base_of_v<NSError, std::remove_pointer_t<U>>) static String toString(NSError *argument) { return String(argument.localizedDescription); }
+    template<typename U = T> requires (std::is_base_of_v<NSObject, std::remove_pointer_t<U>>) static String toString(NSObject *argument) { return String(argument.description); }
+    template<typename U = T> requires (std::is_base_of_v<NSProxy, std::remove_pointer_t<U>>) static String toString(NSProxy *argument) { return String(argument.description); }
 #endif
     template<size_t length> static String toString(const char (&argument)[length]) { return String::fromLatin1(argument); }
 };

--- a/Source/WTF/wtf/Packed.h
+++ b/Source/WTF/wtf/Packed.h
@@ -84,7 +84,8 @@ public:
         m_storage.swap(other.m_storage);
     }
 
-    template<typename Other, typename = std::enable_if_t<Other::isPackedType>>
+    template<typename Other>
+        requires Other::isPackedType
     void swap(Other& other)
     {
         T t1 = get();
@@ -188,8 +189,9 @@ public:
 
     T* operator->() const { return get(); }
 
-    template <typename U = T>
-    typename std::enable_if<!std::is_void_v<U>, U&>::type operator*() const { return *get(); }
+    template<typename U = T>
+        requires (!std::is_void_v<U>)
+    U& operator*() const { return *get(); }
 
     bool operator!() const { return !get(); }
 
@@ -219,7 +221,8 @@ public:
         m_storage.swap(other.m_storage);
     }
 
-    template<typename Other, typename = std::enable_if_t<Other::isPackedType>>
+    template<typename Other>
+        requires Other::isPackedType
     void swap(Other& other)
     {
         T* t1 = get();

--- a/Source/WTF/wtf/PointerPreparations.h
+++ b/Source/WTF/wtf/PointerPreparations.h
@@ -35,16 +35,19 @@ namespace WTF {
 
 #if COMPILER_HAS_CLANG_BUILTIN(__builtin_get_vtable_pointer)
 
-template<typename T, typename = std::enable_if_t<std::is_polymorphic_v<T>>>
+template<typename T>
+    requires (std::is_polymorphic_v<T>)
 ALWAYS_INLINE const void* getVTablePointer(const T* o) { return __builtin_get_vtable_pointer(o); }
 
 #else // not COMPILER_HAS_CLANG_BUILTIN(__builtin_get_vtable_pointer)
 
 #if CPU(ARM64E)
-template<typename T, typename = std::enable_if_t<std::is_polymorphic_v<T>>>
+template<typename T>
+    requires (std::is_polymorphic_v<T>)
 ALWAYS_INLINE const void* getVTablePointer(const T* o) { return __builtin_ptrauth_auth(*(reinterpret_cast<const void* const*>(o)), ptrauth_key_cxx_vtable_pointer, 0); }
 #else // not CPU(ARM64E)
-template<typename T, typename = std::enable_if_t<std::is_polymorphic_v<T>>>
+template<typename T>
+    requires (std::is_polymorphic_v<T>)
 ALWAYS_INLINE const void* getVTablePointer(const T* o) { return (*(reinterpret_cast<const void* const*>(o))); }
 #endif // not CPU(ARM64E)
 

--- a/Source/WTF/wtf/PtrTag.h
+++ b/Source/WTF/wtf/PtrTag.h
@@ -209,7 +209,8 @@ enum class PtrTagAction {
 
 constexpr PtrTag AnyPtrTag = static_cast<PtrTag>(-1); // Only used for assertion messages.
 
-template<typename T, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value && !std::is_same<T, PtrType>::value>>
+template<typename T, typename PtrType>
+    requires (std::is_pointer_v<PtrType> && !std::same_as<T, PtrType>)
 inline constexpr T removeCodePtrTag(PtrType ptr)
 {
 #if CPU(ARM64E)
@@ -219,7 +220,8 @@ inline constexpr T removeCodePtrTag(PtrType ptr)
 #endif
 }
 
-template<typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
+template<typename PtrType>
+    requires (std::is_pointer_v<PtrType>)
 inline constexpr PtrType removeCodePtrTag(PtrType ptr)
 {
 #if CPU(ARM64E)
@@ -238,13 +240,15 @@ inline PtrType tagCodePtrImpl(PtrType ptr)
     return PtrTagTraits<tag>::tagCodePtr(ptr);
 }
 
-template<typename T, PtrTag tag, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
+template<typename T, PtrTag tag, typename PtrType>
+    requires (std::is_pointer_v<PtrType>)
 inline T tagCodePtr(PtrType ptr)
 {
     return std::bit_cast<T>(tagCodePtrImpl<PtrTagAction::DebugAssert, tag>(ptr));
 }
 
-template<PtrTag tag, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
+template<PtrTag tag, typename PtrType>
+    requires (std::is_pointer_v<PtrType>)
 inline PtrType tagCodePtr(PtrType ptr) { return tagCodePtrImpl<PtrTagAction::DebugAssert, tag>(ptr); }
 
 template<PtrTagAction tagAction, PtrTag tag, typename PtrType>
@@ -257,13 +261,15 @@ inline PtrType untagCodePtrImpl(PtrType ptr)
     return result;
 }
 
-template<typename T, PtrTag tag, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
+template<typename T, PtrTag tag, typename PtrType>
+    requires (std::is_pointer_v<PtrType>)
 inline T untagCodePtr(PtrType ptr)
 {
     return std::bit_cast<T>(untagCodePtrImpl<PtrTagAction::DebugAssert, tag>(ptr));
 }
 
-template<PtrTag tag, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
+template<PtrTag tag, typename PtrType>
+    requires (std::is_pointer_v<PtrType>)
 inline PtrType untagCodePtr(PtrType ptr) { return untagCodePtrImpl<PtrTagAction::DebugAssert, tag>(ptr); }
 
 template<PtrTagAction tagAction, PtrTag oldTag, PtrTag newTag, typename PtrType>
@@ -299,13 +305,15 @@ inline PtrType retagCodePtrImpl(PtrType ptr)
     return result;
 }
 
-template<typename T, PtrTag oldTag, PtrTag newTag, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
+template<typename T, PtrTag oldTag, PtrTag newTag, typename PtrType>
+    requires (std::is_pointer_v<PtrType>)
 inline T retagCodePtr(PtrType ptr)
 {
     return std::bit_cast<T>(retagCodePtrImpl<PtrTagAction::DebugAssert, oldTag, newTag>(ptr));
 }
 
-template<PtrTag oldTag, PtrTag newTag, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
+template<PtrTag oldTag, PtrTag newTag, typename PtrType>
+    requires (std::is_pointer_v<PtrType>)
 inline PtrType retagCodePtr(PtrType ptr) { return retagCodePtrImpl<PtrTagAction::DebugAssert, oldTag, newTag>(ptr); }
 
 template<typename PtrType>
@@ -372,22 +380,26 @@ inline PtrType tagCFunctionPtrImpl(PtrType ptr)
     return retagCodePtrImpl<tagAction, CFunctionPtrTag, tag>(ptr);
 }
 
-template<typename T, PtrTag tag, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
+template<typename T, PtrTag tag, typename PtrType>
+    requires (std::is_pointer_v<PtrType>)
 inline T tagCFunctionPtr(PtrType ptr)
 {
     return std::bit_cast<T>(tagCFunctionPtrImpl<PtrTagAction::DebugAssert, tag>(ptr));
 }
 
-template<PtrTag tag, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
+template<PtrTag tag, typename PtrType>
+    requires (std::is_pointer_v<PtrType>)
 inline PtrType tagCFunctionPtr(PtrType ptr) { return tagCFunctionPtrImpl<PtrTagAction::DebugAssert, tag>(ptr); }
 
-template<PtrTag newTag, typename FunctionType, class = typename std::enable_if<std::is_pointer<FunctionType>::value && std::is_function<typename std::remove_pointer<FunctionType>::type>::value>::type>
+template<PtrTag newTag, typename FunctionType>
+    requires (std::is_pointer_v<FunctionType> && std::is_function_v<typename std::remove_pointer_t<FunctionType>>)
 inline FunctionType tagCFunction(FunctionType func)
 {
     return tagCFunctionPtrImpl<PtrTagAction::DebugAssert, newTag>(func);
 }
 
-template<typename ReturnType, PtrTag newTag, typename FunctionType, class = typename std::enable_if<std::is_pointer<FunctionType>::value && std::is_function<typename std::remove_pointer<FunctionType>::type>::value>::type>
+template<typename ReturnType, PtrTag newTag, typename FunctionType>
+    requires (std::is_pointer_v<FunctionType> && std::is_function_v<typename std::remove_pointer_t<FunctionType>>)
 inline ReturnType tagCFunction(FunctionType func)
 {
     return std::bit_cast<ReturnType>(tagCFunction<newTag>(func));
@@ -402,19 +414,22 @@ inline PtrType untagCFunctionPtrImpl(PtrType ptr)
     return retagCodePtrImpl<tagAction, tag, CFunctionPtrTag>(ptr);
 }
 
-template<typename T, PtrTag tag, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
+template<typename T, PtrTag tag, typename PtrType>
+    requires (std::is_pointer_v<PtrType>)
 inline T untagCFunctionPtr(PtrType ptr)
 {
     return std::bit_cast<T>(untagCFunctionPtrImpl<PtrTagAction::DebugAssert, tag>(ptr));
 }
 
-template<typename T, PtrTag tag, PtrTagAction tagAction, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
+template<typename T, PtrTag tag, PtrTagAction tagAction, typename PtrType>
+    requires (std::is_pointer_v<PtrType>)
 inline T untagCFunctionPtr(PtrType ptr)
 {
     return std::bit_cast<T>(untagCFunctionPtrImpl<tagAction, tag>(ptr));
 }
 
-template<PtrTag tag, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
+template<PtrTag tag, typename PtrType>
+    requires (std::is_pointer_v<PtrType>)
 inline PtrType untagCFunctionPtr(PtrType ptr) { return untagCFunctionPtrImpl<PtrTagAction::DebugAssert, tag>(ptr); }
 
 #if CPU(ARM64E)

--- a/Source/WTF/wtf/RawPointer.h
+++ b/Source/WTF/wtf/RawPointer.h
@@ -44,7 +44,8 @@ public:
     {
     }
 
-    template<typename T, typename = std::enable_if_t<std::is_function_v<T>, T>>
+    template<typename T>
+        requires (std::is_function_v<T>)
     explicit RawPointer(T* value)
         : m_value(reinterpret_cast<const void*>(value))
     {

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -247,7 +247,8 @@ inline void Ref<X, _PtrTraits, RefDerefTraits>::swap(Ref<Y, _OtherPtrTraits, Oth
     _PtrTraits::swap(m_ptr, other.m_ptr);
 }
 
-template<typename X, typename APtrTraits, typename ARefDerefTraits, typename Y, typename BPtrTraits, typename BRefDerefTraits, typename = std::enable_if_t<!std::is_same<APtrTraits, RawPtrTraits<X>>::value || !std::is_same<BPtrTraits, RawPtrTraits<Y>>::value>>
+template<typename X, typename APtrTraits, typename ARefDerefTraits, typename Y, typename BPtrTraits, typename BRefDerefTraits>
+    requires (!std::is_same_v<APtrTraits, RawPtrTraits<X>> || !std::is_same_v<BPtrTraits, RawPtrTraits<Y>>)
 inline void swap(Ref<X, APtrTraits, ARefDerefTraits>& a, Ref<Y, BPtrTraits, BRefDerefTraits>& b)
 {
     a.swap(b);

--- a/Source/WTF/wtf/SaturatedArithmetic.h
+++ b/Source/WTF/wtf/SaturatedArithmetic.h
@@ -39,9 +39,15 @@
 namespace WTF {
 
 // FIXME: Enhance this so it fails to compile calls where either of the arguments can be outside the range of the integral type instead of quietly converting.
-template<typename SignedIntegralType> std::enable_if_t<std::is_integral_v<SignedIntegralType> && std::is_signed_v<SignedIntegralType>, SignedIntegralType> saturatedSum(SignedIntegralType, SignedIntegralType);
-template<typename UnsignedIntegralType> constexpr std::enable_if_t<std::is_integral_v<UnsignedIntegralType> && !std::is_signed_v<UnsignedIntegralType>, UnsignedIntegralType> saturatedSum(UnsignedIntegralType, UnsignedIntegralType);
-template<typename IntegralType> IntegralType saturatedDifference(IntegralType, IntegralType);
+
+template<std::signed_integral SignedIntegralType>
+SignedIntegralType saturatedSum(SignedIntegralType, SignedIntegralType);
+
+template<std::unsigned_integral UnsignedIntegralType>
+constexpr UnsignedIntegralType saturatedSum(UnsignedIntegralType, UnsignedIntegralType);
+
+template<typename IntegralType>
+IntegralType saturatedDifference(IntegralType, IntegralType);
 
 inline bool signedAddInt32Overflows(int32_t a, int32_t b, int32_t& result)
 {
@@ -108,13 +114,15 @@ template<> inline int32_t saturatedDifference<int32_t>(int32_t a, int32_t b)
     return result;
 }
 
-template<typename UnsignedIntegralType> constexpr std::enable_if_t<std::is_integral_v<UnsignedIntegralType> && !std::is_signed_v<UnsignedIntegralType>, UnsignedIntegralType> saturatedSum(UnsignedIntegralType a, UnsignedIntegralType b)
+template<std::unsigned_integral UnsignedIntegralType>
+constexpr UnsignedIntegralType saturatedSum(UnsignedIntegralType a, UnsignedIntegralType b)
 {
     auto sum = a + b;
     return sum < a ? std::numeric_limits<UnsignedIntegralType>::max() : sum;
 }
 
-template<typename IntegralType, typename... ArgumentTypes> constexpr uint32_t saturatedSum(IntegralType value, ArgumentTypes... arguments)
+template<typename IntegralType, typename... ArgumentTypes>
+constexpr uint32_t saturatedSum(IntegralType value, ArgumentTypes... arguments)
 {
     return saturatedSum<IntegralType>(value, saturatedSum<IntegralType>(arguments...));
 }

--- a/Source/WTF/wtf/SignedPtr.h
+++ b/Source/WTF/wtf/SignedPtr.h
@@ -81,8 +81,9 @@ public:
 
     T* operator->() const { return get(); }
 
-    template <typename U = T>
-    typename std::enable_if<!std::is_void_v<U>, U&>::type operator*() const { return *get(); }
+    template<typename U = T>
+        requires (!std::is_void_v<U>)
+    U& operator*() const { return *get(); }
 
     bool operator!() const { return !m_value; }
     

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1214,10 +1214,11 @@ bool spansOverlap(std::span<T, TExtent> a, std::span<U, UExtent> b)
 /* SAFE_PRINTF */
 
 // https://gist.github.com/sehe/3374327
-template <class T> inline typename std::enable_if<std::is_integral<T>::value, T>::type safePrintfType(T arg) { return arg; }
-template <class T> inline typename std::enable_if<std::is_floating_point<T>::value, T>::type safePrintfType(T arg) { return arg; }
-template <class T> inline typename std::enable_if<std::is_pointer<T>::value, T>::type safePrintfType(T arg) {
-    static_assert(!std::is_same_v<std::remove_cv_t<std::remove_pointer_t<T>>, char>, "char* is not bounds safe; please use a null terminated string type");
+template<std::integral T> inline T safePrintfType(T arg) { return arg; }
+template<std::floating_point T> inline T safePrintfType(T arg) { return arg; }
+template<typename T> requires (std::is_pointer_v<T>) inline T safePrintfType(T arg)
+{
+    static_assert(!std::same_as<std::remove_cv_t<std::remove_pointer_t<T>>, char>, "char* is not bounds safe; please use a null terminated string type");
     return arg;
 }
 

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -341,7 +341,8 @@ public:
         , m_controlBlock(std::exchange(other.m_controlBlock, nullptr))
     { }
 
-    template<typename U, std::enable_if_t<!std::is_pointer_v<U>>* = nullptr>
+    template<typename U>
+        requires (!std::is_pointer_v<U>)
     ThreadSafeWeakPtr(const U& retainedReference)
         : m_objectOfCorrectType(static_cast<const T*>(&retainedReference))
         , m_controlBlock(controlBlock(retainedReference))
@@ -384,7 +385,8 @@ public:
         return *this;
     }
 
-    template<typename U, std::enable_if_t<!std::is_pointer_v<U>>* = nullptr>
+    template<typename U>
+        requires (!std::is_pointer_v<U>)
     ThreadSafeWeakPtr& operator=(const U& retainedReference)
     {
         m_controlBlock = controlBlock(retainedReference);

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1886,7 +1886,8 @@ struct CompactMapper {
 };
 
 template<typename MapFunction, typename DestinationVectorType, typename SourceType>
-struct CompactMapper<MapFunction, DestinationVectorType, SourceType, typename std::enable_if<std::is_rvalue_reference<SourceType&&>::value>::type> {
+    requires (std::is_rvalue_reference_v<SourceType&&>)
+struct CompactMapper<MapFunction, DestinationVectorType, SourceType> {
     using SourceItemType = typename CollectionInspector<SourceType>::SourceItemType;
     using ResultItemType = typename std::invoke_result<MapFunction, SourceItemType&&>::type;
 
@@ -1944,7 +1945,8 @@ struct FlatMapper {
     }
 };
 
-template<typename MapFunction, typename SourceType> requires std::is_rvalue_reference<SourceType&&>::value
+template<typename MapFunction, typename SourceType>
+    requires (std::is_rvalue_reference_v<SourceType&&>)
 struct FlatMapper<MapFunction, SourceType> {
     using SourceItemType = typename CollectionInspector<SourceType>::SourceItemType;
     using DestinationItemType = typename CollectionInspector<typename std::invoke_result<MapFunction, SourceItemType&&>::type>::SourceItemType;

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -45,8 +45,7 @@ enum class EnableWeakPtrThreadingAssertions : bool { No, Yes };
 template<typename T, typename WeakPtrImpl>
 class WeakRef {
 public:
-    template<typename = std::enable_if_t<!IsSmartPtr<T>::value && !std::is_pointer_v<T>>>
-    WeakRef(const T& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
+    WeakRef(const T& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes) requires (!IsSmartPtr<T>::value && !std::is_pointer_v<T>)
         : m_impl(object.weakImpl())
 #if ASSERT_ENABLED
         , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
@@ -139,7 +138,8 @@ private:
 #endif
 };
 
-template<class T, typename = std::enable_if_t<!IsSmartPtr<T>::value && !std::is_pointer_v<T>>>
+template<class T>
+    requires (!IsSmartPtr<T>::value && !std::is_pointer_v<T>)
 WeakRef(const T& value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> WeakRef<T, typename T::WeakPtrImplType>;
 
 template <typename T, typename WeakPtrImpl>

--- a/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
+++ b/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
@@ -137,7 +137,9 @@ template<typename T, typename U> inline T *checked_objc_cast(U *object)
 
 // See RetainPtr.h for: template<typename T> T* dynamic_objc_cast(id object).
 
-template<typename T, typename U, typename = std::enable_if_t<std::is_base_of_v<U, T>>> RetainPtr<T> dynamic_objc_cast(RetainPtr<U>&& object)
+template<typename T, typename U>
+    requires (std::is_base_of_v<U, T>)
+RetainPtr<T> dynamic_objc_cast(RetainPtr<U>&& object)
 {
     static_assert(std::is_base_of_v<U, T>);
     static_assert(!std::is_same_v<U, T>);
@@ -153,7 +155,9 @@ template<typename T> RetainPtr<T> dynamic_objc_cast(RetainPtr<id>&& object)
     return adoptNS(reinterpret_cast<T*>(object.leakRef()));
 }
 
-template<typename T, typename U, typename = std::enable_if_t<std::is_base_of_v<U, T>>> RetainPtr<T> dynamic_objc_cast(const RetainPtr<U>& object)
+template<typename T, typename U>
+    requires (std::is_base_of_v<U, T>)
+RetainPtr<T> dynamic_objc_cast(const RetainPtr<U>& object)
 {
     static_assert(std::is_base_of_v<U, T>);
     static_assert(!std::is_same_v<U, T>);

--- a/Source/WTF/wtf/persistence/PersistentDecoder.h
+++ b/Source/WTF/wtf/persistence/PersistentDecoder.h
@@ -60,14 +60,16 @@ public:
     WTF_EXPORT_PRIVATE Decoder& operator>>(std::optional<float>&);
     WTF_EXPORT_PRIVATE Decoder& operator>>(std::optional<double>&);
 
-    template<typename T, std::enable_if_t<!std::is_arithmetic<typename std::remove_const<T>>::value && !std::is_enum<T>::value>* = nullptr>
+    template<typename T>
+        requires (!std::is_arithmetic_v<typename std::remove_const<T>> && !std::is_enum_v<T>)
     Decoder& operator>>(std::optional<T>& result)
     {
         result = Coder<T>::decodeForPersistence(*this);
         return *this;
     }
 
-    template<typename E, std::enable_if_t<std::is_enum<E>::value>* = nullptr>
+    template<typename E>
+        requires (std::is_enum_v<E>)
     Decoder& operator>>(std::optional<E>& result)
     {
         static_assert(sizeof(E) <= 8, "Enum type T must not be larger than 64 bits!");

--- a/Source/WTF/wtf/persistence/PersistentEncoder.h
+++ b/Source/WTF/wtf/persistence/PersistentEncoder.h
@@ -45,14 +45,16 @@ public:
     WTF_EXPORT_PRIVATE void encodeChecksum();
     WTF_EXPORT_PRIVATE void encodeFixedLengthData(std::span<const uint8_t>);
 
-    template<typename T, std::enable_if_t<std::is_enum<T>::value>* = nullptr>
+    template<typename T>
+        requires (std::is_enum_v<T>)
     Encoder& operator<<(const T& t)
     {
         static_assert(sizeof(T) <= sizeof(uint64_t), "Enum type must not be larger than 64 bits.");
         return *this << static_cast<uint64_t>(t);
     }
 
-    template<typename T, std::enable_if_t<!std::is_enum<T>::value && !std::is_arithmetic<typename std::remove_const<T>>::value>* = nullptr>
+    template<typename T>
+        requires (!std::is_arithmetic_v<typename std::remove_const<T>> && !std::is_enum_v<T>)
     Encoder& operator<<(const T& t)
     {
         Coder<T>::encodeForPersistence(*this, t);

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <algorithm>
+#include <concepts>
 #include <unicode/uchar.h>
 #include <wtf/ASCIICType.h>
 #include <wtf/Float16.h>
@@ -689,7 +690,8 @@ ALWAYS_INLINE const char16_t* find16NonASCII(std::span<const char16_t> data)
 }
 #endif
 
-template<typename CharacterType1, typename CharacterType2, std::enable_if_t<std::is_integral_v<CharacterType1> && std::is_integral_v<CharacterType2> && sizeof(CharacterType1) == sizeof(CharacterType2)>* = nullptr>
+template<std::integral CharacterType1, std::integral CharacterType2>
+    requires (sizeof(CharacterType1) == sizeof(CharacterType2))
 inline size_t find(std::span<const CharacterType1> characters, CharacterType2 matchCharacter, size_t index = 0)
 {
     if constexpr (sizeof(CharacterType1) == 1) {
@@ -732,7 +734,7 @@ inline size_t find(std::span<const Latin1Character> characters, char16_t matchCh
     return find(characters, static_cast<Latin1Character>(matchCharacter), index);
 }
 
-template<typename CharacterType1, typename CharacterType2, std::enable_if_t<std::is_integral_v<CharacterType1> && std::is_integral_v<CharacterType2>>* = nullptr>
+template<std::integral CharacterType1, std::integral CharacterType2>
 inline bool contains(std::span<const CharacterType1> characters, CharacterType2 matchCharacter, size_t index = 0)
 {
     return find(characters, matchCharacter, index) != notFound;

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -53,7 +53,7 @@ template<typename StringType> concept StringTypeAdaptable = requires {
     typename StringTypeAdapter<StringType>;
 };
 
-template<> class StringTypeAdapter<char, void> {
+template<> class StringTypeAdapter<char> {
 public:
     StringTypeAdapter(char character)
         : m_character { character }
@@ -68,7 +68,7 @@ private:
     char m_character;
 };
 
-template<> class StringTypeAdapter<char16_t, void> {
+template<> class StringTypeAdapter<char16_t> {
 public:
     StringTypeAdapter(char16_t character)
         : m_character { character }
@@ -90,7 +90,7 @@ private:
     char16_t m_character;
 };
 
-template<> class StringTypeAdapter<char32_t, void> {
+template<> class StringTypeAdapter<char32_t> {
 public:
     StringTypeAdapter(char32_t character)
         : m_character { character }
@@ -120,7 +120,7 @@ private:
     char32_t m_character;
 };
 
-template<> class StringTypeAdapter<const Latin1Character*, void> {
+template<> class StringTypeAdapter<const Latin1Character*> {
 public:
     StringTypeAdapter(const Latin1Character* characters)
         : m_characters { unsafeSpan(characters) }
@@ -136,7 +136,7 @@ private:
     std::span<const Latin1Character> m_characters;
 };
 
-template<> class StringTypeAdapter<const char16_t*, void> {
+template<> class StringTypeAdapter<const char16_t*> {
 public:
     StringTypeAdapter(const char16_t* characters)
         : m_characters { unsafeSpan(characters) }
@@ -153,7 +153,7 @@ private:
     std::span<const char16_t> m_characters;
 };
 
-template<typename CharacterType, size_t Extent> class StringTypeAdapter<std::span<CharacterType, Extent>, void> {
+template<typename CharacterType, size_t Extent> class StringTypeAdapter<std::span<CharacterType, Extent>> {
 public:
     StringTypeAdapter(std::span<CharacterType, Extent> span)
         : m_characters { span }
@@ -175,23 +175,23 @@ private:
     std::span<const CharacterType> m_characters;
 };
 
-template<> class StringTypeAdapter<CString, void> : public StringTypeAdapter<std::span<const char>, void> {
+template<> class StringTypeAdapter<CString> : public StringTypeAdapter<std::span<const char>> {
 public:
     StringTypeAdapter(const CString& string)
-        : StringTypeAdapter<std::span<const char>, void> { spanReinterpretCast<const char>(string.span()) }
+        : StringTypeAdapter<std::span<const char>> { spanReinterpretCast<const char>(string.span()) }
     {
     }
 };
 
-template<> class StringTypeAdapter<ASCIILiteral, void> : public StringTypeAdapter<std::span<const Latin1Character>, void> {
+template<> class StringTypeAdapter<ASCIILiteral> : public StringTypeAdapter<std::span<const Latin1Character>> {
 public:
     StringTypeAdapter(ASCIILiteral characters)
-        : StringTypeAdapter<std::span<const Latin1Character>, void> { characters.span8() }
+        : StringTypeAdapter<std::span<const Latin1Character>> { characters.span8() }
     {
     }
 };
 
-template<typename CharacterType, size_t InlineCapacity> class StringTypeAdapter<Vector<CharacterType, InlineCapacity>, void> : public StringTypeAdapter<std::span<const CharacterType>> {
+template<typename CharacterType, size_t InlineCapacity> class StringTypeAdapter<Vector<CharacterType, InlineCapacity>> : public StringTypeAdapter<std::span<const CharacterType>> {
 public:
     StringTypeAdapter(const Vector<CharacterType, InlineCapacity>& vector)
         : StringTypeAdapter<std::span<const CharacterType>> { vector.span() }
@@ -199,7 +199,7 @@ public:
     }
 };
 
-template<> class StringTypeAdapter<StringImpl*, void> {
+template<> class StringTypeAdapter<StringImpl*> {
 public:
     StringTypeAdapter(StringImpl* string)
         : m_string { string }
@@ -218,31 +218,31 @@ private:
     SUPPRESS_UNCOUNTED_MEMBER StringImpl* const m_string;
 };
 
-template<> class StringTypeAdapter<AtomStringImpl*, void> : public StringTypeAdapter<StringImpl*, void> {
+template<> class StringTypeAdapter<AtomStringImpl*> : public StringTypeAdapter<StringImpl*> {
 public:
     StringTypeAdapter(AtomStringImpl* string)
-        : StringTypeAdapter<StringImpl*, void> { static_cast<StringImpl*>(string) }
+        : StringTypeAdapter<StringImpl*> { static_cast<StringImpl*>(string) }
     {
     }
 };
 
-template<> class StringTypeAdapter<String, void> : public StringTypeAdapter<StringImpl*, void> {
+template<> class StringTypeAdapter<String> : public StringTypeAdapter<StringImpl*> {
 public:
     StringTypeAdapter(const String& string)
-        : StringTypeAdapter<StringImpl*, void> { string.impl() }
+        : StringTypeAdapter<StringImpl*> { string.impl() }
     {
     }
 };
 
-template<> class StringTypeAdapter<AtomString, void> : public StringTypeAdapter<String, void> {
+template<> class StringTypeAdapter<AtomString> : public StringTypeAdapter<String> {
 public:
     StringTypeAdapter(const AtomString& string)
-        : StringTypeAdapter<String, void> { string.string() }
+        : StringTypeAdapter<String> { string.string() }
     {
     }
 };
 
-template<> class StringTypeAdapter<StringImpl&, void> {
+template<> class StringTypeAdapter<StringImpl&> {
 public:
     StringTypeAdapter(StringImpl& string)
         : m_string { string }
@@ -261,15 +261,15 @@ private:
     SUPPRESS_UNCOUNTED_MEMBER StringImpl& m_string;
 };
 
-template<> class StringTypeAdapter<AtomStringImpl&, void> : public StringTypeAdapter<StringImpl&, void> {
+template<> class StringTypeAdapter<AtomStringImpl&> : public StringTypeAdapter<StringImpl&> {
 public:
     StringTypeAdapter(StringImpl& string)
-        : StringTypeAdapter<StringImpl&, void> { string }
+        : StringTypeAdapter<StringImpl&> { string }
     {
     }
 };
 
-template<> class StringTypeAdapter<Unicode::CheckedUTF8, void> {
+template<> class StringTypeAdapter<Unicode::CheckedUTF8> {
 public:
     StringTypeAdapter(Unicode::CheckedUTF8 characters)
         : m_characters { characters }
@@ -289,15 +289,15 @@ private:
     Unicode::CheckedUTF8 m_characters;
 };
 
-template<size_t Extent> class StringTypeAdapter<std::span<const char8_t, Extent>, void> : public StringTypeAdapter<Unicode::CheckedUTF8, void> {
+template<size_t Extent> class StringTypeAdapter<std::span<const char8_t, Extent>> : public StringTypeAdapter<Unicode::CheckedUTF8> {
 public:
     StringTypeAdapter(std::span<const char8_t, Extent> span)
-        : StringTypeAdapter<Unicode::CheckedUTF8, void> { Unicode::checkUTF8(span) }
+        : StringTypeAdapter<Unicode::CheckedUTF8> { Unicode::checkUTF8(span) }
     {
     }
 };
 
-template<typename... StringTypes> class StringTypeAdapter<std::tuple<StringTypes...>, void> {
+template<typename... StringTypes> class StringTypeAdapter<std::tuple<StringTypes...>> {
 public:
     StringTypeAdapter(const std::tuple<StringTypes...>& tuple)
         : m_tuple { tuple }
@@ -396,7 +396,7 @@ struct IndentationScope {
     Indentation<N>& m_indentation;
 };
 
-template<unsigned N> class StringTypeAdapter<Indentation<N>, void> {
+template<unsigned N> class StringTypeAdapter<Indentation<N>> {
 public:
     StringTypeAdapter(Indentation<N> indentation)
         : m_indentation { indentation }
@@ -437,7 +437,7 @@ inline ASCIICaseConverter asASCIIUppercase(StringView stringView)
     return { StringView::CaseConvertType::Upper, stringView };
 }
 
-template<> class StringTypeAdapter<ASCIICaseConverter, void> {
+template<> class StringTypeAdapter<ASCIICaseConverter> {
 public:
     StringTypeAdapter(const ASCIICaseConverter& converter)
         : m_converter { converter }
@@ -599,7 +599,7 @@ template<typename C, StringTypeAdaptable B> decltype(auto) interleave(const C& c
     );
 }
 
-template<typename C, typename E, typename B> class StringTypeAdapter<Interleave<C, E, B>, void> {
+template<typename C, typename E, typename B> class StringTypeAdapter<Interleave<C, E, B>> {
 public:
     StringTypeAdapter(const Interleave<C, E, B>& interleave)
         : m_interleave { interleave }

--- a/Source/WTF/wtf/text/StringConcatenateNumbers.h
+++ b/Source/WTF/wtf/text/StringConcatenateNumbers.h
@@ -27,14 +27,15 @@
 
 #include <wtf/Compiler.h>
 
+#include <concepts>
 #include <wtf/dtoa.h>
 #include <wtf/text/IntegerToStringConversion.h>
 #include <wtf/text/StringConcatenate.h>
 
 namespace WTF {
 
-template<typename Integer>
-class StringTypeAdapter<Integer, typename std::enable_if_t<std::is_integral_v<Integer>>> {
+template<std::integral Integer>
+class StringTypeAdapter<Integer> {
 public:
     StringTypeAdapter(Integer number)
         : m_number { number }
@@ -51,8 +52,10 @@ private:
 };
 
 template<typename Enum>
-class StringTypeAdapter<Enum, typename std::enable_if_t<std::is_enum_v<Enum>>> {
-using UnderlyingType = typename std::underlying_type_t<Enum>;
+    requires (std::is_enum_v<Enum>)
+class StringTypeAdapter<Enum> {
+private:
+    using UnderlyingType = typename std::underlying_type_t<Enum>;
 public:
     StringTypeAdapter(Enum enumValue)
         : m_enum { enumValue }
@@ -68,8 +71,8 @@ private:
     Enum m_enum;
 };
 
-template<typename FloatingPoint>
-class StringTypeAdapter<FloatingPoint, typename std::enable_if_t<std::is_floating_point<FloatingPoint>::value>> {
+template<std::floating_point FloatingPoint>
+class StringTypeAdapter<FloatingPoint> {
 public:
     StringTypeAdapter(FloatingPoint number)
     {

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -476,7 +476,8 @@ public:
     size_t find(Latin1Character, size_t start = 0);
     size_t find(char, size_t start = 0);
     size_t find(char16_t, size_t start = 0);
-    template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>>* = nullptr>
+    template<typename CodeUnitMatchFunction>
+        requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
     size_t find(CodeUnitMatchFunction, size_t start = 0);
     ALWAYS_INLINE size_t find(ASCIILiteral literal, size_t start = 0) { return find(literal.span8(), start); }
     WTF_EXPORT_PRIVATE size_t find(StringView);
@@ -638,7 +639,8 @@ WTF_EXPORT_PRIVATE bool equalIgnoringASCIICaseNonNull(const StringImpl*, const S
 bool equalLettersIgnoringASCIICase(const StringImpl&, ASCIILiteral);
 bool equalLettersIgnoringASCIICase(const StringImpl*, ASCIILiteral);
 
-template<typename CodeUnit, typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, CodeUnit>>* = nullptr>
+template<typename CodeUnit, typename CodeUnitMatchFunction>
+    requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, CodeUnit>)
 size_t find(std::span<const CodeUnit>, CodeUnitMatchFunction&&, size_t start = 0);
 
 template<typename CharacterType> size_t reverseFindLineTerminator(std::span<const CharacterType>, size_t start = StringImpl::MaxLength);
@@ -693,7 +695,8 @@ template<> ALWAYS_INLINE std::span<const char16_t> StringImpl::span<char16_t>() 
     return span16();
 }
 
-template<typename CodeUnit, typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, CodeUnit>>*>
+template<typename CodeUnit, typename CodeUnitMatchFunction>
+    requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, CodeUnit>)
 inline size_t find(std::span<const CodeUnit> characters, CodeUnitMatchFunction&& matchFunction, size_t start)
 {
     while (start < characters.size()) {
@@ -763,7 +766,8 @@ inline size_t StringImpl::find(char16_t character, size_t start)
     return WTF::find(span16(), character, start);
 }
 
-template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>>*>
+template<typename CodeUnitMatchFunction>
+    requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
 size_t StringImpl::find(CodeUnitMatchFunction matchFunction, size_t start)
 {
     if (is8Bit())

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -155,7 +155,8 @@ public:
     size_t find(char16_t, unsigned start = 0) const;
     size_t find(Latin1Character, unsigned start = 0) const;
     ALWAYS_INLINE size_t find(char c, unsigned start = 0) const { return find(byteCast<Latin1Character>(c), start); }
-    template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>>* = nullptr>
+    template<typename CodeUnitMatchFunction>
+        requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
     size_t find(CodeUnitMatchFunction&&, unsigned start = 0) const;
     ALWAYS_INLINE size_t find(ASCIILiteral literal, unsigned start = 0) const { return find(literal.span8(), start); }
     WTF_EXPORT_PRIVATE size_t find(StringView, unsigned start = 0) const;
@@ -175,7 +176,8 @@ public:
     WTF_EXPORT_PRIVATE std::optional<char32_t> convertToSingleCodePoint() const;
 
     bool contains(char16_t) const;
-    template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>>* = nullptr>
+    template<typename CodeUnitMatchFunction>
+        requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
     bool contains(CodeUnitMatchFunction&&) const;
     bool contains(ASCIILiteral literal) const { return find(literal) != notFound; }
     bool contains(StringView string) const { return find(string) != notFound; }
@@ -598,7 +600,8 @@ inline bool StringView::contains(char16_t character) const
     return find(character) != notFound;
 }
 
-template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>>*>
+template<typename CodeUnitMatchFunction>
+    requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
 inline bool StringView::contains(CodeUnitMatchFunction&& function) const
 {
     return find(std::forward<CodeUnitMatchFunction>(function)) != notFound;
@@ -697,7 +700,8 @@ inline size_t StringView::find(Latin1Character character, unsigned start) const
     return WTF::find(span16(), character, start);
 }
 
-template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>>*>
+template<typename CodeUnitMatchFunction>
+    requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
 inline size_t StringView::find(CodeUnitMatchFunction&& matchFunction, unsigned start) const
 {
     if (is8Bit())
@@ -720,7 +724,7 @@ inline void StringView::invalidate(const StringImpl&)
 
 #endif
 
-template<> class StringTypeAdapter<StringView, void> {
+template<> class StringTypeAdapter<StringView> {
 public:
     StringTypeAdapter(StringView string)
         : m_string { string }

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -156,7 +156,8 @@ public:
     size_t findIgnoringASCIICase(StringView) const;
     size_t findIgnoringASCIICase(StringView, unsigned start) const;
 
-    template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>>* = nullptr>
+    template<typename CodeUnitMatchFunction>
+        requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
     size_t find(CodeUnitMatchFunction matchFunction, unsigned start = 0) const { return m_impl ? m_impl->find(matchFunction, start) : notFound; }
     size_t find(ASCIILiteral literal, unsigned start = 0) const { return m_impl ? m_impl->find(literal, start) : notFound; }
 
@@ -173,7 +174,8 @@ public:
     bool contains(char16_t character) const { return find(character) != notFound; }
     bool contains(ASCIILiteral literal) const { return find(literal) != notFound; }
     bool contains(StringView) const;
-    template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>>* = nullptr>
+    template<typename CodeUnitMatchFunction>
+        requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
     bool contains(CodeUnitMatchFunction matchFunction) const { return find(matchFunction, 0) != notFound; }
     bool containsIgnoringASCIICase(StringView) const;
     bool containsIgnoringASCIICase(StringView, unsigned start) const;

--- a/Source/WebCore/Modules/applepay/PaymentMethod.h
+++ b/Source/WebCore/Modules/applepay/PaymentMethod.h
@@ -47,7 +47,7 @@ public:
     PKPaymentMethod *pkPaymentMethod() const;
 
 private:
-    friend struct IPC::ArgumentCoder<PaymentMethod, void>;
+    friend struct IPC::ArgumentCoder<PaymentMethod>;
     const RetainPtr<PKPaymentMethod> m_pkPaymentMethod;
 };
 

--- a/Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.h
@@ -79,7 +79,7 @@ public:
     bool isRelatedToOrigin(const SecurityOriginData& other) const { return m_origin.isRelated(other); }
 
 private:
-    friend struct IPC::ArgumentCoder<IDBDatabaseIdentifier, void>;
+    friend struct IPC::ArgumentCoder<IDBDatabaseIdentifier>;
 
     String m_databaseName;
     ClientOrigin m_origin;

--- a/Source/WebCore/Modules/indexeddb/IDBGetAllResult.h
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllResult.h
@@ -60,7 +60,7 @@ public:
     WEBCORE_EXPORT Vector<String> allBlobFilePaths() const;
 
 private:
-    friend struct IPC::ArgumentCoder<IDBGetAllResult, void>;
+    friend struct IPC::ArgumentCoder<IDBGetAllResult>;
     IDBGetAllResult(IndexedDB::GetAllType type, Vector<IDBKeyData>&& keys, Vector<IDBValue>&& values, std::optional<IDBKeyPath>&& keyPath)
         : m_type(type)
         , m_keys(WTFMove(keys))

--- a/Source/WebCore/Modules/indexeddb/shared/IDBCursorInfo.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBCursorInfo.h
@@ -74,7 +74,7 @@ public:
 #endif
 
 private:
-    friend struct IPC::ArgumentCoder<IDBCursorInfo, void>;
+    friend struct IPC::ArgumentCoder<IDBCursorInfo>;
     WEBCORE_EXPORT IDBCursorInfo(const IDBResourceIdentifier&, const IDBResourceIdentifier&, IDBObjectStoreIdentifier, Variant<IDBObjectStoreIdentifier, IDBIndexIdentifier>, const IDBKeyRangeData&, IndexedDB::CursorSource, IndexedDB::CursorDirection, IndexedDB::CursorType);
     IDBCursorInfo(IDBTransaction&, IDBObjectStoreIdentifier, const IDBKeyRangeData&, IndexedDB::CursorDirection, IndexedDB::CursorType);
     IDBCursorInfo(IDBTransaction&, IDBObjectStoreIdentifier, IDBIndexIdentifier, const IDBKeyRangeData&, IndexedDB::CursorDirection, IndexedDB::CursorType);

--- a/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.h
@@ -74,7 +74,7 @@ public:
 #endif
 
 private:
-    friend struct IPC::ArgumentCoder<IDBDatabaseInfo, void>;
+    friend struct IPC::ArgumentCoder<IDBDatabaseInfo>;
     IDBObjectStoreInfo* getInfoForExistingObjectStore(const String& objectStoreName);
     IDBObjectStoreInfo* getInfoForExistingObjectStore(IDBObjectStoreIdentifier);
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBOpenRequestData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBOpenRequestData.h
@@ -50,7 +50,7 @@ public:
     bool isDeleteRequest() const { return m_requestType == IndexedDB::RequestType::Delete; }
 
 private:
-    friend struct IPC::ArgumentCoder<IDBOpenRequestData, void>;
+    friend struct IPC::ArgumentCoder<IDBOpenRequestData>;
     WEBCORE_EXPORT IDBOpenRequestData(IDBConnectionIdentifier, IDBResourceIdentifier, IDBDatabaseIdentifier&&, uint64_t requestedVersion, IndexedDB::RequestType);
 
     IDBConnectionIdentifier m_serverConnectionIdentifier;

--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
@@ -70,7 +70,7 @@ public:
     IDBRequestData isolatedCopy();
 
 private:
-    friend struct IPC::ArgumentCoder<IDBRequestData, void>;
+    friend struct IPC::ArgumentCoder<IDBRequestData>;
     WEBCORE_EXPORT IDBRequestData(IDBConnectionIdentifier serverConnectionIdentifier, IDBResourceIdentifier requestIdentifier, IDBResourceIdentifier transactionIdentifier, std::optional<IDBResourceIdentifier>&& cursorIdentifier, std::optional<IDBObjectStoreIdentifier>, std::optional<IDBIndexIdentifier>, IndexedDB::IndexRecordType, uint64_t requestedVersion, IndexedDB::RequestType);
     static void isolatedCopy(const IDBRequestData& source, IDBRequestData& destination);
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h
@@ -68,7 +68,7 @@ public:
 
     WEBCORE_EXPORT IDBResourceIdentifier();
 private:
-    friend struct IPC::ArgumentCoder<IDBResourceIdentifier, void>;
+    friend struct IPC::ArgumentCoder<IDBResourceIdentifier>;
     friend struct IDBResourceIdentifierHashTraits;
     friend void add(Hasher&, const IDBResourceIdentifier&);
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResultData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResultData.h
@@ -114,7 +114,7 @@ public:
     WEBCORE_EXPORT IDBResultData();
 
 private:
-    friend struct IPC::ArgumentCoder<IDBResultData, void>;
+    friend struct IPC::ArgumentCoder<IDBResultData>;
 
     IDBResultData(const IDBResourceIdentifier&);
     IDBResultData(IDBResultType, const IDBResourceIdentifier&);

--- a/Source/WebCore/Modules/speech/SpeechRecognitionUpdate.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionUpdate.h
@@ -60,7 +60,7 @@ public:
     WEBCORE_EXPORT Vector<SpeechRecognitionResultData> result() const;
 
 private:
-    friend struct IPC::ArgumentCoder<SpeechRecognitionUpdate, void>;
+    friend struct IPC::ArgumentCoder<SpeechRecognitionUpdate>;
     using Content = Variant<std::monostate, SpeechRecognitionError, Vector<SpeechRecognitionResultData>>;
     WEBCORE_EXPORT SpeechRecognitionUpdate(SpeechRecognitionConnectionClientIdentifier, SpeechRecognitionUpdateType, Content);
 

--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
@@ -66,7 +66,7 @@ public:
     RenderingResourceIdentifier imageIdentifier() const;
 
 private:
-    friend struct IPC::ArgumentCoder<ARKitBadgeSystemImage, void>;
+    friend struct IPC::ArgumentCoder<ARKitBadgeSystemImage>;
     ARKitBadgeSystemImage(Image& image)
         : SystemImage(SystemImageType::ARKitBadge)
         , m_image(image)

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -150,7 +150,7 @@ public:
     WEBCORE_EXPORT static DeserializationBehavior deserializationBehavior(JSC::JSObject&);
 
 private:
-    friend struct IPC::ArgumentCoder<SerializedScriptValue, void>;
+    friend struct IPC::ArgumentCoder<SerializedScriptValue>;
 
     static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<Ref<MessagePort>>&, SerializationForStorage, SerializationErrorMode, SerializationContext);
     WEBCORE_EXPORT SerializedScriptValue(Vector<unsigned char>&&, std::unique_ptr<ArrayBufferContentsArray>&& = nullptr
@@ -240,7 +240,7 @@ private:
         Vector<URLKeepingBlobAlive> blobHandles { };
         uint64_t memoryCost { 0 };
     };
-    friend struct IPC::ArgumentCoder<Internals, void>;
+    friend struct IPC::ArgumentCoder<Internals>;
 
     static Ref<SerializedScriptValue> create(Internals&& internals)
     {

--- a/Source/WebCore/editing/FontAttributeChanges.h
+++ b/Source/WebCore/editing/FontAttributeChanges.h
@@ -31,7 +31,7 @@
 #include <wtf/Forward.h>
 
 namespace IPC {
-template<typename T, typename> struct ArgumentCoder;
+template<typename> struct ArgumentCoder;
 }
 
 namespace WebCore {
@@ -62,7 +62,7 @@ public:
     Ref<MutableStyleProperties> createStyleProperties() const;
 
 private:
-    friend struct IPC::ArgumentCoder<FontChanges, void>;
+    friend struct IPC::ArgumentCoder<FontChanges>;
     const String& platformFontFamilyNameForCSS() const;
 
     String m_fontName;
@@ -90,7 +90,7 @@ public:
     WEBCORE_EXPORT EditAction editAction() const;
 
 private:
-    friend struct IPC::ArgumentCoder<FontAttributeChanges, void>;
+    friend struct IPC::ArgumentCoder<FontAttributeChanges>;
     std::optional<VerticalAlignChange> m_verticalAlign;
     std::optional<Color> m_backgroundColor;
     std::optional<Color> m_foregroundColor;

--- a/Source/WebCore/inspector/InspectorOverlayLabel.h
+++ b/Source/WebCore/inspector/InspectorOverlayLabel.h
@@ -100,7 +100,7 @@ public:
     static FloatSize expectedSize(const String&, Arrow::Direction);
 
 private:
-    friend struct IPC::ArgumentCoder<InspectorOverlayLabel, void>;
+    friend struct IPC::ArgumentCoder<InspectorOverlayLabel>;
     Vector<Content> m_contents;
     FloatPoint m_location;
     Color m_backgroundColor;

--- a/Source/WebCore/loader/COEPInheritenceViolationReportBody.h
+++ b/Source/WebCore/loader/COEPInheritenceViolationReportBody.h
@@ -43,7 +43,7 @@ public:
     const String& blockedURL() const { return m_blockedURL.string(); }
 
 private:
-    friend struct IPC::ArgumentCoder<COEPInheritenceViolationReportBody, void>;
+    friend struct IPC::ArgumentCoder<COEPInheritenceViolationReportBody>;
     COEPInheritenceViolationReportBody(COEPDisposition, const URL& blockedURL, const String& type);
 
     ViolationReportType reportBodyType() const final { return ViolationReportType::COEPInheritenceViolation; }

--- a/Source/WebCore/loader/CORPViolationReportBody.h
+++ b/Source/WebCore/loader/CORPViolationReportBody.h
@@ -44,7 +44,7 @@ public:
     FetchOptions::Destination destination() const { return m_destination; }
 
 private:
-    friend struct IPC::ArgumentCoder<CORPViolationReportBody, void>;
+    friend struct IPC::ArgumentCoder<CORPViolationReportBody>;
     CORPViolationReportBody(COEPDisposition, const URL& blockedURL, FetchOptions::Destination);
 
     ViolationReportType reportBodyType() const final { return ViolationReportType::CORPViolation; }

--- a/Source/WebCore/loader/ResourceLoadStatistics.h
+++ b/Source/WebCore/loader/ResourceLoadStatistics.h
@@ -132,7 +132,7 @@ struct ResourceLoadStatistics {
     OptionSet<NavigatorAPIsAccessed> navigatorFunctionsAccessed;
     OptionSet<ScreenAPIsAccessed> screenFunctionsAccessed;
 #endif
-    friend struct IPC::ArgumentCoder<ResourceLoadStatistics, void>;
+    friend struct IPC::ArgumentCoder<ResourceLoadStatistics>;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -210,7 +210,7 @@ public:
     bool isHTTPFamily() const { return m_data.protocol() == "http"_s || m_data.protocol() == "https"_s; }
 
 private:
-    friend struct IPC::ArgumentCoder<SecurityOrigin, void>;
+    friend struct IPC::ArgumentCoder<SecurityOrigin>;
     WEBCORE_EXPORT SecurityOrigin();
     explicit SecurityOrigin(const URL&);
     explicit SecurityOrigin(const SecurityOrigin*);

--- a/Source/WebCore/platform/MediaSamplesBlock.h
+++ b/Source/WebCore/platform/MediaSamplesBlock.h
@@ -32,7 +32,7 @@
 #include <wtf/MediaTime.h>
 
 namespace IPC {
-template<typename T, typename> struct ArgumentCoder;
+template<typename> struct ArgumentCoder;
 }
 
 namespace WebCore {
@@ -108,7 +108,7 @@ public:
 
 private:
     // Used by IPC generator
-    friend struct IPC::ArgumentCoder<MediaSamplesBlock, void>;
+    friend struct IPC::ArgumentCoder<MediaSamplesBlock>;
     MediaSamplesBlock(RefPtr<const TrackInfo>&& info, SamplesVector&& items, std::optional<bool> discontinuity)
         : m_info(WTFMove(info))
         , m_samples(WTFMove(items))

--- a/Source/WebCore/platform/ProcessIdentity.h
+++ b/Source/WebCore/platform/ProcessIdentity.h
@@ -61,7 +61,7 @@ public:
 
 private:
 #if HAVE(TASK_IDENTITY_TOKEN)
-    friend struct IPC::ArgumentCoder<ProcessIdentity, void>;
+    friend struct IPC::ArgumentCoder<ProcessIdentity>;
     WEBCORE_EXPORT ProcessIdentity(MachSendRight&& taskIdToken);
     MachSendRight m_taskIdToken;
 #endif

--- a/Source/WebCore/platform/ProcessQualified.h
+++ b/Source/WebCore/platform/ProcessQualified.h
@@ -192,7 +192,7 @@ private:
 };
 
 template<typename T>
-class StringTypeAdapter<WebCore::ProcessQualified<T>, void> : public ProcessQualifiedStringTypeAdapter {
+class StringTypeAdapter<WebCore::ProcessQualified<T>> : public ProcessQualifiedStringTypeAdapter {
 public:
     explicit StringTypeAdapter(const WebCore::ProcessQualified<T>& processQualified)
         : ProcessQualifiedStringTypeAdapter(processQualified.processIdentifier().toUInt64(), processQualified.object().toUInt64()) { }

--- a/Source/WebCore/platform/RegistrableDomain.h
+++ b/Source/WebCore/platform/RegistrableDomain.h
@@ -149,10 +149,10 @@ namespace WTF {
 template<> struct DefaultHash<WebCore::RegistrableDomain> : WebCore::RegistrableDomain::RegistrableDomainHash { };
 template<> struct HashTraits<WebCore::RegistrableDomain> : SimpleClassHashTraits<WebCore::RegistrableDomain> { };
 
-template<> class StringTypeAdapter<WebCore::RegistrableDomain, void> : public StringTypeAdapter<String, void> {
+template<> class StringTypeAdapter<WebCore::RegistrableDomain> : public StringTypeAdapter<String> {
 public:
     StringTypeAdapter(const WebCore::RegistrableDomain& domain)
-        : StringTypeAdapter<String, void>(domain.string())
+        : StringTypeAdapter<String>(domain.string())
     { }
 };
 

--- a/Source/WebCore/platform/ShareableResource.h
+++ b/Source/WebCore/platform/ShareableResource.h
@@ -49,7 +49,7 @@ public:
     WEBCORE_EXPORT RefPtr<SharedBuffer> tryWrapInSharedBuffer() &&;
 
 private:
-    friend struct IPC::ArgumentCoder<ShareableResourceHandle, void>;
+    friend struct IPC::ArgumentCoder<ShareableResourceHandle>;
     friend class ShareableResource;
 
     SharedMemory::Handle m_handle;

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -90,7 +90,7 @@ public:
 #endif
 
 private:
-    friend struct IPC::ArgumentCoder<SharedMemoryHandle, void>;
+    friend struct IPC::ArgumentCoder<SharedMemoryHandle>;
     friend class SharedMemory;
 
     Type m_handle;

--- a/Source/WebCore/platform/ThreadSafeDataBuffer.h
+++ b/Source/WebCore/platform/ThreadSafeDataBuffer.h
@@ -37,7 +37,7 @@ class ThreadSafeDataBuffer;
 class ThreadSafeDataBufferImpl : public ThreadSafeRefCounted<ThreadSafeDataBufferImpl> {
 private:
     friend class ThreadSafeDataBuffer;
-    friend struct IPC::ArgumentCoder<ThreadSafeDataBufferImpl, void>;
+    friend struct IPC::ArgumentCoder<ThreadSafeDataBufferImpl>;
 
     static Ref<ThreadSafeDataBufferImpl> create(Vector<uint8_t>&& data)
     {
@@ -59,7 +59,7 @@ private:
 
 class ThreadSafeDataBuffer {
 private:
-    friend struct IPC::ArgumentCoder<ThreadSafeDataBuffer, void>;
+    friend struct IPC::ArgumentCoder<ThreadSafeDataBuffer>;
 public:
     static ThreadSafeDataBuffer create(Vector<uint8_t>&& data)
     {

--- a/Source/WebCore/platform/TrackInfo.h
+++ b/Source/WebCore/platform/TrackInfo.h
@@ -36,7 +36,7 @@
 #include <wtf/Variant.h>
 
 namespace IPC {
-template<typename T, typename> struct ArgumentCoder;
+template<typename> struct ArgumentCoder;
 }
 
 namespace WebCore {
@@ -124,9 +124,9 @@ protected:
 #endif
 
 private:
-    friend struct IPC::ArgumentCoder<TrackInfo, void>;
-    friend struct IPC::ArgumentCoder<AudioInfo, void>;
-    friend struct IPC::ArgumentCoder<VideoInfo, void>;
+    friend struct IPC::ArgumentCoder<TrackInfo>;
+    friend struct IPC::ArgumentCoder<AudioInfo>;
+    friend struct IPC::ArgumentCoder<VideoInfo>;
     WEBCORE_EXPORT static Ref<TrackInfo> fromVariant(Variant<Ref<AudioInfo>, Ref<VideoInfo>>);
     const TrackType m_type { TrackType::Unknown };
 };
@@ -153,7 +153,7 @@ private:
         : TrackInfo(TrackType::Video) { }
 
     // Used by IPC generator
-    friend struct IPC::ArgumentCoder<VideoInfo, void>;
+    friend struct IPC::ArgumentCoder<VideoInfo>;
     static Ref<VideoInfo> create(FourCC codecName, const String& codecString, WebCore::TrackID trackID, FloatSize size, FloatSize displaySize, uint8_t bitDepth, PlatformVideoColorSpace colorSpace, FourCC boxType, RefPtr<SharedBuffer>&& atomData)
     {
         return adoptRef(*new VideoInfo(codecName, codecString, trackID, size, displaySize, bitDepth, colorSpace, boxType, WTFMove(atomData)));
@@ -209,7 +209,7 @@ private:
         : TrackInfo(TrackType::Audio) { }
 
     // Used by IPC generator
-    friend struct IPC::ArgumentCoder<AudioInfo, void>;
+    friend struct IPC::ArgumentCoder<AudioInfo>;
     static Ref<AudioInfo> create(FourCC codecName, const String& codecString, TrackID trackID, uint32_t rate, uint32_t channels, uint32_t framesPerPacket, uint8_t bitDepth, RefPtr<SharedBuffer>&& cookieData)
     {
         return adoptRef(*new AudioInfo(codecName, codecString, trackID, rate, channels, framesPerPacket, bitDepth, WTFMove(cookieData)));

--- a/Source/WebCore/platform/graphics/FontTaggedSettings.h
+++ b/Source/WebCore/platform/graphics/FontTaggedSettings.h
@@ -71,7 +71,7 @@ private:
 template<typename T>
 class FontTaggedSetting {
 private:
-    friend struct IPC::ArgumentCoder<FontTaggedSetting, void>;
+    friend struct IPC::ArgumentCoder<FontTaggedSetting>;
 public:
     FontTaggedSetting() = delete;
     FontTaggedSetting(FontTag, T value);
@@ -103,7 +103,7 @@ template<typename T> void add(Hasher& hasher, const FontTaggedSetting<T>& settin
 template<typename T>
 class FontTaggedSettings {
 private:
-    friend struct IPC::ArgumentCoder<FontTaggedSettings, void>;
+    friend struct IPC::ArgumentCoder<FontTaggedSettings>;
 public:
     using Setting = FontTaggedSetting<T>;
 

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -150,7 +150,7 @@ public:
     WTF::TextStream& dump(WTF::TextStream&) const;
 
 private:
-    friend struct IPC::ArgumentCoder<GraphicsContextState, void>;
+    friend struct IPC::ArgumentCoder<GraphicsContextState>;
 
     template<typename T>
     void setProperty(Change change, T GraphicsContextState::*property, const T& value)

--- a/Source/WebCore/platform/graphics/LayoutRect.h
+++ b/Source/WebCore/platform/graphics/LayoutRect.h
@@ -221,7 +221,7 @@ public:
     friend bool operator==(const LayoutRect&, const LayoutRect&) = default;
 
 private:
-    friend struct IPC::ArgumentCoder<WebCore::LayoutRect, void>;
+    friend struct IPC::ArgumentCoder<WebCore::LayoutRect>;
 
     LayoutPoint m_location;
     LayoutSize m_size;

--- a/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
+++ b/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
@@ -60,7 +60,7 @@ public:
     constexpr auto operator<=>(const PlatformDynamicRangeLimit&) const = default;
 
 private:
-    friend struct IPC::ArgumentCoder<WebCore::PlatformDynamicRangeLimit, void>;
+    friend struct IPC::ArgumentCoder<WebCore::PlatformDynamicRangeLimit>;
     friend Style::DynamicRangeLimit;
 
     constexpr PlatformDynamicRangeLimit(ValueType value) : m_value(std::clamp(value, 0.0f, 1.0f)) { }

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.h
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.h
@@ -134,7 +134,7 @@ public:
     friend bool operator==(const PlatformTimeRanges&, const PlatformTimeRanges&) = default;
 
 private:
-    friend struct IPC::ArgumentCoder<PlatformTimeRanges, void>;
+    friend struct IPC::ArgumentCoder<PlatformTimeRanges>;
 
     PlatformTimeRanges(Vector<Range>&&);
     PlatformTimeRanges& operator-=(const Range&);

--- a/Source/WebCore/platform/graphics/Region.h
+++ b/Source/WebCore/platform/graphics/Region.h
@@ -127,14 +127,14 @@ public:
 
         Vector<int, 32> m_segments;
         Vector<Span, 16> m_spans;
-        friend struct IPC::ArgumentCoder<WebCore::Region::Shape, void>;
+        friend struct IPC::ArgumentCoder<WebCore::Region::Shape>;
         friend bool operator==(const Shape&, const Shape&) = default;
         WEBCORE_EXPORT friend WTF::TextStream& operator<<(WTF::TextStream&, const Shape&);
     };
     static Region createForTesting(Shape&& shape) { return Region { WTFMove(shape) }; }
     Shape dataForTesting() const { return data(); }
 private:
-    friend struct IPC::ArgumentCoder<WebCore::Region, void>;
+    friend struct IPC::ArgumentCoder<WebCore::Region>;
     explicit Region(Shape&& shape) { setShape(WTFMove(shape)); }
     Shape data() const;
 

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -84,7 +84,7 @@ public:
     WEBCORE_EXPORT static CheckedUint32 calculateSizeInBytes(const IntSize&, const DestinationColorSpace&);
 
 private:
-    friend struct IPC::ArgumentCoder<ShareableBitmapConfiguration, void>;
+    friend struct IPC::ArgumentCoder<ShareableBitmapConfiguration>;
 
     static std::optional<DestinationColorSpace> validateColorSpace(std::optional<DestinationColorSpace>);
     static CheckedUint32 calculateBitsPerComponent(const DestinationColorSpace&);
@@ -125,7 +125,7 @@ public:
     WEBCORE_EXPORT void setOwnershipOfMemory(const ProcessIdentity&, MemoryLedger) const;
 
 private:
-    friend struct IPC::ArgumentCoder<ShareableBitmapHandle, void>;
+    friend struct IPC::ArgumentCoder<ShareableBitmapHandle>;
     friend class ShareableBitmap;
 
     SharedMemory::Handle m_handle;

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.h
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.h
@@ -54,7 +54,7 @@ public:
     bool isCV() const final { return true; }
 
 private:
-    friend struct IPC::ArgumentCoder<VideoFrameCV, void>;
+    friend struct IPC::ArgumentCoder<VideoFrameCV>;
     WEBCORE_EXPORT VideoFrameCV(MediaTime presentationTime, bool isMirrored, Rotation, RetainPtr<CVPixelBufferRef>&&, std::optional<PlatformVideoColorSpace>&&);
     VideoFrameCV(MediaTime presentationTime, bool isMirrored, Rotation, RetainPtr<CVPixelBufferRef>&&, PlatformVideoColorSpace&&);
 

--- a/Source/WebCore/platform/graphics/filters/DistantLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/DistantLightSource.h
@@ -29,7 +29,7 @@
 namespace WebCore {
 
 class DistantLightSource : public LightSource {
-    friend struct IPC::ArgumentCoder<DistantLightSource, void>;
+    friend struct IPC::ArgumentCoder<DistantLightSource>;
 
 public:
     WEBCORE_EXPORT static Ref<DistantLightSource> create(float azimuth, float elevation);

--- a/Source/WebCore/platform/graphics/filters/FilterEffectGeometry.h
+++ b/Source/WebCore/platform/graphics/filters/FilterEffectGeometry.h
@@ -80,7 +80,7 @@ public:
     }
 
 private:
-    friend struct IPC::ArgumentCoder<FilterEffectGeometry, void>;
+    friend struct IPC::ArgumentCoder<FilterEffectGeometry>;
     FloatRect m_boundaries;
     OptionSet<Flags> m_flags;
 };

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.h
@@ -85,7 +85,7 @@ public:
     WEBCORE_EXPORT FilterOperations blend(const FilterOperations&, const BlendingContext&) const;
 
 private:
-    friend struct IPC::ArgumentCoder<FilterOperations, void>;
+    friend struct IPC::ArgumentCoder<FilterOperations>;
     WEBCORE_EXPORT friend WTF::TextStream& operator<<(WTF::TextStream&, const FilterOperations&);
 
     Vector<Ref<FilterOperation>> m_operations;

--- a/Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.h
+++ b/Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.h
@@ -64,7 +64,7 @@ protected:
     AppKitControlSystemImage(AppKitControlSystemImageType);
 
 private:
-    friend struct IPC::ArgumentCoder<AppKitControlSystemImage, void>;
+    friend struct IPC::ArgumentCoder<AppKitControlSystemImage>;
     AppKitControlSystemImageType m_controlType;
 
     Color m_tintColor;

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.h
@@ -73,7 +73,7 @@ public:
     bool containsNonInvertibleMatrix() const;
 
 private:
-    friend struct IPC::ArgumentCoder<TransformOperations, void>;
+    friend struct IPC::ArgumentCoder<TransformOperations>;
     friend WTF::TextStream& operator<<(WTF::TextStream&, const TransformOperations&);
 
     Vector<Ref<TransformOperation>> m_operations;

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -386,7 +386,7 @@ public:
     void logAsInt(MediaConstraintType) const;
     
 private:
-    friend struct IPC::ArgumentCoder<IntConstraint, void>;
+    friend struct IPC::ArgumentCoder<IntConstraint>;
     
     IntConstraint(MediaConstraint&& mediaConstraint, std::optional<int>&& min, std::optional<int>&& max,                   std::optional<int>&& exact, std::optional<int>&& ideal)
         : NumericConstraint<int>(WTFMove(mediaConstraint), WTFMove(min), WTFMove(max), WTFMove(exact), WTFMove(ideal))
@@ -409,7 +409,7 @@ public:
     void logAsDouble(MediaConstraintType) const;
     
 private:
-    friend struct IPC::ArgumentCoder<DoubleConstraint, void>;
+    friend struct IPC::ArgumentCoder<DoubleConstraint>;
     
     DoubleConstraint(MediaConstraint&& mediaConstraint, std::optional<double>&& min, std::optional<double>&& max,                   std::optional<double>&& exact, std::optional<double>&& ideal)
         : NumericConstraint<double>(WTFMove(mediaConstraint), WTFMove(min), WTFMove(max), WTFMove(exact), WTFMove(ideal))
@@ -489,7 +489,7 @@ public:
     void logAsBoolean(MediaConstraintType) const;
 
 private:
-    friend struct IPC::ArgumentCoder<BooleanConstraint, void>;
+    friend struct IPC::ArgumentCoder<BooleanConstraint>;
     
     BooleanConstraint(MediaConstraint&& mediaConstraint, std::optional<bool>&& exact, std::optional<bool>&& ideal)
         : MediaConstraint(WTFMove(mediaConstraint))
@@ -573,7 +573,7 @@ public:
     StringConstraint isolatedCopy() const;
 
 private:
-    friend struct IPC::ArgumentCoder<StringConstraint, void>;
+    friend struct IPC::ArgumentCoder<StringConstraint>;
     
     StringConstraint(MediaConstraint&& mediaConstraint, Vector<String>&& exact, Vector<String>&& ideal)
         : MediaConstraint(WTFMove(mediaConstraint))
@@ -659,7 +659,7 @@ public:
     MediaTrackConstraintSetMap isolatedCopy() const;
 
 private:
-    friend struct IPC::ArgumentCoder<MediaTrackConstraintSetMap, void>;
+    friend struct IPC::ArgumentCoder<MediaTrackConstraintSetMap>;
     std::optional<IntConstraint> m_width;
     std::optional<IntConstraint> m_height;
     std::optional<IntConstraint> m_sampleRate;

--- a/Source/WebCore/platform/network/BlobPart.h
+++ b/Source/WebCore/platform/network/BlobPart.h
@@ -29,14 +29,14 @@
 #include <wtf/URL.h>
 
 namespace IPC {
-template<typename T, typename> struct ArgumentCoder;
+template<typename> struct ArgumentCoder;
 }
 
 namespace WebCore {
 
 class BlobPart {
 private:
-    friend struct IPC::ArgumentCoder<BlobPart, void>;
+    friend struct IPC::ArgumentCoder<BlobPart>;
 public:
     using VariantType = Variant<Vector<uint8_t>, Ref<SharedBuffer>, URL>;
 

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -182,7 +182,7 @@ public:
     WEBCORE_EXPORT URL asBlobURL() const;
 
 private:
-    friend struct IPC::ArgumentCoder<FormData, void>;
+    friend struct IPC::ArgumentCoder<FormData>;
     FormData() = default;
     FormData(const FormData&);
 

--- a/Source/WebCore/platform/network/SocketStreamError.h
+++ b/Source/WebCore/platform/network/SocketStreamError.h
@@ -38,7 +38,7 @@ namespace WebCore {
 
 class SocketStreamError {
 private:
-    friend struct IPC::ArgumentCoder<SocketStreamError, void>;
+    friend struct IPC::ArgumentCoder<SocketStreamError>;
 public:
     SocketStreamError() = default;
 

--- a/Source/WebCore/platform/network/curl/CurlProxySettings.h
+++ b/Source/WebCore/platform/network/curl/CurlProxySettings.h
@@ -73,7 +73,7 @@ public:
     long authMethod() const { return m_authMethod; }
 
 private:
-    friend struct IPC::ArgumentCoder<CurlProxySettings, void>;
+    friend struct IPC::ArgumentCoder<CurlProxySettings>;
     using IPCData = Variant<DefaultData, NoProxyData, CustomData>;
     WEBCORE_EXPORT IPCData toIPCData() const;
     WEBCORE_EXPORT static CurlProxySettings fromIPCData(IPCData&&);

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -170,7 +170,7 @@ public:
 #endif
 
 private:
-    friend struct IPC::ArgumentCoder<EventRegion, void>;
+    friend struct IPC::ArgumentCoder<EventRegion>;
 #if ENABLE(TOUCH_ACTION_REGIONS)
     void uniteTouchActions(const Region&, OptionSet<TouchAction>);
 #endif

--- a/Source/WebCore/svg/SVGPreserveAspectRatioValue.h
+++ b/Source/WebCore/svg/SVGPreserveAspectRatioValue.h
@@ -24,7 +24,7 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace IPC {
-template<typename T, typename> struct ArgumentCoder;
+template<typename> struct ArgumentCoder;
 }
 
 namespace WebCore {
@@ -79,7 +79,7 @@ public:
     String valueAsString() const;
 
 private:
-    friend struct IPC::ArgumentCoder<SVGPreserveAspectRatioValue, void>;
+    friend struct IPC::ArgumentCoder<SVGPreserveAspectRatioValue>;
     SVGPreserveAspectRatioType m_align { SVGPreserveAspectRatioValue::SVG_PRESERVEASPECTRATIO_XMIDYMID };
     SVGMeetOrSliceType m_meetOrSlice { SVGPreserveAspectRatioValue::SVG_MEETORSLICE_MEET };
 

--- a/Source/WebCore/testing/MockContentFilterSettings.h
+++ b/Source/WebCore/testing/MockContentFilterSettings.h
@@ -79,7 +79,7 @@ public:
     MockContentFilterSettings(const MockContentFilterSettings&) = default;
     MockContentFilterSettings& operator=(const MockContentFilterSettings&) = default;
 private:
-    friend struct IPC::ArgumentCoder<MockContentFilterSettings, void>;
+    friend struct IPC::ArgumentCoder<MockContentFilterSettings>;
 
     bool m_enabled { false };
     DecisionPoint m_decisionPoint { DecisionPoint::AfterResponse };

--- a/Source/WebGPU/WGSL/AST/ASTIdentifier.h
+++ b/Source/WebGPU/WGSL/AST/ASTIdentifier.h
@@ -72,10 +72,10 @@ SPECIALIZE_TYPE_TRAITS_WGSL_AST(Identifier);
 
 namespace WTF {
 
-template<> class StringTypeAdapter<WGSL::AST::Identifier, void> : public StringTypeAdapter<StringImpl*, void> {
+template<> class StringTypeAdapter<WGSL::AST::Identifier> : public StringTypeAdapter<StringImpl*> {
 public:
     StringTypeAdapter(const WGSL::AST::Identifier& id)
-        : StringTypeAdapter<StringImpl*, void> { id.id().impl() }
+        : StringTypeAdapter<StringImpl*> { id.id().impl() }
     { }
 };
 

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -307,7 +307,7 @@ const Type* shaderTypeForTexelFormat(TexelFormat, const TypeStore&);
 
 namespace WTF {
 
-template<> class StringTypeAdapter<WGSL::Type, void> {
+template<> class StringTypeAdapter<WGSL::Type> {
 public:
     StringTypeAdapter(const WGSL::Type& type)
         : m_string { type.toString() }

--- a/Source/WebKit/Platform/IPC/ConnectionHandle.h
+++ b/Source/WebKit/Platform/IPC/ConnectionHandle.h
@@ -71,7 +71,7 @@ public:
 #endif
 
 private:
-    friend struct IPC::ArgumentCoder<ConnectionHandle, void>;
+    friend struct IPC::ArgumentCoder<ConnectionHandle>;
 
 #if USE(UNIX_DOMAIN_SOCKETS)
     UnixFileDescriptor m_handle;

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -61,7 +61,7 @@ namespace IPC {
 enum class MessageFlags : uint8_t;
 enum class ShouldDispatchWhenWaitingForSyncReply : uint8_t;
 
-template<typename, typename> struct ArgumentCoder;
+template<typename> struct ArgumentCoder;
 
 #ifdef __OBJC__
 template<typename T> using IsObjCObject = std::enable_if_t<std::is_convertible<T *, id>::value, T *>;
@@ -142,7 +142,7 @@ public:
     template<typename T>
     std::optional<T> decode()
     {
-        std::optional<T> t { ArgumentCoder<std::remove_cvref_t<T>, void>::decode(*this) };
+        std::optional<T> t { ArgumentCoder<std::remove_cvref_t<T>>::decode(*this) };
         if (!t) [[unlikely]]
             markInvalid();
         return t;

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -47,7 +47,7 @@ namespace IPC {
 enum class MessageFlags : uint8_t;
 enum class ShouldDispatchWhenWaitingForSyncReply : uint8_t;
 
-template<typename, typename> struct ArgumentCoder;
+template<typename> struct ArgumentCoder;
 
 class Encoder final {
     WTF_MAKE_TZONE_ALLOCATED(Encoder);
@@ -82,7 +82,7 @@ public:
     template<typename T>
     Encoder& operator<<(T&& t)
     {
-        SUPPRESS_FORWARD_DECL_ARG ArgumentCoder<std::remove_cvref_t<T>, void>::encode(*this, std::forward<T>(t));
+        SUPPRESS_FORWARD_DECL_ARG ArgumentCoder<std::remove_cvref_t<T>>::encode(*this, std::forward<T>(t));
         return *this;
     }
 

--- a/Source/WebKit/Platform/IPC/IPCEvent.h
+++ b/Source/WebKit/Platform/IPC/IPCEvent.h
@@ -62,7 +62,7 @@ public:
 #endif
 
 private:
-    friend struct IPC::ArgumentCoder<Signal, void>;
+    friend struct IPC::ArgumentCoder<Signal>;
 
     friend std::optional<EventSignalPair> createEventSignalPair();
 

--- a/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
@@ -31,7 +31,7 @@
 
 namespace IPC {
 
-template<typename, typename> struct ArgumentCoder;
+template<typename> struct ArgumentCoder;
 
 // IPC encoder which:
 //  - Encodes to a caller buffer with fixed size, does not resize, stops when size runs out
@@ -81,7 +81,7 @@ public:
     template<typename T>
     StreamConnectionEncoder& operator<<(T&& t)
     {
-        ArgumentCoder<std::remove_cvref_t<T>, void>::encode(*this, std::forward<T>(t));
+        ArgumentCoder<std::remove_cvref_t<T>>::encode(*this, std::forward<T>(t));
         return *this;
     }
 

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -1965,7 +1965,7 @@ def generate_webkit_secure_coding_header(serialized_types):
         result.append('    RetainPtr<id> toID() const;')
         result.append('')
         result.append('private:')
-        result.append(f'    friend struct IPC::ArgumentCoder<{type.cpp_struct_or_class_name()}, void>;')
+        result.append(f'    friend struct IPC::ArgumentCoder<{type.cpp_struct_or_class_name()}>;')
         result.append('')
         result.append(f'    {type.cpp_struct_or_class_name()}(')
         for i in range(len(type.dictionary_members)):

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.h
@@ -49,7 +49,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCAVOutputContext, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCAVOutputContext>;
 
     CoreIPCAVOutputContext(
         RetainPtr<NSString>&&,
@@ -70,7 +70,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCNSSomeFoundationType, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCNSSomeFoundationType>;
 
     CoreIPCNSSomeFoundationType(
         RetainPtr<NSString>&&,
@@ -100,7 +100,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCclass NSSomeOtherFoundationType, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCclass NSSomeOtherFoundationType>;
 
     CoreIPCclass NSSomeOtherFoundationType(
         RetainPtr<NSDictionary>&&
@@ -119,7 +119,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCDDScannerResult, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCDDScannerResult>;
 
     CoreIPCDDScannerResult(
         RetainPtr<NSString>&&,

--- a/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h
+++ b/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h
@@ -54,7 +54,7 @@ public:
     operator Vector<Ref<WebCore::ApplePaySetupFeature>>() const;
 
 private:
-    friend struct IPC::ArgumentCoder<PaymentSetupFeatures, void>;
+    friend struct IPC::ArgumentCoder<PaymentSetupFeatures>;
     RetainPtr<NSArray> m_platformFeatures;
 };
 

--- a/Source/WebKit/Shared/CallbackID.h
+++ b/Source/WebKit/Shared/CallbackID.h
@@ -77,7 +77,7 @@ public:
     }
 
 private:
-    friend struct IPC::ArgumentCoder<CallbackID, void>;
+    friend struct IPC::ArgumentCoder<CallbackID>;
     ALWAYS_INLINE explicit CallbackID(uint64_t newID)
         : m_id(newID)
     {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.h
@@ -55,7 +55,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCAVOutputContext, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCAVOutputContext>;
 
     CoreIPCAVOutputContextData m_data;
 };

--- a/Source/WebKit/Shared/Cocoa/CoreIPCArray.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCArray.h
@@ -44,7 +44,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCArray, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCArray>;
 
     CoreIPCArray(Vector<CoreIPCNSCFObject>&&);
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCVPixelBufferRef.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCVPixelBufferRef.h
@@ -54,7 +54,7 @@ public:
     RetainPtr<CVPixelBufferRef> toCF() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCCVPixelBufferRef, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCCVPixelBufferRef>;
 
     MachSendRight sendRightFromPixelBuffer(const RetainPtr<CVPixelBufferRef>&);
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCColor.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCColor.h
@@ -50,7 +50,7 @@ public:
     }
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCColor, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCColor>;
 
     WebCore::Color m_color;
 };

--- a/Source/WebKit/Shared/Cocoa/CoreIPCContacts.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCContacts.h
@@ -46,7 +46,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCCNPostalAddress, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCCNPostalAddress>;
 
     CoreIPCCNPostalAddress(String&& street, String&& subLocality, String&& city, String&& subAdministrativeArea, String&& state, String&& postalCode, String&& country, String&& isoCountryCode, String&& formattedAddress)
         : m_street(WTFMove(street))
@@ -79,7 +79,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCCNPhoneNumber, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCCNPhoneNumber>;
 
     CoreIPCCNPhoneNumber(String&& digits, String&& countryCode)
         : m_digits(WTFMove(digits))
@@ -112,7 +112,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCCNContact, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCCNContact>;
     CoreIPCCNContact() = default;
 
     String m_identifier;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.h
@@ -39,7 +39,7 @@ public:
     static constexpr size_t numberOfComponentIndexes = 14;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCDateComponents, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCDateComponents>;
     CoreIPCDateComponents() = default;
 
     String m_calendarIdentifier;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h
@@ -48,7 +48,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCDictionary, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCDictionary>;
 
     using ValueType = Vector<KeyValuePair<CoreIPCNSCFObject, CoreIPCNSCFObject>>;
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.h
@@ -54,7 +54,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCNSShadow, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCNSShadow>;
 
     WebCore::DoubleSize m_shadowOffset;
     double m_shadowBlurRadius;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.h
@@ -84,7 +84,7 @@ public:
 
     RetainPtr<id> toID() const;
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCNSURLCredential, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCNSURLCredential>;
     CoreIPCNSURLCredentialData m_data;
 };
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLProtectionSpace.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLProtectionSpace.h
@@ -58,7 +58,7 @@ public:
 
     RetainPtr<id> toID() const;
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCNSURLProtectionSpace, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCNSURLProtectionSpace>;
     CoreIPCNSURLProtectionSpaceData m_data;
 };
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
@@ -161,7 +161,7 @@ public:
 
     RetainPtr<id> toID() const;
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCNSURLRequest, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCNSURLRequest>;
     CoreIPCNSURLRequestData m_data;
 };
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h
@@ -58,7 +58,7 @@ public:
     using Value = Variant<IPCRange, WebCore::DoubleRect, UniqueRef<CoreIPCNSCFObject>>;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCNSValue, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCNSValue>;
 
     static Value valueFromNSValue(NSValue *);
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKDateComponentsRange.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKDateComponentsRange.h
@@ -48,7 +48,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCPKDateComponentsRange, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCPKDateComponentsRange>;
     CoreIPCPKDateComponentsRange(std::optional<CoreIPCPKDateComponentsRangeData>&&);
 
     std::optional<CoreIPCPKDateComponentsRangeData> m_data;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.h
@@ -44,7 +44,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCPKContact, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCPKContact>;
 
     CoreIPCPKContact(std::optional<CoreIPCPersonNameComponents>&& name, String&& emailAddress, std::optional<CoreIPCCNPhoneNumber>&& phoneNumber, std::optional<CoreIPCCNPostalAddress>&& postalAddress, String&& supplementarySublocality)
         : m_name(WTFMove(name))

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.h
@@ -42,7 +42,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCPersonNameComponents, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCPersonNameComponents>;
 
     CoreIPCPersonNameComponents(const String& namePrefix, const String& givenName, const String& middleName, const String& familyName, const String& nickname, std::unique_ptr<CoreIPCPersonNameComponents>&& phoneticRepresentation)
         : m_namePrefix(namePrefix)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.h
@@ -45,7 +45,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCPlistArray, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCPlistArray>;
 
     CoreIPCPlistArray(Vector<CoreIPCPlistObject>&&);
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.h
@@ -49,7 +49,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCPlistDictionary, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCPlistDictionary>;
 
     using ValueType = Vector<KeyValuePair<CoreIPCString, CoreIPCPlistObject>>;
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.h
@@ -44,7 +44,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCPresentationIntent, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCPresentationIntent>;
 
     CoreIPCPresentationIntent(int64_t intentKind, int64_t identity, std::unique_ptr<CoreIPCPresentationIntent>&& parentIntent, int64_t column, Vector<int64_t>&& columnAlignments, int64_t columnCount, int64_t headerLevel, const String& languageHint, int64_t ordinal, int64_t row)
         : m_intentKind(intentKind)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h
@@ -66,7 +66,7 @@ public:
     Class objectClass() { return m_secureCoding.get().class; }
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCSecureCoding, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCSecureCoding>;
 
     IPC::CoreIPCRetainPtr<NSObject<NSSecureCoding>> m_secureCoding;
 };

--- a/Source/WebKit/Shared/Cocoa/CoreIPCString.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCString.h
@@ -49,7 +49,7 @@ public:
     RetainPtr<id> toID() const { return m_string.createNSString(); }
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCString, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCString>;
 
     String m_string;
 };

--- a/Source/WebKit/Shared/Cocoa/CoreIPCStringSet.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCStringSet.h
@@ -41,7 +41,7 @@ public:
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCStringSet, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCStringSet>;
 
     CoreIPCStringSet(Vector<String>&&);
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCURL.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCURL.h
@@ -48,7 +48,7 @@ public:
     RetainPtr<id> toID() const { return m_url.createNSURL(); }
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCURL, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCURL>;
 
     URL m_url;
 };

--- a/Source/WebKit/Shared/Databases/IndexedDB/WebIDBResult.h
+++ b/Source/WebKit/Shared/Databases/IndexedDB/WebIDBResult.h
@@ -56,7 +56,7 @@ public:
     const Vector<SandboxExtension::Handle>& handles() const { return m_handles; }
 
 private:
-    friend struct IPC::ArgumentCoder<WebIDBResult, void>;
+    friend struct IPC::ArgumentCoder<WebIDBResult>;
     WebCore::IDBResultData m_resultData;
     Vector<SandboxExtension::Handle> m_handles;
 };

--- a/Source/WebKit/Shared/MonotonicObjectIdentifier.h
+++ b/Source/WebKit/Shared/MonotonicObjectIdentifier.h
@@ -69,7 +69,7 @@ public:
     }
 
 private:
-    friend struct IPC::ArgumentCoder<MonotonicObjectIdentifier, void>;
+    friend struct IPC::ArgumentCoder<MonotonicObjectIdentifier>;
     template<typename U> friend MonotonicObjectIdentifier<U> makeMonotonicObjectIdentifier(uint64_t);
     friend struct HashTraits<MonotonicObjectIdentifier>;
     template<typename U> friend struct MonotonicObjectIdentifierHash;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -239,7 +239,7 @@ public:
     std::optional<WebCore::RenderingResourceIdentifier> contentsRenderingResourceIdentifier() const { return m_contentsRenderingResourceIdentifier; };
 
 private:
-    friend struct IPC::ArgumentCoder<RemoteLayerBackingStoreProperties, void>;
+    friend struct IPC::ArgumentCoder<RemoteLayerBackingStoreProperties>;
 
     LayerContentsBufferInfo lookupCachedBuffer(RemoteLayerTreeNode&);
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -241,7 +241,7 @@ public:
 #endif
 
 private:
-    friend struct IPC::ArgumentCoder<RemoteLayerTreeTransaction, void>;
+    friend struct IPC::ArgumentCoder<RemoteLayerTreeTransaction>;
 
     // Do not use, IPC constructor only
     explicit RemoteLayerTreeTransaction();

--- a/Source/WebKit/Shared/glib/UserMessage.h
+++ b/Source/WebKit/Shared/glib/UserMessage.h
@@ -88,7 +88,7 @@ struct UserMessage {
     };
 
 private:
-    friend struct IPC::ArgumentCoder<UserMessage, void>;
+    friend struct IPC::ArgumentCoder<UserMessage>;
 
     using IPCData = Variant<NullMessage, ErrorMessage, DataMessage>;
     static UserMessage fromIPCData(IPCData&&);

--- a/Source/WebKit/Shared/mac/SecItemRequestData.h
+++ b/Source/WebKit/Shared/mac/SecItemRequestData.h
@@ -58,7 +58,7 @@ public:
     RetainPtr<CFDictionaryRef> protectedAttributesToMatch() const { return m_attributesToMatch; }
 
 private:
-    friend struct IPC::ArgumentCoder<WebKit::SecItemRequestData, void>;
+    friend struct IPC::ArgumentCoder<WebKit::SecItemRequestData>;
 
     Type m_type { Type::Invalid };
     RetainPtr<CFDictionaryRef> m_queryDictionary;

--- a/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h
@@ -42,7 +42,7 @@ public:
     WebCore::ShareableBitmap* bitmap() const { return m_bitmap.get(); }
 
 private:
-    friend struct IPC::ArgumentCoder<WCBackingStore, void>;
+    friend struct IPC::ArgumentCoder<WCBackingStore>;
 
     WCBackingStore(std::optional<ImageBufferBackendHandle>&&);
     std::optional<ImageBufferBackendHandle> handle() const;

--- a/Source/bmalloc/bmalloc/Packed.h
+++ b/Source/bmalloc/bmalloc/Packed.h
@@ -84,7 +84,8 @@ public:
         m_storage.swap(other.m_storage);
     }
 
-    template<typename Other, typename = std::enable_if_t<Other::isPackedType>>
+    template<typename Other>
+        requires Other::isPackedType
     void swap(Other& other)
     {
         T t1 = get();
@@ -195,7 +196,8 @@ public:
         m_storage.swap(other.m_storage);
     }
 
-    template<typename Other, typename = std::enable_if_t<Other::isPackedType>>
+    template<typename Other>
+        requires Other::isPackedType
     void swap(Other& other)
     {
         T* t1 = get();

--- a/Tools/TestWebKitAPI/Tests/WTF/MoveOnly.h
+++ b/Tools/TestWebKitAPI/Tests/WTF/MoveOnly.h
@@ -99,7 +99,7 @@ template<> struct DefaultHash<MoveOnly> {
     static constexpr bool hasHashInValue = true; // This is not correct, but for debugging of RobinHoodHashSet.
 };
 
-template<> class StringTypeAdapter<MoveOnly, void> {
+template<> class StringTypeAdapter<MoveOnly> {
 public:
     StringTypeAdapter(const MoveOnly& moveOnly)
         : m_moveOnly { moveOnly }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -317,7 +317,7 @@ public:
     Vector<uint8_t> takeBytes() { return std::exchange(m_bytes, { }); }
     template<typename T> TestEncoder& operator<<(T&& t)
     {
-        TestArgumentCoder<std::remove_cvref_t<T>, void>::encode(*this, std::forward<T>(t));
+        TestArgumentCoder<std::remove_cvref_t<T>>::encode(*this, std::forward<T>(t));
         return *this;
     }
     template<typename T, size_t Extent> void encodeSpan(std::span<T, Extent> span)
@@ -347,7 +347,7 @@ public:
         RELEASE_ASSERT(decode<IPC::MessageName>() == T::asyncMessageReplyName());
         decode<uint64_t>();
     }
-    template<typename T> std::optional<T> decode() { return TestArgumentCoder<std::remove_cvref_t<T>, void>::decode(*this); }
+    template<typename T> std::optional<T> decode() { return TestArgumentCoder<std::remove_cvref_t<T>>::decode(*this); }
     template<typename T> std::optional<T> decodeInteger()
     {
         while (m_bufferPosition != m_buffer.end() && bufferOffset() % alignof(T))


### PR DESCRIPTION
#### 46496e5fd6f7ddf79ae435b18f4c815dc6e338a5
<pre>
Replace std::enable_if with requires/concepts (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301805">https://bugs.webkit.org/show_bug.cgi?id=301805</a>

Reviewed by Darin Adler.

First pass of replacing uses of std::enable_if/std::enable_if_t with
the requires/concepts. This pass focuses on WTF and only does the
following trivial transformations:

  - std::is_same::value/std::is_same_v -&gt; std::same_as
  - std::is_integer::value/std::is_integer_v -&gt; std::integral
  - std::is_integer::value/std::is_integer_v + std::is_signed::value/std::is_signed_v -&gt; std::signed_integral
  - std::is_integer::value/std::is_integer_v + std::is_unsigned::value/std::is_unsigned_v -&gt; std::unsigned_integral
  - std::is_floating_point::value/std::is_floating_point_v -&gt; std::floating_point
  - IsSmartPtr::value -&gt; SmartPtr
  - IsSmartPtr::value + !IsSmartPtr::isNullable -&gt; NonNullableSmartPtr
  - std::is_*::value -&gt; std::is_*_v (e.g. std::is_function::value -&gt; std::is_function_v)
  - std::*::type -&gt; std::*_t (e.g. std::remove_pointer::type -&gt; std::remove_pointer_t)

Further adoption of stricter concepts, which might change the semantics,
such as std::is_base_of_v -&gt; std::derived_from, can be done in follow ups.

* Source/JavaScriptCore/assembler/CodeLocation.h:
* Source/JavaScriptCore/assembler/LinkBuffer.h:
* Source/WTF/wtf/ArgumentCoder.h:
* Source/WTF/wtf/CagedPtr.h:
* Source/WTF/wtf/CallbackAggregator.h:
* Source/WTF/wtf/CheckedArithmetic.h:
* Source/WTF/wtf/CodePtr.h:
* Source/WTF/wtf/CompactPointerTuple.h:
* Source/WTF/wtf/CompactPtr.h:
* Source/WTF/wtf/CompactUniquePtrTuple.h:
* Source/WTF/wtf/CompletionHandler.h:
* Source/WTF/wtf/EnumClassOperatorOverloads.h:
* Source/WTF/wtf/EnumTraits.h:
* Source/WTF/wtf/FastMalloc.h:
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/Function.h:
* Source/WTF/wtf/FunctionTraits.h:
* Source/WTF/wtf/HashFunctions.h:
* Source/WTF/wtf/HashSet.h:
* Source/WTF/wtf/Hasher.h:
* Source/WTF/wtf/JSONValues.h:
* Source/WTF/wtf/ListHashSet.h:
* Source/WTF/wtf/Lock.h:
* Source/WTF/wtf/Locker.h:
* Source/WTF/wtf/Logger.h:
* Source/WTF/wtf/Packed.h:
* Source/WTF/wtf/PointerPreparations.h:
* Source/WTF/wtf/PtrTag.h:
* Source/WTF/wtf/RawPointer.h:
* Source/WTF/wtf/Ref.h:
* Source/WTF/wtf/SaturatedArithmetic.h:
* Source/WTF/wtf/SignedPtr.h:
* Source/WTF/wtf/StdLibExtras.h:
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
* Source/WTF/wtf/Vector.h:
* Source/WTF/wtf/WeakRef.h:
* Source/WTF/wtf/cocoa/TypeCastsCocoa.h:
* Source/WTF/wtf/persistence/PersistentDecoder.h:
* Source/WTF/wtf/persistence/PersistentEncoder.h:
* Source/WTF/wtf/text/StringCommon.h:
* Source/WTF/wtf/text/StringConcatenate.h:
* Source/WTF/wtf/text/StringConcatenateNumbers.h:
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/StringView.h:
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/Modules/applepay/PaymentMethod.h:
* Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.h:
* Source/WebCore/Modules/indexeddb/IDBGetAllResult.h:
* Source/WebCore/Modules/indexeddb/shared/IDBCursorInfo.h:
* Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.h:
* Source/WebCore/Modules/indexeddb/shared/IDBOpenRequestData.h:
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h:
* Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h:
* Source/WebCore/Modules/indexeddb/shared/IDBResultData.h:
* Source/WebCore/Modules/speech/SpeechRecognitionUpdate.h:
* Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h:
* Source/WebCore/bindings/js/SerializedScriptValue.h:
* Source/WebCore/editing/FontAttributeChanges.h:
* Source/WebCore/inspector/InspectorOverlayLabel.h:
* Source/WebCore/loader/COEPInheritenceViolationReportBody.h:
* Source/WebCore/loader/CORPViolationReportBody.h:
* Source/WebCore/loader/ResourceLoadStatistics.h:
* Source/WebCore/page/SecurityOrigin.h:
* Source/WebCore/platform/MediaSamplesBlock.h:
* Source/WebCore/platform/ProcessIdentity.h:
* Source/WebCore/platform/ProcessQualified.h:
* Source/WebCore/platform/RegistrableDomain.h:
* Source/WebCore/platform/ShareableResource.h:
* Source/WebCore/platform/SharedMemory.h:
* Source/WebCore/platform/ThreadSafeDataBuffer.h:
* Source/WebCore/platform/TrackInfo.h:
* Source/WebCore/platform/graphics/FontTaggedSettings.h:
* Source/WebCore/platform/graphics/GraphicsContextState.h:
* Source/WebCore/platform/graphics/LayoutRect.h:
* Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h:
* Source/WebCore/platform/graphics/PlatformTimeRanges.h:
* Source/WebCore/platform/graphics/Region.h:
* Source/WebCore/platform/graphics/ShareableBitmap.h:
* Source/WebCore/platform/graphics/cv/VideoFrameCV.h:
* Source/WebCore/platform/graphics/filters/DistantLightSource.h:
* Source/WebCore/platform/graphics/filters/FilterEffectGeometry.h:
* Source/WebCore/platform/graphics/filters/FilterOperations.h:
* Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.h:
* Source/WebCore/platform/graphics/transforms/TransformOperations.h:
* Source/WebCore/platform/mediastream/MediaConstraints.h:
* Source/WebCore/platform/network/BlobPart.h:
* Source/WebCore/platform/network/FormData.h:
* Source/WebCore/platform/network/SocketStreamError.h:
* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/svg/SVGPreserveAspectRatioValue.h:
* Source/WebCore/testing/MockContentFilterSettings.h:
* Source/WebGPU/WGSL/AST/ASTIdentifier.h:
* Source/WebGPU/WGSL/Types.h:
* Source/WebKit/Platform/IPC/ConnectionHandle.h:
* Source/WebKit/Platform/IPC/Decoder.h:
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/IPCEvent.h:
* Source/WebKit/Platform/IPC/StreamConnectionEncoder.h:
* Source/WebKit/Scripts/generate-serializers.py:
* Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h:
* Source/WebKit/Shared/CallbackID.h:
* Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.h:
* Source/WebKit/Shared/Cocoa/CoreIPCArray.h:
* Source/WebKit/Shared/Cocoa/CoreIPCCVPixelBufferRef.h:
* Source/WebKit/Shared/Cocoa/CoreIPCColor.h:
* Source/WebKit/Shared/Cocoa/CoreIPCContacts.h:
* Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.h:
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLProtectionSpace.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPKDateComponentsRange.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.h:
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h:
* Source/WebKit/Shared/Cocoa/CoreIPCString.h:
* Source/WebKit/Shared/Cocoa/CoreIPCStringSet.h:
* Source/WebKit/Shared/Cocoa/CoreIPCURL.h:
* Source/WebKit/Shared/Databases/IndexedDB/WebIDBResult.h:
* Source/WebKit/Shared/MonotonicObjectIdentifier.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/mac/SecItemRequestData.h:
* Source/bmalloc/bmalloc/Packed.h:
* Tools/TestWebKitAPI/Tests/WTF/MoveOnly.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/302456@main">https://commits.webkit.org/302456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9588ccef9c36edb2603062a80033e8500e4f78aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129139 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1275 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66205 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78982 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/128489 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/958 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33798 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79798 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121130 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138992 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127591 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1155 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106702 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27161 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/980 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30541 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53760 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1264 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64616 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160606 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1090 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40091 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1188 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->