### PR TITLE
[iOS] PDF page number indicator should be capsule shaped

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebKit/Configurations/AllowedSPI-legacy.toml
@@ -52,7 +52,6 @@ selectors = [
     { name = "rectValue", class = "?" },
     { name = "rtfData", class = "?" },
     { name = "sendResponse:", class = "?" },
-    { name = "setAllowsGroupBlending:", class = "?" },
     { name = "setDefaultActionBundleIdentifier:", class = "?" },
     { name = "setHasHighLatencyDataProvider:", class = "?" },
     { name = "setRecipe:", class = "?" },

--- a/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
@@ -30,10 +30,7 @@
 
 #import "UIKitSPI.h"
 #import "WKWebViewIOS.h"
-#import <WebCore/GraphicsTypes.h>
 #import <WebCore/LocalizedStrings.h>
-#import <WebCore/PlatformCAFilters.h>
-#import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/RetainPtr.h>
@@ -42,7 +39,6 @@
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 static constexpr CGFloat indicatorFontSize = 16;
-static constexpr CGFloat indicatorCornerRadius = 7;
 static constexpr CGFloat indicatorMargin = 20;
 static constexpr CGFloat indicatorVerticalPadding = 6;
 static constexpr CGFloat indicatorHorizontalPadding = 10;
@@ -69,8 +65,6 @@ static constexpr Seconds indicatorMoveDuration { 0.3_s };
 
     self.alpha = 0;
     self.userInteractionEnabled = NO;
-    self.layer.allowsGroupOpacity = NO;
-    self.layer.allowsGroupBlending = NO;
 
 #if HAVE(UI_GLASS_EFFECT)
     bool shouldUseBlurEffectForBackdrop = PAL::currentUserInterfaceIdiomIsVision();
@@ -90,7 +84,7 @@ static constexpr Seconds indicatorMoveDuration { 0.3_s };
     _backdropView =  adoptNS([[UIVisualEffectView alloc] initWithEffect:visualEffect.get()]);
     [_backdropView setFrame:self.bounds];
     [_backdropView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
-    [[_backdropView layer] setCornerRadius:indicatorCornerRadius];
+    [_backdropView setCornerConfiguration:[UICornerConfiguration capsuleConfiguration]];
     [_backdropView setClipsToBounds:YES];
     [self addSubview:_backdropView.get()];
 
@@ -103,7 +97,6 @@ static constexpr Seconds indicatorMoveDuration { 0.3_s };
         [_label setTextColor:[UIColor blackColor]];
     [_label setAdjustsFontSizeToFitWidth:YES];
     [_label setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
-    WebCore::PlatformCAFilters::setBlendingFiltersOnLayer([_label layer], WebCore::BlendMode::PlusDarker);
     [[_backdropView contentView] addSubview:_label.get()];
 
     [self updatePosition:self.frame];


### PR DESCRIPTION
#### 6fa879c460e402f5c20e7a3313bf4dde02f40e36
<pre>
[iOS] PDF page number indicator should be capsule shaped
<a href="https://bugs.webkit.org/show_bug.cgi?id=301817">https://bugs.webkit.org/show_bug.cgi?id=301817</a>
<a href="https://rdar.apple.com/163877995">rdar://163877995</a>

Reviewed by Wenson Hsieh.

Other similar UI presented in iOS, namely a similiar indicator in
Preview.app, is capsule shaped. In this patch, we bring visual parity to
the page number indicator by adopting the convenient `capsule` corner
configuration.

* Source/WebKit/Configurations/AllowedSPI-legacy.toml:
Drive-by: Since we no longer call allowsGroupBlending, we can drop
it from the list of (grandfathered) allowed SPI.

* Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm:
(-[WKPDFPageNumberIndicator initWithFrame:view:pageCount:]):
Drive-by: Drop unnecessary layer setup calls such as
allowsGroup[Opacity|Blending], as well as setting a kCAFilterPlusD
blending filter on the backdrop view&apos;s layer.

Canonical link: <a href="https://commits.webkit.org/302463@main">https://commits.webkit.org/302463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69ee3cf78ff901e348492185632bbd2325abfe6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136534 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80540 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f69f7abe-005e-4954-9bd0-babfbc5ec23b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98345 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66217 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/99fd8bbb-8579-4c94-a66b-87a221a21e66) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78993 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9f3fce3-c260-4c15-b326-a7f20ac0caee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/969 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79814 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109417 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139007 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106879 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106714 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/992 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30552 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53783 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20168 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1279 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64632 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1105 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1150 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1203 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->