### PR TITLE
[Win] More robust approach to cleaning build dir

### DIFF
--- a/Tools/CISupport/built-product-archive
+++ b/Tools/CISupport/built-product-archive
@@ -32,6 +32,8 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
+import time
 import zipfile
 
 webkitTopAbsPath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -112,9 +114,25 @@ def determineWebKitBuildDirectories(platform, fullPlatform, configuration, cross
     
     return _topLevelBuildDirectory
 
+def handleRemoveError(func, path, excinfo):
+    # Sometimes there's DLLs remaining in WebKitBuild that hit a permission error on unlinking
+    # We'll move them into a temp directory, which we'll attempt to remove but ignore errors
+    # On container restart, the stale locks should clear and the clean up should work
+    print("Failed to delete:", path)
+    timestamp = int(time.time())
+    new_path = os.path.join(tempfile.gettempdir(), 'WebKitTrash', f"{os.path.basename(path)}.locked.{timestamp}")
+    os.makedirs(os.path.dirname(new_path))
+    shutil.move(path, new_path)
+    print("Moved to:", new_path)
 
-def removeDirectoryIfExists(thinDirectory):
-    if os.path.isdir(thinDirectory):
+def removeDirectoryIfExists(thinDirectory, platform):
+    if not os.path.isdir(thinDirectory):
+        return
+
+    if platform in ('win'):
+        shutil.rmtree(thinDirectory, onexc=handleRemoveError)
+        shutil.rmtree(os.path.join(tempfile.gettempdir(), 'WebKitTrash'), ignore_errors=True)
+    else:
         shutil.rmtree(thinDirectory)
 
 
@@ -241,7 +259,7 @@ def archiveBuiltProduct(configuration, platform, fullPlatform, minify=False):
 
     if platform in ['ios', 'tvos', 'visionos', 'watchos']:
         combinedDirectory = os.path.join(_topLevelBuildDirectory, 'combined-mac-and-{}'.format(platform))
-        removeDirectoryIfExists(combinedDirectory)
+        removeDirectoryIfExists(combinedDirectory, platform)
         os.makedirs(combinedDirectory)
         if subprocess.call(['/bin/cp', '-pR', _configurationBuildDirectory, combinedDirectory]):
             return 1
@@ -261,7 +279,7 @@ def archiveBuiltProduct(configuration, platform, fullPlatform, minify=False):
         thinDirectory = os.path.join(_configurationBuildDirectory, 'thin')
         thinBinDirectory = os.path.join(thinDirectory, 'bin')
 
-        removeDirectoryIfExists(thinDirectory)
+        removeDirectoryIfExists(thinDirectory, platform)
         copyBuildFiles(binDirectory, thinBinDirectory, ['*.ilk'])
 
         if createZip(thinDirectory, configuration):
@@ -346,12 +364,7 @@ def extractBuiltProduct(configuration, platform):
 
     archiveFile = os.path.join(_topLevelBuildDirectory, configuration + '.zip')
 
-    # Sometimes there's files remaining in WebKitBuild that hit a permission error on unlinking
-    # The rm utility in msys bash is able to remove the files, so we'll use that here
-    if platform in ('win'):
-        subprocess.call(['bash', '-c', 'rm -rf '+ _configurationBuildDirectory])
-
-    removeDirectoryIfExists(_configurationBuildDirectory)
+    removeDirectoryIfExists(_configurationBuildDirectory, platform)
     os.makedirs(_configurationBuildDirectory)
 
     if platform in ('mac', 'ios', 'visionos', 'tvos', 'watchos'):


### PR DESCRIPTION
#### cce1a30f8b733d965968fdfd149698f3b2e80c35
<pre>
[Win] More robust approach to cleaning build dir
<a href="https://bugs.webkit.org/show_bug.cgi?id=301834">https://bugs.webkit.org/show_bug.cgi?id=301834</a>

Reviewed by Yusuke Suzuki.

When extracting the built product, sometimes the worker can&apos;t delete
some of the DLLs in the build directory. I can&apos;t see any processes
holding the lock on the DLLs, so we&apos;re stuck until the container is
restarted.

To unblock the build, we&apos;ll move the files we can&apos;t delete to a
temporary WebKitTrash location. We&apos;ll try and delete the WebKitTrash but
ignore any errors - next time the container restarts those files should
get cleaned up.

Canonical link: <a href="https://commits.webkit.org/302473@main">https://commits.webkit.org/302473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/376459a2cff6244a585f321903610ef8c4d2dd93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80579 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98373 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66278 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79020 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33839 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79845 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139039 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1194 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106905 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106741 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27178 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30582 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53833 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1310 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1136 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->