### PR TITLE
Unreviewed, fixing DST issues

### DIFF
--- a/JSTests/mozilla/ecma/Date/15.9.5.14.js
+++ b/JSTests/mozilla/ecma/Date/15.9.5.14.js
@@ -43,7 +43,9 @@
     var TZ_ADJUST = TZ_DIFF * msPerHour;
 
     // get the current time
-    var now = (new Date()).valueOf();
+    // This test does not work well with DST, so using a fixed date. See https://github.com/WebKit/WebKit/pull/53239
+    // var now = (new Date()).valueOf();
+    var now = 1764524660000;
 
     // get time for 29 feb 2000
 

--- a/JSTests/mozilla/ecma/Date/15.9.5.34-1.js
+++ b/JSTests/mozilla/ecma/Date/15.9.5.34-1.js
@@ -43,7 +43,10 @@
 
     writeHeaderToLog( SECTION + " Date.prototype.setMonth(mon [, date ] )");
 
-    var now =  (new Date()).valueOf();
+    // get the current time
+    // This test does not work well with DST, so using a fixed date. See https://github.com/WebKit/WebKit/pull/53239
+    // var now = (new Date()).valueOf();
+    var now = 1764524660000;
 
     getFunctionCases();
     getTestCases();


### PR DESCRIPTION
#### 6ee51561939d34d9c9307650ec2322b4314ef35a
<pre>
Unreviewed, fixing DST issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=301815">https://bugs.webkit.org/show_bug.cgi?id=301815</a>
<a href="https://rdar.apple.com/163876304">rdar://163876304</a>

Adjusting tests similar to 302398@main.

* JSTests/mozilla/ecma/Date/15.9.5.14.js:
* JSTests/mozilla/ecma/Date/15.9.5.34-1.js:

Canonical link: <a href="https://commits.webkit.org/302448@main">https://commits.webkit.org/302448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecb3ce963813d5a63f786569cc13b0cad00b8f10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136494 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80494 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/69064cda-54aa-4606-bdad-8e5af033c472) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1251 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98311 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66184 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c10d1374-91aa-475c-bb91-1df255941d3b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132062 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78956 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bd1578d3-9c31-4ec5-aeda-d05b7cc43028) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79773 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121107 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138968 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127567 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1134 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106847 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106674 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30519 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53728 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20160 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1240 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160581 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1066 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40078 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1112 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1164 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->