### PR TITLE
REGRESSION(299927@main): Command-clicking Reddit link no longer opens new tab

### DIFF
--- a/LayoutTests/http/tests/navigation-api/policy-decision-deny-prevents-navigate-event-expected.txt
+++ b/LayoutTests/http/tests/navigation-api/policy-decision-deny-prevents-navigate-event-expected.txt
@@ -1,0 +1,11 @@
+Policy delegate: attempt to load http://127.0.0.1:8000/security/resources/empty.html?test with navigation type 'link clicked'
+Tests that the navigate event doesn't get fired if the client blocks the navigation via policy decision.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The navigate event was not fired
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/navigation-api/policy-decision-deny-prevents-navigate-event.html
+++ b/LayoutTests/http/tests/navigation-api/policy-decision-deny-prevents-navigate-event.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that the navigate event doesn't get fired if the client blocks the navigation via policy decision.");
+jsTestIsAsync = true;
+
+navigateEventWasFired = false;
+
+onload = () => {
+    frame = document.getElementById("testFrame");
+
+    // Deny navigations.
+    frame.contentWindow.testRunner.setCustomPolicyDelegate(true, false);
+    frame.contentWindow.testRunner.skipPolicyDelegateNotifyDone();
+
+    setTimeout(() => {
+        frame.contentWindow.navigation.onnavigate = () => {
+            frame.contentWindow.navigation.onnavigate = null;
+            navigateEventWasFired = true;
+            testFailed("The navigate event was fired unexpectedly");
+            finishJSTest();
+        };
+
+        internals.withUserGesture(() => {
+            testLink.style = "display:none";
+            testLink.click();
+        });
+        setTimeout(() => {
+            if (navigateEventWasFired)
+                return;
+            testPassed("The navigate event was not fired");
+            finishJSTest();
+        }, 100);
+    }, 0);
+};
+</script>
+<iframe id="testFrame" name="testFrame" src="/security/resources/empty.html"></iframe>
+<a id="testLink" target="testFrame" href="/security/resources/empty.html?test">Click me</a>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-cross-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-cross-origin.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<a id="a" href="https://does-not-exist/foo.html"></a>
+<script src="/common/get-host-info.sub.js"></script>
+<a id="a"></a>
 <script>
 async_test(t => {
   navigation.onnavigate = t.step_func_done(e => {
@@ -12,7 +13,7 @@ async_test(t => {
     assert_false(e.hashChange);
     assert_equals(e.formData, null);
     assert_equals(e.downloadRequest, null);
-    assert_equals(e.destination.url, "https://does-not-exist/foo.html");
+    assert_equals(e.destination.url, a.href);
     assert_false(e.destination.sameDocument);
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
@@ -20,6 +21,7 @@ async_test(t => {
     assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
   });
+  a.href = get_host_info().HTTPS_REMOTE_ORIGIN + "/does-not-exist.html";
   a.click();
 }, "<a> cross-origin navigate event");
 </script>

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -303,6 +303,7 @@ public:
     const Vector<ResourceResponse>& responses() const { return m_responses; }
 
     const NavigationAction& triggeringAction() const { return m_triggeringAction; }
+    NavigationAction& triggeringAction() { return m_triggeringAction; }
     void setTriggeringAction(NavigationAction&&);
     void setTriggeringNavigationAPIType(NavigationNavigationType type) { m_triggeringAction.setNavigationAPIType(type); };
 

--- a/Source/WebCore/loader/FrameLoadRequest.cpp
+++ b/Source/WebCore/loader/FrameLoadRequest.cpp
@@ -58,6 +58,8 @@ FrameLoadRequest::FrameLoadRequest(LocalFrame& frame, ResourceRequest&& resource
 
 FrameLoadRequest::~FrameLoadRequest() = default;
 
+FrameLoadRequest::FrameLoadRequest(const FrameLoadRequest&) = default;
+FrameLoadRequest& FrameLoadRequest::operator=(const FrameLoadRequest&) = default;
 FrameLoadRequest::FrameLoadRequest(FrameLoadRequest&&) = default;
 FrameLoadRequest& FrameLoadRequest::operator=(FrameLoadRequest&&) = default;
 

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -111,6 +111,8 @@ public:
 
     WEBCORE_EXPORT ~FrameLoadRequest();
 
+    WEBCORE_EXPORT FrameLoadRequest(const FrameLoadRequest&);
+    WEBCORE_EXPORT FrameLoadRequest& operator=(const FrameLoadRequest&);
     WEBCORE_EXPORT FrameLoadRequest(FrameLoadRequest&&);
     WEBCORE_EXPORT FrameLoadRequest& operator=(FrameLoadRequest&&);
 

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -557,6 +557,8 @@ private:
     uint64_t m_requiredCookiesVersion { 0 };
 
     const Ref<DocumentPrefetcher> m_documentPrefetcher;
+
+    Function<bool()> m_pendingDispatchNavigateEvent;
 };
 
 // This function is called by createWindow() in JSDOMWindowBase.cpp, for example, for

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -128,6 +128,8 @@ public:
     std::optional<NavigationNavigationType> navigationAPIType() const { return m_navigationAPIType; }
     void setNavigationAPIType(NavigationNavigationType navigationAPIType) { m_navigationAPIType = navigationAPIType; }
 
+    void setPendingDispatchNavigateEvent(std::function<bool()>&& function) { m_pendingDispatchNavigateEvent = WTFMove(function); }
+    std::function<bool()> takePendingDispatchNavigateEvent() { return std::exchange(m_pendingDispatchNavigateEvent, nullptr); }
 
 private:
     // Do not add a strong reference to the originating document or a subobject that holds the
@@ -140,6 +142,7 @@ private:
     std::optional<BackForwardItemIdentifier> m_targetBackForwardItemIdentifier;
     std::optional<BackForwardItemIdentifier> m_sourceBackForwardItemIdentifier;
     std::optional<PrivateClickMeasurement> m_privateClickMeasurement;
+    std::function<bool()> m_pendingDispatchNavigateEvent;
 
     NavigationType m_type;
     std::optional<NavigationNavigationType> m_navigationAPIType;


### PR DESCRIPTION
#### 0a26e2324b05b49545cbd3e3a45e47934530d48f
<pre>
REGRESSION(299927@main): Command-clicking Reddit link no longer opens new tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=301832">https://bugs.webkit.org/show_bug.cgi?id=301832</a>
<a href="https://rdar.apple.com/162982187">rdar://162982187</a>

Reviewed by Rupin Mittal.

Make sure we delay firing the navigate event after the client has allowed
the navigation to occur via the navigation policy decision. Previously,
we&apos;d fire the JS event first, allow the page to process the navigation
before the client app is even made aware of the navigation.

Test: http/tests/navigation-api/policy-decision-deny-prevents-navigate-event.html

* LayoutTests/http/tests/navigation-api/policy-decision-deny-prevents-navigate-event-expected.txt: Added.
* LayoutTests/http/tests/navigation-api/policy-decision-deny-prevents-navigate-event.html: Added.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-cross-origin.html:
Fix existing WPT test to run properly with the WebKit infrastructure. The test was trying to load
&quot;<a href="https://does-not-exist&quot">https://does-not-exist&quot</a>; which is a not local and thus gets rejected by our WebKitTestRunner (tests cannnot
try to load anything from the internet). This was previously not observed because the load rejection by
WebKitTestRunner happens in the navigation policy decision and the policy decision would prevously not prevent
the navigate event from firing.

* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::triggeringAction):
* Source/WebCore/loader/FrameLoadRequest.cpp:
* Source/WebCore/loader/FrameLoadRequest.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/NavigationAction.h:
(WebCore::NavigationAction::setPendingDispatchNavigateEvent):
(WebCore::NavigationAction::std::function&lt;bool):

Canonical link: <a href="https://commits.webkit.org/302468@main">https://commits.webkit.org/302468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44c1c016fbc81b36f9c19834e471febae4403ae1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136568 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80589 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e2c86049-92a2-46c4-b48b-746ae75e65ef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98375 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66276 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/446ebf33-9f69-4381-9ed0-5173b6e8bea4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79021 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8baf7bc4-2b2b-4d13-92c9-5457cae25568) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1000 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33841 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79847 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139041 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106906 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106742 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27173 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1022 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53837 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64666 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1139 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1184 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1237 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->