### PR TITLE
[AutoFill Debugging] Add more options to avoid extracting node identifiers, event listeners and DOM attributes

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -131,7 +131,10 @@ addEventListener("load", async () => {
     document.body.textContent = await UIHelper.requestDebugText({
         normalize: true,
         includeRects: true,
-        includeURLs: true
+        includeURLs: true,
+        includeNodeIdentifiers: true,
+        includeEventListeners: true,
+        includeAccessibilityAttributes: true,
     });
 
     testRunner.notifyDone();

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html
@@ -32,7 +32,11 @@
         if (!window.testRunner)
             return;
 
-        const debugText = await UIHelper.requestDebugText();
+        const debugText = await UIHelper.requestDebugText({
+            includeNodeIdentifiers: true,
+            includeEventListeners: true,
+            includeAccessibilityAttributes: true,
+        });
 
         error1 = await UIHelper.performTextExtractionInteraction("highlightText", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Document title"),

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
@@ -34,7 +34,11 @@
         if (!window.testRunner)
             return;
 
-        const debugText = await UIHelper.requestDebugText();
+        const debugText = await UIHelper.requestDebugText({
+            includeNodeIdentifiers: true,
+            includeEventListeners: true,
+            includeAccessibilityAttributes: true,
+        });
 
         clickError = await UIHelper.performTextExtractionInteraction("click", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Click Me")

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
@@ -1,33 +1,25 @@
 root
-    role='banner'
-        aria-label='Main Page Title','Welcome to Test Page'
-    navigation,role='navigation',aria-label='Main navigation'
+    '    \nWelcome to Test Page'
+    navigation
         list
             list-item
-                link,uid=…,events=[click],'Section 1'
+                link,'Section 1'
             list-item
-                link,uid=…,events=[click],'Section 2'
-    role='main'
-        '    \nHere’s to the crazy ones…\n\n\n    '
-        section,aria-label='Interactive Elements'
-            button,uid=…,events=[click],aria-label='Test button','Click Me'
-            '        \nThis button does nothing\n\n        '
-            textFormControl,'text',uid=…,placeholder='Enter text here','Enter text here'
-            uid=…,role='button',events=[click,keyboard],'Clickable Div'
-        section,aria-label='Content with Roles'
-            article,role='article','            \n\n                \nArticle Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content…\n\n\n        '
-            role='complementary',aria-label='Related information'
-                '            \nRelated Links\n\n\n            '
-                list
-                    list-item
-                        link,uid=…,events=[hover],'Example Link'
-                    list-item
-                        link,uid=…,events=[hover],'Test Link'
-            role='region'
-                role='status','Ready'
-                button,uid=…,events=[click],'Update Status'
-        '    \nThe quick brown fox jumped…'
-    role='contentinfo'
-        '    \nFooter content with '
-        role='img',aria-label='copyright symbol','©'
-        ' 2024'
+                link,'Section 2'
+    '    \nHere’s to the crazy ones…\n\n\n    '
+    section
+        button,'Click Me'
+        '        \nThis button does nothing\n\n        '
+        textFormControl,'text',placeholder='Enter text here','Enter text here'
+        '        \nClickable Div\n\n    '
+    section
+        article,'            \n\n                \nArticle Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content…\n\n\n        '
+        '        \n\n            \nRelated Links\n\n\n            '
+        list
+            list-item
+                link,'Example Link'
+            list-item
+                link,'Test Link'
+        '        \n\n        \n\n            \nReady\n\n            '
+        button,'Update Status'
+    '    \nThe quick brown fox jumped…\n\n\n\n\n    \nFooter content with © 2024'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight.html
@@ -88,6 +88,9 @@ addEventListener("load", async () => {
         normalize: true,
         includeRects: false,
         includeURLs: false,
+        includeNodeIdentifiers: false,
+        includeEventListeners: false,
+        includeAccessibilityAttributes: false,
         wordLimit: 5
     });
 

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -75,7 +75,9 @@ struct Request {
     std::optional<WebCore::FloatRect> collectionRectInRootView;
     bool mergeParagraphs { false };
     bool skipNearlyTransparentContent { false };
-    bool canIncludeIdentifiers { false };
+    bool includeNodeIdentifiers { false };
+    bool includeEventListeners { false };
+    bool includeAccessibilityAttributes { false };
 };
 
 struct Editable {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6735,7 +6735,9 @@ header: <WebCore/TextExtractionTypes.h>
     std::optional<WebCore::FloatRect> collectionRectInRootView;
     bool mergeParagraphs;
     bool skipNearlyTransparentContent;
-    bool canIncludeIdentifiers;
+    bool includeNodeIdentifiers;
+    bool includeEventListeners;
+    bool includeAccessibilityAttributes;
 };
 
 header: <WebCore/TextExtractionTypes.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6837,7 +6837,7 @@ static inline std::optional<WebCore::NodeIdentifier> toNodeIdentifier(const Stri
 
     auto rectInWebView = configuration.targetRect;
     bool mergeParagraphs = configuration.mergeParagraphs;
-    bool canIncludeIdentifiers = configuration.canIncludeIdentifiers;
+    bool includeNodeIdentifiers = configuration.includeNodeIdentifiers;
     bool skipNearlyTransparentContent = configuration.skipNearlyTransparentContent;
     auto rectInRootView = [&]() -> std::optional<WebCore::FloatRect> {
         if (CGRectIsNull(rectInWebView))
@@ -6854,7 +6854,9 @@ static inline std::optional<WebCore::NodeIdentifier> toNodeIdentifier(const Stri
         .collectionRectInRootView = WTFMove(rectInRootView),
         .mergeParagraphs = mergeParagraphs,
         .skipNearlyTransparentContent = skipNearlyTransparentContent,
-        .canIncludeIdentifiers = canIncludeIdentifiers,
+        .includeNodeIdentifiers = includeNodeIdentifiers,
+        .includeEventListeners = !!configuration.includeEventListeners,
+        .includeAccessibilityAttributes = !!configuration.includeAccessibilityAttributes,
     };
 
     _page->requestTextExtraction(WTFMove(request), WTFMove(completion));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -54,6 +54,24 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @property (nonatomic) BOOL includeRects;
 
 /*!
+ Include node IDs for interactive nodes.
+ The default value is `YES`.
+ */
+@property (nonatomic) BOOL includeNodeIdentifiers;
+
+/*!
+ Include information about event listeners.
+ The default value is `YES`.
+ */
+@property (nonatomic) BOOL includeEventListeners;
+
+/*!
+ Include accessibility attributes (e.g. `role`, `aria-label`).
+ The default value is `YES`.
+ */
+@property (nonatomic) BOOL includeAccessibilityAttributes;
+
+/*!
  Max number of words to include per paragraph; remaining text is truncated with an ellipsis (…).
  The default value is `NSUIntegerMax`.
  */

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -37,10 +37,12 @@
     if (!(self = [super init]))
         return nil;
 
-    _canIncludeIdentifiers = YES;
     _shouldFilterText = YES;
     _includeURLs = YES;
     _includeRects = YES;
+    _includeNodeIdentifiers = YES;
+    _includeEventListeners = YES;
+    _includeAccessibilityAttributes = YES;
     _targetRect = CGRectNull;
     _maxWordsPerParagraph = NSUIntegerMax;
     return self;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -45,12 +45,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL skipNearlyTransparentContent;
 
 /*!
- Whether to include unique identifiers, for each interactive element.
- Defaults to `YES`.
- */
-@property (nonatomic) BOOL canIncludeIdentifiers;
-
-/*!
  Defaults to `YES`.
  */
 @property (nonatomic) BOOL shouldFilterText;

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
@@ -111,7 +111,9 @@ extension WKWebView {
             configuration.targetRect = visibleRect
             configuration.mergeParagraphs = true
             configuration.skipNearlyTransparentContent = true
-            configuration.canIncludeIdentifiers = false
+            configuration.includeNodeIdentifiers = false
+            configuration.includeEventListeners = false
+            configuration.includeAccessibilityAttributes = false
             configuration.shouldFilterText = false
             if let result = await _requestTextExtraction(configuration) {
                 collector.collect(createIntelligenceElement(item: result.rootItem))

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -47,6 +47,9 @@ dictionary TextExtractionTestOptions {
     boolean clipToBounds = false;
     boolean includeRects = false;
     boolean includeURLs = false;
+    boolean includeNodeIdentifiers = false;
+    boolean includeEventListeners = false;
+    boolean includeAccessibilityAttributes = false;
     boolean mergeParagraphs = false;
     boolean skipNearlyTransparentContent = false;
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -62,9 +62,11 @@ struct TextExtractionTestOptions {
     bool clipToBounds { false };
     bool includeRects { false };
     bool includeURLs { false };
+    bool includeNodeIdentifiers { false };
+    bool includeEventListeners { false };
+    bool includeAccessibilityAttributes { false };
     bool mergeParagraphs { false };
     bool skipNearlyTransparentContent { false };
-    bool canIncludeIdentifiers { false };
 };
 
 TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef, JSValueRef);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -74,10 +74,12 @@ TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef context, JSV
     options.clipToBounds = booleanProperty(context, (JSObjectRef)argument, "clipToBounds", false);
     options.includeRects = booleanProperty(context, (JSObjectRef)argument, "includeRects", false);
     options.includeURLs = booleanProperty(context, (JSObjectRef)argument, "includeURLs", false);
+    options.includeEventListeners = booleanProperty(context, (JSObjectRef)argument, "includeEventListeners", false);
+    options.includeAccessibilityAttributes = booleanProperty(context, (JSObjectRef)argument, "includeAccessibilityAttributes", false);
     options.wordLimit = static_cast<unsigned>(numericProperty(context, (JSObjectRef)argument, "wordLimit"));
     options.mergeParagraphs = booleanProperty(context, (JSObjectRef)argument, "mergeParagraphs", false);
     options.skipNearlyTransparentContent = booleanProperty(context, (JSObjectRef)argument, "skipNearlyTransparentContent", false);
-    options.canIncludeIdentifiers = booleanProperty(context, (JSObjectRef)argument, "canIncludeIdentifiers", false);
+    options.includeNodeIdentifiers = booleanProperty(context, (JSObjectRef)argument, "includeNodeIdentifiers", false);
     return &options;
 }
 

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -345,6 +345,9 @@ RetainPtr<_WKTextExtractionConfiguration> createTextExtractionConfiguration(WKWe
     RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
     [configuration setIncludeRects:options && options->includeRects];
     [configuration setIncludeURLs:options && options->includeURLs];
+    [configuration setIncludeNodeIdentifiers:options && options->includeNodeIdentifiers];
+    [configuration setIncludeEventListeners:options && options->includeEventListeners];
+    [configuration setIncludeAccessibilityAttributes:options && options->includeAccessibilityAttributes];
     if (auto wordLimit = options ? options->wordLimit : 0)
         [configuration setMaxWordsPerParagraph:static_cast<NSUInteger>(wordLimit)];
     [configuration setTargetRect:extractionRect];


### PR DESCRIPTION
#### 6aadf8ea12703357e6be30ab8055507c19f21d82
<pre>
[AutoFill Debugging] Add more options to avoid extracting node identifiers, event listeners and DOM attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=301810">https://bugs.webkit.org/show_bug.cgi?id=301810</a>
<a href="https://rdar.apple.com/163864325">rdar://163864325</a>

Reviewed by Abrar Rahman Protyasha.

Add support for three new properties, which can be used to shrink the size of debug text extraction
output by:

1. Not including node identifiers (`uid`) for interactive elements.
2. Not including event listener data (`events=[click,key]`).
3. Not including accessibility attributes (`aria-label=…`).

* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt:

Adjust existing layout tests to include node identifiers if needed.

* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight.html:

Adjust and rebaseline this layout test for lightweight text extraction, so that it excludes node
identifiers, event listeners and attributes.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::extractItem):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestTextExtractionInternal:completion:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:

Add plumbing for a couple new properties, `includeAccessibilityAttributes` and
`includeEventListeners`. Additionally, rename `canIncludeIdentifiers` to `includeNodeIdentifiers`
and move it from an internal property to the private header.

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration init]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionTestOptions):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::createTextExtractionConfiguration):

Canonical link: <a href="https://commits.webkit.org/302444@main">https://commits.webkit.org/302444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a74ded7359510ad248ed6d0f89b5079966526e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80483 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a483d4c8-8638-4f25-9f99-0f20a7737e13) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98303 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66176 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fef25ee0-8e56-4516-be13-bd8518a406e8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132054 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1005 "Found 1 new test failure: http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78948 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/607bd9f1-3ed3-46a5-bcb4-5e62a55c8aef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/929 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33769 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79765 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109376 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34265 "Found 1 new test failure: fast/images/individual-animation-toggle.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138960 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106839 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106666 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27155 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/951 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30512 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53711 "Hash 6a74ded7 for PR 53299 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64584 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1058 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1156 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->