### PR TITLE
TrackPrivateBase's label/language should return a String

### DIFF
--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -176,17 +176,17 @@ void AudioTrack::idChanged(TrackID id)
     });
 }
 
-void AudioTrack::labelChanged(const AtomString& label)
+void AudioTrack::labelChanged(const String& label)
 {
-    setLabel(label);
+    setLabel(AtomString { label.isolatedCopy() });
     m_clients.forEach([this] (auto& client) {
         client.audioTrackLabelChanged(*this);
     });
 }
 
-void AudioTrack::languageChanged(const AtomString& language)
+void AudioTrack::languageChanged(const String& language)
 {
-    setLanguage(language);
+    setLanguage(AtomString { language.isolatedCopy() });
 }
 
 void AudioTrack::willRemove()

--- a/Source/WebCore/html/track/AudioTrack.h
+++ b/Source/WebCore/html/track/AudioTrack.h
@@ -82,8 +82,8 @@ private:
 
     // TrackPrivateBaseClient
     void idChanged(TrackID) final;
-    void labelChanged(const AtomString&) final;
-    void languageChanged(const AtomString&) final;
+    void labelChanged(const String&) final;
+    void languageChanged(const String&) final;
     void willRemove() final;
 
     void updateKindFromPrivate();

--- a/Source/WebCore/html/track/InbandGenericTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandGenericTextTrack.cpp
@@ -236,8 +236,8 @@ void InbandGenericTextTrack::newCuesParsed()
     if (!document)
         return;
 
-    for (auto& cueData : parser().takeCues()) {
-        auto cue = VTTCue::create(*document, cueData);
+    for (auto&& cueData : parser().takeCues()) {
+        auto cue = VTTCue::create(*document, WTFMove(cueData));
 
         auto existingCue = cueToExtend(cue);
         if (!existingCue)

--- a/Source/WebCore/html/track/InbandTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandTextTrack.cpp
@@ -60,7 +60,7 @@ Ref<InbandTextTrack> InbandTextTrack::create(ScriptExecutionContext& context, In
 }
 
 InbandTextTrack::InbandTextTrack(ScriptExecutionContext& context, InbandTextTrackPrivate& trackPrivate)
-    : TextTrack(&context, emptyAtom(), trackPrivate.id(), trackPrivate.label(), trackPrivate.language(), InBand)
+    : TextTrack(&context, emptyAtom(), trackPrivate.id(), AtomString { trackPrivate.label().isolatedCopy() }, AtomString { trackPrivate.language().isolatedCopy() }, InBand)
     , m_private(trackPrivate)
 {
     addClientToTrackPrivateBase(*this, trackPrivate);
@@ -146,7 +146,7 @@ size_t InbandTextTrack::inbandTrackIndex()
     return m_private->trackIndex();
 }
 
-AtomString InbandTextTrack::inBandMetadataTrackDispatchType() const
+String InbandTextTrack::inBandMetadataTrackDispatchType() const
 {
     return m_private->inBandMetadataTrackDispatchType();
 }
@@ -156,14 +156,14 @@ void InbandTextTrack::idChanged(TrackID id)
     setId(id);
 }
 
-void InbandTextTrack::labelChanged(const AtomString& label)
+void InbandTextTrack::labelChanged(const String& label)
 {
-    setLabel(label);
+    setLabel(AtomString { label.isolatedCopy() });
 }
 
-void InbandTextTrack::languageChanged(const AtomString& language)
+void InbandTextTrack::languageChanged(const String& language)
 {
-    setLanguage(language);
+    setLanguage(AtomString { language.isolatedCopy() });
 }
 
 void InbandTextTrack::willRemove()

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -47,7 +47,7 @@ public:
     bool isDefault() const override;
     size_t inbandTrackIndex();
 
-    AtomString inBandMetadataTrackDispatchType() const override;
+    String inBandMetadataTrackDispatchType() const override;
 
     void setPrivate(InbandTextTrackPrivate&);
 #if !RELEASE_LOG_DISABLED
@@ -67,8 +67,8 @@ protected:
 private:
     bool isInband() const final { return true; }
     void idChanged(TrackID) override;
-    void labelChanged(const AtomString&) override;
-    void languageChanged(const AtomString&) override;
+    void labelChanged(const String&) override;
+    void languageChanged(const String&) override;
     void willRemove() override;
 
     void addDataCue(const MediaTime&, const MediaTime&, std::span<const uint8_t>) override { ASSERT_NOT_REACHED(); }

--- a/Source/WebCore/html/track/InbandWebVTTTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandWebVTTTextTrack.cpp
@@ -85,8 +85,8 @@ void InbandWebVTTTextTrack::newCuesParsed()
     if (!document)
         return;
 
-    for (auto& cueData : parser().takeCues()) {
-        auto cue = VTTCue::create(*document, cueData);
+    for (auto&& cueData : parser().takeCues()) {
+        auto cue = VTTCue::create(*document, WTFMove(cueData));
         auto existingCue = matchCue(cue, TextTrackCue::IgnoreDuration);
         if (!existingCue) {
             INFO_LOG(LOGIDENTIFIER, cue.get());

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -71,7 +71,7 @@ public:
     const AtomString& kindKeyword() const;
     void setKindKeywordIgnoringASCIICase(StringView);
 
-    virtual AtomString inBandMetadataTrackDispatchType() const { return emptyAtom(); }
+    virtual String inBandMetadataTrackDispatchType() const { return emptyString(); }
 
     enum class Mode { Disabled, Hidden, Showing };
     Mode mode() const;

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -213,8 +213,15 @@ void TrackBase::removeClientFromTrackPrivateBase(TrackPrivateBase& track)
     track.removeClient(m_clientRegistrationId);
 }
 
-MediaTrackBase::MediaTrackBase(ScriptExecutionContext* context, Type type, const std::optional<AtomString>& id, TrackID trackId, const AtomString& label, const AtomString& language)
-    : TrackBase(context, type, id, trackId, label, language)
+static std::optional<AtomString> trackUID(const std::optional<String>& id)
+{
+    if (!id)
+        return { };
+    return AtomString { *id };
+}
+
+MediaTrackBase::MediaTrackBase(ScriptExecutionContext* context, Type type, const std::optional<String>& id, TrackID trackId, const String& label, const String& language)
+    : TrackBase(context, type, trackUID(id), trackId, AtomString { label.isolatedCopy() }, AtomString { language.isolatedCopy() })
 {
 }
 

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -126,7 +126,7 @@ public:
     virtual void setKind(const AtomString&);
 
 protected:
-    MediaTrackBase(ScriptExecutionContext*, Type, const std::optional<AtomString>& id, TrackID, const AtomString& label, const AtomString& language);
+    MediaTrackBase(ScriptExecutionContext*, Type, const std::optional<String>& id, TrackID, const String& label, const String& language);
 
     void setKindInternal(const AtomString&);
 

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -272,9 +272,9 @@ Ref<VTTCue> VTTCue::create(Document& document, double start, double end, String&
     return cue;
 }
 
-Ref<VTTCue> VTTCue::create(Document& document, const WebVTTCueData& data)
+Ref<VTTCue> VTTCue::create(Document& document, Ref<WebVTTCueData>&& data)
 {
-    auto cue = adoptRef(*new VTTCue(document, data));
+    auto cue = adoptRef(*new VTTCue(document, WTFMove(data)));
     cue->suspendIfNeeded();
     return cue;
 }
@@ -294,15 +294,15 @@ VTTCue::VTTCue(Document& document, const MediaTime& start, const MediaTime& end,
 {
 }
 
-VTTCue::VTTCue(Document& document, const WebVTTCueData& cueData)
+VTTCue::VTTCue(Document& document, Ref<WebVTTCueData>&& cueData)
     : VTTCue(document, MediaTime::zeroTime(), MediaTime::zeroTime(), { })
 {
-    m_originalStartTime = cueData.originalStartTime();
-    setText(cueData.content());
-    setStartTime(cueData.startTime());
-    setEndTime(cueData.endTime());
-    setId(cueData.id());
-    setCueSettings(cueData.settings());
+    m_originalStartTime = cueData->originalStartTime();
+    setText(cueData->content());
+    setStartTime(cueData->startTime());
+    setEndTime(cueData->endTime());
+    setId(AtomString { cueData->id() });
+    setCueSettings(cueData->settings());
 }
 
 VTTCue::~VTTCue()

--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -119,7 +119,7 @@ class VTTCue
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(VTTCue);
 public:
     static Ref<VTTCue> create(Document&, double start, double end, String&& content);
-    static Ref<VTTCue> create(Document&, const WebVTTCueData&);
+    static Ref<VTTCue> create(Document&, Ref<WebVTTCueData>&&);
 
     virtual ~VTTCue();
 
@@ -233,7 +233,7 @@ protected:
     void toJSON(JSON::Object&) const override;
 
 private:
-    VTTCue(Document&, const WebVTTCueData&);
+    VTTCue(Document&, Ref<WebVTTCueData>&&);
 
     void createWebVTTNodeTree();
 

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -155,17 +155,17 @@ void VideoTrack::idChanged(TrackID id)
     });
 }
 
-void VideoTrack::labelChanged(const AtomString& label)
+void VideoTrack::labelChanged(const String& label)
 {
-    setLabel(label);
+    setLabel(AtomString { label.isolatedCopy() });
     m_clients.forEach([this] (auto& client) {
         client.videoTrackLabelChanged(*this);
     });
 }
 
-void VideoTrack::languageChanged(const AtomString& language)
+void VideoTrack::languageChanged(const String& language)
 {
-    setLanguage(language);
+    setLanguage(AtomString { language.isolatedCopy() });
 }
 
 void VideoTrack::willRemove()

--- a/Source/WebCore/html/track/VideoTrack.h
+++ b/Source/WebCore/html/track/VideoTrack.h
@@ -84,8 +84,8 @@ private:
 
     // TrackPrivateBaseClient
     void idChanged(TrackID) final;
-    void labelChanged(const AtomString&) final;
-    void languageChanged(const AtomString&) final;
+    void labelChanged(const String&) final;
+    void languageChanged(const String&) final;
     void willRemove() final;
 
     bool enabled() const final { return selected(); }

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -288,7 +288,7 @@ WebVTTParser::ParseState WebVTTParser::collectWebVTTBlock(const String& line)
         if (!m_styleSheets.isEmpty())
             m_client.newStyleSheetsParsed();
         if (!m_previousLine.isEmpty() && !m_previousLine.contains("-->"_s))
-            m_currentId = AtomString { m_previousLine };
+            m_currentId = m_previousLine;
         
         return state;
     }
@@ -430,7 +430,7 @@ WebVTTParser::ParseState WebVTTParser::collectCueId(const String& line)
 {
     if (line.contains("-->"_s))
         return collectTimingsAndSettings(line);
-    m_currentId = AtomString { line };
+    m_currentId = line;
     return TimingsAndSettings;
 }
 
@@ -573,7 +573,7 @@ void WebVTTParser::createNewCue()
 
 void WebVTTParser::resetCueValues()
 {
-    m_currentId = emptyAtom();
+    m_currentId = emptyString();
     m_currentSettings = emptyString();
     m_currentStartTime = MediaTime::zeroTime();
     m_currentEndTime = MediaTime::zeroTime();

--- a/Source/WebCore/html/track/WebVTTParser.h
+++ b/Source/WebCore/html/track/WebVTTParser.h
@@ -73,8 +73,8 @@ public:
     MediaTime endTime() const { return m_endTime; }
     void setEndTime(const MediaTime& endTime) { m_endTime = endTime; }
 
-    AtomString id() const { return m_id; }
-    void setId(const AtomString& id) { m_id = id; }
+    String id() const { return m_id; }
+    void setId(const String& id) { m_id = id; }
 
     String content() const { return m_content; }
     void setContent(const String& content) { m_content = content; }
@@ -91,7 +91,7 @@ private:
     MediaTime m_startTime;
     MediaTime m_endTime;
     MediaTime m_originalStartTime;
-    AtomString m_id;
+    String m_id;
     String m_content;
     String m_settings;
 };
@@ -174,7 +174,7 @@ private:
 
     BufferedLineReader m_lineReader;
     const Ref<TextResourceDecoder> m_decoder;
-    AtomString m_currentId;
+    String m_currentId;
     MediaTime m_currentStartTime;
     MediaTime m_currentEndTime;
     StringBuilder m_currentContent;

--- a/Source/WebCore/loader/TextTrackLoader.cpp
+++ b/Source/WebCore/loader/TextTrackLoader.cpp
@@ -202,8 +202,8 @@ Vector<Ref<VTTCue>> TextTrackLoader::getNewCues()
     if (!m_cueParser)
         return { };
 
-    return m_cueParser->takeCues().map([this](auto& cueData) {
-        return VTTCue::create(protectedDocument(), cueData);
+    return map(m_cueParser->takeCues(), [this](auto&& cueData) {
+        return VTTCue::create(protectedDocument(), WTFMove(cueData));
     });
 }
 

--- a/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
@@ -71,10 +71,10 @@ public:
     virtual bool isMainProgramContent() const { return true; }
     virtual bool isEasyToRead() const { return false; }
     virtual bool isDefault() const { return false; }
-    AtomString label() const override { return emptyAtom(); }
-    AtomString language() const override { return emptyAtom(); }
-    std::optional<AtomString> trackUID() const override { return emptyAtom(); }
-    virtual AtomString inBandMetadataTrackDispatchType() const { return emptyAtom(); }
+    String label() const override { return emptyString(); }
+    String language() const override { return emptyString(); }
+    std::optional<String> trackUID() const override { return emptyString(); }
+    virtual String inBandMetadataTrackDispatchType() const { return emptyString(); }
 
     CueFormat cueFormat() const { return m_format; }
     

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TrackPrivateBase);
 
-std::optional<AtomString> TrackPrivateBase::trackUID() const
+std::optional<String> TrackPrivateBase::trackUID() const
 {
     return std::nullopt;
 }

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.h
@@ -38,7 +38,7 @@
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
-#include <wtf/text/AtomString.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -59,11 +59,11 @@ public:
     void removeClient(uint32_t); // Can be called multiple times with the same id.
 
     virtual TrackID id() const { return 0; }
-    virtual AtomString label() const { return emptyAtom(); }
-    virtual AtomString language() const { return emptyAtom(); }
+    virtual String label() const { return emptyString(); }
+    virtual String language() const { return emptyString(); }
 
     virtual int trackIndex() const { return 0; }
-    virtual std::optional<AtomString> trackUID() const;
+    virtual std::optional<String> trackUID() const;
     virtual std::optional<bool> defaultEnabled() const;
 
     virtual MediaTime startTimeVariance() const { return MediaTime::zeroTime(); }

--- a/Source/WebCore/platform/graphics/TrackPrivateBaseClient.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBaseClient.h
@@ -52,8 +52,8 @@ public:
     enum Type { Text, Audio, Video };
     virtual constexpr Type type() const = 0;
     virtual void idChanged(TrackID) = 0;
-    virtual void labelChanged(const AtomString&) = 0;
-    virtual void languageChanged(const AtomString&) = 0;
+    virtual void labelChanged(const String&) = 0;
+    virtual void languageChanged(const String&) = 0;
     virtual void willRemove() = 0;
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
@@ -79,8 +79,8 @@ public:
 
     int index() const;
     TrackID id() const;
-    AtomString label() const;
-    AtomString language() const;
+    String label() const;
+    String language() const;
 
     static String languageForAVAssetTrack(AVAssetTrack*);
     static String languageForAVMediaSelectionOption(AVMediaSelectionOption *);

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -279,7 +279,7 @@ TrackID AVTrackPrivateAVFObjCImpl::id() const
     return 0;
 }
 
-AtomString AVTrackPrivateAVFObjCImpl::label() const
+String AVTrackPrivateAVFObjCImpl::label() const
 {
     ASSERT(m_assetTrack || m_mediaSelectionOption);
 
@@ -291,7 +291,7 @@ AtomString AVTrackPrivateAVFObjCImpl::label() const
 
     NSArray *titles = [PAL::getAVMetadataItemClassSingleton() metadataItemsFromArray:commonMetadata withKey:AVMetadataCommonKeyTitle keySpace:AVMetadataKeySpaceCommon];
     if (![titles count])
-        return emptyAtom();
+        return emptyString();
 
     // If possible, return a title in one of the user's preferred languages.
     NSArray *titlesForPreferredLanguages = [PAL::getAVMetadataItemClassSingleton() metadataItemsFromArray:titles filteredAndSortedAccordingToPreferredLanguages:[NSLocale preferredLanguages]];
@@ -300,21 +300,21 @@ AtomString AVTrackPrivateAVFObjCImpl::label() const
     return [[titles objectAtIndex:0] stringValue];
 }
 
-AtomString AVTrackPrivateAVFObjCImpl::language() const
+String AVTrackPrivateAVFObjCImpl::language() const
 {
     if (m_assetTrack) {
         auto language = languageForAVAssetTrack(m_assetTrack.get());
         if (!language.isEmpty())
-            return AtomString { language };
+            return language;
     }
 
     if (m_mediaSelectionOption) {
         auto language = languageForAVMediaSelectionOption(m_mediaSelectionOption->avMediaSelectionOption());
         if (!language.isEmpty())
-            return AtomString { language };
+            return language;
     }
 
-    return emptyAtom();
+    return emptyString();
 }
 
 String AVTrackPrivateAVFObjCImpl::languageForAVAssetTrack(AVAssetTrack* track)

--- a/Source/WebCore/platform/graphics/avfoundation/AudioTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioTrackPrivateAVF.h
@@ -38,21 +38,21 @@ class AudioTrackPrivateAVF : public AudioTrackPrivate {
 public:
     Kind kind() const override { return m_kind; }
     TrackID id() const override { return m_id; }
-    AtomString label() const override { return m_label; }
-    AtomString language() const override { return m_language; }
+    String label() const override { return m_label; }
+    String language() const override { return m_language; }
     int trackIndex() const override { return m_index; }
 
 protected:
     void setKind(Kind kind) { m_kind = kind; }
     void setId(TrackID newId) { m_id = newId; }
-    void setLabel(const AtomString& label) { m_label = label; }
-    void setLanguage(const AtomString& language) { m_language = language; }
+    void setLabel(const String& label) { m_label = label; }
+    void setLanguage(const String& language) { m_language = language; }
     void setTrackIndex(int index) { m_index = index; }
-    
+
     Kind m_kind { Kind::None };
     TrackID m_id;
-    AtomString m_label;
-    AtomString m_language;
+    String m_label;
+    String m_language;
     int m_index { 0 };
 
     AudioTrackPrivateAVF() = default;

--- a/Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.h
@@ -49,8 +49,8 @@ public:
 
     Kind kind() const override { return m_kind; }
     TrackID id() const override { return m_id; }
-    AtomString inBandMetadataTrackDispatchType() const override { return m_inBandMetadataTrackDispatchType; }
-    void setInBandMetadataTrackDispatchType(const AtomString& value) { m_inBandMetadataTrackDispatchType = value; }
+    String inBandMetadataTrackDispatchType() const override { return m_inBandMetadataTrackDispatchType; }
+    void setInBandMetadataTrackDispatchType(const String& value) { m_inBandMetadataTrackDispatchType = value; }
 
 #if ENABLE(DATACUE_VALUE)
     void addDataCue(const MediaTime& start, const MediaTime& end, Ref<SerializedPlatformDataCue>&&, const String&);
@@ -68,7 +68,7 @@ private:
 
     Kind m_kind;
     TrackID m_id;
-    AtomString m_inBandMetadataTrackDispatchType;
+    String m_inBandMetadataTrackDispatchType;
     MediaTime m_currentCueStartTime;
 #if ENABLE(DATACUE_VALUE)
     Vector<IncompleteMetaDataCue> m_incompleteCues;

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -36,6 +36,7 @@
 #include <JavaScriptCore/DataView.h>
 #include <JavaScriptCore/Int8Array.h>
 #include <pal/avfoundation/MediaTimeAVFoundation.h>
+#include <wtf/CrossThreadCopier.h>
 #include <wtf/MediaTime.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -564,7 +565,7 @@ void InbandTextTrackPrivateAVF::processVTTSample(CMSampleBufferRef sampleBuffer,
             ISOWebVTTCue cueData = ISOWebVTTCue(presentationTime, PAL::toMediaTime(timingInfo.duration));
             cueData.read(view);
 
-            notifyMainThreadClient([cueData = WTFMove(cueData)](auto& client) mutable {
+            notifyMainThreadClient([cueData = crossThreadCopy(WTFMove(cueData))](auto& client) mutable {
                 downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(WTFMove(cueData));
             });
         }

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h
@@ -50,8 +50,8 @@ public:
 
     TrackID id() const final { return m_trackID; }
     Kind kind() const override { return m_kind; }
-    AtomString label() const override { return m_label; }
-    AtomString language() const override { return m_language; }
+    String label() const override { return m_label; }
+    String language() const override { return m_language; }
 
     void setMode(InbandTextTrackPrivate::Mode) final;
 
@@ -92,8 +92,8 @@ protected:
 
     void setKind(Kind kind) { m_kind = kind; }
     void setId(TrackID newId) { m_trackID = newId; }
-    void setLabel(const AtomString& label) { m_label = label; }
-    void setLanguage(const AtomString& language) { m_language = language; }
+    void setLabel(const String& label) { m_label = label; }
+    void setLanguage(const String& language) { m_language = language; }
 
     Ref<InbandGenericCue> processCueAttributes(CFAttributedStringRef);
     void processAttributedStrings(CFArrayRef, const MediaTime&);
@@ -124,8 +124,8 @@ private:
     PendingCueStatus m_pendingCueStatus { None };
 
     Kind m_kind { Kind::None };
-    AtomString m_label;
-    AtomString m_language;
+    String m_label;
+    String m_language;
     int m_index { 0 };
     TrackID m_trackID { 0 };
     bool m_hasBeenReported { false };

--- a/Source/WebCore/platform/graphics/avfoundation/VideoTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/VideoTrackPrivateAVF.h
@@ -39,20 +39,20 @@ public:
     int trackIndex() const override { return m_index; }
     Kind kind() const override { return m_kind; }
     TrackID id() const override { return m_id; }
-    AtomString label() const override { return m_label; }
-    AtomString language() const override { return m_language; }
+    String label() const override { return m_label; }
+    String language() const override { return m_language; }
 
 protected:
     void setKind(Kind kind) { m_kind = kind; }
     void setId(TrackID newId) { m_id = newId; }
-    void setLabel(const AtomString& label) { m_label = label; }
-    void setLanguage(const AtomString& language) { m_language = language; }
+    void setLabel(const String& label) { m_label = label; }
+    void setLanguage(const String& language) { m_language = language; }
     void setTrackIndex(int index) { m_index = index; }
 
     Kind m_kind { Kind::None };
     TrackID m_id;
-    AtomString m_label;
-    AtomString m_language;
+    String m_label;
+    String m_language;
     int m_index { 0 };
 
     VideoTrackPrivateAVF() = default;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.h
@@ -49,7 +49,7 @@ public:
 
     TrackID id() const final { return m_id; }
     InbandTextTrackPrivate::Kind kind() const final { return InbandTextTrackPrivate::Kind::Chapters; }
-    AtomString language() const final;
+    String language() const final;
 
     int trackIndex() const final { return m_index; }
     void setTextTrackIndex(int index) { m_index = index; }
@@ -59,7 +59,7 @@ public:
 private:
     InbandChapterTrackPrivateAVFObjC(RetainPtr<NSLocale>, TrackID);
 
-    AtomString inBandMetadataTrackDispatchType() const final { return "com.apple.chapters"_s; }
+    String inBandMetadataTrackDispatchType() const final { return "com.apple.chapters"_s; }
     ASCIILiteral logClassName() const final { return "InbandChapterTrackPrivateAVFObjC"_s; }
 
     struct ChapterData {
@@ -72,7 +72,7 @@ private:
 
     Vector<ChapterData> m_processedChapters;
     RetainPtr<NSLocale> m_locale;
-    mutable AtomString m_language;
+    mutable String m_language;
     const TrackID m_id;
     int m_index { 0 };
 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h
@@ -58,8 +58,8 @@ public:
     bool containsOnlyForcedSubtitles() const override;
     bool isMainProgramContent() const override;
     bool isEasyToRead() const override;
-    AtomString label() const override;
-    AtomString language() const override;
+    String label() const override;
+    String language() const override;
     bool isDefault() const override;
 
     void disconnect() override;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm
@@ -138,7 +138,7 @@ bool InbandTextTrackPrivateAVFObjC::isEasyToRead() const
     return hasMediaCharacteristic(AVMediaCharacteristicEasyToRead);
 }
 
-AtomString InbandTextTrackPrivateAVFObjC::label() const
+String InbandTextTrackPrivateAVFObjC::label() const
 {
     NSArray<AVMetadataItem*>* commonMetadata = nil;
     if (m_mediaSelectionOption)
@@ -146,7 +146,7 @@ AtomString InbandTextTrackPrivateAVFObjC::label() const
     else if (m_assetTrack)
         commonMetadata = [m_assetTrack commonMetadata];
     if (!commonMetadata)
-        return emptyAtom();
+        return emptyString();
 
     RetainPtr<NSString> title;
     RetainPtr<NSArray> titles = [PAL::getAVMetadataItemClassSingleton() metadataItemsFromArray:commonMetadata withKey:AVMetadataCommonKeyTitle keySpace:AVMetadataKeySpaceCommon];
@@ -160,18 +160,18 @@ AtomString InbandTextTrackPrivateAVFObjC::label() const
             title = [[titles objectAtIndex:0] stringValue];
     }
 
-    return title ? AtomString(title.get()) : emptyAtom();
+    return title.get();
 }
 
-AtomString InbandTextTrackPrivateAVFObjC::language() const
+String InbandTextTrackPrivateAVFObjC::language() const
 {
     if (m_mediaSelectionOption)
-        return AtomString(AVTrackPrivateAVFObjCImpl::languageForAVMediaSelectionOption(m_mediaSelectionOption.get()));
+        return AVTrackPrivateAVFObjCImpl::languageForAVMediaSelectionOption(m_mediaSelectionOption.get());
 
     if (m_assetTrack)
-        return AtomString(AVTrackPrivateAVFObjCImpl::languageForAVAssetTrack(m_assetTrack.get()));
+        return AVTrackPrivateAVFObjCImpl::languageForAVAssetTrack(m_assetTrack.get());
 
-    return emptyAtom();
+    return emptyString();
 }
 
 bool InbandTextTrackPrivateAVFObjC::isDefault() const

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
@@ -50,8 +50,8 @@ void VideoTrackPrivateMediaSourceAVFObjC::resetPropertiesFromTrack()
     setTrackIndex(m_impl->index());
     setKind(m_impl->videoKind());
     setId(m_impl->id());
-    setLabel(m_impl->label());
-    setLanguage(m_impl->language());
+    setLabel(m_impl->label().isolatedCopy());
+    setLanguage(m_impl->language().isolatedCopy());
     setConfiguration(m_impl->videoTrackConfiguration());
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
@@ -65,17 +65,17 @@ std::optional<bool> AudioTrackPrivateWebM::defaultEnabled() const
     return std::nullopt;
 }
 
-AtomString AudioTrackPrivateWebM::label() const
+String AudioTrackPrivateWebM::label() const
 {
     if (m_label.isNull())
-        m_label = m_track.name.is_present() ? AtomString::fromUTF8(m_track.name.value()) : emptyAtom();
+        m_label = m_track.name.is_present() ? String::fromUTF8(m_track.name.value()) : emptyString();
     return m_label;
 }
 
-AtomString AudioTrackPrivateWebM::language() const
+String AudioTrackPrivateWebM::language() const
 {
     if (m_language.isNull())
-        m_language = m_track.language.is_present() ? AtomString::fromUTF8(m_track.language.value()) : emptyAtom();
+        m_language = m_track.language.is_present() ? String::fromUTF8(m_track.language.value()) : emptyString();
     return m_language;
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.h
@@ -42,8 +42,8 @@ public:
     virtual ~AudioTrackPrivateWebM() = default;
 
     TrackID id() const final;
-    AtomString label() const final;
-    AtomString language() const final;
+    String label() const final;
+    String language() const final;
     int trackIndex() const final;
     std::optional<bool> defaultEnabled() const final;
     std::optional<MediaTime> codecDelay() const;
@@ -62,8 +62,8 @@ private:
     webm::TrackEntry m_track;
     RefPtr<AudioInfo> m_formatDescription;
     MediaTime m_discardPadding { MediaTime::invalidTime() };
-    mutable AtomString m_label;
-    mutable AtomString m_language;
+    mutable String m_label;
+    mutable String m_language;
 };
 
 }

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
@@ -75,17 +75,17 @@ std::optional<bool> VideoTrackPrivateWebM::defaultEnabled() const
     return std::nullopt;
 }
 
-AtomString VideoTrackPrivateWebM::label() const
+String VideoTrackPrivateWebM::label() const
 {
     if (m_label.isNull())
-        m_label = m_track.name.is_present() ? AtomString::fromUTF8(m_track.name.value()) : emptyAtom();
+        m_label = m_track.name.is_present() ? String::fromUTF8(m_track.name.value()) : emptyString();
     return m_label;
 }
 
-AtomString VideoTrackPrivateWebM::language() const
+String VideoTrackPrivateWebM::language() const
 {
     if (m_language.isNull())
-        m_language = m_track.language.is_present() ? AtomString::fromUTF8(m_track.language.value()) : emptyAtom();
+        m_language = m_track.language.is_present() ? String::fromUTF8(m_track.language.value()) : emptyString();
     return m_language;
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h
@@ -42,8 +42,8 @@ public:
     virtual ~VideoTrackPrivateWebM() = default;
 
     TrackID id() const final;
-    AtomString label() const final;
-    AtomString language() const final;
+    String label() const final;
+    String language() const final;
     int trackIndex() const final;
     std::optional<bool> defaultEnabled() const final;
     uint32_t width() const;
@@ -60,8 +60,8 @@ private:
     void updateConfiguration();
 
     webm::TrackEntry m_track;
-    mutable AtomString m_label;
-    mutable AtomString m_language;
+    mutable String m_label;
+    mutable String m_language;
     RefPtr<VideoInfo> m_formatDescription;
 };
 

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
@@ -63,7 +63,7 @@ public:
     int trackIndex() const final { return m_index; }
 
     TrackID id() const final { return m_trackID.value_or(m_id); }
-    std::optional<AtomString> trackUID() const final
+    std::optional<String> trackUID() const final
     {
         auto player = m_player.get();
 
@@ -73,8 +73,8 @@ public:
         return std::nullopt;
     }
 
-    AtomString label() const final { return m_label; }
-    AtomString language() const final { return m_language; }
+    String label() const final { return m_label; }
+    String language() const final { return m_language; }
 
     void updateConfigurationFromCaps(GRefPtr<GstCaps>&&) final;
 

--- a/Source/WebCore/platform/graphics/gstreamer/InbandMetadataTextTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandMetadataTextTrackPrivateGStreamer.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class InbandMetadataTextTrackPrivateGStreamer : public InbandTextTrackPrivate {
 public:
-    static Ref<InbandMetadataTextTrackPrivateGStreamer> create(Kind kind, CueFormat cueFormat, const AtomString& id = emptyAtom())
+    static Ref<InbandMetadataTextTrackPrivateGStreamer> create(Kind kind, CueFormat cueFormat, const String& id = emptyString())
     {
         return adoptRef(*new InbandMetadataTextTrackPrivateGStreamer(kind, cueFormat, id));
     }
@@ -41,9 +41,9 @@ public:
     ~InbandMetadataTextTrackPrivateGStreamer() = default;
 
     Kind kind() const override { return m_kind; }
-    std::optional<AtomString> trackUID() const override { return m_stringId; }
-    AtomString inBandMetadataTrackDispatchType() const override { return m_inBandMetadataTrackDispatchType; }
-    void setInBandMetadataTrackDispatchType(const AtomString& value) { m_inBandMetadataTrackDispatchType = value; }
+    std::optional<String> trackUID() const override { return m_stringId; }
+    String inBandMetadataTrackDispatchType() const override { return m_inBandMetadataTrackDispatchType; }
+    void setInBandMetadataTrackDispatchType(const String& value) { m_inBandMetadataTrackDispatchType = value; }
 
     void addDataCue(const MediaTime& start, const MediaTime& end, std::span<const uint8_t> data)
     {
@@ -65,7 +65,7 @@ public:
     }
 
 private:
-    InbandMetadataTextTrackPrivateGStreamer(Kind kind, CueFormat cueFormat, const AtomString& id)
+    InbandMetadataTextTrackPrivateGStreamer(Kind kind, CueFormat cueFormat, const String& id)
         : InbandTextTrackPrivate(cueFormat)
         , m_kind(kind)
         , m_stringId(id)
@@ -74,8 +74,8 @@ private:
     }
 
     Kind m_kind;
-    AtomString m_stringId;
-    AtomString m_inBandMetadataTrackDispatchType;
+    String m_stringId;
+    String m_inBandMetadataTrackDispatchType;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
@@ -70,7 +70,7 @@ InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer(unsigned index,
     ensureTextTrackDebugCategoryInitialized();
     installUpdateConfigurationHandlers();
 
-    GST_INFO("Track %" PRIu64 " got stream start. GStreamer stream-id: %s", m_id, m_gstStreamId.string().utf8().data());
+    GST_INFO("Track %" PRIu64 " got stream start. GStreamer stream-id: %s", m_id, m_gstStreamId.utf8().data());
 
     GST_DEBUG("Stream %" GST_PTR_FORMAT, m_stream.get());
     auto caps = adoptGRef(gst_stream_get_caps(m_stream.get()));

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h
@@ -59,9 +59,9 @@ public:
 
     Kind kind() const final { return m_kind; }
     TrackID id() const final { return m_trackID.value_or(m_id); }
-    std::optional<AtomString> trackUID() const final { return std::nullopt; }
-    AtomString label() const final { return m_label; }
-    AtomString language() const final { return m_language; }
+    std::optional<String> trackUID() const final { return std::nullopt; }
+    String label() const final { return m_label; }
+    String language() const final { return m_language; }
     int trackIndex() const final { return m_index; }
 
     void handleSample(GRefPtr<GstSample>&&);

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
@@ -68,7 +68,7 @@ public:
     const GRefPtr<GstCaps>& initialCaps() { return m_initialCaps; }
 
     TrackID streamId() const { return m_id; }
-    const AtomString& gstStreamId() const { return m_gstStreamId; }
+    const String& gstStreamId() const { return m_gstStreamId; }
 
     virtual void updateConfigurationFromCaps(GRefPtr<GstCaps>&&) { }
 
@@ -97,9 +97,9 @@ protected:
 
     Ref<MainThreadNotifier<MainThreadNotification>> m_notifier;
     unsigned m_index;
-    AtomString m_label;
-    AtomString m_language;
-    AtomString m_gstStreamId;
+    String m_label;
+    String m_language;
+    String m_gstStreamId;
     // Track ID parsed from stream-id.
     TrackID m_id;
     GRefPtr<GstPad> m_pad;
@@ -114,8 +114,8 @@ protected:
     bool updateTrackIDFromTags(const GRefPtr<GstTagList>&);
 
 private:
-    bool getLanguageCode(GstTagList* tags, AtomString& value);
-    static AtomString generateUniquePlaybin2StreamID(TrackType, unsigned index);
+    bool getLanguageCode(GstTagList* tags, String& value);
+    static String generateUniquePlaybin2StreamID(TrackType, unsigned index);
     static char prefixForType(TrackType);
     template<class StringType>
     bool getTag(GstTagList* tags, const gchar* tagName, StringType& value);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
@@ -64,7 +64,7 @@ public:
     int trackIndex() const final { return m_index; }
 
     TrackID id() const final { return m_trackID.value_or(m_id); }
-    std::optional<AtomString> trackUID() const final
+    std::optional<String> trackUID() const final
     {
         auto player = m_player.get();
 
@@ -74,8 +74,8 @@ public:
         return std::nullopt;
     }
 
-    AtomString label() const final { return m_label; }
-    AtomString language() const final { return m_language; }
+    String label() const final { return m_label; }
+    String language() const final { return m_language; }
 
     void updateConfigurationFromCaps(GRefPtr<GstCaps>&&) final;
 

--- a/Source/WebCore/platform/graphics/iso/ISOVTTCue.h
+++ b/Source/WebCore/platform/graphics/iso/ISOVTTCue.h
@@ -42,7 +42,7 @@ namespace WebCore {
 class ISOWebVTTCue final : public ISOBox {
 public:
     ISOWebVTTCue(const MediaTime& presentationTime, const MediaTime& duration);
-    WEBCORE_EXPORT ISOWebVTTCue(MediaTime&& presentationTime, MediaTime&& duration, AtomString&& cueID, String&& cueText, String&& settings = { }, String&& sourceID = { }, String&& originalStartTime = { });
+    WEBCORE_EXPORT ISOWebVTTCue(const MediaTime& presentationTime, const MediaTime& duration, String&& cueID, String&& cueText, String&& settings = { }, String&& sourceID = { }, String&& originalStartTime = { });
     ISOWebVTTCue(const ISOWebVTTCue&) = default;
     WEBCORE_EXPORT ISOWebVTTCue();
     WEBCORE_EXPORT ISOWebVTTCue(ISOWebVTTCue&&);
@@ -57,7 +57,7 @@ public:
     const MediaTime& duration() const { return m_duration; }
 
     const String& sourceID() const { return m_sourceID; }
-    const AtomString& id() const { return m_identifier; }
+    const String& id() const { return m_identifier; }
     const String& originalStartTime() const { return m_originalStartTime; }
     const String& settings() const { return m_settings; }
     const String& cueText() const { return m_cueText; }
@@ -66,12 +66,15 @@ public:
 
     WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) override;
 
+    ISOWebVTTCue isolatedCopy() const &;
+    ISOWebVTTCue isolatedCopy() &&;
+
 private:
     MediaTime m_presentationTime;
     MediaTime m_duration;
 
     String m_sourceID;
-    AtomString m_identifier;
+    String m_identifier;
     String m_originalStartTime;
     String m_settings;
     String m_cueText;

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
@@ -91,8 +91,8 @@ private:
 
     // AudioTrackPrivate
     Kind kind() const final { return Kind::Main; }
-    std::optional<AtomString> trackUID() const { return AtomString { m_streamTrack->id() }; }
-    AtomString label() const final { return AtomString { m_streamTrack->label() }; }
+    std::optional<String> trackUID() const { return m_streamTrack->id(); }
+    String label() const final { return m_streamTrack->label(); }
     int trackIndex() const final { return m_index; }
     bool isBackedByMediaStreamTrack() const final { return true; }
 

--- a/Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h
@@ -55,9 +55,9 @@ private:
     }
 
     Kind kind() const final { return Kind::Main; }
-    std::optional<AtomString> trackUID() const { return AtomString { m_streamTrack->id() }; }
-    AtomString label() const final { return AtomString { m_streamTrack->label() }; }
-    AtomString language() const final { return emptyAtom(); }
+    std::optional<String> trackUID() const { return m_streamTrack->id(); }
+    String label() const final { return m_streamTrack->label(); }
+    String language() const final { return emptyString(); }
     int trackIndex() const final { return m_index; }
 
     const Ref<MediaStreamTrackPrivate> m_streamTrack;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
@@ -107,12 +107,12 @@ void RemoteAudioTrackProxy::idChanged(TrackID)
     configurationChanged();
 }
 
-void RemoteAudioTrackProxy::labelChanged(const AtomString&)
+void RemoteAudioTrackProxy::labelChanged(const String&)
 {
     configurationChanged();
 }
 
-void RemoteAudioTrackProxy::languageChanged(const AtomString&)
+void RemoteAudioTrackProxy::languageChanged(const String&)
 {
     configurationChanged();
 }

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
@@ -76,8 +76,8 @@ private:
 
     // TrackPrivateBaseClient
     void idChanged(WebCore::TrackID) final;
-    void labelChanged(const AtomString&) final;
-    void languageChanged(const AtomString&) final;
+    void labelChanged(const String&) final;
+    void languageChanged(const String&) final;
     void willRemove() final;
 
     AudioTrackPrivateRemoteConfiguration configuration();

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
@@ -100,12 +100,12 @@ void RemoteTextTrackProxy::idChanged(TrackID)
     configurationChanged();
 }
 
-void RemoteTextTrackProxy::labelChanged(const AtomString&)
+void RemoteTextTrackProxy::labelChanged(const String&)
 {
     configurationChanged();
 }
 
-void RemoteTextTrackProxy::languageChanged(const AtomString&)
+void RemoteTextTrackProxy::languageChanged(const String&)
 {
     configurationChanged();
 }

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
@@ -85,8 +85,8 @@ private:
 
     // TrackPrivateBaseClient
     void idChanged(WebCore::TrackID) final;
-    void labelChanged(const AtomString&) final;
-    void languageChanged(const AtomString&) final;
+    void labelChanged(const String&) final;
+    void languageChanged(const String&) final;
     void willRemove() final;
 
     TextTrackPrivateRemoteConfiguration& configuration();

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
@@ -99,12 +99,12 @@ void RemoteVideoTrackProxy::idChanged(TrackID)
     updateConfiguration();
 }
 
-void RemoteVideoTrackProxy::labelChanged(const AtomString&)
+void RemoteVideoTrackProxy::labelChanged(const String&)
 {
     updateConfiguration();
 }
 
-void RemoteVideoTrackProxy::languageChanged(const AtomString&)
+void RemoteVideoTrackProxy::languageChanged(const String&)
 {
     updateConfiguration();
 }

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
@@ -76,8 +76,8 @@ private:
 
     // TrackPrivateBaseClient
     void idChanged(WebCore::TrackID) final;
-    void labelChanged(const AtomString&) final;
-    void languageChanged(const AtomString&) final;
+    void labelChanged(const String&) final;
+    void languageChanged(const String&) final;
     void willRemove() final;
 
     VideoTrackPrivateRemoteConfiguration configuration();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6189,7 +6189,7 @@ header: <WebCore/ISOVTTCue.h>
 [CustomHeader] class WebCore::ISOWebVTTCue {
     MediaTime presentationTime();
     MediaTime duration();
-    AtomString id();
+    String id();
     String cueText();
     String settings();
     String sourceID();

--- a/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
@@ -74,7 +74,7 @@ void AudioTrackPrivateRemote::updateConfiguration(AudioTrackPrivateRemoteConfigu
         m_label = configuration.label;
         if (changed) {
             notifyClients([label = crossThreadCopy(m_label)](auto& client) {
-                client.labelChanged(AtomString { label.isolatedCopy() });
+                client.labelChanged(label);
             });
         };
     }
@@ -84,7 +84,7 @@ void AudioTrackPrivateRemote::updateConfiguration(AudioTrackPrivateRemoteConfigu
         m_language = configuration.language;
         if (changed) {
             notifyClients([language = crossThreadCopy(m_language)](auto& client) {
-                client.languageChanged(AtomString { language.isolatedCopy() });
+                client.languageChanged(language);
             });
         };
     }

--- a/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h
@@ -55,8 +55,8 @@ private:
 
     using AudioTrackKind = WebCore::AudioTrackPrivate::Kind;
     AudioTrackKind kind() const final { return m_kind; }
-    AtomString label() const final { return AtomString { m_label.isolatedCopy() }; }
-    AtomString language() const final { return AtomString { m_language.isolatedCopy() }; }
+    String label() const final { return m_label; }
+    String language() const final { return m_language; }
     int trackIndex() const final { return m_trackIndex; }
     void setEnabled(bool) final;
     MediaTime startTimeVariance() const final { return m_startTimeVariance; }

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
@@ -32,6 +32,7 @@
 #include "GPUProcessConnection.h"
 #include "MediaPlayerPrivateRemote.h"
 #include "RemoteMediaPlayerProxyMessages.h"
+#include <WebCore/ISOVTTCue.h>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -77,7 +78,7 @@ void TextTrackPrivateRemote::updateConfiguration(TextTrackPrivateRemoteConfigura
         m_label = configuration.label;
         if (changed) {
             notifyClients([label = crossThreadCopy(m_label)](auto& client) {
-                client.labelChanged(AtomString { label.isolatedCopy() });
+                client.labelChanged(label);
             });
         }
     }
@@ -87,7 +88,7 @@ void TextTrackPrivateRemote::updateConfiguration(TextTrackPrivateRemoteConfigura
         m_language = configuration.language;
         if (changed) {
             notifyClients([language = crossThreadCopy(m_language)](auto& client) {
-                client.languageChanged(AtomString { language.isolatedCopy() });
+                client.languageChanged(language);
             });
         }
     }
@@ -131,6 +132,7 @@ void TextTrackPrivateRemote::removeGenericCue(Ref<InbandGenericCue> cue)
 
 void TextTrackPrivateRemote::parseWebVTTFileHeader(String&& header)
 {
+    assertIsMainRunLoop();
     ASSERT(hasOneClient());
     notifyMainThreadClient([&](auto& client) {
         downcast<InbandTextTrackPrivateClient>(client).parseWebVTTFileHeader(WTFMove(header));
@@ -139,6 +141,7 @@ void TextTrackPrivateRemote::parseWebVTTFileHeader(String&& header)
 
 void TextTrackPrivateRemote::parseWebVTTCueData(std::span<const uint8_t> data)
 {
+    assertIsMainRunLoop();
     ASSERT(hasOneClient());
     notifyMainThreadClient([&](auto& client) {
         downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(data);
@@ -147,6 +150,7 @@ void TextTrackPrivateRemote::parseWebVTTCueData(std::span<const uint8_t> data)
 
 void TextTrackPrivateRemote::parseWebVTTCueDataStruct(ISOWebVTTCue&& cueData)
 {
+    assertIsMainRunLoop();
     ASSERT(hasOneClient());
     notifyMainThreadClient([&](auto& client) {
         downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(WTFMove(cueData));
@@ -155,6 +159,7 @@ void TextTrackPrivateRemote::parseWebVTTCueDataStruct(ISOWebVTTCue&& cueData)
 
 void TextTrackPrivateRemote::addDataCue(MediaTime&& start, MediaTime&& end, std::span<const uint8_t> data)
 {
+    assertIsMainRunLoop();
     ASSERT(hasOneClient());
     notifyMainThreadClient([&](auto& client) {
         downcast<InbandTextTrackPrivateClient>(client).addDataCue(WTFMove(start), WTFMove(end), data);
@@ -164,6 +169,7 @@ void TextTrackPrivateRemote::addDataCue(MediaTime&& start, MediaTime&& end, std:
 #if ENABLE(DATACUE_VALUE)
 void TextTrackPrivateRemote::addDataCueWithType(MediaTime&& start, MediaTime&& end, SerializedPlatformDataCueValue&& dataValue, String&& type)
 {
+    assertIsMainRunLoop();
     ASSERT(hasOneClient());
     notifyMainThreadClient([&](auto& client) {
         downcast<InbandTextTrackPrivateClient>(client).addDataCue(WTFMove(start), WTFMove(end), WebCore::SerializedPlatformDataCue::create(WTFMove(dataValue)), type);
@@ -172,6 +178,7 @@ void TextTrackPrivateRemote::addDataCueWithType(MediaTime&& start, MediaTime&& e
 
 void TextTrackPrivateRemote::updateDataCue(MediaTime&& start, MediaTime&& end, SerializedPlatformDataCueValue&& dataValue)
 {
+    assertIsMainRunLoop();
     ASSERT(hasOneClient());
     notifyMainThreadClient([&](auto& client) {
         downcast<InbandTextTrackPrivateClient>(client).updateDataCue(WTFMove(start), WTFMove(end), WebCore::SerializedPlatformDataCue::create(WTFMove(dataValue)));
@@ -180,6 +187,7 @@ void TextTrackPrivateRemote::updateDataCue(MediaTime&& start, MediaTime&& end, S
 
 void TextTrackPrivateRemote::removeDataCue(MediaTime&& start, MediaTime&& end, SerializedPlatformDataCueValue&& dataValue)
 {
+    assertIsMainRunLoop();
     ASSERT(hasOneClient());
     notifyMainThreadClient([&](auto& client) {
         downcast<InbandTextTrackPrivateClient>(client).removeDataCue(WTFMove(start), WTFMove(end), WebCore::SerializedPlatformDataCue::create(WTFMove(dataValue)));

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h
@@ -75,10 +75,10 @@ public:
     void updateConfiguration(TextTrackPrivateRemoteConfiguration&&);
 
     WebCore::TrackID id() const final { return m_id; }
-    AtomString label() const final { return AtomString { m_label.isolatedCopy() }; }
-    AtomString language() const final { return AtomString { m_language.isolatedCopy() }; }
+    String label() const final { return m_label; }
+    String language() const final { return m_language; }
     int trackIndex() const final { return m_trackIndex; }
-    AtomString inBandMetadataTrackDispatchType() const final { return AtomString { m_inBandMetadataTrackDispatchType.isolatedCopy() }; }
+    String inBandMetadataTrackDispatchType() const final { return m_inBandMetadataTrackDispatchType; }
 
     using TextTrackKind = WebCore::InbandTextTrackPrivate::Kind;
     TextTrackKind kind() const final { return m_kind; }

--- a/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
@@ -74,7 +74,7 @@ void VideoTrackPrivateRemote::updateConfiguration(VideoTrackPrivateRemoteConfigu
         m_label = configuration.label;
         if (changed && hasClients()) {
             notifyClients([label = crossThreadCopy(m_label)](auto& client) {
-                client.labelChanged(AtomString { label.isolatedCopy() });
+                client.labelChanged(label);
             });
         }
     }
@@ -84,7 +84,7 @@ void VideoTrackPrivateRemote::updateConfiguration(VideoTrackPrivateRemoteConfigu
         m_language = configuration.language;
         if (changed && hasClients()) {
             notifyClients([language = crossThreadCopy(m_language)](auto& client) {
-                client.languageChanged(AtomString { language.isolatedCopy() });
+                client.languageChanged(language);
             });
         }
     }

--- a/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h
@@ -53,8 +53,8 @@ public:
     using VideoTrackKind = WebCore::VideoTrackPrivate::Kind;
     VideoTrackKind kind() const final { return m_kind; }
     WebCore::TrackID id() const final { return m_id; }
-    AtomString label() const final { return AtomString { m_label.isolatedCopy() }; }
-    AtomString language() const final { return AtomString { m_language.isolatedCopy() }; }
+    String label() const final { return m_label; }
+    String language() const final { return m_language; }
     int trackIndex() const final { return m_trackIndex; }
     MediaTime startTimeVariance() const final { return m_startTimeVariance; }
 


### PR DESCRIPTION
#### bd2c5cb034caad9a6d36421ecb4acacf4b35ac20
<pre>
TrackPrivateBase&apos;s label/language should return a String
<a href="https://bugs.webkit.org/show_bug.cgi?id=301842">https://bugs.webkit.org/show_bug.cgi?id=301842</a>
<a href="https://rdar.apple.com/163911707">rdar://163911707</a>

Reviewed by Youenn Fablet.

In preparation for running the SourceBufferPrivate/MediaSourcePrivate
in the content process, we need the TrackPrivateBase to use Strings rather
than AtomStrings.
The TrackPrivateBase is created and owned by the SourceBufferPrivate.
While the SourceBufferPrivate was up to now a main thread only object,
this assumption is no longer going to be true: SourceBufferPrivate may
run in a worker&apos;s thread.
By making the TrackPrivateBase use Strings instead of AtomStrings we can
allow to move the objects between threads.
Many of the inherited class members had been moved to Strings in 274956@main.
We converted two base class members.
When building an {Audio,Video,Text}Track from an {Audio,Video,Text}TrackPrivate
take an isolatedCopy before converting to an AtomString. The AtomString conversion
mutate the original String, even if const that makes it non-isolated.

No change in observable behaviours.
Covered by existing tests.
* Source/WebCore/html/track/AudioTrack.cpp:
(WebCore::AudioTrack::labelChanged):
(WebCore::AudioTrack::languageChanged):
* Source/WebCore/html/track/AudioTrack.h:
* Source/WebCore/html/track/InbandTextTrack.cpp:
(WebCore::InbandTextTrack::InbandTextTrack):
(WebCore::InbandTextTrack::inBandMetadataTrackDispatchType const):
(WebCore::InbandTextTrack::labelChanged):
(WebCore::InbandTextTrack::languageChanged):
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/html/track/TextTrack.h:
(WebCore::TextTrack::inBandMetadataTrackDispatchType const):
* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::trackUID):
(WebCore::MediaTrackBase::MediaTrackBase):
* Source/WebCore/html/track/TrackBase.h:
* Source/WebCore/html/track/VideoTrack.cpp:
(WebCore::VideoTrack::VideoTrack):
(WebCore::VideoTrack::labelChanged):
(WebCore::VideoTrack::languageChanged):
* Source/WebCore/html/track/VideoTrack.h:
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::parseCueData):
* Source/WebCore/platform/graphics/InbandTextTrackPrivate.h:
(WebCore::InbandTextTrackPrivate::inBandMetadataTrackDispatchType const):
* Source/WebCore/platform/graphics/TrackPrivateBase.cpp:
(WebCore::TrackPrivateBase::trackUID const):
* Source/WebCore/platform/graphics/TrackPrivateBase.h:
* Source/WebCore/platform/graphics/TrackPrivateBaseClient.h:
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h:
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm:
(WebCore::AVTrackPrivateAVFObjCImpl::label const):
(WebCore::AVTrackPrivateAVFObjCImpl::language const):
* Source/WebCore/platform/graphics/avfoundation/AudioTrackPrivateAVF.h:
(WebCore::AudioTrackPrivateAVF::setLabel):
(WebCore::AudioTrackPrivateAVF::setLanguage):
* Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.h:
(WebCore::InbandMetadataTextTrackPrivateAVF::setInBandMetadataTrackDispatchType):
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp:
(WebCore::InbandTextTrackPrivateAVF::processVTTSample):
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h:
(WebCore::InbandTextTrackPrivateAVF::setLabel):
(WebCore::InbandTextTrackPrivateAVF::setLanguage):
* Source/WebCore/platform/graphics/avfoundation/VideoTrackPrivateAVF.h:
(WebCore::VideoTrackPrivateAVF::setLabel):
(WebCore::VideoTrackPrivateAVF::setLanguage):
* Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm:
(WebCore::InbandChapterTrackPrivateAVFObjC::processChapters):
(WebCore::InbandChapterTrackPrivateAVFObjC::language const):
* Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm:
(WebCore::InbandTextTrackPrivateAVFObjC::label const):
(WebCore::InbandTextTrackPrivateAVFObjC::language const):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm:
(WebCore::VideoTrackPrivateMediaSourceAVFObjC::resetPropertiesFromTrack):
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp:
(WebCore::AudioTrackPrivateWebM::label const):
(WebCore::AudioTrackPrivateWebM::language const):
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp:
(WebCore::VideoTrackPrivateWebM::label const):
(WebCore::VideoTrackPrivateWebM::language const):
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h:
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer):
(WebCore::TrackPrivateBaseGStreamer::setPad):
(WebCore::TrackPrivateBaseGStreamer::getLanguageCode):
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfTagsChanged):
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged):
(WebCore::TrackPrivateBaseGStreamer::updateTrackIDFromTags):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h:
(WebCore::TrackPrivateBaseGStreamer::gstStreamId const):
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h:
* Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp:
(WebCore::ISOWebVTTCue::ISOWebVTTCue):
(WebCore::ISOWebVTTCue::parse):
(WebCore::ISOWebVTTCue::isolatedCopy const):
(WebCore::ISOWebVTTCue::isolatedCopy):
* Source/WebCore/platform/graphics/iso/ISOVTTCue.h:
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h:
* Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h:
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp:
(WebKit::RemoteAudioTrackProxy::labelChanged):
(WebKit::RemoteAudioTrackProxy::languageChanged):
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp:
(WebKit::RemoteTextTrackProxy::labelChanged):
(WebKit::RemoteTextTrackProxy::languageChanged):
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp:
(WebKit::RemoteVideoTrackProxy::labelChanged):
(WebKit::RemoteVideoTrackProxy::languageChanged):
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/302527@main">https://commits.webkit.org/302527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3eec9b8691a2a95c4ace59798737fc230be42f73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129385 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136762 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80793 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6f5b46f7-b777-44fe-83f2-1158e40eb5d0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98539 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/66434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c45ae95-cf6c-4ffc-9335-beb7b451853e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79190 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7a20c2d0-a797-4059-a8f1-bddc4ac10f5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34018 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80039 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139235 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1381 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107065 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106909 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27216 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1171 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30751 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54090 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1503 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64866 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1320 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1357 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1425 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->