### PR TITLE
Support setting safeToCompareToEmptyOrDeleted in MemberBasedHash

### DIFF
--- a/Source/JavaScriptCore/b3/B3CheckSpecial.h
+++ b/Source/JavaScriptCore/b3/B3CheckSpecial.h
@@ -97,12 +97,14 @@ public:
             return *this == Key(WTF::HashTableDeletedValue);
         }
 
+        static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
         unsigned hash() const
         {
             // Seriously, we don't need to be smart here. It just doesn't matter.
             return m_kind.hash() + m_numArgs + m_stackmapRole;
         }
-        
+
     private:
         Air::Kind m_kind;
         RoleMode m_stackmapRole;
@@ -136,18 +138,9 @@ private:
     unsigned m_numCheckArgs;
 };
 
-struct CheckSpecialKeyHash {
-    static unsigned hash(const CheckSpecial::Key& key) { return key.hash(); }
-    static bool equal(const CheckSpecial::Key& a, const CheckSpecial::Key& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::B3
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::B3::CheckSpecial::Key> : JSC::B3::CheckSpecialKeyHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::B3::CheckSpecial::Key> : SimpleClassHashTraits<JSC::B3::CheckSpecial::Key> {

--- a/Source/JavaScriptCore/b3/B3Kind.h
+++ b/Source/JavaScriptCore/b3/B3Kind.h
@@ -199,7 +199,9 @@ public:
     {
         return *this == Kind(WTF::HashTableDeletedValue);
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
 private:
     Opcode m_opcode;
     bool m_isChill : 1 { false };
@@ -233,18 +235,9 @@ inline Kind cloningForbidden(Kind kind)
     return kind;
 }
 
-struct KindHash {
-    static unsigned hash(const Kind& key) { return key.hash(); }
-    static bool equal(const Kind& a, const Kind& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::B3
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::B3::Kind> : JSC::B3::KindHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::B3::Kind> : public SimpleClassHashTraits<JSC::B3::Kind> {

--- a/Source/JavaScriptCore/b3/B3ValueKey.h
+++ b/Source/JavaScriptCore/b3/B3ValueKey.h
@@ -164,7 +164,9 @@ public:
     {
         return *this == ValueKey(WTF::HashTableDeletedValue);
     }
-        
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
 private:
     SIMDInfo m_simdInfo { };
     Kind m_kind { };
@@ -194,18 +196,10 @@ private:
     } u;
 };
 
-struct ValueKeyHash {
-    static unsigned hash(const ValueKey& key) { return key.hash(); }
-    static bool equal(const ValueKey& a, const ValueKey& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
 
 } } // namespace JSC::B3
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::B3::ValueKey> : JSC::B3::ValueKeyHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::B3::ValueKey> : public SimpleClassHashTraits<JSC::B3::ValueKey> {

--- a/Source/JavaScriptCore/b3/air/AirArg.h
+++ b/Source/JavaScriptCore/b3/air/AirArg.h
@@ -1739,6 +1739,8 @@ public:
         return *this == Arg(WTF::HashTableDeletedValue);
     }
 
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     unsigned hash() const
     {
         // This really doesn't have to be that great.
@@ -1761,12 +1763,6 @@ private:
     JSC::SIMDInfo m_simdInfo;
 };
 
-struct ArgHash {
-    static unsigned hash(const Arg& key) { return key.hash(); }
-    static bool equal(const Arg& a, const Arg& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } } // namespace JSC::B3::Air
 
 namespace WTF {
@@ -1777,9 +1773,6 @@ JS_EXPORT_PRIVATE void printInternal(PrintStream&, JSC::B3::Air::Arg::Phase);
 JS_EXPORT_PRIVATE void printInternal(PrintStream&, JSC::B3::Air::Arg::Timing);
 JS_EXPORT_PRIVATE void printInternal(PrintStream&, JSC::B3::Air::Arg::Role);
 JS_EXPORT_PRIVATE void printInternal(PrintStream&, JSC::B3::Air::Arg::Signedness);
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::B3::Air::Arg> : JSC::B3::Air::ArgHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::B3::Air::Arg> : SimpleClassHashTraits<JSC::B3::Air::Arg> {

--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -392,7 +392,7 @@ private:
     Vector<std::unique_ptr<BasicBlock>> m_blocks;
     SparseCollection<Special> m_specials;
     std::unique_ptr<CFG> m_cfg;
-    SmallSet<Tmp, TmpHash, 2> m_fastTmps;
+    SmallSet<Tmp, DefaultHash<Tmp>, 2> m_fastTmps;
     CCallSpecial* m_cCallSpecial { nullptr };
     unsigned m_numGPTmps { 0 };
     unsigned m_numFPTmps { 0 };

--- a/Source/JavaScriptCore/b3/air/AirTmp.h
+++ b/Source/JavaScriptCore/b3/air/AirTmp.h
@@ -199,6 +199,8 @@ public:
         return *this == Tmp(WTF::HashTableDeletedValue);
     }
 
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     unsigned hash() const
     {
         return WTF::IntHash<int>::hash(m_value);
@@ -311,18 +313,9 @@ private:
     int m_value;
 };
 
-struct TmpHash {
-    static unsigned hash(const Tmp& key) { return key.hash(); }
-    static bool equal(const Tmp& a, const Tmp& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } } // namespace JSC::B3::Air
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::B3::Air::Tmp> : JSC::B3::Air::TmpHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::B3::Air::Tmp> : SimpleClassHashTraits<JSC::B3::Air::Tmp> { };

--- a/Source/JavaScriptCore/bytecode/BytecodeIndex.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIndex.h
@@ -63,6 +63,7 @@ public:
     unsigned hash() const { return intHash(m_packedBits); }
     static BytecodeIndex deletedValue() { return fromBits(invalidOffset - 1); }
     bool isHashTableDeletedValue() const { return *this == deletedValue(); }
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
 
     static BytecodeIndex fromBits(uint32_t bits);
     BytecodeIndex withCheckpoint(Checkpoint checkpoint) const { return BytecodeIndex(offset(), checkpoint); }
@@ -101,18 +102,9 @@ inline BytecodeIndex BytecodeIndex::fromBits(uint32_t bits)
     return result;
 }
 
-struct BytecodeIndexHash {
-    static unsigned hash(const BytecodeIndex& key) { return key.hash(); }
-    static bool equal(const BytecodeIndex& a, const BytecodeIndex& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } // namespace JSC
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::BytecodeIndex> : JSC::BytecodeIndexHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::BytecodeIndex> : SimpleClassHashTraits<JSC::BytecodeIndex> {

--- a/Source/JavaScriptCore/bytecode/CallVariant.h
+++ b/Source/JavaScriptCore/bytecode/CallVariant.h
@@ -146,24 +146,20 @@ public:
     {
         return m_callee == deletedToken();
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     friend auto operator<=>(const CallVariant&, const CallVariant&) = default;
     
     unsigned hash() const
     {
         return WTF::PtrHash<JSCell*>::hash(m_callee);
     }
-    
+
 private:
     static JSCell* deletedToken() { return std::bit_cast<JSCell*>(static_cast<uintptr_t>(1)); }
     
     JSCell* m_callee;
-};
-
-struct CallVariantHash {
-    static unsigned hash(const CallVariant& key) { return key.hash(); }
-    static bool equal(const CallVariant& a, const CallVariant& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };
 
 typedef Vector<CallVariant, 1> CallVariantList;
@@ -178,9 +174,6 @@ CallVariantList despecifiedVariantList(const CallVariantList&);
 } // namespace JSC
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::CallVariant> : JSC::CallVariantHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::CallVariant> : SimpleClassHashTraits<JSC::CallVariant> { };

--- a/Source/JavaScriptCore/bytecode/CodeOrigin.h
+++ b/Source/JavaScriptCore/bytecode/CodeOrigin.h
@@ -144,7 +144,9 @@ public:
         return m_bytecodeIndex.isHashTableDeletedValue() && !!m_inlineCallFrame;
 #endif
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     // The inline depth is the depth of the inline stack, so 1 = not inlined,
     // 2 = inlined one deep, etc.
     unsigned inlineDepth() const;
@@ -286,12 +288,6 @@ inline bool CodeOrigin::operator==(const CodeOrigin& other) const
         && inlineCallFrame() == other.inlineCallFrame();
 }
 
-struct CodeOriginHash {
-    static unsigned hash(const CodeOrigin& key) { return key.hash(); }
-    static bool equal(const CodeOrigin& a, const CodeOrigin& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 struct CodeOriginApproximateHash {
     static unsigned hash(const CodeOrigin& key) { return key.approximateHash(); }
     static bool equal(const CodeOrigin& a, const CodeOrigin& b) { return a.isApproximatelyEqualTo(b); }
@@ -301,9 +297,6 @@ struct CodeOriginApproximateHash {
 } // namespace JSC
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::CodeOrigin> : JSC::CodeOriginHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::CodeOrigin> : SimpleClassHashTraits<JSC::CodeOrigin> {

--- a/Source/JavaScriptCore/bytecode/DFGExitProfile.h
+++ b/Source/JavaScriptCore/bytecode/DFGExitProfile.h
@@ -131,7 +131,9 @@ public:
     {
         return m_kind == ExitKindUnset && m_bytecodeIndex.isHashTableDeletedValue();
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     void dump(PrintStream& out) const;
 
 private:
@@ -141,19 +143,10 @@ private:
     ExitingInlineKind m_inlineKind;
 };
 
-struct FrequentExitSiteHash {
-    static unsigned hash(const FrequentExitSite& key) { return key.hash(); }
-    static bool equal(const FrequentExitSite& a, const FrequentExitSite& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::DFG
 
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::DFG::FrequentExitSite> : JSC::DFG::FrequentExitSiteHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::DFG::FrequentExitSite> : SimpleClassHashTraits<JSC::DFG::FrequentExitSite> { };

--- a/Source/JavaScriptCore/bytecode/DirectEvalCodeCache.h
+++ b/Source/JavaScriptCore/bytecode/DirectEvalCodeCache.h
@@ -74,18 +74,6 @@ namespace JSC {
 
             bool isHashTableDeletedValue() const { return m_source.isHashTableDeletedValue(); }
 
-            struct Hash {
-                static unsigned hash(const CacheKey& key)
-                {
-                    return key.hash();
-                }
-                static bool equal(const CacheKey& lhs, const CacheKey& rhs)
-                {
-                    return lhs == rhs;
-                }
-                static constexpr bool safeToCompareToEmptyOrDeleted = false;
-            };
-
             typedef SimpleClassHashTraits<CacheKey> HashTraits;
 
         private:
@@ -159,7 +147,7 @@ namespace JSC {
 
         void setSlow(JSGlobalObject*, JSCell* owner, const CacheLookupKey& cacheKey, DirectEvalExecutable*);
 
-        typedef UncheckedKeyHashMap<CacheKey, WriteBarrier<DirectEvalExecutable>, CacheKey::Hash, CacheKey::HashTraits> EvalCacheMap;
+        typedef UncheckedKeyHashMap<CacheKey, WriteBarrier<DirectEvalExecutable>, DefaultHash<CacheKey>, CacheKey::HashTraits> EvalCacheMap;
         EvalCacheMap m_cacheMap;
         Lock m_lock;
     };

--- a/Source/JavaScriptCore/bytecode/LazyOperandValueProfile.h
+++ b/Source/JavaScriptCore/bytecode/LazyOperandValueProfile.h
@@ -85,25 +85,17 @@ public:
     {
         return !m_operand.isValid() && m_bytecodeIndex.isHashTableDeletedValue();
     }
-private: 
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
+private:
     BytecodeIndex m_bytecodeIndex;
     Operand m_operand;
-};
-
-struct LazyOperandValueProfileKeyHash {
-    static unsigned hash(const LazyOperandValueProfileKey& key) { return key.hash(); }
-    static bool equal(
-        const LazyOperandValueProfileKey& a,
-        const LazyOperandValueProfileKey& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };
 
 } // namespace JSC
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::LazyOperandValueProfileKey> : JSC::LazyOperandValueProfileKeyHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::LazyOperandValueProfileKey> : public GenericHashTraits<JSC::LazyOperandValueProfileKey> {

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
@@ -210,7 +210,9 @@ public:
     {
         return !m_object && m_condition.isHashTableDeletedValue();
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     // Two conditions are compatible if they are identical or if they speak of different uids or
     // different objects. If false is returned, you have to decide how to resolve the conflict -
     // for example if there is a Presence and an Equivalence then in some cases you'll want the
@@ -302,22 +304,10 @@ private:
     PropertyCondition m_condition;
 };
 
-struct ObjectPropertyConditionHash {
-    static unsigned hash(const ObjectPropertyCondition& key) { return key.hash(); }
-    static bool equal(
-        const ObjectPropertyCondition& a, const ObjectPropertyCondition& b)
-    {
-        return a == b;
-    }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
 
 } // namespace JSC
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::ObjectPropertyCondition> : JSC::ObjectPropertyConditionHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::ObjectPropertyCondition> : SimpleClassHashTraits<JSC::ObjectPropertyCondition> { };

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.h
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.h
@@ -274,7 +274,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     {
         return !m_header.pointer() && m_header.type() == Absence;
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     // Two conditions are compatible if they are identical or if they speak of different uids. If
     // false is returned, you have to decide how to resolve the conflict - for example if there is
     // a Presence and an Equivalence then in some cases you'll want the more general of the two
@@ -385,24 +387,11 @@ private:
     } u;
 };
 
-struct PropertyConditionHash {
-    static unsigned hash(const PropertyCondition& key) { return key.hash(); }
-    static bool equal(
-        const PropertyCondition& a, const PropertyCondition& b)
-    {
-        return a == b;
-    }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } // namespace JSC
 
 namespace WTF {
 
 void printInternal(PrintStream&, JSC::PropertyCondition::Kind);
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::PropertyCondition> : JSC::PropertyConditionHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::PropertyCondition> : SimpleClassHashTraits<JSC::PropertyCondition> { };

--- a/Source/JavaScriptCore/dfg/DFGAbstractHeap.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractHeap.h
@@ -294,6 +294,8 @@ public:
         return kind() == InvalidAbstractHeap && payloadImpl().isTop();
     }
 
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     static AbstractHeapKind superKind(AbstractHeapKind kind)
     {
         switch (kind) {
@@ -388,20 +390,11 @@ private:
     int64_t m_value;
 };
 
-struct AbstractHeapHash {
-    static unsigned hash(const AbstractHeap& key) { return key.hash(); }
-    static bool equal(const AbstractHeap& a, const AbstractHeap& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::DFG
 
 namespace WTF {
 
 void printInternal(PrintStream&, JSC::DFG::AbstractHeapKind);
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::DFG::AbstractHeap> : JSC::DFG::AbstractHeapHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::DFG::AbstractHeap> : SimpleClassHashTraits<JSC::DFG::AbstractHeap> { };

--- a/Source/JavaScriptCore/dfg/DFGDesiredGlobalProperty.h
+++ b/Source/JavaScriptCore/dfg/DFGDesiredGlobalProperty.h
@@ -63,6 +63,8 @@ public:
         return !m_globalObject && m_identifierNumber == UINT_MAX;
     }
 
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     unsigned hash() const
     {
         return WTF::PtrHash<JSGlobalObject*>::hash(m_globalObject) + m_identifierNumber * 7;
@@ -83,18 +85,9 @@ private:
     unsigned m_identifierNumber { 0 };
 };
 
-struct DesiredGlobalPropertyHash {
-    static unsigned hash(const DesiredGlobalProperty& key) { return key.hash(); }
-    static bool equal(const DesiredGlobalProperty& a, const DesiredGlobalProperty& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::DFG
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::DFG::DesiredGlobalProperty> : JSC::DFG::DesiredGlobalPropertyHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::DFG::DesiredGlobalProperty> : SimpleClassHashTraits<JSC::DFG::DesiredGlobalProperty> { };

--- a/Source/JavaScriptCore/dfg/DFGHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGHeapLocation.h
@@ -171,7 +171,9 @@ public:
     {
         return m_heap.isHashTableDeletedValue();
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     void dump(PrintStream& out) const;
     
 private:
@@ -181,12 +183,6 @@ private:
     LazyNode m_index;
     Node* m_descriptor;
     void* m_extraState { nullptr };
-};
-
-struct HeapLocationHash {
-    static unsigned hash(const HeapLocation& key) { return key.hash(); }
-    static bool equal(const HeapLocation& a, const HeapLocation& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };
 
 inline LocationKind indexedPropertyLocForResultType(NodeFlags canonicalResultRepresentation)
@@ -231,9 +227,6 @@ inline LocationKind indexedPropertyLocToOutOfBoundsSaneChain(LocationKind locati
 } } // namespace JSC::DFG
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::DFG::HeapLocation> : JSC::DFG::HeapLocationHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::DFG::HeapLocation> : SimpleClassHashTraits<JSC::DFG::HeapLocation> {

--- a/Source/JavaScriptCore/dfg/DFGMinifiedID.h
+++ b/Source/JavaScriptCore/dfg/DFGMinifiedID.h
@@ -56,7 +56,8 @@ public:
     void dump(PrintStream& out) const { out.print(m_index.get()); }
     
     bool isHashTableDeletedValue() const { return m_index.get() == otherInvalidIndex(); }
-    
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     static MinifiedID fromBits(unsigned value)
     {
         MinifiedID result;
@@ -75,18 +76,9 @@ private:
     Packed<unsigned> m_index { invalidIndex() };
 };
 
-struct MinifiedIDHash {
-    static unsigned hash(const MinifiedID& key) { return key.hash(); }
-    static bool equal(const MinifiedID& a, const MinifiedID& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::DFG
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::DFG::MinifiedID> : JSC::DFG::MinifiedIDHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::DFG::MinifiedID> : SimpleClassHashTraits<JSC::DFG::MinifiedID> {

--- a/Source/JavaScriptCore/dfg/DFGNodeFlowProjection.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeFlowProjection.h
@@ -100,7 +100,9 @@ public:
     {
         return *this == NodeFlowProjection(WTF::HashTableDeletedValue);
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     // Phi shadow projections can become invalid because the Phi might be folded to something else.
     bool isStillValid() const
     {
@@ -123,18 +125,9 @@ public:
     uintptr_t m_word { 0 };
 };
 
-struct NodeFlowProjectionHash {
-    static unsigned hash(NodeFlowProjection key) { return key.hash(); }
-    static bool equal(NodeFlowProjection a, NodeFlowProjection b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::DFG
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::DFG::NodeFlowProjection> : JSC::DFG::NodeFlowProjectionHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::DFG::NodeFlowProjection> : SimpleClassHashTraits<JSC::DFG::NodeFlowProjection> { };

--- a/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h
@@ -112,6 +112,8 @@ public:
         return m_kind == InvalidPromotedLocationKind && m_info;
     }
 
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     // These are the locations / values that are strictly needed to allocate the object. When
     // object allocation sinking is breaking cycles for materialization, edges marked
     // !neededForMaterialization are prioritized.
@@ -135,12 +137,6 @@ public:
 private:
     PromotedLocationKind m_kind;
     unsigned m_info;
-};
-
-struct PromotedLocationDescriptorHash {
-    static unsigned hash(const PromotedLocationDescriptor& key) { return key.hash(); }
-    static bool equal(const PromotedLocationDescriptor& a, const PromotedLocationDescriptor& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };
 
 class PromotedHeapLocation {
@@ -191,7 +187,9 @@ public:
     {
         return m_meta.isHashTableDeletedValue();
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     void dump(PrintStream& out) const;
     
 private:
@@ -199,26 +197,14 @@ private:
     PromotedLocationDescriptor m_meta;
 };
 
-struct PromotedHeapLocationHash {
-    static unsigned hash(const PromotedHeapLocation& key) { return key.hash(); }
-    static bool equal(const PromotedHeapLocation& a, const PromotedHeapLocation& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::DFG
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::DFG::PromotedHeapLocation> : JSC::DFG::PromotedHeapLocationHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::DFG::PromotedHeapLocation> : SimpleClassHashTraits<JSC::DFG::PromotedHeapLocation> {
     static constexpr bool emptyValueIsZero = false;
 };
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::DFG::PromotedLocationDescriptor> : JSC::DFG::PromotedLocationDescriptorHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::DFG::PromotedLocationDescriptor> : SimpleClassHashTraits<JSC::DFG::PromotedLocationDescriptor> {

--- a/Source/JavaScriptCore/dfg/DFGPropertyTypeKey.h
+++ b/Source/JavaScriptCore/dfg/DFGPropertyTypeKey.h
@@ -71,6 +71,8 @@ public:
         return !m_structure && m_uid == deletedUID();
     }
 
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     void dumpInContext(PrintStream& out, DumpContext* context) const
     {
         out.print(pointerDumpInContext(m_structure, context), "+", m_uid);
@@ -91,18 +93,9 @@ private:
     UniquedStringImpl* m_uid;
 };
 
-struct PropertyTypeKeyHash {
-    static unsigned hash(const PropertyTypeKey& key) { return key.hash(); }
-    static bool equal(const PropertyTypeKey& a, const PropertyTypeKey& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::DFG
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::DFG::PropertyTypeKey> : JSC::DFG::PropertyTypeKeyHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::DFG::PropertyTypeKey> : SimpleClassHashTraits<JSC::DFG::PropertyTypeKey> {

--- a/Source/JavaScriptCore/dfg/DFGPureValue.h
+++ b/Source/JavaScriptCore/dfg/DFGPureValue.h
@@ -130,7 +130,9 @@ public:
     {
         return m_op == LastNodeType && m_info;
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     void dump(PrintStream& out) const;
     
 private:
@@ -142,18 +144,9 @@ private:
     Graph* m_graph { nullptr };
 };
 
-struct PureValueHash {
-    static unsigned hash(const PureValue& key) { return key.hash(); }
-    static bool equal(const PureValue& a, const PureValue& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::DFG
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::DFG::PureValue> : JSC::DFG::PureValueHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::DFG::PureValue> : SimpleClassHashTraits<JSC::DFG::PureValue> {

--- a/Source/JavaScriptCore/ftl/FTLLocation.h
+++ b/Source/JavaScriptCore/ftl/FTLLocation.h
@@ -125,7 +125,8 @@ public:
     bool operator!() const { return !static_cast<bool>(*this); }
     
     bool isHashTableDeletedValue() const { return kind() == Unprocessed && u.variable.offset; }
-    
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     bool operator==(const Location& other) const
     {
         return m_kind == other.m_kind
@@ -188,20 +189,11 @@ private:
     } u;
 };
 
-struct LocationHash {
-    static unsigned hash(const Location& key) { return key.hash(); }
-    static bool equal(const Location& a, const Location& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::FTL
 
 namespace WTF {
 
 void printInternal(PrintStream&, JSC::FTL::Location::Kind);
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::FTL::Location> : JSC::FTL::LocationHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::FTL::Location> : SimpleClassHashTraits<JSC::FTL::Location> { };

--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -76,6 +76,7 @@ using JSInstruction = BaseInstruction<JSOpcodeTraits>;
         unsigned hash() const { return intHash(m_bits); }
         static CallSiteIndex deletedValue() { return fromBits(s_invalidIndex - 1); }
         bool isHashTableDeletedValue() const { return *this == deletedValue(); }
+        static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
 
         uint32_t bits() const { return m_bits; }
         static CallSiteIndex fromBits(uint32_t bits) { return CallSiteIndex(bits); }
@@ -86,12 +87,6 @@ using JSInstruction = BaseInstruction<JSOpcodeTraits>;
         static constexpr uint32_t s_invalidIndex = std::numeric_limits<uint32_t>::max();
 
         uint32_t m_bits { s_invalidIndex };
-    };
-
-    struct CallSiteIndexHash {
-        static unsigned hash(const CallSiteIndex& key) { return key.hash(); }
-        static bool equal(const CallSiteIndex& a, const CallSiteIndex& b) { return a == b; }
-        static constexpr bool safeToCompareToEmptyOrDeleted = true;
     };
 
     class DisposableCallSiteIndex : public CallSiteIndex {
@@ -439,9 +434,6 @@ JS_EXPORT_PRIVATE bool isFromJSCode(void* returnAddress);
 } // namespace JSC
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::CallSiteIndex> : JSC::CallSiteIndexHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::CallSiteIndex> : SimpleClassHashTraits<JSC::CallSiteIndex> {

--- a/Source/JavaScriptCore/jit/ICStats.h
+++ b/Source/JavaScriptCore/jit/ICStats.h
@@ -156,7 +156,9 @@ public:
     {
         return *this == ICEvent(WTF::HashTableDeletedValue);
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     void dump(PrintStream&) const;
     
     void log() const;
@@ -169,20 +171,11 @@ private:
     PropertyLocation m_propertyLocation;
 };
 
-struct ICEventHash {
-    static unsigned hash(const ICEvent& key) { return key.hash(); }
-    static bool equal(const ICEvent& a, const ICEvent& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } // namespace JSC
 
 namespace WTF {
 
 void printInternal(PrintStream&, JSC::ICEvent::Kind);
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::ICEvent> : JSC::ICEventHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::ICEvent> : SimpleClassHashTraits<JSC::ICEvent> {

--- a/Source/JavaScriptCore/jit/JITCompilationKey.h
+++ b/Source/JavaScriptCore/jit/JITCompilationKey.h
@@ -61,7 +61,9 @@ public:
     {
         return !m_codeBlock && m_mode != JITCompilationMode::InvalidCompilation;
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     JITCompilationMode mode() const { return m_mode; }
     
     friend bool operator==(const JITCompilationKey&, const JITCompilationKey&) = default;
@@ -79,18 +81,9 @@ private:
     JITCompilationMode m_mode;
 };
 
-struct JITCompilationKeyHash {
-    static unsigned hash(const JITCompilationKey& key) { return key.hash(); }
-    static bool equal(const JITCompilationKey& a, const JITCompilationKey& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } // namespace JSC
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::JITCompilationKey> : JSC::JITCompilationKeyHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::JITCompilationKey> : SimpleClassHashTraits<JSC::JITCompilationKey> { };

--- a/Source/JavaScriptCore/jit/Reg.h
+++ b/Source/JavaScriptCore/jit/Reg.h
@@ -113,6 +113,7 @@ public:
     constexpr explicit operator bool() const { return isSet(); }
 
     constexpr bool isHashTableDeletedValue() const { return m_index == deleted(); }
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
 
     constexpr bool isGPR() const
     {
@@ -189,12 +190,6 @@ private:
 };
 static_assert(sizeof(Reg) == 1);
 
-struct RegHash {
-    static unsigned hash(const Reg& key) { return key.hash(); }
-    static bool equal(const Reg& a, const Reg& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 ALWAYS_INLINE constexpr Width conservativeWidthWithoutVectors(const Reg reg)
 {
     return reg.isFPR() ? Width64 : widthForBytes(sizeof(CPURegister));
@@ -218,9 +213,6 @@ ALWAYS_INLINE constexpr unsigned conservativeRegisterBytesWithoutVectors(const R
 } // namespace JSC
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::Reg> : JSC::RegHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::Reg> : SimpleClassHashTraits<JSC::Reg> {

--- a/Source/JavaScriptCore/parser/SourceCodeKey.h
+++ b/Source/JavaScriptCore/parser/SourceCodeKey.h
@@ -119,12 +119,6 @@ public:
             && (m_sourceCode == other.m_sourceCode || string() == other.string());
     }
 
-    struct Hash {
-        static unsigned hash(const SourceCodeKey& key) { return key.hash(); }
-        static bool equal(const SourceCodeKey& a, const SourceCodeKey& b) { return a == b; }
-        static constexpr bool safeToCompareToEmptyOrDeleted = false;
-    };
-
     struct HashTraits : SimpleClassHashTraits<SourceCodeKey> {
         static constexpr bool hasIsEmptyValueFunction = true;
         static bool isEmptyValue(const SourceCodeKey& key) { return key.isNull(); }

--- a/Source/JavaScriptCore/profiler/ProfilerOrigin.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOrigin.h
@@ -65,7 +65,8 @@ public:
     unsigned hash() const;
     
     bool isHashTableDeletedValue() const;
-    
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     void dump(PrintStream&) const;
     Ref<JSON::Value> toJSON(Dumper&) const;
 
@@ -84,18 +85,9 @@ inline bool Origin::isHashTableDeletedValue() const
     return m_bytecodeIndex.isHashTableDeletedValue();
 }
 
-struct OriginHash {
-    static unsigned hash(const Origin& key) { return key.hash(); }
-    static bool equal(const Origin& a, const Origin& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::Profiler
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::Profiler::Origin> : JSC::Profiler::OriginHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::Profiler::Origin> : SimpleClassHashTraits<JSC::Profiler::Origin> { };

--- a/Source/JavaScriptCore/profiler/ProfilerOriginStack.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOriginStack.h
@@ -64,7 +64,8 @@ public:
     unsigned hash() const;
     
     bool isHashTableDeletedValue() const;
-    
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     void dump(PrintStream&) const;
     Ref<JSON::Value> toJSON(Dumper&) const;
     
@@ -77,18 +78,9 @@ inline bool OriginStack::isHashTableDeletedValue() const
     return m_stack.size() == 1 && m_stack[0].isHashTableDeletedValue();
 }
 
-struct OriginStackHash {
-    static unsigned hash(const OriginStack& key) { return key.hash(); }
-    static bool equal(const OriginStack& a, const OriginStack& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } } // namespace JSC::Profiler
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::Profiler::OriginStack> : JSC::Profiler::OriginStackHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::Profiler::OriginStack> : SimpleClassHashTraits<JSC::Profiler::OriginStack> { };

--- a/Source/JavaScriptCore/runtime/CodeCache.h
+++ b/Source/JavaScriptCore/runtime/CodeCache.h
@@ -77,7 +77,7 @@ struct SourceCodeValue {
 
 class CodeCacheMap {
 public:
-    typedef UncheckedKeyHashMap<SourceCodeKey, SourceCodeValue, SourceCodeKey::Hash, SourceCodeKey::HashTraits> MapType;
+    typedef UncheckedKeyHashMap<SourceCodeKey, SourceCodeValue, DefaultHash<SourceCodeKey>, SourceCodeKey::HashTraits> MapType;
     typedef MapType::iterator iterator;
     typedef MapType::AddResult AddResult;
 

--- a/Source/JavaScriptCore/runtime/ControlFlowProfiler.h
+++ b/Source/JavaScriptCore/runtime/ControlFlowProfiler.h
@@ -52,6 +52,7 @@ struct BasicBlockKey {
     { }
 
     bool isHashTableDeletedValue() const { return m_startOffset == -2 && m_endOffset == -2; }
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
     friend bool operator==(const BasicBlockKey&, const BasicBlockKey&) = default;
     unsigned hash() const { return m_startOffset + m_endOffset + 1; }
 
@@ -59,18 +60,9 @@ struct BasicBlockKey {
     int m_endOffset;
 };
 
-struct BasicBlockKeyHash {
-    static unsigned hash(const BasicBlockKey& key) { return key.hash(); }
-    static bool equal(const BasicBlockKey& a, const BasicBlockKey& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } // namespace JSC
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::BasicBlockKey> : JSC::BasicBlockKeyHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::BasicBlockKey> : SimpleClassHashTraits<JSC::BasicBlockKey> {

--- a/Source/JavaScriptCore/runtime/PrototypeKey.h
+++ b/Source/JavaScriptCore/runtime/PrototypeKey.h
@@ -60,7 +60,8 @@ public:
     
     explicit operator bool() const { return *this != PrototypeKey(); }
     bool isHashTableDeletedValue() const { return *this == PrototypeKey(WTF::HashTableDeletedValue); }
-    
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     unsigned hash() const
     {
         return WTF::IntHash<uintptr_t>::hash(std::bit_cast<uintptr_t>(m_prototype) ^ std::bit_cast<uintptr_t>(m_executable) ^ std::bit_cast<uintptr_t>(m_classInfo)) + m_inlineCapacity;
@@ -75,18 +76,9 @@ private:
     const ClassInfo* m_classInfo { nullptr };
 };
 
-struct PrototypeKeyHash {
-    static unsigned hash(const PrototypeKey& key) { return key.hash(); }
-    static bool equal(const PrototypeKey& a, const PrototypeKey& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } // namespace JSC
 
 namespace WTF {
-
-template<typename> struct DefaultHash;
-template<> struct DefaultHash<JSC::PrototypeKey> : JSC::PrototypeKeyHash { };
 
 template<typename> struct HashTraits;
 template<> struct HashTraits<JSC::PrototypeKey> : SimpleClassHashTraits<JSC::PrototypeKey> { };

--- a/Source/JavaScriptCore/runtime/TypeProfiler.h
+++ b/Source/JavaScriptCore/runtime/TypeProfiler.h
@@ -71,6 +71,8 @@ struct QueryKey {
             && m_searchDescriptor == TypeProfilerSearchDescriptorFunctionReturn;
     }
 
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     friend bool operator==(const QueryKey&, const QueryKey&) = default;
 
     unsigned hash() const 
@@ -84,18 +86,9 @@ struct QueryKey {
     TypeProfilerSearchDescriptor m_searchDescriptor;
 };
 
-struct QueryKeyHash {
-    static unsigned hash(const QueryKey& key) { return key.hash(); }
-    static bool equal(const QueryKey& a, const QueryKey& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } // namespace JSC
 
 namespace WTF {
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::QueryKey> : JSC::QueryKeyHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::QueryKey> : SimpleClassHashTraits<JSC::QueryKey> {

--- a/Source/JavaScriptCore/runtime/VarOffset.h
+++ b/Source/JavaScriptCore/runtime/VarOffset.h
@@ -201,7 +201,9 @@ public:
     {
         return m_kind == VarKind::Invalid && !m_offset;
     }
-    
+
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     void dump(PrintStream&) const;
     
 private:
@@ -209,20 +211,11 @@ private:
     unsigned m_offset;
 };
 
-struct VarOffsetHash {
-    static unsigned hash(const VarOffset& key) { return key.hash(); }
-    static bool equal(const VarOffset& a, const VarOffset& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 } // namespace JSC
 
 namespace WTF {
 
 void printInternal(PrintStream&, JSC::VarKind);
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<JSC::VarOffset> : JSC::VarOffsetHash { };
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::VarOffset> : SimpleClassHashTraits<JSC::VarOffset> {

--- a/Source/WTF/wtf/GenericHashKey.h
+++ b/Source/WTF/wtf/GenericHashKey.h
@@ -69,6 +69,7 @@ public:
 
     constexpr bool isHashTableDeletedValue() const { return std::holds_alternative<DeletedKey>(m_value); }
     constexpr bool isHashTableEmptyValue() const { return std::holds_alternative<EmptyKey>(m_value); }
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = false;
 
     constexpr bool operator==(const GenericHashKey& other) const
     {
@@ -88,12 +89,6 @@ template<typename K, typename H> struct HashTraits<GenericHashKey<K, H>> : Gener
     static bool isEmptyValue(const GenericHashKey<K, H>& value) { return value.isHashTableEmptyValue(); }
     static void constructDeletedValue(GenericHashKey<K, H>& slot) { slot = GenericHashKey<K, H> { HashTableDeletedValue }; }
     static bool isDeletedValue(const GenericHashKey<K, H>& value) { return value.isHashTableDeletedValue(); }
-};
-
-template<typename K, typename H> struct DefaultHash<GenericHashKey<K, H>> {
-    static unsigned hash(const GenericHashKey<K, H>& key) { return key.hash(); }
-    static bool equal(const GenericHashKey<K, H>& a, const GenericHashKey<K, H>& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = false;
 };
 
 }

--- a/Source/WTF/wtf/HashFunctions.h
+++ b/Source/WTF/wtf/HashFunctions.h
@@ -270,7 +270,13 @@ namespace WTF {
     template<HashableWithMemberFunction T> struct MemberBasedHash {
         static unsigned hash(const T& key) { return key.hash(); }
         static bool equal(const T& a, const T& b) { return a == b; }
-        static constexpr bool safeToCompareToEmptyOrDeleted = false;
+        static constexpr bool safeToCompareToEmptyOrDeleted = [] {
+            if constexpr (requires { T::safeToCompareToHashTableEmptyOrDeletedValue; }) {
+                static_assert(std::same_as<decltype(T::safeToCompareToHashTableEmptyOrDeletedValue), const bool>);
+                return T::safeToCompareToHashTableEmptyOrDeletedValue;
+            } else
+                return false;
+        }();
     };
     template<HashableWithMemberFunction T> struct DefaultHash<T> : MemberBasedHash<T> { };
 

--- a/Source/WebCore/platform/Cookie.h
+++ b/Source/WebCore/platform/Cookie.h
@@ -123,19 +123,6 @@ struct Cookie {
     Cookie isolatedCopy() && { return { WTFMove(name).isolatedCopy(), WTFMove(value).isolatedCopy(), WTFMove(domain).isolatedCopy(), WTFMove(path).isolatedCopy(), WTFMove(partitionKey).isolatedCopy(), created, expires, httpOnly, secure, session, WTFMove(comment).isolatedCopy(), WTFMove(commentURL).isolatedCopy(), WTFMove(ports), sameSite }; }
 };
 
-struct CookieHash {
-    static unsigned hash(const Cookie& key)
-    {
-        return key.hash();
-    }
-
-    static bool equal(const Cookie& a, const Cookie& b)
-    {
-        return a == b;
-    }
-    static const bool safeToCompareToEmptyOrDeleted = false;
-};
-
 namespace CookieUtil {
 
 WEBCORE_EXPORT String defaultPathForURL(const URL&);
@@ -145,8 +132,6 @@ WEBCORE_EXPORT String defaultPathForURL(const URL&);
 } // namespace WebCore
 
 namespace WTF {
-    template<typename T> struct DefaultHash;
-    template<> struct DefaultHash<WebCore::Cookie> : WebCore::CookieHash { };
     template<> struct HashTraits<WebCore::Cookie> : GenericHashTraits<WebCore::Cookie> {
         static WebCore::Cookie emptyValue() { return { }; }
         static void constructDeletedValue(WebCore::Cookie& slot) { new (NotNull, &slot.name) String(WTF::HashTableDeletedValue); }

--- a/Source/WebCore/platform/Site.h
+++ b/Source/WebCore/platform/Site.h
@@ -54,12 +54,6 @@ public:
 
     bool operator==(const Site&) const = default;
 
-    struct Hash {
-        static unsigned hash(const Site& site) { return site.hash(); }
-        static bool equal(const Site& a, const Site& b) { return a == b; }
-        static const bool safeToCompareToEmptyOrDeleted = false;
-    };
-
 private:
     String m_protocol;
     RegistrableDomain m_domain;
@@ -70,7 +64,6 @@ WEBCORE_EXPORT TextStream& operator<<(TextStream&, const Site&);
 } // namespace WebCore
 
 namespace WTF {
-template<> struct DefaultHash<WebCore::Site> : WebCore::Site::Hash { };
 template<> struct HashTraits<WebCore::Site> : SimpleClassHashTraits<WebCore::Site> {
     static WebCore::Site emptyValue() { return { WTF::HashTableEmptyValue }; }
 };

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -90,12 +90,6 @@ struct FontPlatformDataCacheKeyHashTraits : public SimpleClassHashTraits<FontPla
     }
 };
 
-struct FontDataCacheKeyHash {
-    static unsigned hash(const FontPlatformData& data) { return data.hash(); }
-    static bool equal(const FontPlatformData& a, const FontPlatformData& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
 struct FontDataCacheKeyTraits : WTF::GenericHashTraits<FontPlatformData> {
 #if USE(SKIA)
     static constexpr bool emptyValueIsZero = false;
@@ -119,9 +113,9 @@ struct FontDataCacheKeyTraits : WTF::GenericHashTraits<FontPlatformData> {
 };
 
 using FontPlatformDataCache = HashMap<FontPlatformDataCacheKey, std::unique_ptr<FontPlatformData>, FontPlatformDataCacheKeyHash, FontPlatformDataCacheKeyHashTraits>;
-using FontDataCache = HashMap<FontPlatformData, Ref<Font>, FontDataCacheKeyHash, FontDataCacheKeyTraits>;
+using FontDataCache = HashMap<FontPlatformData, Ref<Font>, DefaultHash<FontPlatformData>, FontDataCacheKeyTraits>;
 #if ENABLE(OPENTYPE_VERTICAL)
-using FontVerticalDataCache = HashMap<FontPlatformData, RefPtr<OpenTypeVerticalData>, FontDataCacheKeyHash, FontDataCacheKeyTraits>;
+using FontVerticalDataCache = HashMap<FontPlatformData, RefPtr<OpenTypeVerticalData>, DefaultHash<FontPlatformData>, FontDataCacheKeyTraits>;
 #endif
 
 struct FontCache::FontDataCaches {

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -399,6 +399,8 @@ public:
         return m_isHashTableDeletedValue;
     }
 
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     bool isEmoji() const
     {
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/graphics/WidthCache.h
+++ b/Source/WebCore/platform/graphics/WidthCache.h
@@ -73,6 +73,8 @@ private:
 
         bool isHashTableDeletedValue() const { return m_hashAndLength == s_deletedValueLength; }
         bool isHashTableEmptyValue() const { return !m_hashAndLength; }
+        // Empty and deleted values have lengths that are not equal to any valid length.
+        static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
 
         friend bool operator==(const SmallStringKey&, const SmallStringKey&) = default;
 
@@ -93,12 +95,6 @@ private:
 
         std::array<char16_t, s_capacity> m_characters { };
         unsigned m_hashAndLength { 0 };
-    };
-
-    struct SmallStringKeyHash {
-        static unsigned hash(const SmallStringKey& key) { return key.hash(); }
-        static bool equal(const SmallStringKey& a, const SmallStringKey& b) { return a == b; }
-        static constexpr bool safeToCompareToEmptyOrDeleted = true; // Empty and deleted values have lengths that are not equal to any valid length.
     };
 
     struct SmallStringKeyHashTraits : SimpleClassHashTraits<SmallStringKey> {
@@ -221,7 +217,7 @@ private:
         return false;
     }
 
-    using Map = HashMap<SmallStringKey, float, SmallStringKeyHash, SmallStringKeyHashTraits, WTF::FloatWithZeroEmptyKeyHashTraits<float>>;
+    using Map = HashMap<SmallStringKey, float, DefaultHash<SmallStringKey>, SmallStringKeyHashTraits, WTF::FloatWithZeroEmptyKeyHashTraits<float>>;
     using SingleCharMap = HashMap<uint32_t, float, DefaultHash<uint32_t>, HashTraits<uint32_t>, WTF::FloatWithZeroEmptyKeyHashTraits<float>>;
 
     static constexpr int s_minInterval = -3; // A cache hit pays for about 3 cache misses.

--- a/Source/WebCore/rendering/CSSValueKey.h
+++ b/Source/WebCore/rendering/CSSValueKey.h
@@ -34,6 +34,8 @@ struct CSSValueKey {
 
     friend bool operator==(const CSSValueKey&, const CSSValueKey&) = default;
 
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
+
     unsigned cssValueID;
     bool useDarkAppearance;
     bool useElevatedUserInterfaceLevel;
@@ -48,18 +50,10 @@ inline unsigned CSSValueKey::hash() const
 
 namespace WTF {
 
-struct CSSValueKeyHash {
-    static unsigned hash(const WebCore::CSSValueKey& key) { return key.hash(); }
-    static bool equal(const WebCore::CSSValueKey& a, const WebCore::CSSValueKey& b) { return a == b; }
-    static const bool safeToCompareToEmptyOrDeleted = true;
-};
-
 template<> struct HashTraits<WebCore::CSSValueKey> : GenericHashTraits<WebCore::CSSValueKey> {
     static WebCore::CSSValueKey emptyValue() { return WebCore::CSSValueKey { WebCore::CSSValueInvalid, false, false}; }
     static void constructDeletedValue(WebCore::CSSValueKey& slot) { new (NotNull, &slot) WebCore::CSSValueKey { WebCore::CSSValueInvalid, true, true}; }
     static bool isDeletedValue(const WebCore::CSSValueKey& slot) { return slot.cssValueID == WebCore::CSSValueInvalid && slot.useDarkAppearance && slot.useElevatedUserInterfaceLevel; }
 };
-
-template<> struct DefaultHash<WebCore::CSSValueKey> : CSSValueKeyHash { };
 
 } // namespace WTF

--- a/Source/WebCore/rendering/TextAutoSizing.h
+++ b/Source/WebCore/rendering/TextAutoSizing.h
@@ -50,6 +50,7 @@ public:
 
     const RenderStyle* style() const { ASSERT(!isDeleted()); return m_style.get(); }
     bool isDeleted() const { return HashTraits<std::unique_ptr<RenderStyle>>::isDeletedValue(m_style); }
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
 
     unsigned hash() const { return m_hash; }
 
@@ -66,12 +67,6 @@ inline bool operator==(const TextAutoSizingKey& a, const TextAutoSizingKey& b)
         return a.style() == b.style();
     return a.style()->equalForTextAutosizing(*b.style());
 }
-
-struct TextAutoSizingHash {
-    static unsigned hash(const TextAutoSizingKey& key) { return key.hash(); }
-    static bool equal(const TextAutoSizingKey& a, const TextAutoSizingKey& b) { return a == b; }
-    static const bool safeToCompareToEmptyOrDeleted = true;
-};
 
 struct TextAutoSizingHashTranslator {
     static unsigned hash(const RenderStyle& style)
@@ -125,7 +120,7 @@ public:
     void reset();
 
 private:
-    HashMap<TextAutoSizingKey, std::unique_ptr<TextAutoSizingValue>, TextAutoSizingHash, TextAutoSizingTraits> m_textNodes;
+    HashMap<TextAutoSizingKey, std::unique_ptr<TextAutoSizingValue>, DefaultHash<TextAutoSizingKey>, TextAutoSizingTraits> m_textNodes;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebFoundTextRange.h
+++ b/Source/WebKit/Shared/WebFoundTextRange.h
@@ -51,6 +51,7 @@ struct WebFoundTextRange {
 
         bool operator==(const PDFData& other) const = default;
         unsigned hash() const;
+        static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
     };
 
     Variant<DOMData, PDFData> data { DOMData { } };
@@ -69,12 +70,6 @@ TextStream& operator<<(TextStream&, const WebFoundTextRange::PDFData&);
 } // namespace WebKit
 
 namespace WTF {
-
-struct WebFoundTextRangePDFDataHash {
-    static unsigned hash(const WebKit::WebFoundTextRange::PDFData& data) { return data.hash(); }
-    static bool equal(const WebKit::WebFoundTextRange::PDFData& a, const WebKit::WebFoundTextRange::PDFData& b) { return a == b; }
-    static const bool safeToCompareToEmptyOrDeleted = true;
-};
 
 template<> struct HashTraits<WebKit::WebFoundTextRange::PDFData> : GenericHashTraits<WebKit::WebFoundTextRange::PDFData> {
     static constexpr bool emptyValueIsZero = false;
@@ -104,12 +99,7 @@ public:
     {
         return data == deletedSentinel;
     }
-};
-
-struct WebFoundTextRangeHash {
-    static unsigned hash(const WebKit::WebFoundTextRange& range) { return range.hash(); }
-    static bool equal(const WebKit::WebFoundTextRange& a, const WebKit::WebFoundTextRange& b) { return a == b; }
-    static const bool safeToCompareToEmptyOrDeleted = true;
+    static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
 };
 
 template<> struct HashTraits<WebKit::WebFoundTextRange> : GenericHashTraits<WebKit::WebFoundTextRange> {
@@ -118,8 +108,5 @@ template<> struct HashTraits<WebKit::WebFoundTextRange> : GenericHashTraits<WebK
     static void constructDeletedValue(WebKit::WebFoundTextRange& slot) { new (NotNull, &slot.frameIdentifier) AtomString { HashTableDeletedValue }; }
     static bool isDeletedValue(const WebKit::WebFoundTextRange& range) { return range.frameIdentifier.isHashTableDeletedValue(); }
 };
-
-template<> struct DefaultHash<WebKit::WebFoundTextRange::PDFData> : WebFoundTextRangePDFDataHash { };
-template<> struct DefaultHash<WebKit::WebFoundTextRange> : WebFoundTextRangeHash { };
 
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -155,15 +155,6 @@ HashSet<String> toStrings(const WebExtensionMatchPattern::MatchPatternSet&);
 
 namespace WTF {
 
-struct WebExtensionMatchPatternHash {
-    static unsigned hash(const WebKit::WebExtensionMatchPattern& pattern) { return pattern.hash(); }
-    static bool equal(const WebKit::WebExtensionMatchPattern& a, const WebKit::WebExtensionMatchPattern& b) { return a == b; }
-    static const bool safeToCompareToEmptyOrDeleted = false;
-};
-
-template<typename T> struct DefaultHash;
-template<> struct DefaultHash<WebKit::WebExtensionMatchPattern> : WebExtensionMatchPatternHash { };
-
 template<> struct HashTraits<WebKit::WebExtensionMatchPattern> : SimpleClassHashTraits<WebKit::WebExtensionMatchPattern> {
     static const bool emptyValueIsZero = false;
     static const bool hasIsEmptyValueFunction = true;


### PR DESCRIPTION
#### acb1c76129d479ba1b60f43ab9d4c446205dc957
<pre>
Support setting safeToCompareToEmptyOrDeleted in MemberBasedHash
<a href="https://bugs.webkit.org/show_bug.cgi?id=301816">https://bugs.webkit.org/show_bug.cgi?id=301816</a>
<a href="https://rdar.apple.com/163877354">rdar://163877354</a>

Reviewed by Darin Adler and Sam Weinig.

Allow Hash types with safeToCompareToEmptyOrDeleted = true to be replaced with MemberBasedHash too.

To signal that the comparison is safe the type itself can have optional

static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;

field which is then picked up by MemberBasedHash.

Use this to remove lots of boilerplate.
Also clean up a few additional cases with safeToCompareToEmptyOrDeleted = false.

* Source/JavaScriptCore/b3/B3CheckSpecial.h:
(JSC::B3::CheckSpecialKeyHash::hash): Deleted.
(JSC::B3::CheckSpecialKeyHash::equal): Deleted.
* Source/JavaScriptCore/b3/B3Kind.h:
(JSC::B3::KindHash::hash): Deleted.
(JSC::B3::KindHash::equal): Deleted.
* Source/JavaScriptCore/b3/B3ValueKey.h:
(JSC::B3::ValueKeyHash::hash): Deleted.
(JSC::B3::ValueKeyHash::equal): Deleted.
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::ArgHash::hash): Deleted.
(JSC::B3::Air::ArgHash::equal): Deleted.
* Source/JavaScriptCore/b3/air/AirCode.h:
* Source/JavaScriptCore/b3/air/AirTmp.h:
(JSC::B3::Air::TmpHash::hash): Deleted.
(JSC::B3::Air::TmpHash::equal): Deleted.
* Source/JavaScriptCore/bytecode/BytecodeIndex.h:
(JSC::BytecodeIndexHash::hash): Deleted.
(JSC::BytecodeIndexHash::equal): Deleted.
* Source/JavaScriptCore/bytecode/CallVariant.h:
(JSC::CallVariantHash::hash): Deleted.
(JSC::CallVariantHash::equal): Deleted.
* Source/JavaScriptCore/bytecode/CodeOrigin.h:
(JSC::CodeOriginHash::hash): Deleted.
(JSC::CodeOriginHash::equal): Deleted.
* Source/JavaScriptCore/bytecode/DFGExitProfile.h:
(JSC::DFG::FrequentExitSiteHash::hash): Deleted.
(JSC::DFG::FrequentExitSiteHash::equal): Deleted.
* Source/JavaScriptCore/bytecode/DirectEvalCodeCache.h:
(JSC::DirectEvalCodeCache::CacheKey::Hash::hash): Deleted.
(JSC::DirectEvalCodeCache::CacheKey::Hash::equal): Deleted.
* Source/JavaScriptCore/bytecode/LazyOperandValueProfile.h:
(JSC::LazyOperandValueProfileKeyHash::hash): Deleted.
(JSC::LazyOperandValueProfileKeyHash::equal): Deleted.
* Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h:
(JSC::ObjectPropertyConditionHash::hash): Deleted.
(JSC::ObjectPropertyConditionHash::equal): Deleted.
* Source/JavaScriptCore/bytecode/PropertyCondition.h:
(JSC::PropertyConditionHash::hash): Deleted.
(JSC::PropertyConditionHash::equal): Deleted.
* Source/JavaScriptCore/dfg/DFGAbstractHeap.h:
(JSC::DFG::AbstractHeapHash::hash): Deleted.
(JSC::DFG::AbstractHeapHash::equal): Deleted.
* Source/JavaScriptCore/dfg/DFGDesiredGlobalProperty.h:
(JSC::DFG::DesiredGlobalPropertyHash::hash): Deleted.
(JSC::DFG::DesiredGlobalPropertyHash::equal): Deleted.
* Source/JavaScriptCore/dfg/DFGHeapLocation.h:
(JSC::DFG::HeapLocationHash::hash): Deleted.
(JSC::DFG::HeapLocationHash::equal): Deleted.
* Source/JavaScriptCore/dfg/DFGMinifiedID.h:
(JSC::DFG::MinifiedIDHash::hash): Deleted.
(JSC::DFG::MinifiedIDHash::equal): Deleted.
* Source/JavaScriptCore/dfg/DFGNodeFlowProjection.h:
(JSC::DFG::NodeFlowProjectionHash::hash): Deleted.
(JSC::DFG::NodeFlowProjectionHash::equal): Deleted.
* Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h:
(JSC::DFG::PromotedLocationDescriptorHash::hash): Deleted.
(JSC::DFG::PromotedLocationDescriptorHash::equal): Deleted.
(JSC::DFG::PromotedHeapLocationHash::hash): Deleted.
(JSC::DFG::PromotedHeapLocationHash::equal): Deleted.
* Source/JavaScriptCore/dfg/DFGPropertyTypeKey.h:
(JSC::DFG::PropertyTypeKeyHash::hash): Deleted.
(JSC::DFG::PropertyTypeKeyHash::equal): Deleted.
* Source/JavaScriptCore/dfg/DFGPureValue.h:
(JSC::DFG::PureValueHash::hash): Deleted.
(JSC::DFG::PureValueHash::equal): Deleted.
* Source/JavaScriptCore/ftl/FTLLocation.h:
(JSC::FTL::LocationHash::hash): Deleted.
(JSC::FTL::LocationHash::equal): Deleted.
* Source/JavaScriptCore/interpreter/CallFrame.h:
(JSC::CallSiteIndexHash::hash): Deleted.
(JSC::CallSiteIndexHash::equal): Deleted.
* Source/JavaScriptCore/jit/ICStats.h:
(JSC::ICEventHash::hash): Deleted.
(JSC::ICEventHash::equal): Deleted.
* Source/JavaScriptCore/jit/JITCompilationKey.h:
(JSC::JITCompilationKeyHash::hash): Deleted.
(JSC::JITCompilationKeyHash::equal): Deleted.
* Source/JavaScriptCore/jit/Reg.h:
(JSC::RegHash::hash): Deleted.
(JSC::RegHash::equal): Deleted.
* Source/JavaScriptCore/parser/SourceCodeKey.h:
(JSC::SourceCodeKey::Hash::hash): Deleted.
(JSC::SourceCodeKey::Hash::equal): Deleted.
* Source/JavaScriptCore/profiler/ProfilerOrigin.h:
(JSC::Profiler::OriginHash::hash): Deleted.
(JSC::Profiler::OriginHash::equal): Deleted.
* Source/JavaScriptCore/profiler/ProfilerOriginStack.h:
(JSC::Profiler::OriginStackHash::hash): Deleted.
(JSC::Profiler::OriginStackHash::equal): Deleted.
* Source/JavaScriptCore/runtime/CodeCache.h:
* Source/JavaScriptCore/runtime/ControlFlowProfiler.h:
(JSC::BasicBlockKeyHash::hash): Deleted.
(JSC::BasicBlockKeyHash::equal): Deleted.
* Source/JavaScriptCore/runtime/PrototypeKey.h:
(JSC::PrototypeKeyHash::hash): Deleted.
(JSC::PrototypeKeyHash::equal): Deleted.
* Source/JavaScriptCore/runtime/TypeProfiler.h:
(JSC::QueryKeyHash::hash): Deleted.
(JSC::QueryKeyHash::equal): Deleted.
* Source/JavaScriptCore/runtime/VarOffset.h:
(JSC::VarOffsetHash::hash): Deleted.
(JSC::VarOffsetHash::equal): Deleted.
* Source/WTF/wtf/GenericHashKey.h:
* Source/WTF/wtf/HashFunctions.h:
* Source/WebCore/platform/Cookie.h:
(WebCore::CookieHash::hash): Deleted.
(WebCore::CookieHash::equal): Deleted.
* Source/WebCore/platform/Site.h:
(WebCore::Site::Hash::hash): Deleted.
(WebCore::Site::Hash::equal): Deleted.
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::FontDataCacheKeyHash::hash): Deleted.
(WebCore::FontDataCacheKeyHash::equal): Deleted.
* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/WidthCache.h:
(WebCore::WidthCache::SmallStringKeyHash::hash): Deleted.
(WebCore::WidthCache::SmallStringKeyHash::equal): Deleted.
* Source/WebCore/rendering/CSSValueKey.h:
(WTF::CSSValueKeyHash::hash): Deleted.
(WTF::CSSValueKeyHash::equal): Deleted.
* Source/WebCore/rendering/TextAutoSizing.h:
(WebCore::TextAutoSizingHash::hash): Deleted.
(WebCore::TextAutoSizingHash::equal): Deleted.
* Source/WebKit/Shared/WebFoundTextRange.h:
(WTF::WebFoundTextRangePDFDataHash::hash): Deleted.
(WTF::WebFoundTextRangePDFDataHash::equal): Deleted.
(WTF::WebFoundTextRangeHash::hash): Deleted.
(WTF::WebFoundTextRangeHash::equal): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
(WTF::WebExtensionMatchPatternHash::hash): Deleted.
(WTF::WebExtensionMatchPatternHash::equal): Deleted.

Canonical link: <a href="https://commits.webkit.org/302472@main">https://commits.webkit.org/302472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8bb5fb8a70b8eaabcbbd2fb17e92652b30ddbfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136575 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80590 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7c16b988-2a33-4537-be21-9b16f9af9c1f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98382 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66282 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a266576d-165c-4b38-b51c-d4d52d1ed107) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132145 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79031 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33853 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79854 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121189 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139049 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127650 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106913 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106749 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27177 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30595 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53848 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1321 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64675 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160664 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1146 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40105 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1191 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1245 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->