### PR TITLE
WIP: Reddit Cmd Click

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1554,6 +1554,7 @@ bool FrameLoader::isStopLoadingAllowed() const
 
 void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& referrer, FrameLoadType newLoadType, Event* event, RefPtr<FormState>&& formState, std::optional<PrivateClickMeasurement>&& privateClickMeasurement, CompletionHandler<void()>&& completionHandler)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadURL) - " << frameLoadRequest.resourceRequest().url());
     FRAMELOADER_RELEASE_LOG_FORWARDABLE(FRAMELOADER_LOAD_URL);
     ASSERT(frameLoadRequest.resourceRequest().httpMethod() == "GET"_s);
 
@@ -1654,6 +1655,7 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
     // exactly the same so pages with '#' links and DHTML side effects
     // work properly.
     if (shouldPerformFragmentNavigation(isFormSubmission, httpMethod, newLoadType, newURL)) {
+        ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadURL) - calling dispatchNavigateEvent for fragment navigation");
         if (!dispatchNavigateEvent(newLoadType, frameLoadRequest, true, formState.get(), event))
             return;
 
@@ -1668,14 +1670,27 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
         return;
     }
 
+    // if (isSameOrigin && newLoadType != FrameLoadType::Reload) {
+    //     if (action.type() != NavigationType::LinkClicked || !action.mouseEventData()->metaKey) {
+    //         ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadURL) - about to call dispatchNavigateEvent");
+    //         if (!dispatchNavigateEvent(newLoadType, frameLoadRequest, false, formState.get(), event)) {
+    //             ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadURL) - dispatchNavigateEvent is false, early return");
+    //             return;
+    //         } else {
+    //             ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadURL) - dispatchNavigateEvent is true, continuing");
+    //         }
+    //     }
+    // }
+
     if (isSameOrigin && newLoadType != FrameLoadType::Reload) {
-        if (!dispatchNavigateEvent(newLoadType, frameLoadRequest, false, formState.get(), event))
-            return;
+        ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadURL) - WOULD HAVE FIRED HERE");
+    } else {
+        ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadURL) - WOULD *NOT* HAVE FIRED HERE - isSameOrigin - " << isSameOrigin);
     }
 
     // Must grab this now, since this load may stop the previous load and clear this flag.
     bool isRedirect = m_quickRedirectComing;
-    loadWithNavigationAction(WTFMove(request), WTFMove(action), newLoadType, WTFMove(formState), allowNavigationToInvalidURL, frameLoadRequest.shouldTreatAsContinuingLoad(), [this, protectedThis = Ref { *this }, isRedirect, sameURL, newLoadType, completionHandler = completionHandlerCaller.release()] () mutable {
+    loadWithNavigationAction(WTFMove(request), WTFMove(action), newLoadType, WTFMove(formState), allowNavigationToInvalidURL, frameLoadRequest.shouldTreatAsContinuingLoad(), WTFMove(frameLoadRequest), isSameOrigin, event, [this, protectedThis = Ref { *this }, isRedirect, sameURL, newLoadType, completionHandler = completionHandlerCaller.release()] () mutable {
         if (isRedirect) {
             m_quickRedirectComing = false;
             if (RefPtr provisionalDocumentLoader = m_provisionalDocumentLoader)
@@ -1764,8 +1779,10 @@ void FrameLoader::load(FrameLoadRequest&& request)
     load(loader.get(), request.protectedRequesterSecurityOrigin().ptr());
 }
 
-void FrameLoader::loadWithNavigationAction(ResourceRequest&& request, NavigationAction&& action, FrameLoadType type, RefPtr<FormState>&& formState, AllowNavigationToInvalidURL allowNavigationToInvalidURL, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, CompletionHandler<void()>&& completionHandler)
+void FrameLoader::loadWithNavigationAction(ResourceRequest&& request, NavigationAction&& action, FrameLoadType type, RefPtr<FormState>&& formState, AllowNavigationToInvalidURL allowNavigationToInvalidURL, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<FrameLoadRequest> frameLoadRequest, bool isSameOrigin, Event* event, CompletionHandler<void()>&& completionHandler)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadWithNavigationAction) - " << request.url());
+
     FRAMELOADER_RELEASE_LOG_FORWARDABLE(FRAMELOADER_LOADWITHNAVIGATIONACTION);
 
     m_errorOccurredInLoading = false;
@@ -1795,7 +1812,7 @@ void FrameLoader::loadWithNavigationAction(ResourceRequest&& request, Navigation
     if (m_documentLoader)
         loader->setOverrideEncoding(m_documentLoader->overrideEncoding());
 
-    loadWithDocumentLoader(loader.ptr(), type, WTFMove(formState), allowNavigationToInvalidURL, WTFMove(completionHandler));
+    loadWithDocumentLoader(loader.ptr(), type, WTFMove(formState), allowNavigationToInvalidURL,WTFMove(frameLoadRequest), isSameOrigin, event, WTFMove(completionHandler));
 }
 
 void FrameLoader::load(DocumentLoader& newDocumentLoader, const SecurityOrigin* requesterOrigin)
@@ -1840,11 +1857,13 @@ void FrameLoader::load(DocumentLoader& newDocumentLoader, const SecurityOrigin* 
         type = FrameLoadType::Reload;
     }
 
-    loadWithDocumentLoader(&newDocumentLoader, type, nullptr, AllowNavigationToInvalidURL::Yes);
+    loadWithDocumentLoader(&newDocumentLoader, type, nullptr, AllowNavigationToInvalidURL::Yes, std::nullopt, false, nullptr);
 }
 
-void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType type, RefPtr<FormState>&& formState, AllowNavigationToInvalidURL allowNavigationToInvalidURL, CompletionHandler<void()>&& completionHandler)
+void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType type, RefPtr<FormState>&& formState, AllowNavigationToInvalidURL allowNavigationToInvalidURL, std::optional<FrameLoadRequest> frameLoadRequest, bool isSameOrigin, Event* event, CompletionHandler<void()>&& completionHandler)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadWithDocumentLoader) - called");
+
     FRAMELOADER_RELEASE_LOG_FORWARDABLE(FRAMELOADER_LOADWITHDOCUMENTLOADER_FRAME_LOAD_STARTED);
 
     m_errorOccurredInLoading = false;
@@ -1871,6 +1890,8 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
 
     const URL& newURL = loader->request().url();
 
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadWithDocumentLoader) - " << newURL.string());
+
     // Only the first iframe navigation or the first iframe navigation after about:blank should be reported.
     // https://www.w3.org/TR/resource-timing-2/#resources-included-in-the-performanceresourcetiming-interface
     if (m_shouldReportResourceTimingToParentFrame && !m_previousURL.isNull() && m_previousURL != aboutBlankURL())
@@ -1891,6 +1912,14 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
 
     const String& httpMethod = loader->request().httpMethod();
 
+    RefPtr protectedFormState = formState;
+
+    if (shouldPerformFragmentNavigation(isFormSubmission, httpMethod, policyChecker().loadType(), newURL)) {
+        ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadWithDocumentLoader) - shouldPerformFragmentNavigation");
+    } else {
+        ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadWithDocumentLoader) - should *NOT* PerformFragmentNavigation");
+    }
+
     if (shouldPerformFragmentNavigation(isFormSubmission, httpMethod, policyChecker().loadType(), newURL)) {
 
         RefPtr oldDocumentLoader = m_documentLoader;
@@ -1903,7 +1932,16 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
         RefPtr<SecurityOrigin> requesterOrigin;
         if (auto& requester = loader->triggeringAction().requester())
             requesterOrigin = requester->securityOrigin.copyRef();
-        policyChecker().checkNavigationPolicy(ResourceRequest(loader->request()), ResourceResponse { }  /* redirectResponse */, oldDocumentLoader.get(), WTFMove(formState), [this, protectedThis = Ref { *this }, requesterOrigin = WTFMove(requesterOrigin)] (const ResourceRequest& request, WeakPtr<FormState>&&, NavigationPolicyDecision navigationPolicyDecision) {
+        policyChecker().checkNavigationPolicy(ResourceRequest(loader->request()), ResourceResponse { }  /* redirectResponse */, oldDocumentLoader.get(), WTFMove(formState), [this, protectedThis = Ref { *this }, requesterOrigin = WTFMove(requesterOrigin), type, protectedFormState, frameLoadRequest = WTFMove(frameLoadRequest), event] (const ResourceRequest& request, WeakPtr<FormState>&&, NavigationPolicyDecision navigationPolicyDecision) {
+
+            if (type != FrameLoadType::Reload && frameLoadRequest && navigationPolicyDecision == NavigationPolicyDecision::ContinueLoad && !frameLoadRequest->isInitialFrameSrcLoad()) {
+                ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadWithDocumentLoader - 1) - about to call dispatchNavigateEvent");
+                if (!dispatchNavigateEvent(type, *frameLoadRequest, false, protectedFormState.get(), event))
+                    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadWithDocumentLoader - 1) - dispatch failed");
+                else
+                    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadWithDocumentLoader - 1) - dispatch succeeded");
+            }
+
             continueFragmentScrollAfterNavigationPolicy(request, requesterOrigin.get(), navigationPolicyDecision == NavigationPolicyDecision::ContinueLoad, NavigationHistoryBehavior::Auto);
         }, PolicyDecisionMode::Synchronous);
         return;
@@ -1924,13 +1962,26 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
     frame->protectedNavigationScheduler()->cancel(NewLoadInProgress::Yes);
 
     if (shouldTreatCurrentLoadAsContinuingLoad()) {
+        ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadWithDocumentLoader) - calling continueLoadAfterNavigationPolicy");
         continueLoadAfterNavigationPolicy(loader->request(), formState.get(), NavigationPolicyDecision::ContinueLoad, allowNavigationToInvalidURL);
         return;
     }
 
     auto policyDecisionMode = loader->triggeringAction().isFromNavigationAPI() ? PolicyDecisionMode::Synchronous : PolicyDecisionMode::Asynchronous;
     RELEASE_ASSERT(!isBackForwardLoadType(policyChecker().loadType()) || history().provisionalItem());
-    policyChecker().checkNavigationPolicy(ResourceRequest(loader->request()), ResourceResponse { } /* redirectResponse */, loader, WTFMove(formState), [this, protectedThis = Ref { *this }, allowNavigationToInvalidURL, completionHandler = completionHandlerCaller.release()] (const ResourceRequest& request, WeakPtr<FormState>&& weakFormState, NavigationPolicyDecision navigationPolicyDecision) mutable {
+    policyChecker().checkNavigationPolicy(ResourceRequest(loader->request()), ResourceResponse { } /* redirectResponse */, loader, WTFMove(formState), [this, protectedThis = Ref { *this }, allowNavigationToInvalidURL, completionHandler = completionHandlerCaller.release(), type, protectedFormState, frameLoadRequest = WTFMove(frameLoadRequest), isSameOrigin, event] (const ResourceRequest& request, WeakPtr<FormState>&& weakFormState, NavigationPolicyDecision navigationPolicyDecision) mutable {
+
+        if (isSameOrigin && type != FrameLoadType::Reload && frameLoadRequest && navigationPolicyDecision == NavigationPolicyDecision::ContinueLoad) {
+            ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadWithDocumentLoader - 2) - about to call dispatchNavigateEvent");
+            if (!dispatchNavigateEvent(type, *frameLoadRequest, false, protectedFormState.get(), event)) {
+                ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadWithDocumentLoader - 2) - dispatch failed");
+                // return;
+            }
+            else
+                ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::loadWithDocumentLoader - 2) - dispatch succeeded");
+
+        }
+
         continueLoadAfterNavigationPolicy(request, RefPtr { weakFormState.get() }.get(), navigationPolicyDecision, allowNavigationToInvalidURL);
         completionHandler();
     }, policyDecisionMode, determineNavigationType(type, NavigationHistoryBehavior::Auto));
@@ -2038,7 +2089,7 @@ void FrameLoader::reloadWithOverrideEncoding(const String& encoding)
 
     loader->setOverrideEncoding(encoding);
 
-    loadWithDocumentLoader(loader.ptr(), FrameLoadType::Reload, { }, AllowNavigationToInvalidURL::Yes);
+    loadWithDocumentLoader(loader.ptr(), FrameLoadType::Reload, { }, AllowNavigationToInvalidURL::Yes, std::nullopt, false, nullptr);
 }
 
 void FrameLoader::reload(OptionSet<ReloadOption> options, bool isRequestFromClientOrUserInput)
@@ -2091,7 +2142,7 @@ void FrameLoader::reload(OptionSet<ReloadOption> options, bool isRequestFromClie
         return FrameLoadType::Reload;
     };
 
-    loadWithDocumentLoader(loader.ptr(), frameLoadTypeForReloadOptions(options), { }, AllowNavigationToInvalidURL::Yes);
+    loadWithDocumentLoader(loader.ptr(), frameLoadTypeForReloadOptions(options), { }, AllowNavigationToInvalidURL::Yes, std::nullopt, true, nullptr);
 }
 
 void FrameLoader::stopAllLoaders(ClearProvisionalItem clearProvisionalItem, StopLoadingPolicy stopLoadingPolicy)
@@ -3596,7 +3647,7 @@ void FrameLoader::loadPostRequest(FrameLoadRequest&& request, const String& refe
     if (!frameName.isEmpty()) {
         // The search for a target frame is done earlier in the case of form submission.
         if (targetFrame) {
-            targetFrame->loader().loadWithNavigationAction(WTFMove(workingResourceRequest), WTFMove(action), loadType, WTFMove(formState), allowNavigationToInvalidURL, request.shouldTreatAsContinuingLoad(), WTFMove(completionHandler));
+            targetFrame->loader().loadWithNavigationAction(WTFMove(workingResourceRequest), WTFMove(action), loadType, WTFMove(formState), allowNavigationToInvalidURL, request.shouldTreatAsContinuingLoad(), std::nullopt, false, event, WTFMove(completionHandler));
             return;
         }
 
@@ -3626,7 +3677,7 @@ void FrameLoader::loadPostRequest(FrameLoadRequest&& request, const String& refe
 
     // must grab this now, since this load may stop the previous load and clear this flag
     bool isRedirect = m_quickRedirectComing;
-    loadWithNavigationAction(WTFMove(workingResourceRequest), WTFMove(action), loadType, WTFMove(formState), allowNavigationToInvalidURL, request.shouldTreatAsContinuingLoad(), [this, protectedThis = Ref { *this }, isRedirect, completionHandler = WTFMove(completionHandler)] () mutable {
+    loadWithNavigationAction(WTFMove(workingResourceRequest), WTFMove(action), loadType, WTFMove(formState), allowNavigationToInvalidURL, request.shouldTreatAsContinuingLoad(), std::nullopt, false, event, [this, protectedThis = Ref { *this }, isRedirect, completionHandler = WTFMove(completionHandler)] () mutable {
         if (isRedirect) {
             m_quickRedirectComing = false;
             if (RefPtr provisionalDocumentLoader = m_provisionalDocumentLoader)
@@ -4218,7 +4269,7 @@ void FrameLoader::continueLoadAfterNewWindowPolicy(ResourceRequest&& request,
 
     NavigationAction newAction { frame->protectedDocument().releaseNonNull(), request, InitiatedByMainFrame::Unknown, action.isRequestFromClientOrUserInput(), NavigationType::Other, action.shouldOpenExternalURLsPolicy(), nullptr, action.downloadAttribute() };
     newAction.setShouldReplaceDocumentIfJavaScriptURL(action.shouldReplaceDocumentIfJavaScriptURL());
-    mainFrameLoader->loadWithNavigationAction(WTFMove(request), WTFMove(newAction), FrameLoadType::Standard, formState, allowNavigationToInvalidURL, ShouldTreatAsContinuingLoad::No);
+    mainFrameLoader->loadWithNavigationAction(WTFMove(request), WTFMove(newAction), FrameLoadType::Standard, formState, allowNavigationToInvalidURL, ShouldTreatAsContinuingLoad::No, std::nullopt, false, nullptr);
 }
 
 ResourceLoaderIdentifier FrameLoader::requestFromDelegate(ResourceRequest& request, ResourceError& error)
@@ -4384,6 +4435,8 @@ RefPtr<Frame> FrameLoader::findFrameForNavigation(const AtomString& name, Docume
 
 bool FrameLoader::dispatchNavigateEvent(FrameLoadType loadType, const FrameLoadRequest& request, bool isSameDocument, FormState* formState, Event* event, SerializedScriptValue* classicHistoryAPIState)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::dispatchNavigateEvent) - " << request.resourceRequest().url());
+
     RefPtr document = m_frame->document();
     if (!document || !document->settings().navigationAPIEnabled())
         return true;
@@ -4421,6 +4474,7 @@ bool FrameLoader::dispatchNavigateEvent(FrameLoadType loadType, const FrameLoadR
     if (!formState && sourceElement && sourceElement->document().frame() != m_frame.ptr())
         sourceElement = nullptr;
 
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (FL::dispatchNavigateEvent) - calling Navigation::dispatchPushReplaceReloadNavigateEvent");
     return window->protectedNavigation()->dispatchPushReplaceReloadNavigateEvent(newURL, navigationType, isSameDocument, formState, classicHistoryAPIState, sourceElement.get());
 }
 
@@ -4478,7 +4532,7 @@ void FrameLoader::loadDifferentDocumentItem(HistoryItem& item, HistoryItem* from
 
         documentLoader->setLastCheckedRequest(ResourceRequest());
         cachedPage = nullptr; // Call to loadWithDocumentLoader() below may destroy the CachedPage.
-        loadWithDocumentLoader(documentLoader.get(), loadType, { }, AllowNavigationToInvalidURL::Yes);
+        loadWithDocumentLoader(documentLoader.get(), loadType, { }, AllowNavigationToInvalidURL::Yes, std::nullopt, false, nullptr);
         return;
     }
 
@@ -4568,7 +4622,7 @@ void FrameLoader::loadDifferentDocumentItem(HistoryItem& item, HistoryItem* from
     action.setSourceBackForwardItem(fromItem);
     action.setNavigationAPIType(determineNavigationType(loadType, NavigationHistoryBehavior::Auto));
 
-    loadWithNavigationAction(WTFMove(request), WTFMove(action), loadType, { }, AllowNavigationToInvalidURL::Yes, shouldTreatAsContinuingLoad);
+    loadWithNavigationAction(WTFMove(request), WTFMove(action), loadType, { }, AllowNavigationToInvalidURL::Yes, shouldTreatAsContinuingLoad, std::nullopt, false, nullptr);
 }
 
 bool FrameLoader::shouldDispatchNavigateEventForHistoryTraversal(const HistoryItem& item, const HistoryItem* fromItem)

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -426,10 +426,10 @@ private:
 
     void dispatchDidCommitLoad(std::optional<HasInsecureContent> initialHasInsecureContent, std::optional<UsedLegacyTLS> initialUsedLegacyTLS, std::optional<WasPrivateRelayed> initialWasPrivateRelayed);
 
-    void loadWithDocumentLoader(DocumentLoader*, FrameLoadType, RefPtr<FormState>&&, AllowNavigationToInvalidURL, CompletionHandler<void()>&& = [] { }); // Calls continueLoadAfterNavigationPolicy
+    void loadWithDocumentLoader(DocumentLoader*, FrameLoadType, RefPtr<FormState>&&, AllowNavigationToInvalidURL, std::optional<FrameLoadRequest>, bool isSameOrigin, Event*, CompletionHandler<void()>&& = [] { }); // Calls continueLoadAfterNavigationPolicy
     void load(DocumentLoader&, const SecurityOrigin* requesterOrigin); // Calls loadWithDocumentLoader
 
-    void loadWithNavigationAction(ResourceRequest&&, NavigationAction&&, FrameLoadType, RefPtr<FormState>&&, AllowNavigationToInvalidURL, ShouldTreatAsContinuingLoad, CompletionHandler<void()>&& = [] { }); // Calls loadWithDocumentLoader
+    void loadWithNavigationAction(ResourceRequest&&, NavigationAction&&, FrameLoadType, RefPtr<FormState>&&, AllowNavigationToInvalidURL, ShouldTreatAsContinuingLoad, std::optional<FrameLoadRequest>, bool isSameOrigin, Event*, CompletionHandler<void()>&& = [] { }); // Calls loadWithDocumentLoader
 
     void loadPostRequest(FrameLoadRequest&&, const String& referrer, FrameLoadType, Event*, RefPtr<FormState>&&, CompletionHandler<void()>&&);
     void loadURL(FrameLoadRequest&&, const String& referrer, FrameLoadType, Event*, RefPtr<FormState>&&, std::optional<PrivateClickMeasurement>&&, CompletionHandler<void()>&&);

--- a/Source/WebCore/page/FrameConsoleClient.cpp
+++ b/Source/WebCore/page/FrameConsoleClient.cpp
@@ -214,6 +214,8 @@ void FrameConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel 
         additionalArguments = messageArgumentsVector.subspan(1);
     }
 
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - CONSOLE - " << messageText);
+
     auto message = makeUnique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, type, level, messageText, arguments.copyRef(), lexicalGlobalObject);
 
     String url = message->url();

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2363,6 +2363,8 @@ void LocalDOMWindow::languagesChanged()
 
 void LocalDOMWindow::dispatchLoadEvent()
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (LocalDOMWindow::dispatchLoadEvent)");
+
     // If we did not protect it, the document loader and its timing subobject might get destroyed
     // as a side effect of what event handling code does.
     Ref protectedThis { *this };

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -990,6 +990,14 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     bool canIntercept = documentCanHaveURLRewritten(*document, destination->url()) && (!isTraversal || isSameDocument);
     bool canBeCanceled = !isTraversal || (document->isTopDocument() && isSameDocument); // FIXME: and user involvement is not browser-ui or navigation's relevant global object has transient activation.
     bool hashChange = !classicHistoryAPIState && equalIgnoringFragmentIdentifier(document->url(), destination->url()) && !equalRespectingNullity(document->url().fragmentIdentifier(),  destination->url().fragmentIdentifier());
+
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (N::innerDispatchNavigateEvent) - hashChange - " << hashChange);
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (N::innerDispatchNavigateEvent) - !classicHistoryAPIState - " << !classicHistoryAPIState);
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (N::innerDispatchNavigateEvent) - equalIgnoringFragmentIdentifier(document->url(), destination->url()) - " << equalIgnoringFragmentIdentifier(document->url(), destination->url()));
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (N::innerDispatchNavigateEvent) - !equalRespectingNullity(document->url().fragmentIdentifier(),  destination->url().fragmentIdentifier() - " << !equalRespectingNullity(document->url().fragmentIdentifier(),  destination->url().fragmentIdentifier()));
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (N::innerDispatchNavigateEvent) - document->url() - " << document->url());
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (N::innerDispatchNavigateEvent) - destination->url() - " << destination->url());
+
     auto info = apiMethodTracker ? apiMethodTracker->info : JSC::jsUndefined();
 
     RefPtr scriptExecutionContext = this->scriptExecutionContext();
@@ -1186,6 +1194,13 @@ Navigation::DispatchResult Navigation::dispatchTraversalNavigateEvent(HistoryIte
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-push/replace/reload-navigate-event
 bool Navigation::dispatchPushReplaceReloadNavigateEvent(const URL& url, NavigationNavigationType navigationType, bool isSameDocument, FormState* formState, SerializedScriptValue* classicHistoryAPIState, Element* sourceElement)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - (N::dispatchPushReplaceReloadNavigateEvent) - params - ");
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - url - " << url.string());
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - isSameDocument - " << isSameDocument);
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - formState - " << !!formState);
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - classicHistoryAPIState - " << !!classicHistoryAPIState);
+    ALWAYS_LOG_WITH_STREAM(stream << "RLOG - sourceElement - " << !!sourceElement);
+
     Ref destination = NavigationDestination::create(url, nullptr, isSameDocument);
     if (classicHistoryAPIState)
         destination->setStateObject(classicHistoryAPIState);


### PR DESCRIPTION
#### df82530dfbd413ba4a61aae574f73a0253cb5b40
<pre>
WIP: Reddit Cmd Click

Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::loadWithNavigationAction):
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::reloadWithOverrideEncoding):
(WebCore::FrameLoader::reload):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::continueLoadAfterNewWindowPolicy):
(WebCore::FrameLoader::dispatchNavigateEvent):
(WebCore::FrameLoader::loadDifferentDocumentItem):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/FrameConsoleClient.cpp:
(WebCore::FrameConsoleClient::messageWithTypeAndLevel):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::dispatchLoadEvent):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::dispatchPushReplaceReloadNavigateEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df82530dfbd413ba4a61aae574f73a0253cb5b40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129205 "37 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1463 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40105 "Failed to checkout and rebase branch from PR 53331") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136582 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80599 "Failed to checkout and rebase branch from PR 53331") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8d866b1a-81aa-4cb0-9fb5-715072637348) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131076 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1571 "Failed to checkout and rebase branch from PR 53331") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1340 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98384 "Found 13 new test failures: imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-crossdocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-crossdocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-crossdocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-cross-origin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-same-origin-cross-document.html imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-intercept.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/80599 "Failed to checkout and rebase branch from PR 53331") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2e694cc1-0089-429d-b230-f49c2d5f32f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132152 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1150 "Unexpected infrastructure issue, retrying build") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115738 "Found 6 new API test failures: TestWebKitAPI.ProcessSwap.ReuseSuspendedProcessForRegularNavigationRetainBundlePage, TestWebKitAPI.SiteIsolation.WebProcessCacheCrashWithZeroSharedProcess, TestWebKitAPI.WebKit.CreateNewPageDelegateFrameLoadState, TestWebKitAPI.WebKit.NewFirstVisuallyNonEmptyLayoutFrames, TestWebKitAPI.WebKit.CookieCachePruning, TestWebKitAPI.ProcessSwap.ReuseSuspendedProcessForRegularNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79034 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/acccd925-c05a-44c8-a734-63af33cfff77) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1018 "Found 13 new test failures: imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-crossdocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-crossdocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-crossdocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-cross-origin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-same-origin-cross-document.html imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-intercept.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33856 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79861 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109468 "Found 3 new API test failures: TestWebKitAPI.WebKit.CookieCachePruning, TestWebKitAPI.ProcessSwap.ReuseSuspendedProcessForRegularNavigationRetainBundlePage, TestWebKitAPI.ProcessSwap.ReuseSuspendedProcessForRegularNavigation (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/34351 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (failure); Uploaded test results; layout-tests (failure); Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139056 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1255 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1211 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Skipped layout-tests; layout-tests (failure); Uploaded test results; layout-tests (failure); Compiled WebKit (warnings); layout-tests (cancelled)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106916 "Found 12 new test failures: imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-crossdocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-crossdocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-crossdocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-sameorigin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-cross-origin.html imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-intercept.html imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-preventDefault.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106752 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1035 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/30598 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (failure); Uploaded test results; layout-tests (failure); Compiled WebKit (cancelled)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53855 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1328 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64682 "Found 2 new failures in loader/FrameLoader.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1153 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1197 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1252 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->