### PR TITLE
Allow to iterate over all CoreAudioSharedUnits

### DIFF
--- a/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
@@ -250,7 +250,9 @@ Vector<AVAudioSessionCaptureDevice> AVAudioSessionCaptureDeviceManager::retrieve
         if (currentInput != m_lastDefaultMicrophone.get()) {
             auto device = AVAudioSessionCaptureDevice::createInput(currentInput, currentInput);
             callOnWebThreadOrDispatchAsyncOnMainThread(makeBlockPtr([device = crossThreadCopy(WTFMove(device))] () mutable {
-                CoreAudioSharedUnit::singleton().handleNewCurrentMicrophoneDevice(WTFMove(device));
+                CoreAudioSharedUnit::forEach([&device](auto& unit) {
+                    unit.handleNewCurrentMicrophoneDevice(device);
+                });
             }).get());
         }
         m_lastDefaultMicrophone = currentInput;

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -356,7 +356,7 @@ void BaseAudioSharedUnit::audioSamplesAvailable(const MediaTime& time, const Pla
     }
 }
 
-void BaseAudioSharedUnit::handleNewCurrentMicrophoneDevice(CaptureDevice&& device)
+void BaseAudioSharedUnit::handleNewCurrentMicrophoneDevice(const CaptureDevice& device)
 {
     forEachClient([&device](auto& client) {
         client.handleNewCurrentMicrophoneDevice(device);

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -94,7 +94,7 @@ public:
 
     const String& persistentIDForTesting() const { return m_capturingDevice ? m_capturingDevice->first : emptyString(); }
 
-    void handleNewCurrentMicrophoneDevice(CaptureDevice&&);
+    void handleNewCurrentMicrophoneDevice(const CaptureDevice&);
 
     uint32_t captureDeviceID() const { return m_capturingDevice ? m_capturingDevice->second : 0; }
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -141,7 +141,6 @@ public:
 
     WEBCORE_EXPORT void registerSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer&);
     WEBCORE_EXPORT void unregisterSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer&);
-    WEBCORE_EXPORT bool isAudioCaptureUnitRunning();
     WEBCORE_EXPORT bool shouldAudioCaptureUnitRenderAudio();
 
 private:

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -81,7 +81,9 @@ public:
         virtual bool canRenderAudio() const { return true; }
     };
 
-    WEBCORE_EXPORT static CoreAudioSharedUnit& singleton();
+    // The default unit - the only one that may render audio when capturing
+    WEBCORE_EXPORT static CoreAudioSharedUnit& defaultSingleton();
+    WEBCORE_EXPORT static void forEach(NOESCAPE Function<void(CoreAudioSharedUnit&)>&&);
     ~CoreAudioSharedUnit();
 
     using CreationCallback = Function<Expected<UniqueRef<InternalUnit>, OSStatus>(bool enableEchoCancellation)>;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
@@ -71,7 +71,7 @@ void unregisterAudioInputMuteChangeListener(WebCoreAudioInputMuteChangeListener*
 - (void)handleMuteStatusChangedNotification:(NSNotification*)notification
 {
     RetainPtr<NSNumber> newMuteState = [notification.userInfo valueForKey:AVAudioApplicationMuteStateKey];
-    WebCore::CoreAudioSharedUnit::singleton().handleMuteStatusChangedNotification(newMuteState.get().boolValue);
+    WebCore::CoreAudioSharedUnit::defaultSingleton().handleMuteStatusChangedNotification(newMuteState.get().boolValue);
 }
 
 @end
@@ -188,7 +188,7 @@ void CoreAudioSharedUnit::processVoiceActivityEvent(AudioObjectID deviceID)
         return;
 
     callOnMainRunLoop([] {
-        CoreAudioSharedUnit::singleton().voiceActivityDetected();
+        CoreAudioSharedUnit::defaultSingleton().voiceActivityDetected();
     });
 }
 #endif // PLATFORM(MAC) && HAVE(VOICEACTIVITYDETECTION)
@@ -197,7 +197,7 @@ bool CoreAudioSharedInternalUnit::setVoiceActivityDetection(bool shouldEnable)
 {
 #if HAVE(VOICEACTIVITYDETECTION)
 #if PLATFORM(MAC)
-    auto deviceID = CoreAudioSharedUnit::singleton().captureDeviceID();
+    auto deviceID = CoreAudioSharedUnit::defaultSingleton().captureDeviceID();
     if (!deviceID && defaultInputDevice(&deviceID))
         return false;
     return manageSpeechActivityListener(deviceID, shouldEnable);
@@ -206,7 +206,7 @@ bool CoreAudioSharedInternalUnit::setVoiceActivityDetection(bool shouldEnable)
     AUVoiceIOMutedSpeechActivityEventListener listener = ^(AUVoiceIOSpeechActivityEvent event) {
         if (event == kAUVoiceIOSpeechActivityHasStarted) {
             callOnMainThread([] {
-                CoreAudioSharedUnit::singleton().voiceActivityDetected();
+                CoreAudioSharedUnit::defaultSingleton().voiceActivityDetected();
             });
         }
     };

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -168,19 +168,19 @@ static bool s_shouldIncreaseBufferSize;
 void MockAudioSharedUnit::enable()
 {
     s_shouldIncreaseBufferSize = false;
-    CoreAudioSharedUnit::singleton().setSampleRateRange({ 44100, 96000 });
-    CoreAudioSharedUnit::singleton().setInternalUnitCreationCallback([](bool enableEchoCancellation) {
+    CoreAudioSharedUnit::defaultSingleton().setSampleRateRange({ 44100, 96000 });
+    CoreAudioSharedUnit::defaultSingleton().setInternalUnitCreationCallback([](bool enableEchoCancellation) {
         UniqueRef<CoreAudioSharedUnit::InternalUnit> result = makeUniqueRef<MockAudioSharedInternalUnit>(enableEchoCancellation);
         return result;
     });
-    CoreAudioSharedUnit::singleton().setInternalUnitGetSampleRateCallback([] { return 44100; });
+    CoreAudioSharedUnit::defaultSingleton().setInternalUnitGetSampleRateCallback([] { return 44100; });
 }
 
 void MockAudioSharedUnit::disable()
 {
-    CoreAudioSharedUnit::singleton().setSampleRateRange({ 8000, 96000 });
-    CoreAudioSharedUnit::singleton().setInternalUnitCreationCallback({ });
-    CoreAudioSharedUnit::singleton().setInternalUnitGetSampleRateCallback({ });
+    CoreAudioSharedUnit::defaultSingleton().setSampleRateRange({ 8000, 96000 });
+    CoreAudioSharedUnit::defaultSingleton().setInternalUnitCreationCallback({ });
+    CoreAudioSharedUnit::defaultSingleton().setInternalUnitGetSampleRateCallback({ });
 }
 
 void MockAudioSharedUnit::increaseBufferSize()
@@ -274,8 +274,8 @@ bool MockAudioSharedInternalUnit::setVoiceActivityDetection(bool shouldEnable)
 
 void MockAudioSharedInternalUnit::voiceDetected()
 {
-    CoreAudioSharedUnit::singleton().voiceActivityDetected();
-    CoreAudioSharedUnit::singleton().disableVoiceActivityThrottleTimerForTesting();
+    CoreAudioSharedUnit::defaultSingleton().voiceActivityDetected();
+    CoreAudioSharedUnit::defaultSingleton().disableVoiceActivityThrottleTimerForTesting();
 }
 
 void MockAudioSharedInternalUnit::reconfigure()
@@ -419,7 +419,7 @@ OSStatus MockAudioSharedInternalUnit::set(AudioUnitPropertyID property, AudioUni
     }
     if (property == kAudioOutputUnitProperty_CurrentDevice) {
         ASSERT(!*static_cast<const uint32_t*>(value));
-        auto device = MockRealtimeMediaSourceCenter::mockDeviceWithPersistentID(CoreAudioSharedUnit::singleton().persistentIDForTesting());
+        auto device = MockRealtimeMediaSourceCenter::mockDeviceWithPersistentID(CoreAudioSharedUnit::defaultSingleton().persistentIDForTesting());
         if (!device)
             return -1;
 

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -190,10 +190,15 @@ void MockRealtimeAudioSource::setIsInterrupted(bool isInterrupted)
 {
     UNUSED_PARAM(isInterrupted);
 #if PLATFORM(COCOA)
-    if (isInterrupted)
-        CoreAudioSharedUnit::singleton().suspend();
-    else
-        CoreAudioSharedUnit::singleton().resume();
+    if (isInterrupted) {
+        CoreAudioSharedUnit::forEach([](auto& unit) {
+            unit.suspend();
+        });
+    } else {
+        CoreAudioSharedUnit::forEach([](auto& unit) {
+            unit.resume();
+        });
+    }
 #elif USE(GSTREAMER)
     for (auto* source : MockRealtimeAudioSourceGStreamer::allMockRealtimeAudioSources())
         source->setInterruptedForTesting(isInterrupted);

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -448,7 +448,9 @@ void MockRealtimeMediaSourceCenter::triggerMockCaptureConfigurationChange(bool f
         auto devices = audioCaptureDeviceManager().captureDevices();
         if (devices.size() > 1) {
             MockAudioSharedUnit::increaseBufferSize();
-            CoreAudioSharedUnit::singleton().handleNewCurrentMicrophoneDevice(WTFMove(devices[1]));
+            CoreAudioSharedUnit::forEach([&devices](auto& unit) {
+                unit.handleNewCurrentMicrophoneDevice(devices[1]);
+            });
         }
     }
     if (forDisplay) {

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -1262,7 +1262,7 @@ void GPUConnectionToWebProcess::updateCaptureAccess(bool allowAudioCapture, bool
 {
 #if PLATFORM(MAC) && ENABLE(MEDIA_STREAM)
     if (allowAudioCapture)
-        CoreAudioSharedUnit::singleton().prewarmAudioUnitCreation([] { });
+        CoreAudioSharedUnit::defaultSingleton().prewarmAudioUnitCreation([] { });
 #endif
 
     m_allowsAudioCapture |= allowAudioCapture;

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -241,7 +241,7 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters,
     SandboxExtension::consumePermanently(parameters.microphoneSandboxExtensionHandle);
 #endif
 #if PLATFORM(IOS_FAMILY)
-    CoreAudioSharedUnit::singleton().setStatusBarWasTappedCallback([weakProcess = WeakPtr { *this }] (auto completionHandler) {
+    CoreAudioSharedUnit::defaultSingleton().setStatusBarWasTappedCallback([weakProcess = WeakPtr { *this }] (auto completionHandler) {
         if (RefPtr process = weakProcess.get())
             process->parentProcessConnection()->sendWithAsyncReply(Messages::GPUProcessProxy::StatusBarWasTapped(), [] { }, 0);
         completionHandler();
@@ -434,7 +434,7 @@ void GPUProcess::setOrientationForMediaCapture(WebCore::IntDegrees orientation)
 void GPUProcess::enableMicrophoneMuteStatusAPI()
 {
 #if PLATFORM(COCOA)
-    CoreAudioSharedUnit::singleton().setMuteStatusChangedCallback([weakProcess = WeakPtr { *this }] (bool isMuting) {
+    CoreAudioSharedUnit::defaultSingleton().setMuteStatusChangedCallback([weakProcess = WeakPtr { *this }] (bool isMuting) {
         if (RefPtr process = weakProcess.get())
             process->protectedParentProcessConnection()->send(Messages::GPUProcessProxy::MicrophoneMuteStatusChanged(isMuting), 0);
     });

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -314,7 +314,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::captureUnitIsSt
 void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::captureUnitHasStopped()
 {
     // Capture unit has stopped and audio will no longer be rendered through it so start the local unit.
-    if (m_isPlaying && !WebCore::CoreAudioSharedUnit::singleton().isSuspended())
+    if (m_isPlaying && !WebCore::CoreAudioSharedUnit::defaultSingleton().isSuspended())
         protectedLocalUnit()->start();
 }
 
@@ -343,7 +343,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::endAudioSession
     if (!m_isPlaying)
         return;
 
-    if (m_shouldRegisterAsSpeakerSamplesProducer && (WebCore::CoreAudioSharedUnit::singleton().isRunning() || WebCore::CoreAudioSharedUnit::singleton().isSuspended()))
+    if (m_shouldRegisterAsSpeakerSamplesProducer && (WebCore::CoreAudioSharedUnit::defaultSingleton().isRunning() || WebCore::CoreAudioSharedUnit::defaultSingleton().isSuspended()))
         return;
 
     protectedLocalUnit()->start();


### PR DESCRIPTION
#### f708ddaefa23bfecfd9854d30d2421f473e19d5e
<pre>
Allow to iterate over all CoreAudioSharedUnits
<a href="https://rdar.apple.com/163919516">rdar://163919516</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301849">https://bugs.webkit.org/show_bug.cgi?id=301849</a>

Reviewed by Eric Carlson.

We introduce CoreAudioSharedUnit::forEach to allow suspending/resuming/reconfiguring all units.
This is implemented via a WeakHashSet.

We rename CoreAudioSharedUnit::singleton to CoreAudioSharedUnit::defaultSingleton as we plan to progressively restrict this method to the audio unit that is responsible for audio rendering.
To do so, we plan to split of the functionality of CoreAudioSharedUnit into specific classes.

No change of behavior.

Canonical link: <a href="https://commits.webkit.org/302520@main">https://commits.webkit.org/302520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a57ab23bee9c7020f9214f8a9593f339d07105c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129277 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136653 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80670 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b875488f-d426-4d57-a152-567127f1addf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98448 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66349 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1145 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/115801 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; re-run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79099 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33920 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79931 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109525 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139126 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106977 "Passed tests") | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1371 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106816 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27213 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30656 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53947 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1396 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64752 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1216 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1252 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1318 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->