### PR TITLE
Always allocate ScrollerMac in heap

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -47,7 +47,7 @@ class ScrollerPairMac;
 
 struct ScrollbarColor;
 
-class ScrollerMac final : public CanMakeThreadSafeCheckedPtr<ScrollerMac, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
+class ScrollerMac final : public CanMakeThreadSafeCheckedPtr<ScrollerMac> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ScrollerMac);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollerMac);
     friend class ScrollerPairMac;

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -95,12 +95,12 @@ public:
     bool inLiveResize() const { return m_inLiveResize; }
 
     // Only for use by WebScrollerImpPairDelegateMac. Do not use elsewhere!
-    ScrollerMac& verticalScroller() { return m_verticalScroller; }
-    CheckedRef<ScrollerMac> checkedVerticalScroller()  { return m_verticalScroller; }
-    CheckedRef<const ScrollerMac> checkedVerticalScroller() const { return m_verticalScroller; }
-    ScrollerMac& horizontalScroller() { return m_horizontalScroller; }
-    CheckedRef<ScrollerMac> checkedHorizontalScroller() { return m_horizontalScroller; }
-    CheckedRef<const ScrollerMac> checkedHorizontalScroller() const { return m_horizontalScroller; }
+    ScrollerMac& verticalScroller() { return m_verticalScroller.get(); }
+    CheckedRef<ScrollerMac> checkedVerticalScroller()  { return m_verticalScroller.get(); }
+    CheckedRef<const ScrollerMac> checkedVerticalScroller() const { return m_verticalScroller.get(); }
+    ScrollerMac& horizontalScroller() { return m_horizontalScroller.get(); }
+    CheckedRef<ScrollerMac> checkedHorizontalScroller() { return m_horizontalScroller.get(); }
+    CheckedRef<const ScrollerMac> checkedHorizontalScroller() const { return m_horizontalScroller.get(); }
 
     String scrollbarStateForOrientation(ScrollbarOrientation) const;
 
@@ -134,8 +134,8 @@ private:
 
     ScrollbarHoverState m_scrollbarHoverState;
 
-    ScrollerMac m_verticalScroller;
-    ScrollerMac m_horizontalScroller;
+    const UniqueRef<ScrollerMac> m_verticalScroller;
+    const UniqueRef<ScrollerMac> m_horizontalScroller;
 
     std::optional<FloatPoint> m_lastScrollOffset;
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -139,8 +139,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollerPairMac);
 
 ScrollerPairMac::ScrollerPairMac(ScrollingTreeScrollingNode& node)
     : m_scrollingNode(node)
-    , m_verticalScroller(*this, ScrollbarOrientation::Vertical)
-    , m_horizontalScroller(*this, ScrollbarOrientation::Horizontal)
+    , m_verticalScroller(makeUniqueRef<ScrollerMac>(*this, ScrollbarOrientation::Vertical))
+    , m_horizontalScroller(makeUniqueRef<ScrollerMac>(*this, ScrollbarOrientation::Horizontal))
 {
 }
 
@@ -234,18 +234,18 @@ void ScrollerPairMac::contentsSizeChanged()
 void ScrollerPairMac::setUsePresentationValues(bool inMomentumPhase)
 {
     m_usingPresentationValues = inMomentumPhase;
-    m_horizontalScroller.setUsePresentationValue(m_usingPresentationValues);
-    m_verticalScroller.setUsePresentationValue(m_usingPresentationValues);
+    m_horizontalScroller->setUsePresentationValue(m_usingPresentationValues);
+    m_verticalScroller->setUsePresentationValue(m_usingPresentationValues);
 }
 
 void ScrollerPairMac::setHorizontalScrollbarPresentationValue(float scrollbValue)
 {
-    m_horizontalScroller.setUsePresentationValue(scrollbValue);
+    m_horizontalScroller->setUsePresentationValue(scrollbValue);
 }
 
 void ScrollerPairMac::setVerticalScrollbarPresentationValue(float scrollbValue)
 {
-    m_verticalScroller.setUsePresentationValue(scrollbValue);
+    m_verticalScroller->setUsePresentationValue(scrollbValue);
 }
 
 void ScrollerPairMac::updateValues()
@@ -355,8 +355,8 @@ void ScrollerPairMac::setScrollbarStyle(ScrollbarStyle style)
     m_scrollbarStyle = style;
 
     ensureOnMainThreadWithProtectedThis([scrollerStyle = nsScrollerStyle(style)](auto& scrollerPair) {
-        scrollerPair.m_horizontalScroller.updateScrollbarStyle();
-        scrollerPair.m_verticalScroller.updateScrollbarStyle();
+        scrollerPair.m_horizontalScroller->updateScrollbarStyle();
+        scrollerPair.m_verticalScroller->updateScrollbarStyle();
         [scrollerPair.m_scrollerImpPair setScrollerStyle:scrollerStyle];
     });
 }


### PR DESCRIPTION
#### 4a8e8a07afc5484b53cf7b1fb0fa21f7f1dbddd1
<pre>
Always allocate ScrollerMac in heap
<a href="https://bugs.webkit.org/show_bug.cgi?id=301845">https://bugs.webkit.org/show_bug.cgi?id=301845</a>

Reviewed by Anne van Kesteren.

Always allocate ScrollerMac in heap so that operator delete destructs it.

No new tests since there should be no behavioral differences.

* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
(WebCore::ScrollerPairMac::verticalScroller):
(WebCore::ScrollerPairMac::checkedVerticalScroller):
(WebCore::ScrollerPairMac::checkedVerticalScroller const):
(WebCore::ScrollerPairMac::horizontalScroller):
(WebCore::ScrollerPairMac::checkedHorizontalScroller):
(WebCore::ScrollerPairMac::checkedHorizontalScroller const):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::ScrollerPairMac):
(WebCore::ScrollerPairMac::setUsePresentationValues):
(WebCore::ScrollerPairMac::setHorizontalScrollbarPresentationValue):
(WebCore::ScrollerPairMac::setVerticalScrollbarPresentationValue):
(WebCore::ScrollerPairMac::setScrollbarStyle):

Canonical link: <a href="https://commits.webkit.org/302500@main">https://commits.webkit.org/302500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d046cf7e8d6bfb07b5f7d829450f9051cea8140

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136577 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80591 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9d00334e-d767-47e8-af63-78a8505429c9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98381 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66299 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9f882234-64e8-46f7-ba73-87d667ded7ee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79030 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/211ff8cc-c1db-4aa0-90ae-614ac024efc2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33848 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79856 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109455 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139051 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1206 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106911 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106747 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1030 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30591 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53850 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20184 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1323 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64677 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1148 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1193 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1247 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->