### PR TITLE
[Modernization] Replace WTF::makeReversedRange with std::views::reverse

### DIFF
--- a/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
@@ -33,7 +33,7 @@
 
 #include <array>
 #include <mutex>
-#include <wtf/IteratorRange.h>
+#include <ranges>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/OSRandomSource.h>
@@ -140,7 +140,7 @@ void ARC4RandomNumberGenerator::randomValues(std::span<uint8_t> buffer)
 {
     Locker locker { m_lock };
 
-    for (auto& byte : WTF::makeReversedRange(buffer)) {
+    for (auto& byte : buffer | std::views::reverse) {
         m_count--;
         stirIfNeeded();
         byte = getByte();

--- a/Source/WTF/wtf/IteratorRange.h
+++ b/Source/WTF/wtf/IteratorRange.h
@@ -96,31 +96,6 @@ SizedIteratorRange<Container, Iterator> makeSizedIteratorRange(const Container& 
     return SizedIteratorRange<Container, Iterator>(container, std::forward<Iterator>(begin), std::forward<Iterator>(end));
 }
 
-template<typename Container>
-IteratorRange<typename Container::reverse_iterator> makeReversedRange(Container& container)
-{
-    return makeIteratorRange(std::rbegin(container), std::rend(container));
-}
-
-template<typename Container>
-IteratorRange<typename Container::const_reverse_iterator> makeReversedRange(const Container& container)
-{
-    return makeIteratorRange(std::crbegin(container), std::crend(container));
-}
-
-template<SizedContainer Container>
-SizedIteratorRange<Container, typename Container::reverse_iterator> makeReversedRange(Container& container)
-{
-    return makeSizedIteratorRange(container, std::rbegin(container), std::rend(container));
-}
-
-template<SizedContainer Container>
-SizedIteratorRange<Container, typename Container::const_reverse_iterator> makeReversedRange(const Container& container)
-{
-    return makeSizedIteratorRange(container, std::crbegin(container), std::crend(container));
-}
-
 } // namespace WTF
 
 using WTF::IteratorRange;
-using WTF::makeReversedRange;

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -249,14 +249,18 @@ public:
     iterator& operator++() { ++m_iterator; return *this; }
     iterator operator++(int)
     {
-        iterator temp = *this;
+        iterator result = *this;
         ++(*this);
-        return temp;
+        return result;
     }
 
     iterator& operator--() { --m_iterator; return *this; }
-
-    // postfix -- intentionally omitted
+    iterator operator--(int)
+    {
+        iterator result = *this;
+        --(*this);
+        return result;
+    }
 
     // Comparison.
     friend bool operator==(const iterator&, const iterator&) = default;
@@ -328,9 +332,9 @@ public:
 
     const_iterator operator++(int)
     {
-        const_iterator temp = *this;
+        const_iterator result = *this;
         ++(*this);
-        return temp;
+        return result;
     }
 
     const_iterator& operator--()
@@ -350,7 +354,12 @@ public:
         return *this;
     }
 
-    // postfix -- intentionally omitted
+    const_iterator operator--(int)
+    {
+        const_iterator result = *this;
+        --(*this);
+        return result;
+    }
 
     // Comparison.
     bool operator==(const const_iterator& other) const

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -32,9 +32,9 @@
 
 #include "URLParser.h"
 #include <mutex>
+#include <ranges>
 #include <unicode/uidna.h>
 #include <unicode/uscript.h>
-#include <wtf/IteratorRange.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/WTFString.h>
@@ -440,7 +440,7 @@ static inline bool isSecondLevelDomainNameAllowedByTLDRules(std::span<const char
 {
     ASSERT(!buffer.empty());
 
-    for (auto ch : makeReversedRange(buffer)) {
+    for (auto ch : buffer | std::views::reverse) {
         if (characterIsAllowed(ch))
             continue;
         

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -36,6 +36,7 @@
 #include "Logging.h"
 #include "LocalFrameInlines.h"
 #include "TextIterator.h"
+#include <ranges>
 
 namespace WebCore {
 
@@ -465,7 +466,7 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
                     return range;
             }
         } else {
-            for (auto& range : makeReversedRange(ranges)) {
+            for (auto& range : ranges | std::views::reverse) {
                 if (range < startRange)
                     return range;
             }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -112,6 +112,7 @@
 #include "UserGestureIndicator.h"
 #include "VisibleUnits.h"
 #include <numeric>
+#include <ranges>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/MakeString.h>
@@ -460,7 +461,7 @@ std::optional<SimpleRange> AccessibilityObject::misspellingRange(const SimpleRan
                 return *misspellingRange;
         }
     } else {
-        for (auto& misspelling : makeReversedRange(misspellings)) {
+        for (auto& misspelling : misspellings | std::views::reverse) {
             auto misspellingRange = editor->rangeForTextCheckingResult(misspelling);
             if (misspellingRange && is_lt(treeOrder<ComposedTree>(misspellingRange->start, start.start)))
                 return *misspellingRange;

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -50,6 +50,7 @@
 #include "Settings.h"
 #include "StyleOriginatedAnimation.h"
 #include "WebAnimationTypes.h"
+#include <ranges>
 
 #if ENABLE(THREADED_ANIMATIONS)
 #include "AcceleratedEffectStackUpdater.h"
@@ -268,7 +269,7 @@ IGNORE_GCC_WARNINGS_END
         return { };
     }();
 
-    for (auto& animationWithHigherCompositeOrder : makeReversedRange(protectedAnimations)) {
+    for (auto& animationWithHigherCompositeOrder : protectedAnimations | std::views::reverse) {
         if (&animation == animationWithHigherCompositeOrder)
             break;
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10929,7 +10929,7 @@ void Document::removeTopLayerElement(Element& element)
 
 HTMLDialogElement* Document::activeModalDialog() const
 {
-    for (auto& element : makeReversedRange(m_topLayerElements)) {
+    for (auto& element : m_topLayerElements | std::views::reverse) {
         if (auto* dialog = dynamicDowncast<HTMLDialogElement>(element.get()); dialog && dialog->isModal())
             return dialog;
     }
@@ -11023,7 +11023,7 @@ void Document::handlePopoverLightDismiss(const PointerEvent& event, Node& target
                 return second;
             if (!second)
                 return first;
-            for (auto& element : makeReversedRange(m_autoPopoverList)) {
+            for (auto& element : m_autoPopoverList | std::views::reverse) {
                 if (element.ptr() == first || element.ptr() == second)
                     return element.ptr();
             }

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -58,6 +58,7 @@
 #include "SVGSVGElement.h"
 #include "Settings.h"
 #include "UserGestureIndicator.h"
+#include <ranges>
 #include <wtf/LoggerHelper.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -101,7 +102,7 @@ DocumentFullscreen::DocumentFullscreen(Document& document)
 
 Element* DocumentFullscreen::fullscreenElement() const
 {
-    for (Ref element : makeReversedRange(document().topLayerElements())) {
+    for (Ref element : document().topLayerElements() | std::views::reverse) {
         if (element->hasFullscreenFlag())
             return element.unsafePtr();
     }
@@ -375,7 +376,7 @@ ExceptionOr<void> DocumentFullscreen::willEnterFullscreen(Element& element, HTML
     }
 
     bool elementWasFullscreen = &element == element.protectedDocument()->protectedFullscreen()->fullscreenElement();
-    for (auto ancestor : makeReversedRange(ancestors))
+    for (auto ancestor : ancestors | std::views::reverse)
         elementEnterFullscreen(ancestor);
 
     if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(element); iframe && !elementWasFullscreen)
@@ -636,7 +637,7 @@ void DocumentFullscreen::finishExitFullscreen(Frame& currentFrame, ExitMode mode
         }
     }
 
-    for (Ref descendantDocument : makeReversedRange(descendantDocuments)) {
+    for (Ref descendantDocument : descendantDocuments | std::views::reverse) {
         queueFullscreenChangeEventForDocument(descendantDocument);
         unfullscreenDocument(descendantDocument);
     }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -172,6 +172,7 @@
 #include "markup.h"
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/JSONObject.h>
+#include <ranges>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -4676,7 +4677,7 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
     // Resolve and cache styles starting from the most distant ancestor.
     // FIXME: This is not as efficient as it could be. For example if an ancestor has a non-inherited style change but
     // the styles are otherwise clean we would not need to re-resolve descendants.
-    for (auto& element : makeReversedRange(elementsRequiringComputedStyle)) {
+    for (auto& element : elementsRequiringComputedStyle | std::views::reverse) {
         if (computedStyle && computedStyle->containerType() != ContainerType::Normal && mode != ResolveComputedStyleMode::Editability) {
             // If we find a query container we need to bail out and do full style update to resolve it.
             if (document->updateStyleIfNeeded())

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -97,6 +97,7 @@
 #include "VisibleSelection.h"
 #include "VisibleUnits.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
+#include <ranges>
 #include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
 #include <wtf/URLParser.h>
@@ -581,7 +582,7 @@ String StyledMarkupAccumulator::takeResults()
         length += string.length();
     StringBuilder result;
     result.reserveCapacity(length);
-    for (auto& string : makeReversedRange(m_reversedPrecedingMarkup))
+    for (auto& string : m_reversedPrecedingMarkup | std::views::reverse)
         result.append(string);
     result.append(takeMarkup());
     // Remove '\0' characters because they are not visibly rendered to the user.

--- a/Source/WebCore/html/closewatcher/CloseWatcherManager.cpp
+++ b/Source/WebCore/html/closewatcher/CloseWatcherManager.cpp
@@ -29,6 +29,7 @@
 #include "Event.h"
 #include "EventNames.h"
 #include "KeyboardEvent.h"
+#include <ranges>
 
 namespace WebCore {
 
@@ -78,7 +79,7 @@ void CloseWatcherManager::escapeKeyHandler(KeyboardEvent& event)
     if (!m_groups.isEmpty() && !event.defaultHandled() && event.isTrusted() && event.key() == "Escape"_s) {
         auto& group = m_groups.last();
         Vector<Ref<CloseWatcher>> groupCopy(group);
-        for (Ref watcher : makeReversedRange(groupCopy)) {
+        for (Ref watcher : groupCopy | std::views::reverse) {
             if (!watcher->requestToClose())
                 break;
         }

--- a/Source/WebCore/layout/floats/FloatingContext.cpp
+++ b/Source/WebCore/layout/floats/FloatingContext.cpp
@@ -35,6 +35,7 @@
 #include "LayoutElementBox.h"
 #include "LayoutShape.h"
 #include "RenderStyleInlines.h"
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -412,7 +413,7 @@ FloatingContext::Constraints FloatingContext::constraints(LayoutUnit candidateTo
 
     auto constraints = Constraints { };
     if (mayBeAboveLastFloat == MayBeAboveLastFloat::No) {
-        for (auto& floatItem : makeReversedRange(placedFloats.list())) {
+        for (auto& floatItem : placedFloats.list() | std::views::reverse) {
             if ((constraints.start && floatItem.isStartPositioned()) || (constraints.end && !floatItem.isStartPositioned()))
                 continue;
 
@@ -433,7 +434,7 @@ FloatingContext::Constraints FloatingContext::constraints(LayoutUnit candidateTo
                 break;
         }
     } else {
-        for (auto& floatItem : makeReversedRange(placedFloats.list())) {
+        for (auto& floatItem : placedFloats.list() | std::views::reverse) {
             auto edgeAndBottom = computeFloatEdgeAndBottom(floatItem);
             if (!edgeAndBottom)
                 continue;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -37,6 +37,7 @@
 #include "LayoutElementBox.h"
 #include "RenderStyleInlines.h"
 #include "RubyFormattingContext.h"
+#include <ranges>
 
 namespace WebCore {
 namespace Layout {
@@ -611,7 +612,7 @@ LineEndingTruncationPolicy InlineFormattingUtils::lineEndingTruncationPolicy(con
 
 std::optional<LineLayoutResult::InlineContentEnding> InlineFormattingUtils::inlineContentEnding(const Line::Result& lineContent)
 {
-    for (auto& run : makeReversedRange(lineContent.runs)) {
+    for (auto& run : lineContent.runs | std::views::reverse) {
         if (run.isOpaque())
             continue;
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -33,6 +33,7 @@
 #include "RenderStyleInlines.h"
 #include "TextFlags.h"
 #include "TextUtil.h"
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -346,7 +347,7 @@ void Line::appendText(const InlineTextItem& inlineTextItem, const RenderStyle& s
         if (InlineTextItem::shouldPreserveSpacesAndTabs(inlineTextItem))
             return false;
         // This content is collapsible. Let's check if the last item is collapsed.
-        for (auto& run : makeReversedRange(m_runs)) {
+        for (auto& run : m_runs | std::views::reverse) {
             if (run.isAtomicInlineBox())
                 return false;
             // https://drafts.csswg.org/css-text-3/#white-space-phase-1
@@ -417,7 +418,7 @@ void Line::appendText(const InlineTextItem& inlineTextItem, const RenderStyle& s
                     return m_contentLogicalWidth - std::max(0.f, lastRun.logicalWidth());
                 // FIXME: Let's see if we need to optimize for this is the rare case of both letter and word spacing being negative.
                 auto rightMostPosition = InlineLayoutUnit { };
-                for (auto& run : makeReversedRange(m_runs))
+                for (auto& run : m_runs | std::views::reverse)
                     rightMostPosition = std::max(rightMostPosition, run.logicalRight());
                 return std::max(0.f, rightMostPosition);
             }();
@@ -587,7 +588,7 @@ void Line::appendOpaqueBox(const InlineItem& inlineItem, const RenderStyle& styl
 
 void Line::addTrailingHyphen(InlineLayoutUnit hyphenLogicalWidth)
 {
-    for (auto& run : makeReversedRange(m_runs)) {
+    for (auto& run : m_runs | std::views::reverse) {
         if (!run.isText())
             continue;
         run.setNeedsHyphen(hyphenLogicalWidth);
@@ -600,7 +601,7 @@ void Line::addTrailingHyphen(InlineLayoutUnit hyphenLogicalWidth)
 bool Line::lineHasVisuallyNonEmptyContent() const
 {
     auto& formattingContext = this->formattingContext();
-    for (auto& run : makeReversedRange(m_runs)) {
+    for (auto& run : m_runs | std::views::reverse) {
         if (Line::Run::isContentfulOrHasDecoration(run, formattingContext))
             return true;
     }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
@@ -30,6 +30,7 @@
 #include <WebCore/InlineLineTypes.h>
 #include <WebCore/InlineTextItem.h>
 #include <WebCore/RenderStyle.h>
+#include <ranges>
 #include <unicode/ubidi.h>
 #include <wtf/Range.h>
 
@@ -333,7 +334,7 @@ inline bool Line::hasContentOrListMarker() const
 
 inline bool Line::hasContent() const
 {
-    for (auto& run : makeReversedRange(m_runs)) {
+    for (auto& run : m_runs | std::views::reverse) {
         if (run.isContentful() && !run.isGenerated())
             return true;
     }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -39,6 +39,7 @@
 #include "StyleLineBoxContain.h"
 #include "TextUtil.h"
 #include "UnicodeBidi.h"
+#include <ranges>
 #include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
@@ -410,7 +411,7 @@ void LineBuilder::initialize(const InlineRect& initialLineLogicalRect, const Inl
             ancestor = &ancestor->parent();
         }
         // Let's treat these spanning inline items as opaque bidi content. They should not change the bidi levels on adjacent content.
-        for (auto* spanningInlineBox : makeReversedRange(spanningLayoutBoxList))
+        for (auto* spanningInlineBox : spanningLayoutBoxList | std::views::reverse)
             m_lineSpanningInlineBoxes.append({ *spanningInlineBox, InlineItem::Type::InlineBoxStart, InlineItem::opaqueBidiLevel });
     };
     createLineSpanningInlineBoxes();
@@ -1798,7 +1799,7 @@ bool LineBuilder::isLastLineWithInlineContent(const LineContent& lineContent, si
             // This is both the first and the last line.
             return true;
         }
-        for (auto& lineRun : makeReversedRange(lineRuns)) {
+        for (auto& lineRun : lineRuns | std::views::reverse) {
             if (Line::Run::isContentfulOrHasDecoration(lineRun, formattingContext))
                 return true;
         }

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -35,6 +35,7 @@
 #include "RenderStyleInlines.h"
 #include "RubyFormattingContext.h"
 #include "TextUtil.h"
+#include <ranges>
 #include <wtf/ListHashSet.h>
 #include <wtf/Range.h>
 #include <wtf/text/MakeString.h>
@@ -924,7 +925,7 @@ void InlineDisplayContentBuilder::processBidiContent(const LineLayoutResult& lin
     handleInlineBoxes();
 
     auto handleTrailingOpenInlineBoxes = [&] {
-        for (auto& lineRun : makeReversedRange(lineLayoutResult.inlineAndOpaqueContent)) {
+        for (auto& lineRun : lineLayoutResult.inlineAndOpaqueContent | std::views::reverse) {
             if (!lineRun.isInlineBoxStart() || lineRun.bidiLevel() != InlineItem::opaqueBidiLevel)
                 break;
             // These are trailing inline box start runs (without the closing inline box end <span> <-line breaks here</span>).
@@ -1217,7 +1218,7 @@ void InlineDisplayContentBuilder::processRubyContent(InlineDisplay::Boxes& displ
     auto lineBoxLogicalRect = lineBox().logicalRect();
     auto writingMode = root().writingMode();
     auto isHorizontalWritingMode = writingMode.isHorizontal();
-    for (auto baseIndex : makeReversedRange(rubyBaseStartIndexListWithAnnotation)) {
+    for (auto baseIndex : rubyBaseStartIndexListWithAnnotation | std::views::reverse) {
         auto& annotationBox = *displayBoxes[baseIndex].layoutBox().associatedRubyAnnotationBox();
         auto annotationBorderBoxVisualRect = [&] {
             // FIXME: We may wanna go back to full logical geometry on BoxGeometry (instead of this with visual left) and resolve it when

--- a/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
@@ -30,6 +30,7 @@
 #include "InlineFormattingContext.h"
 #include "InlineLine.h"
 #include "RenderStyleInlines.h"
+#include <ranges>
 
 namespace WebCore {
 namespace Layout {
@@ -76,7 +77,7 @@ static InlineLayoutUnit baseLogicalWidthFromRubyBaseEnd(const Box& rubyBaseLayou
     // Canidate content is supposed to hold the base content and in case of soft wrap opportunities, line may have some base content too.
     auto baseLogicalWidth = InlineLayoutUnit { 0.f };
     auto hasSeenRubyBaseStart = false;
-    for (auto& candidateRun : makeReversedRange(candidateRuns)) {
+    for (auto& candidateRun : candidateRuns | std::views::reverse) {
         auto& inlineItem = candidateRun.inlineItem;
         if (inlineItem.isInlineBoxStart() && &inlineItem.layoutBox() == &rubyBaseLayoutBox) {
             hasSeenRubyBaseStart = true;
@@ -87,7 +88,7 @@ static InlineLayoutUnit baseLogicalWidthFromRubyBaseEnd(const Box& rubyBaseLayou
     if (hasSeenRubyBaseStart)
         return baseLogicalWidth;
     // Let's check the line for the rest of the base content.
-    for (auto& lineRun : makeReversedRange(lineRuns)) {
+    for (auto& lineRun : lineRuns | std::views::reverse) {
         if ((lineRun.isInlineBoxStart() || lineRun.isLineSpanningInlineBoxStart()) && &lineRun.layoutBox() == &rubyBaseLayoutBox)
             break;
         baseLogicalWidth += lineRun.logicalWidth();
@@ -376,7 +377,7 @@ void RubyFormattingContext::applyAnnotationContributionToLayoutBounds(LineBox& l
     // However, if the line-height specified on the ruby container is less than the distance between the top of the top ruby annotation
     // container and the bottom of the bottom ruby annotation container, then additional leading is added on the appropriate side(s).
     MaximumLayoutBoundsStretchMap descentRubySet;
-    for (auto& inlineLevelBox : makeReversedRange(lineBox.nonRootInlineLevelBoxes())) {
+    for (auto& inlineLevelBox : lineBox.nonRootInlineLevelBoxes() | std::views::reverse) {
         if (!inlineLevelBox.isInlineBox() || !inlineLevelBox.layoutBox().isRubyBase())
             continue;
         adjustLayoutBoundsAndStretchAncestorRubyBase(lineBox, inlineLevelBox, descentRubySet, inlineFormattingContext);

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -59,6 +59,7 @@
 #include "RenderView.h"
 #include "SVGTextFragment.h"
 #include "ShapeOutsideInfo.h"
+#include <ranges>
 #include <wtf/Assertions.h>
 #include <wtf/Range.h>
 
@@ -223,7 +224,7 @@ static const InlineDisplay::Line& lastLineWithInlineContent(const InlineDisplay:
 {
     // Out-of-flow/float content only don't produce lines with inline content. They should not be taken into
     // account when computing content box height/baselines.
-    for (auto& line : makeReversedRange(lines)) {
+    for (auto& line : lines | std::views::reverse) {
         ASSERT(line.boxCount());
         if (line.boxCount() > 1)
             return line;
@@ -804,7 +805,7 @@ bool LineLayout::hasEllipsisInBlockDirectionOnLastFormattedLine() const
     if (!m_inlineContent)
         return false;
 
-    for (auto& line : makeReversedRange(m_inlineContent->displayContent().lines)) {
+    for (auto& line : m_inlineContent->displayContent().lines | std::views::reverse) {
         if (line.boxCount() == 1) {
             // Out-of-flow content could initiate a line with no inline content.
             continue;
@@ -1178,7 +1179,7 @@ bool LineLayout::hitTest(const HitTestRequest& request, HitTestResult& result, c
 
     LayerPaintScope layerPaintScope(layerRenderer);
 
-    for (auto& box : makeReversedRange(boxRange)) {
+    for (auto& box : boxRange | std::views::reverse) {
         bool visibleForHitTesting = request.userTriggered() ? box.isVisible() : box.isVisibleIgnoringUsedVisibility();
         if (!visibleForHitTesting)
             continue;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -130,6 +130,7 @@
 #include "SVGViewElement.h"
 #include "SVGViewSpec.h"
 #include "ScriptController.h"
+#include "ScriptDisallowedScope.h"
 #include "ScriptSourceCode.h"
 #include "ScrollAnimator.h"
 #include "SecurityOrigin.h"
@@ -147,7 +148,7 @@
 #include "UserGestureIndicator.h"
 #include "WindowFeatures.h"
 #include "XMLDocumentParser.h"
-#include <dom/ScriptDisallowedScope.h>
+#include <ranges>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
@@ -3209,7 +3210,7 @@ void FrameLoader::checkLoadComplete(LoadWillContinueInAnotherProcess loadWillCon
     }
 
     // To process children before their parents, iterate the vector backwards.
-    for (Ref frame : makeReversedRange(frames)) {
+    for (Ref frame : frames | std::views::reverse) {
         if (frame->page())
             frame->loader().checkLoadCompleteForThisFrame(loadWillContinueInAnotherProcess);
     }

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -143,6 +143,7 @@
 #include "WheelEventDeltaFilter.h"
 #include "WheelEventTestMonitor.h"
 #include "WindowsKeyboardCodes.h"
+#include <ranges>
 #include <wtf/Assertions.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RuntimeApplicationChecks.h>
@@ -3063,7 +3064,7 @@ void EventHandler::updateMouseEventTargetNode(const AtomString& eventType, Node*
             if (auto elementUnderMouse = m_elementUnderMouse)
                 elementUnderMouse->dispatchMouseEvent(platformMouseEvent, eventNames.mouseoverEvent, 0, m_lastElementUnderMouse.get());
 
-            for (auto& chain : makeReversedRange(enteredElementsChain)) {
+            for (auto& chain : enteredElementsChain | std::views::reverse) {
                 if (!chain)
                     continue;
 

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -41,6 +41,7 @@
 #include "PointerEvent.h"
 #include "Quirks.h"
 #include <algorithm>
+#include <ranges>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -241,7 +242,7 @@ void PointerCaptureController::dispatchEnterOrLeaveEvent(const AtomString& type,
     }
 
     if (type == eventNames().pointerenterEvent) {
-        for (auto& element : makeReversedRange(targetChain))
+        for (auto& element : targetChain | std::views::reverse)
             dispatchEvent(PointerEvent::create(type, event, { }, { }, index, isPrimary, view, touchDelta), element.ptr());
     } else {
         for (auto& element : targetChain)
@@ -316,7 +317,7 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
         if (currentTarget)
             dispatchOverOrOutEvent(eventNames().pointeroverEvent, currentTarget.get(), platformTouchEvent, index, isPrimary, view, touchDelta);
 
-        for (auto& chain : makeReversedRange(enteredElementsChain)) {
+        for (auto& chain : enteredElementsChain | std::views::reverse) {
             if (hasCapturingPointerEnterListener || chain->hasEventListeners(eventNames().pointerenterEvent))
                 dispatchEvent(PointerEvent::create(eventNames().pointerenterEvent, platformTouchEvent, coalescedEvents, predictedEvents, index, isPrimary, view, touchDelta), chain.ptr());
         }

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
@@ -39,6 +39,7 @@
 #include "ScrollingTreeOverflowScrollingNodeCoordinated.h"
 #include "ScrollingTreePositionedNodeCoordinated.h"
 #include "ScrollingTreeStickyNodeCoordinated.h"
+#include <ranges>
 
 namespace WebCore {
 
@@ -151,7 +152,7 @@ RefPtr<ScrollingTreeNode> ScrollingTreeCoordinated::scrollingNodeForPoint(FloatP
         collectDescendantLayersAtPoint(layersAtPoint, Ref { *rootContentsLayer }, point);
     }
 
-    for (auto& layer : makeReversedRange(layersAtPoint)) {
+    for (auto& layer : layersAtPoint | std::views::reverse) {
         Locker locker { layer->lock() };
         auto* scrollingNode = nodeForID(layer->scrollingNodeID());
         if (is<ScrollingTreeScrollingNode>(scrollingNode))

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -35,6 +35,7 @@
 #include "LayoutRect.h"
 #include "TextRun.h"
 #include "WidthIterator.h"
+#include <ranges>
 #include <wtf/MainThread.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
@@ -1146,7 +1147,7 @@ std::pair<unsigned, bool> FontCascade::expansionOpportunityCountInternal(std::sp
                 isAfterExpansion = false;
         }
     } else {
-        for (auto character : makeReversedRange(characters)) {
+        for (auto character : characters | std::views::reverse) {
             if (treatAsSpace(character)) {
                 ++count;
                 isAfterExpansion = true;

--- a/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp
@@ -28,6 +28,7 @@
 
 #include "Filter.h"
 #include "GraphicsContext.h"
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -69,7 +70,7 @@ void TransparencyLayerContextSwitcher::beginDrawSourceImage(GraphicsContext& des
 
 void TransparencyLayerContextSwitcher::endDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&)
 {
-    for ([[maybe_unused]] auto& filterStyle : makeReversedRange(m_filterStyles)) {
+    for ([[maybe_unused]] auto& filterStyle : m_filterStyles) {
         destinationContext.endTransparencyLayer();
         destinationContext.restore();
     }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -58,6 +58,7 @@
 #include <QuartzCore/CATransform3D.h>
 #include <limits.h>
 #include <pal/spi/cf/CFUtilitiesSPI.h>
+#include <ranges>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/HexNumber.h>
 #include <wtf/MathExtras.h>
@@ -3596,7 +3597,7 @@ void GraphicsLayerCA::updateAnimations()
 
             LayerPropertyAnimation* earliestAnimation = nullptr;
             Vector<RefPtr<PlatformCAAnimation>> caAnimations;
-            for (auto* animation : makeReversedRange(animations)) {
+            for (auto* animation : animations | std::views::reverse) {
                 if (!animation->m_beginTime)
                     animation->m_beginTime = currentTime - animationGroupBeginTime;
                 if (auto beginTime = animation->computedBeginTime()) {

--- a/Source/WebCore/platform/ios/wak/WKView.mm
+++ b/Source/WebCore/platform/ios/wak/WKView.mm
@@ -31,8 +31,8 @@
 #import "WAKViewInternal.h"
 #import "WAKWindow.h"
 #import "WKUtilities.h"
+#import <ranges>
 #import <wtf/Assertions.h>
-#import <wtf/IteratorRange.h>
 
 void _WKViewSetSuperview(WKViewRef view, WKViewRef superview)
 {
@@ -658,7 +658,7 @@ CGPoint WKViewConvertPointFromBase(WKViewRef view, CGPoint p)
         return CGPointZero;
 
     CGPoint aPoint = p;
-    for (auto& ancestorView : makeReversedRange(ancestorViews))
+    for (auto& ancestorView : ancestorViews | std::views::reverse)
         aPoint = WKViewConvertPointFromSuperview(ancestorView, aPoint);
     return aPoint;
 }
@@ -687,7 +687,7 @@ CGRect WKViewConvertRectFromBase(WKViewRef view, CGRect r)
         return CGRectZero;
     
     CGRect aRect = r;
-    for (auto& ancestorView : makeReversedRange(ancestorViews))
+    for (auto& ancestorView : ancestorViews | std::views::reverse)
         aRect = WKViewConvertRectFromSuperview(ancestorView, aRect);
     return aRect;
 }

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -168,7 +168,7 @@ template<typename Layers> void BackgroundPainter::paintFillLayersImpl(const Colo
         context.beginTransparencyLayer(1);
     }
 
-    for (auto& layer : std::ranges::reverse_view(fillLayers.usedValues()))
+    for (auto& layer : fillLayers.usedValues() | std::views::reverse)
         paintFillLayerImpl(color, FillLayerToPaint<typename Layers::value_type> { .layer = layer, .isLast = &layer == &fillLayers.usedLast() }, rect, bleedAvoidance, { }, { }, op, backgroundObject, baseBgColorUsage);
 
     if (shouldDrawBackgroundInSeparateBuffer)

--- a/Source/WebCore/rendering/InlineBoxPainter.cpp
+++ b/Source/WebCore/rendering/InlineBoxPainter.cpp
@@ -297,7 +297,7 @@ void InlineBoxPainter::paintDecorations()
 
 template<typename Layers> void InlineBoxPainter::paintFillLayers(const Color& color, const Layers& fillLayers, const LayoutRect& rect, CompositeOperator op)
 {
-    for (auto& layer : std::ranges::reverse_view(fillLayers.usedValues()))
+    for (auto& layer : fillLayers.usedValues() | std::views::reverse)
         paintFillLayer(color, FillLayerToPaint<typename Layers::value_type> { .layer = layer, .isLast = &layer == &fillLayers.usedLast() }, rect, op);
 }
 

--- a/Source/WebCore/rendering/LayerAncestorClippingStack.cpp
+++ b/Source/WebCore/rendering/LayerAncestorClippingStack.cpp
@@ -29,6 +29,7 @@
 #include "GraphicsLayer.h"
 #include "ScrollingConstraints.h"
 #include "ScrollingCoordinator.h"
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -100,7 +101,7 @@ GraphicsLayer* LayerAncestorClippingStack::lastLayer() const
 
 std::optional<ScrollingNodeID> LayerAncestorClippingStack::lastOverflowScrollProxyNodeID() const
 {
-    for (auto& entry : makeReversedRange(m_stack)) {
+    for (auto& entry : m_stack | std::views::reverse) {
         if (entry.overflowScrollProxyNodeID)
             return entry.overflowScrollProxyNodeID;
     }

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -79,6 +79,7 @@
 #include "TextBoxTrimmer.h"
 #include "TextUtil.h"
 #include "VisiblePosition.h"
+#include <ranges>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -3200,7 +3201,7 @@ bool RenderBlockFlow::hitTestFloats(const HitTestRequest& request, HitTestResult
     if (auto* renderView = dynamicDowncast<RenderView>(*this))
         adjustedLocation += toLayoutSize(renderView->frameView().scrollPosition());
 
-    for (auto& floatingObject : makeReversedRange(m_floatingObjects->set())) {
+    for (auto& floatingObject : m_floatingObjects->set() | std::views::reverse) {
         auto& renderer = floatingObject->renderer();
         if (floatingObject->shouldPaint()) {
             LayoutPoint childPoint = flipFloatForWritingModeForChild(*floatingObject, adjustedLocation + floatingObject->translationOffsetToAncestor());

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -53,6 +53,7 @@
 #include "StyledMarkedText.h"
 #include "TextPaintStyle.h"
 #include "TextPainter.h"
+#include <ranges>
 
 #if ENABLE(WRITING_TOOLS)
 #include "GraphicsContextCG.h"
@@ -851,7 +852,7 @@ void TextBoxPainter::paintBackgroundDecorations(TextDecorationPainter& decoratio
     auto decoratingBoxList = DecoratingBoxList { };
     collectDecoratingBoxesForBackgroundPainting(decoratingBoxList, textBox, textBoxPaintRect.location(), markedText.style.textDecorationStyles);
 
-    for (auto& decoratingBox : makeReversedRange(decoratingBoxList)) {
+    for (auto& decoratingBox : decoratingBoxList | std::views::reverse) {
         auto computedTextDecorationType = WebCore::computedTextDecorationType(decoratingBox.style, decoratingBox.textDecorationStyles);
         auto computedBackgroundDecorationGeometry = [&] {
             auto textDecorationThickness = computedTextDecorationThickness(decoratingBox.style, m_document.deviceScaleFactor());

--- a/Source/WebCore/rendering/svg/SVGTextChunk.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextChunk.cpp
@@ -27,6 +27,7 @@
 #include "SVGInlineTextBoxInlines.h"
 #include "SVGTextContentElement.h"
 #include "SVGTextFragment.h"
+#include <ranges>
 
 namespace WebCore {
 
@@ -101,7 +102,7 @@ float SVGTextChunk::totalLength() const
         }
     }
 
-    for (auto& box : makeReversedRange(m_boxes)) {
+    for (auto& box : m_boxes | std::views::reverse) {
         if (box.fragments.size()) {
             lastFragment = &box.fragments.last();
             break;

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1197,7 +1197,7 @@ static RefPtr<Element> findLastAcceptableAnchorWithName(ResolvedScopedName ancho
 
     const auto& anchors = anchorsForAnchorName.get(anchorName);
 
-    for (auto& anchor : makeReversedRange(anchors)) {
+    for (auto& anchor : anchors | std::views::reverse) {
         if (isAcceptableAnchorElement(anchor.get(), anchorPositionedElement, anchorName))
             return anchor->element();
     }

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -39,6 +39,7 @@
 #include "RenderView.h"
 #include "StyleRule.h"
 #include "StyleScope.h"
+#include <ranges>
 
 namespace WebCore::Style {
 
@@ -186,7 +187,7 @@ const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requ
     }
 
     if (evaluationState && !requiredAxes.isEmpty()) {
-        for (auto& container : makeReversedRange(evaluationState->sizeQueryContainers)) {
+        for (auto& container : evaluationState->sizeQueryContainers | std::views::reverse) {
             if (isContainerForQuery(container))
                 return container.ptr();
         }

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -40,6 +40,7 @@
 #include "StyleScopeRuleSets.h"
 #include "StyleSheetContents.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include <ranges>
 #include <wtf/SetForScope.h>
 
 namespace WebCore {
@@ -355,7 +356,7 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
 
         SelectorMatchingState selectorMatchingState;
         selectorMatchingState.selectorFilter.parentStackReserveInitialCapacity(ancestors.size());
-        for (auto* ancestor : makeReversedRange(ancestors)) {
+        for (auto* ancestor : ancestors | std::views::reverse) {
             invalidateIfNeeded(*ancestor, &selectorMatchingState);
             selectorMatchingState.selectorFilter.pushParent(ancestor);
         }
@@ -393,7 +394,7 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
 
         SelectorMatchingState selectorMatchingState;
         selectorMatchingState.selectorFilter.parentStackReserveInitialCapacity(elementAndAncestors.size());
-        for (auto* elementOrAncestor : makeReversedRange(elementAndAncestors)) {
+        for (auto* elementOrAncestor : elementAndAncestors | std::views::reverse) {
             for (auto* sibling = elementOrAncestor->previousElementSibling(); sibling; sibling = sibling->previousElementSibling())
                 invalidateIfNeeded(*sibling, &selectorMatchingState);
 
@@ -409,7 +410,7 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
 
         SelectorMatchingState selectorMatchingState;
         selectorMatchingState.selectorFilter.parentStackReserveInitialCapacity(ancestors.size());
-        for (auto* ancestor : makeReversedRange(ancestors)) {
+        for (auto* ancestor : ancestors | std::views::reverse) {
             selectorMatchingState.selectorFilter.pushParent(ancestor);
             for (auto& ancestorChild : childrenOfType<Element>(*ancestor))
                 invalidateIfNeeded(ancestorChild, &selectorMatchingState);

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -44,6 +44,7 @@
 #include "StyleResolver.h"
 #include "StyleScope.h"
 #include "StyleSheetContents.h"
+#include <ranges>
 
 namespace WebCore {
 namespace Style {
@@ -338,7 +339,7 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
                 auto alreadyContains = [&](const CSSSelectorList& invalidationSelector) {
                     constexpr auto maximumSearchCount = 8;
                     auto count = 0;
-                    for (auto& existing : makeReversedRange(builder.invalidationSelectors)) {
+                    for (auto& existing : builder.invalidationSelectors | std::views::reverse) {
                         if (++count > maximumSearchCount)
                             break;
                         if (invalidationSelector == *existing)

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -38,6 +38,7 @@
 #include "DocumentQuirks.h"
 #include "DocumentTimeline.h"
 #include "DocumentView.h"
+#include "EventTarget.h"
 #include "HTMLBodyElement.h"
 #include "HTMLInputElement.h"
 #include "HTMLMeterElement.h"
@@ -72,7 +73,7 @@
 #include "ViewTransition.h"
 #include "WebAnimationTypes.h"
 #include "WebAnimationUtilities.h"
-#include "dom/EventTarget.h"
+#include <ranges>
 
 namespace WebCore {
 
@@ -603,7 +604,7 @@ std::optional<ResolvedStyle> TreeResolver::resolveAncestorFirstLinePseudoElement
         if (parent().resolvedFirstLineAndLetterChild)
             return nullptr;
 
-        for (auto& parent : makeReversedRange(m_parentStack)) {
+        for (auto& parent : m_parentStack | std::views::reverse) {
             if (parent.style.display() == DisplayType::Contents)
                 continue;
             if (!supportsFirstLineAndLetterPseudoElement(parent.style))
@@ -641,7 +642,7 @@ std::optional<ResolvedStyle> TreeResolver::resolveAncestorFirstLetterPseudoEleme
         if (!skipInlines && !isChildInBlockFormattingContext(*elementUpdate.style))
             return nullptr;
 
-        for (auto& parent : makeReversedRange(m_parentStack)) {
+        for (auto& parent : m_parentStack | std::views::reverse) {
             if (parent.style.display() == DisplayType::Contents)
                 continue;
             if (skipInlines && parent.style.display() == DisplayType::Inline)
@@ -725,7 +726,7 @@ const RenderStyle* TreeResolver::documentElementStyle() const
 auto TreeResolver::boxGeneratingParent() const -> const Parent*
 {
     // 'display: contents' doesn't generate boxes.
-    for (auto& parent : makeReversedRange(m_parentStack)) {
+    for (auto& parent : m_parentStack | std::views::reverse) {
         if (parent.style.display() == DisplayType::None)
             return nullptr;
         if (parent.style.display() != DisplayType::Contents)

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -61,7 +61,6 @@
 #include "WebAnimation.h"
 #include "WebAnimationUtilities.h"
 #include <ranges>
-#include <wtf/IndexedRange.h>
 
 namespace WebCore {
 
@@ -408,7 +407,7 @@ void Styleable::updateCSSAnimations(const RenderStyle* currentStyle, const Rende
     // cause the existing animation for ‘a’ to become the second animation in the list and a new animation will be created for the
     // first item in the list.
     if (!currentAnimationList.isInitial()) {
-        for (auto& currentAnimation : std::ranges::reverse_view(currentAnimationList.usedValues())) {
+        for (auto& currentAnimation : currentAnimationList.usedValues() | std::views::reverse) {
             auto keyframesName = currentAnimation.name().tryKeyframesName();
             if (!keyframesName || keyframesName->name.isEmpty())
                 continue;
@@ -465,7 +464,7 @@ static KeyframeEffect* keyframeEffectForElementAndProperty(const Styleable& styl
 {
     if (auto* keyframeEffectStack = styleable.keyframeEffectStack()) {
         auto effects = keyframeEffectStack->sortedEffects();
-        for (const auto& effect : makeReversedRange(effects)) {
+        for (const auto& effect : effects | std::views::reverse) {
             if (effect->animatesProperty(property))
                 return effect.get();
         }

--- a/Source/WebCore/style/values/backgrounds/StyleFillLayers.h
+++ b/Source/WebCore/style/values/backgrounds/StyleFillLayers.h
@@ -32,7 +32,7 @@
 #include <WebCore/StyleImageOrNone.h>
 #include <WebCore/StylePosition.h>
 #include <WebCore/StyleRepeatStyle.h>
-#include <wtf/IteratorRange.h>
+#include <ranges>
 
 namespace WebCore {
 
@@ -55,7 +55,7 @@ template<FillLayer T>
 void computeClipMax(const CoordinatedValueList<T>& list)
 {
     auto computedClipMax = FillBox::NoClip;
-    for (auto& layer : std::ranges::reverse_view(list.usedValues())) {
+    for (auto& layer : list.usedValues() | std::views::reverse) {
         computedClipMax = clipMax(computedClipMax, layer.clip());
         layer.setClipMax(computedClipMax);
     }

--- a/Source/WebCore/style/values/borders/StyleBoxShadow.cpp
+++ b/Source/WebCore/style/values/borders/StyleBoxShadow.cpp
@@ -34,6 +34,7 @@
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StylePrimitiveNumericTypes+Serialization.h"
 #include "StyleShadowInterpolation.h"
+#include <ranges>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
@@ -69,7 +70,7 @@ Ref<CSSValue> CSSValueCreation<BoxShadowList>::operator()(CSSValuePool&, const R
 {
     CSS::BoxShadowProperty::List list;
 
-    for (const auto& shadow : makeReversedRange(value))
+    for (const auto& shadow : value | std::views::reverse)
         list.value.append(toCSS(shadow, style));
 
     return CSSBoxShadowPropertyValue::create(CSS::BoxShadowProperty { WTFMove(list) });
@@ -89,7 +90,7 @@ auto CSSValueConversion<BoxShadows>::operator()(BuilderState& state, const CSSVa
             return CSS::Keyword::None { };
         },
         [&](const typename CSS::BoxShadowProperty::List& list) -> BoxShadows {
-            return BoxShadows::List::map(makeReversedRange(list), [&](const CSS::BoxShadow& element) {
+            return BoxShadows::List::map(list | std::views::reverse, [&](const CSS::BoxShadow& element) {
                 return toStyle(element, state);
             });
         }
@@ -100,7 +101,7 @@ auto CSSValueConversion<BoxShadows>::operator()(BuilderState& state, const CSSVa
 
 void Serialize<BoxShadowList>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const BoxShadowList& value)
 {
-    serializationForCSSOnRangeLike(builder, context, style, makeReversedRange(value), SerializationSeparatorString<BoxShadowList>);
+    serializationForCSSOnRangeLike(builder, context, style, value | std::views::reverse, SerializationSeparatorString<BoxShadowList>);
 }
 
 // MARK: - Blending

--- a/Source/WebCore/style/values/borders/StyleShadowInterpolation.h
+++ b/Source/WebCore/style/values/borders/StyleShadowInterpolation.h
@@ -51,7 +51,7 @@ struct ShadowInterpolation {
         // FIXME: Something like LLVM ADT's zip_shortest (https://llvm.org/doxygen/structllvm_1_1detail_1_1zip__shortest.html) would allow this to be done without indexing:
         //
         // return std::ranges::all_of(
-        //     zip_shortest(makeReversedRange(fromShadows), makeReversedRange(toShadows)),
+        //     zip_shortest(fromShadows | std::views::reverse, toShadows | std::views::reverse),
         //     [](const auto& pair) {
         //         return shadowStyle(std::get<0>(pair)) == shadowStyle(std::get<1>(pair));
         //     }

--- a/Source/WebCore/style/values/text-decoration/StyleTextShadow.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextShadow.cpp
@@ -35,6 +35,7 @@
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StylePrimitiveNumericTypes+Serialization.h"
 #include "StyleShadowInterpolation.h"
+#include <ranges>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
@@ -64,7 +65,7 @@ Ref<CSSValue> CSSValueCreation<TextShadowList>::operator()(CSSValuePool&, const 
 {
     CSS::TextShadowProperty::List list;
 
-    for (const auto& shadow : makeReversedRange(value))
+    for (const auto& shadow : value | std::views::reverse)
         list.value.append(toCSS(shadow, style));
 
     return CSSTextShadowPropertyValue::create(CSS::TextShadowProperty { WTFMove(list) });
@@ -84,7 +85,7 @@ auto CSSValueConversion<TextShadows>::operator()(BuilderState& state, const CSSV
             return CSS::Keyword::None { };
         },
         [&](const typename CSS::TextShadowProperty::List& list) -> TextShadows {
-            return TextShadows::List::map(makeReversedRange(list), [&](const CSS::TextShadow& element) {
+            return TextShadows::List::map(list | std::views::reverse, [&](const CSS::TextShadow& element) {
                 return toStyle(element, state);
             });
         }
@@ -95,7 +96,7 @@ auto CSSValueConversion<TextShadows>::operator()(BuilderState& state, const CSSV
 
 void Serialize<TextShadowList>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const TextShadowList& value)
 {
-    serializationForCSSOnRangeLike(builder, context, style, makeReversedRange(value), SerializationSeparatorString<TextShadowList>);
+    serializationForCSSOnRangeLike(builder, context, style, value | std::views::reverse, SerializationSeparatorString<TextShadowList>);
 }
 
 // MARK: - Blending

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -41,6 +41,7 @@
 #import <WebCore/WebCoreCALayerExtras.h>
 #import <pal/cocoa/CoreMaterialSoftLink.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <ranges>
 #import <wtf/SoftLinking.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -154,7 +155,7 @@ bool mayContainEditableElementsInRect(UIView *rootView, const WebCore::FloatRect
     if (viewsInRect.isEmpty())
         return false;
     bool possiblyHasEditableElements = true;
-    for (RetainPtr view : WTF::makeReversedRange(viewsInRect)) {
+    for (RetainPtr view : viewsInRect | std::views::reverse) {
         if (![view isKindOfClass:WKCompositingView.class])
             continue;
         auto* node = RemoteLayerTreeNode::forCALayer([view layer]);
@@ -203,7 +204,7 @@ OptionSet<WebCore::TouchAction> touchActionsForPoint(UIView *rootView, const Web
         return { WebCore::TouchAction::Auto };
 
     RetainPtr<UIView> hitView;
-    for (RetainPtr view : WTF::makeReversedRange(viewsAtPoint)) {
+    for (RetainPtr view : viewsAtPoint | std::views::reverse) {
         // We only hit WKChildScrollView directly if its content layer doesn't have an event region.
         // We don't generate the region if there is nothing interesting in it, meaning the touch-action is auto.
         if ([view isKindOfClass:[WKChildScrollView class]])
@@ -237,7 +238,7 @@ OptionSet<WebCore::EventListenerRegionType> eventListenerTypesAtPoint(UIView *ro
         return { };
 
     RetainPtr<UIView> hitView;
-    for (RetainPtr view : WTF::makeReversedRange(viewsAtPoint)) {
+    for (RetainPtr view : viewsAtPoint | std::views::reverse) {
         if ([view isKindOfClass:[WKCompositingView class]]) {
             hitView = WTFMove(view);
             break;
@@ -303,7 +304,7 @@ static Class scrollViewScrollIndicatorClassSingleton()
 
     LOG_WITH_STREAM(UIHitTesting, stream << (void*)self << "_web_findDescendantViewAtPoint " << WebCore::FloatPoint(point) << " found " << viewsAtPoint.size() << " views");
 
-    for (RetainPtr view : WTF::makeReversedRange(viewsAtPoint)) {
+    for (RetainPtr view : viewsAtPoint | std::views::reverse) {
         if ([view conformsToProtocol:@protocol(WKNativelyInteractible)]) {
             LOG_WITH_STREAM(UIHitTesting, stream << " " << (void*)view.get() << " is natively interactible");
             CGPoint subviewPoint = [view convertPoint:point fromView:self];

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -57,6 +57,7 @@
 #include <WebCore/TreeScope.h>
 #include <WebCore/TypedElementDescendantIteratorInlines.h>
 #include <WebCore/UserGestureIndicator.h>
+#include <ranges>
 #include <wtf/LoggerHelper.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -775,7 +776,7 @@ void WebFullScreenManager::enterFullScreenForOwnerElements(WebCore::FrameIdentif
         if (RefPtr element = frame->ownerElement())
             elements.append(element.releaseNonNull());
     }
-    for (auto element : makeReversedRange(elements))
+    for (auto element : elements | std::views::reverse)
         DocumentFullscreen::elementEnterFullscreen(element);
 
     completionHandler();

--- a/Tools/TestWebKitAPI/Tests/WTF/IteratorRange.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/IteratorRange.cpp
@@ -31,62 +31,6 @@
 
 namespace TestWebKitAPI {
 
-TEST(WTF_IteratorRange, MakeReversedRange)
-{
-    Vector<int> intVector { 10, 11, 12, 13 };
-
-    auto reversedRange = WTF::makeReversedRange(intVector);
-
-    static_assert(std::is_same<decltype(reversedRange.begin()), typename Vector<int>::reverse_iterator>::value, "IteratorRange has correct begin() iterator type");
-    static_assert(std::is_same<decltype(reversedRange.end()), typename Vector<int>::reverse_iterator>::value, "IteratorRange has correct end() iterator type");
-
-    EXPECT_EQ(reversedRange.begin(), intVector.rbegin());
-    EXPECT_EQ(reversedRange.end(), intVector.rend());
-
-    std::array<int, 4> expectedResults { { 13, 12, 11, 10 } };
-    size_t index = 0;
-
-    for (auto& value : reversedRange)
-        EXPECT_EQ(value, expectedResults[index++]);
-}
-
-TEST(WTF_IteratorRange, MakeConstReversedRange)
-{
-    const Vector<int> intVector { 10, 11, 12, 13 };
-
-    auto reversedRange = WTF::makeReversedRange(intVector);
-
-    static_assert(std::is_same<decltype(reversedRange.begin()), typename Vector<int>::const_reverse_iterator>::value, "IteratorRange has correct begin() iterator type");
-    static_assert(std::is_same<decltype(reversedRange.end()), typename Vector<int>::const_reverse_iterator>::value, "IteratorRange has correct end() iterator type");
-
-    EXPECT_EQ(reversedRange.begin(), intVector.rbegin());
-    EXPECT_EQ(reversedRange.end(), intVector.rend());
-
-    std::array<int, 4> expectedResults { { 13, 12, 11, 10 } };
-    size_t index = 0;
-
-    for (auto& value : reversedRange)
-        EXPECT_EQ(value, expectedResults[index++]);
-}
-
-TEST(WTF_IteratorRange, MakeReversedRangeFromRange)
-{
-    Vector<int> intVector { 10, 11, 12, 13 };
-
-    auto range = IteratorRange { intVector.begin(), intVector.end() };
-
-    auto reversedRange = makeReversedRange(range);
-
-    EXPECT_EQ(reversedRange.begin(), intVector.rbegin());
-    EXPECT_EQ(reversedRange.end(), intVector.rend());
-
-    std::array<int, 4> expectedResults { { 13, 12, 11, 10 } };
-    size_t index = 0;
-
-    for (auto& value : reversedRange)
-        EXPECT_EQ(value, expectedResults[index++]);
-}
-
 struct OneWayIterator {
     int* ptr;
 


### PR DESCRIPTION
#### 3f05dc5ec966a1f1d630d0b6130cc0cb988a5210
<pre>
[Modernization] Replace WTF::makeReversedRange with std::views::reverse
<a href="https://bugs.webkit.org/show_bug.cgi?id=301825">https://bugs.webkit.org/show_bug.cgi?id=301825</a>

Reviewed by Darin Adler.

Replaces uses of `WTF::makeReversedRange` with `std::views::reverse`.

To allow `std::views::reverse` to work with `WTF::ListHashSet`, the
`WTF::ListHashSet` iterators needed to be updated to conform to the
`std::bidirectional_iterator` concept, which required adding postfix
decrement operators that had been previously omitted intentionally.
The goal of the intentional omission was to avoid accidental performance
issues when manually using iterators, but we mostly use try to avoid
direct iterator usage and being able to use std::ranges is a good tradeoff.

* Source/WTF/wtf/CryptographicallyRandomNumber.cpp:
* Source/WTF/wtf/IteratorRange.h:
* Source/WTF/wtf/ListHashSet.h:
* Source/WTF/wtf/URLHelpers.cpp:
* Source/WebCore/accessibility/AXSearchManager.cpp:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
* Source/WebCore/animation/DocumentTimeline.cpp:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/DocumentFullscreen.cpp:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/editing/markup.cpp:
* Source/WebCore/html/closewatcher/CloseWatcherManager.cpp:
* Source/WebCore/layout/floats/FloatingContext.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLine.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
* Source/WebCore/loader/FrameLoader.cpp:
* Source/WebCore/page/EventHandler.cpp:
* Source/WebCore/page/PointerCaptureController.cpp:
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp:
* Source/WebCore/platform/graphics/FontCascade.cpp:
* Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
* Source/WebCore/platform/ios/wak/WKView.mm:
* Source/WebCore/rendering/LayerAncestorClippingStack.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/TextBoxPainter.cpp:
* Source/WebCore/rendering/svg/SVGTextChunk.cpp:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
* Source/WebCore/style/StyleInvalidator.cpp:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
* Source/WebCore/style/StyleTreeResolver.cpp:
* Source/WebCore/style/Styleable.cpp:
* Source/WebCore/style/values/backgrounds/StyleFillLayers.h:
* Source/WebCore/style/values/borders/StyleBoxShadow.cpp:
* Source/WebCore/style/values/borders/StyleShadowInterpolation.h:
* Source/WebCore/style/values/text-decoration/StyleTextShadow.cpp:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
* Tools/TestWebKitAPI/Tests/WTF/IteratorRange.cpp:

Canonical link: <a href="https://commits.webkit.org/302487@main">https://commits.webkit.org/302487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/347e2568c9a2881a93b8026ac83924eb24efa804

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129265 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1398 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132212 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/79095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/33913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79919 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121256 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139114 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127717 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1265 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112130 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/106812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27187 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/1086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/30649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53935 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1384 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64740 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160731 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1207 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40112 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->