### PR TITLE
[AutoFill Debugging] Add a way to scope text extraction to a given node (by JS handle)

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -29,6 +29,7 @@
 #include <WebCore/FloatRect.h>
 #include <WebCore/FloatSize.h>
 #include <WebCore/NodeIdentifier.h>
+#include <WebCore/WebKitJSHandle.h>
 #include <wtf/Forward.h>
 #include <wtf/URL.h>
 
@@ -72,7 +73,8 @@ enum class EventListenerCategory : uint8_t {
 };
 
 struct Request {
-    std::optional<WebCore::FloatRect> collectionRectInRootView;
+    std::optional<FloatRect> collectionRectInRootView;
+    std::optional<JSHandleIdentifier> targetNodeHandleIdentifier;
     bool mergeParagraphs { false };
     bool skipNearlyTransparentContent { false };
     bool includeNodeIdentifiers { false };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6733,6 +6733,7 @@ header: <WebCore/TextExtractionTypes.h>
 header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::Request {
     std::optional<WebCore::FloatRect> collectionRectInRootView;
+    std::optional<WebCore::JSHandleIdentifier> targetNodeHandleIdentifier;
     bool mergeParagraphs;
     bool skipNearlyTransparentContent;
     bool includeNodeIdentifiers;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6828,6 +6828,24 @@ static inline std::optional<WebCore::NodeIdentifier> toNodeIdentifier(const Stri
 
 @implementation WKWebView (WKTextExtraction)
 
+#if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+
+static std::optional<WebCore::JSHandleIdentifier> mainFrameJSHandleIdentifier(_WKJSHandle *nodeHandle)
+{
+    if (!nodeHandle)
+        return std::nullopt;
+
+    auto info = nodeHandle->_ref->info();
+    if (!info.frameInfo.isMainFrame) {
+        // FIXME: Blocked on support for text extraction in subframes.
+        return std::nullopt;
+    }
+
+    return info.identifier;
+}
+
+#endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+
 - (void)_requestTextExtractionInternal:(_WKTextExtractionConfiguration *)configuration completion:(CompletionHandler<void(std::optional<WebCore::TextExtraction::Item>&&)>&&)completion
 {
 #if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
@@ -6839,7 +6857,7 @@ static inline std::optional<WebCore::NodeIdentifier> toNodeIdentifier(const Stri
     bool mergeParagraphs = configuration.mergeParagraphs;
     bool includeNodeIdentifiers = configuration.includeNodeIdentifiers;
     bool skipNearlyTransparentContent = configuration.skipNearlyTransparentContent;
-    auto rectInRootView = [&]() -> std::optional<WebCore::FloatRect> {
+    auto rectInRootView = [&] -> std::optional<WebCore::FloatRect> {
         if (CGRectIsNull(rectInWebView))
             return std::nullopt;
 
@@ -6852,6 +6870,7 @@ static inline std::optional<WebCore::NodeIdentifier> toNodeIdentifier(const Stri
 
     WebCore::TextExtraction::Request request {
         .collectionRectInRootView = WTFMove(rectInRootView),
+        .targetNodeHandleIdentifier = mainFrameJSHandleIdentifier(configuration.targetNode),
         .mergeParagraphs = mergeParagraphs,
         .skipNearlyTransparentContent = skipNearlyTransparentContent,
         .includeNodeIdentifiers = includeNodeIdentifiers,

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -30,6 +30,7 @@
 NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class WKWebView;
+@class _WKJSHandle;
 
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @interface _WKTextExtractionConfiguration : NSObject
@@ -76,6 +77,12 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  The default value is `NSUIntegerMax`.
  */
 @property (nonatomic) NSUInteger maxWordsPerParagraph;
+
+/*!
+ If specified, text extraction is limited to the subtree of this node.
+ The default value is `nil`.
+ */
+@property (nonatomic, copy, nullable) _WKJSHandle *targetNode;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -30,7 +30,9 @@
 #import <WebKit/WKError.h>
 #import <wtf/RetainPtr.h>
 
-@implementation _WKTextExtractionConfiguration
+@implementation _WKTextExtractionConfiguration {
+    RetainPtr<_WKJSHandle> _targetNode;
+}
 
 - (instancetype)init
 {
@@ -46,6 +48,16 @@
     _targetRect = CGRectNull;
     _maxWordsPerParagraph = NSUIntegerMax;
     return self;
+}
+
+- (_WKJSHandle *)targetNode
+{
+    return _targetNode.get();
+}
+
+- (void)setTargetNode:(_WKJSHandle *)targetNode
+{
+    _targetNode = adoptNS([targetNode copy]);
 }
 
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
@@ -762,8 +762,7 @@ TEST(WKWebView, SnapshotNodeByJSHandle)
 
     RetainPtr world = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
     auto querySelector = [&](ASCIILiteral selector) -> RetainPtr<_WKJSHandle> {
-        RetainPtr script = [NSString stringWithFormat:@"webkit.createJSHandle(document.querySelector('%s'))", selector.characters()];
-        return dynamic_objc_cast<_WKJSHandle>([webView objectByEvaluatingJavaScript:script.get() inFrame:nil inContentWorld:world.get()]);
+        return [webView querySelector:@(selector.characters()) frame:nil world:world.get()];
     };
 
     {

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -33,6 +33,7 @@
 #endif
 
 @class _WKFrameTreeNode;
+@class _WKJSHandle;
 @class _WKProcessPoolConfiguration;
 
 #if PLATFORM(IOS_FAMILY)
@@ -152,6 +153,7 @@ class Color;
 - (unsigned)waitUntilClientWidthIs:(unsigned)expectedClientWidth;
 - (CGRect)elementRectFromSelector:(NSString *)selector;
 - (CGPoint)elementMidpointFromSelector:(NSString *)selector;
+- (_WKJSHandle *)querySelector:(NSString *)selector frame:(WKFrameInfo *)frame world:(WKContentWorld *)world;
 @end
 
 #endif // __cplusplus

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -46,6 +46,7 @@
 #import <WebKit/WebKitPrivate.h>
 #import <WebKit/_WKActivatedElementInfo.h>
 #import <WebKit/_WKFrameTreeNode.h>
+#import <WebKit/_WKJSHandle.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKTextInputContext.h>
 #import <objc/runtime.h>
@@ -804,6 +805,12 @@ static IterationStatus forEachCALayer(CALayer *layer, IterationStatus(^visitor)(
     }];
     TestWebKitAPI::Util::run(&done);
     return result.autorelease();
+}
+
+- (_WKJSHandle *)querySelector:(NSString *)selector frame:(WKFrameInfo *)frame world:(WKContentWorld *)world
+{
+    RetainPtr script = [NSString stringWithFormat:@"window.webkit.createJSHandle(document.querySelector('%@'))", selector];
+    return dynamic_objc_cast<_WKJSHandle>([self objectByEvaluatingJavaScript:script.get() inFrame:frame inContentWorld:world]);
 }
 
 @end


### PR DESCRIPTION
#### 1403129e02472b16a4eb6a8a5b61c097983b7c08
<pre>
[AutoFill Debugging] Add a way to scope text extraction to a given node (by JS handle)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301831">https://bugs.webkit.org/show_bug.cgi?id=301831</a>
<a href="https://rdar.apple.com/163902445">rdar://163902445</a>

Reviewed by Abrar Rahman Protyasha.

Add support for a new property on `_WKTextExtractionConfiguration`, which clients can use to scope
text extraction to a given element by specifying a `_WKJSHandle`.

Tests: TextExtractionTests.TargetNode

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::collectText):

Refactor `collectText(Document&amp;)` to take a `Node&amp;` instead, representing the scope of text
extraction in the DOM (it currently defaults to the `body` element in the given `Document`).

(WebCore::TextExtraction::extractItem):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(mainFrameJSHandleIdentifier):
(-[WKWebView _requestTextExtractionInternal:completion:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration targetNode]):
(-[_WKTextExtractionConfiguration setTargetNode:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, TargetNode)):

Add an API test to exercise this new property.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm:
(TestWebKitAPI::TEST(WKWebView, SnapshotNodeByJSHandle)):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView querySelector:frame:world:]):

Add a testing helper to return a `_WKJSHandle` corresponding to the result of evaluating
`document.querySelector(…)`.

Canonical link: <a href="https://commits.webkit.org/302464@main">https://commits.webkit.org/302464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da405fed5300a21b6650edb6897d6c3e10a554f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80562 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3cc27578-7b70-416b-9934-a5e9f4dea346) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98359 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66233 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a3f32e7d-85b3-44ce-8f19-fb232b8df61c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132119 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79007 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bbddc231-add9-4c65-bb59-e9e1100be051) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33825 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79831 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139024 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106893 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106729 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27168 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1005 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30568 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53810 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1296 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64649 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1122 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1167 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1220 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->