### PR TITLE
[JSC] Clean up Redundant Code in Date Constructor (`millisecondsFromComponents()`)

### DIFF
--- a/JSTests/stress/date-constructor.js
+++ b/JSTests/stress/date-constructor.js
@@ -1,0 +1,170 @@
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected)) {
+        throw new Error(`Expected: ${expected}, actual value: ${actual}`);
+    }
+}
+
+for (var i = 0; i < testLoopCount; i++) {
+    // Date constructor
+    shouldBe(new Date(1, 1, 1, 1, 1, 1, 1).valueOf(), -2174741938999);
+    shouldBe(new Date(NaN, 1, 1, 1, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1, NaN, 1, 1, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1, 1, NaN, 1, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1, 1, 1, NaN, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1, 1, 1, 1, NaN, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1, 1, 1, 1, 1, NaN, 1).valueOf(), NaN);
+    shouldBe(new Date(1, 1, 1, 1, 1, 1, NaN).valueOf(), NaN);
+    shouldBe(new Date(1, 1, 1, NaN).valueOf(), NaN);
+    shouldBe(new Date(1, 1, 1, NaN, 10).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, 1, 1, 1, 1).valueOf(), 633862861001);
+    shouldBe(new Date(NaN, 1, 1, 1, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, NaN, 1, 1, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, NaN, 1, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, NaN, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, 1, NaN, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, 1, 1, NaN, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, 1, 1, 1, NaN).valueOf(), NaN);
+    shouldBe(new Date(Infinity, 1, 1, 1, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, Infinity, 1, 1, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, Infinity, 1, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, Infinity, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, 1, Infinity, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, 1, 1, Infinity, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, 1, 1, 1, Infinity).valueOf(), NaN);
+    shouldBe(new Date(-Infinity, 1, 1, 1, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, -Infinity, 1, 1, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, -Infinity, 1, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, -Infinity, 1, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, 1, -Infinity, 1, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, 1, 1, -Infinity, 1).valueOf(), NaN);
+    shouldBe(new Date(1990, 1, 1, 1, 1, 1, -Infinity).valueOf(), NaN);
+    shouldBe(new Date(NaN).valueOf(), NaN);
+    shouldBe(new Date(Infinity).valueOf(), NaN);
+    shouldBe(new Date(-Infinity).valueOf(), NaN);
+    shouldBe(new Date(0).valueOf(), 0);
+    shouldBe(new Date(-0).valueOf(), 0);
+    shouldBe(new Date(-10).valueOf(), -10);
+
+    shouldBe(new Date("1990", 1, 1, 3, 10, 10).valueOf(), 633870610000);
+    shouldBe(new Date("1990", 1, "1", 3, NaN, 10).valueOf(), NaN);
+    shouldBe(new Date("1990", 1, "1", 3, Infinity, 10).valueOf(), NaN);
+    shouldBe(new Date("1990", 1, "1", 3, "Infinity", 10).valueOf(), NaN);
+    shouldBe(new Date("1990", 1, "1", 3, "NaN", 10).valueOf(), NaN);
+    shouldBe(new Date("1990", 1, "1", 3, "random", 10).valueOf(), NaN);
+    shouldBe(new Date("1990", 1, "1", 3, "", 10).valueOf(), 633870010000);
+    shouldBe(new Date(1990, 1, "1", 3, "9", 10).valueOf(), 633870550000);
+    shouldBe(new Date("1990", "1", "1", "3", "9", "10").valueOf(), 633870550000);
+
+    // Date.UTC
+    shouldBe(Date.UTC(1, 1, 1, 1, 10).valueOf(), -2174770200000);
+    shouldBe(Date.UTC(NaN, 1, 1, 1, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1, NaN, 1, 1, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1, 1, NaN, 1, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1, 1, 1, NaN, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1, 1, 1, 1, NaN, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1, 1, 1, 1, 10, NaN).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, 3, 10, 10, 10).valueOf(), 633841810010);
+    shouldBe(Date.UTC(NaN, 1, 1, 3, 10, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, NaN, 1, 3, 10, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, NaN, 3, 10, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, NaN, 10, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, 3, NaN, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, 3, 10, NaN, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, 3, 10, 10, NaN).valueOf(), NaN);
+    shouldBe(Date.UTC(Infinity, 1, 1, 3, 10, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, Infinity, 1, 3, 10, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, Infinity, 3, 10, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, Infinity, 10, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, 3, Infinity, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, 3, 10, Infinity, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, 3, 10, 10, Infinity).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, 3, 10, 10, Infinity).valueOf(), NaN);
+    shouldBe(Date.UTC(-Infinity, 1, 1, 3, 10, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, -Infinity, 1, 3, 10, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, -Infinity, 3, 10, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, -Infinity, 10, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, 3, -Infinity, 10, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, 3, 10, -Infinity, 10).valueOf(), NaN);
+    shouldBe(Date.UTC(1990, 1, 1, 3, 10, 10, -Infinity).valueOf(), NaN);
+    shouldBe(Date.UTC(NaN).valueOf(), NaN);
+    shouldBe(Date.UTC(Infinity).valueOf(), NaN);
+    shouldBe(Date.UTC(-Infinity).valueOf(), NaN);
+    shouldBe(Date.UTC(0).valueOf(), -2208988800000);
+    shouldBe(Date.UTC(-0).valueOf(), -2208988800000);
+    shouldBe(Date.UTC(-10).valueOf(), -62482752000000);
+
+    shouldBe(Date.UTC("1990", 1, 1, 3, 10, 10).valueOf(), 633841810000);
+    shouldBe(Date.UTC("1990", 1, "1", 3, NaN, 10).valueOf(), NaN);
+    shouldBe(Date.UTC("1990", 1, "1", 3, Infinity, 10).valueOf(), NaN);
+    shouldBe(Date.UTC("1990", 1, "1", 3, "Infinity", 10).valueOf(), NaN);
+    shouldBe(Date.UTC("1990", 1, "1", 3, "NaN", 10).valueOf(), NaN);
+    shouldBe(Date.UTC("1990", 1, "1", 3, "random", 10).valueOf(), NaN);
+    shouldBe(Date.UTC("1990", 1, "1", 3, "", 10).valueOf(), 633841210000);
+    shouldBe(Date.UTC(1990, 1, "1", 3, "9", 10).valueOf(), 633841750000);
+    shouldBe(Date.UTC("1990", "1", "1", "3", "9", "10").valueOf(), 633841750000);
+
+    // valueOf
+    var mutable = 0;
+    function generateObj(value) {
+        return {
+            valueOf: () => {
+                mutable += 10;
+                return value;
+            },
+        };
+    }
+
+    shouldBe(Date.UTC(generateObj(1)).valueOf(), -2177452800000);
+    shouldBe(mutable, 10);
+
+    shouldBe(Date.UTC(generateObj(1990)).valueOf(), 631152000000);
+    shouldBe(mutable, 20);
+
+    shouldBe(Date.UTC(generateObj(NaN)).valueOf(), NaN);
+    shouldBe(mutable, 30);
+
+    shouldBe(Date.UTC(generateObj(Infinity)).valueOf(), NaN);
+    shouldBe(mutable, 40);
+
+    shouldBe(Date.UTC(generateObj(-Infinity)).valueOf(), NaN);
+    shouldBe(mutable, 50);
+
+    shouldBe(Date.UTC(1990, NaN, generateObj(1)).valueOf(), NaN);
+    shouldBe(mutable, 60);
+
+    shouldBe(Date.UTC(1990, Infinity, generateObj(1)).valueOf(), NaN);
+    shouldBe(mutable, 70);
+
+    shouldBe(Date.UTC(1990, -Infinity, generateObj(1)).valueOf(), NaN);
+    shouldBe(mutable, 80);
+
+    shouldBe(new Date(generateObj(1)).valueOf(), 1);
+    shouldBe(mutable, 90);
+
+    shouldBe(new Date(generateObj(1990)).valueOf(), 1990);
+    shouldBe(mutable, 100);
+
+    shouldBe(new Date(generateObj(NaN)).valueOf(), NaN);
+    shouldBe(mutable, 110);
+
+    shouldBe(new Date(1990, NaN, generateObj(1)).valueOf(), NaN);
+    shouldBe(mutable, 120);
+
+    shouldBe(new Date(1990, Infinity, generateObj(1)).valueOf(), NaN);
+    shouldBe(mutable, 130);
+
+    shouldBe(new Date(1990, -Infinity, generateObj(1)).valueOf(), NaN);
+    shouldBe(mutable, 140);
+
+    shouldBe(new Date(generateObj(1990), generateObj(1), generateObj(1)).valueOf(), 633859200000);
+    shouldBe(mutable, 170);
+
+    shouldBe(new Date(generateObj(1990), generateObj(NaN), generateObj(1)).valueOf(), NaN);
+    shouldBe(mutable, 200);
+
+    shouldBe(new Date(generateObj(NaN), generateObj(1), generateObj(1)).valueOf(), NaN);
+    shouldBe(mutable, 230);
+
+    shouldBe(new Date(generateObj(NaN), 1, 1).valueOf(), NaN);
+    shouldBe(mutable, 240);
+}


### PR DESCRIPTION
#### bfa2198e28e0edc6e49c1329c2de9a871adeeddb
<pre>
[JSC] Clean up Redundant Code in Date Constructor (`millisecondsFromComponents()`)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301818">https://bugs.webkit.org/show_bug.cgi?id=301818</a>

Reviewed by Yusuke Suzuki.

This patch reduces redundant looping and simplifies argument conversion
in Date constructor[1] and Date.UTC()[2].

[1]: <a href="https://tc39.es/ecma262/#sec-date">https://tc39.es/ecma262/#sec-date</a>
[2]: <a href="https://tc39.es/ecma262/#sec-date.utc">https://tc39.es/ecma262/#sec-date.utc</a>

* JSTests/stress/date-constructor.js: Added.
(shouldBe):
(i.generateObj):
* Source/JavaScriptCore/runtime/DateConstructor.cpp:
(JSC::millisecondsFromComponents):
(JSC::toIntegerOrInfinity): Deleted.

Canonical link: <a href="https://commits.webkit.org/302593@main">https://commits.webkit.org/302593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fa9e80ff360fd653ea176e1f8d7dbd9c4fd9a9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80605 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98394 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66306 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132165 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79044 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33871 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79874 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121209 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139069 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127670 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106925 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106763 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27269 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30610 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53865 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1340 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64695 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160684 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1164 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40108 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->