### PR TITLE
Make BaseAudioSharedUnit::allowStarting static

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -88,10 +88,20 @@ void BaseAudioSharedUnit::forEachClient(NOESCAPE const Function<void(CoreAudioCa
 
 const static OSStatus lowPriorityError1 = 560557684;
 const static OSStatus lowPriorityError2 = 561017449;
+
+#if ASSERT_ENABLED
+static bool s_isBaseAudioSharedUnitAllowedToStart = false;
+
+void BaseAudioSharedUnit::allowStarting()
+{
+    s_isBaseAudioSharedUnitAllowedToStart = true;
+}
+#endif
+
 void BaseAudioSharedUnit::startProducingData()
 {
     ASSERT(isMainThread());
-    ASSERT(m_isAllowedToStart);
+    ASSERT(s_isBaseAudioSharedUnitAllowedToStart);
 
     if (m_suspended)
         resume();

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -99,7 +99,7 @@ public:
     uint32_t captureDeviceID() const { return m_capturingDevice ? m_capturingDevice->second : 0; }
 
 #if ASSERT_ENABLED
-    void allowStarting() { m_isAllowedToStart = true; }
+    WEBCORE_EXPORT static void allowStarting();
 #endif
 
 protected:
@@ -173,9 +173,6 @@ private:
     bool m_isProducingMicrophoneSamples { true };
     Function<void()> m_voiceActivityCallback;
     std::unique_ptr<Timer> m_voiceActivityThrottleTimer;
-#if ASSERT_ENABLED
-    bool m_isAllowedToStart { false };
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -94,7 +94,7 @@ GPUProcess::GPUProcess()
 {
     RELEASE_LOG(Process, "%p - GPUProcess::GPUProcess:", this);
 #if ASSERT_ENABLED && PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
-    CoreAudioSharedUnit::singleton().allowStarting();
+    CoreAudioSharedUnit::allowStarting();
 #endif
 }
 


### PR DESCRIPTION
#### 41074f15296c38da98ae72c453a2af2021e5887c
<pre>
Make BaseAudioSharedUnit::allowStarting static
<a href="https://rdar.apple.com/163918767">rdar://163918767</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301848">https://bugs.webkit.org/show_bug.cgi?id=301848</a>

Reviewed by Eric Carlson.

As a a way to phase out CoreAudioSharedUnit::singleton, we refactor the code to make BaseAudioSharedUnit::allowStarting static.
No change of behavior.

Canonical link: <a href="https://commits.webkit.org/302481@main">https://commits.webkit.org/302481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51f4e5539754f747d74c7a9eba85b195b9b2c967

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80635 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dfce199c-35ee-46b1-a25a-fc18f6dd72cf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1378 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/98418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66318 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e20cfe0f-760d-4b6f-b82d-fe7d470142d7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132192 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115774 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79069 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5cdc46ff-5efa-41a8-939e-e3cba53c4637) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33893 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79900 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109498 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139095 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1292 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/1245 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106787 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27184 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1067 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30630 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53905 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1364 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64720 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1188 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1225 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1287 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->