### PR TITLE
Pass a color parsing context to parser when parsing colors in SVG

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -740,7 +740,6 @@ svg/SVGUseElement.cpp
 svg/animation/SVGSMILElement.cpp
 svg/graphics/SVGImage.cpp
 svg/properties/SVGAnimatedString.cpp
-svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
 testing/Internals.cpp
 [ Mac ] testing/Internals.mm
 workers/WorkerGlobalScope.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -538,7 +538,6 @@ svg/SVGToOTFFontConversion.cpp
 svg/SVGUseElement.cpp
 svg/graphics/SVGImage.cpp
 svg/properties/SVGAnimatedString.cpp
-svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
 testing/Internals.cpp
 [ Mac ] testing/Internals.mm
 testing/ServiceWorkerInternals.cpp

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -1804,19 +1804,4 @@ void CSSParser::consumeDeclarationValue(CSSParserTokenRange range, CSSPropertyID
     CSSPropertyParser::parseValue(propertyID, important, range, m_context, topContext().m_parsedProperties, ruleType);
 }
 
-std::optional<Style::Color> CSSParser::parseColorOrCurrentColorWithoutContext(const String& string)
-{
-    if (auto color = CSSParserFastPaths::parseSimpleColor(string, CSSParserContext(HTMLStandardMode)))
-        return *color;
-    // FIXME: Unclear why we want to ignore the boolean argument "strict" and always pass strictCSSParserContext here.
-    auto value = CSSPropertyParser::parseStylePropertyLonghand(CSSPropertyColor, string, strictCSSParserContext());
-    if (!value)
-        return std::nullopt;
-    if (value->isColor())
-        return CSSColorValue::absoluteColor(*value);
-    if (value->valueID() == CSSValueCurrentcolor)
-        return Style::Color();
-    return std::nullopt;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -124,7 +124,6 @@ public:
     static IsImportant consumeTrailingImportantAndWhitespace(CSSParserTokenRange&);
 
     static RefPtr<StyleRuleNestedDeclarations> parseNestedDeclarations(const CSSParserContext&, const String&);
-    static std::optional<Style::Color> parseColorOrCurrentColorWithoutContext(const String&);
 
     CSSTokenizer* tokenizer() const { return m_tokenizer.get(); }
 

--- a/Source/WebCore/svg/SVGAnimateElementBase.cpp
+++ b/Source/WebCore/svg/SVGAnimateElementBase.cpp
@@ -102,11 +102,12 @@ void SVGAnimateElementBase::resetAnimation()
 
 bool SVGAnimateElementBase::setFromAndToValues(const String& fromString, const String& toString)
 {
-    if (!targetElement())
+    RefPtr target = targetElement();
+    if (!target)
         return false;
 
     if (RefPtr animator = this->animator()) {
-        animator->setFromAndToValues(*protectedTargetElement(), animateRangeString(fromString), animateRangeString(toString));
+        animator->setFromAndToValues(*target, animateRangeString(fromString), animateRangeString(toString));
         return true;
     }
     return false;
@@ -114,7 +115,8 @@ bool SVGAnimateElementBase::setFromAndToValues(const String& fromString, const S
 
 bool SVGAnimateElementBase::setFromAndByValues(const String& fromString, const String& byString)
 {
-    if (!targetElement())
+    RefPtr target = targetElement();
+    if (!target)
         return false;
 
     if (animationMode() == AnimationMode::By && (!isAdditive() || isDiscreteAnimator()))
@@ -124,7 +126,7 @@ bool SVGAnimateElementBase::setFromAndByValues(const String& fromString, const S
         return false;
 
     if (RefPtr animator = this->animator()) {
-        animator->setFromAndByValues(*protectedTargetElement(), animateRangeString(fromString), animateRangeString(byString));
+        animator->setFromAndByValues(*target, animateRangeString(fromString), animateRangeString(byString));
         return true;
     }
     return false;
@@ -132,14 +134,15 @@ bool SVGAnimateElementBase::setFromAndByValues(const String& fromString, const S
 
 bool SVGAnimateElementBase::setToAtEndOfDurationValue(const String& toAtEndOfDurationString)
 {
-    if (!targetElement() || toAtEndOfDurationString.isEmpty())
+    RefPtr target = targetElement();
+    if (!target || toAtEndOfDurationString.isEmpty())
         return false;
 
     if (isDiscreteAnimator())
         return true;
 
     if (RefPtr animator = this->animator()) {
-        animator->setToAtEndOfDurationValue(animateRangeString(toAtEndOfDurationString));
+        animator->setToAtEndOfDurationValue(*target, animateRangeString(toAtEndOfDurationString));
         return true;
     }
     return false;
@@ -147,16 +150,18 @@ bool SVGAnimateElementBase::setToAtEndOfDurationValue(const String& toAtEndOfDur
 
 void SVGAnimateElementBase::startAnimation()
 {
-    if (!targetElement())
+    RefPtr target = targetElement();
+    if (!target)
         return;
 
     if (RefPtr protectedAnimator = this->animator())
-        protectedAnimator->start(*protectedTargetElement());
+        protectedAnimator->start(*target);
 }
 
 void SVGAnimateElementBase::calculateAnimatedValue(float progress, unsigned repeatCount)
 {
-    if (!targetElement())
+    RefPtr target = targetElement();
+    if (!target)
         return;
 
     ASSERT(progress >= 0 && progress <= 1);
@@ -167,35 +172,38 @@ void SVGAnimateElementBase::calculateAnimatedValue(float progress, unsigned repe
         progress = progress < 0.5 ? 0 : 1;
 
     if (RefPtr animator = this->animator())
-        animator->animate(*protectedTargetElement(), progress, repeatCount);
+        animator->animate(*target, progress, repeatCount);
 }
 
 void SVGAnimateElementBase::applyResultsToTarget()
 {
-    if (!targetElement())
+    RefPtr target = targetElement();
+    if (!target)
         return;
 
     if (RefPtr animator = this->animator())
-        animator->apply(*protectedTargetElement());
+        animator->apply(*target);
 }
 
 void SVGAnimateElementBase::stopAnimation(SVGElement* targetElement)
 {
-    if (!targetElement)
+    RefPtr target = targetElement;
+    if (!target)
         return;
 
     if (RefPtr animator = this->animatorIfExists())
-        animator->stop(*targetElement);
+        animator->stop(*target);
 }
 
 std::optional<float> SVGAnimateElementBase::calculateDistance(const String& fromString, const String& toString)
 {
     // FIXME: A return value of float is not enough to support paced animations on lists.
-    if (!targetElement())
+    RefPtr target = targetElement();
+    if (!target)
         return { };
 
     if (RefPtr animator = this->animator())
-        return animator->calculateDistance(*protectedTargetElement(), fromString, toString);
+        return animator->calculateDistance(*target, fromString, toString);
 
     return { };
 }

--- a/Source/WebCore/svg/SVGAnimateMotionElement.h
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.h
@@ -26,7 +26,7 @@
 namespace WebCore {
 
 class AffineTransform;
-            
+
 class SVGAnimateMotionElement final : public SVGAnimationElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SVGAnimateMotionElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAnimateMotionElement);

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -64,7 +64,7 @@ Ref<SVGClipPathElement> SVGClipPathElement::create(const QualifiedName& tagName,
 void SVGClipPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == SVGNames::clipPathUnitsAttr) {
-        auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
         if (propertyValue > 0)
             m_clipPathUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
     }

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
@@ -53,7 +53,7 @@ void SVGComponentTransferFunctionElement::attributeChanged(const QualifiedName& 
 {
     switch (name.nodeName()) {
     case AttributeNames::typeAttr: {
-        ComponentTransferType propertyValue = SVGPropertyTraits<ComponentTransferType>::fromString(newValue);
+        ComponentTransferType propertyValue = SVGPropertyTraits<ComponentTransferType>::fromString(*this, newValue);
         if (enumToUnderlyingType(propertyValue))
             m_type->setBaseValInternal<ComponentTransferType>(propertyValue);
         break;

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
@@ -56,7 +56,7 @@ struct SVGPropertyTraits<ComponentTransferType> {
         return emptyString();
     }
 
-    static ComponentTransferType fromString(const String& value)
+    static ComponentTransferType fromString(SVGElement&, const String& value)
     {
         static constexpr std::pair<PackedASCIILiteral<uint64_t>, ComponentTransferType> mappings[] = {
             { "discrete"_s, ComponentTransferType::FECOMPONENTTRANSFER_TYPE_DISCRETE },

--- a/Source/WebCore/svg/SVGFEBlendElement.h
+++ b/Source/WebCore/svg/SVGFEBlendElement.h
@@ -32,7 +32,7 @@ template<>
 struct SVGPropertyTraits<BlendMode> {
     static unsigned highestEnumValue() { return static_cast<unsigned>(BlendMode::Luminosity); }
 
-    static BlendMode fromString(const String& string)
+    static BlendMode fromString(SVGElement&, const String& string)
     {
         BlendMode mode = BlendMode::Normal;
         parseBlendMode(string, mode);

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
@@ -64,7 +64,7 @@ void SVGFEColorMatrixElement::attributeChanged(const QualifiedName& name, const 
 {
     switch (name.nodeName()) {
     case AttributeNames::typeAttr: {
-        auto propertyValue = SVGPropertyTraits<ColorMatrixType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<ColorMatrixType>::fromString(*this, newValue);
         if (enumToUnderlyingType(propertyValue))
             Ref { m_type }->setBaseValInternal<ColorMatrixType>(propertyValue);
         break;

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.h
@@ -50,7 +50,7 @@ struct SVGPropertyTraits<ColorMatrixType> {
         return emptyString();
     }
 
-    static ColorMatrixType fromString(const String& value)
+    static ColorMatrixType fromString(SVGElement&, const String& value)
     {
         if (value == "matrix"_s)
             return ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX;

--- a/Source/WebCore/svg/SVGFECompositeElement.cpp
+++ b/Source/WebCore/svg/SVGFECompositeElement.cpp
@@ -58,7 +58,7 @@ void SVGFECompositeElement::attributeChanged(const QualifiedName& name, const At
 {
     switch (name.nodeName()) {
     case AttributeNames::operatorAttr: {
-        CompositeOperationType propertyValue = SVGPropertyTraits<CompositeOperationType>::fromString(newValue);
+        CompositeOperationType propertyValue = SVGPropertyTraits<CompositeOperationType>::fromString(*this, newValue);
         if (enumToUnderlyingType(propertyValue))
             Ref { m_svgOperator }->setBaseValInternal<CompositeOperationType>(propertyValue);
         break;

--- a/Source/WebCore/svg/SVGFECompositeElement.h
+++ b/Source/WebCore/svg/SVGFECompositeElement.h
@@ -61,7 +61,7 @@ struct SVGPropertyTraits<CompositeOperationType> {
         return emptyString();
     }
 
-    static CompositeOperationType fromString(const String& value)
+    static CompositeOperationType fromString(SVGElement&, const String& value)
     {
         static constexpr std::pair<ComparableASCIILiteral, CompositeOperationType> mappings[] = {
             { "arithmetic"_s, CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC },

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -83,7 +83,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
         break;
     }
     case AttributeNames::edgeModeAttr: {
-        EdgeModeType propertyValue = SVGPropertyTraits<EdgeModeType>::fromString(newValue);
+        EdgeModeType propertyValue = SVGPropertyTraits<EdgeModeType>::fromString(*this, newValue);
         if (propertyValue != EdgeModeType::Unknown)
             Ref { m_edgeMode }->setBaseValInternal<EdgeModeType>(propertyValue);
         else

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
@@ -49,7 +49,7 @@ struct SVGPropertyTraits<EdgeModeType> {
         return emptyString();
     }
 
-    static EdgeModeType fromString(const String& value)
+    static EdgeModeType fromString(SVGElement&, const String& value)
     {
         if (value == "duplicate"_s)
             return EdgeModeType::Duplicate;

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
@@ -55,13 +55,13 @@ void SVGFEDisplacementMapElement::attributeChanged(const QualifiedName& name, co
 {
     switch (name.nodeName()) {
     case AttributeNames::xChannelSelectorAttr: {
-        auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(*this, newValue);
         if (enumToUnderlyingType(propertyValue))
             Ref { m_xChannelSelector }->setBaseValInternal<ChannelSelectorType>(propertyValue);
         break;
     }
     case AttributeNames::yChannelSelectorAttr: {
-        auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(*this, newValue);
         if (enumToUnderlyingType(propertyValue))
             Ref { m_yChannelSelector }->setBaseValInternal<ChannelSelectorType>(propertyValue);
         break;

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.h
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.h
@@ -49,7 +49,7 @@ struct SVGPropertyTraits<ChannelSelectorType> {
         return emptyString();
     }
 
-    static ChannelSelectorType fromString(const String& value)
+    static ChannelSelectorType fromString(SVGElement&, const String& value)
     {
         if (value == "R"_s)
             return ChannelSelectorType::CHANNEL_R;

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -75,7 +75,7 @@ void SVGFEGaussianBlurElement::attributeChanged(const QualifiedName& name, const
         Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::edgeModeAttr: {
-        auto propertyValue = SVGPropertyTraits<EdgeModeType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<EdgeModeType>::fromString(*this, newValue);
         if (propertyValue != EdgeModeType::Unknown)
             Ref { m_edgeMode }->setBaseValInternal<EdgeModeType>(propertyValue);
         else

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -56,7 +56,7 @@ void SVGFEMorphologyElement::attributeChanged(const QualifiedName& name, const A
 {
     switch (name.nodeName()) {
     case AttributeNames::operatorAttr: {
-        MorphologyOperatorType propertyValue = SVGPropertyTraits<MorphologyOperatorType>::fromString(newValue);
+        MorphologyOperatorType propertyValue = SVGPropertyTraits<MorphologyOperatorType>::fromString(*this, newValue);
         if (propertyValue != MorphologyOperatorType::Unknown)
             Ref { m_svgOperator }->setBaseValInternal<MorphologyOperatorType>(propertyValue);
         break;

--- a/Source/WebCore/svg/SVGFEMorphologyElement.h
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.h
@@ -46,7 +46,7 @@ struct SVGPropertyTraits<MorphologyOperatorType> {
         return emptyString();
     }
 
-    static MorphologyOperatorType fromString(const String& value)
+    static MorphologyOperatorType fromString(SVGElement&, const String& value)
     {
         if (value == "erode"_s)
             return MorphologyOperatorType::Erode;

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -60,13 +60,13 @@ void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const A
 {
     switch (name.nodeName()) {
     case AttributeNames::typeAttr: {
-        TurbulenceType propertyValue = SVGPropertyTraits<TurbulenceType>::fromString(newValue);
+        TurbulenceType propertyValue = SVGPropertyTraits<TurbulenceType>::fromString(*this, newValue);
         if (propertyValue != TurbulenceType::Unknown)
             Ref { m_type }->setBaseValInternal<TurbulenceType>(propertyValue);
         break;
     }
     case AttributeNames::stitchTilesAttr: {
-        SVGStitchOptions propertyValue = SVGPropertyTraits<SVGStitchOptions>::fromString(newValue);
+        SVGStitchOptions propertyValue = SVGPropertyTraits<SVGStitchOptions>::fromString(*this, newValue);
         if (propertyValue > 0)
             Ref { m_stitchTiles }->setBaseValInternal<SVGStitchOptions>(propertyValue);
         break;

--- a/Source/WebCore/svg/SVGFETurbulenceElement.h
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.h
@@ -52,7 +52,7 @@ struct SVGPropertyTraits<SVGStitchOptions> {
         return emptyString();
     }
 
-    static SVGStitchOptions fromString(const String& value)
+    static SVGStitchOptions fromString(SVGElement&, const String& value)
     {
         if (value == "stitch"_s)
             return SVG_STITCHTYPE_STITCH;
@@ -81,7 +81,7 @@ struct SVGPropertyTraits<TurbulenceType> {
         return emptyString();
     }
 
-    static TurbulenceType fromString(const String& value)
+    static TurbulenceType fromString(SVGElement&, const String& value)
     {
         if (value == "fractalNoise"_s)
             return TurbulenceType::FractalNoise;

--- a/Source/WebCore/svg/SVGFilterElement.cpp
+++ b/Source/WebCore/svg/SVGFilterElement.cpp
@@ -73,13 +73,13 @@ void SVGFilterElement::attributeChanged(const QualifiedName& name, const AtomStr
 
     switch (name.nodeName()) {
     case AttributeNames::filterUnitsAttr: {
-        SVGUnitTypes::SVGUnitType propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
+        SVGUnitTypes::SVGUnitType propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
         if (propertyValue > 0)
             Ref { m_filterUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;
     }
     case AttributeNames::primitiveUnitsAttr: {
-        SVGUnitTypes::SVGUnitType propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
+        SVGUnitTypes::SVGUnitType propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
         if (propertyValue > 0)
             Ref { m_primitiveUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;

--- a/Source/WebCore/svg/SVGGradientElement.cpp
+++ b/Source/WebCore/svg/SVGGradientElement.cpp
@@ -57,7 +57,7 @@ void SVGGradientElement::attributeChanged(const QualifiedName& name, const AtomS
 {
     switch (name.nodeName()) {
     case AttributeNames::gradientUnitsAttr: {
-        auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
         if (propertyValue > 0)
             Ref { m_gradientUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;
@@ -66,7 +66,7 @@ void SVGGradientElement::attributeChanged(const QualifiedName& name, const AtomS
         Ref { m_gradientTransform }->baseVal()->parse(newValue);
         break;
     case AttributeNames::spreadMethodAttr: {
-        auto propertyValue = SVGPropertyTraits<SVGSpreadMethodType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<SVGSpreadMethodType>::fromString(*this, newValue);
         if (propertyValue > 0)
             Ref { m_spreadMethod }->setBaseValInternal<SVGSpreadMethodType>(propertyValue);
         break;

--- a/Source/WebCore/svg/SVGGradientElement.h
+++ b/Source/WebCore/svg/SVGGradientElement.h
@@ -58,7 +58,7 @@ struct SVGPropertyTraits<SVGSpreadMethodType> {
         return emptyString();
     }
 
-    static SVGSpreadMethodType fromString(const String& value)
+    static SVGSpreadMethodType fromString(SVGElement&, const String& value)
     {
         if (value == "pad"_s)
             return SVGSpreadMethodPad;

--- a/Source/WebCore/svg/SVGMarkerElement.cpp
+++ b/Source/WebCore/svg/SVGMarkerElement.cpp
@@ -71,13 +71,13 @@ void SVGMarkerElement::attributeChanged(const QualifiedName& name, const AtomStr
     auto parseError = SVGParsingError::None;
     switch (name.nodeName()) {
     case AttributeNames::markerUnitsAttr: {
-        auto propertyValue = SVGPropertyTraits<SVGMarkerUnitsType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<SVGMarkerUnitsType>::fromString(*this, newValue);
         if (propertyValue != SVGMarkerUnitsType::Unknown)
             Ref { m_markerUnits }->setBaseValInternal<SVGMarkerUnitsType>(propertyValue);
         return;
     }
     case AttributeNames::orientAttr: {
-        auto pair = SVGPropertyTraits<std::pair<SVGAngleValue, SVGMarkerOrientType>>::fromString(newValue);
+        auto pair = SVGPropertyTraits<std::pair<SVGAngleValue, SVGMarkerOrientType>>::fromString(*this, newValue);
         Ref { m_orientAngle }->setBaseValInternal(pair.first);
         Ref { m_orientType }->setBaseValInternal(pair.second);
         return;

--- a/Source/WebCore/svg/SVGMarkerTypes.h
+++ b/Source/WebCore/svg/SVGMarkerTypes.h
@@ -61,7 +61,7 @@ struct SVGPropertyTraits<SVGMarkerUnitsType> {
         ASSERT_NOT_REACHED();
         return emptyString();
     }
-    static SVGMarkerUnitsType fromString(const String& value)
+    static SVGMarkerUnitsType fromString(SVGElement&, const String& value)
     {
         if (value == "userSpaceOnUse"_s)
             return SVGMarkerUnitsType::UserSpaceOnUse;
@@ -79,7 +79,7 @@ struct SVGPropertyTraits<SVGMarkerOrientType> {
         return autoStartReverseString;
     }
     static unsigned highestEnumValue() { return SVGMarkerOrientAutoStartReverse; }
-    static SVGMarkerOrientType fromString(const String& string)
+    static SVGMarkerOrientType fromString(SVGElement&, const String& string)
     {
         if (string == autoAtom())
             return SVGMarkerOrientAuto;
@@ -99,10 +99,10 @@ struct SVGPropertyTraits<SVGMarkerOrientType> {
 
 template<>
 struct SVGPropertyTraits<std::pair<SVGAngleValue, SVGMarkerOrientType>> {
-    static std::pair<SVGAngleValue, SVGMarkerOrientType> fromString(const String& string)
+    static std::pair<SVGAngleValue, SVGMarkerOrientType> fromString(SVGElement& targetElement, const String& string)
     {
         SVGAngleValue angle;
-        SVGMarkerOrientType orientType = SVGPropertyTraits<SVGMarkerOrientType>::fromString(string);
+        SVGMarkerOrientType orientType = SVGPropertyTraits<SVGMarkerOrientType>::fromString(targetElement, string);
         if (orientType == SVGMarkerOrientUnknown) {
             auto result = angle.setValueAsString(string);
             if (!result.hasException())

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -77,13 +77,13 @@ void SVGMaskElement::attributeChanged(const QualifiedName& name, const AtomStrin
     auto parseError = SVGParsingError::None;
     switch (name.nodeName()) {
     case AttributeNames::maskUnitsAttr: {
-        auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
         if (propertyValue > 0)
             Ref { m_maskUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;
     }
     case AttributeNames::maskContentUnitsAttr: {
-        auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
         if (propertyValue > 0)
             Ref { m_maskContentUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -80,13 +80,13 @@ void SVGPatternElement::attributeChanged(const QualifiedName& name, const AtomSt
     auto parseError = SVGParsingError::None;
     switch (name.nodeName()) {
     case AttributeNames::patternUnitsAttr: {
-        auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
         if (propertyValue > 0)
             Ref { m_patternUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;
     }
     case AttributeNames::patternContentUnitsAttr: {
-        auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
         if (propertyValue > 0)
             Ref { m_patternContentUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -235,7 +235,7 @@ void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString
     reportAttributeParsingError(parseError, name, newValue);
 
     SVGFitToViewBox::parseAttribute(name, newValue);
-    SVGZoomAndPan::parseAttribute(name, newValue);
+    SVGZoomAndPan::parseAttribute(*this, name, newValue);
     SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -172,7 +172,7 @@ void SVGTextContentElement::attributeChanged(const QualifiedName& name, const At
     auto parseError = SVGParsingError::None;
 
     if (name == SVGNames::lengthAdjustAttr) {
-        auto propertyValue = SVGPropertyTraits<SVGLengthAdjustType>::fromString(newValue);
+        auto propertyValue = SVGPropertyTraits<SVGLengthAdjustType>::fromString(*this, newValue);
         if (propertyValue > 0)
             m_lengthAdjust->setBaseValInternal<SVGLengthAdjustType>(propertyValue);
     } else if (name == SVGNames::textLengthAttr)

--- a/Source/WebCore/svg/SVGTextContentElement.h
+++ b/Source/WebCore/svg/SVGTextContentElement.h
@@ -52,7 +52,7 @@ template<> struct SVGPropertyTraits<SVGLengthAdjustType> {
         return emptyString();
     }
 
-    static SVGLengthAdjustType fromString(const String& value)
+    static SVGLengthAdjustType fromString(SVGElement&, const String& value)
     {
         if (value == "spacingAndGlyphs"_s)
             return SVGLengthAdjustSpacingAndGlyphs;

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -79,13 +79,13 @@ void SVGTextPathElement::attributeChanged(const QualifiedName& name, const AtomS
         Ref { m_startOffset }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError));
         break;
     case AttributeNames::methodAttr: {
-        SVGTextPathMethodType propertyValue = SVGPropertyTraits<SVGTextPathMethodType>::fromString(newValue);
+        SVGTextPathMethodType propertyValue = SVGPropertyTraits<SVGTextPathMethodType>::fromString(*this, newValue);
         if (propertyValue > 0)
             Ref { m_method }->setBaseValInternal<SVGTextPathMethodType>(propertyValue);
         break;
     }
     case AttributeNames::spacingAttr: {
-        SVGTextPathSpacingType propertyValue = SVGPropertyTraits<SVGTextPathSpacingType>::fromString(newValue);
+        SVGTextPathSpacingType propertyValue = SVGPropertyTraits<SVGTextPathSpacingType>::fromString(*this, newValue);
         if (propertyValue > 0)
             Ref { m_spacing }->setBaseValInternal<SVGTextPathSpacingType>(propertyValue);
         break;

--- a/Source/WebCore/svg/SVGTextPathElement.h
+++ b/Source/WebCore/svg/SVGTextPathElement.h
@@ -59,7 +59,7 @@ struct SVGPropertyTraits<SVGTextPathMethodType> {
         return emptyString();
     }
 
-    static SVGTextPathMethodType fromString(const String& value)
+    static SVGTextPathMethodType fromString(SVGElement&, const String& value)
     {
         if (value == "align"_s)
             return SVGTextPathMethodAlign;
@@ -88,7 +88,7 @@ struct SVGPropertyTraits<SVGTextPathSpacingType> {
         return emptyString();
     }
 
-    static SVGTextPathSpacingType fromString(const String& value)
+    static SVGTextPathSpacingType fromString(SVGElement&, const String& value)
     {
         if (value == autoAtom())
             return SVGTextPathSpacingAuto;

--- a/Source/WebCore/svg/SVGUnitTypes.h
+++ b/Source/WebCore/svg/SVGUnitTypes.h
@@ -55,7 +55,7 @@ struct SVGPropertyTraits<SVGUnitTypes::SVGUnitType> {
         return emptyString();
     }
 
-    static SVGUnitTypes::SVGUnitType fromString(const String& value)
+    static SVGUnitTypes::SVGUnitType fromString(SVGElement&, const String& value)
     {
         if (value == "userSpaceOnUse"_s)
             return SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE;

--- a/Source/WebCore/svg/SVGViewElement.cpp
+++ b/Source/WebCore/svg/SVGViewElement.cpp
@@ -48,7 +48,7 @@ Ref<SVGViewElement> SVGViewElement::create(const QualifiedName& tagName, Documen
 void SVGViewElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGFitToViewBox::parseAttribute(name, newValue);
-    SVGZoomAndPan::parseAttribute(name, newValue);
+    SVGZoomAndPan::parseAttribute(*this, name, newValue);
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 

--- a/Source/WebCore/svg/SVGZoomAndPan.cpp
+++ b/Source/WebCore/svg/SVGZoomAndPan.cpp
@@ -50,11 +50,11 @@ std::optional<SVGZoomAndPanType> SVGZoomAndPan::parseZoomAndPan(StringParsingBuf
     return parseZoomAndPanGeneric(buffer);
 }
 
-void SVGZoomAndPan::parseAttribute(const QualifiedName& attributeName, const AtomString& value)
+void SVGZoomAndPan::parseAttribute(SVGElement& element, const QualifiedName& attributeName, const AtomString& value)
 {
     if (attributeName != SVGNames::zoomAndPanAttr)
         return;
-    m_zoomAndPan = SVGPropertyTraits<SVGZoomAndPanType>::fromString(value);
+    m_zoomAndPan = SVGPropertyTraits<SVGZoomAndPanType>::fromString(element, value);
 }
 
 }

--- a/Source/WebCore/svg/SVGZoomAndPan.h
+++ b/Source/WebCore/svg/SVGZoomAndPan.h
@@ -28,6 +28,8 @@
 
 namespace WebCore {
 
+class SVGElement;
+
 class SVGZoomAndPan {
     WTF_MAKE_NONCOPYABLE(SVGZoomAndPan);
 public:
@@ -43,7 +45,7 @@ public:
     ExceptionOr<void> setZoomAndPan(unsigned) { return Exception { ExceptionCode::NoModificationAllowedError }; }
     void reset() { m_zoomAndPan = SVGPropertyTraits<SVGZoomAndPanType>::initialValue(); }
 
-    void parseAttribute(const QualifiedName&, const AtomString&);
+    void parseAttribute(SVGElement&, const QualifiedName&, const AtomString&);
 
 protected:
     SVGZoomAndPan() = default;

--- a/Source/WebCore/svg/SVGZoomAndPanType.h
+++ b/Source/WebCore/svg/SVGZoomAndPanType.h
@@ -39,7 +39,7 @@ template<>
 struct SVGPropertyTraits<SVGZoomAndPanType> {
     static SVGZoomAndPanType initialValue() { return SVGZoomAndPanMagnify; }
     static String toString(SVGZoomAndPanType) { return emptyString(); }
-    static SVGZoomAndPanType fromString(const String& value)
+    static SVGZoomAndPanType fromString(SVGElement&, const String& value)
     {
         if (value == "disable"_s)
             return SVGZoomAndPanDisable;

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimator.h
@@ -62,9 +62,9 @@ public:
         m_function.setFromAndByValues(targetElement, from, by);
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) override
+    void setToAtEndOfDurationValue(SVGElement& targetElement, const String& toAtEndOfDuration) override
     {
-        m_function.setToAtEndOfDurationValue(toAtEndOfDuration);
+        m_function.setToAtEndOfDurationValue(targetElement, toAtEndOfDuration);
     }
 
     void start(SVGElement&) override

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h
@@ -45,10 +45,10 @@ public:
     }
 
 private:
-    void setFromAndToValues(SVGElement&, const String& from, const String& to) final
+    void setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) final
     {
-        auto pairFrom = SVGPropertyTraits<std::pair<SVGAngleValue, SVGMarkerOrientType>>::fromString(from);
-        auto pairTo = SVGPropertyTraits<std::pair<SVGAngleValue, SVGMarkerOrientType>>::fromString(to);
+        auto pairFrom = SVGPropertyTraits<std::pair<SVGAngleValue, SVGMarkerOrientType>>::fromString(targetElement, from);
+        auto pairTo = SVGPropertyTraits<std::pair<SVGAngleValue, SVGMarkerOrientType>>::fromString(targetElement, to);
 
         m_animatedPropertyAnimator1->m_function.m_from = pairFrom.first;
         m_animatedPropertyAnimator1->m_function.m_to = pairTo.first;
@@ -119,10 +119,10 @@ public:
     }
 
 private:
-    void setFromAndToValues(SVGElement&, const String& from, const String& to) final
+    void setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) final
     {
-        auto pairFrom = SVGPropertyTraits<std::pair<int, int>>::fromString(from);
-        auto pairTo = SVGPropertyTraits<std::pair<int, int>>::fromString(to);
+        auto pairFrom = SVGPropertyTraits<std::pair<int, int>>::fromString(targetElement, from);
+        auto pairTo = SVGPropertyTraits<std::pair<int, int>>::fromString(targetElement, to);
 
         m_animatedPropertyAnimator1->m_function.m_from = pairFrom.first;
         m_animatedPropertyAnimator1->m_function.m_to = pairTo.first;
@@ -131,10 +131,10 @@ private:
         m_animatedPropertyAnimator2->m_function.m_to = pairTo.second;
     }
 
-    void setFromAndByValues(SVGElement&, const String& from, const String& by) final
+    void setFromAndByValues(SVGElement& targetElement, const String& from, const String& by) final
     {
-        auto pairFrom = SVGPropertyTraits<std::pair<int, int>>::fromString(from);
-        auto pairBy = SVGPropertyTraits<std::pair<int, int>>::fromString(by);
+        auto pairFrom = SVGPropertyTraits<std::pair<int, int>>::fromString(targetElement, from);
+        auto pairBy = SVGPropertyTraits<std::pair<int, int>>::fromString(targetElement, by);
 
         m_animatedPropertyAnimator1->m_function.m_from = pairFrom.first;
         m_animatedPropertyAnimator1->m_function.m_to = pairFrom.first + pairBy.first;
@@ -143,9 +143,9 @@ private:
         m_animatedPropertyAnimator2->m_function.m_to = pairFrom.second + pairBy.second;
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) final
+    void setToAtEndOfDurationValue(SVGElement& targetElement, const String& toAtEndOfDuration) final
     {
-        auto pairToAtEndOfDuration = SVGPropertyTraits<std::pair<int, int>>::fromString(toAtEndOfDuration);
+        auto pairToAtEndOfDuration = SVGPropertyTraits<std::pair<int, int>>::fromString(targetElement, toAtEndOfDuration);
         m_animatedPropertyAnimator1->m_function.m_toAtEndOfDuration = pairToAtEndOfDuration.first;
         m_animatedPropertyAnimator2->m_function.m_toAtEndOfDuration = pairToAtEndOfDuration.second;
     }
@@ -163,10 +163,10 @@ public:
     }
 
 private:
-    void setFromAndToValues(SVGElement&, const String& from, const String& to) final
+    void setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) final
     {
-        auto pairFrom = SVGPropertyTraits<std::pair<float, float>>::fromString(from);
-        auto pairTo = SVGPropertyTraits<std::pair<float, float>>::fromString(to);
+        auto pairFrom = SVGPropertyTraits<std::pair<float, float>>::fromString(targetElement, from);
+        auto pairTo = SVGPropertyTraits<std::pair<float, float>>::fromString(targetElement, to);
         
         m_animatedPropertyAnimator1->m_function.m_from = pairFrom.first;
         m_animatedPropertyAnimator1->m_function.m_to = pairTo.first;
@@ -175,10 +175,10 @@ private:
         m_animatedPropertyAnimator2->m_function.m_to = pairTo.second;
     }
 
-    void setFromAndByValues(SVGElement&, const String& from, const String& by) final
+    void setFromAndByValues(SVGElement& targetElement, const String& from, const String& by) final
     {
-        auto pairFrom = SVGPropertyTraits<std::pair<float, float>>::fromString(from);
-        auto pairBy = SVGPropertyTraits<std::pair<float, float>>::fromString(by);
+        auto pairFrom = SVGPropertyTraits<std::pair<float, float>>::fromString(targetElement, from);
+        auto pairBy = SVGPropertyTraits<std::pair<float, float>>::fromString(targetElement, by);
         
         m_animatedPropertyAnimator1->m_function.m_from = pairFrom.first;
         m_animatedPropertyAnimator1->m_function.m_to = pairFrom.first + pairBy.first;
@@ -187,9 +187,9 @@ private:
         m_animatedPropertyAnimator2->m_function.m_to = pairFrom.second + pairBy.second;
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) final
+    void setToAtEndOfDurationValue(SVGElement& targetElement, const String& toAtEndOfDuration) final
     {
-        auto pairToAtEndOfDuration = SVGPropertyTraits<std::pair<float, float>>::fromString(toAtEndOfDuration);
+        auto pairToAtEndOfDuration = SVGPropertyTraits<std::pair<float, float>>::fromString(targetElement, toAtEndOfDuration);
         m_animatedPropertyAnimator1->m_function.m_toAtEndOfDuration = pairToAtEndOfDuration.first;
         m_animatedPropertyAnimator2->m_function.m_toAtEndOfDuration = pairToAtEndOfDuration.second;
     }

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveFunction.h
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveFunction.h
@@ -45,7 +45,7 @@ public:
         addFromAndToValues(targetElement);
     }
 
-    void setToAtEndOfDurationValue(const String&) override
+    void setToAtEndOfDurationValue(SVGElement&, const String&) override
     {
         ASSERT_NOT_REACHED();
     }

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveListFunctionImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveListFunctionImpl.h
@@ -52,7 +52,7 @@ public:
         m_to->parse(to);
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) override
+    void setToAtEndOfDurationValue(SVGElement&, const String& toAtEndOfDuration) override
     {
         m_toAtEndOfDuration->parse(toAtEndOfDuration);
     }
@@ -111,7 +111,7 @@ public:
         m_to->parse(to);
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) override
+    void setToAtEndOfDurationValue(SVGElement&, const String& toAtEndOfDuration) override
     {
         m_toAtEndOfDuration->parse(toAtEndOfDuration);
     }
@@ -161,7 +161,7 @@ public:
         m_to->parse(to);
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) override
+    void setToAtEndOfDurationValue(SVGElement&, const String& toAtEndOfDuration) override
     {
         m_toAtEndOfDuration->parse(toAtEndOfDuration);
     }
@@ -214,7 +214,7 @@ public:
         m_to->parse(to);
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) override
+    void setToAtEndOfDurationValue(SVGElement&, const String& toAtEndOfDuration) override
     {
         m_toAtEndOfDuration->parse(toAtEndOfDuration);
     }

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
@@ -26,31 +26,14 @@
 #include "config.h"
 #include "SVGAnimationAdditiveValueFunctionImpl.h"
 
-#include "CSSPropertyParserConsumer+Color.h"
-#include "ContainerNodeInlines.h"
-#include "RenderElement.h"
-#include "SVGElement.h"
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
 
-Color SVGAnimationColorFunction::colorFromString(SVGElement& targetElement, const String& string)
+std::optional<float> SVGAnimationColorFunction::calculateDistance(SVGElement& targetElement, const String& from, const String& to) const
 {
-    if (auto color = SVGPropertyTraits<Color>::parse(string)) {
-        if (color->isCurrentColor()) {
-            if (auto* renderer = targetElement.renderer())
-                return renderer->style().visitedDependentColor(CSSPropertyColor);
-        }
-        return color->resolvedColor();
-    }
-
-    return { };
-}
-
-std::optional<float> SVGAnimationColorFunction::calculateDistance(SVGElement&, const String& from, const String& to) const
-{
-    auto simpleFrom = CSSPropertyParserHelpers::deprecatedParseColorRawWithoutContext(from.trim(deprecatedIsSpaceOrNewline)).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
-    auto simpleTo = CSSPropertyParserHelpers::deprecatedParseColorRawWithoutContext(to.trim(deprecatedIsSpaceOrNewline)).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
+    auto simpleFrom = SVGPropertyTraits<Color>::fromString(targetElement, from).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
+    auto simpleTo = SVGPropertyTraits<Color>::fromString(targetElement, to).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
 
     float red = simpleFrom.red - simpleTo.red;
     float green = simpleFrom.green - simpleTo.green;

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h
@@ -72,13 +72,13 @@ public:
 
     void setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) override
     {
-        m_from = colorFromString(targetElement, from);
-        m_to = colorFromString(targetElement, to);
+        m_from = SVGPropertyTraits<Color>::fromString(targetElement, from);
+        m_to = SVGPropertyTraits<Color>::fromString(targetElement, to);
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) override
+    void setToAtEndOfDurationValue(SVGElement& targetElement, const String& toAtEndOfDuration) override
     {
-        m_toAtEndOfDuration = SVGPropertyTraits<Color>::fromString(toAtEndOfDuration);
+        m_toAtEndOfDuration = SVGPropertyTraits<Color>::fromString(targetElement, toAtEndOfDuration);
     }
 
     void animate(SVGElement&, float progress, unsigned repeatCount, Color& animated)
@@ -107,8 +107,6 @@ private:
         // Ignores any alpha and sets alpha on result to 100% opaque.
         m_to = makeFromComponentsClamping<SRGBA<uint8_t>>(simpleTo.red + simpleFrom.red, simpleTo.green + simpleFrom.green, simpleTo.blue + simpleFrom.blue);
     }
-
-    static Color colorFromString(SVGElement&, const String&);
 };
 
 class SVGAnimationIntegerFunction final : public SVGAnimationAdditiveValueFunction<int> {
@@ -118,15 +116,15 @@ public:
     using Base = SVGAnimationAdditiveValueFunction<int>;
     using Base::Base;
 
-    void setFromAndToValues(SVGElement&, const String& from, const String& to) override
+    void setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) override
     {
-        m_from = SVGPropertyTraits<int>::fromString(from);
-        m_to = SVGPropertyTraits<int>::fromString(to);
+        m_from = SVGPropertyTraits<int>::fromString(targetElement, from);
+        m_to = SVGPropertyTraits<int>::fromString(targetElement, to);
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) final
+    void setToAtEndOfDurationValue(SVGElement& targetElement, const String& toAtEndOfDuration) final
     {
-        m_toAtEndOfDuration = SVGPropertyTraits<int>::fromString(toAtEndOfDuration);
+        m_toAtEndOfDuration = SVGPropertyTraits<int>::fromString(targetElement, toAtEndOfDuration);
     }
 
     void animate(SVGElement&, float progress, unsigned repeatCount, int& animated)
@@ -159,7 +157,7 @@ public:
         m_to = SVGLengthValue(m_lengthMode, to);
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) override
+    void setToAtEndOfDurationValue(SVGElement&, const String& toAtEndOfDuration) override
     {
         m_toAtEndOfDuration = SVGLengthValue(m_lengthMode, toAtEndOfDuration);
     }
@@ -203,15 +201,15 @@ public:
     using Base = SVGAnimationAdditiveValueFunction<float>;
     using Base::Base;
 
-    void setFromAndToValues(SVGElement&, const String& from, const String& to) override
+    void setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) override
     {
-        m_from = SVGPropertyTraits<float>::fromString(from);
-        m_to = SVGPropertyTraits<float>::fromString(to);
+        m_from = SVGPropertyTraits<float>::fromString(targetElement, from);
+        m_to = SVGPropertyTraits<float>::fromString(targetElement, to);
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) override
+    void setToAtEndOfDurationValue(SVGElement& targetElement, const String& toAtEndOfDuration) override
     {
-        m_toAtEndOfDuration = SVGPropertyTraits<float>::fromString(toAtEndOfDuration);
+        m_toAtEndOfDuration = SVGPropertyTraits<float>::fromString(targetElement, toAtEndOfDuration);
     }
 
     void animate(SVGElement&, float progress, unsigned repeatCount, float& animated)
@@ -243,7 +241,7 @@ public:
         m_to = SVGPathByteStream(to);
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) override
+    void setToAtEndOfDurationValue(SVGElement&, const String& toAtEndOfDuration) override
     {
         m_toAtEndOfDuration = SVGPathByteStream(toAtEndOfDuration);
     }
@@ -286,15 +284,15 @@ public:
     using Base = SVGAnimationAdditiveValueFunction<FloatRect>;
     using Base::Base;
 
-    void setFromAndToValues(SVGElement&, const String& from, const String& to) override
+    void setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) override
     {
-        m_from = SVGPropertyTraits<FloatRect>::fromString(from);
-        m_to = SVGPropertyTraits<FloatRect>::fromString(to);
+        m_from = SVGPropertyTraits<FloatRect>::fromString(targetElement, from);
+        m_to = SVGPropertyTraits<FloatRect>::fromString(targetElement, to);
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) override
+    void setToAtEndOfDurationValue(SVGElement& targetElement, const String& toAtEndOfDuration) override
     {
-        m_toAtEndOfDuration = SVGPropertyTraits<FloatRect>::fromString(toAtEndOfDuration);
+        m_toAtEndOfDuration = SVGPropertyTraits<FloatRect>::fromString(targetElement, toAtEndOfDuration);
     }
 
     void animate(SVGElement&, float progress, unsigned repeatCount, FloatRect& animated)

--- a/Source/WebCore/svg/properties/SVGAnimationDiscreteFunction.h
+++ b/Source/WebCore/svg/properties/SVGAnimationDiscreteFunction.h
@@ -37,7 +37,7 @@ public:
 
     bool isDiscrete() const override { return true; }
 
-    void setToAtEndOfDurationValue(const String&) override
+    void setToAtEndOfDurationValue(SVGElement&, const String&) override
     {
         ASSERT_NOT_REACHED();
     }

--- a/Source/WebCore/svg/properties/SVGAnimationDiscreteFunctionImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimationDiscreteFunctionImpl.h
@@ -35,10 +35,10 @@ public:
     using Base = SVGAnimationDiscreteFunction<bool>;
     using Base::Base;
 
-    void setFromAndToValues(SVGElement&, const String& from, const String& to) override
+    void setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) override
     {
-        m_from = SVGPropertyTraits<bool>::fromString(from);
-        m_to = SVGPropertyTraits<bool>::fromString(to);
+        m_from = SVGPropertyTraits<bool>::fromString(targetElement, from);
+        m_to = SVGPropertyTraits<bool>::fromString(targetElement, to);
     }
 };
 
@@ -51,10 +51,10 @@ class SVGAnimationEnumerationFunction : public SVGAnimationDiscreteFunction<Enum
 public:
     using Base::Base;
 
-    void setFromAndToValues(SVGElement&, const String& from, const String& to) override
+    void setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) override
     {
-        m_from = SVGPropertyTraits<EnumType>::fromString(from);
-        m_to = SVGPropertyTraits<EnumType>::fromString(to);
+        m_from = SVGPropertyTraits<EnumType>::fromString(targetElement, from);
+        m_to = SVGPropertyTraits<EnumType>::fromString(targetElement, to);
     }
 };
 

--- a/Source/WebCore/svg/properties/SVGAnimationFunction.h
+++ b/Source/WebCore/svg/properties/SVGAnimationFunction.h
@@ -39,7 +39,7 @@ public:
 
     virtual void setFromAndToValues(SVGElement& targetElement, const String&, const String&) = 0;
     virtual void setFromAndByValues(SVGElement& targetElement, const String&, const String&) = 0;
-    virtual void setToAtEndOfDurationValue(const String&) = 0;
+    virtual void setToAtEndOfDurationValue(SVGElement& targetElement, const String&) = 0;
 
     virtual std::optional<float> calculateDistance(SVGElement&, const String&, const String&) const { return { }; }
 protected:

--- a/Source/WebCore/svg/properties/SVGAttributeAnimator.h
+++ b/Source/WebCore/svg/properties/SVGAttributeAnimator.h
@@ -67,7 +67,7 @@ public:
 
     virtual void setFromAndToValues(SVGElement&, const String&, const String&) { }
     virtual void setFromAndByValues(SVGElement&, const String&, const String&) { }
-    virtual void setToAtEndOfDurationValue(const String&) { }
+    virtual void setToAtEndOfDurationValue(SVGElement&, const String&) { }
 
     virtual void start(SVGElement&) = 0;
     virtual void animate(SVGElement&, float progress, unsigned repeatCount) = 0;

--- a/Source/WebCore/svg/properties/SVGPrimitivePropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGPrimitivePropertyAnimator.h
@@ -58,7 +58,7 @@ public:
     void start(SVGElement& targetElement) override
     {
         String baseValue = computeCSSPropertyValue(targetElement, cssPropertyID(m_attributeName.localName()));
-        m_property->setValue(SVGPropertyTraits<PropertyType>::fromString(baseValue));
+        m_property->setValue(SVGPropertyTraits<PropertyType>::fromString(targetElement, baseValue));
     }
 
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) override

--- a/Source/WebCore/svg/properties/SVGPropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGPropertyAnimator.h
@@ -50,9 +50,9 @@ public:
         m_function.setFromAndByValues(targetElement, from, by);
     }
 
-    void setToAtEndOfDurationValue(const String& toAtEndOfDuration) override
+    void setToAtEndOfDurationValue(SVGElement& targetElement, const String& toAtEndOfDuration) override
     {
-        m_function.setToAtEndOfDurationValue(toAtEndOfDuration);
+        m_function.setToAtEndOfDurationValue(targetElement, toAtEndOfDuration);
     }
 
 protected:

--- a/Source/WebCore/svg/properties/SVGPropertyTraits.h
+++ b/Source/WebCore/svg/properties/SVGPropertyTraits.h
@@ -30,10 +30,11 @@
 #include <WebCore/FloatRect.h>
 #include <WebCore/QualifiedName.h>
 #include <WebCore/SVGParserUtilities.h>
-#include <WebCore/StyleColor.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+class SVGElement;
 
 template<typename PropertyType>
 struct SVGPropertyTraits { };
@@ -41,7 +42,7 @@ struct SVGPropertyTraits { };
 template<>
 struct SVGPropertyTraits<bool> {
     static bool initialValue() { return false; }
-    static bool fromString(const String& string) { return string == "true"_s; }
+    static bool fromString(SVGElement&, const String& string) { return string == "true"_s; }
     static std::optional<bool> parse(const QualifiedName&, const String&) { ASSERT_NOT_REACHED(); return initialValue(); }
     static String toString(bool type) { return type ? trueAtom() : falseAtom(); }
 };
@@ -49,11 +50,7 @@ struct SVGPropertyTraits<bool> {
 template<>
 struct SVGPropertyTraits<Color> {
     static Color initialValue() { return Color(); }
-    static Color fromString(const String& string) { return CSSPropertyParserHelpers::deprecatedParseColorRawWithoutContext(string.trim(deprecatedIsSpaceOrNewline)); }
-    static std::optional<Style::Color> parse(const String& string)
-    {
-        return CSSParser::parseColorOrCurrentColorWithoutContext(string.trim(deprecatedIsSpaceOrNewline));
-    }
+    static Color fromString(SVGElement&, const String&);
     static String toString(const Color& type) { return serializationForHTML(type); }
 };
 
@@ -67,7 +64,7 @@ struct SVGPropertyTraits<unsigned> {
 template<>
 struct SVGPropertyTraits<int> {
     static int initialValue() { return 0; }
-    static int fromString(const String&);
+    static int fromString(SVGElement&, const String&);
     static std::optional<int> parse(const QualifiedName&, const String&) { ASSERT_NOT_REACHED(); return initialValue(); }
     static String toString(int type) { return String::number(type); }
 };
@@ -75,7 +72,7 @@ struct SVGPropertyTraits<int> {
 template<>
 struct SVGPropertyTraits<std::pair<int, int>> {
     static std::pair<int, int> initialValue() { return { }; }
-    static std::pair<int, int> fromString(const String& string)
+    static std::pair<int, int> fromString(SVGElement&, const String& string)
     {
         auto result = parseNumberOptionalNumber(string);
         if (!result)
@@ -89,7 +86,7 @@ struct SVGPropertyTraits<std::pair<int, int>> {
 template<>
 struct SVGPropertyTraits<float> {
     static float initialValue() { return 0; }
-    static float fromString(const String& string)
+    static float fromString(SVGElement&, const String& string)
     {
         return parseNumber(string).value_or(0);
     }
@@ -103,7 +100,7 @@ struct SVGPropertyTraits<float> {
 template<>
 struct SVGPropertyTraits<std::pair<float, float>> {
     static std::pair<float, float> initialValue() { return { }; }
-    static std::pair<float, float> fromString(const String& string)
+    static std::pair<float, float> fromString(SVGElement&, const String& string)
     {
         return valueOrDefault(parseNumberOptionalNumber(string));
     }
@@ -114,7 +111,7 @@ struct SVGPropertyTraits<std::pair<float, float>> {
 template<>
 struct SVGPropertyTraits<FloatPoint> {
     static FloatPoint initialValue() { return FloatPoint(); }
-    static FloatPoint fromString(const String& string)
+    static FloatPoint fromString(SVGElement&, const String& string)
     {
         return valueOrDefault(parsePoint(string));
     }
@@ -131,7 +128,7 @@ struct SVGPropertyTraits<FloatPoint> {
 template<>
 struct SVGPropertyTraits<FloatRect> {
     static FloatRect initialValue() { return FloatRect(); }
-    static FloatRect fromString(const String& string)
+    static FloatRect fromString(SVGElement&, const String& string)
     {
         return valueOrDefault(parseRect(string));
     }
@@ -148,7 +145,7 @@ struct SVGPropertyTraits<FloatRect> {
 template<>
 struct SVGPropertyTraits<String> {
     static String initialValue() { return String(); }
-    static String fromString(const String& string) { return string; }
+    static String fromString(SVGElement&, const String& string) { return string; }
     static std::optional<String> parse(const QualifiedName&, const String& string) { return string; }
     static String toString(const String& string) { return string; }
 };


### PR DESCRIPTION
#### 02e22593fc4a8399e29375613632dea94bccbe81
<pre>
Pass a color parsing context to parser when parsing colors in SVG
<a href="https://bugs.webkit.org/show_bug.cgi?id=301808">https://bugs.webkit.org/show_bug.cgi?id=301808</a>

Reviewed by Anne van Kesteren.

Unifies all the color parsing done by SVG animation code
to use a single entry point, SVGPropertyTraits&lt;Color&gt;::fromString.

To make this work, all SVGPropertyTraits&lt;*&gt;::fromString functions
now have a `SVGElement&amp;` first parameter. To make that work, a bit
of plumbing was required.

The implementation of SVGPropertyTraits&lt;*&gt;::fromString is modeled
on the `parseColor` function in CanvasStyle.cpp. If more of these
explicit `CSS::PlatformColorResolutionDelegate` implementations
are needed, some additional sharing can be done.

This allows us to remove `CSSParser::parseColorOrCurrentColorWithoutContext`
and a few uses of `CSSPropertyParserHelpers::deprecatedParseColorRawWithoutContext`
leaving only three remaining (ApplicationManifestParser, HTMLMetaElement,
and StyleProperties).

* Source/WebCore/css/parser/CSSParser.cpp:
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/svg/SVGAnimateElementBase.cpp:
* Source/WebCore/svg/SVGAnimateMotionElement.h:
* Source/WebCore/svg/SVGClipPathElement.cpp:
* Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp:
* Source/WebCore/svg/SVGComponentTransferFunctionElement.h:
* Source/WebCore/svg/SVGFEBlendElement.h:
* Source/WebCore/svg/SVGFEColorMatrixElement.cpp:
* Source/WebCore/svg/SVGFEColorMatrixElement.h:
* Source/WebCore/svg/SVGFECompositeElement.cpp:
* Source/WebCore/svg/SVGFECompositeElement.h:
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
* Source/WebCore/svg/SVGFEConvolveMatrixElement.h:
* Source/WebCore/svg/SVGFEDisplacementMapElement.cpp:
* Source/WebCore/svg/SVGFEDisplacementMapElement.h:
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
* Source/WebCore/svg/SVGFEMorphologyElement.h:
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
* Source/WebCore/svg/SVGFETurbulenceElement.h:
* Source/WebCore/svg/SVGFilterElement.cpp:
* Source/WebCore/svg/SVGGradientElement.cpp:
* Source/WebCore/svg/SVGGradientElement.h:
* Source/WebCore/svg/SVGMarkerElement.cpp:
* Source/WebCore/svg/SVGMarkerTypes.h:
* Source/WebCore/svg/SVGMaskElement.cpp:
* Source/WebCore/svg/SVGPatternElement.cpp:
* Source/WebCore/svg/SVGSVGElement.cpp:
* Source/WebCore/svg/SVGTextContentElement.cpp:
* Source/WebCore/svg/SVGTextContentElement.h:
* Source/WebCore/svg/SVGTextPathElement.cpp:
* Source/WebCore/svg/SVGTextPathElement.h:
* Source/WebCore/svg/SVGUnitTypes.h:
* Source/WebCore/svg/SVGViewElement.cpp:
* Source/WebCore/svg/SVGZoomAndPan.cpp:
* Source/WebCore/svg/SVGZoomAndPan.h:
* Source/WebCore/svg/SVGZoomAndPanType.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyAnimator.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h:
* Source/WebCore/svg/properties/SVGAnimationAdditiveFunction.h:
* Source/WebCore/svg/properties/SVGAnimationAdditiveListFunctionImpl.h:
* Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp:
* Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h:
* Source/WebCore/svg/properties/SVGAnimationDiscreteFunction.h:
* Source/WebCore/svg/properties/SVGAnimationDiscreteFunctionImpl.h:
* Source/WebCore/svg/properties/SVGAnimationFunction.h:
* Source/WebCore/svg/properties/SVGAttributeAnimator.h:
* Source/WebCore/svg/properties/SVGPrimitivePropertyAnimator.h:
* Source/WebCore/svg/properties/SVGPropertyAnimator.h:
* Source/WebCore/svg/properties/SVGPropertyTraits.cpp:
* Source/WebCore/svg/properties/SVGPropertyTraits.h:

Canonical link: <a href="https://commits.webkit.org/302455@main">https://commits.webkit.org/302455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4584d62d73d6f9d23f2f222bbc8d2029486709d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80525 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98333 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66204 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115682 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/959 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33799 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79799 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138993 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106867 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106701 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27160 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30542 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53763 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1266 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64618 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160607 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1092 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/160607 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1137 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->