### PR TITLE
Address more safer cpp warnings in WebKit/WebProcess/InjectedBundle

### DIFF
--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -953,6 +953,16 @@ void HitTestResult::toggleEnhancedFullscreenForVideo() const
 #endif
 }
 
+RefPtr<Node> HitTestResult::protectedInnerNonSharedNode() const
+{
+    return innerNonSharedNode();
+}
+
+RefPtr<Element> HitTestResult::protectedURLElement() const
+{
+    return URLElement();
+}
+
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 HTMLImageElement* HitTestResult::imageElement() const
 {

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -62,11 +62,13 @@ public:
 
     void setInnerNonSharedNode(Node*);
     Node* innerNonSharedNode() const { return m_innerNonSharedNode.get(); }
+    WEBCORE_EXPORT RefPtr<Node> protectedInnerNonSharedNode() const;
 
     WEBCORE_EXPORT Element* innerNonSharedElement() const;
 
     void setURLElement(Element*);
     Element* URLElement() const { return m_innerURLElement.get(); }
+    WEBCORE_EXPORT RefPtr<Element> protectedURLElement() const;
 
     void setScrollbar(RefPtr<Scrollbar>&&);
     Scrollbar* scrollbar() const { return m_scrollbar.get(); }

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -14,14 +14,10 @@ Platform/IPC/ArgumentCoders.h
 [ iOS ] UIProcess/ios/WKContentViewInteraction.mm
 [ iOS ] UIProcess/ios/WebPageProxyIOS.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
-WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
 WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
-WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
 WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
 WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
-WebProcess/InjectedBundle/API/mac/WKDOMText.mm
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
-WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 [ iOS ] WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 [ iOS ] WebProcess/WebPage/WebFoundTextRangeController.cpp
 [ iOS ] WebProcess/WebPage/ios/FindControllerIOS.mm

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -7,7 +7,6 @@
 [ iOS ] UIProcess/ios/WKContentView.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
-WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 [ iOS ] WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
 [ iOS ] WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 [ iOS ] WebProcess/WebPage/ViewGestureGeometryCollector.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -48,24 +48,15 @@ Platform/IPC/ArgumentCoders.h
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
 [ iOS ] WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
-WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.mm
-WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
-WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.mm
-WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
-WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
-WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
 WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
 WebProcess/InjectedBundle/API/c/mac/WKBundleMac.mm
 [ Mac ] WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
 WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
-WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
 WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
 WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
-WebProcess/InjectedBundle/API/mac/WKDOMText.mm
 WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
-WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 [ iOS ] WebProcess/Network/NetworkProcessConnection.cpp
 [ iOS ] WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 [ iOS ] WebProcess/WebCoreSupport/WebChromeClientCocoa.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -25,7 +25,6 @@
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenViewController.mm
 [ iOS ] UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
 [ iOS ] WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
-WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 [ iOS ] WebProcess/Network/NetworkProcessConnection.cpp
 [ iOS ] WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
 [ iOS ] WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.mm
@@ -38,7 +38,7 @@
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKWebProcessPlugInCSSStyleDeclarationHandle.class, self))
         return;
-    _cssStyleDeclarationHandle->~InjectedBundleCSSStyleDeclarationHandle();
+    SUPPRESS_UNCOUNTED_ARG _cssStyleDeclarationHandle->~InjectedBundleCSSStyleDeclarationHandle();
     [super dealloc];
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.mm
@@ -44,7 +44,7 @@
 
 - (WKWebProcessPlugInNodeHandle *)nodeHandle
 {
-    return WebKit::wrapper(_hitTestResult->nodeHandle()).autorelease();
+    return WebKit::wrapper(Ref { *_hitTestResult }->nodeHandle()).autorelease();
 }
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
@@ -40,11 +40,16 @@
     AlignedStorage<WebKit::InjectedBundleNodeHandle> _nodeHandle;
 }
 
+static Ref<WebKit::InjectedBundleNodeHandle> protectedNodeHandle(WKWebProcessPlugInNodeHandle *handle)
+{
+    return *handle->_nodeHandle;
+}
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKWebProcessPlugInNodeHandle.class, self))
         return;
-    _nodeHandle->~InjectedBundleNodeHandle();
+    SUPPRESS_UNCOUNTED_ARG _nodeHandle->~InjectedBundleNodeHandle();
     [super dealloc];
 }
 
@@ -57,7 +62,7 @@
 
 - (WKWebProcessPlugInFrame *)htmlIFrameElementContentFrame
 {
-    return WebKit::wrapper(_nodeHandle->htmlIFrameElementContentFrame()).autorelease();
+    return WebKit::wrapper(protectedNodeHandle(self)->htmlIFrameElementContentFrame()).autorelease();
 }
 
 - (CocoaImage *)renderedImageWithOptions:(WKSnapshotOptions)options
@@ -71,7 +76,7 @@
     if (width)
         optionalWidth = width.floatValue;
 
-    auto image = _nodeHandle->renderedImage(WebKit::toSnapshotOptions(options), options & kWKSnapshotOptionsExcludeOverflow, optionalWidth);
+    auto image = protectedNodeHandle(self)->renderedImage(WebKit::toSnapshotOptions(options), options & kWKSnapshotOptionsExcludeOverflow, optionalWidth);
     if (!image)
         return nil;
 
@@ -88,42 +93,42 @@
 
 - (CGRect)elementBounds
 {
-    return _nodeHandle->elementBounds();
+    return protectedNodeHandle(self)->elementBounds();
 }
 
 - (BOOL)HTMLInputElementIsAutoFilled
 {
-    return _nodeHandle->isHTMLInputElementAutoFilled();
+    return protectedNodeHandle(self)->isHTMLInputElementAutoFilled();
 }
 
 - (BOOL)HTMLInputElementIsAutoFilledAndViewable
 {
-    return _nodeHandle->isHTMLInputElementAutoFilledAndViewable();
+    return protectedNodeHandle(self)->isHTMLInputElementAutoFilledAndViewable();
 }
 
 - (BOOL)HTMLInputElementIsAutoFilledAndObscured
 {
-    return _nodeHandle->isHTMLInputElementAutoFilledAndObscured();
+    return protectedNodeHandle(self)->isHTMLInputElementAutoFilledAndObscured();
 }
 
 - (void)setHTMLInputElementIsAutoFilled:(BOOL)isAutoFilled
 {
-    _nodeHandle->setHTMLInputElementAutoFilled(isAutoFilled);
+    protectedNodeHandle(self)->setHTMLInputElementAutoFilled(isAutoFilled);
 }
 
 - (void)setHTMLInputElementIsAutoFilledAndViewable:(BOOL)isAutoFilledAndViewable
 {
-    _nodeHandle->setHTMLInputElementAutoFilledAndViewable(isAutoFilledAndViewable);
+    protectedNodeHandle(self)->setHTMLInputElementAutoFilledAndViewable(isAutoFilledAndViewable);
 }
 
 - (void)setHTMLInputElementIsAutoFilledAndObscured:(BOOL)isAutoFilledAndObscured
 {
-    _nodeHandle->setHTMLInputElementAutoFilledAndObscured(isAutoFilledAndObscured);
+    protectedNodeHandle(self)->setHTMLInputElementAutoFilledAndObscured(isAutoFilledAndObscured);
 }
 
 - (BOOL)isHTMLInputElementAutoFillButtonEnabled
 {
-    return _nodeHandle->isHTMLInputElementAutoFillButtonEnabled();
+    return protectedNodeHandle(self)->isHTMLInputElementAutoFillButtonEnabled();
 }
 
 static WebCore::AutoFillButtonType toAutoFillButtonType(_WKAutoFillButtonType autoFillButtonType)
@@ -169,52 +174,52 @@ static _WKAutoFillButtonType toWKAutoFillButtonType(WebCore::AutoFillButtonType 
 
 - (void)setHTMLInputElementAutoFillButtonEnabledWithButtonType:(_WKAutoFillButtonType)autoFillButtonType
 {
-    _nodeHandle->setHTMLInputElementAutoFillButtonEnabled(toAutoFillButtonType(autoFillButtonType));
+    protectedNodeHandle(self)->setHTMLInputElementAutoFillButtonEnabled(toAutoFillButtonType(autoFillButtonType));
 }
 
 - (_WKAutoFillButtonType)htmlInputElementAutoFillButtonType
 {
-    return toWKAutoFillButtonType(_nodeHandle->htmlInputElementAutoFillButtonType());
+    return toWKAutoFillButtonType(protectedNodeHandle(self)->htmlInputElementAutoFillButtonType());
 }
 
 - (_WKAutoFillButtonType)htmlInputElementLastAutoFillButtonType
 {
-    return toWKAutoFillButtonType(_nodeHandle->htmlInputElementLastAutoFillButtonType());
+    return toWKAutoFillButtonType(protectedNodeHandle(self)->htmlInputElementLastAutoFillButtonType());
 }
 
 - (BOOL)HTMLInputElementIsUserEdited
 {
-    return _nodeHandle->htmlInputElementLastChangeWasUserEdit();
+    return protectedNodeHandle(self)->htmlInputElementLastChangeWasUserEdit();
 }
 
 - (BOOL)HTMLTextAreaElementIsUserEdited
 {
-    return _nodeHandle->htmlTextAreaElementLastChangeWasUserEdit();
+    return protectedNodeHandle(self)->htmlTextAreaElementLastChangeWasUserEdit();
 }
 
 - (BOOL)isSelectElement
 {
-    return _nodeHandle->isSelectElement();
+    return protectedNodeHandle(self)->isSelectElement();
 }
 
 - (BOOL)isSelectableTextNode
 {
-    return _nodeHandle->isSelectableTextNode();
+    return protectedNodeHandle(self)->isSelectableTextNode();
 }
 
 - (BOOL)isTextField
 {
-    return _nodeHandle->isTextField();
+    return protectedNodeHandle(self)->isTextField();
 }
 
 - (WKWebProcessPlugInNodeHandle *)HTMLTableCellElementCellAbove
 {
-    return WebKit::wrapper(_nodeHandle->htmlTableCellElementCellAbove()).autorelease();
+    return WebKit::wrapper(protectedNodeHandle(self)->htmlTableCellElementCellAbove()).autorelease();
 }
 
 - (WKWebProcessPlugInFrame *)frame
 {
-    return WebKit::wrapper(_nodeHandle->document()->documentFrame()).autorelease();
+    return WebKit::wrapper(protectedNodeHandle(self)->document()->documentFrame()).autorelease();
 }
 
 - (WebKit::InjectedBundleNodeHandle&)_nodeHandle

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
@@ -38,11 +38,16 @@
     AlignedStorage<WebKit::InjectedBundleRangeHandle> _rangeHandle;
 }
 
+static Ref<WebKit::InjectedBundleRangeHandle> protectedRangeHandle(WKWebProcessPlugInRangeHandle *handle)
+{
+    return *handle->_rangeHandle;
+}
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKWebProcessPlugInRangeHandle.class, self))
         return;
-    _rangeHandle->~InjectedBundleRangeHandle();
+    SUPPRESS_UNCOUNTED_ARG _rangeHandle->~InjectedBundleRangeHandle();
     [super dealloc];
 }
 
@@ -55,12 +60,12 @@
 
 - (WKWebProcessPlugInFrame *)frame
 {
-    return wrapper(_rangeHandle->document()->documentFrame()).autorelease();
+    return wrapper(protectedRangeHandle(self)->document()->documentFrame()).autorelease();
 }
 
 - (NSString *)text
 {
-    return _rangeHandle->text().createNSString().autorelease();
+    return protectedRangeHandle(self)->text().createNSString().autorelease();
 }
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
@@ -33,6 +33,11 @@
     AlignedStorage<WebKit::InjectedBundleScriptWorld> _world;
 }
 
+static Ref<WebKit::InjectedBundleScriptWorld> protectedWorld(WKWebProcessPlugInScriptWorld *world)
+{
+    return *world->_world;
+}
+
 + (WKWebProcessPlugInScriptWorld *)world
 {
     return WebKit::wrapper(WebKit::InjectedBundleScriptWorld::create(WebKit::ContentWorldIdentifier::generate())).autorelease();
@@ -47,28 +52,28 @@
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKWebProcessPlugInScriptWorld.class, self))
         return;
-    _world->~InjectedBundleScriptWorld();
+    SUPPRESS_UNCOUNTED_ARG _world->~InjectedBundleScriptWorld();
     [super dealloc];
 }
 
 - (void)clearWrappers
 {
-    _world->clearWrappers();
+    protectedWorld(self)->clearWrappers();
 }
 
 - (void)makeAllShadowRootsOpen
 {
-    _world->makeAllShadowRootsOpen();
+    protectedWorld(self)->makeAllShadowRootsOpen();
 }
 
 - (void)exposeClosedShadowRootsForExtensions
 {
-    _world->exposeClosedShadowRootsForExtensions();
+    protectedWorld(self)->exposeClosedShadowRootsForExtensions();
 }
 
 - (void)disableOverrideBuiltinsBehavior
 {
-    _world->disableOverrideBuiltinsBehavior();
+    protectedWorld(self)->disableOverrideBuiltinsBehavior();
 }
 
 - (NSString *)name

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
@@ -45,7 +45,7 @@
 - (instancetype)initWithDocument:(std::reference_wrapper<WebCore::Document>)document
 {
     if (self = [super init])
-        _token = document.get().createParserYieldToken();
+        _token = Ref { document.get() }->createParserYieldToken();
     return self;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h
@@ -40,7 +40,7 @@ class Document;
 
 @interface WKDOMNode () {
 @package
-    RefPtr<WebCore::Node> _impl;
+    const RefPtr<WebCore::Node> _impl;
 }
 
 - (id)_initWithImpl:(WebCore::Node*)impl;
@@ -48,7 +48,7 @@ class Document;
 
 @interface WKDOMRange () {
 @package
-    RefPtr<WebCore::Range> _impl;
+    const RefPtr<WebCore::Range> _impl;
 }
 
 - (id)_initWithImpl:(WebCore::Range*)impl;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
@@ -44,7 +44,8 @@
     if (!self)
         return nil;
 
-    _impl = impl;
+    RELEASE_ASSERT(impl);
+    lazyInitialize(_impl, Ref { *impl });
     WebKit::WKDOMNodeCache().add(impl, self);
 
     return self;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
@@ -44,7 +44,8 @@
     if (!self)
         return nil;
 
-    _impl = impl;
+    RELEASE_ASSERT(impl);
+    lazyInitialize(_impl, Ref { *impl });
     WebKit::WKDOMRangeCache().add(impl, self);
 
     return self;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
@@ -52,12 +52,12 @@ Ref<InjectedBundleHitTestResult> InjectedBundleHitTestResult::create(const HitTe
 
 RefPtr<InjectedBundleNodeHandle> InjectedBundleHitTestResult::nodeHandle() const
 {
-    return InjectedBundleNodeHandle::getOrCreate(m_hitTestResult.innerNonSharedNode());
+    return InjectedBundleNodeHandle::getOrCreate(m_hitTestResult.protectedInnerNonSharedNode().get());
 }
 
 RefPtr<InjectedBundleNodeHandle> InjectedBundleHitTestResult::urlElementHandle() const
 {
-    return InjectedBundleNodeHandle::getOrCreate(m_hitTestResult.URLElement());
+    return InjectedBundleNodeHandle::getOrCreate(m_hitTestResult.protectedURLElement().get());
 }
 
 RefPtr<WebFrame> InjectedBundleHitTestResult::frame() const
@@ -156,7 +156,7 @@ IntRect InjectedBundleHitTestResult::imageRect() const
     if (!coreFrame)
         return imageRect;
     
-    auto* view = coreFrame->view();
+    CheckedPtr view = coreFrame->view();
     if (!view)
         return imageRect;
     


### PR DESCRIPTION
#### 592a0de98827ed52ded85a4eece56e8f6610dc46
<pre>
Address more safer cpp warnings in WebKit/WebProcess/InjectedBundle
<a href="https://bugs.webkit.org/show_bug.cgi?id=301839">https://bugs.webkit.org/show_bug.cgi?id=301839</a>

Reviewed by Darin Adler and Anne van Kesteren.

* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::protectedInnerNonSharedNode const):
(WebCore::HitTestResult::protectedURLElement const):
* Source/WebCore/rendering/HitTestResult.h:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.mm:
(-[WKWebProcessPlugInCSSStyleDeclarationHandle dealloc]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm:
(protectedFrame):
(-[WKWebProcessPlugInFrame dealloc]):
(-[WKWebProcessPlugInFrame jsContextForWorld:]):
(-[WKWebProcessPlugInFrame jsContextForServiceWorkerWorld:]):
(-[WKWebProcessPlugInFrame hitTest:]):
(-[WKWebProcessPlugInFrame hitTest:options:]):
(-[WKWebProcessPlugInFrame jsCSSStyleDeclarationForCSSStyleDeclarationHandle:inWorld:]):
(-[WKWebProcessPlugInFrame jsNodeForNodeHandle:inWorld:]):
(-[WKWebProcessPlugInFrame jsRangeForRangeHandle:inWorld:]):
(-[WKWebProcessPlugInFrame _browserContextController]):
(-[WKWebProcessPlugInFrame URL]):
(-[WKWebProcessPlugInFrame childFrames]):
(-[WKWebProcessPlugInFrame containsAnyFormElements]):
(-[WKWebProcessPlugInFrame isMainFrame]):
(-[WKWebProcessPlugInFrame _securityOrigin]):
(-[WKWebProcessPlugInFrame appleTouchIconURLs]):
(-[WKWebProcessPlugInFrame faviconURLs]):
(-[WKWebProcessPlugInFrame _parentFrame]):
(-[WKWebProcessPlugInFrame _hasCustomContentProvider]):
(-[WKWebProcessPlugInFrame _certificateChain]):
(-[WKWebProcessPlugInFrame _serverTrust]):
(-[WKWebProcessPlugInFrame _provisionalURL]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.mm:
(-[WKWebProcessPlugInHitTestResult nodeHandle]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm:
(protectedNodeHandle):
(-[WKWebProcessPlugInNodeHandle dealloc]):
(-[WKWebProcessPlugInNodeHandle htmlIFrameElementContentFrame]):
(-[WKWebProcessPlugInNodeHandle renderedImageWithOptions:width:]):
(-[WKWebProcessPlugInNodeHandle elementBounds]):
(-[WKWebProcessPlugInNodeHandle HTMLInputElementIsAutoFilled]):
(-[WKWebProcessPlugInNodeHandle HTMLInputElementIsAutoFilledAndViewable]):
(-[WKWebProcessPlugInNodeHandle HTMLInputElementIsAutoFilledAndObscured]):
(-[WKWebProcessPlugInNodeHandle setHTMLInputElementIsAutoFilled:]):
(-[WKWebProcessPlugInNodeHandle setHTMLInputElementIsAutoFilledAndViewable:]):
(-[WKWebProcessPlugInNodeHandle setHTMLInputElementIsAutoFilledAndObscured:]):
(-[WKWebProcessPlugInNodeHandle isHTMLInputElementAutoFillButtonEnabled]):
(-[WKWebProcessPlugInNodeHandle setHTMLInputElementAutoFillButtonEnabledWithButtonType:]):
(-[WKWebProcessPlugInNodeHandle htmlInputElementAutoFillButtonType]):
(-[WKWebProcessPlugInNodeHandle htmlInputElementLastAutoFillButtonType]):
(-[WKWebProcessPlugInNodeHandle HTMLInputElementIsUserEdited]):
(-[WKWebProcessPlugInNodeHandle HTMLTextAreaElementIsUserEdited]):
(-[WKWebProcessPlugInNodeHandle isSelectElement]):
(-[WKWebProcessPlugInNodeHandle isSelectableTextNode]):
(-[WKWebProcessPlugInNodeHandle isTextField]):
(-[WKWebProcessPlugInNodeHandle HTMLTableCellElementCellAbove]):
(-[WKWebProcessPlugInNodeHandle frame]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm:
(protectedRangeHandle):
(-[WKWebProcessPlugInRangeHandle dealloc]):
(-[WKWebProcessPlugInRangeHandle frame]):
(-[WKWebProcessPlugInRangeHandle text]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm:
(protectedWorld):
(-[WKWebProcessPlugInScriptWorld dealloc]):
(-[WKWebProcessPlugInScriptWorld clearWrappers]):
(-[WKWebProcessPlugInScriptWorld makeAllShadowRootsOpen]):
(-[WKWebProcessPlugInScriptWorld exposeClosedShadowRootsForExtensions]):
(-[WKWebProcessPlugInScriptWorld disableOverrideBuiltinsBehavior]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm:
(-[WKDOMDocumentParserYieldToken initWithDocument:]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h:
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm:
(-[WKDOMNode _initWithImpl:]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm:
(-[WKDOMRange _initWithImpl:]):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp:
(WebKit::InjectedBundleHitTestResult::nodeHandle const):
(WebKit::InjectedBundleHitTestResult::urlElementHandle const):
(WebKit::InjectedBundleHitTestResult::imageRect const):

Canonical link: <a href="https://commits.webkit.org/302475@main">https://commits.webkit.org/302475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b35909ceeaee6bef1b170cbef7c167232c2a0fba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136585 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80597 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/de31b8fc-c7d4-4034-80bf-d8ba8fbbddee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98386 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66284 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e97516e3-4256-4c38-ab08-01d104de8fc3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132155 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1093 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115741 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79036 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f7763f74-4648-455d-8906-8c91c57f5f31) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1014 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33859 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79864 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109464 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34354 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139059 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1213 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106918 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106754 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/27179 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1037 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30601 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53858 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20170 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1331 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64685 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1156 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1199 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1255 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->