### PR TITLE
CoreAudioCaptureSource should have a ref to its CoreAudioSharedUnit

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -63,7 +63,6 @@ platform/graphics/filters/software/FEMorphologySoftwareApplier.h
 platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
 platform/mediarecorder/MediaRecorderPrivate.h
 platform/mediastream/AudioMediaStreamTrackRenderer.h
-platform/mediastream/mac/CoreAudioCaptureSource.h
 platform/mock/ScrollbarsControllerMock.h
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.h
 plugins/PluginData.h

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -49,6 +49,7 @@ namespace WebCore {
 
 class AudioSampleBufferList;
 class AudioSampleDataSource;
+class CoreAudioSharedUnit;
 class CaptureDeviceInfo;
 class WebAudioSourceProviderAVFObjC;
 
@@ -105,7 +106,11 @@ private:
     ASCIILiteral logClassName() const override { return "CoreAudioCaptureSource"_s; }
 #endif
 
+    Ref<CoreAudioSharedUnit> protectedUnit();
+    Ref<const CoreAudioSharedUnit> protectedUnit() const;
+
     uint32_t m_captureDeviceID { 0 };
+    Ref<CoreAudioSharedUnit> m_unit;
 
     std::optional<RealtimeMediaSourceCapabilities> m_capabilities;
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
@@ -115,7 +120,6 @@ private:
     bool m_echoCancellationChanging { false };
 
     std::optional<bool> m_echoCancellationCapability;
-    BaseAudioSharedUnit* m_overrideUnit { nullptr };
 };
 
 class CoreAudioSpeakerSamplesProducer {

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -555,8 +555,8 @@ OSStatus CoreAudioSharedUnit::processMicrophoneSamples(AudioUnitRenderActionFlag
             m_minimumMicrophoneSampleFrames = inNumberFrames;
             // Our buffer might be too small, the preferred buffer size or sample rate might have changed.
             callOnMainThread([weakThis = WeakPtr { *this }] {
-                if (weakThis)
-                    weakThis->reconfigure();
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->reconfigure();
             });
         }
         return err;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -126,6 +126,11 @@ public:
 
     const std::optional<CAAudioStreamDescription>& microphoneProcFormat() const { return m_microphoneProcFormat; }
 
+    LongCapabilityRange sampleRateCapacities() const final { return m_sampleRateCapabilities; }
+    int actualSampleRate() const final;
+
+    void delaySamples(Seconds) final;
+
 private:
     CoreAudioSharedUnit();
 
@@ -135,12 +140,10 @@ private:
 
     static size_t preferredIOBufferSize();
 
-    LongCapabilityRange sampleRateCapacities() const final { return m_sampleRateCapabilities; }
 
     bool hasAudioUnit() const final { return !!m_ioUnit; }
     void captureDeviceChanged() final;
     OSStatus reconfigureAudioUnit() final;
-    void delaySamples(Seconds) final;
 
     OSStatus setupAudioUnit();
     void cleanupAudioUnit() final;
@@ -154,7 +157,6 @@ private:
     bool migrateToNewDefaultDevice(const CaptureDevice&) final;
     void deallocateStoredVPIOUnit();
 #endif
-    int actualSampleRate() const final;
     void resetSampleRate();
 
     void willChangeCaptureDevice() final;


### PR DESCRIPTION
#### a051a95261803d47b1f5d47801be6a1b0828400d
<pre>
CoreAudioCaptureSource should have a ref to its CoreAudioSharedUnit
<a href="https://rdar.apple.com/163918367">rdar://163918367</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301847">https://bugs.webkit.org/show_bug.cgi?id=301847</a>

Reviewed by Anne Van Kesteren.

As a preliminary step towards supporting capture of microphone with or without echo cancellation, we make CoreAudioCaptureSource keep a ref to its audio unit.
This reduces the use of CoreAudioSharedUnit::singleton().
There should be no behavioral changes.
Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/302529@main">https://commits.webkit.org/302529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a05ec50c726f02960fcb0aeb44f7c6c46a1ec8d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80792 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7e9989d0-6ea5-43fe-a6dc-72ebf2c49255) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98535 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66432 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7ac0f4c9-07a8-4969-98ec-bbf4a3ee08be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79186 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/db633867-1326-4988-99b9-c92458a82ff8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34009 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80034 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139230 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107060 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106904 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27218 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1162 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30742 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/54085 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1498 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64861 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1315 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1352 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1420 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->