### PR TITLE
[JSC] Assert arguments of `CachedCall::callWithArguments` using `Integrity::auditCell`

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -903,6 +903,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     inspector/remote/RemoteInspector.h
 
     interpreter/CachedCall.h
+    interpreter/CachedCallInlines.h
     interpreter/CalleeBits.h
     interpreter/CallFrame.h
     interpreter/CallFrameInlines.h
@@ -1409,6 +1410,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/WriteBarrierInlines.h
 
     tools/Integrity.h
+    tools/IntegrityInlines.h
     tools/LLVMProfiling.h
     tools/SourceProfiler.h
 

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1722,6 +1722,7 @@
 		A7F9935F0FD7325100A0B2D0 /* JSONObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A7F9935D0FD7325100A0B2D0 /* JSONObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A7FB61001040C38B0017A286 /* PropertyDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = A7FB604B103F5EAB0017A286 /* PropertyDescriptor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A7FCC26D17A0B6AA00786D1A /* FTLSwitchCase.h in Headers */ = {isa = PBXBuildFile; fileRef = A7FCC26C17A0B6AA00786D1A /* FTLSwitchCase.h */; };
+		AA45D14F2EB82FEB00FCBD16 /* CachedCallInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = AA45D14E2EB82FEB00FCBD16 /* CachedCallInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AA785BEB2E77BECA0097F688 /* JSPromiseAllContext.h in Headers */ = {isa = PBXBuildFile; fileRef = AA785BEA2E77BECA0097F688 /* JSPromiseAllContext.h */; };
 		AA785BEE2E77BED70097F688 /* JSPromiseAllContextInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = AA785BED2E77BED70097F688 /* JSPromiseAllContextInlines.h */; };
 		AD00659E1ECAC812000CA926 /* WasmLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = AD00659D1ECAC7FE000CA926 /* WasmLimits.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2236,7 +2237,7 @@
 		FEC503FE2B51E09700176A93 /* LineColumn.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC503FD2B51E09700176A93 /* LineColumn.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEC5797323105B5100BCA83F /* VMInspectorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC5797223105B4800BCA83F /* VMInspectorInlines.h */; };
 		FEC5797623105F4E00BCA83F /* Integrity.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC5797523105F4300BCA83F /* Integrity.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FEC579782310954C00BCA83F /* IntegrityInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC579772310954B00BCA83F /* IntegrityInlines.h */; };
+		FEC579782310954C00BCA83F /* IntegrityInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC579772310954B00BCA83F /* IntegrityInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FECB8B271D25BB85006F2463 /* FunctionOverridesTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FECB8B251D25BB6E006F2463 /* FunctionOverridesTest.cpp */; };
 		FED287B215EC9A5700DA8161 /* LLIntOpcode.h in Headers */ = {isa = PBXBuildFile; fileRef = FED287B115EC9A5700DA8161 /* LLIntOpcode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FED5FA3429A0859C00798A7F /* WasmBBQJIT.h in Headers */ = {isa = PBXBuildFile; fileRef = FED5FA3229A0859C00798A7F /* WasmBBQJIT.h */; };
@@ -5427,6 +5428,7 @@
 		A7FF647A18C52E8500B55307 /* SpillRegistersMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpillRegistersMode.h; sourceTree = "<group>"; };
 		A8E894310CD0602400367179 /* JSCallbackObjectFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCallbackObjectFunctions.h; sourceTree = "<group>"; };
 		A8E894330CD0603F00367179 /* JSGlobalObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGlobalObject.h; sourceTree = "<group>"; };
+		AA45D14E2EB82FEB00FCBD16 /* CachedCallInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CachedCallInlines.h; sourceTree = "<group>"; };
 		AA785BEA2E77BECA0097F688 /* JSPromiseAllContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSPromiseAllContext.h; sourceTree = "<group>"; };
 		AA785BEC2E77BECF0097F688 /* JSPromiseAllContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSPromiseAllContext.cpp; sourceTree = "<group>"; };
 		AA785BED2E77BED70097F688 /* JSPromiseAllContextInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSPromiseAllContextInlines.h; sourceTree = "<group>"; };
@@ -7095,6 +7097,7 @@
 			children = (
 				AAE814122E667AED00DF3D3A /* CachedCall.cpp */,
 				A7F8690E0F9584A100558697 /* CachedCall.h */,
+				AA45D14E2EB82FEB00FCBD16 /* CachedCallInlines.h */,
 				796DAA2A1E89CCD6005DF24A /* CalleeBits.h */,
 				1429D8DB0ED2205B00B89619 /* CallFrame.cpp */,
 				1429D8DC0ED2205B00B89619 /* CallFrame.h */,
@@ -10902,6 +10905,7 @@
 				FE8DE54D23AC1E86005C9142 /* CacheableIdentifierInlines.h in Headers */,
 				144CA3502224180100817789 /* CachedBytecode.h in Headers */,
 				072F534E2E3C0B7100389E15 /* CachedCall.h in Headers */,
+				AA45D14F2EB82FEB00FCBD16 /* CachedCallInlines.h in Headers */,
 				65B8392E1BACAD360044E824 /* CachedRecovery.h in Headers */,
 				E39EEAF322812450008474F4 /* CachedSpecialPropertyAdaptiveStructureWatchpoint.h in Headers */,
 				14F09C2A2231923100CF88EB /* CachedTypes.h in Headers */,

--- a/Source/JavaScriptCore/interpreter/CachedCallInlines.h
+++ b/Source/JavaScriptCore/interpreter/CachedCallInlines.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Codeblog CORP.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include <JavaScriptCore/CachedCall.h>
+
+#if ASSERT_ENABLED
+#include <JavaScriptCore/IntegrityInlines.h>
+#endif
+
+namespace JSC {
+
+template<typename... Args> requires (std::is_convertible_v<Args, JSValue> && ...)
+ALWAYS_INLINE JSValue CachedCall::callWithArguments(JSGlobalObject* globalObject, JSValue thisValue, Args... args)
+{
+    VM& vm = m_vm;
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT_WITH_MESSAGE(!thisValue.isEmpty(), "Expected thisValue to be non-empty. Use jsUndefined() if you meant to use undefined.");
+#if ASSERT_ENABLED
+    if constexpr (sizeof...(args) > 0) {
+        size_t argIndex = 0;
+        auto checkArg = [&argIndex, &vm](JSValue arg) {
+            ASSERT_WITH_MESSAGE(!arg.isEmpty(), "arguments[%zu] is JSValue(). Use jsUndefined() if you meant to make it undefined.", argIndex);
+            if (arg.isCell())
+                Integrity::auditCell(vm, arg.asCell());
+            ++argIndex;
+        };
+        (checkArg(args), ...);
+    }
+#endif
+
+#if CPU(ARM64) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
+    ASSERT(sizeof...(args) == static_cast<size_t>(m_protoCallFrame.argumentCount()));
+    constexpr unsigned argumentCountIncludingThis = 1 + sizeof...(args);
+    if constexpr (argumentCountIncludingThis <= 4) {
+        if (m_numParameters <= argumentCountIncludingThis) [[likely]] {
+            JSValue result = m_vm.interpreter.tryCallWithArguments(*this, thisValue, args...);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (result)
+                return result;
+        }
+    }
+#endif
+
+    clearArguments();
+    setThis(thisValue);
+    (appendArgument(args), ...);
+
+    if (hasOverflowedArguments()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return { };
+    }
+
+    RELEASE_AND_RETURN(scope, call());
+}
+
+}

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -27,7 +27,7 @@
 #include "ArrayConstructor.h"
 #include "ArrayPrototypeInlines.h"
 #include "BuiltinNames.h"
-#include "CachedCall.h"
+#include "CachedCallInlines.h"
 #include "IntegrityInlines.h"
 #include "InterpreterInlines.h"
 #include "JSArrayInlines.h"

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <JavaScriptCore/CachedCall.h>
+#include <JavaScriptCore/CachedCallInlines.h>
 #include <JavaScriptCore/IterationModeMetadata.h>
 #include <JavaScriptCore/JSArrayIterator.h>
 #include <JavaScriptCore/JSCJSValue.h>

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -49,7 +49,7 @@
 
 #pragma once
 
-#include "CachedCall.h"
+#include "CachedCallInlines.h"
 #include "Error.h"
 #include "InterpreterInlines.h"
 #include "JSArrayBufferViewInlines.h"

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -29,7 +29,7 @@
 #include "JSIteratorPrototype.h"
 
 #include "BuiltinNames.h"
-#include "CachedCall.h"
+#include "CachedCallInlines.h"
 #include "InterpreterInlines.h"
 #include "IteratorOperations.h"
 #include "JSCBuiltins.h"

--- a/Source/JavaScriptCore/runtime/MapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/MapPrototype.cpp
@@ -27,7 +27,7 @@
 #include "MapPrototype.h"
 
 #include "BuiltinNames.h"
-#include "CachedCall.h"
+#include "CachedCallInlines.h"
 #include "GetterSetter.h"
 #include "InterpreterInlines.h"
 #include "JSCInlines.h"

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -21,7 +21,7 @@
 #include "config.h"
 #include "RegExpPrototype.h"
 
-#include "CachedCall.h"
+#include "CachedCallInlines.h"
 #include "InterpreterInlines.h"
 #include "IntegrityInlines.h"
 #include "JSArray.h"

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "SetPrototype.h"
 
-#include "CachedCall.h"
+#include "CachedCallInlines.h"
 #include "InterpreterInlines.h"
 #include "BuiltinNames.h"
 #include "GetterSetter.h"

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "CachedCall.h"
+#include "CachedCallInlines.h"
 #include "ExceptionHelpers.h"
 #include "JSCellButterfly.h"
 #include "ObjectConstructor.h"

--- a/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "WeakMapPrototype.h"
 
-#include "CachedCall.h"
+#include "CachedCallInlines.h"
 #include "InterpreterInlines.h"
 #include "JSCInlines.h"
 #include "JSWeakMapInlines.h"

--- a/Source/JavaScriptCore/tools/IntegrityInlines.h
+++ b/Source/JavaScriptCore/tools/IntegrityInlines.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include "Integrity.h"
-#include "JSCJSValue.h"
-#include "StructureID.h"
-#include "VM.h"
-#include "VMManager.h"
+#include <JavaScriptCore/Integrity.h>
+#include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/StructureID.h>
+#include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/VMManager.h>
 #include <wtf/Atomics.h>
 #include <wtf/Gigacage.h>
 


### PR DESCRIPTION
#### d4a934d34478f4b03d3bb4c4ce6f9595fd76a07d
<pre>
[JSC] Assert arguments of `CachedCall::callWithArguments` using `Integrity::auditCell`
<a href="https://bugs.webkit.org/show_bug.cgi?id=301833">https://bugs.webkit.org/show_bug.cgi?id=301833</a>

Reviewed by Yusuke Suzuki.

This patch changes to assert arguments of `CachedCall:callWithArguments` using `Integrity::auditCell`.

Also, following the best practice that `**Inlines.h` should not be included from any header file other
than `**Inlines.h`[1], this patch creates a new `CachedCallInlines.h`.

[1]: <a href="https://github.com/WebKit/WebKit/wiki/Analyzing-Build-Performance#avoid-including-inlinesh-headers-in-other-headers">https://github.com/WebKit/WebKit/wiki/Analyzing-Build-Performance#avoid-including-inlinesh-headers-in-other-headers</a>

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/interpreter/CachedCall.h:
(JSC::CachedCall::callWithArguments): Deleted.
* Source/JavaScriptCore/interpreter/CachedCallInlines.h: Added.
(JSC::CachedCall::callWithArguments):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
* Source/JavaScriptCore/runtime/IteratorOperations.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
* Source/JavaScriptCore/runtime/MapPrototype.cpp:
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
* Source/JavaScriptCore/runtime/WeakMapPrototype.cpp:
* Source/JavaScriptCore/tools/IntegrityInlines.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/302981@main">https://commits.webkit.org/302981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42e3a7814e1e2b8724e6e2c2b46df0c3c8d32ab5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129176 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98363 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66264 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79010 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33831 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79835 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121167 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109437 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34327 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139028 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127628 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1186 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106896 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106732 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27506 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1011 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30574 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53816 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1300 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64653 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160642 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1126 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40101 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1171 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->