### PR TITLE
Use C++20 std::ranges::any_of in WebCore

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -100,7 +100,7 @@ private:
 
         ~SharedGLData()
         {
-            ASSERT(std::any_of(contextDataMap().begin(), contextDataMap().end(),
+            ASSERT(std::ranges::any_of(contextDataMap(),
                 [this](auto& entry) { return entry.value == this; }));
             contextDataMap().removeIf([this](auto& entry) { return entry.value == this; });
         }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp
@@ -413,21 +413,21 @@ void TextureMapperAnimations::apply(TextureMapperAnimation::ApplicationResult& a
 
 bool TextureMapperAnimations::hasActiveAnimationsOfType(AnimatedProperty type) const
 {
-    return std::any_of(m_animations.begin(), m_animations.end(), [&type](const auto& animation) {
+    return std::ranges::any_of(m_animations, [&type](const auto& animation) {
         return animation.keyframes().property() == type;
     });
 }
 
 bool TextureMapperAnimations::hasRunningAnimations() const
 {
-    return std::any_of(m_animations.begin(), m_animations.end(), [](const auto& animation) {
+    return std::ranges::any_of(m_animations, [](const auto& animation) {
         return animation.state() == TextureMapperAnimation::State::Playing;
     });
 }
 
 bool TextureMapperAnimations::hasRunningTransformAnimations() const
 {
-    return std::any_of(m_animations.begin(), m_animations.end(), [](const auto& animation) {
+    return std::ranges::any_of(m_animations, [](const auto& animation) {
         switch (animation.keyframes().property()) {
         case AnimatedProperty::Translate:
         case AnimatedProperty::Rotate:

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -1479,7 +1479,7 @@ bool TextureMapperLayer::descendantsOrSelfHaveRunningAnimations() const
     if (m_animations.hasRunningAnimations())
         return true;
 
-    return std::any_of(m_children.begin(), m_children.end(),
+    return std::ranges::any_of(m_children,
         [](TextureMapperLayer* child) {
             return child->descendantsOrSelfHaveRunningAnimations();
         });


### PR DESCRIPTION
#### 0cc86eb1cf5f17b6370ae4988f85e5e6a38d118a
<pre>
Use C++20 std::ranges::any_of in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=301827">https://bugs.webkit.org/show_bug.cgi?id=301827</a>
<a href="https://rdar.apple.com/163898358">rdar://163898358</a>

Reviewed by Darin Adler and Sam Weinig.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::endOfStream):
* Source/WebCore/crypto/openssl/CryptoKeyRSAOpenSSL.cpp:
(WebCore::exponentVectorToUInt32):
* Source/WebCore/platform/graphics/egl/GLDisplay.cpp:
(WebCore::GLDisplay::GLDisplay):
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapperGLData::SharedGLData::~SharedGLData):
* Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp:
(WebCore::TextureMapperAnimations::hasActiveAnimationsOfType const):
(WebCore::TextureMapperAnimations::hasRunningAnimations const):
(WebCore::TextureMapperAnimations::hasRunningTransformAnimations const):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::descendantsOrSelfHaveRunningAnimations const):

Canonical link: <a href="https://commits.webkit.org/302462@main">https://commits.webkit.org/302462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c56d98e3a98a6b5b74fd1ea40c86ff10ed51cdd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98344 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66216 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78992 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33808 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79813 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109418 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139006 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106878 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106713 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27165 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/991 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30551 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53782 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1278 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64631 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1104 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1149 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->